### PR TITLE
Removes Interaction System Exception

### DIFF
--- a/SS14.Server.GameObjects/EntitySystems/InteractionSystem.cs
+++ b/SS14.Server.GameObjects/EntitySystems/InteractionSystem.cs
@@ -112,6 +112,7 @@ namespace SS14.Server.GameObjects.EntitySystems
 
         private bool DoEmptyHandToActorInteraction(Entity user, Entity obj)
         {
+            // TODO Implementation for this
             return true;
         }
 

--- a/SS14.Server.GameObjects/EntitySystems/InteractionSystem.cs
+++ b/SS14.Server.GameObjects/EntitySystems/InteractionSystem.cs
@@ -112,7 +112,7 @@ namespace SS14.Server.GameObjects.EntitySystems
 
         private bool DoEmptyHandToActorInteraction(Entity user, Entity obj)
         {
-            throw new NotImplementedException();
+            return true;
         }
 
         private bool DoHandsToLargeObjectInteraction(Entity user, Entity obj)


### PR DESCRIPTION
This code would crash servers testing out interaction code whenever they click on an empty tile needlessly. This replaces the code with a simple return 1.