### PR TITLE
Fix the esc menu

### DIFF
--- a/SS14.Client/UserInterface/Components/MenuWindow.cs
+++ b/SS14.Client/UserInterface/Components/MenuWindow.cs
@@ -73,25 +73,21 @@ namespace SS14.Client.UserInterface.Components
             //Create a new one.
             Dispose();
         }
+
+        override protected void CloseButtonClicked(ImageButton sender)
+        {
+            ToggleVisible();
+        }
+
         public override bool KeyDown(KeyEventArgs e)
         {
             if (e.Code != Keyboard.Key.Escape)
             {
                 return false;
             }
- 
-            if (!Focus)
-            {
-                SetVisible(true);
-                Focus = true;
-                return true;
-            }
-            else
-            {
-                SetVisible(false);
-                Focus = false;
-                return true;
-            }
+            
+            ToggleVisible();
+            return true;
         }
     }
 }

--- a/SS14.Client/UserInterface/Components/Window.cs
+++ b/SS14.Client/UserInterface/Components/Window.cs
@@ -1,4 +1,4 @@
-using SFML.Graphics;
+﻿using SFML.Graphics;
 using SFML.System;
 using SFML.Window;
 using SS14.Client.Graphics.VertexData;
@@ -37,7 +37,7 @@ namespace SS14.Client.UserInterface.Components
             Update(0);
         }
 
-        private void CloseButtonClicked(ImageButton sender)
+        virtual protected void CloseButtonClicked(ImageButton sender)
         {
             Dispose();
         }


### PR DESCRIPTION
The esc menu would previously dispose of itself if you used the X button, however this menu is meant simply to toggle invisbility on and off when you press X or esc.
Fixes #296