### PR TITLE
Fixes a rare out of bounds exception

### DIFF
--- a/SS14.Shared/Maths/FloatMath.cs
+++ b/SS14.Shared/Maths/FloatMath.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 
 namespace SS14.Shared.Maths
@@ -57,10 +57,25 @@ namespace SS14.Shared.Maths
          {
              return radians/Pi*180;
          }
-         public static float ToRadians(float degrees)
-         {
-             return degrees/180*Pi;
-         }
-     }
- }
+        public static float ToRadians(float degrees)
+        {
+            return degrees / 180 * Pi;
+        }
+
+        public static float Clamp(float val, float min, float max)
+        {
+            if (val < min) return min;
+            else if (val > max) return max;
+            else return val;
+        }
+
+        public static int Clamp(int val, int min, int max)
+        {
+            if (val < min) return min;
+            else if (val > max) return max;
+            else return val;
+        }
+
+    }
+}
 

--- a/SS14.Shared/Maths/FloatMath.cs
+++ b/SS14.Shared/Maths/FloatMath.cs
@@ -62,19 +62,13 @@ namespace SS14.Shared.Maths
             return degrees / 180 * Pi;
         }
 
-        public static float Clamp(float val, float min, float max)
+        public static T Clamp<T>(this T val, T min, T max) where T : IComparable<T>
         {
-            if (val < min) return min;
-            else if (val > max) return max;
+            if (val.CompareTo(min) < 0) return min;
+            else if (val.CompareTo(max) > 0) return max;
             else return val;
         }
 
-        public static int Clamp(int val, int min, int max)
-        {
-            if (val < min) return min;
-            else if (val > max) return max;
-            else return val;
-        }
 
     }
 }

--- a/SS14.Shared/Maths/SfmlExt.cs
+++ b/SS14.Shared/Maths/SfmlExt.cs
@@ -1,4 +1,4 @@
-using SFML.Graphics;
+﻿using SFML.Graphics;
 using SFML.System;
 using System;
 
@@ -109,7 +109,8 @@ namespace SS14.Shared.Maths
             // Add 22.5° to offset the angles since 0° is inside one.
             angle += 22.5f;
 
-            return AngleDirections[(int)Math.Floor(angle/45f)];
+            int dirindex = FloatMath.Clamp((int)Math.Floor(angle / 45f), 0, 8);
+            return AngleDirections[dirindex];
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes a crash that occurs from the following
>return AngleDirections[(int)Math.Floor(angle/45f)];

System.IndexOutOfRangeException: 'Index was outside the bounds of the array.'

That occurs most likely due to a float rounding error