### PR TITLE
Fixes Exceptions on Rejoining

### DIFF
--- a/SS14.Server/BaseServer.cs
+++ b/SS14.Server/BaseServer.cs
@@ -495,7 +495,7 @@ namespace SS14.Server
             if (!connections.Any())
             {
                 //No clients -- don't send state
-                stateManager.Clear();
+                stateManager.CullAll();
             }
             else
             {

--- a/SS14.Server/GameState/GameStateManager.cs
+++ b/SS14.Server/GameState/GameStateManager.cs
@@ -42,7 +42,8 @@ namespace SS14.Server.GameStates
             if (!ackedStates.ContainsKey(client.ConnectionId))
                 return toState - new SS14.Shared.GameStates.GameState(0); //The client has no state!
 
-            SS14.Shared.GameStates.GameState fromState = this[ackedStates[client.ConnectionId]];
+            var ackack = ackedStates[client.ConnectionId];
+            SS14.Shared.GameStates.GameState fromState = this[ackack];
             return toState - fromState;
         }
 
@@ -63,11 +64,12 @@ namespace SS14.Server.GameStates
             return ackedStates[client.ConnectionId];
         }
 
-        #endregion IGameStateManager Members
-
         public void CullAll()
         {
+            ackedStates.Clear();
             Clear();
         }
+
+        #endregion IGameStateManager Members
     }
 }

--- a/SS14.Server/Interfaces/GameState/IGameStateManager.cs
+++ b/SS14.Server/Interfaces/GameState/IGameStateManager.cs
@@ -13,5 +13,6 @@ namespace SS14.Server.Interfaces.GameState
         GameStateDelta GetDelta(INetChannel client, uint state);
         SS14.Shared.GameStates.GameState GetFullState(uint state);
         uint GetLastStateAcked(INetChannel client);
+        void CullAll();
     }
 }

--- a/SS14.Shared/GameObjects/ComponentManager.cs
+++ b/SS14.Shared/GameObjects/ComponentManager.cs
@@ -82,5 +82,11 @@ namespace SS14.Shared.GameObjects
                 component.Update(frameTime);
             }
         }
+
+        public void Cull()
+        {
+            allComponents.Clear();
+            components.Clear();
+        }
     }
 }

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -421,7 +421,9 @@ namespace SS14.Shared.GameObjects
             }
             _components.Clear();
             _netIDs.Clear();
-//          _componentReferences.Clear();
+            _componentReferences.Clear();
+            var componentmanager = IoCManager.Resolve<IComponentManager>();
+            componentmanager.Cull();
         }
 
         public IEnumerable<IComponent> GetComponents()

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -421,7 +421,7 @@ namespace SS14.Shared.GameObjects
             }
             _components.Clear();
             _netIDs.Clear();
-            _componentReferences.Clear();
+//          _componentReferences.Clear();
         }
 
         public IEnumerable<IComponent> GetComponents()

--- a/SS14.Shared/Interfaces/GameObjects/IComponentManager.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponentManager.cs
@@ -30,6 +30,11 @@ namespace SS14.Shared.Interfaces.GameObjects
         void RemoveComponent(IComponent component);
 
         /// <summary>
+        /// Clear the master component list
+        /// </summary>
+        void Cull();
+
+        /// <summary>
         /// Big update method -- loops through all components in order of family and calls Update() on them.
         /// </summary>
         /// <param name="frameTime">Time since the last frame was rendered.</param>


### PR DESCRIPTION
This fixes two different exceptions you received when rejoining

1. A server exception that occurred due to the fact that the gamestatemanager would get cleared if everyone disconnected, but the list that it uses as keys to itself would not get cleared. Now both are cleared.

2. A client exception that occurred due to the component references list being completely cleared. This doesn't get regenerated upon reconnect, @PJB3005 may have to say whether or not this is wise but you cannot reconnect with it there.

Client still looks like shit when you reconnect though, and you cant move your player character, and the console has a line that says player.name variable is already defined.
![](https://puu.sh/x7Vbq/fbfe1c4696.jpg)