### PR TITLE
Tiles Helper Functions

### DIFF
--- a/SS14.Shared/Interfaces/Map/IMapGrid.cs
+++ b/SS14.Shared/Interfaces/Map/IMapGrid.cs
@@ -154,6 +154,12 @@ namespace SS14.Shared.Interfaces.Map
         /// <returns></returns>
         Vector2 GridTileToWorld(MapGrid.Indices gridTile);
 
+        /// <summary>
+        ///     Transforms grid indices into an outvar tile, returns false if no tile is found
+        /// </summary>
+        /// <param name="gridTile">The Grid Tile indices.</param>
+        /// <returns></returns>
+        bool IndicesToTile(MapGrid.Indices indices, out TileRef tile)
         #endregion
     }
 }

--- a/SS14.Shared/Interfaces/Map/IMapGrid.cs
+++ b/SS14.Shared/Interfaces/Map/IMapGrid.cs
@@ -159,7 +159,8 @@ namespace SS14.Shared.Interfaces.Map
         /// </summary>
         /// <param name="gridTile">The Grid Tile indices.</param>
         /// <returns></returns>
-        bool IndicesToTile(MapGrid.Indices indices, out TileRef tile)
+        bool IndicesToTile(MapGrid.Indices indices, out TileRef tile);
+
         #endregion
     }
 }

--- a/SS14.Shared/Map/Chunk.cs
+++ b/SS14.Shared/Map/Chunk.cs
@@ -64,6 +64,14 @@ namespace SS14.Shared.Map
             var indices = ChunkTileToGridTile(new MapGrid.Indices(xTile, yTile));
             return new TileRef(_mapManager, _grid.Index, indices.X, indices.Y, _tiles[xTile, yTile]);
         }
+        public TileRef GetTile(MapGrid.Indices indices)
+        {
+            // array out of bounds
+            if (indices.X >= ChunkSize || indices.Y >= ChunkSize)
+                throw new ArgumentException("Tile indices out of bounds.");
+            
+            return new TileRef(_mapManager, _grid.Index, indices.X, indices.Y, _tiles[indices.X, indices.Y]);
+        }
 
         /// <inheritdoc />
         [Obsolete("Enumerate over the chunk instead.")]

--- a/SS14.Shared/Map/Chunk.cs
+++ b/SS14.Shared/Map/Chunk.cs
@@ -59,7 +59,7 @@ namespace SS14.Shared.Map
         {
             // array out of bounds
             if (xTile >= ChunkSize || yTile >= ChunkSize)
-                throw new ArgumentException("Tile indices out of bounds.");
+                throw new ArgumentOutOfRangeException("Tile indices out of bounds.");
 
             var indices = ChunkTileToGridTile(new MapGrid.Indices(xTile, yTile));
             return new TileRef(_mapManager, _grid.Index, indices.X, indices.Y, _tiles[xTile, yTile]);
@@ -67,8 +67,8 @@ namespace SS14.Shared.Map
         public TileRef GetTile(MapGrid.Indices indices)
         {
             // array out of bounds
-            if (indices.X >= ChunkSize || indices.Y >= ChunkSize)
-                throw new ArgumentException("Tile indices out of bounds.");
+            if (indices.X >= ChunkSize || indices.X < 0 || indices.Y >= ChunkSize || indices.Y < 0)
+                throw new ArgumentOutOfRangeException("Tile indices out of bounds.");
             
             return new TileRef(_mapManager, _grid.Index, indices.X, indices.Y, _tiles[indices.X, indices.Y]);
         }

--- a/SS14.Shared/Map/MapGrid.cs
+++ b/SS14.Shared/Map/MapGrid.cs
@@ -314,6 +314,19 @@ namespace SS14.Shared.Map
             return LocalToWorld(local);
         }
 
+        /// <inheritdoc />
+        public bool IndicesToTile(MapGrid.Indices indices, out TileRef tile)
+        {
+            MapGrid.Indices chunkindices = new MapGrid.Indices(indices.X / ChunkSize, indices.Y / ChunkSize);
+            if (!_chunks.ContainsKey(chunkindices))
+            {
+                tile = new TileRef(); //Nothing should ever use or access this, bool check should occur first
+                return false;
+            }
+            Chunk chunk = _chunks[chunkindices];
+            tile = chunk.GetTile(new MapGrid.Indices(indices.X % ChunkSize, indices.Y % ChunkSize));
+            return true;
+        }
 
         #endregion
     }

--- a/SS14.Shared/Map/TileRef.cs
+++ b/SS14.Shared/Map/TileRef.cs
@@ -1,5 +1,6 @@
 ﻿using SS14.Shared.Interfaces.Map;
 using SS14.Shared.IoC;
+using SS14.Shared.Maths;
 using Vector2f = OpenTK.Vector2;
 
 namespace SS14.Shared.Map
@@ -47,6 +48,44 @@ namespace SS14.Shared.Map
         public override string ToString()
         {
             return $"TileRef: {X},{Y}";
+        }
+
+        public bool GetStep(Direction dir, out TileRef steptile)
+        {
+            MapGrid.Indices currenttile = _gridTile;
+            MapGrid.Indices shift;
+            switch (dir)
+            {
+                case Direction.East:
+                    shift = new MapGrid.Indices(1, 0);
+                    break;
+                case Direction.West:
+                    shift = new MapGrid.Indices(-1, 0);
+                    break;
+                case Direction.North:
+                    shift = new MapGrid.Indices(0, 1);
+                    break;
+                case Direction.South:
+                    shift = new MapGrid.Indices(0, -1);
+                    break;
+                case Direction.NorthEast:
+                    shift = new MapGrid.Indices(1, 1);
+                    break;
+                case Direction.SouthEast:
+                    shift = new MapGrid.Indices(1, -1);
+                    break;
+                case Direction.NorthWest:
+                    shift = new MapGrid.Indices(-1, 1);
+                    break;
+                case Direction.SouthWest:
+                    shift = new MapGrid.Indices(-1, -1);
+                    break;
+                default:
+                    steptile = new TileRef();
+                    return false;
+            }
+            currenttile += shift;
+            return _manager.GetGrid(_gridIndex).IndicesToTile(currenttile, out steptile);
         }
     }
 }


### PR DESCRIPTION
Creates a helper function for making tile indices into tile refs using the grid system, and creates a function to get a tileref one step in any particular direction of another tileref.