### PR TITLE
Shifts down the mob's bounding box by 0.6 tiles

### DIFF
--- a/Resources/Prototypes/Entities/Mobs.yml
+++ b/Resources/Prototypes/Entities/Mobs.yml
@@ -13,6 +13,7 @@
   - type: BoundingBox
     sizeX: 0.9
     sizeY: 0.9
+    offsetY: 0.6
     
   - type: ParticleSystem
   - type: Physics


### PR DESCRIPTION
This centers it just slightly above the feet of the mob. Otherwise the bounding box of the mob allows it to directly have its legs over walls when colliding with them, and colliding at walls from the bottom at chest height.

This is how it used to look
![](http://puu.sh/xib5J/a2aa526f22.jpg)