### PR TITLE
Snapgrid placement

### DIFF
--- a/SS14.Client/Placement/Modes/AlignSnapgridBorder.cs
+++ b/SS14.Client/Placement/Modes/AlignSnapgridBorder.cs
@@ -1,0 +1,46 @@
+﻿using OpenTK;
+using SFML.Graphics;
+using SS14.Client.GameObjects;
+using SS14.Client.Graphics;
+using SS14.Shared.Interfaces.Map;
+using SS14.Shared.GameObjects;
+using SS14.Shared.Interfaces.GameObjects.Components;
+using SS14.Shared.Utility;
+using SS14.Shared.Maths;
+using System;
+
+namespace SS14.Client.Placement.Modes
+{
+    public class AlignSnapgridBorder : PlacementMode
+    {
+        public AlignSnapgridBorder(PlacementManager pMan) : base(pMan)
+        {
+        }
+
+        public override bool Update(Vector2i mouseS, IMapManager currentMap)
+        {
+            if (currentMap == null) return false;
+
+            mouseScreen = mouseS;
+            mouseWorld = CluwneLib.ScreenToWorld(mouseScreen);
+
+            if (!currentMap.TryFindGridAt(mouseWorld, out IMapGrid currentgrid)) //Cant find a grid
+                return false;
+
+            var mouselocal = currentgrid.WorldToLocal(mouseWorld); //Convert code to local grid coordinates
+            var snapsize = currentgrid.SnapSize; //Find snap size
+            mouselocal = new Vector2( //Round local coordinates onto the snap grid
+                (float)Math.Round((mouselocal.X * 32 / (double)snapsize), MidpointRounding.AwayFromZero) * snapsize / 32,
+                (float)Math.Round((mouselocal.Y * 32 / (double)snapsize), MidpointRounding.AwayFromZero) * snapsize / 32);
+
+            //Convert back to original world and screen coordinates after applying offset
+            mouseWorld = currentgrid.LocalToWorld(mouselocal) + new Vector2(pManager.CurrentPrototype.PlacementOffset.X, pManager.CurrentPrototype.PlacementOffset.Y);
+            mouseScreen = (Vector2i)CluwneLib.WorldToScreen(mouseWorld);
+
+            if (!RangeCheck())
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/SS14.Client/Placement/Modes/AlignSnapgridBorder.cs
+++ b/SS14.Client/Placement/Modes/AlignSnapgridBorder.cs
@@ -11,9 +11,9 @@ using System;
 
 namespace SS14.Client.Placement.Modes
 {
-    public class AlignSnapgridBorder : PlacementMode
+    public class SnapgridBorder : PlacementMode
     {
-        public AlignSnapgridBorder(PlacementManager pMan) : base(pMan)
+        public SnapgridBorder(PlacementManager pMan) : base(pMan)
         {
         }
 
@@ -30,8 +30,8 @@ namespace SS14.Client.Placement.Modes
             var mouselocal = currentgrid.WorldToLocal(mouseWorld); //Convert code to local grid coordinates
             var snapsize = currentgrid.SnapSize; //Find snap size
             mouselocal = new Vector2( //Round local coordinates onto the snap grid
-                (float)Math.Round((mouselocal.X * 32 / (double)snapsize), MidpointRounding.AwayFromZero) * snapsize / 32,
-                (float)Math.Round((mouselocal.Y * 32 / (double)snapsize), MidpointRounding.AwayFromZero) * snapsize / 32);
+                (float)Math.Round((mouselocal.X / (double)snapsize), MidpointRounding.AwayFromZero) * snapsize,
+                (float)Math.Round((mouselocal.Y / (double)snapsize), MidpointRounding.AwayFromZero) * snapsize);
 
             //Convert back to original world and screen coordinates after applying offset
             mouseWorld = currentgrid.LocalToWorld(mouselocal) + new Vector2(pManager.CurrentPrototype.PlacementOffset.X, pManager.CurrentPrototype.PlacementOffset.Y);

--- a/SS14.Client/Placement/Modes/AlignSnapgridCenter.cs
+++ b/SS14.Client/Placement/Modes/AlignSnapgridCenter.cs
@@ -1,0 +1,46 @@
+﻿using OpenTK;
+using SFML.Graphics;
+using SS14.Client.GameObjects;
+using SS14.Client.Graphics;
+using SS14.Shared.Interfaces.Map;
+using SS14.Shared.GameObjects;
+using SS14.Shared.Interfaces.GameObjects.Components;
+using SS14.Shared.Utility;
+using SS14.Shared.Maths;
+using System;
+
+namespace SS14.Client.Placement.Modes
+{
+    public class AlignSnapgridCenter : PlacementMode
+    {
+        public AlignSnapgridCenter(PlacementManager pMan) : base(pMan)
+        {
+        }
+
+        public override bool Update(Vector2i mouseS, IMapManager currentMap)
+        {
+            if (currentMap == null) return false;
+
+            mouseScreen = mouseS;
+            mouseWorld = CluwneLib.ScreenToWorld(mouseScreen);
+            
+            if (!currentMap.TryFindGridAt(mouseWorld, out IMapGrid currentgrid)) //Cant find a grid
+                return false;
+
+            var mouselocal = currentgrid.WorldToLocal(mouseWorld); //Convert code to local grid coordinates
+            var snapsize = currentgrid.SnapSize; //Find snap size
+            mouselocal = new Vector2( //Round local coordinates onto the snap grid
+                (float)(Math.Round((mouselocal.X*32 / (double)snapsize-0.5), MidpointRounding.AwayFromZero)+0.5) * snapsize / 32, 
+                (float)(Math.Round((mouselocal.Y*32 / (double)snapsize-0.5), MidpointRounding.AwayFromZero)+0.5) * snapsize / 32);
+
+            //Convert back to original world and screen coordinates after applying offset
+            mouseWorld = currentgrid.LocalToWorld(mouselocal) + new Vector2(pManager.CurrentPrototype.PlacementOffset.X, pManager.CurrentPrototype.PlacementOffset.Y);
+            mouseScreen = (Vector2i)CluwneLib.WorldToScreen(mouseWorld);
+
+            if (!RangeCheck())
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/SS14.Client/Placement/Modes/AlignSnapgridCenter.cs
+++ b/SS14.Client/Placement/Modes/AlignSnapgridCenter.cs
@@ -11,9 +11,9 @@ using System;
 
 namespace SS14.Client.Placement.Modes
 {
-    public class AlignSnapgridCenter : PlacementMode
+    public class SnapgridCenter : PlacementMode
     {
-        public AlignSnapgridCenter(PlacementManager pMan) : base(pMan)
+        public SnapgridCenter(PlacementManager pMan) : base(pMan)
         {
         }
 
@@ -30,8 +30,8 @@ namespace SS14.Client.Placement.Modes
             var mouselocal = currentgrid.WorldToLocal(mouseWorld); //Convert code to local grid coordinates
             var snapsize = currentgrid.SnapSize; //Find snap size
             mouselocal = new Vector2( //Round local coordinates onto the snap grid
-                (float)(Math.Round((mouselocal.X*32 / (double)snapsize-0.5), MidpointRounding.AwayFromZero)+0.5) * snapsize / 32, 
-                (float)(Math.Round((mouselocal.Y*32 / (double)snapsize-0.5), MidpointRounding.AwayFromZero)+0.5) * snapsize / 32);
+                (float)(Math.Round((mouselocal.X / (double)snapsize-0.5), MidpointRounding.AwayFromZero)+0.5) * snapsize, 
+                (float)(Math.Round((mouselocal.Y / (double)snapsize-0.5), MidpointRounding.AwayFromZero)+0.5) * snapsize);
 
             //Convert back to original world and screen coordinates after applying offset
             mouseWorld = currentgrid.LocalToWorld(mouselocal) + new Vector2(pManager.CurrentPrototype.PlacementOffset.X, pManager.CurrentPrototype.PlacementOffset.Y);

--- a/SS14.Client/SS14.Client.csproj
+++ b/SS14.Client/SS14.Client.csproj
@@ -174,6 +174,8 @@
     <Compile Include="Interfaces\GameObjects\IClientEntityManager.cs" />
     <Compile Include="Interfaces\IGameController.cs" />
     <Compile Include="Map\MapRenderer.cs" />
+    <Compile Include="Placement\Modes\AlignSnapgridCenter.cs" />
+    <Compile Include="Placement\Modes\AlignSnapgridBorder.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="ss14.ico" />

--- a/SS14.Client/UserInterface/Components/EntitySpawnPanel.cs
+++ b/SS14.Client/UserInterface/Components/EntitySpawnPanel.cs
@@ -62,8 +62,8 @@ namespace SS14.Client.UserInterface.Components
                                   {
                                       "PlaceFree",
                                       "PlaceNearby",
-                                      "AlignSnapgridCenter",
-                                      "AlignSnapgridBorder",
+                                      "SnapgridCenter",
+                                      "SnapgridBorder",
                                       "AlignSimilar",
                                       "AlignTileAny",
                                       "AlignTileEmpty",
@@ -72,7 +72,7 @@ namespace SS14.Client.UserInterface.Components
                                       "AlignWall",
                                   });
 
-            _lstOverride = new Listbox(130, 125, resourceCache, initOpts);
+            _lstOverride = new Listbox(140, 125, resourceCache, initOpts);
             _lstOverride.SelectItem("PlaceFree");
             _lstOverride.ItemSelected += _lstOverride_ItemSelected;
             _lstOverride.Position = _overLabel.Position + new Vector2i(0, _overLabel.ClientArea.Height);

--- a/SS14.Client/UserInterface/Components/EntitySpawnPanel.cs
+++ b/SS14.Client/UserInterface/Components/EntitySpawnPanel.cs
@@ -62,6 +62,8 @@ namespace SS14.Client.UserInterface.Components
                                   {
                                       "PlaceFree",
                                       "PlaceNearby",
+                                      "AlignSnapgridCenter",
+                                      "AlignSnapgridBorder",
                                       "AlignSimilar",
                                       "AlignTileAny",
                                       "AlignTileEmpty",
@@ -70,7 +72,7 @@ namespace SS14.Client.UserInterface.Components
                                       "AlignWall",
                                   });
 
-            _lstOverride = new Listbox(120, 125, resourceCache, initOpts);
+            _lstOverride = new Listbox(130, 125, resourceCache, initOpts);
             _lstOverride.SelectItem("PlaceFree");
             _lstOverride.ItemSelected += _lstOverride_ItemSelected;
             _lstOverride.Position = _overLabel.Position + new Vector2i(0, _overLabel.ClientArea.Height);

--- a/SS14.Shared/Interfaces/Map/IMapGrid.cs
+++ b/SS14.Shared/Interfaces/Map/IMapGrid.cs
@@ -23,7 +23,7 @@ namespace SS14.Shared.Interfaces.Map
         /// <summary>
         ///     The distance between the snap grid, between each center snap and between each offset snap grid location
         /// </summary>
-        int SnapSize { get; }
+        float SnapSize { get; }
 
         /// <summary>
         ///     The origin of the grid in world coordinates. Make sure to set this!

--- a/SS14.Shared/Interfaces/Map/IMapGrid.cs
+++ b/SS14.Shared/Interfaces/Map/IMapGrid.cs
@@ -21,6 +21,11 @@ namespace SS14.Shared.Interfaces.Map
         ushort ChunkSize { get; }
 
         /// <summary>
+        ///     The distance between the snap grid, between each center snap and between each offset snap grid location
+        /// </summary>
+        int SnapSize { get; }
+
+        /// <summary>
         ///     The origin of the grid in world coordinates. Make sure to set this!
         /// </summary>
         Vector2 WorldPosition { get; set; }

--- a/SS14.Shared/Interfaces/Map/IMapManager.cs
+++ b/SS14.Shared/Interfaces/Map/IMapManager.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
-using OpenTK;
 using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Map;
+using SS14.Shared.Maths;
+using OpenTK;
 
 namespace SS14.Shared.Interfaces.Map
 {
@@ -59,8 +60,9 @@ namespace SS14.Shared.Interfaces.Map
         /// </summary>
         /// <param name="gridId">The id of the new grid to create.</param>
         /// <param name="chunkSize">Optional chunk size of the new grid.</param>
+        /// <param name="snapSize">Optional size of the snap grid</param>
         /// <returns></returns>
-        IMapGrid CreateGrid(int gridId, ushort chunkSize = 16);
+        IMapGrid CreateGrid(int gridId, ushort chunkSize = 16, int snapSize = 32);
 
         /// <summary>
         ///     Checks if a grid exists with the given ID.
@@ -83,6 +85,19 @@ namespace SS14.Shared.Interfaces.Map
         /// <param name="mapGrid">The grid associated with the grid ID. If no grid exists, this is null.</param>
         /// <returns></returns>
         bool TryGetGrid(int gridId, out IMapGrid mapGrid);
+
+        /// <summary>
+        ///     Finds the grid at this world coordinate
+        /// </summary>
+        /// <param name="xWorld">The X coordinate in the world.</param>
+        /// <param name="yWorld">The Y coordinate in the world.</param>
+        bool TryFindGridAt(float xWorld, float yWorld, out IMapGrid currentgrid);
+
+        /// <summary>
+        ///     Finds the grid at this world coordinate
+        /// </summary>
+        /// <param name="WorldPos">The X coordinate in the world.</param>
+        bool TryFindGridAt(Vector2 worldPos, out IMapGrid currentgrid);
 
         /// <summary>
         ///     Alias of IMapManager.GetGrid(IMapManager.DefaultGridId);

--- a/SS14.Shared/Interfaces/Map/IMapManager.cs
+++ b/SS14.Shared/Interfaces/Map/IMapManager.cs
@@ -62,7 +62,7 @@ namespace SS14.Shared.Interfaces.Map
         /// <param name="chunkSize">Optional chunk size of the new grid.</param>
         /// <param name="snapSize">Optional size of the snap grid</param>
         /// <returns></returns>
-        IMapGrid CreateGrid(int gridId, ushort chunkSize = 16, int snapSize = 32);
+        IMapGrid CreateGrid(int gridId, ushort chunkSize = 16, float snapSize = 1);
 
         /// <summary>
         ///     Checks if a grid exists with the given ID.

--- a/SS14.Shared/Map/MapGrid.cs
+++ b/SS14.Shared/Map/MapGrid.cs
@@ -53,7 +53,7 @@ namespace SS14.Shared.Map
             }
         }
 
-        internal MapGrid(MapManager mapManager, int gridIndex, ushort chunkSize, int snapsize)
+        internal MapGrid(MapManager mapManager, int gridIndex, ushort chunkSize, float snapsize)
         {
             _mapManager = mapManager;
             Index = gridIndex;
@@ -73,7 +73,7 @@ namespace SS14.Shared.Map
         public ushort ChunkSize { get; }
 
         /// <inheritdoc />
-        public int SnapSize { get; }
+        public float SnapSize { get; }
 
         public int Index { get; }
 

--- a/SS14.Shared/Map/MapGrid.cs
+++ b/SS14.Shared/Map/MapGrid.cs
@@ -53,11 +53,12 @@ namespace SS14.Shared.Map
             }
         }
 
-        internal MapGrid(MapManager mapManager, int gridIndex, ushort chunkSize)
+        internal MapGrid(MapManager mapManager, int gridIndex, ushort chunkSize, int snapsize)
         {
             _mapManager = mapManager;
             Index = gridIndex;
             ChunkSize = chunkSize;
+            SnapSize = snapsize;
         }
 
         /// <summary>
@@ -70,6 +71,9 @@ namespace SS14.Shared.Map
 
         /// <inheritdoc />
         public ushort ChunkSize { get; }
+
+        /// <inheritdoc />
+        public int SnapSize { get; }
 
         public int Index { get; }
 

--- a/SS14.Shared/Map/MapManager.cs
+++ b/SS14.Shared/Map/MapManager.cs
@@ -77,7 +77,7 @@ namespace SS14.Shared.Map
         /// <param name="chunkSize">Optional chunk size of the new grid.</param>
         /// <param name="snapSize">Optional size of the snap grid</param>
         /// <returns></returns>
-        public IMapGrid CreateGrid(int gridId, ushort chunkSize = 32, int snapSize = 32)
+        public IMapGrid CreateGrid(int gridId, ushort chunkSize = 32, float snapSize = 1)
         {
             var newGrid = new MapGrid(this, gridId, chunkSize, snapSize);
             _grids.Add(gridId, newGrid);

--- a/SS14.Shared/Map/MapManager.cs
+++ b/SS14.Shared/Map/MapManager.cs
@@ -75,10 +75,11 @@ namespace SS14.Shared.Map
         /// </summary>
         /// <param name="gridId">The id of the new grid to create.</param>
         /// <param name="chunkSize">Optional chunk size of the new grid.</param>
+        /// <param name="snapSize">Optional size of the snap grid</param>
         /// <returns></returns>
-        public IMapGrid CreateGrid(int gridId, ushort chunkSize = 32)
+        public IMapGrid CreateGrid(int gridId, ushort chunkSize = 32, int snapSize = 32)
         {
-            var newGrid = new MapGrid(this, gridId, chunkSize);
+            var newGrid = new MapGrid(this, gridId, chunkSize, snapSize);
             _grids.Add(gridId, newGrid);
             return newGrid;
         }
@@ -182,6 +183,40 @@ namespace SS14.Shared.Map
                 if (kvGrid.Value.AABBWorld.Contains(pos))
                     gridList.Add(kvGrid.Value);
             return gridList;
+        }
+
+        /// <summary>
+        ///     Finds the grid at this world coordinate
+        /// </summary>
+        /// <param name="xWorld">The X coordinate in the world.</param>
+        /// <param name="yWorld">The Y coordinate in the world.</param>
+        public bool TryFindGridAt(float xWorld, float yWorld, out IMapGrid currentgrid)
+        {
+            var pos = new Vector2(xWorld, yWorld);
+            foreach (var kvGrid in _grids)
+                if (kvGrid.Value.AABBWorld.Contains(pos))
+                {
+                    currentgrid = kvGrid.Value;
+                    return true;
+                }
+            currentgrid = GetDefaultGrid();
+            return false;
+        }
+
+        /// <summary>
+        ///     Finds the grid at this world coordinate
+        /// </summary>
+        /// <param name="WorldPos">The X coordinate in the world.</param>
+        public bool TryFindGridAt(Vector2 worldPos, out IMapGrid currentgrid)
+        {
+            foreach (var kvGrid in _grids)
+                if (kvGrid.Value.AABBWorld.Contains(worldPos))
+                {
+                    currentgrid = kvGrid.Value;
+                    return true;
+                }
+            currentgrid = GetDefaultGrid();
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
This creates two placement modes, one for aligning along a snap grid, and another for aligning along a half offset snap grid.

Things like walls, doors, or windows would be on this 'border' snap grid, and things like wires or pipes would be on this 'center' snap grid.