### PR TITLE
Adds rendering color parameter to sprite components

### DIFF
--- a/SS14.Client/GameObjects/AnimatedSprite.cs
+++ b/SS14.Client/GameObjects/AnimatedSprite.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using SS14.Shared.Maths;
+using OpenTK.Graphics;
 
 namespace SS14.Client.Graphics.Sprite
 {
@@ -135,10 +136,12 @@ namespace SS14.Client.Graphics.Sprite
             return _currentSprite;
         }
 
-        public void Draw()
+        public void Draw(Color4 Color)
         {
             _currentSprite.Scale = new SFML.System.Vector2f(HorizontalFlip ? -1 : 1, 1);
+            _currentSprite.Color = Color.Convert();
             _currentSprite.Draw();
+            _currentSprite.Color = Color4.White.Convert();
         }
 
         public void SetPosition(float x, float y)

--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -198,12 +198,14 @@ namespace SS14.Client.GameObjects
 
             if (mapping.TryGetNode("color", out node))
             {
-                Color = System.Drawing.Color.FromName(node.ToString());
-            }
-
-            if (mapping.TryGetNode("hexcolor", out node))
-            {
-                Color = node.AsHexColor();
+                try
+                {
+                    Color = System.Drawing.Color.FromName(node.ToString());
+                }
+                catch
+                {
+                    Color = node.AsHexColor();
+                }
             }
 
             if (mapping.TryGetNode("sprite", out node))

--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using SS14.Shared.Maths;
 using YamlDotNet.RepresentationModel;
 using Vector2i = SS14.Shared.Maths.Vector2i;
+using OpenTK.Graphics;
 
 namespace SS14.Client.GameObjects
 {
@@ -34,6 +35,7 @@ namespace SS14.Client.GameObjects
         protected bool visible = true;
         public DrawDepth DrawDepth { get; set; }
         private SpeechBubble _speechBubble;
+        public Color4 Color { get; set; }
 
         public override Type StateType => typeof(AnimatedSpriteComponentState);
 
@@ -194,6 +196,16 @@ namespace SS14.Client.GameObjects
                 SetDrawDepth(node.AsEnum<DrawDepth>());
             }
 
+            if (mapping.TryGetNode("color", out node))
+            {
+                Color = System.Drawing.Color.FromName(node.ToString());
+            }
+
+            if (mapping.TryGetNode("hexcolor", out node))
+            {
+                Color = node.AsHexColor();
+            }
+
             if (mapping.TryGetNode("sprite", out node))
             {
                 baseSprite = node.AsString();
@@ -234,7 +246,7 @@ namespace SS14.Client.GameObjects
                 return;
 
             sprite.HorizontalFlip = HorizontalFlip;
-            sprite.Draw();
+            sprite.Draw(Color);
 
             //Render slaves above
             IEnumerable<IRenderableComponent> renderablesAbove = from IRenderableComponent c in slaves

--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -35,7 +35,7 @@ namespace SS14.Client.GameObjects
         protected bool visible = true;
         public DrawDepth DrawDepth { get; set; }
         private SpeechBubble _speechBubble;
-        public Color4 Color { get; set; }
+        public Color4 Color { get; set; } = Color4.White;
 
         public override Type StateType => typeof(AnimatedSpriteComponentState);
 

--- a/SS14.Client/GameObjects/Components/Renderable/ItemSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/ItemSpriteComponent.cs
@@ -153,12 +153,14 @@ namespace SS14.Client.GameObjects
 
             if (mapping.TryGetNode("color", out node))
             {
-                Color = System.Drawing.Color.FromName(node.ToString());
-            }
-
-            if (mapping.TryGetNode("hexcolor", out node))
-            {
-                Color = node.AsHexColor();
+                try
+                {
+                    Color = System.Drawing.Color.FromName(node.ToString());
+                }
+                catch
+                {
+                    Color = node.AsHexColor();
+                }
             }
 
             if (mapping.TryGetNode("basename", out node))

--- a/SS14.Client/GameObjects/Components/Renderable/ItemSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/ItemSpriteComponent.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using SS14.Shared.Maths;
 using YamlDotNet.RepresentationModel;
+using OpenTK.Graphics;
 
 namespace SS14.Client.GameObjects
 {
@@ -148,6 +149,16 @@ namespace SS14.Client.GameObjects
             if (mapping.TryGetNode("drawdepth", out node))
             {
                 SetDrawDepth(node.AsEnum<DrawDepth>());
+            }
+
+            if (mapping.TryGetNode("color", out node))
+            {
+                Color = System.Drawing.Color.FromName(node.ToString());
+            }
+
+            if (mapping.TryGetNode("hexcolor", out node))
+            {
+                Color = node.AsHexColor();
             }
 
             if (mapping.TryGetNode("basename", out node))

--- a/SS14.Client/GameObjects/Components/Renderable/MobSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/MobSpriteComponent.cs
@@ -114,12 +114,14 @@ namespace SS14.Client.GameObjects
 
             if (mapping.TryGetNode("color", out node))
             {
-                Color = System.Drawing.Color.FromName(node.ToString());
-            }
-
-            if (mapping.TryGetNode("hexcolor", out node))
-            {
-                Color = node.AsHexColor();
+                try
+                {
+                    Color = System.Drawing.Color.FromName(node.ToString());
+                }
+                catch
+                {
+                    Color = node.AsHexColor();
+                }
             }
         }
 

--- a/SS14.Client/GameObjects/Components/Renderable/MobSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/MobSpriteComponent.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using SS14.Shared.Maths;
 using YamlDotNet.RepresentationModel;
+using OpenTK.Graphics;
 
 namespace SS14.Client.GameObjects
 {
@@ -105,10 +106,20 @@ namespace SS14.Client.GameObjects
                 SetDrawDepth(node.AsEnum<DrawDepth>());
             }
 
-            if (mapping.TryGetNode("drawdepth", out node))
+            if (mapping.TryGetNode("basename", out node))
             {
                 _basename = node.AsString();
                 LoadSprites();
+            }
+
+            if (mapping.TryGetNode("color", out node))
+            {
+                Color = System.Drawing.Color.FromName(node.ToString());
+            }
+
+            if (mapping.TryGetNode("hexcolor", out node))
+            {
+                Color = node.AsHexColor();
             }
         }
 

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using SS14.Shared.Maths;
 using YamlDotNet.RepresentationModel;
 using Vector2i = SS14.Shared.Maths.Vector2i;
+using SS14.Client.Graphics.Utility;
 
 namespace SS14.Client.GameObjects
 {
@@ -40,6 +41,7 @@ namespace SS14.Client.GameObjects
         protected Dictionary<string, Sprite> sprites = new Dictionary<string, Sprite>();
         protected bool visible = true;
         public DrawDepth DrawDepth { get; set; }
+        public Color4 Color { get; set; }
 
         public override Type StateType => typeof(SpriteComponentState);
 
@@ -271,6 +273,16 @@ namespace SS14.Client.GameObjects
                 SetDrawDepth(node.AsEnum<DrawDepth>());
             }
 
+            if (mapping.TryGetNode("color", out node))
+            {
+                Color = System.Drawing.Color.FromName(node.ToString());
+            }
+
+            if (mapping.TryGetNode("hexcolor", out node))
+            {
+                Color = node.AsHexColor();
+            }
+
             if (mapping.TryGetNode<YamlSequenceNode>("sprites", out var sequence))
             {
                 foreach (YamlNode spriteNode in sequence)
@@ -311,7 +323,9 @@ namespace SS14.Client.GameObjects
                 return;
 
             spriteToRender.Scale = new Vector2f(HorizontalFlip ? -1 : 1, 1);
+            spriteToRender.Color = this.Color.Convert();
             spriteToRender.Draw();
+            spriteToRender.Color = Color4.White.Convert();
 
             //Render slaves above
             IEnumerable<SpriteComponent> renderablesAbove = from SpriteComponent c in slaves

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -275,12 +275,14 @@ namespace SS14.Client.GameObjects
 
             if (mapping.TryGetNode("color", out node))
             {
-                Color = System.Drawing.Color.FromName(node.ToString());
-            }
-
-            if (mapping.TryGetNode("hexcolor", out node))
-            {
-                Color = node.AsHexColor();
+                try
+                {
+                    Color = System.Drawing.Color.FromName(node.ToString());
+                }
+                catch
+                {
+                    Color = node.AsHexColor();
+                }
             }
 
             if (mapping.TryGetNode<YamlSequenceNode>("sprites", out var sequence))

--- a/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -41,7 +41,7 @@ namespace SS14.Client.GameObjects
         protected Dictionary<string, Sprite> sprites = new Dictionary<string, Sprite>();
         protected bool visible = true;
         public DrawDepth DrawDepth { get; set; }
-        public Color4 Color { get; set; }
+        public Color4 Color { get; set; } = Color4.White;
 
         public override Type StateType => typeof(SpriteComponentState);
 

--- a/SS14.Client/Interfaces/GameObjects/ISpriteRenderableComponent.cs
+++ b/SS14.Client/Interfaces/GameObjects/ISpriteRenderableComponent.cs
@@ -1,3 +1,4 @@
+﻿using OpenTK.Graphics;
 using SFML.Graphics;
 
 namespace SS14.Client.Interfaces.GameObjects
@@ -5,5 +6,6 @@ namespace SS14.Client.Interfaces.GameObjects
     public interface ISpriteRenderableComponent : IRenderableComponent
     {
         Sprite GetCurrentSprite();
+        Color4 Color { get; set; }
     }
 }

--- a/SS14.Server/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Server/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -66,6 +66,16 @@ namespace SS14.Server.GameObjects
                 DrawDepth = node.AsEnum<DrawDepth>();
             }
 
+            if (mapping.TryGetNode("color", out node))
+            {
+                Color = System.Drawing.Color.FromName(node.ToString());
+            }
+
+            if (mapping.TryGetNode("hexcolor", out node))
+            {
+                Color = node.AsHexColor();
+            }
+
             if (mapping.TryGetNode("sprite", out node))
             {
                 SpriteName = node.AsString();

--- a/SS14.Server/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Server/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -66,16 +66,6 @@ namespace SS14.Server.GameObjects
                 DrawDepth = node.AsEnum<DrawDepth>();
             }
 
-            if (mapping.TryGetNode("color", out node))
-            {
-                Color = System.Drawing.Color.FromName(node.ToString());
-            }
-
-            if (mapping.TryGetNode("hexcolor", out node))
-            {
-                Color = node.AsHexColor();
-            }
-
             if (mapping.TryGetNode("sprite", out node))
             {
                 SpriteName = node.AsString();


### PR DESCRIPTION
- You can load up a color from the system color names as a parameter
- You can alternatively load a color through a hex color parameter which takes hex strings

This causes the sprite to display as the color when being rendered, it changes the color to the color variable, renders it, and resets it afterwards.

Unfortunately it does not affect when you generically use getsprite(spritename). Might be nice to implement getting a fully descriptive sprite from the entity prototype system later that includes color.