### PR TITLE
Adds closeto function for checking floating point equality

### DIFF
--- a/SS14.Shared/Maths/FloatMath.cs
+++ b/SS14.Shared/Maths/FloatMath.cs
@@ -69,7 +69,29 @@ namespace SS14.Shared.Maths
             else return val;
         }
 
+        public static bool CloseTo(float A, float B)
+        {
+            var epsilon = Math.Min(A, B) * 0.00001; // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            return Math.Abs(A - B) <= epsilon;
+        }
 
+        public static bool CloseTo(float A, double B)
+        {
+            var epsilon = Math.Min(A, B) * 0.00001; // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            return Math.Abs(A - B) <= epsilon;
+        }
+
+        public static bool CloseTo(double A, float B)
+        {
+            var epsilon = Math.Min(A, B) * 0.00001; // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            return Math.Abs(A - B) <= epsilon;
+        }
+
+        public static bool CloseTo(double A, double B)
+        {
+            var epsilon = Math.Min(A, B) * 0.00001; // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            return Math.Abs(A - B) <= epsilon;
+        }
     }
 }
 


### PR DESCRIPTION
The MSDN reference guide suggests using .001% of the floating point value to check for floating point equality. This gets the smaller values epsilon based on this point and checks equality between any combination of float and double and returns a bool based on whether or not they are equal.