### PR TITLE
Changes CloseTo again slightly

### DIFF
--- a/SS14.Shared/Maths/FloatMath.cs
+++ b/SS14.Shared/Maths/FloatMath.cs
@@ -71,25 +71,25 @@ namespace SS14.Shared.Maths
 
         public static bool CloseTo(float A, float B)
         {
-            var epsilon = Math.Min(A, B) * 0.00001; // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            var epsilon = Math.Max(Math.Max(Math.Abs(A), Math.Abs(B)) * 0.00001, .00001); // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
             return Math.Abs(A - B) <= epsilon;
         }
 
         public static bool CloseTo(float A, double B)
         {
-            var epsilon = Math.Min(A, B) * 0.00001; // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            var epsilon = Math.Max(Math.Max(Math.Abs(A), Math.Abs(B)) * 0.00001, .00001); // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
             return Math.Abs(A - B) <= epsilon;
         }
 
         public static bool CloseTo(double A, float B)
         {
-            var epsilon = Math.Min(A, B) * 0.00001; // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            var epsilon = Math.Max(Math.Max(Math.Abs(A), Math.Abs(B)) * 0.00001, .00001); // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
             return Math.Abs(A - B) <= epsilon;
         }
 
         public static bool CloseTo(double A, double B)
         {
-            var epsilon = Math.Min(A, B) * 0.00001; // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
+            var epsilon = Math.Max(Math.Max(Math.Abs(A), Math.Abs(B)) * 0.00001, .00001); // .001% of the smaller value for the epsilon check as per MSDN reference suggestion
             return Math.Abs(A - B) <= epsilon;
         }
     }


### PR DESCRIPTION
I went and read some guides on comparing floating point numbers, and it seems that relative comparisons like the one I initially did work great for values >1, but as values get very close to zero they become extremely hard to compare based on relative epsilon due to larger/smaller/similar amounts of error.

So this caps epsilon to a relative minimum of 10^-5.