### PR TITLE
Makes mouseclicktype an enum

### DIFF
--- a/SS14.Client/GameObjects/Components/Input/ClickableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Input/ClickableComponent.cs
@@ -24,7 +24,7 @@ namespace SS14.Client.GameObjects
             return component.WasClicked(worldPos);
         }
 
-        public void DispatchClick(IEntity user, Clicktype clickType)
+        public void DispatchClick(IEntity user, ClickType clickType)
         {
             OnClick?.Invoke(this, new ClickEventArgs(user, Owner, clickType));
             Owner.SendComponentNetworkMessage(this, clickType, (int)user.Uid);

--- a/SS14.Client/GameObjects/Components/Input/ClickableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Input/ClickableComponent.cs
@@ -24,7 +24,7 @@ namespace SS14.Client.GameObjects
             return component.WasClicked(worldPos);
         }
 
-        public void DispatchClick(IEntity user, int clickType)
+        public void DispatchClick(IEntity user, Clicktype clickType)
         {
             OnClick?.Invoke(this, new ClickEventArgs(user, Owner, clickType));
             Owner.SendComponentNetworkMessage(this, clickType, (int)user.Uid);

--- a/SS14.Client/Interfaces/GameObjects/Components/IClientClickableComponent.cs
+++ b/SS14.Client/Interfaces/GameObjects/Components/IClientClickableComponent.cs
@@ -24,6 +24,6 @@ namespace SS14.Client.Interfaces.GameObjects.Components
         /// </summary>
         /// <param name="userUID">The entity owned by the player that clicked.</param>
         /// <param name="clickType">See <see cref="MouseClickType" />.</param>
-        void DispatchClick(IEntity user, Clicktype clickType);
+        void DispatchClick(IEntity user, ClickType clickType);
     }
 }

--- a/SS14.Client/Interfaces/GameObjects/Components/IClientClickableComponent.cs
+++ b/SS14.Client/Interfaces/GameObjects/Components/IClientClickableComponent.cs
@@ -24,6 +24,6 @@ namespace SS14.Client.Interfaces.GameObjects.Components
         /// </summary>
         /// <param name="userUID">The entity owned by the player that clicked.</param>
         /// <param name="clickType">See <see cref="MouseClickType" />.</param>
-        void DispatchClick(IEntity user, int clickType);
+        void DispatchClick(IEntity user, Clicktype clickType);
     }
 }

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -636,10 +636,10 @@ namespace SS14.Client.State.States
             switch (e.Button)
             {
                 case Mouse.Button.Left:
-                    clickable.DispatchClick(PlayerManager.LocalPlayer.ControlledEntity, Clicktype.Left);
+                    clickable.DispatchClick(PlayerManager.LocalPlayer.ControlledEntity, ClickType.Left);
                     break;
                 case Mouse.Button.Right:
-                    clickable.DispatchClick(PlayerManager.LocalPlayer.ControlledEntity, Clicktype.Right);
+                    clickable.DispatchClick(PlayerManager.LocalPlayer.ControlledEntity, ClickType.Right);
                     break;
                 case Mouse.Button.Middle:
                     OpenEntityEditWindow(entToClick);

--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -636,10 +636,10 @@ namespace SS14.Client.State.States
             switch (e.Button)
             {
                 case Mouse.Button.Left:
-                    clickable.DispatchClick(PlayerManager.LocalPlayer.ControlledEntity, MouseClickType.Left);
+                    clickable.DispatchClick(PlayerManager.LocalPlayer.ControlledEntity, Clicktype.Left);
                     break;
                 case Mouse.Button.Right:
-                    clickable.DispatchClick(PlayerManager.LocalPlayer.ControlledEntity, MouseClickType.Right);
+                    clickable.DispatchClick(PlayerManager.LocalPlayer.ControlledEntity, Clicktype.Right);
                     break;
                 case Mouse.Button.Middle:
                     OpenEntityEditWindow(entToClick);

--- a/SS14.Server/GameObjects/Components/ClickableComponent.cs
+++ b/SS14.Server/GameObjects/Components/ClickableComponent.cs
@@ -13,7 +13,7 @@ namespace SS14.Server.GameObjects
 
         public override void HandleNetworkMessage(IncomingEntityComponentMessage message)
         {
-            Clicktype type = (Clicktype)((int)message.MessageParameters[0]); // Click type.
+            ClickType type = (ClickType)((int)message.MessageParameters[0]); // Click type.
             var uid = (int)message.MessageParameters[1]; // ID of the user
             var user = Owner.EntityManager.GetEntity(new EntityUid(uid));
 

--- a/SS14.Server/GameObjects/Components/ClickableComponent.cs
+++ b/SS14.Server/GameObjects/Components/ClickableComponent.cs
@@ -1,5 +1,6 @@
 ﻿using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects.Components;
+using SS14.Shared.IoC;
 using System;
 
 namespace SS14.Server.GameObjects
@@ -9,11 +10,19 @@ namespace SS14.Server.GameObjects
         public override string Name => "Clickable";
         public override uint? NetID => NetIDs.CLICKABLE;
 
+
+        //private readonly InteractionSystem InteractionController;
+
+        //ClickableComponent()
+        //{
+        //    InteractionController = IoCManager.Resolve<EntitySystemManager>().GetEntitySystem<InteractionSystem>();
+        //}
+
         public event EventHandler<ClickEventArgs> OnClick;
 
         public override void HandleNetworkMessage(IncomingEntityComponentMessage message)
         {
-            var type = (int)message.MessageParameters[0]; // Click type.
+            Clicktype type = (Clicktype)((int)message.MessageParameters[0]); // Click type.
             var uid = (int)message.MessageParameters[1]; // ID of the user
             var user = Owner.EntityManager.GetEntity(new EntityUid(uid));
 

--- a/SS14.Server/GameObjects/Components/ClickableComponent.cs
+++ b/SS14.Server/GameObjects/Components/ClickableComponent.cs
@@ -1,6 +1,5 @@
 ﻿using SS14.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects.Components;
-using SS14.Shared.IoC;
 using System;
 
 namespace SS14.Server.GameObjects
@@ -9,14 +8,6 @@ namespace SS14.Server.GameObjects
     {
         public override string Name => "Clickable";
         public override uint? NetID => NetIDs.CLICKABLE;
-
-
-        //private readonly InteractionSystem InteractionController;
-
-        //ClickableComponent()
-        //{
-        //    InteractionController = IoCManager.Resolve<EntitySystemManager>().GetEntitySystem<InteractionSystem>();
-        //}
 
         public event EventHandler<ClickEventArgs> OnClick;
 

--- a/SS14.Shared/GameObjects/EntityEvents.cs
+++ b/SS14.Shared/GameObjects/EntityEvents.cs
@@ -27,7 +27,7 @@ namespace SS14.Shared.GameObjects
     {
         public EntityUid Clicker { get; set; }
         public EntityUid Clicked { get; set; }
-        public int MouseButton { get; set; }
+        public Clicktype MouseButton { get; set; }
     }
 
 }

--- a/SS14.Shared/GameObjects/EntityEvents.cs
+++ b/SS14.Shared/GameObjects/EntityEvents.cs
@@ -27,7 +27,7 @@ namespace SS14.Shared.GameObjects
     {
         public EntityUid Clicker { get; set; }
         public EntityUid Clicked { get; set; }
-        public Clicktype MouseButton { get; set; }
+        public ClickType MouseButton { get; set; }
     }
 
 }

--- a/SS14.Shared/GameObjects/StaticConstants.cs
+++ b/SS14.Shared/GameObjects/StaticConstants.cs
@@ -1,79 +1,69 @@
-using SS14.Shared.GameObjects;
+﻿using SS14.Shared.GameObjects;
 
 namespace SS14.Shared.GameObjects
 {
     public class MouseClickType
     {
-        public const int None = 0;
-        public const int Left = 1;
-        public const int Right = 2;
-        public const int LeftAlt = 3;
-        public const int RightAlt = 4;
-        public const int LeftShift = 5;
-        public const int RightShift = 6;
-        public const int LeftCtrl = 7;
-        public const int RightCtrl = 8;
-
-        public static int ConvertComponentMessageTypeToClickType(ComponentMessageType type)
+        public static Clicktype ConvertComponentMessageTypeToClickType(ComponentMessageType type)
         {
-            int result = 0;
+            Clicktype result = 0;
             switch (type)
             {
                 case ComponentMessageType.LeftClick:
-                    result = MouseClickType.Left;
+                    result = Clicktype.Left;
                     break;
                 case ComponentMessageType.RightClick:
-                    result = MouseClickType.Right;
+                    result = Clicktype.Right;
                     break;
                 case ComponentMessageType.AltLeftClick:
-                    result = MouseClickType.LeftAlt;
+                    result = Clicktype.LeftAlt;
                     break;
                 case ComponentMessageType.AltRightClick:
-                    result = MouseClickType.RightAlt;
+                    result = Clicktype.RightAlt;
                     break;
                 case ComponentMessageType.ShiftLeftClick:
-                    result = MouseClickType.LeftShift;
+                    result = Clicktype.LeftShift;
                     break;
                 case ComponentMessageType.ShiftRightClick:
-                    result = MouseClickType.RightShift;
+                    result = Clicktype.RightShift;
                     break;
                 case ComponentMessageType.CtrlLeftClick:
-                    result = MouseClickType.LeftCtrl;
+                    result = Clicktype.LeftCtrl;
                     break;
                 case ComponentMessageType.CtrlRightClick:
-                    result = MouseClickType.RightCtrl;
+                    result = Clicktype.RightCtrl;
                     break;
             }
             return result;
         }
 
-        public static ComponentMessageType ConvertClickTypeToComponentMessageType(int clickType)
+        public static ComponentMessageType ConvertClickTypeToComponentMessageType(Clicktype clickType)
         {
             ComponentMessageType result = ComponentMessageType.Null;
             switch(clickType)
             {
-                case MouseClickType.Left:
+                case Clicktype.Left:
                     result = ComponentMessageType.LeftClick;
                     break;
-                case MouseClickType.Right:
+                case Clicktype.Right:
                     result = ComponentMessageType.RightClick;
                     break;
-                case MouseClickType.LeftAlt:
+                case Clicktype.LeftAlt:
                     result = ComponentMessageType.AltLeftClick;
                     break;
-                case MouseClickType.RightAlt:
+                case Clicktype.RightAlt:
                     result = ComponentMessageType.AltRightClick;
                     break;
-                case MouseClickType.LeftShift:
+                case Clicktype.LeftShift:
                     result = ComponentMessageType.ShiftLeftClick;
                     break;
-                case MouseClickType.RightShift:
+                case Clicktype.RightShift:
                     result = ComponentMessageType.ShiftRightClick;
                     break;
-                case MouseClickType.LeftCtrl:
+                case Clicktype.LeftCtrl:
                     result = ComponentMessageType.CtrlLeftClick;
                     break;
-                case MouseClickType.RightCtrl:
+                case Clicktype.RightCtrl:
                     result = ComponentMessageType.CtrlRightClick;
                     break;
 
@@ -82,6 +72,16 @@ namespace SS14.Shared.GameObjects
         }
     }
 
-
-
+    public enum Clicktype
+    {
+        None = 0,
+        Left = 1,
+        Right = 2,
+        LeftAlt = 3,
+        RightAlt = 4,
+        LeftShift = 5,
+        RightShift = 6,
+        LeftCtrl = 7,
+        RightCtrl = 8
+    }
 }

--- a/SS14.Shared/GameObjects/StaticConstants.cs
+++ b/SS14.Shared/GameObjects/StaticConstants.cs
@@ -4,66 +4,66 @@ namespace SS14.Shared.GameObjects
 {
     public class MouseClickType
     {
-        public static Clicktype ConvertComponentMessageTypeToClickType(ComponentMessageType type)
+        public static ClickType ConvertComponentMessageTypeToClickType(ComponentMessageType type)
         {
-            Clicktype result = 0;
+            ClickType result = 0;
             switch (type)
             {
                 case ComponentMessageType.LeftClick:
-                    result = Clicktype.Left;
+                    result = ClickType.Left;
                     break;
                 case ComponentMessageType.RightClick:
-                    result = Clicktype.Right;
+                    result = ClickType.Right;
                     break;
                 case ComponentMessageType.AltLeftClick:
-                    result = Clicktype.LeftAlt;
+                    result = ClickType.LeftAlt;
                     break;
                 case ComponentMessageType.AltRightClick:
-                    result = Clicktype.RightAlt;
+                    result = ClickType.RightAlt;
                     break;
                 case ComponentMessageType.ShiftLeftClick:
-                    result = Clicktype.LeftShift;
+                    result = ClickType.LeftShift;
                     break;
                 case ComponentMessageType.ShiftRightClick:
-                    result = Clicktype.RightShift;
+                    result = ClickType.RightShift;
                     break;
                 case ComponentMessageType.CtrlLeftClick:
-                    result = Clicktype.LeftCtrl;
+                    result = ClickType.LeftCtrl;
                     break;
                 case ComponentMessageType.CtrlRightClick:
-                    result = Clicktype.RightCtrl;
+                    result = ClickType.RightCtrl;
                     break;
             }
             return result;
         }
 
-        public static ComponentMessageType ConvertClickTypeToComponentMessageType(Clicktype clickType)
+        public static ComponentMessageType ConvertClickTypeToComponentMessageType(ClickType clickType)
         {
             ComponentMessageType result = ComponentMessageType.Null;
             switch(clickType)
             {
-                case Clicktype.Left:
+                case ClickType.Left:
                     result = ComponentMessageType.LeftClick;
                     break;
-                case Clicktype.Right:
+                case ClickType.Right:
                     result = ComponentMessageType.RightClick;
                     break;
-                case Clicktype.LeftAlt:
+                case ClickType.LeftAlt:
                     result = ComponentMessageType.AltLeftClick;
                     break;
-                case Clicktype.RightAlt:
+                case ClickType.RightAlt:
                     result = ComponentMessageType.AltRightClick;
                     break;
-                case Clicktype.LeftShift:
+                case ClickType.LeftShift:
                     result = ComponentMessageType.ShiftLeftClick;
                     break;
-                case Clicktype.RightShift:
+                case ClickType.RightShift:
                     result = ComponentMessageType.ShiftRightClick;
                     break;
-                case Clicktype.LeftCtrl:
+                case ClickType.LeftCtrl:
                     result = ComponentMessageType.CtrlLeftClick;
                     break;
-                case Clicktype.RightCtrl:
+                case ClickType.RightCtrl:
                     result = ComponentMessageType.CtrlRightClick;
                     break;
 
@@ -72,7 +72,7 @@ namespace SS14.Shared.GameObjects
         }
     }
 
-    public enum Clicktype
+    public enum ClickType
     {
         None = 0,
         Left = 1,

--- a/SS14.Shared/Interfaces/GameObjects/Components/IClickableComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/Components/IClickableComponent.cs
@@ -1,3 +1,4 @@
+﻿using SS14.Shared.GameObjects;
 using System;
 
 namespace SS14.Shared.Interfaces.GameObjects.Components
@@ -28,9 +29,9 @@ namespace SS14.Shared.Interfaces.GameObjects.Components
         /// <summary>
         /// The type of mouse click. See the constants in <see cref="MouseClickType" /> for what this value means.
         /// </summary>
-        public int ClickType { get; }
+        public Clicktype ClickType { get; }
 
-        public ClickEventArgs(IEntity user, IEntity source, int clickType)
+        public ClickEventArgs(IEntity user, IEntity source, Clicktype clickType)
         {
             User = user;
             Source = source;

--- a/SS14.Shared/Interfaces/GameObjects/Components/IClickableComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/Components/IClickableComponent.cs
@@ -29,9 +29,9 @@ namespace SS14.Shared.Interfaces.GameObjects.Components
         /// <summary>
         /// The type of mouse click. See the constants in <see cref="MouseClickType" /> for what this value means.
         /// </summary>
-        public Clicktype ClickType { get; }
+        public ClickType ClickType { get; }
 
-        public ClickEventArgs(IEntity user, IEntity source, Clicktype clickType)
+        public ClickEventArgs(IEntity user, IEntity source, ClickType clickType)
         {
             User = user;
             Source = source;


### PR DESCRIPTION
What is a bunch of public const int doing where an enum can easily replace it? Mouseclicktype defines a bunch of public const int, rather than merely using an enum which is what it is functionally doing.