### PR TITLE
Prevents sprite exceptions

### DIFF
--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -232,6 +232,11 @@ namespace SS14.Client.GameObjects
                 baseSprite = node.AsString();
                 SetSprite(baseSprite);
             }
+            else
+            {
+                baseSprite = "";
+                SetSprite(""); //Use default sprite
+            }
         }
 
         public virtual void Render(Vector2 topLeft, Vector2 bottomRight)
@@ -397,15 +402,19 @@ namespace SS14.Client.GameObjects
             var newState = (AnimatedSpriteComponentState)state;
             DrawDepth = newState.DrawDepth;
             visible = newState.Visible;
-            if (sprite.Name != newState.Name)
-                SetSprite(newState.Name);
+            if(sprite != null)
+            {
+                if (sprite.Name != newState.Name)
+                    SetSprite(newState.Name);
 
-            if (sprite.CurrentAnimationStateKey != newState.CurrentAnimation)
-                sprite.SetAnimationState(newState.CurrentAnimation ?? "idle");
+                if (sprite.CurrentAnimationStateKey != newState.CurrentAnimation)
+                    sprite.SetAnimationState(newState.CurrentAnimation ?? "idle");
+            }
 
             SetMaster((EntityUid?) newState.MasterUid);
 
-            sprite.SetLoop(newState.Loop);
+            if(sprite != null)
+                sprite.SetLoop(newState.Loop);
         }
     }
 }

--- a/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
+++ b/SS14.Client/GameObjects/Components/Renderable/AnimatedSpriteComponent.cs
@@ -402,19 +402,15 @@ namespace SS14.Client.GameObjects
             var newState = (AnimatedSpriteComponentState)state;
             DrawDepth = newState.DrawDepth;
             visible = newState.Visible;
-            if(sprite != null)
-            {
-                if (sprite.Name != newState.Name)
-                    SetSprite(newState.Name);
+            if (sprite.Name != newState.Name)
+                SetSprite(newState.Name);
 
-                if (sprite.CurrentAnimationStateKey != newState.CurrentAnimation)
-                    sprite.SetAnimationState(newState.CurrentAnimation ?? "idle");
-            }
+            if (sprite.CurrentAnimationStateKey != newState.CurrentAnimation)
+                sprite.SetAnimationState(newState.CurrentAnimation ?? "idle");
 
             SetMaster((EntityUid?) newState.MasterUid);
-
-            if(sprite != null)
-                sprite.SetLoop(newState.Loop);
+            
+            sprite.SetLoop(newState.Loop);
         }
     }
 }


### PR DESCRIPTION
Even though setsprite has a default value that it gets set to, unless you give basesprite a non-null value and call setsprite it will cause the animatedsprite components to have an exception without fail. This happens if you don't include it in the prototype for whatever reason.