### PR TITLE
Adds the same event subscriber entity has to entitysystems

### DIFF
--- a/SS14.Shared/GameObjects/System/EntitySystem.cs
+++ b/SS14.Shared/GameObjects/System/EntitySystem.cs
@@ -51,5 +51,10 @@ namespace SS14.Shared.GameObjects.System
         public virtual void Update(float frameTime)
         {
         }
+
+        public void SubscribeEvent<T>(EntityEventHandler<EntityEventArgs> evh, IEntityEventSubscriber s) where T : EntityEventArgs
+        {
+            EntityManager.SubscribeEvent<T>(evh, s);
+        }
     }
 }

--- a/SS14.Shared/GameObjects/System/EntitySystem.cs
+++ b/SS14.Shared/GameObjects/System/EntitySystem.cs
@@ -56,5 +56,15 @@ namespace SS14.Shared.GameObjects.System
         {
             EntityManager.SubscribeEvent<T>(evh, s);
         }
+
+        public void UnsubscribeEvent<T>(IEntityEventSubscriber s) where T : EntityEventArgs
+        {
+            EntityManager.UnsubscribeEvent<T>(s);
+        }
+
+        public void RaiseEvent(EntityEventArgs toRaise)
+        {
+            EntityManager.RaiseEvent(this, toRaise);
+        }
     }
 }


### PR DESCRIPTION
This is some boilerplate code for entitysystems that entities already use to make the syntax very simple for subscribing to global RaiseEvent()s that are called in the engine repo. I'm using this for my wip interaction system to replace badcode.