### PR TITLE
Fix stored object clicking bug

### DIFF
--- a/SS14.Client/State/States/GameScreen.cs
+++ b/SS14.Client/State/States/GameScreen.cs
@@ -162,7 +162,8 @@ namespace SS14.Client.State.States
             foreach (IEntity entity in entities)
             {
                 if (entity.TryGetComponent<IClientClickableComponent>(out var component)
-                 && component.CheckClick(mousePosWorld, out int drawdepthofclicked))
+                && entity.GetComponent<ITransformComponent>().IsMapTransform
+                && component.CheckClick(mousePosWorld, out int drawdepthofclicked))
                 {
                     clickedEntities.Add((entity, drawdepthofclicked));
                 }


### PR DESCRIPTION
Fixes a humorous bug where you click on things that are contained in another thing because the mousedown doesn't check if something is on the map or not