### PR TITLE
 Make handle message use optional arguments

### DIFF
--- a/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
+++ b/SS14.Client/GameObjects/Components/Collidable/CollidableComponent.cs
@@ -15,6 +15,7 @@ using SS14.Shared.Utility;
 using YamlDotNet.RepresentationModel;
 using System.Linq;
 using System.Collections.Generic;
+using SS14.Shared.Interfaces.Network;
 
 namespace SS14.Client.GameObjects
 {
@@ -120,9 +121,9 @@ namespace SS14.Client.GameObjects
         ///     this will be null.
         /// </param>
         /// <param name="message">Message that was sent.</param>
-        public override void HandleMessage(object owner, ComponentMessage message)
+        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
         {
-            base.HandleMessage(owner, message);
+            base.HandleMessage(message, netChannel, component);
 
             switch (message)
             {

--- a/SS14.Server/GameObjects/Components/ClickableComponent.cs
+++ b/SS14.Server/GameObjects/Components/ClickableComponent.cs
@@ -1,5 +1,7 @@
 ﻿using SS14.Shared.GameObjects;
+using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.GameObjects.Components;
+using SS14.Shared.Interfaces.Network;
 
 namespace SS14.Server.GameObjects
 {
@@ -8,9 +10,9 @@ namespace SS14.Server.GameObjects
         public override string Name => "Clickable";
         public override uint? NetID => NetIDs.CLICKABLE;
 
-        public override void HandleMessage(object owner, ComponentMessage message)
+        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
         {
-            base.HandleMessage(owner, message);
+            base.HandleMessage(message, netChannel, component);
 
             switch (message)
             {

--- a/SS14.Server/GameObjects/Components/Container/Container.cs
+++ b/SS14.Server/GameObjects/Components/Container/Container.cs
@@ -29,6 +29,8 @@ namespace SS14.Server.GameObjects.Components.Container
 
         private List<IEntity> ContainerList = new List<IEntity>();
 
+        public IReadOnlyCollection<IEntity> ContainedEntities => ContainerList.AsReadOnly();
+
         /// <summary>
         /// Shortcut method to make creation of containers easier.
         /// Creates a new container on the entity and gives it back to you.
@@ -38,7 +40,7 @@ namespace SS14.Server.GameObjects.Components.Container
         /// <returns>The new container.</returns>
         /// <exception cref="ArgumentException">Thrown if there already is a container with the specified ID.</exception>
         /// <seealso cref="IContainerManager.MakeContainer{T}(string)" />
-        public static IContainer Create(string id, IEntity entity)
+        public static Container Create(string id, IEntity entity)
         {
             if (!entity.TryGetComponent<IContainerManager>(out var containermanager))
             {

--- a/SS14.Server/GameObjects/Components/Input/KeyBindingInputComponent.cs
+++ b/SS14.Server/GameObjects/Components/Input/KeyBindingInputComponent.cs
@@ -3,6 +3,8 @@ using SS14.Shared.GameObjects;
 using SS14.Shared.Log;
 using SS14.Shared.Enums;
 using SS14.Shared.Input;
+using SS14.Shared.Interfaces.GameObjects;
+using SS14.Shared.Interfaces.Network;
 
 namespace SS14.Server.GameObjects
 {
@@ -14,9 +16,9 @@ namespace SS14.Server.GameObjects
         public override string Name => "KeyBindingInput";
         public override uint? NetID => NetIDs.KEY_BINDING_INPUT;
 
-        public override void HandleMessage(object owner, ComponentMessage message)
+        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
         {
-            base.HandleMessage(owner, message);
+            base.HandleMessage(message, netChannel, component);
 
             switch (message)
             {

--- a/SS14.Server/GameObjects/Components/Mover/PlayerInputMoverComponent.cs
+++ b/SS14.Server/GameObjects/Components/Mover/PlayerInputMoverComponent.cs
@@ -3,6 +3,7 @@ using SS14.Shared.Enums;
 using SS14.Shared.GameObjects;
 using SS14.Shared.Input;
 using SS14.Shared.Interfaces.GameObjects;
+using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Log;
 using SS14.Shared.Maths;
 
@@ -51,9 +52,9 @@ namespace SS14.Server.GameObjects
         ///     this will be null.
         /// </param>
         /// <param name="message">Message that was sent.</param>
-        public override void HandleMessage(object owner, ComponentMessage message)
+        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
         {
-            base.HandleMessage(owner, message);
+            base.HandleMessage(message, netChannel, component);
 
             switch (message)
             {

--- a/SS14.Shared/GameObjects/Component.cs
+++ b/SS14.Shared/GameObjects/Component.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using SS14.Shared.GameObjects.Serialization;
 using SS14.Shared.Interfaces.GameObjects;
+using SS14.Shared.Interfaces.Network;
 using SS14.Shared.Reflection;
 using YamlDotNet.RepresentationModel;
 
@@ -93,7 +94,7 @@ namespace SS14.Shared.GameObjects
         }
 
         /// <inheritdoc />
-        public virtual void HandleMessage(object owner, ComponentMessage message) { }
+        public virtual void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null) { }
 
         /// <inheritdoc />
         public virtual ComponentState GetComponentState()

--- a/SS14.Shared/GameObjects/Entity.cs
+++ b/SS14.Shared/GameObjects/Entity.cs
@@ -170,14 +170,21 @@ namespace SS14.Shared.GameObjects
             foreach (var component in _components)
             {
                 if(owner != component)
-                    component.HandleMessage(owner, message);
+                    component.HandleMessage(message, component: owner);
             }
         }
 
         /// <inheritdoc />
         public void SendNetworkMessage(IComponent owner, ComponentMessage message)
         {
-            EntityNetworkManager.SendComponentNetworkMessage(this, owner, message);
+            if(message.Directed)
+            {
+                EntityNetworkManager.SendDirectedComponentNetworkMessage(null, this, owner, message);
+            }
+            else
+            {
+                EntityNetworkManager.SendComponentNetworkMessage(this, owner, message);
+            }
         }
 
         #endregion Unified Messaging
@@ -198,13 +205,13 @@ namespace SS14.Shared.GameObjects
                     if (compMsg.Directed)
                     {
                         if (_netIDs.TryGetValue(message.Message.NetId, out var component))
-                                component.HandleMessage(compChannel, compMsg);
+                                component.HandleMessage(compMsg, netChannel: compChannel);
                     }
                     else
                     {
                         foreach (var component in _components)
                         {
-                            component.HandleMessage(compChannel, compMsg);
+                            component.HandleMessage(compMsg, netChannel: compChannel);
                         }
                     }
                 }

--- a/SS14.Shared/Interfaces/GameObjects/IComponent.cs
+++ b/SS14.Shared/Interfaces/GameObjects/IComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Serialization;
+using SS14.Shared.Interfaces.Network;
 using YamlDotNet.RepresentationModel;
 
 namespace SS14.Shared.Interfaces.GameObjects
@@ -105,7 +106,7 @@ namespace SS14.Shared.Interfaces.GameObjects
         ///     If the message was raised remotely, this contains the PlayerSession that sent it.
         /// </param>
         /// <param name="message">Message that was sent.</param>
-        void HandleMessage(object owner, ComponentMessage message);
+        void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null);
 
         /// <summary>
         ///     Get the component's state for replicating on the client.


### PR DESCRIPTION
Instead of arbitrarily using object as the first argument and killing type safety
