### PR TITLE
Companion PR

### DIFF
--- a/SS14.Client/KeyBindings.xml
+++ b/SS14.Client/KeyBindings.xml
@@ -9,4 +9,5 @@
   <Binding Key="Tab" Function="SwitchHands" />
   <Binding Key="Shift" Function="Run" />
   <Binding Key="F" Function="ActivateItemInHand" />
+  <Binding Key="C" Function="OpenCharacterMenu" />
 </KeyBindings>

--- a/SS14.Client/UserInterface/Controls/TextureRect.cs
+++ b/SS14.Client/UserInterface/Controls/TextureRect.cs
@@ -1,4 +1,4 @@
-using SS14.Client.Graphics;
+﻿using SS14.Client.Graphics;
 
 namespace SS14.Client.UserInterface.Controls
 {
@@ -18,7 +18,7 @@ namespace SS14.Client.UserInterface.Controls
         {
             // TODO: Maybe store the texture passed in in case it's like a TextureResource or whatever.
             get => new GodotTextureSource(SceneControl.Texture);
-            set => SceneControl.Texture = value.GodotTexture;
+            set => SceneControl.Texture = value?.GodotTexture;
         }
 
         new private Godot.TextureRect SceneControl;

--- a/SS14.Shared/Input/KeyFunctions.cs
+++ b/SS14.Shared/Input/KeyFunctions.cs
@@ -22,5 +22,6 @@
         Drop,
         Run,
         ActivateItemInHand,
+        OpenCharacterMenu
     }
 }


### PR DESCRIPTION
https://github.com/space-wizards/space-station-14-content/pull/61

Adds a keybind for opening the character menu and makes texture rect not die when setting texture to null