### PR TITLE
Fix Species UI Overlay Removal

### DIFF
--- a/Content.Client/GameObjects/Components/Mobs/SpeciesUI.cs
+++ b/Content.Client/GameObjects/Components/Mobs/SpeciesUI.cs
@@ -118,7 +118,7 @@ namespace Content.Client.GameObjects
             if (_currentEffect != ScreenEffects.None)
             {
                 var appliedeffect = EffectsDictionary[_currentEffect];
-                _overlayManager.RemoveOverlay(nameof(appliedeffect));
+                _overlayManager.RemoveOverlay(appliedeffect.ID);
             }
 
             _currentEffect = ScreenEffects.None;


### PR DESCRIPTION
Soooo nameof turns a variable into a string of that variable. I'm not sure where I copied that from but ID is the proper value.

Fixes #144