### PR TITLE
Make Attackby (etc) parameters use event args.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "RobustToolbox"]
 	path = RobustToolbox
-	url = https://github.com/PrPleGoo/RobustToolbox.git
+	url = https://github.com/space-wizards/RobustToolbox.git
 	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "RobustToolbox"]
 	path = RobustToolbox
-	url = https://github.com/space-wizards/RobustToolbox.git
+	url = https://github.com/PrPleGoo/RobustToolbox.git
 	branch = master

--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -1,7 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Content.Server.GameObjects.Components.Interactable.Tools;
-using Content.Server.GameObjects.Components.Sound;
 using Content.Server.GameObjects.Components.Stack;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.Construction;
@@ -18,7 +17,7 @@ using static Content.Shared.Construction.ConstructionStepTool;
 
 namespace Content.Server.GameObjects.Components.Construction
 {
-    public class ConstructionComponent : Component, IAttackby
+    public class ConstructionComponent : Component, IAttackBy
     {
         public override string Name => "Construction";
 
@@ -41,11 +40,11 @@ namespace Content.Server.GameObjects.Components.Construction
             random = new Random();
         }
 
-        public bool Attackby(IEntity user, IEntity attackwith)
+        public bool AttackBy(AttackByEventArgs eventArgs)
         {
             var stage = Prototype.Stages[Stage];
 
-            if (TryProcessStep(stage.Forward, attackwith))
+            if (TryProcessStep(stage.Forward, eventArgs.AttackWith))
             {
                 Stage++;
                 if (Stage == Prototype.Stages.Count - 1)
@@ -65,7 +64,7 @@ namespace Content.Server.GameObjects.Components.Construction
                 }
             }
 
-            else if (TryProcessStep(stage.Backward, attackwith))
+            else if (TryProcessStep(stage.Backward, eventArgs.AttackWith))
             {
                 Stage--;
                 if (Stage == 0)

--- a/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
@@ -41,7 +41,7 @@ namespace Content.Server.GameObjects
             base.OnRemove();
         }
 
-        public bool Attackhand(IEntity user)
+        public bool AttackHand(AttackHandEventArgs eventArgs)
         {
             if (_state == DoorState.Open)
             {

--- a/Content.Server/GameObjects/Components/Healing/HealingComponent.cs
+++ b/Content.Server/GameObjects/Components/Healing/HealingComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Content.Server.GameObjects.Components.Stack;
 using SS14.Shared.GameObjects;
 using Content.Server.GameObjects.EntitySystems;
@@ -54,9 +54,9 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
             Owner.Delete();
         }
 
-        bool IUse.UseEntity(IEntity user)
+        bool IUse.UseEntity(UseEntityEventArgs eventArgs)
         {
-            if (!user.TryGetComponent(out DamageableComponent damagecomponent)) return false;
+            if (!eventArgs.User.TryGetComponent(out DamageableComponent damagecomponent)) return false;
             if (Owner.TryGetComponent(out StackComponent stackComponent))
             {
                 if (!stackComponent.Use(1))

--- a/Content.Server/GameObjects/Components/Healing/HealingComponent.cs
+++ b/Content.Server/GameObjects/Components/Healing/HealingComponent.cs
@@ -31,14 +31,14 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
             serializer.DataField(ref Damage, "damage", DamageType.Brute);
         }
 
-        void IAfterAttack.Afterattack(IEntity user, GridCoordinates clicklocation, IEntity attacked)
+        void IAfterAttack.AfterAttack(AfterAttackEventArgs eventArgs)
         {
-            if (attacked == null)
+            if (eventArgs.Attacked == null)
             {
                 return;
             }
 
-            if (!attacked.TryGetComponent(out DamageableComponent damagecomponent)) return;
+            if (!eventArgs.Attacked.TryGetComponent(out DamageableComponent damagecomponent)) return;
             if (Owner.TryGetComponent(out StackComponent stackComponent))
             {
                 if (!stackComponent.Use(1))

--- a/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Server.GameObjects.Components.Interactable
     /// <summary>
     ///     Component that represents a handheld lightsource which can be toggled on and off.
     /// </summary>
-    internal class HandheldLightComponent : Component, IUse, IExamine, IAttackby
+    internal class HandheldLightComponent : Component, IUse, IExamine, IAttackBy
     {
         public const float Wattage = 10;
         [ViewVariables] private ContainerSlot _cellContainer;
@@ -41,15 +41,15 @@ namespace Content.Server.GameObjects.Components.Interactable
         [ViewVariables]
         public bool Activated { get; private set; }
 
-        bool IAttackby.Attackby(IEntity user, IEntity attackwith)
+        bool IAttackBy.AttackBy(AttackByEventArgs eventArgs)
         {
-            if (!attackwith.HasComponent<PowerCellComponent>()) return false;
+            if (!eventArgs.AttackWith.HasComponent<PowerCellComponent>()) return false;
 
             if (Cell != null) return false;
 
-            user.GetComponent<IHandsComponent>().Drop(attackwith, _cellContainer);
+            eventArgs.User.GetComponent<IHandsComponent>().Drop(eventArgs.AttackWith, _cellContainer);
 
-            return _cellContainer.Insert(attackwith);
+            return _cellContainer.Insert(eventArgs.AttackWith);
         }
 
         string IExamine.Examine()

--- a/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
@@ -59,7 +59,7 @@ namespace Content.Server.GameObjects.Components.Interactable
             return null;
         }
 
-        bool IUse.UseEntity(IEntity user)
+        bool IUse.UseEntity(UseEntityEventArgs eventArgs)
         {
             return ToggleStatus();
         }

--- a/Content.Server/GameObjects/Components/Interactable/Tools/CrowbarComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/Tools/CrowbarComponent.cs
@@ -25,14 +25,14 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
             IoCManager.InjectDependencies(this);
         }
 
-        public void Afterattack(IEntity user, GridCoordinates clicklocation, IEntity attacked)
+        public void AfterAttack(AfterAttackEventArgs eventArgs)
         {
-            var tile = clicklocation.Grid.GetTile(clicklocation);
+            var tile = eventArgs.ClickLocation.Grid.GetTile(eventArgs.ClickLocation);
             var tileDef = (ContentTileDefinition) tile.TileDef;
             if (tileDef.CanCrowbar)
             {
                 var underplating = _tileDefinitionManager["underplating"];
-                clicklocation.Grid.SetTile(clicklocation, underplating.TileId);
+                eventArgs.ClickLocation.Grid.SetTile(eventArgs.ClickLocation, underplating.TileId);
                _entitySystemManager.GetEntitySystem<AudioSystem>().Play("/Audio/items/crowbar.ogg", Owner);
             }
         }

--- a/Content.Server/GameObjects/Components/Interactable/Tools/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/Tools/WelderComponent.cs
@@ -115,7 +115,7 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
             return Fuel > 0;
         }
 
-        public bool UseEntity(IEntity user)
+        public bool UseEntity(UseEntityEventArgs eventArgs)
         {
             return ToggleStatus();
         }

--- a/Content.Server/GameObjects/Components/Items/Storage/ItemComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ItemComponent.cs
@@ -2,10 +2,11 @@
 using SS14.Server.Interfaces.GameObjects;
 using Content.Shared.GameObjects;
 using SS14.Shared.Interfaces.GameObjects;
+using Content.Server.GameObjects.EntitySystems;
 
 namespace Content.Server.GameObjects
 {
-    public class ItemComponent : StoreableComponent, EntitySystems.IAttackHand
+    public class ItemComponent : StoreableComponent, IAttackHand
     {
         public override string Name => "Item";
 
@@ -26,9 +27,9 @@ namespace Content.Server.GameObjects
             }
         }
 
-        public bool Attackhand(IEntity user)
+        public bool AttackHand(AttackHandEventArgs eventArgs)
         {
-            var hands = user.GetComponent<IHandsComponent>();
+            var hands = eventArgs.User.GetComponent<IHandsComponent>();
             hands.PutInHand(this, hands.ActiveIndex, fallback: false);
             return true;
         }

--- a/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Server.GameObjects
     /// <summary>
     /// Storage component for containing entities within this one, matches a UI on the client which shows stored entities
     /// </summary>
-    public class ServerStorageComponent : SharedStorageComponent, IAttackby, IUse, IActivate
+    public class ServerStorageComponent : SharedStorageComponent, IAttackBy, IUse, IActivate
     {
         private Container storage;
 
@@ -131,25 +131,25 @@ namespace Content.Server.GameObjects
         /// <param name="user"></param>
         /// <param name="attackwith"></param>
         /// <returns></returns>
-        bool IAttackby.Attackby(IEntity user, IEntity attackwith)
+        bool IAttackBy.AttackBy(AttackByEventArgs eventArgs)
         {
             _ensureInitialCalculated();
-            Logger.DebugS("Storage", "Storage (UID {0}) attacked by user (UID {1}) with entity (UID {2}).", Owner.Uid, user.Uid, attackwith.Uid);
+            Logger.DebugS("Storage", "Storage (UID {0}) attacked by user (UID {1}) with entity (UID {2}).", Owner.Uid, eventArgs.User.Uid, eventArgs.AttackWith.Uid);
 
-            if (!user.TryGetComponent(out HandsComponent hands))
+            if (!eventArgs.User.TryGetComponent(out HandsComponent hands))
                 return false;
             
             //Check that we can drop the item from our hands first otherwise we obviously cant put it inside
             if (CanInsert(hands.GetActiveHand.Owner) &&  hands.Drop(hands.ActiveIndex))
             {
-                if (Insert(attackwith))
+                if (Insert(eventArgs.AttackWith))
                 {
                     return true;
                 }
             }
             else
             {
-                Owner.PopupMessage(user, "Can't insert.");
+                Owner.PopupMessage(eventArgs.User, "Can't insert.");
             }
             return false;
         }
@@ -323,6 +323,11 @@ namespace Content.Server.GameObjects
             }
 
             _storageInitialCalculated = true;
+        }
+
+        public bool Attackby(AttackByEventArgs eventArgs)
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
@@ -302,9 +302,9 @@ namespace Content.Server.GameObjects
         }
 
         /// <inheritdoc />
-        void IActivate.Activate(IEntity user)
+        void IActivate.Activate(ActivateEventArgs eventArgs)
         {
-            ((IUse) this).UseEntity(new UseEntityEventArgs { User = user });
+            ((IUse) this).UseEntity(new UseEntityEventArgs { User = eventArgs.User });
         }
 
         private void _ensureInitialCalculated()

--- a/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
@@ -159,10 +159,10 @@ namespace Content.Server.GameObjects
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        bool IUse.UseEntity(IEntity user)
+        bool IUse.UseEntity(UseEntityEventArgs eventArgs)
         {
             _ensureInitialCalculated();
-            var user_session = user.GetComponent<BasicActorComponent>().playerSession;
+            var user_session = eventArgs.User.GetComponent<BasicActorComponent>().playerSession;
             Logger.DebugS("Storage", "Storage (UID {0}) \"used\" by player session (UID {1}).", Owner.Uid, user_session.AttachedEntityUid);
             SubscribeSession(user_session);
             SendNetworkMessage(new OpenStorageUIMessage(), user_session.ConnectedClient);
@@ -304,7 +304,7 @@ namespace Content.Server.GameObjects
         /// <inheritdoc />
         void IActivate.Activate(IEntity user)
         {
-            ((IUse) this).UseEntity(user);
+            ((IUse) this).UseEntity(new UseEntityEventArgs { User = user });
         }
 
         private void _ensureInitialCalculated()

--- a/Content.Server/GameObjects/Components/Power/ApcComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcComponent.cs
@@ -106,9 +106,9 @@ namespace Content.Server.GameObjects.Components.Power
             return net.Lack > 0 ? ApcExternalPowerState.Low : ApcExternalPowerState.Good;
         }
 
-        bool IAttackHand.Attackhand(IEntity user)
+        bool IAttackHand.AttackHand(AttackHandEventArgs eventArgs)
         {
-            if (!user.TryGetComponent(out IActorComponent actor))
+            if (!eventArgs.User.TryGetComponent(out IActorComponent actor))
             {
                 return false;
             }

--- a/Content.Server/GameObjects/Components/Power/PowerDebugTool.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerDebugTool.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.GameObjects.Components.Power;
@@ -11,18 +11,18 @@ namespace Content.Server.GameObjects.Components.Power
 {
     public class PowerDebugTool : SharedPowerDebugTool, IAfterAttack
     {
-        void IAfterAttack.Afterattack(IEntity user, GridCoordinates clicklocation, IEntity attacked)
+        void IAfterAttack.AfterAttack(AfterAttackEventArgs eventArgs)
         {
-            if (attacked == null)
+            if (eventArgs.Attacked == null)
             {
                 return;
             }
 
             var builder = new StringBuilder();
 
-            builder.AppendFormat("Entity: {0} ({1})\n", attacked.Name, attacked.Uid);
+            builder.AppendFormat("Entity: {0} ({1})\n", eventArgs.Attacked.Name, eventArgs.Attacked.Uid);
 
-            if (attacked.TryGetComponent<PowerNodeComponent>(out var node))
+            if (eventArgs.Attacked.TryGetComponent<PowerNodeComponent>(out var node))
             {
                 builder.AppendFormat("Power Node:\n");
                 if (node.Parent == null)
@@ -50,7 +50,7 @@ namespace Content.Server.GameObjects.Components.Power
                 }
             }
 
-            if (attacked.TryGetComponent<PowerDeviceComponent>(out var device))
+            if (eventArgs.Attacked.TryGetComponent<PowerDeviceComponent>(out var device))
             {
                 builder.AppendFormat(@"Power Device:
   Load: {0} W
@@ -75,7 +75,7 @@ namespace Content.Server.GameObjects.Components.Power
                 }
             }
 
-            if (attacked.TryGetComponent<PowerStorageNetComponent>(out var storage))
+            if (eventArgs.Attacked.TryGetComponent<PowerStorageNetComponent>(out var storage))
             {
                 var stateSeconds = (DateTime.Now - storage.LastChargeStateChange).TotalSeconds;
                 builder.AppendFormat(@"Power Storage:
@@ -84,14 +84,14 @@ namespace Content.Server.GameObjects.Components.Power
 ", storage.Capacity, storage.Charge, storage.ChargeRate, storage.DistributionRate, storage.ChargePowernet, storage.LastChargeState, storage.GetChargeState(), stateSeconds);
             }
 
-            if (attacked.TryGetComponent<PowerTransferComponent>(out var transfer))
+            if (eventArgs.Attacked.TryGetComponent<PowerTransferComponent>(out var transfer))
             {
                 builder.AppendFormat(@"Power Transfer:
   Powernet: {0}
 ", transfer.Parent.Uid);
             }
 
-            OpenDataWindowClientSide(user, builder.ToString());
+            OpenDataWindowClientSide(eventArgs.User, builder.ToString());
         }
 
         private void OpenDataWindowClientSide(IEntity user, string data)

--- a/Content.Server/GameObjects/Components/Power/PowerTransferComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerTransferComponent.cs
@@ -8,13 +8,14 @@ using SS14.Shared.Interfaces.GameObjects;
 using Content.Server.GameObjects.Components.Interactable.Tools;
 using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.ViewVariables;
+using System;
 
 namespace Content.Server.GameObjects.Components.Power
 {
     /// <summary>
     /// Component to transfer power to nearby components, can create powernets and connect to nodes
     /// </summary>
-    public class PowerTransferComponent : Component, IAttackby
+    public class PowerTransferComponent : Component, IAttackBy
     {
         public override string Name => "PowerTransfer";
 
@@ -133,9 +134,9 @@ namespace Content.Server.GameObjects.Components.Power
             return Parent != null && Parent.Dirty == false && !Regenerating;
         }
 
-        public bool Attackby(IEntity user, IEntity attackwith)
+        public bool AttackBy(AttackByEventArgs eventArgs)
         {
-            if (attackwith.TryGetComponent(out WirecutterComponent wirecutter))
+            if (eventArgs.AttackWith.TryGetComponent(out WirecutterComponent wirecutter))
             {
                 Owner.Delete();
                 return true;

--- a/Content.Server/GameObjects/Components/Power/PoweredLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PoweredLightComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Content.Server.GameObjects.Components.Sound;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Server.Interfaces.GameObjects;
@@ -23,7 +23,7 @@ namespace Content.Server.GameObjects.Components.Power
     /// <summary>
     ///     Component that represents a wall light. It has a light bulb that can be replaced when broken.
     /// </summary>
-    public class PoweredLightComponent : Component, IAttackHand, IAttackby
+    public class PoweredLightComponent : Component, IAttackHand, IAttackBy
     {
         public override string Name => "PoweredLight";
 
@@ -50,9 +50,9 @@ namespace Content.Server.GameObjects.Components.Power
             }
         }
 
-        bool IAttackby.Attackby(IEntity user, IEntity attackwith)
+        bool IAttackBy.AttackBy(AttackByEventArgs eventArgs)
         {
-            return InsertBulb(attackwith);
+            return InsertBulb(eventArgs.AttackWith);
         }
 
         bool IAttackHand.Attackhand(IEntity user)

--- a/Content.Server/GameObjects/Components/Power/PoweredLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PoweredLightComponent.cs
@@ -55,16 +55,16 @@ namespace Content.Server.GameObjects.Components.Power
             return InsertBulb(eventArgs.AttackWith);
         }
 
-        bool IAttackHand.Attackhand(IEntity user)
+        bool IAttackHand.AttackHand(AttackHandEventArgs eventArgs)
         {
-            if (user.GetComponent<InventoryComponent>().GetSlotItem(EquipmentSlotDefines.Slots.GLOVES) != null)
+            if (eventArgs.User.GetComponent<InventoryComponent>().GetSlotItem(EquipmentSlotDefines.Slots.GLOVES) != null)
             {
-                EjectBulb(user);
+                EjectBulb(eventArgs.User);
                 UpdateLight();
                 return true;
             }
 
-            if (!user.TryGetComponent(out DamageableComponent damageableComponent)) return false;
+            if (!eventArgs.User.TryGetComponent(out DamageableComponent damageableComponent)) return false;
             damageableComponent.TakeDamage(DamageType.Heat, 20);
             return true;
         }

--- a/Content.Server/GameObjects/Components/Stack/StackComponent.cs
+++ b/Content.Server/GameObjects/Components/Stack/StackComponent.cs
@@ -1,7 +1,6 @@
-using System;
+﻿using System;
 using Content.Server.GameObjects.EntitySystems;
 using SS14.Shared.GameObjects;
-using SS14.Shared.Interfaces.GameObjects;
 using SS14.Shared.Interfaces.Reflection;
 using SS14.Shared.IoC;
 using SS14.Shared.Serialization;
@@ -10,7 +9,7 @@ using SS14.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Stack
 {
     // TODO: Naming and presentation and such could use some improvement.
-    public class StackComponent : Component, IAttackby, IExamine
+    public class StackComponent : Component, IAttackBy, IExamine
     {
         private const string SerializationCache = "stack";
         private int _count = 50;
@@ -97,9 +96,9 @@ namespace Content.Server.GameObjects.Components.Stack
             StackType = stackType;
         }
 
-        public bool Attackby(IEntity user, IEntity attackwith)
+        public bool AttackBy(AttackByEventArgs eventArgs)
         {
-            if (attackwith.TryGetComponent<StackComponent>(out var stack))
+            if (eventArgs.AttackWith.TryGetComponent<StackComponent>(out var stack))
             {
                 if (!stack.StackType.Equals(StackType))
                 {

--- a/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
@@ -32,15 +32,15 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
             serializer.DataField(ref ArcWidth, "arcwidth", 90);
         }
 
-        void IAfterAttack.Afterattack(IEntity user, GridCoordinates clicklocation, IEntity attacked)
+        void IAfterAttack.AfterAttack(AfterAttackEventArgs eventArgs)
         {
-            var location = user.GetComponent<ITransformComponent>().GridPosition;
-            var angle = new Angle(clicklocation.ToWorld().Position - location.ToWorld().Position);
-            var entities = IoCManager.Resolve<IServerEntityManager>().GetEntitiesInArc(user.GetComponent<ITransformComponent>().GridPosition, Range, angle, ArcWidth);
+            var location = eventArgs.User.GetComponent<ITransformComponent>().GridPosition;
+            var angle = new Angle(eventArgs.ClickLocation.ToWorld().Position - location.ToWorld().Position);
+            var entities = IoCManager.Resolve<IServerEntityManager>().GetEntitiesInArc(eventArgs.User.GetComponent<ITransformComponent>().GridPosition, Range, angle, ArcWidth);
 
             foreach (var entity in entities)
             {
-                if (!entity.GetComponent<ITransformComponent>().IsMapTransform || entity == user)
+                if (!entity.GetComponent<ITransformComponent>().IsMapTransform || entity == eventArgs.User)
                     continue;
 
                 if (entity.TryGetComponent(out DamageableComponent damagecomponent))

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Hitscan/HitscanWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Hitscan/HitscanWeaponComponent.cs
@@ -1,9 +1,8 @@
-﻿﻿using Content.Shared.GameObjects;
+﻿using Content.Shared.GameObjects;
 using SS14.Server.GameObjects.EntitySystems;
 using SS14.Shared.Audio;
 using SS14.Shared.GameObjects.EntitySystemMessages;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.Interfaces.GameObjects.Components;
 using SS14.Shared.Interfaces.Physics;
 using SS14.Shared.Interfaces.Timing;
 using SS14.Shared.IoC;
@@ -12,15 +11,15 @@ using SS14.Shared.Maths;
 using SS14.Shared.Physics;
 using SS14.Shared.Serialization;
 using System;
- using Content.Server.GameObjects.Components.Sound;
- using SS14.Shared.GameObjects;
+using Content.Server.GameObjects.Components.Sound;
+using SS14.Shared.GameObjects;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Server.GameObjects.Components.Power;
 using Content.Shared.Interfaces;
 
 namespace Content.Server.GameObjects.Components.Weapon.Ranged.Hitscan
 {
-    public class HitscanWeaponComponent : Component, IAttackby
+    public class HitscanWeaponComponent : Component, IAttackBy
     {
         private const float MaxLength = 20;
         public override string Name => "HitscanWeapon";
@@ -60,15 +59,15 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Hitscan
             rangedWeapon.FireHandler = Fire;
         }
 
-        public bool Attackby(IEntity user, IEntity attackwith)
+        public bool AttackBy(AttackByEventArgs eventArgs)
         {
-            if (!attackwith.TryGetComponent(out PowerStorageComponent component))
+            if (!eventArgs.AttackWith.TryGetComponent(out PowerStorageComponent component))
             {
                 return false;
             }
             if (capacitorComponent.Full)
             {
-                Owner.PopupMessage(user, "Capacitor at max charge");
+                Owner.PopupMessage(eventArgs.User, "Capacitor at max charge");
                 return false;
             }
             capacitorComponent.FillFrom(component);

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticMagazineWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticMagazineWeaponComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Content.Server.GameObjects.Components.Sound;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.GameObjects;
@@ -6,17 +6,15 @@ using Content.Shared.GameObjects.Components.Weapons.Ranged;
 using Content.Shared.Interfaces;
 using SS14.Server.GameObjects;
 using SS14.Server.GameObjects.Components.Container;
-using SS14.Server.GameObjects.EntitySystems;
 using SS14.Shared.Audio;
 using SS14.Shared.Interfaces.GameObjects;
-using SS14.Shared.IoC;
 using SS14.Shared.Maths;
 using SS14.Shared.Serialization;
 using SS14.Shared.Utility;
 
 namespace Content.Server.GameObjects.Components.Weapon.Ranged.Projectile
 {
-    public class BallisticMagazineWeaponComponent : BallisticWeaponComponent, IUse, IAttackby
+    public class BallisticMagazineWeaponComponent : BallisticWeaponComponent, IUse, IAttackBy
     {
         public override string Name => "BallisticMagazineWeapon";
 
@@ -202,26 +200,26 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Projectile
             return true;
         }
 
-        public bool Attackby(IEntity user, IEntity attackwith)
+        public bool AttackBy(AttackByEventArgs eventArgs)
         {
-            if (!attackwith.TryGetComponent(out BallisticMagazineComponent component))
+            if (!eventArgs.AttackWith.TryGetComponent(out BallisticMagazineComponent component))
             {
                 return false;
             }
 
             if (Magazine != null)
             {
-                Owner.PopupMessage(user, "Already got a magazine.");
+                Owner.PopupMessage(eventArgs.User, "Already got a magazine.");
                 return false;
             }
 
             if (component.MagazineType != MagazineType || component.Caliber != Caliber)
             {
-                Owner.PopupMessage(user, "Magazine doesn't fit.");
+                Owner.PopupMessage(eventArgs.User, "Magazine doesn't fit.");
                 return false;
             }
 
-            return InsertMagazine(attackwith);
+            return InsertMagazine(eventArgs.AttackWith);
         }
 
         private void _magazineAmmoCountChanged()

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticMagazineWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticMagazineWeaponComponent.cs
@@ -185,16 +185,16 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Projectile
             _updateAppearance();
         }
 
-        public bool UseEntity(IEntity user)
+        public bool UseEntity(UseEntityEventArgs eventArgs)
         {
             var ret = EjectMagazine();
             if (ret)
             {
-                Owner.PopupMessage(user, "Magazine ejected");
+                Owner.PopupMessage(eventArgs.User, "Magazine ejected");
             }
             else
             {
-                Owner.PopupMessage(user, "No magazine");
+                Owner.PopupMessage(eventArgs.User, "No magazine");
             }
 
             return true;

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -57,7 +57,7 @@ namespace Content.Server.GameObjects.EntitySystems
     /// <summary>
     /// This interface gives components behavior when being clicked by objects outside the range of direct use
     /// </summary>
-    public interface IRangedAttackby
+    public interface IRangedAttackBy
     {
         /// <summary>
         /// Called when we try to interact with an entity out of range
@@ -66,7 +66,14 @@ namespace Content.Server.GameObjects.EntitySystems
         /// <param name="attackwith"></param>
         /// <param name="clicklocation"></param>
         /// <returns></returns>
-        bool RangedAttackby(IEntity user, IEntity attackwith, GridCoordinates clicklocation);
+        bool RangedAttackBy(RangedAttackByEventArgs eventArgs);
+    }
+
+    public class RangedAttackByEventArgs : EventArgs
+    {
+        public IEntity User { get; set; }
+        public IEntity Weapon { get; set; }
+        public GridCoordinates ClickLocation { get; set; }
     }
 
     /// <summary>
@@ -358,12 +365,12 @@ namespace Content.Server.GameObjects.EntitySystems
         /// <param name="attacked"></param>
         public static void RangedInteraction(IEntity user, IEntity weapon, IEntity attacked, GridCoordinates clicklocation)
         {
-            List<IRangedAttackby> rangedusables = attacked.GetAllComponents<IRangedAttackby>().ToList();
+            List<IRangedAttackBy> rangedusables = attacked.GetAllComponents<IRangedAttackBy>().ToList();
 
             //See if we have a ranged attack interaction
             for (var i = 0; i < rangedusables.Count; i++)
             {
-                if (rangedusables[i].RangedAttackby(user, weapon, clicklocation)) //If an attackby returns a status completion we finish our attack
+                if (rangedusables[i].RangedAttackBy(new RangedAttackByEventArgs { User = user, Weapon = weapon, ClickLocation = clicklocation })) //If an attackby returns a status completion we finish our attack
                 {
                     return;
                 }

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Content.Server.Interfaces.GameObjects;
-using SS14.Server.Interfaces.GameObjects;
 using SS14.Shared.GameObjects;
 using SS14.Shared.GameObjects.Systems;
 using SS14.Shared.Interfaces.GameObjects;
@@ -10,7 +9,6 @@ using Content.Shared.Input;
 using SS14.Shared.Input;
 using SS14.Shared.Log;
 using SS14.Shared.Map;
-using SS14.Server.GameObjects;
 using SS14.Server.GameObjects.EntitySystems;
 using SS14.Server.Interfaces.Player;
 using SS14.Shared.Interfaces.GameObjects.Components;
@@ -21,7 +19,7 @@ namespace Content.Server.GameObjects.EntitySystems
     /// <summary>
     /// This interface gives components behavior when being clicked on or "attacked" by a user with an object in their hand
     /// </summary>
-    public interface IAttackby
+    public interface IAttackBy
     {
         /// <summary>
         /// Called when using one object on another
@@ -29,7 +27,13 @@ namespace Content.Server.GameObjects.EntitySystems
         /// <param name="user"></param>
         /// <param name="attackwith"></param>
         /// <returns></returns>
-        bool Attackby(IEntity user, IEntity attackwith);
+        bool AttackBy(AttackByEventArgs eventArgs);
+    }
+
+    public class AttackByEventArgs : EventArgs
+    {
+        public IEntity User { get; set; }
+        public IEntity AttackWith { get; set; }
     }
 
     /// <summary>
@@ -263,11 +267,11 @@ namespace Content.Server.GameObjects.EntitySystems
         /// <param name="attacked"></param>
         public static void Interaction(IEntity user, IEntity weapon, IEntity attacked, GridCoordinates clicklocation)
         {
-            List<IAttackby> interactables = attacked.GetAllComponents<IAttackby>().ToList();
+            List<IAttackBy> interactables = attacked.GetAllComponents<IAttackBy>().ToList();
 
             for (var i = 0; i < interactables.Count; i++)
             {
-                if (interactables[i].Attackby(user, weapon)) //If an attackby returns a status completion we finish our attack
+                if (interactables[i].AttackBy(new AttackByEventArgs { User = user, AttackWith = weapon })) //If an attackby returns a status completion we finish our attack
                 {
                     return;
                 }

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -125,7 +125,12 @@ namespace Content.Server.GameObjects.EntitySystems
         ///     Called when this component is activated by another entity.
         /// </summary>
         /// <param name="user">Entity that activated this component.</param>
-        void Activate(IEntity user);
+        void Activate(ActivateEventArgs eventArgs);
+    }
+
+    public class ActivateEventArgs : EventArgs
+    {
+        public IEntity User { get; set; }
     }
 
     /// <summary>
@@ -159,7 +164,7 @@ namespace Content.Server.GameObjects.EntitySystems
             if (!playerEnt.Transform.GridPosition.InRange(used.Transform.GridPosition, INTERACTION_RANGE))
                 return;
 
-            activateComp.Activate(playerEnt);
+            activateComp.Activate(new ActivateEventArgs { User = playerEnt });
         }
 
         private void HandleUseItemInHand(ICommonSession session, GridCoordinates coords, EntityUid uid)

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -30,9 +30,8 @@ namespace Content.Server.GameObjects.EntitySystems
         bool AttackBy(AttackByEventArgs eventArgs);
     }
 
-    public class AttackByEventArgs : EventArgs
+    public class AttackByEventArgs : AttackHandEventArgs
     {
-        public IEntity User { get; set; }
         public IEntity AttackWith { get; set; }
     }
 
@@ -46,7 +45,12 @@ namespace Content.Server.GameObjects.EntitySystems
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        bool Attackhand(IEntity user);
+        bool AttackHand(AttackHandEventArgs eventArgs);
+    }
+
+    public class AttackHandEventArgs : EventArgs
+    {
+        public IEntity User { get; set; }
     }
 
     /// <summary>
@@ -301,7 +305,7 @@ namespace Content.Server.GameObjects.EntitySystems
 
             for (var i = 0; i < interactables.Count; i++)
             {
-                if (interactables[i].Attackhand(user)) //If an attackby returns a status completion we finish our attack
+                if (interactables[i].AttackHand(new AttackHandEventArgs { User = user})) //If an attackby returns a status completion we finish our attack
                 {
                     return;
                 }

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -30,8 +30,9 @@ namespace Content.Server.GameObjects.EntitySystems
         bool AttackBy(AttackByEventArgs eventArgs);
     }
 
-    public class AttackByEventArgs : AttackHandEventArgs
+    public class AttackByEventArgs : EventArgs
     {
+        public IEntity User { get; set; }
         public IEntity AttackWith { get; set; }
     }
 

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -88,7 +88,14 @@ namespace Content.Server.GameObjects.EntitySystems
         /// <param name="user"></param>
         /// <param name="clicklocation"></param>
         /// <param name="attacked">The entity that was clicked on out of range. May be null if no entity was clicked on.true</param>
-        void Afterattack(IEntity user, GridCoordinates clicklocation, IEntity attacked);
+        void AfterAttack(AfterAttackEventArgs eventArgs);
+    }
+
+    public class AfterAttackEventArgs : EventArgs
+    {
+        public IEntity User { get; set; }
+        public GridCoordinates ClickLocation { get; set; }
+        public IEntity Attacked { get; set; }
     }
 
     /// <summary>
@@ -266,7 +273,7 @@ namespace Content.Server.GameObjects.EntitySystems
 
             for (var i = 0; i < afterattacks.Count; i++)
             {
-                afterattacks[i].Afterattack(user, clicklocation, null);
+                afterattacks[i].AfterAttack(new AfterAttackEventArgs { User = user, ClickLocation = clicklocation });
             }
         }
 
@@ -297,7 +304,7 @@ namespace Content.Server.GameObjects.EntitySystems
 
             for (var i = 0; i < afterattacks.Count; i++)
             {
-                afterattacks[i].Afterattack(user, clicklocation, attacked);
+                afterattacks[i].AfterAttack(new AfterAttackEventArgs { User = user, ClickLocation = clicklocation, Attacked = attacked });
             }
         }
 
@@ -383,7 +390,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 //See if we have a ranged attack interaction
                 for (var i = 0; i < afterattacks.Count; i++)
                 {
-                    afterattacks[i].Afterattack(user, clicklocation, attacked);
+                    afterattacks[i].AfterAttack(new AfterAttackEventArgs { User = user, ClickLocation = clicklocation, Attacked = attacked });
                 }
             }
         }

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -108,7 +108,12 @@ namespace Content.Server.GameObjects.EntitySystems
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        bool UseEntity(IEntity user);
+        bool UseEntity(UseEntityEventArgs eventArgs);
+    }
+
+    public class UseEntityEventArgs : EventArgs
+    {
+        public IEntity User { get; set; }
     }
 
     /// <summary>
@@ -356,7 +361,7 @@ namespace Content.Server.GameObjects.EntitySystems
             //Try to use item on any components which have the interface
             for (var i = 0; i < usables.Count; i++)
             {
-                if (usables[i].UseEntity(user)) //If an attackby returns a status completion we finish our attack
+                if (usables[i].UseEntity(new UseEntityEventArgs { User = user })) //If an attackby returns a status completion we finish our attack
                 {
                     return;
                 }


### PR DESCRIPTION
AttackBy with an EventArg object for a parameter
AttackHand with an EventArg object for a parameter
AttackByEventArgs inherits from EventArgs again
RangedAttackBy with an EventArg object for a parameter
AfterAttack with an EventArg object for a parameter
UseEntity with an EventArg object for a parameter
Activate with an EventArg object for a parameter
Fixes #74 