### PR TITLE
Fixes server crash due to null construction step

### DIFF
--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -93,6 +93,10 @@ namespace Content.Server.GameObjects.Components.Construction
 
         bool TryProcessStep(ConstructionStep step, IEntity slapped)
         {
+            if (step == null)
+            {
+                return false;
+            }
             var sound = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<AudioSystem>();
 
             switch (step)


### PR DESCRIPTION
This fixes a crash caused by inputting an invalid step into a construction ghost.  I tested this on the SMES, generator, and APC. Repro steps:
1. Place a construction ghost with more than one stage. This doesn't seem to occur if you use an invalid step on the first stage of construction. Complete the first stage normally.
2. For the second stage click the ghost with the wrong item. So, for example, I clicked the SMES with a steel sheet instead of a cable coil on it's second stage. This should cause the server to crash.

When you click a construction ghost `ConstructionComponent.AttackBy` tries calling `ConstructionComponent.TryProcessStep` with the forward step of the construction stage, and if that fails it tries the backwards step. In many construction prototypes the backwards step is null for all stages and so clicking the construction ghost with an invalid step results in a crash due to the step value passed to `TryProcessStep` being null. This fixes that by checking for a null step value at the beginning of `TryProcessStep` and returning false if it's encountered. 