### PR TITLE
Verb Visibility

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.GameObjects;
@@ -168,7 +168,7 @@ namespace Content.Client.GameObjects.EntitySystems
                     }
                 }
 
-                var disabled = verb.IsDisabled(user, component);
+                var disabled = verb.GetVisibility(user, component) != VerbVisibility.Visible;
                 var button = new Button
                 {
                     Text = verb.GetText(user, component),

--- a/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
@@ -164,9 +164,9 @@ namespace Content.Server.GameObjects.Components.Interactable
                 return component.Cell == null ? "Eject cell (cell missing)" : "Eject cell";
             }
 
-            protected override bool IsDisabled(IEntity user, HandheldLightComponent component)
+            protected override VerbVisibility GetVisibility(IEntity user, HandheldLightComponent component)
             {
-                return component.Cell == null;
+                return component.Cell == null ? VerbVisibility.Disabled : VerbVisibility.Visible;
             }
 
             protected override void Activate(IEntity user, HandheldLightComponent component)

--- a/Content.Server/GameObjects/Components/Items/Storage/ItemComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ItemComponent.cs
@@ -68,13 +68,14 @@ namespace Content.Server.GameObjects
                 return "Pick Up";
             }
 
-            protected override bool IsDisabled(IEntity user, ItemComponent component)
+            protected override VerbVisibility GetVisibility(IEntity user, ItemComponent component)
             {
                 if (user.TryGetComponent(out HandsComponent hands) && hands.IsHolding(component.Owner))
                 {
-                    return true;
+                    return VerbVisibility.Disabled;
                 }
-                return false;
+
+                return VerbVisibility.Visible;
             }
 
             protected override void Activate(IEntity user, ItemComponent component)

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticMagazineWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticMagazineWeaponComponent.cs
@@ -257,9 +257,9 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Projectile
                 return component.Magazine == null ? "Eject magazine (magazine missing)" : "Eject magazine";
             }
 
-            protected override bool IsDisabled(IEntity user, BallisticMagazineWeaponComponent component)
+            protected override VerbVisibility GetVisibility(IEntity user, BallisticMagazineWeaponComponent component)
             {
-                return component.Magazine == null;
+                return component.Magazine == null ? VerbVisibility.Disabled : VerbVisibility.Visible;
             }
 
             protected override void Activate(IEntity user, BallisticMagazineWeaponComponent component)

--- a/Content.Server/GameObjects/EntitySystems/VerbSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/VerbSystem.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Content.Shared.GameObjects;
 using Content.Shared.GameObjects.EntitySystemMessages;
 using Robust.Server.Interfaces.Player;
@@ -61,11 +61,15 @@ namespace Content.Server.GameObjects.EntitySystems
                                 continue;
                             }
                         }
+                        
+                        var vis = verb.GetVisibility(userEntity, component);
+                        if(vis == VerbVisibility.Invisible)
+                            continue;
 
                         // TODO: These keys being giant strings is inefficient as hell.
                         data.Add(new VerbsResponseMessage.VerbData(verb.GetText(userEntity, component),
                             $"{component.GetType()}:{verb.GetType()}",
-                            !verb.IsDisabled(userEntity, component)));
+                            vis == VerbVisibility.Visible));
                     }
 
                     var response = new VerbsResponseMessage(data, req.EntityUid);

--- a/Content.Shared/GameObjects/Verb.cs
+++ b/Content.Shared/GameObjects/Verb.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.Interfaces.GameObjects;
@@ -33,13 +33,12 @@ namespace Content.Shared.GameObjects
         public abstract string GetText(IEntity user, IComponent component);
 
         /// <summary>
-        ///     Gets whether this verb is "disabled" in the right click menu.
-        ///     The verb is still visible in disabled state, but greyed out.
+        ///     Gets the visibility level of this verb in the right click menu.
         /// </summary>
         /// <param name="user">The entity of the user opening this menu.</param>
         /// <param name="component">The component instance for which this verb is being loaded.</param>
-        /// <returns>True if the verb is disabled, false otherwise.</returns>
-        public abstract bool IsDisabled(IEntity user, IComponent component);
+        /// <returns>The visibility level of the verb in the client's right click menu.</returns>
+        public abstract VerbVisibility GetVisibility(IEntity user, IComponent component);
 
         /// <summary>
         ///     Invoked when this verb is activated from the right click menu.
@@ -66,13 +65,12 @@ namespace Content.Shared.GameObjects
         protected abstract string GetText(IEntity user, T component);
 
         /// <summary>
-        ///     Gets whether this verb is "disabled" in the right click menu.
-        ///     The verb is still visible in disabled state, but greyed out.
+        ///     Gets the visibility level of this verb in the right click menu.
         /// </summary>
         /// <param name="user">The entity of the user opening this menu.</param>
         /// <param name="component">The component instance for which this verb is being loaded.</param>
-        /// <returns>True if the verb is disabled, false otherwise.</returns>
-        protected abstract bool IsDisabled(IEntity user, T component);
+        /// <returns>The visibility level of the verb in the client's right click menu.</returns>
+        protected abstract VerbVisibility GetVisibility(IEntity user, T component);
 
         /// <summary>
         ///     Invoked when this verb is activated from the right click menu.
@@ -81,17 +79,19 @@ namespace Content.Shared.GameObjects
         /// <param name="component">The component instance for which this verb is being loaded.</param>
         protected abstract void Activate(IEntity user, T component);
 
-
+        /// <inheritdoc />
         public sealed override string GetText(IEntity user, IComponent component)
         {
             return GetText(user, (T) component);
         }
 
-        public sealed override bool IsDisabled(IEntity user, IComponent component)
+        /// <inheritdoc />
+        public sealed override VerbVisibility GetVisibility(IEntity user, IComponent component)
         {
-            return IsDisabled(user, (T) component);
+            return GetVisibility(user, (T) component);
         }
 
+        /// <inheritdoc />
         public sealed override void Activate(IEntity user, IComponent component)
         {
             Activate(user, (T) component);
@@ -128,5 +128,26 @@ namespace Content.Shared.GameObjects
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Possible states of visibility for the verb in the right click menu.
+    /// </summary>
+    public enum VerbVisibility
+    {
+        /// <summary>
+        /// The verb will be listed in the right click menu.
+        /// </summary>
+        Visible,
+
+        /// <summary>
+        /// The verb will be listed, but it will be grayed out and unable to be clicked on.
+        /// </summary>
+        Disabled,
+
+        /// <summary>
+        /// The verb will not be listed in the right click menu.
+        /// </summary>
+        Invisible
     }
 }


### PR DESCRIPTION
Verbs used to have two visibility states, enabled and disabled. Now they have three, Visible, Disabled, and Invisible. This is useful for when you have a verb registered for a specific component, but want to hide it on a per-entity basis.