### PR TITLE
Examine Improvements

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/ExamineSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/ExamineSystem.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Content.Shared.GameObjects.EntitySystemMessages;
 using Content.Shared.Input;
@@ -7,6 +7,7 @@ using Robust.Client.GameObjects.EntitySystems;
 using Robust.Client.Interfaces.GameObjects.Components;
 using Robust.Client.Interfaces.Input;
 using Robust.Client.Interfaces.UserInterface;
+using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.GameObjects;
@@ -25,10 +26,14 @@ namespace Content.Client.GameObjects.EntitySystems
     {
         public const string StyleClassEntityTooltip = "entity-tooltip";
 
+        public const float ExamineRange = 1.5f;
+        public const float ExamineRangeSquared = ExamineRange * ExamineRange;
+
 #pragma warning disable 649
         [Dependency] private IInputManager _inputManager;
         [Dependency] private IUserInterfaceManager _userInterfaceManager;
         [Dependency] private IEntityManager _entityManager;
+        [Dependency] private IPlayerManager _playerManager;
 #pragma warning restore 649
 
         private Popup _examineTooltipOpen;
@@ -56,6 +61,13 @@ namespace Content.Client.GameObjects.EntitySystems
                 return;
             }
 
+            var playerEntity = _playerManager.LocalPlayer.ControlledEntity;
+            if(playerEntity == null)
+                return;
+            
+            if((entity.Transform.WorldPosition - playerEntity.Transform.WorldPosition).LengthSquared > ExamineRangeSquared)
+                return;
+
             DoExamine(entity);
         }
 
@@ -70,6 +82,7 @@ namespace Content.Client.GameObjects.EntitySystems
             _userInterfaceManager.StateRoot.AddChild(_examineTooltipOpen);
             var panel = new PanelContainer();
             panel.AddStyleClass(StyleClassEntityTooltip);
+            panel.ModulateSelfOverride = Color.LightGray.WithAlpha(0.90f);
             _examineTooltipOpen.AddChild(panel);
             panel.SetAnchorAndMarginPreset(Control.LayoutPreset.Wide);
             var vBox = new VBoxContainer();

--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -13,13 +13,13 @@ namespace Content.Client.Input
         {
             var common = contexts.GetContext("common");
             common.AddFunction(ContentKeyFunctions.FocusChat);
+            common.AddFunction(ContentKeyFunctions.ExamineEntity);
 
             var human = contexts.GetContext("human");
             human.AddFunction(ContentKeyFunctions.SwapHands);
             human.AddFunction(ContentKeyFunctions.Drop);
             human.AddFunction(ContentKeyFunctions.ActivateItemInHand);
             human.AddFunction(ContentKeyFunctions.OpenCharacterMenu);
-            human.AddFunction(ContentKeyFunctions.ExamineEntity);
             human.AddFunction(ContentKeyFunctions.UseItemInHand);
             human.AddFunction(ContentKeyFunctions.ActivateItemInWorld);
             human.AddFunction(ContentKeyFunctions.ThrowItemInHand);


### PR DESCRIPTION
* Added a range check for examining entities. Now you can't examine things across the map, or between maps.
* Made the examine window a little transparent so that you can see things behind it. This prevents the examine popup from occluding gameplay.
* Moved the ExamineEntity bind from Human to Common context so that it will always be available to clients. Ghosts can now examine things.

This does not include any of the mouse handling discussed in Discord. I did not feel like dealing with it.