### PR TITLE
Adds collision to several power entities

### DIFF
--- a/Resources/Prototypes/Entities/Power.yml
+++ b/Resources/Prototypes/Entities/Power.yml
@@ -41,6 +41,8 @@
   components:
   - type: Clickable
   - type: BoundingBox
+    aabb: -0.5, -0.5, 0.3, 0.5
+  - type: Collidable
   - type: Sprite
     texture: Objects/generator.png
   - type: Icon
@@ -105,6 +107,8 @@
   components:
   - type: Clickable
   - type: BoundingBox
+    aabb: -0.5, -0.5, 0.5, 0.5
+  - type: Collidable
   - type: Sprite
     netsync: false
     sprite: Buildings/smes.rsi
@@ -140,6 +144,8 @@
   components:
   - type: Clickable
   - type: BoundingBox
+    aabb: -0.5, -0.25, 0.5, 0.25
+  - type: Collidable
   - type: Sprite
     texture: Objects/wiredmachine.png
   - type: Icon
@@ -156,6 +162,8 @@
   components:
   - type: Clickable
   - type: BoundingBox
+    aabb: -0.5, -0.25, 0.5, 0.25
+  - type: Collidable
   - type: Sprite
     texture: Objects/wirelessmachine.png
   - type: Icon


### PR DESCRIPTION
Adds the `Collidable` component to several power entities and aabb values to their bounding boxes. This allows the player to collide with them. Entities this edits: 
- SMES
- Generator
- WiredMachine (shield generator sprite)
- WirelessMachine (vending machine sprite)