### PR TITLE
Apc variable charge bar color

### DIFF
--- a/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
@@ -3,12 +3,14 @@ using Content.Shared.GameObjects.Components.Power;
 using NJsonSchema.Validation;
 using OpenTK.Graphics.OpenGL4;
 using Robust.Client.GameObjects.Components.UserInterface;
+using Robust.Client.Graphics.Drawing;
 using Robust.Client.Interfaces.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.GameObjects.Components.UserInterface;
 using Robust.Shared.IoC;
+using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 namespace Content.Client.GameObjects.Components.Power
@@ -65,6 +67,45 @@ namespace Content.Client.GameObjects.Components.Power
             }
 
             _chargeBar.Value = castState.Charge;
+            UpdateChargeBarColor(castState.Charge);
+        }
+
+        private void UpdateChargeBarColor(float charge)
+        {
+            float normalizedCharge = charge / _chargeBar.MaxValue;
+
+            float leftHue = 0.0f;// Red
+            float middleHue = 0.08f;// Orange
+            float rightHue = 0.33f;// Green
+            float saturation = 1.0f;// Uniform saturation
+            float value = 0.65f;// Uniform value / brightness
+            float alpha = 1.0f;// Uniform alpha
+
+            // These should add up to 1.0 or your transition won't be smooth
+            float leftSideSize = 0.5f;// Fraction of _chargeBar lerped from leftHue to middleHue
+            float rightSideSize = 0.5f;// Fraction of _chargeBar lerped from middleHue to rightHue
+
+            float finalHue;
+            if (normalizedCharge <= leftSideSize)
+            {
+                normalizedCharge /= leftSideSize;// Adjust range to 0.0 to 1.0
+                finalHue = FloatMath.Lerp(leftHue, middleHue, normalizedCharge);
+            }
+            else
+            {
+                normalizedCharge = (normalizedCharge - leftSideSize) / rightSideSize;// Adjust range to 0.0 to 1.0.
+                finalHue = FloatMath.Lerp(middleHue, rightHue, normalizedCharge);
+            }
+
+            // Check if null first to avoid repeatedly creating this.
+            if (_chargeBar.ForegroundStyleBoxOverride == null)
+            {
+                _chargeBar.ForegroundStyleBoxOverride = new StyleBoxFlat();
+            }
+
+            var foregroundStyleBoxOverride = (StyleBoxFlat)_chargeBar.ForegroundStyleBoxOverride;
+            foregroundStyleBoxOverride.BackgroundColor =
+                Color.FromHsv(new Vector4(finalHue, saturation, value, alpha));
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
@@ -75,10 +75,10 @@ namespace Content.Client.GameObjects.Components.Power
             float normalizedCharge = charge / _chargeBar.MaxValue;
 
             float leftHue = 0.0f;// Red
-            float middleHue = 0.08f;// Orange
+            float middleHue = 0.066f;// Orange
             float rightHue = 0.33f;// Green
             float saturation = 1.0f;// Uniform saturation
-            float value = 0.65f;// Uniform value / brightness
+            float value = 0.8f;// Uniform value / brightness
             float alpha = 1.0f;// Uniform alpha
 
             // These should add up to 1.0 or your transition won't be smooth


### PR DESCRIPTION
This PR makes the APC charge bar change color based on it's charge value. I've tried to make the code simple to edit so the color transition can easily be tweaked in the future. 

There are several important values to keep in mind. First you have `leftHue`, `middleHue`, and `rightHue`. These represent the three hue values that are lerped between to form the color gradient based on `normalizedCharge`.  `leftHue` represents the hue if the apc has zero charge. `middleHue` represents half charged, and `rightHue` is full charge. Currently it transitions from green (`rightHue`) to orange (`middleHue`) to red (`leftHue`). `saturation` and `value` (brightness) are uniform across all charge values.

Finally, there's `leftSideSize` and `rightSideSize`. Changing these values lets you make different portions of the color transition larger or smaller. If you want the transition from `leftHue` to `middleHue` (red to orange) to be larger you should increase the size of `leftSideSize` and decrease the size of `rightSideSize` by the same amount. `leftSideSize` and `rightSideSize` should always add up to 1.0 to ensure smooth transitions. I've made the transitions equal in size by default, as I found that made the best result.

Here's the resulting appearance: 
![green->orange->red, 50% - 50% transitions](https://user-images.githubusercontent.com/8206401/58363069-bc2acc80-7e6c-11e9-9452-ad632c67ba9e.gif)
