### PR TITLE
APC charge percentage label

### DIFF
--- a/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
@@ -68,6 +68,8 @@ namespace Content.Client.GameObjects.Components.Power
 
             _chargeBar.Value = castState.Charge;
             UpdateChargeBarColor(castState.Charge);
+            float ChargePercentage = (castState.Charge / _chargeBar.MaxValue) * 100.0f;
+            _window.ChargePercentage.Text = " " + ChargePercentage.ToString("0.00") + "%";
         }
 
         private void UpdateChargeBarColor(float charge)
@@ -123,6 +125,7 @@ namespace Content.Client.GameObjects.Components.Power
             public Button BreakerButton { get; set; }
             public Label ExternalPowerStateLabel { get; set; }
             public ProgressBar ChargeBar { get; set; }
+            public Label ChargePercentage { get; set; }
 
             public ApcWindow()
             {
@@ -156,8 +159,10 @@ namespace Content.Client.GameObjects.Components.Power
                     Page = 0.0f,
                     Value = 0.5f
                 };
+                ChargePercentage = new Label("ChargePercentage");
                 charge.AddChild(chargeLabel);
                 charge.AddChild(ChargeBar);
+                charge.AddChild(ChargePercentage);
                 rows.AddChild(charge);
 
                 Contents.AddChild(rows);


### PR DESCRIPTION
Adds a label for charge percentage to the APC gui. Example where I toggle the main breaker a few times: 
![JRtiocpUCr](https://user-images.githubusercontent.com/8206401/58443689-93e7db80-80c1-11e9-80d5-3efffbe91076.gif)
