### PR TITLE
APC gui colored external power state

### DIFF
--- a/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
@@ -55,12 +55,15 @@ namespace Content.Client.GameObjects.Components.Power
             {
                 case ApcExternalPowerState.None:
                     _externalPowerStateLabel.Text = "None";
+                    _externalPowerStateLabel.FontColorOverride = new Color(0.8f, 0.0f, 0.0f);
                     break;
                 case ApcExternalPowerState.Low:
                     _externalPowerStateLabel.Text = "Low";
+                    _externalPowerStateLabel.FontColorOverride = new Color(0.9f, 0.36f, 0.0f);
                     break;
                 case ApcExternalPowerState.Good:
                     _externalPowerStateLabel.Text = "Good";
+                    _externalPowerStateLabel.FontColorOverride = new Color(0.024f, 0.8f, 0.0f);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Content.Client.UserInterface;
 using Content.Shared.GameObjects.Components.Power;
 using NJsonSchema.Validation;
 using OpenTK.Graphics.OpenGL4;
@@ -55,15 +56,15 @@ namespace Content.Client.GameObjects.Components.Power
             {
                 case ApcExternalPowerState.None:
                     _externalPowerStateLabel.Text = "None";
-                    _externalPowerStateLabel.FontColorOverride = new Color(0.8f, 0.0f, 0.0f);
+                    _externalPowerStateLabel.SetOnlyStyleClass(NanoStyle.StyleClassPowerStateNone);
                     break;
                 case ApcExternalPowerState.Low:
                     _externalPowerStateLabel.Text = "Low";
-                    _externalPowerStateLabel.FontColorOverride = new Color(0.9f, 0.36f, 0.0f);
+                    _externalPowerStateLabel.SetOnlyStyleClass(NanoStyle.StyleClassPowerStateLow);
                     break;
                 case ApcExternalPowerState.Good:
                     _externalPowerStateLabel.Text = "Good";
-                    _externalPowerStateLabel.FontColorOverride = new Color(0.024f, 0.8f, 0.0f);
+                    _externalPowerStateLabel.SetOnlyStyleClass(NanoStyle.StyleClassPowerStateGood);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -145,10 +146,11 @@ namespace Content.Client.GameObjects.Components.Power
                 var externalStatus = new HBoxContainer("ExternalStatus");
                 var externalStatusLabel = new Label("Label") { Text = "External Power: " };
                 ExternalPowerStateLabel = new Label("Status") { Text = "Good" };
+                ExternalPowerStateLabel.SetOnlyStyleClass(NanoStyle.StyleClassPowerStateGood);
                 externalStatus.AddChild(externalStatusLabel);
                 externalStatus.AddChild(ExternalPowerStateLabel);
                 rows.AddChild(externalStatus);
-
+                
                 var charge = new HBoxContainer("Charge");
                 var chargeLabel = new Label("Label") { Text = "Charge:" };
                 ChargeBar = new ProgressBar("Charge")

--- a/Content.Client/UserInterface/NanoStyle.cs
+++ b/Content.Client/UserInterface/NanoStyle.cs
@@ -1,4 +1,4 @@
-using Content.Client.GameObjects.EntitySystems;
+﻿using Content.Client.GameObjects.EntitySystems;
 using Content.Client.Utility;
 using Robust.Client.Graphics.Drawing;
 using Robust.Client.Interfaces.ResourceManagement;
@@ -15,6 +15,11 @@ namespace Content.Client.UserInterface
         public const string StyleClassLabelHeading = "LabelHeading";
         public const string StyleClassButtonBig = "ButtonBig";
         private static readonly Color NanoGold = Color.FromHex("#A88B5E");
+
+        //Used by the APC and SMES menus
+        public const string StyleClassPowerStateNone = "PowerStateNone";
+        public const string StyleClassPowerStateLow = "PowerStateLow";
+        public const string StyleClassPowerStateGood = "PowerStateGood";
 
         public Stylesheet Stylesheet { get; }
 
@@ -420,6 +425,22 @@ namespace Content.Client.UserInterface
                 {
                     new StyleProperty("font", notoSans16)
                 }),
+
+                //APC and SMES power state label colors
+                new StyleRule(new SelectorElement(typeof(Label), new []{StyleClassPowerStateNone}, null, null), new []
+                {
+                    new StyleProperty(Label.StylePropertyFontColor, new Color(0.8f, 0.0f, 0.0f))
+                }),
+
+                new StyleRule(new SelectorElement(typeof(Label), new []{StyleClassPowerStateLow}, null, null), new []
+                {
+                    new StyleProperty(Label.StylePropertyFontColor, new Color(0.9f, 0.36f, 0.0f))
+                }),
+
+                new StyleRule(new SelectorElement(typeof(Label), new []{StyleClassPowerStateGood}, null, null), new []
+                {
+                    new StyleProperty(Label.StylePropertyFontColor, new Color(0.024f, 0.8f, 0.0f))
+                }), 
             });
         }
     }


### PR DESCRIPTION
Makes the APC external power label change color based on it's state. This allows users to see it's state at a glance more easily. 

Good = Green
![Robust Client_nKIOYVjCH6](https://user-images.githubusercontent.com/8206401/58443741-e88b5680-80c1-11e9-94a7-045d762833d6.png)

Low = Orange
![Robust Client_95nukyBh5W](https://user-images.githubusercontent.com/8206401/58443747-efb26480-80c1-11e9-88d8-1ec812fd9d36.png)

None = Red
![Robust Client_cUW2FwfH2Q](https://user-images.githubusercontent.com/8206401/58443751-f50faf00-80c1-11e9-95a8-eb3d0c86aaee.png)
