### PR TITLE
Simple quick equip

### DIFF
--- a/Content.Server/GameObjects/Components/Items/Clothing/ClothingComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Clothing/ClothingComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Serialization;
 using System;
 using System.Collections.Generic;
 using Content.Server.GameObjects.EntitySystems;
+using Robust.Shared.Utility;
 using static Content.Shared.GameObjects.Components.Inventory.EquipmentSlotDefines;
 
 namespace Content.Server.GameObjects
@@ -64,17 +65,16 @@ namespace Content.Server.GameObjects
             if (!eventArgs.User.TryGetComponent(out InventoryComponent inv)
             ||  !eventArgs.User.TryGetComponent(out HandsComponent hands)) return false;
 
-            foreach (var pair in SlotMasks)
+            foreach (var (slot, flag) in SlotMasks)
             {
-                if ((SlotFlags & pair.Value) == 0) continue;
+                // We check if the clothing can be equipped in this slot.
+                if ((SlotFlags & flag) == 0) continue;
 
-
-
-                if (inv.TryGetSlotItem(pair.Key, out ItemComponent item))
+                if (inv.TryGetSlotItem(slot, out ItemComponent item))
                 {
-                    if (!inv.CanUnequip(pair.Key)) continue;
+                    if (!inv.CanUnequip(slot)) continue;
                     hands.Drop(Owner);
-                    inv.Unequip(pair.Key);
+                    inv.Unequip(slot);
                     hands.PutInHand(item);
                 }
                 else
@@ -82,7 +82,7 @@ namespace Content.Server.GameObjects
                     hands.Drop(Owner);
                 }
 
-                return inv.Equip(pair.Key, this);
+                return inv.Equip(slot, this);
             }
 
             return false;

--- a/Content.Server/GameObjects/Components/Items/Clothing/ClothingComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Clothing/ClothingComponent.cs
@@ -1,14 +1,15 @@
-﻿using Content.Shared.GameObjects;
+using Content.Shared.GameObjects;
 using Content.Shared.GameObjects.Components.Items;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
 using System;
 using System.Collections.Generic;
+using Content.Server.GameObjects.EntitySystems;
 using static Content.Shared.GameObjects.Components.Inventory.EquipmentSlotDefines;
 
 namespace Content.Server.GameObjects
 {
-    public class ClothingComponent : ItemComponent
+    public class ClothingComponent : ItemComponent, IUse
     {
         public override string Name => "Clothing";
         public override uint? NetID => ContentNetIDs.CLOTHING;
@@ -16,6 +17,7 @@ namespace Content.Server.GameObjects
 
         public SlotFlags SlotFlags = SlotFlags.PREVENTEQUIP; //Different from None, NONE allows equips if no slot flags are required
 
+        private bool _quickEquipEnabled = true;
         private int _heatResistance;
         public int HeatResistance => _heatResistance;
 
@@ -46,12 +48,44 @@ namespace Content.Server.GameObjects
                 }
             });
 
+            serializer.DataField(ref _quickEquipEnabled, "QuickEquip", true);
+
             serializer.DataFieldCached(ref _heatResistance, "HeatResistance", 323);
         }
 
         public override ComponentState GetComponentState()
         {
             return new ClothingComponentState(ClothingEquippedPrefix, EquippedPrefix);
+        }
+
+        public bool UseEntity(UseEntityEventArgs eventArgs)
+        {
+            if (!_quickEquipEnabled) return false;
+            if (!eventArgs.User.TryGetComponent(out InventoryComponent inv)
+            ||  !eventArgs.User.TryGetComponent(out HandsComponent hands)) return false;
+
+            foreach (var pair in SlotMasks)
+            {
+                if ((SlotFlags & pair.Value) == 0) continue;
+
+
+
+                if (inv.TryGetSlotItem(pair.Key, out ItemComponent item))
+                {
+                    if (!inv.CanUnequip(pair.Key)) continue;
+                    hands.Drop(Owner);
+                    inv.Unequip(pair.Key);
+                    hands.PutInHand(item);
+                }
+                else
+                {
+                    hands.Drop(Owner);
+                }
+
+                return inv.Equip(pair.Key, this);
+            }
+
+            return false;
         }
     }
 }

--- a/Resources/Prototypes/Entities/Clothing/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/backpacks.yml
@@ -12,6 +12,7 @@
     state: backpack
   - type: Clothing
     Size: 9999
+    QuickEquip: false
     Slots:
     - back
     sprite: Clothing/backpack.rsi


### PR DESCRIPTION
Using a piece of clothing in your active hand will try to equip it. If the slot already has a piece of clothing, it'll swap it. Note: Backpacks are excluded from quick equip for now, since it would become impossible to open them otherwise.