### PR TITLE
Fix crash caused by invalid construction ghost shader name

### DIFF
--- a/Resources/Prototypes/Entities/markers/construction_ghost.yml
+++ b/Resources/Prototypes/Entities/markers/construction_ghost.yml
@@ -10,7 +10,7 @@
   - type: Collidable
   - type: Clickable
     baseshader: unshaded
-    selectionshader: selection_outline_unshaded
+    selectionshader: unshaded
 
 - type: entity
   name: somebody-messed-up frame

--- a/Resources/Prototypes/Entities/markers/construction_ghost.yml
+++ b/Resources/Prototypes/Entities/markers/construction_ghost.yml
@@ -9,8 +9,6 @@
   - type: ConstructionGhost
   - type: Collidable
   - type: Clickable
-    baseshader: unshaded
-    selectionshader: unshaded
 
 - type: entity
   name: somebody-messed-up frame


### PR DESCRIPTION
Construction ghosts were using a shader called `selection_outline_unshader`, which is not a valid shader name. This caused a crash when constructing things. This fixes that problem by updating them to use a valid shader: `unshaded`.

Should fix #310. I'm only able to confirm that it fixes the issue on windows 10 however. Don't have a linux instance setup to test this on.