### PR TITLE
Replace non-existent prototype in ToolLockerFillComponent

### DIFF
--- a/Content.Server/GameObjects/Components/Items/Storage/Fill/ToolLockerFillComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/Fill/ToolLockerFillComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
@@ -80,7 +80,7 @@ namespace Content.Server.GameObjects.Components.Items.Storage.Fill
 
             if (random.Prob(0.4f))
             {
-                Spawn("HelmetEngineering");
+                Spawn("HatHardhatRed");
             }
 
             for (var i = 0; i < 3; i++)


### PR DESCRIPTION
Previously this component would sometimes try to use a non-existent prototype, `HelmetEngineering`. This would result in a server crash upon loading any map that uses the `Tool Locker (Filled)` entity. This replaces that non existent prototype with `HatHardhatRed`, which does exist, and is something you might expect to find in a tool locker. I also checked all the other prototypes that this component uses, and the rest do exist.