### PR TITLE
Disable footstep sounds for ghosts

### DIFF
--- a/Content.Server/GameObjects/Components/Mobs/FootstepSoundComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/FootstepSoundComponent.cs
@@ -1,0 +1,21 @@
+﻿using Robust.Shared.GameObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Content.Server.Mobs;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Server.GameObjects.Components.Mobs
+{
+    /// <summary>
+    ///     Mobs will only make footstep sounds if they have this component.
+    /// </summary>
+    [RegisterComponent]
+    public class FootstepSoundComponent : Component
+    {
+        public override string Name => "FootstepSound";
+    }
+}

--- a/Content.Server/GameObjects/EntitySystems/MoverSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/MoverSystem.cs
@@ -153,6 +153,12 @@ namespace Content.Server.GameObjects.EntitySystems
                 if (mover.StepSoundDistance > distanceNeeded)
                 {
                     mover.StepSoundDistance = 0;
+
+                    if (mover.Owner.Prototype.ID == "MobObserver" || mover.Owner.Prototype.ID == "AdminObserver")
+                    {
+                        return;
+                    }
+
                     if (mover.Owner.TryGetComponent<InventoryComponent>(out var inventory)
                         && inventory.TryGetSlotItem<ItemComponent>(EquipmentSlotDefines.Slots.SHOES, out var item)
                         && item.Owner.TryGetComponent<FootstepModifierComponent>(out var modifier))

--- a/Content.Server/GameObjects/EntitySystems/MoverSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/MoverSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Content.Server.GameObjects.Components;
+using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.Components.Movement;
 using Content.Server.Interfaces.GameObjects.Components.Movement;
 using Content.Shared.Audio;
@@ -154,7 +155,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 {
                     mover.StepSoundDistance = 0;
 
-                    if (mover.Owner.Prototype.ID == "MobObserver" || mover.Owner.Prototype.ID == "AdminObserver")
+                    if (!mover.Owner.HasComponent<FootstepSoundComponent>())
                     {
                         return;
                     }

--- a/Resources/Prototypes/Entities/mobs/human.yml
+++ b/Resources/Prototypes/Entities/mobs/human.yml
@@ -67,4 +67,5 @@
   - type: Teleportable
   - type: Examiner
   - type: CharacterInfo
+  - type: FootstepSound
 


### PR DESCRIPTION
Adds a check before playing footstep sounds to check if the mover is a ghost. Doesn't play footstep sounds if they are a ghost.

Fixes #218 