### PR TITLE
Vending machines now show entity name rather than prototype ID

### DIFF
--- a/Content.Client/VendingMachines/VendingMachineMenu.cs
+++ b/Content.Client/VendingMachines/VendingMachineMenu.cs
@@ -48,12 +48,14 @@ namespace Content.Client.VendingMachines
             _cachedInventory = inventory;
             foreach (VendingMachineInventoryEntry entry in inventory)
             {
+                var itemName = _prototypeManager.Index<EntityPrototype>(entry.ID).Name;
+
                 Texture icon = null;
                 if(_prototypeManager.TryIndex(entry.ID, out EntityPrototype prototype))
                 {
                     icon = IconComponent.GetPrototypeIcon(prototype, _resourceCache).TextureFor(Direction.South);
                 }
-                _items.AddItem($"{entry.ID} ({entry.Amount} left)", icon);
+                _items.AddItem($"{itemName} ({entry.Amount} left)", icon);
             }
         }
 


### PR DESCRIPTION
It didn't matter until now because for the only vending machine that was originally implemented the ID and the name were the same.