### PR TITLE
Fix part of the reagent dispenser ui being cutoff when first opened

### DIFF
--- a/Content.Client/GameObjects/Components/Chemistry/ReagentDispenserWindow.cs
+++ b/Content.Client/GameObjects/Components/Chemistry/ReagentDispenserWindow.cs
@@ -78,7 +78,7 @@ namespace Content.Client.GameObjects.Components.Chemistry
                     new Panel{CustomMinimumSize = (0.0f, 10.0f)}, //Padding
                     (ChemicalList = new GridContainer //Grid of which reagents can be dispensed.
                     {
-                        CustomMinimumSize = (470.0f, 200.0f),
+                        CustomMinimumSize = (503.0f, 200.0f),
                         SizeFlagsVertical = SizeFlags.FillExpand,
                         SizeFlagsHorizontal = SizeFlags.FillExpand,
                         Columns = 5


### PR DESCRIPTION
Currently when you first open a reagent dispensers UI some of it's buttons are cut off on the right side:

![Robust Client_oMGfG84bu0](https://user-images.githubusercontent.com/8206401/66775988-55e22d00-ee93-11e9-94ad-594cfbd259d6.png)

This fixes that:

![Robust Client_m8DK4RRiFR](https://user-images.githubusercontent.com/8206401/66776027-74e0bf00-ee93-11e9-93cf-aededca6f803.png)
