### PR TITLE
Add an atmospherics engine

### DIFF
--- a/Content.Server/Atmos/AtmosphereMap.cs
+++ b/Content.Server/Atmos/AtmosphereMap.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.GameObjects;
+using Content.Server.GameObjects.Components.Atmos;
+using Content.Server.Interfaces.Atmos;
+using Robust.Shared.GameObjects.Components.Transform;
+using Robust.Shared.Interfaces.GameObjects.Components;
+using Robust.Shared.Interfaces.Map;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Atmos
+{
+    internal class AtmosphereMap : IAtmosphereMap
+    {
+#pragma warning disable 649
+        // ReSharper disable once InconsistentNaming
+        [Dependency] private readonly IMapManager MapManager;
+#pragma warning restore 649
+
+        private readonly Dictionary<GridId, GridAtmosphereManager> _gridAtmosphereManagers =
+            new Dictionary<GridId, GridAtmosphereManager>();
+
+        public IGridAtmosphereManager GetGridAtmosphereManager(GridId grid)
+        {
+            if (_gridAtmosphereManagers.TryGetValue(grid, out var manager))
+                return manager;
+
+            if (!MapManager.GridExists(grid))
+                throw new ArgumentException("Cannot get atmosphere of missing grid", nameof(grid));
+
+            manager = new GridAtmosphereManager(MapManager.GetGrid(grid));
+            _gridAtmosphereManagers[grid] = manager;
+            return manager;
+        }
+
+        public IAtmosphere GetAtmosphere(ITransformComponent position) =>
+            GetGridAtmosphereManager(position.GridID).GetAtmosphere(position.GridPosition);
+
+        public void Update(float frameTime)
+        {
+            foreach (var atmos in _gridAtmosphereManagers.Values)
+            {
+                atmos.Update(frameTime);
+            }
+        }
+    }
+
+    internal class GridAtmosphereManager : IGridAtmosphereManager
+    {
+        private readonly IMapGrid _grid;
+        private Dictionary<MapIndices, Atmosphere> _atmospheres = new Dictionary<MapIndices, Atmosphere>();
+
+        private HashSet<MapIndices> _invalidatedPositions = new HashSet<MapIndices>();
+
+        public GridAtmosphereManager(IMapGrid grid)
+        {
+            _grid = grid;
+        }
+
+        public IAtmosphere GetAtmosphere(GridCoordinates coordinates) => GetAtmosphere(GridToMapCoord(coordinates));
+
+        private Atmosphere GetAtmosphere(MapIndices pos)
+        {
+            if (_atmospheres.TryGetValue(pos, out var atmosphere))
+                return atmosphere;
+
+            // If this is clearly space - such as someone moving round outside the station - just return immediately
+            // and don't add anything to the grid map
+            if (IsSpace(pos))
+                return null;
+
+            // If the block is obstructed:
+            // If the air blocker is marked as 'use adjacent atmosphere' then the cell behaves as if
+            // you got one of it's adjacent atmospheres. If not, it returns null.
+            var obstruction = GetObstructingComponent(pos);
+            if (obstruction != null)
+                return obstruction.UseAdjacentAtmosphere ? GetAdjacentAtmospheres(pos).FirstOrDefault().Value : null;
+
+            var connected = FindConnectedCells(pos);
+
+            if (connected == null)
+            {
+                // Since this is on a floor tile, it's fairly likely this is a room with
+                // a breach. As such, cache this position for sake of static objects like
+                // air vents which call this constantly.
+                _atmospheres[pos] = null;
+                return null;
+            }
+
+            // TODO create default atmosphere
+            atmosphere = new Atmosphere();
+
+            foreach (var c in connected)
+                _atmospheres[c] = atmosphere;
+
+            return atmosphere;
+        }
+
+        public void Invalidate(GridCoordinates coordinates)
+        {
+            _invalidatedPositions.Add(GridToMapCoord(coordinates));
+        }
+
+        private MapIndices GridToMapCoord(GridCoordinates pos) => _grid.SnapGridCellFor(pos, SnapGridOffset.Center);
+
+        private List<MapIndices> FindConnectedCells(MapIndices start)
+        {
+            var inner = new HashSet<MapIndices>();
+            var edge = new HashSet<MapIndices> {start};
+
+            // Basic inner/edge finder
+            // The inner list is all the positions we know are empty, and take no further actions.
+            // The edge list is all the positions for whom we have not searched their neighbours.
+            // Move stuff from edge to inner, while adding adjacent empty locations to edge
+            // When edge is empty, we have filled the entire room.
+
+            while (edge.Count > 0)
+            {
+                var temp = new List<MapIndices>(edge);
+                edge.Clear();
+                foreach (var pos in temp)
+                {
+                    inner.Add(pos);
+
+                    if (IsSpace(pos))
+                        return null;
+
+                    Check(inner, edge, pos, Direction.North);
+                    Check(inner, edge, pos, Direction.South);
+                    Check(inner, edge, pos, Direction.East);
+                    Check(inner, edge, pos, Direction.West);
+                }
+            }
+
+            return new List<MapIndices>(inner);
+        }
+
+        private void Check(ICollection<MapIndices> inner, ISet<MapIndices> edges, MapIndices pos, Direction dir)
+        {
+            pos += (MapIndices) CardinalToIntVec(dir);
+            if (IsObstructed(pos))
+                return;
+
+            if (inner.Contains(pos))
+                return;
+
+            edges.Add(pos);
+        }
+
+        private static Vector2i CardinalToIntVec(Direction dir)
+        {
+            switch (dir)
+            {
+                case Direction.North:
+                    return new Vector2i(0, 1);
+                case Direction.East:
+                    return new Vector2i(1, 0);
+                case Direction.South:
+                    return new Vector2i(0, -1);
+                case Direction.West:
+                    return new Vector2i(-1, 0);
+                default:
+                    throw new ArgumentException($"Direction dir {dir} is not a cardinal direction", nameof(dir));
+            }
+        }
+
+        private bool IsObstructed(MapIndices pos) => GetObstructingComponent(pos) != null;
+
+        private AirtightComponent GetObstructingComponent(MapIndices pos)
+        {
+            foreach (var v in _grid.GetSnapGridCell(pos, SnapGridOffset.Center))
+            {
+                if (v.Owner.TryGetComponent<AirtightComponent>(out var ac))
+                    return ac;
+            }
+
+            return null;
+        }
+
+        private bool IsSpace(MapIndices pos)
+        {
+            // TODO use ContentTileDefinition to define in YAML whether or not a tile is considered space
+            return _grid.GetTileRef(pos).Tile.IsEmpty;
+        }
+
+        public void Update(float frameTime)
+        {
+            if (_invalidatedPositions.Count != 0)
+                Revalidate();
+        }
+
+        private void Revalidate()
+        {
+            foreach (var pos in _invalidatedPositions)
+            {
+                if (IsObstructed(pos))
+                    SplitAtmospheres(pos);
+                else
+                    MergeAtmospheres(pos);
+            }
+
+            _invalidatedPositions.Clear();
+        }
+
+        private void SplitAtmospheres(MapIndices pos)
+        {
+            // Remove the now-covered atmosphere
+            _atmospheres.Remove(pos);
+
+            var adjacent = GetAdjacentAtmospheres(pos);
+            var adjacentPositions = adjacent.Select(p => Offset(pos, p.Key)).ToList();
+            var adjacentAtmospheres = new HashSet<Atmosphere>(adjacent.Values);
+
+            foreach (var atmos in adjacentAtmospheres)
+            {
+                var i = 0;
+                int? spaceIdx = null;
+                var sides = new Dictionary<MapIndices, int>();
+
+                foreach (var pair in adjacent.Where(p => p.Value == atmos))
+                {
+                    var edgePos = Offset(pos, pair.Key);
+                    if (sides.ContainsKey(edgePos))
+                        continue;
+
+                    var connected = FindConnectedCells(edgePos);
+                    if (connected == null)
+                    {
+                        if (spaceIdx == null)
+                            spaceIdx = i++;
+                        sides[edgePos] = (int) spaceIdx;
+                        continue;
+                    }
+
+                    foreach (var connectedPos in connected.Intersect(adjacentPositions))
+                        sides[connectedPos] = i;
+
+                    i++;
+                }
+
+                // If the sides were all connected, this atmosphere is intact
+                if (i == 1)
+                    continue;
+
+                // If any of the sides that used to have this atmosphere are now exposed to space, remove
+                // all the old atmosphere's cells.
+                if (spaceIdx != null)
+                {
+                    foreach (var rpos in FindRoomContents(atmos))
+                        _atmospheres.Remove(rpos);
+                }
+
+                // Split up each of the sides
+                for (var j = 0; j < i; j++)
+                {
+                    // Find a position to represent this
+                    var basePos = sides.First(p => p.Value == j).Key;
+
+                    var connected = FindConnectedCells(basePos);
+
+                    if(connected == null)
+                        continue;
+
+                    var newAtmos = new Atmosphere();
+
+                    // TODO copy over contents of atmos
+
+                    foreach (var cpos in connected)
+                        _atmospheres[cpos] = newAtmos;
+                }
+            }
+        }
+
+        private void MergeAtmospheres(MapIndices pos)
+        {
+            var adjacent = new HashSet<Atmosphere>(GetAdjacentAtmospheres(pos).Values);
+
+            // If this block doesn't separate two atmospheres, there's nothing to do
+            if (adjacent.Count <= 1)
+                return;
+
+            // Fuse all adjacent atmospheres
+            Atmosphere replacement;
+            if (adjacent.Contains(null))
+            {
+                replacement = null;
+            }
+            else
+            {
+                replacement = new Atmosphere();
+                foreach (var atmos in adjacent)
+                {
+                    // TODO Add atmos's gasses into replacement
+                }
+            }
+
+            var allCells = new List<MapIndices> {pos};
+            foreach (var atmos in adjacent)
+                allCells.AddRange(FindRoomContents(atmos));
+
+            foreach (var cellPos in allCells)
+                _atmospheres[cellPos] = replacement;
+        }
+
+        private Dictionary<Direction, Atmosphere> GetAdjacentAtmospheres(MapIndices pos)
+        {
+            var sides = new Dictionary<Direction, Atmosphere>();
+            foreach (var dir in Cardinal())
+            {
+                var side = Offset(pos, dir);
+                if (IsObstructed(side))
+                    continue;
+
+                sides[dir] = GetAtmosphere(side);
+            }
+
+            return sides;
+        }
+
+        private static MapIndices Offset(MapIndices pos, Direction dir)
+        {
+            return pos + (MapIndices) CardinalToIntVec(dir);
+        }
+
+        private IEnumerable<MapIndices> FindRoomContents(Atmosphere atmos)
+        {
+            // TODO this is O(n) with respect to the map size, so solve this some other way
+            var poses = new List<MapIndices>();
+            foreach (var (pos, cellAtmos) in _atmospheres)
+            {
+                if (cellAtmos == atmos)
+                    poses.Add(pos);
+            }
+
+            return poses;
+        }
+
+        private static IEnumerable<Direction> Cardinal() =>
+            new[]
+            {
+                Direction.North, Direction.East, Direction.South, Direction.West
+            };
+    }
+
+    internal class Atmosphere : IAtmosphere
+    {
+    }
+}

--- a/Content.Server/Atmos/AtmosphereMap.cs
+++ b/Content.Server/Atmos/AtmosphereMap.cs
@@ -144,7 +144,7 @@ namespace Content.Server.Atmos
 
         private void Check(ICollection<MapIndices> inner, ISet<MapIndices> edges, MapIndices pos, Direction dir)
         {
-            pos += (MapIndices) CardinalToIntVec(dir);
+            pos += (MapIndices) dir.CardinalToIntVec();
             if (IsObstructed(pos))
                 return;
 
@@ -152,23 +152,6 @@ namespace Content.Server.Atmos
                 return;
 
             edges.Add(pos);
-        }
-
-        private static Vector2i CardinalToIntVec(Direction dir)
-        {
-            switch (dir)
-            {
-                case Direction.North:
-                    return new Vector2i(0, 1);
-                case Direction.East:
-                    return new Vector2i(1, 0);
-                case Direction.South:
-                    return new Vector2i(0, -1);
-                case Direction.West:
-                    return new Vector2i(-1, 0);
-                default:
-                    throw new ArgumentException($"Direction dir {dir} is not a cardinal direction", nameof(dir));
-            }
         }
 
         private bool IsObstructed(MapIndices pos) => GetObstructingComponent(pos) != null;
@@ -215,7 +198,7 @@ namespace Content.Server.Atmos
             _atmospheres.Remove(pos);
 
             var adjacent = GetAdjacentAtmospheres(pos);
-            var adjacentPositions = adjacent.Select(p => Offset(pos, p.Key)).ToList();
+            var adjacentPositions = adjacent.Select(p => pos.Offset(p.Key)).ToList();
             var adjacentAtmospheres = new HashSet<Atmosphere>(adjacent.Values);
 
             foreach (var atmos in adjacentAtmospheres)
@@ -226,7 +209,7 @@ namespace Content.Server.Atmos
 
                 foreach (var pair in adjacent.Where(p => p.Value == atmos))
                 {
-                    var edgePos = Offset(pos, pair.Key);
+                    var edgePos = pos.Offset(pair.Key);
                     if (sides.ContainsKey(edgePos))
                         continue;
 
@@ -326,7 +309,7 @@ namespace Content.Server.Atmos
             var sides = new Dictionary<Direction, Atmosphere>();
             foreach (var dir in Cardinal())
             {
-                var side = Offset(pos, dir);
+                var side = pos.Offset(dir);
                 if (IsObstructed(side))
                     continue;
 
@@ -335,8 +318,6 @@ namespace Content.Server.Atmos
 
             return sides;
         }
-
-        private static MapIndices Offset(MapIndices pos, Direction dir) => pos + (MapIndices) CardinalToIntVec(dir);
 
         private IEnumerable<MapIndices> FindRoomContents(Atmosphere atmos)
         {

--- a/Content.Server/Atmos/EntityNetworkUtils.cs
+++ b/Content.Server/Atmos/EntityNetworkUtils.cs
@@ -1,0 +1,31 @@
+using System;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.Server.Atmos
+{
+    public static class EntityNetworkUtils
+    {
+        public static Vector2i CardinalToIntVec(this Direction dir)
+        {
+            switch (dir)
+            {
+                case Direction.North:
+                    return new Vector2i(0, 1);
+                case Direction.East:
+                    return new Vector2i(1, 0);
+                case Direction.South:
+                    return new Vector2i(0, -1);
+                case Direction.West:
+                    return new Vector2i(-1, 0);
+                default:
+                    throw new ArgumentException($"Direction dir {dir} is not a cardinal direction", nameof(dir));
+            }
+        }
+
+        public static MapIndices Offset(this MapIndices pos, Direction dir)
+        {
+            return pos + (MapIndices) dir.CardinalToIntVec();
+        }
+    }
+}

--- a/Content.Server/Atmos/Gas.cs
+++ b/Content.Server/Atmos/Gas.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Atmos
+{
+    public enum Gas
+    {
+        Oxygen,
+        Nitrogen,
+        Plasma,
+        CarbonDioxide,
+    }
+}

--- a/Content.Server/EntryPoint.cs
+++ b/Content.Server/EntryPoint.cs
@@ -1,6 +1,8 @@
-﻿using Content.Server.Chat;
+using Content.Server.Atmos;
+using Content.Server.Chat;
 using Content.Server.GameTicking;
 using Content.Server.Interfaces;
+using Content.Server.Interfaces.Atmos;
 using Content.Server.Interfaces.Chat;
 using Content.Server.Interfaces.GameTicking;
 using Content.Server.Sandbox;
@@ -50,6 +52,7 @@ namespace Content.Server
             IoCManager.Register<IChatManager, ChatManager>();
             IoCManager.Register<IMoMMILink, MoMMILink>();
             IoCManager.Register<ISandboxManager, SandboxManager>();
+            IoCManager.Register<IAtmosphereMap, AtmosphereMap>();
             if (TestingCallbacks != null)
             {
                 var cast = (ServerModuleTestingCallbacks) TestingCallbacks;

--- a/Content.Server/GameObjects/Components/Atmos/AirtightComponent.cs
+++ b/Content.Server/GameObjects/Components/Atmos/AirtightComponent.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Content.Server.Interfaces.Atmos;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components.Transform;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Server.GameObjects.Components.Atmos
+{
+    [RegisterComponent]
+    public class AirtightComponent : Component
+    {
+#pragma warning disable 649
+        [Dependency] private readonly IAtmosphereMap _atmosphereMap;
+#pragma warning restore 649
+
+        public override string Name => "Airtight";
+
+        public bool UseAdjacentAtmosphere;
+
+        public override void ExposeData(ObjectSerializer serializer)
+        {
+            base.ExposeData(serializer);
+
+            serializer.DataField(ref UseAdjacentAtmosphere, "adjacentAtmosphere", false);
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            // Using the SnapGrid is critical for the performance of the room builder, and thus if
+            // it is absent the component will not be airtight. An exception is much easier to track
+            // down than the object magically not being airtight, so throw one if the SnapGrid component
+            // is missing.
+            if (!Owner.HasComponent<SnapGridComponent>())
+                throw new Exception("Airtight entities must have a SnapGrid component");
+        }
+
+        protected override void Startup()
+        {
+            base.Startup();
+            Owner.Transform.OnMove += OnTransformMove;
+            UpdatePosition();
+        }
+
+        protected override void Shutdown()
+        {
+            base.Shutdown();
+            Owner.Transform.OnMove -= OnTransformMove;
+            UpdatePosition();
+        }
+
+        private void OnTransformMove(object sender, MoveEventArgs args)
+        {
+            UpdatePosition(args.OldPosition);
+            UpdatePosition(args.NewPosition);
+        }
+
+        private void UpdatePosition() => UpdatePosition(Owner.Transform.GridPosition);
+
+        private void UpdatePosition(GridCoordinates pos)
+        {
+            _atmosphereMap.GetGridAtmosphereManager(Owner.Transform.GridID).Invalidate(pos);
+        }
+    }
+}

--- a/Content.Server/GameObjects/EntitySystems/AtmosSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AtmosSystem.cs
@@ -1,0 +1,18 @@
+﻿using Content.Server.Interfaces.Atmos;
+using Robust.Shared.GameObjects.Systems;
+using Robust.Shared.IoC;
+
+namespace Content.Server.GameObjects.EntitySystems
+{
+    class AtmosSystem : EntitySystem
+    {
+#pragma warning disable 649
+        [Dependency] private readonly IAtmosphereMap _atmosphereMap;
+#pragma warning restore 649
+
+        public override void Update(float frameTime)
+        {
+            _atmosphereMap.Update(frameTime);
+        }
+    }
+}

--- a/Content.Server/Interfaces/Atmos/GasProperty.cs
+++ b/Content.Server/Interfaces/Atmos/GasProperty.cs
@@ -1,0 +1,22 @@
+using Content.Server.Atmos;
+
+namespace Content.Server.Interfaces.Atmos
+{
+    public struct GasProperty
+    {
+        /// <summary>
+        /// The type of this gas
+        /// </summary>
+        public Gas Gas;
+
+        /// <summary>
+        /// The volume, in mols, of the gas
+        /// </summary>
+        public float Volume;
+
+        /// <summary>
+        /// The partial pressure of this gas, in kilopascals
+        /// </summary>
+        public float PartialPressure;
+    }
+}

--- a/Content.Server/Interfaces/Atmos/IAtmosphereMap.cs
+++ b/Content.Server/Interfaces/Atmos/IAtmosphereMap.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Content.Server.Atmos;
 using Robust.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.Map;
 
@@ -81,5 +83,97 @@ namespace Content.Server.Interfaces.Atmos
     /// </remarks>
     public interface IAtmosphere
     {
+        /// <summary>
+        /// All the gasses contained in this atmosphere
+        /// </summary>
+        IEnumerable<GasProperty> Gasses { get; }
+
+        /// <summary>
+        /// The volume of the room enclosed by this atmosphere, in cubic meters
+        /// </summary>
+        float Volume { get; }
+
+        /// <summary>
+        /// The total pressure of this room, in kilopascals
+        /// </summary>
+        /// <remarks>
+        /// Governed by the ideal gas law
+        /// </remarks>
+        float Pressure { get; }
+
+        /// <summary>
+        /// The combined quantity of all gasses in this room, in mols
+        /// </summary>
+        /// <remarks>
+        /// This function must be constant time with respect to the contents of the atmosphere.
+        /// </remarks>
+        float Quantity { get; }
+
+        /// <summary>
+        /// The mass of the contents of this atmosphere
+        /// </summary>
+        float Mass { get; }
+
+        /// <summary>
+        /// The temperature of this atmosphere, in degrees kelvin.
+        /// </summary>
+        float Temperature { get; set; }
+
+        /// <summary>
+        /// Under the ideal gas law, this returns a coefficent to convert a quantity (in
+        /// mols) into a pressure (in kilopascals).
+        /// </summary>
+        /// <remarks>
+        /// <code>PV=nRT</code>
+        /// For any given gas in this atmosphere:
+        /// <code>partialPressure = gasVolume * atmos.PressureRatio</code>
+        /// This function <b>must</b> be constant time with respect to the number of gasses present, as
+        /// it will be called extremely frequently. The use of a backing field is encouraged.
+        /// </remarks>
+        float PressureRatio { get; }
+
+        /// <summary>
+        /// Gets the quantity of a given gas
+        /// </summary>
+        /// <param name="gas">The type of gas to look for</param>
+        /// <returns>The quantity of the gas in mols</returns>
+        float QuantityOf(Gas gas);
+
+        /// <summary>
+        /// The partial pressure of a specific gas
+        /// </summary>
+        /// <param name="gas">The gas in question</param>
+        /// <returns>The partial pressure in kilopascals</returns>
+        float PartialPressureOf(Gas gas);
+
+        /// <summary>
+        /// Adds a quantity of gas to this room
+        /// </summary>
+        /// <remarks>
+        /// This attempts to add the specified quantity of gas to the room. The
+        /// amount successfully added is returned.
+        ///
+        /// It is legal to pass a negative quantity, which will be removed from the atmosphere. The
+        /// return value will be the change in quantity, thus a negative value.
+        /// </remarks>
+        /// <param name="gas">The type of gas to add</param>
+        /// <param name="quantity">The quantity, in mols, to add</param>
+        /// <param name="temperature">The temperature of the incoming gas, in kelvin</param>
+        /// <returns>The quantity of gas actually added</returns>
+        float Add(Gas gas, float quantity, float temperature);
+
+        /// <summary>
+        /// Sets the quantity of a type of gas in the atmosphere.
+        /// </summary>
+        /// <remarks>
+        /// Some gas containers may not be able to hold more than a certain amount of gas, and thus
+        /// may return a value lower than the passed volume.
+        ///
+        /// <paramref name="volume"/> must not be negative.
+        /// </remarks>
+        /// <param name="gas">The type of gas to affect</param>
+        /// <param name="volume">The desired volume</param>
+        /// <returns>The actual volume</returns>
+        float SetQuantity(Gas gas, float quantity);
     }
 }

--- a/Content.Server/Interfaces/Atmos/IAtmosphereMap.cs
+++ b/Content.Server/Interfaces/Atmos/IAtmosphereMap.cs
@@ -1,0 +1,85 @@
+using Robust.Shared.Interfaces.GameObjects.Components;
+using Robust.Shared.Map;
+
+namespace Content.Server.Interfaces.Atmos
+{
+    /// <summary>
+    /// The server-wide atmosphere manager. This encapsulates the atmospherics backend, which
+    /// divides the world up into different atmospheres enclosed in their own rooms.
+    /// </summary>
+    public interface IAtmosphereMap
+    {
+        /// <summary>
+        /// Get the atmosphere manager for a grid, by it's ID
+        /// </summary>
+        /// <remarks>
+        /// Must throw an ArgumentException if the grid does not exist in the Map Manager.
+        /// </remarks>
+        /// <param name="grid">The ID of the grid in question</param>
+        /// <returns>The atmosphere manager for the selected grid</returns>
+        IGridAtmosphereManager GetGridAtmosphereManager(GridId grid);
+
+        /// <summary>
+        /// Get the atmosphere for a given transform.
+        /// </summary>
+        /// <remarks>
+        /// This must be functionally equivalent to:
+        /// <code>
+        /// GetGridAtmosphereManager(position.GridID).GetAtmosphere(position.GridPosition);
+        /// </code>
+        /// This method is provided since looking up the atmosphere of an entity is a very
+        /// common operation, and the implementation may wish to apply optimisations for this
+        /// use-case.
+        /// </remarks>
+        /// <param name="position">The position at which to find the atmosphere</param>
+        /// <returns>The atmosphere at the given point, or <code>null</code> in the vacuum of space</returns>
+        IAtmosphere GetAtmosphere(ITransformComponent position);
+
+        /// <summary>
+        /// Update all the ship's atmospheres, both for reactions and updating modified rooms.
+        /// </summary>
+        /// <param name="frameTime">The time since the last update</param>
+        void Update(float frameTime);
+    }
+
+    /// <summary>
+    /// Manages the various separate atmospheres inside a single grid.
+    /// </summary>
+    /// <remarks>
+    /// Airlocks separate
+    /// atmospheres (as the name implies) and thus the station will have many different
+    /// atmospheres.
+    /// </remarks>
+    public interface IGridAtmosphereManager
+    {
+        /// <summary>
+        /// Get the atmosphere at a position on the grid
+        /// </summary>
+        /// <remarks>
+        /// This operation may perform expensive tasks (such as finding the outline of
+        /// the room), however repeat calls must be fast.
+        /// </remarks>
+        /// <param name="coordinates">The position on the grid</param>
+        /// <returns>The relevant atmosphere, or <code>null</code> if this cell
+        /// is connected to space</returns>
+        IAtmosphere GetAtmosphere(GridCoordinates coordinates);
+
+        /// <summary>
+        /// Notify the atmosphere system that something at a given position may have changed.
+        /// </summary>
+        /// <param name="coordinates"></param>
+        void Invalidate(GridCoordinates coordinates);
+    }
+
+    /// <summary>
+    /// Represents a single 'region' of the station, inside which air can mix freely.
+    /// </summary>
+    /// <remarks>
+    /// Every cell in a region has a path to every other cell
+    /// without passing through any solid walls, or passing through airlocks
+    /// and similar objects which can block gas flow.
+    /// </remarks>
+    public interface IAtmosphere
+    {
+    }
+}

--- a/Resources/Prototypes/Entities/buildings/airlock_base.yml
+++ b/Resources/Prototypes/Entities/buildings/airlock_base.yml
@@ -41,5 +41,9 @@
     interfaces:
     - key: enum.WiresUiKey.Key
       type: WiresBoundUserInterface
+  - type: Airtight
+    adjacentAtmosphere: true
+  - type: SnapGrid
+    offset: Center
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/buildings/walls.yml
+++ b/Resources/Prototypes/Entities/buildings/walls.yml
@@ -22,6 +22,7 @@
     sizeY: 32
   - type: SnapGrid
     offset: Center
+  - type: Airtight
 
   - type: IconSmooth
     key: walls


### PR DESCRIPTION
Hello,

This PR adds two significant atmospherics-related systems:

* The basic zone area detection system - this identifies zones that are fully enclosed from space, and enclosed from other zones. It can handle zones being broken up (when walls are placed cutting a zone in two), and merged (when walls are removed, connecting two zones).
* The basic atmospheric contents system. It handles the various gas contents of zones ('Atmospheres' in the code) and performs the proper PV=nRT calculations to determine an atmosphere's pressure from it's temperature, volume and contents.

# Performance:

Calculating a new zone: When the atmosphere for a zone is first queried it is calculated, as `O(n)` with respect to the number of cells in the zone. If the zone is exposed to space, the search is cancelled as soon as that is discovered, and the cell is cached as being exposed to space.

Adding blocks: When a block is added inside an atmosphere, a fastpath check is done to determine if all it's non-obstructed sides are connected (eg, if the side above and the side to the left contain the same atmosphere and the block on the upper-left diagonal is empty, it can fastpath). If this fails, it calculates the connected sides which is `O(n)` with respect to the total number of cells for all connected atmospheres.

Removing blocks: If the block only touches a single atmosphere, it fastpaths. Otherwise the atmospheres are joined which is `O(n)` with respect to the number of cells in the new area.

Querying the atmosphere at a cell (`IAtmosphereMap.GetAtmosphere`):
* If an atmosphere is present at the queried point, this is a single Dictionary lookup
* Otherwise if the tile is space, that is returned
* Finally an atmospherics calculation is performed. In the worst case this is an area exposed to space but not directly on space, such as a room with a wall missing. In this case the space value is cached for the given position, however something like walking around will incur a performance penalty (this could be mostly fixed by caching space into all explored areas).

Finally, since rooms are lazy-calculated, if nothing queries the atmosphere there is only a negligible overhead.

# API

Calling `IAtmosphereMap.GetAtmosphere` will return the atmosphere at the given position, `null` if the tile is exposed to space and an atmosphere. Both major interfaces (`IAtmosphereMap` and `IAtmosphere`) are well documented, and should be very easy to use. 