### PR TITLE
Basic rotatable component

### DIFF
--- a/Content.Client/EntryPoint.cs
+++ b/Content.Client/EntryPoint.cs
@@ -111,6 +111,7 @@ namespace Content.Client
                 "MedicalScanner",
                 "WirePlacer",
                 "Species",
+                "Rotatable",
             };
 
             foreach (var ignoreName in registerIgnore)

--- a/Content.Server/GameObjects/Components/RotatableComponent.cs
+++ b/Content.Server/GameObjects/Components/RotatableComponent.cs
@@ -1,0 +1,53 @@
+using Content.Server.Interfaces;
+using Content.Shared.GameObjects;
+using Robust.Server.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Maths;
+
+namespace Content.Server.GameObjects.Components
+{
+    [RegisterComponent]
+    public class RotatableComponent : Component
+    {
+#pragma warning disable 649
+        [Dependency] private readonly IServerNotifyManager _notifyManager;
+        [Dependency] private readonly ILocalizationManager _localizationManager;
+#pragma warning restore 649
+        public override string Name => "Rotatable";
+
+        private void TryRotate(IEntity user)
+        {
+            if (Owner.TryGetComponent(out PhysicsComponent physics))
+            {
+                if (physics.Anchored)
+                {
+                    _notifyManager.PopupMessage(Owner.Transform.GridPosition, user, _localizationManager.GetString("It's stuck."));
+                    return;
+                }
+            }
+            Owner.Transform.LocalRotation += Angle.FromDegrees(90);
+        }
+
+        [Verb]
+        public sealed class RotateVerb : Verb<RotatableComponent>
+        {
+            protected override string GetText(IEntity user, RotatableComponent component)
+            {
+                return "Rotate";
+            }
+
+            protected override VerbVisibility GetVisibility(IEntity user, RotatableComponent component)
+            {
+                return VerbVisibility.Visible;
+            }
+
+            protected override void Activate(IEntity user, RotatableComponent component)
+            {
+                component.TryRotate(user);
+            }
+        }
+    }
+}

--- a/Content.Server/GameObjects/Components/RotatableComponent.cs
+++ b/Content.Server/GameObjects/Components/RotatableComponent.cs
@@ -18,7 +18,7 @@ namespace Content.Server.GameObjects.Components
 #pragma warning restore 649
         public override string Name => "Rotatable";
 
-        private void TryRotate(IEntity user)
+        private void TryRotate(IEntity user, Angle angle)
         {
             if (Owner.TryGetComponent(out PhysicsComponent physics))
             {
@@ -28,7 +28,8 @@ namespace Content.Server.GameObjects.Components
                     return;
                 }
             }
-            Owner.Transform.LocalRotation += Angle.FromDegrees(90);
+
+            Owner.Transform.LocalRotation += angle;
         }
 
         [Verb]
@@ -36,7 +37,7 @@ namespace Content.Server.GameObjects.Components
         {
             protected override string GetText(IEntity user, RotatableComponent component)
             {
-                return "Rotate";
+                return "Rotate clockwise";
             }
 
             protected override VerbVisibility GetVisibility(IEntity user, RotatableComponent component)
@@ -46,8 +47,28 @@ namespace Content.Server.GameObjects.Components
 
             protected override void Activate(IEntity user, RotatableComponent component)
             {
-                component.TryRotate(user);
+                component.TryRotate(user, Angle.FromDegrees(90));
             }
         }
+
+        [Verb]
+        public sealed class RotateCounterVerb : Verb<RotatableComponent>
+        {
+            protected override string GetText(IEntity user, RotatableComponent component)
+            {
+                return "Rotate counter-clockwise";
+            }
+
+            protected override VerbVisibility GetVisibility(IEntity user, RotatableComponent component)
+            {
+                return VerbVisibility.Visible;
+            }
+
+            protected override void Activate(IEntity user, RotatableComponent component)
+            {
+                component.TryRotate(user, Angle.FromDegrees(-90));
+            }
+        }
+
     }
 }

--- a/Resources/Prototypes/Entities/buildings/furniture.yml
+++ b/Resources/Prototypes/Entities/buildings/furniture.yml
@@ -16,6 +16,7 @@
   name: White Office Chair
   id: chairOfficeLight
   components:
+  - type: Rotatable
   - type: Clickable
   - type: Collidable
   - type: Sprite
@@ -29,6 +30,7 @@
   name: Dark Office Chair
   id: chairOfficeDark
   components:
+  - type: Rotatable
   - type: Clickable
   - type: Collidable
   - type: Sprite

--- a/Resources/Prototypes/Entities/buildings/vending_machines.yml
+++ b/Resources/Prototypes/Entities/buildings/vending_machines.yml
@@ -2,6 +2,9 @@
   id: VendingMachine
   name: vending machine
   components:
+  - type: Physics
+    Anchored: true
+  - type: Rotatable
   - type: Clickable
   - type: Sprite
     sprite: Buildings/VendingMachines/empty.rsi


### PR DESCRIPTION
- Added a Rotatable component that provides a "Rotate" verb.
- Can't rotate anchored objects
- Only added the component to vending machines and roller chairs for now

Questions:
- Is this the right way to go? Should this be bound to some key, maybe? R?
- If it IS the right way to go, should I make another verb to rotate counter-clockwise?
- Should I make a Wrenchable component for the simplest case of things that can be anchored/unanchored with a wrench? We currently lack a way to do this.