### PR TITLE
Fix crowbar distance to work on adjacent tiles

### DIFF
--- a/Content.Server/GameObjects/Components/Interactable/Tools/CrowbarComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/Tools/CrowbarComponent.cs
@@ -31,11 +31,10 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
             var mapGrid = _mapManager.GetGrid(eventArgs.ClickLocation.GridID);
             var tile = mapGrid.GetTileRef(eventArgs.ClickLocation);
 
-            var ownerLocation = Owner.Transform.GridPosition;
-            var tileCenterX = tile.X + 0.5;
-            var tileCenterY = tile.Y + 0.5;
+            var coordinates = mapGrid.GridTileToLocal(tile.GridIndices);
+            float distance = coordinates.Distance(_mapManager, Owner.Transform.GridPosition);
 
-            if (Distance(ownerLocation.X, tileCenterX, ownerLocation.Y, tileCenterY) > MAX_DISTANCE)
+            if (distance > MAX_DISTANCE)
             {
                 return;
             }
@@ -47,11 +46,6 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
                 mapGrid.SetTile(eventArgs.ClickLocation, new Tile(underplating.TileId));
                _entitySystemManager.GetEntitySystem<AudioSystem>().Play("/Audio/items/crowbar.ogg", Owner);
             }
-        }
-
-        private double Distance(float x1, double x2, float y1, double y2)
-        {
-            return Math.Sqrt(Math.Pow(x1 - x2, 2) + Math.Pow(y1 - y2, 2));
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Interactable/Tools/CrowbarComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/Tools/CrowbarComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.GameObjects.EntitySystems;
+﻿using System;
+using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.Maps;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
@@ -18,6 +19,8 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
         [Dependency] private readonly IMapManager _mapManager;
 #pragma warning restore 649
 
+        private double MAX_DISTANCE = 1.5;
+
         /// <summary>
         /// Tool that can be used to crowbar things apart, such as deconstructing
         /// </summary>
@@ -27,6 +30,16 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
         {
             var mapGrid = _mapManager.GetGrid(eventArgs.ClickLocation.GridID);
             var tile = mapGrid.GetTileRef(eventArgs.ClickLocation);
+
+            var ownerLocation = Owner.Transform.GridPosition;
+            var tileCenterX = tile.X + 0.5;
+            var tileCenterY = tile.Y + 0.5;
+
+            if (Distance(ownerLocation.X, tileCenterX, ownerLocation.Y, tileCenterY) > MAX_DISTANCE)
+            {
+                return;
+            }
+
             var tileDef = (ContentTileDefinition)_tileDefinitionManager[tile.Tile.TypeId];
             if (tileDef.CanCrowbar)
             {
@@ -34,6 +47,11 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
                 mapGrid.SetTile(eventArgs.ClickLocation, new Tile(underplating.TileId));
                _entitySystemManager.GetEntitySystem<AudioSystem>().Play("/Audio/items/crowbar.ogg", Owner);
             }
+        }
+
+        private double Distance(float x1, double x2, float y1, double y2)
+        {
+            return Math.Sqrt(Math.Pow(x1 - x2, 2) + Math.Pow(y1 - y2, 2));
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Interactable/Tools/CrowbarComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/Tools/CrowbarComponent.cs
@@ -19,8 +19,6 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
         [Dependency] private readonly IMapManager _mapManager;
 #pragma warning restore 649
 
-        private double MAX_DISTANCE = 1.5;
-
         /// <summary>
         /// Tool that can be used to crowbar things apart, such as deconstructing
         /// </summary>
@@ -34,7 +32,7 @@ namespace Content.Server.GameObjects.Components.Interactable.Tools
             var coordinates = mapGrid.GridTileToLocal(tile.GridIndices);
             float distance = coordinates.Distance(_mapManager, Owner.Transform.GridPosition);
 
-            if (distance > MAX_DISTANCE)
+            if (distance > InteractionSystem.InteractionRange)
             {
                 return;
             }


### PR DESCRIPTION
This limits crowbar to work on adjacent tiles only.

I assume here that adjacent are not more than 1.5 tiles far away.

Do you propose this code to be moved to some other place? Or is there already some code that calculates this distance?