### PR TITLE
Fix RangedWeapon firing when not in combat mode

### DIFF
--- a/Content.Server/GameObjects/Components/Weapon/Ranged/RangedWeapon.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/RangedWeapon.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Content.Server.GameObjects.Components.Mobs;
 using Content.Shared.GameObjects.Components.Weapons.Ranged;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.GameObjects;
@@ -63,6 +64,10 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged
         {
             if (!user.TryGetComponent(out HandsComponent hands) || hands.GetActiveHand?.Owner != Owner)
             {
+                return;
+            }
+
+            if(!user.TryGetComponent(out CombatModeComponent combat) || !combat.IsInCombatMode) {
                 return;
             }
 


### PR DESCRIPTION
Fixes: #397
Adds a check to RangedWeapon.cs to check for combat mode before firing.