### PR TITLE
Fixes PowerProvider range calculation

### DIFF
--- a/Content.Server/GameObjects/Components/Power/PowerProviderComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerProviderComponent.cs
@@ -285,7 +285,7 @@ namespace Content.Server.GameObjects.Components.Power
             if (this == device)
                 return false;
 
-            return (device.Owner.Transform.WorldPosition - Owner.Transform.WorldPosition).LengthSquared <= _range;
+            return (device.Owner.Transform.WorldPosition - Owner.Transform.WorldPosition).Length <= _range;
         }
     }
 }


### PR DESCRIPTION
PowerProvider was checking the squared distance between it and devices against its range, which meant that its effective range was the sqrt of what it should have been.