### PR TITLE
Fix various bugs with construction

### DIFF
--- a/Content.Client/Construction/ConstructionMenu.cs
+++ b/Content.Client/Construction/ConstructionMenu.cs
@@ -161,17 +161,17 @@ namespace Content.Client.Construction
                             {
                                 case ConstructionStepMaterial.MaterialType.Metal:
                                     icon = ResourceCache.GetResource<TextureResource>(
-                                        "/Textures/Objects/sheet_metal.png");
+                                        "/Textures/Objects/Materials/sheet_metal.png");
                                     text = $"Metal x{mat.Amount}";
                                     break;
                                 case ConstructionStepMaterial.MaterialType.Glass:
                                     icon = ResourceCache.GetResource<TextureResource>(
-                                        "/Textures/Objects/sheet_glass.png");
+                                        "/Textures/Objects/Materials/sheet_glass.png");
                                     text = $"Glass x{mat.Amount}";
                                     break;
                                 case ConstructionStepMaterial.MaterialType.Cable:
                                     icon = ResourceCache.GetResource<TextureResource>(
-                                        "/Textures/Objects/cable_coil.png");
+                                        "/Textures/Objects/Tools/cable_coil.png");
                                     text = $"Cable Coil x{mat.Amount}";
                                     break;
                                 default:
@@ -183,16 +183,16 @@ namespace Content.Client.Construction
                             switch (tool.Tool)
                             {
                                 case ConstructionStepTool.ToolType.Wrench:
-                                    icon = ResourceCache.GetResource<TextureResource>("/Textures/Objects/wrench.png");
+                                    icon = ResourceCache.GetResource<TextureResource>("/Textures/Objects/Tools/wrench.png");
                                     text = "Wrench";
                                     break;
                                 case ConstructionStepTool.ToolType.Crowbar:
-                                    icon = ResourceCache.GetResource<TextureResource>("/Textures/Objects/crowbar.png");
+                                    icon = ResourceCache.GetResource<TextureResource>("/Textures/Objects/Tools/crowbar.png");
                                     text = "Crowbar";
                                     break;
                                 case ConstructionStepTool.ToolType.Screwdriver:
                                     icon = ResourceCache.GetResource<TextureResource>(
-                                        "/Textures/Objects/screwdriver.png");
+                                        "/Textures/Objects/Tools/screwdriver.png");
                                     text = "Screwdriver";
                                     break;
                                 case ConstructionStepTool.ToolType.Welder:
@@ -202,7 +202,7 @@ namespace Content.Client.Construction
                                     break;
                                 case ConstructionStepTool.ToolType.Wirecutters:
                                     icon = ResourceCache.GetResource<TextureResource>(
-                                        "/Textures/Objects/wirecutter.png");
+                                        "/Textures/Objects/Tools/wirecutter.png");
                                     text = "Wirecutters";
                                     break;
                                 default:

--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -91,7 +91,16 @@ namespace Content.Server.GameObjects.Components.Construction
         {
             Prototype = prototype;
             Stage = 1;
-            Sprite.AddLayerWithSprite(prototype.Stages[1].Icon);
+            if(prototype.Stages[1].Icon != null)
+            {
+                Sprite.AddLayerWithSprite(prototype.Stages[1].Icon);
+            }
+            else
+            {
+                Sprite.AddLayerWithSprite(prototype.Icon);
+            }
+            
+
         }
 
         bool TryProcessStep(ConstructionStep step, IEntity slapped)

--- a/Resources/Prototypes/Construction/structures.yml
+++ b/Resources/Prototypes/Construction/structures.yml
@@ -4,10 +4,10 @@
   category: Structures
   description: Keeps the air in and the greytide out.
   icon:
-    sprite: Buildings/wall.rsi
+    sprite: Buildings/Walls/solid.rsi
     state: full
   objecttype: Structure
-  result: wall
+  result: solid_wall
   placementmode: SnapgridCenter
   steps:
   - material: Metal
@@ -25,7 +25,9 @@
   name: Table
   id: table
   category: Structures
-  icon: Objects/Furniture/worktop_single.png
+  icon: 
+    sprite: Buildings/table_solid.rsi
+    state: plain_preview
   result: table
   placementmode: SnapgridCenter
   steps:

--- a/Resources/Prototypes/Construction/weapons.yml
+++ b/Resources/Prototypes/Construction/weapons.yml
@@ -5,6 +5,7 @@
   keywords: [melee]
   description: A crude spear for when you need to put holes in somebody.
   icon: Objects/Melee/spear.rsi/spear.png
+  result: Spear
   objecttype: Item
   steps:
   - material: Metal


### PR DESCRIPTION
Fixes: #228 

Perhaps one day someone should de-hardcode all this. I think allowing just a generic `EntityPrototype` to be a constructionstep is a good idea for down the road. Right now its a bit too complicated to do anything like that.
This doesn't fix the `ConstructionMenu` list being all jittery if you resize the window.