### PR TITLE
Server-side GlobalVerbs now work when used

### DIFF
--- a/Content.Server/GameObjects/EntitySystems/VerbSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/VerbSystem.cs
@@ -112,6 +112,27 @@ namespace Content.Server.GameObjects.EntitySystems
                         break;
                     }
 
+                    foreach (var globalVerb in VerbUtility.GetGlobalVerbs(Assembly.GetExecutingAssembly()))
+                    {
+                        if (globalVerb.GetType().ToString() != use.VerbKey)
+                        {
+                            continue;
+                        }
+
+                        if (globalVerb.RequireInteractionRange)
+                        {
+                            var distanceSquared = (userEntity.Transform.WorldPosition - entity.Transform.WorldPosition)
+                                .LengthSquared;
+                            if (distanceSquared > VerbUtility.InteractionRangeSquared)
+                            {
+                                break;
+                            }
+                        }
+
+                        globalVerb.Activate(userEntity, entity);
+                        break;
+                    }
+
                     break;
                 }
             }


### PR DESCRIPTION
While helping @dylanstrategie with the Rejuvenate verb, we discovered that Server-side `GlobalVerb`s are never actually activated... This was technically fine as there were no Server-side `GlobalVerb`s, but since dylan is rewriting Rejuv to be one, then it's obviously a problem.