### PR TITLE
Add filled toolbelt variant for easy engineering

### DIFF
--- a/Content.Server/GameObjects/Components/Items/Storage/Fill/UtilityBeltClothingFillComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/Fill/UtilityBeltClothingFillComponent.cs
@@ -1,0 +1,36 @@
+﻿using Robust.Server.Interfaces.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Random;
+using Robust.Shared.IoC;
+
+namespace Content.Server.GameObjects.Components.Items.Storage.Fill
+{
+    [RegisterComponent]
+    internal sealed class UtilityBeltClothingFillComponent : Component, IMapInit
+    {
+        public override string Name => "UtilityBeltClothingFill";
+
+#pragma warning disable 649
+        [Dependency] private readonly IEntityManager _entityManager;
+#pragma warning restore 649
+
+        void IMapInit.MapInit()
+        {
+            var storage = Owner.GetComponent<IStorageComponent>();
+
+            void Spawn(string prototype)
+            {
+                storage.Insert(_entityManager.SpawnEntity(prototype));
+            }
+
+            Spawn("Crowbar");
+            Spawn("Wrench");
+            Spawn("Screwdriver");
+            Spawn("Wirecutter");
+            Spawn("Welder");
+            Spawn("Multitool");
+            Spawn("CableStack");
+        }
+    }
+}

--- a/Resources/Maps/stationstation.yml
+++ b/Resources/Maps/stationstation.yml
@@ -3049,7 +3049,7 @@ entities:
       mask: 5
       bounds: -0.25,-0.25,0.25,0.25
     type: Collidable
-- type: UtilityBeltClothing
+- type: UtilityBeltClothingFilled
   uid: 260
   components:
   - grid: 0
@@ -3067,7 +3067,7 @@ entities:
         entities: []
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- type: UtilityBeltClothing
+- type: UtilityBeltClothingFilled
   uid: 261
   components:
   - grid: 0

--- a/Resources/Prototypes/Entities/items/clothing/belts.yml
+++ b/Resources/Prototypes/Entities/items/clothing/belts.yml
@@ -20,7 +20,13 @@
     sprite: Clothing/belt_utility.rsi
     state: utilitybelt
   - type: Clothing
-    Size: 30
+    Size: 50
     sprite: Clothing/belt_utility.rsi
   - type: Storage
-    Capacity: 30
+    Capacity: 40 # Full tool loadout is 35, plus an extra
+
+- type: entity
+  id: UtilityBeltClothingFilled
+  parent: UtilityBeltClothing
+  components:
+  - type: UtilityBeltClothingFill

--- a/Resources/Prototypes/Entities/items/clothing/belts.yml
+++ b/Resources/Prototypes/Entities/items/clothing/belts.yml
@@ -30,3 +30,4 @@
   parent: UtilityBeltClothing
   components:
   - type: UtilityBeltClothingFill
+  


### PR DESCRIPTION
- Toolbelt capacity increased to 40 from 30 to hold all its tools from a typical SS13 inventory plus one extra slot for a flashlight/T-ray/donk pocket/whatevs
- Toolbelt now has a filled version with the good old inventory everyone came to know and love (plus a multitool)
- Two toolbelts on the map swapped with new variant for easy tool testing