### PR TITLE
Add null check before using prototype in ReagentDispenserWindow

### DIFF
--- a/Content.Client/GameObjects/Components/Chemistry/ReagentDispenserWindow.cs
+++ b/Content.Client/GameObjects/Components/Chemistry/ReagentDispenserWindow.cs
@@ -237,7 +237,7 @@ namespace Content.Client.GameObjects.Components.Chemistry
                 }
 
                 //Check if the reagent is being moused over. If so, color it green.
-                if (proto.ID == highlightedReagentId)
+                if (proto != null && proto.ID == highlightedReagentId)
                 {
                     ContainerInfo.Children.Add(new HBoxContainer
                     {


### PR DESCRIPTION
Should fix #460. I'm unable to reproduce it myself, but the stack trace shows the crash occurring on the edited line, likely because `prop` is null. This fixes that by adding a null check before using `prop`.