### PR TITLE
Fix crash on restart

### DIFF
--- a/Content.Client/GameObjects/Components/HUD/Inventory/ClientInventoryComponent.cs
+++ b/Content.Client/GameObjects/Components/HUD/Inventory/ClientInventoryComponent.cs
@@ -34,6 +34,7 @@ namespace Content.Client.GameObjects
         {
             base.OnRemove();
 
+            InterfaceController?.PlayerDetached();
             InterfaceController?.Dispose();
         }
 


### PR DESCRIPTION
Entities weren't getting removed from the HumanInventoryInterfaceController on restart, so Clyde would try to render the deleted entities, leading to a crash.

This change clears SpriteView.Sprites from all the InventoryButtons before disposal when ClientInventoryComponent is removed.