### PR TITLE
ActivateItemInWorld opens storage in hands

### DIFF
--- a/Content.Client/GameObjects/Components/Items/ClientHandsComponent.cs
+++ b/Content.Client/GameObjects/Components/Items/ClientHandsComponent.cs
@@ -188,5 +188,14 @@ namespace Content.Client.GameObjects
                 SendNetworkMessage(new ActivateInhandMsg());
             }
         }
+
+        public void SendOpenStorage(string index)
+        {
+            var entity = GetEntity(index);
+            if (entity != null)
+            {
+                SendNetworkMessage(new OpenHandStorageUIMessage(index));
+            }
+        }
     }
 }

--- a/Content.Client/Interfaces/GameObjects/Components/Items/IHandsComponent.cs
+++ b/Content.Client/Interfaces/GameObjects/Components/Items/IHandsComponent.cs
@@ -12,5 +12,6 @@ namespace Content.Client.Interfaces.GameObjects
 
         void SendChangeHand(string index);
         void AttackByInHand(string index);
+        void SendOpenStorage(string index);
     }
 }

--- a/Content.Client/UserInterface/HandsGui.cs
+++ b/Content.Client/UserInterface/HandsGui.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using Content.Client.GameObjects;
+using Content.Client.GameObjects.Components.Storage;
 using Content.Client.GameObjects.EntitySystems;
 using Content.Client.Interfaces.GameObjects;
 using Content.Client.Utility;
 using Content.Shared.GameObjects.Components.Items;
+using Content.Shared.GameObjects.Components.Storage;
 using Content.Shared.Input;
 using Robust.Client.Graphics;
 using Robust.Client.Interfaces.GameObjects.Components;
@@ -230,6 +232,19 @@ namespace Content.Client.UserInterface
             hands.AttackByInHand(hand);
         }
 
+        private void ActivateItemInWorld(string hand)
+        {
+            if (!TryGetHands(out var hands))
+                return;
+            var entity = hands.GetEntity(hand);
+            if (entity == null)
+                return;
+            if (entity.HasComponent<ClientStorageComponent>())
+            {
+               hands.SendOpenStorage(hand);
+            }
+        }
+
         protected override bool HasPoint(Vector2 point)
         {
             return _handL.Contains((Vector2i) point) || _handR.Contains((Vector2i) point);
@@ -239,10 +254,10 @@ namespace Content.Client.UserInterface
         {
             base.KeyBindDown(args);
 
-            if (!args.CanFocus)
-            {
-                return;
-            }
+            //if (!args.CanFocus)
+            //{
+            //    return;
+            //}
 
             var leftHandContains = _handL.Contains((Vector2i) args.RelativePosition);
             var rightHandContains = _handR.Contains((Vector2i) args.RelativePosition);
@@ -298,6 +313,11 @@ namespace Content.Client.UserInterface
                 var esm = IoCManager.Resolve<IEntitySystemManager>();
                 esm.GetEntitySystem<VerbSystem>()
                     .OpenContextMenu(entity, new ScreenCoordinates(args.PointerLocation.Position));
+            }
+
+            else if (args.Function == ContentKeyFunctions.ActivateItemInWorld)
+            {
+                ActivateItemInWorld(handIndex);
             }
         }
 

--- a/Content.Server/GameObjects/Components/GUI/ServerHandsComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/ServerHandsComponent.cs
@@ -509,6 +509,29 @@ namespace Content.Server.GameObjects
 
                     break;
                 }
+
+                case OpenHandStorageUIMessage msg:
+                {
+                    if (!hands.TryGetValue(msg.Index, out var slot))
+                    {
+                        Logger.WarningS("go.comp.hands", "Got a OpenHandStorageUIMessage with invalid hand index '{0}'", msg.Index);
+                        return;
+                    }
+
+                    var playerMan = IoCManager.Resolve<IPlayerManager>();
+                    var session = playerMan.GetSessionByChannel(netChannel);
+                    var playerEntity = session.AttachedEntity;
+
+                    if (playerEntity != Owner || slot.ContainedEntity == null)
+                        return;
+
+                    if (slot.ContainedEntity.TryGetComponent<ServerStorageComponent>(out ServerStorageComponent storage))
+                    {
+                        storage.OpenStorageUI(Owner);
+                    }
+
+                    break;
+                }
             }
         }
 

--- a/Content.Shared/GameObjects/Components/Items/SharedHandsComponent.cs
+++ b/Content.Shared/GameObjects/Components/Items/SharedHandsComponent.cs
@@ -61,4 +61,16 @@ namespace Content.Shared.GameObjects
             Index = index;
         }
     }
+
+    [Serializable, NetSerializable]
+    public class OpenHandStorageUIMessage : ComponentMessage
+    {
+        public string Index { get; }
+
+        public OpenHandStorageUIMessage(string index)
+        {
+            Directed = true;
+            Index = index;
+        }
+    }
 }


### PR DESCRIPTION
#440 

Pressing E while hovering over a storage item in your hands opens it.

I wasn't sure how to implement the little clickable button also suggested in that issue, so I'll add it later when I figure it out.