### PR TITLE
Fix bug with chemical reactions which cause other reactions

### DIFF
--- a/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -192,14 +192,27 @@ namespace Content.Server.GameObjects.Components.Chemistry
 
         private void CheckForReaction()
         {
-            //Check the solution for every reaction
-            foreach (var reaction in _reactions)
+            bool checkForNewReaction = false;
+            while (true)
             {
-                if (SolutionValidReaction(reaction, out int unitReactions))
+                //Check the solution for every reaction
+                foreach (var reaction in _reactions)
                 {
-                    PerformReaction(reaction, unitReactions);
-                    break; //Only perform one reaction per solution per update.
+                    if (SolutionValidReaction(reaction, out int unitReactions))
+                    {
+                        PerformReaction(reaction, unitReactions);
+                        checkForNewReaction = true; 
+                        break;
+                    }
                 }
+
+                //Check for a new reaction if a reaction occurs, run loop again.
+                if (checkForNewReaction)
+                {
+                    checkForNewReaction = false;
+                    continue;
+                }
+                return;
             }
         }
 


### PR DESCRIPTION
`SolutionComponent.CheckForReaction` only checks for a reaction once each time something is added to the solution. This means that if a reaction generates reagents that result in another valid reaction, that second reaction won't occur until something else is added to the solution. This fixes that by repeatedly checking for a reaction until no more occur.

This was found by @unusualcrow . A quick way to see the bug is to add reagents to a beaker in this order: potassium, hydrogen, oxygen. The hydrogen and oxygen with react and make water. That water should then react with the potassium and explode, but doesn't until you add more reagents to the solution triggering another reaction check.