### PR TITLE
Fixes the player being able to use the chem dispenser when they'…

### DIFF
--- a/Content.Server/GameObjects/Components/Chemistry/ReagentDispenserComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/ReagentDispenserComponent.cs
@@ -156,11 +156,8 @@ namespace Content.Server.GameObjects.Components.Chemistry
             //Need player entity to check if they are still able to use the dispenser
             if (playerEntity == null) 
                 return false;
-            //Get species component that has damage state
-            if (!playerEntity.TryGetComponent(out SpeciesComponent species)) 
-                return false;
             //Check if player can interact in their current state
-            if (!species.CurrentDamageState.CanInteract() || !species.CurrentDamageState.CanUse())
+            if (!ActionBlockerSystem.CanInteract(playerEntity) || !ActionBlockerSystem.CanUse(playerEntity))
                 return false;
 
             return true;

--- a/Content.Server/GameObjects/Components/Chemistry/ReagentDispenserComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/ReagentDispenserComponent.cs
@@ -11,6 +11,7 @@ using Robust.Server.GameObjects.Components.UserInterface;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Prototypes;
@@ -101,6 +102,9 @@ namespace Content.Server.GameObjects.Components.Chemistry
         /// <param name="obj">A user interface message from the client.</param>
         private void OnUiReceiveMessage(ServerBoundUserInterfaceMessage obj)
         {
+            if(!PlayerCanUseDispenser(obj.Session.AttachedEntity))
+                return;
+
             var msg = (UiButtonPressedMessage) obj.Message;
             switch (msg.Button)
             {
@@ -140,6 +144,26 @@ namespace Content.Server.GameObjects.Components.Chemistry
             }
 
             ClickSound();
+        }
+
+        /// <summary>
+        /// Checks whether the player entity is able to use the chem dispenser.
+        /// </summary>
+        /// <param name="playerEntity">The player entity.</param>
+        /// <returns>Returns true if the entity can use the dispenser, and false if it cannot.</returns>
+        private bool PlayerCanUseDispenser(IEntity playerEntity)
+        {
+            //Need player entity to check if they are still able to use the dispenser
+            if (playerEntity == null) 
+                return false;
+            //Get species component that has damage state
+            if (!playerEntity.TryGetComponent(out SpeciesComponent species)) 
+                return false;
+            //Check if player can interact in their current state
+            if (!species.CurrentDamageState.CanInteract() || !species.CurrentDamageState.CanUse())
+                return false;
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #478. Adds a check to `ReagentDispenserComponent.OnUiReceiveMessage()` that checks if the players `SpeciesComponent` has a damage state that prevents them from interacting with the chem dispenser. Currently doesn't let them use it if they don't have a `SpeciesComponent`, or if they have an action blocker for `CanUse` or `CanInteract`. 