### PR TITLE
New entity collision layers

### DIFF
--- a/Content.Server/AI/AimShootLifeProcessor.cs
+++ b/Content.Server/AI/AimShootLifeProcessor.cs
@@ -111,7 +111,7 @@ namespace Content.Server.AI
 
                 // build the ray
                 var dir = entity.GetComponent<ITransformComponent>().WorldPosition - myTransform.WorldPosition;
-                var ray = new Ray(myTransform.WorldPosition, dir.Normalized, (int)(CollisionGroup.Mob | CollisionGroup.Grid));
+                var ray = new Ray(myTransform.WorldPosition, dir.Normalized, (int)(CollisionGroup.MobImpassable | CollisionGroup.Impassable));
 
                 // cast the ray
                 var result = _physMan.IntersectRay(ray, maxRayLen);

--- a/Content.Server/AI/WanderProcessor.cs
+++ b/Content.Server/AI/WanderProcessor.cs
@@ -126,7 +126,7 @@ namespace Content.Server.AI
             for (var i = 0; i < 3; i++) // you get 3 chances to find a place to walk
             {
                 var dir = new Vector2(Random01(ref rngState) * 2 - 1, Random01(ref rngState) *2 -1);
-                var ray = new Ray(entWorldPos, dir, (int) CollisionGroup.Grid);
+                var ray = new Ray(entWorldPos, dir, (int) CollisionGroup.Impassable);
                 var rayResult = _physMan.IntersectRay(ray, MaxWalkDistance, SelfEntity);
 
                 if (rayResult.DidHitObject && rayResult.Distance > 1) // hit an impassable object

--- a/Content.Server/GameObjects/Components/Projectiles/ThrownItemComponent.cs
+++ b/Content.Server/GameObjects/Components/Projectiles/ThrownItemComponent.cs
@@ -41,7 +41,7 @@ namespace Content.Server.GameObjects.Components
             // This would allow ricochets off walls, and weird gravity effects from slowing the object.
             if (collidedwith.Count > 0 && Owner.TryGetComponent(out CollidableComponent body) && body.PhysicsShapes.Count >= 1)
             {
-                body.PhysicsShapes[0].CollisionMask &= (int)~CollisionGroup.Mob;
+                body.PhysicsShapes[0].CollisionMask &= (int)~CollisionGroup.MobImpassable;
                 body.IsScrapingFloor = true;
 
                 // KYS, your job is finished. Trigger ILand as well.

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Hitscan/HitscanWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Hitscan/HitscanWeaponComponent.cs
@@ -89,7 +89,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Hitscan
             var userPosition = user.Transform.WorldPosition; //Remember world positions are ephemeral and can only be used instantaneously
             var angle = new Angle(clickLocation.Position - userPosition);
 
-            var ray = new Ray(userPosition, angle.ToVec(), (int)(CollisionGroup.Grid | CollisionGroup.Mob));
+            var ray = new Ray(userPosition, angle.ToVec(), (int)(CollisionGroup.Impassable | CollisionGroup.MobImpassable));
             var rayCastResults = IoCManager.Resolve<IPhysicsManager>().IntersectRay(ray, MaxLength,
                 Owner.Transform.GetMapTransform().Owner);
 

--- a/Content.Server/GameObjects/EntitySystems/HandsSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/HandsSystem.cs
@@ -196,7 +196,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 if(colComp.PhysicsShapes.Count == 0)
                     colComp.PhysicsShapes.Add(new PhysShapeAabb());
 
-                colComp.PhysicsShapes[0].CollisionMask |= (int)CollisionGroup.Mob;
+                colComp.PhysicsShapes[0].CollisionMask |= (int)CollisionGroup.MobImpassable;
                 colComp.IsScrapingFloor = false;
             }
 

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -9,15 +9,16 @@ namespace Content.Shared.Physics
     [Flags, PublicAPI]
     public enum CollisionGroup
     {
-		None      = 0,
-		Grid      = 1 <<  0, // Walls
-		Mob       = 1 <<  1, // Mobs, like the player or NPCs
-		Fixture   = 1 <<  2, // wall fixtures, like APC or posters
-		Items     = 1 <<  3, // Items on the ground
-		Furniture = 1 <<  4, // Tables, machines
+		None            = 0,
+		Opaque          = 1 <<  0, // 1 Blocks light, for lasers
+		Impassable      = 1 <<  1, // 2 Walls, objects impassable by any means
+		MobImpassable   = 1 <<  2, // 4 Mobs, players, crabs, etc
+		VaultImpassable = 1 <<  3, // 8 Things that cannot be jumped over, not half walls or tables
+		SmallImpassable = 1 <<  4, // 16 Things a smaller object - a cat, a crab - can't go through - a wall, but not a computer terminal or a table
+        Clickable       = 1 <<  5, // 32 Temporary "dummy" layer to ensure that objects can still be clicked even if they don't collide with anything (you can't interact with objects that have no layer, including items)
 
         // 32 possible groups
-        MobMask = Grid | Mob | Furniture,
+        MobMask = Impassable | MobImpassable | VaultImpassable | SmallImpassable,
         AllMask = -1,
     }
 }

--- a/Resources/Maps/stationstation.yml
+++ b/Resources/Maps/stationstation.yml
@@ -105,12 +105,6 @@ entities:
     type: Transform
   - charge: 1200
     type: HitscanWeaponCapacitor
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: LaserItem
   uid: 1
   components:
@@ -120,12 +114,6 @@ entities:
     type: Transform
   - charge: 1200
     type: HitscanWeaponCapacitor
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Brutepack
   uid: 2
   components:
@@ -133,12 +121,6 @@ entities:
     pos: -2.106966,-1.457896
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Ointment
   uid: 3
   components:
@@ -146,12 +128,6 @@ entities:
     pos: -1.481966,-1.317271
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Spear
   uid: 4
   components:
@@ -159,12 +135,6 @@ entities:
     pos: -4.144312,7.499083
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Spear
   uid: 5
   components:
@@ -172,12 +142,6 @@ entities:
     pos: -1.238062,7.436583
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: PowerCellSmallHigh
   uid: 6
   components:
@@ -185,10 +149,6 @@ entities:
     pos: -2.67511,-10.351
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.15,-0.3,0.2,0.3
-    type: Collidable
 - type: PowerCellSmallHigh
   uid: 7
   components:
@@ -196,10 +156,6 @@ entities:
     pos: -2.55011,-10.6635
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.15,-0.3,0.2,0.3
-    type: Collidable
 - type: OuterclothingVest
   uid: 8
   components:
@@ -207,12 +163,6 @@ entities:
     pos: 1.412994,7.507263
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: solid_wall
   uid: 9
   components:
@@ -220,10 +170,6 @@ entities:
     pos: -7.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 10
   components:
@@ -231,10 +177,6 @@ entities:
     pos: -7.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 11
   components:
@@ -242,10 +184,6 @@ entities:
     pos: -7.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 12
   components:
@@ -253,10 +191,6 @@ entities:
     pos: -7.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 13
   components:
@@ -264,10 +198,6 @@ entities:
     pos: -7.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 14
   components:
@@ -275,10 +205,6 @@ entities:
     pos: 0.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 15
   components:
@@ -286,10 +212,6 @@ entities:
     pos: -0.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 16
   components:
@@ -297,10 +219,6 @@ entities:
     pos: 3.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 17
   components:
@@ -308,10 +226,6 @@ entities:
     pos: 4.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 18
   components:
@@ -319,10 +233,6 @@ entities:
     pos: -7.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 19
   components:
@@ -330,10 +240,6 @@ entities:
     pos: -7.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 20
   components:
@@ -341,10 +247,6 @@ entities:
     pos: -7.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 21
   components:
@@ -352,10 +254,6 @@ entities:
     pos: -7.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 22
   components:
@@ -363,10 +261,6 @@ entities:
     pos: 2.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 23
   components:
@@ -374,10 +268,6 @@ entities:
     pos: 1.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 24
   components:
@@ -385,10 +275,6 @@ entities:
     pos: -1.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: poweredsmalllight
   uid: 25
   components:
@@ -396,9 +282,6 @@ entities:
     pos: -4.5,-5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -416,12 +299,6 @@ entities:
     pos: -15.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Wire
   uid: 27
   components:
@@ -429,9 +306,6 @@ entities:
     pos: 8.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredsmalllight
   uid: 28
   components:
@@ -439,9 +313,6 @@ entities:
     pos: 0.5,-5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -458,12 +329,6 @@ entities:
   - parent: 25
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Wire
   uid: 30
   components:
@@ -471,9 +336,6 @@ entities:
     pos: -6.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: solid_wall
   uid: 31
   components:
@@ -481,10 +343,6 @@ entities:
     pos: -7.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 32
   components:
@@ -492,10 +350,6 @@ entities:
     pos: -10.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: airlock_engineering
   uid: 33
   components:
@@ -503,11 +357,6 @@ entities:
     pos: -12.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: solid_wall
   uid: 34
   components:
@@ -515,10 +364,6 @@ entities:
     pos: -10.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 35
   components:
@@ -526,10 +371,6 @@ entities:
     pos: -10.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 36
   components:
@@ -537,10 +378,6 @@ entities:
     pos: -10.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 37
   components:
@@ -548,10 +385,6 @@ entities:
     pos: -10.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 38
   components:
@@ -559,10 +392,6 @@ entities:
     pos: -10.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 39
   components:
@@ -570,10 +399,6 @@ entities:
     pos: -3.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 40
   components:
@@ -581,10 +406,6 @@ entities:
     pos: 1.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 41
   components:
@@ -592,10 +413,6 @@ entities:
     pos: 0.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 42
   components:
@@ -603,10 +420,6 @@ entities:
     pos: -0.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 43
   components:
@@ -614,10 +427,6 @@ entities:
     pos: -1.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 44
   components:
@@ -625,10 +434,6 @@ entities:
     pos: -2.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 45
   components:
@@ -636,10 +441,6 @@ entities:
     pos: -3.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 46
   components:
@@ -647,10 +448,6 @@ entities:
     pos: -4.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 47
   components:
@@ -658,10 +455,6 @@ entities:
     pos: -5.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 48
   components:
@@ -669,10 +462,6 @@ entities:
     pos: -6.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 49
   components:
@@ -680,10 +469,6 @@ entities:
     pos: 4.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 50
   components:
@@ -691,10 +476,6 @@ entities:
     pos: 5.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 51
   components:
@@ -702,10 +483,6 @@ entities:
     pos: 6.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 52
   components:
@@ -713,10 +490,6 @@ entities:
     pos: -7.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 53
   components:
@@ -724,10 +497,6 @@ entities:
     pos: -2.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 54
   components:
@@ -735,10 +504,6 @@ entities:
     pos: -6.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 55
   components:
@@ -746,10 +511,6 @@ entities:
     pos: -5.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 56
   components:
@@ -757,10 +518,6 @@ entities:
     pos: -4.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 57
   components:
@@ -768,10 +525,6 @@ entities:
     pos: 6.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 58
   components:
@@ -779,10 +532,6 @@ entities:
     pos: 6.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 59
   components:
@@ -790,10 +539,6 @@ entities:
     pos: 6.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 60
   components:
@@ -801,10 +546,6 @@ entities:
     pos: 6.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 61
   components:
@@ -812,10 +553,6 @@ entities:
     pos: 6.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 62
   components:
@@ -823,10 +560,6 @@ entities:
     pos: 5.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 63
   components:
@@ -834,10 +567,6 @@ entities:
     pos: -7.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 64
   components:
@@ -845,10 +574,6 @@ entities:
     pos: -7.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 65
   components:
@@ -856,10 +581,6 @@ entities:
     pos: -8.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 66
   components:
@@ -867,10 +588,6 @@ entities:
     pos: -9.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 67
   components:
@@ -878,10 +595,6 @@ entities:
     pos: -10.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 68
   components:
@@ -889,10 +602,6 @@ entities:
     pos: -7.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: catwalk
   uid: 69
   components:
@@ -900,9 +609,6 @@ entities:
     pos: -6.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 70
   components:
@@ -910,9 +616,6 @@ entities:
     pos: -8.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: solid_wall
   uid: 71
   components:
@@ -920,10 +623,6 @@ entities:
     pos: 5.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 72
   components:
@@ -931,10 +630,6 @@ entities:
     pos: 5.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 73
   components:
@@ -942,10 +637,6 @@ entities:
     pos: 6.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 74
   components:
@@ -953,10 +644,6 @@ entities:
     pos: 6.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: catwalk
   uid: 75
   components:
@@ -964,9 +651,6 @@ entities:
     pos: 4.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: LargeBeaker
   uid: 76
   components:
@@ -974,12 +658,6 @@ entities:
     pos: 23.494947,7.0422435
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -990,10 +668,6 @@ entities:
     pos: 7.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: airlock_external
   uid: 78
   components:
@@ -1001,11 +675,6 @@ entities:
     pos: 7.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_external
   uid: 79
   components:
@@ -1013,11 +682,6 @@ entities:
     pos: 5.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_engineering
   uid: 80
   components:
@@ -1025,11 +689,6 @@ entities:
     pos: -7.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_engineering
   uid: 81
   components:
@@ -1037,11 +696,6 @@ entities:
     pos: 3.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_engineering
   uid: 82
   components:
@@ -1049,11 +703,6 @@ entities:
     pos: 2.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: solid_wall
   uid: 83
   components:
@@ -1061,10 +710,6 @@ entities:
     pos: 6.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 84
   components:
@@ -1072,10 +717,6 @@ entities:
     pos: 6.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: table
   uid: 85
   components:
@@ -1083,11 +724,6 @@ entities:
     pos: -3.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 86
   components:
@@ -1095,11 +731,6 @@ entities:
     pos: -2.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 87
   components:
@@ -1107,11 +738,6 @@ entities:
     pos: -1.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 88
   components:
@@ -1119,11 +745,6 @@ entities:
     pos: -0.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: WirelessMachine
   uid: 89
   components:
@@ -1131,12 +752,6 @@ entities:
     pos: 5.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: crate_generic
   uid: 90
   components:
@@ -1144,12 +759,6 @@ entities:
     pos: 5.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.4,-0.4,0.4,0.4
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -1165,9 +774,6 @@ entities:
     pos: -6.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 92
   components:
@@ -1175,9 +781,6 @@ entities:
     pos: -7.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 93
   components:
@@ -1185,9 +788,6 @@ entities:
     pos: -8.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 94
   components:
@@ -1195,9 +795,6 @@ entities:
     pos: -8.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 95
   components:
@@ -1205,9 +802,6 @@ entities:
     pos: -8.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 96
   components:
@@ -1215,9 +809,6 @@ entities:
     pos: -8.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 97
   components:
@@ -1225,9 +816,6 @@ entities:
     pos: -8.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 98
   components:
@@ -1235,9 +823,6 @@ entities:
     pos: -8.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 99
   components:
@@ -1245,9 +830,6 @@ entities:
     pos: -6.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 100
   components:
@@ -1255,9 +837,6 @@ entities:
     pos: -6.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 101
   components:
@@ -1265,9 +844,6 @@ entities:
     pos: -6.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 102
   components:
@@ -1275,9 +851,6 @@ entities:
     pos: -6.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 103
   components:
@@ -1285,9 +858,6 @@ entities:
     pos: 4.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 104
   components:
@@ -1295,9 +865,6 @@ entities:
     pos: 4.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 105
   components:
@@ -1305,9 +872,6 @@ entities:
     pos: 4.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 106
   components:
@@ -1315,9 +879,6 @@ entities:
     pos: 4.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 107
   components:
@@ -1325,9 +886,6 @@ entities:
     pos: 5.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 108
   components:
@@ -1335,9 +893,6 @@ entities:
     pos: 6.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 109
   components:
@@ -1345,9 +900,6 @@ entities:
     pos: 7.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 110
   components:
@@ -1355,9 +907,6 @@ entities:
     pos: 2.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 111
   components:
@@ -1365,9 +914,6 @@ entities:
     pos: -4.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 112
   components:
@@ -1375,9 +921,6 @@ entities:
     pos: 3.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 113
   components:
@@ -1385,9 +928,6 @@ entities:
     pos: 2.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 114
   components:
@@ -1395,9 +935,6 @@ entities:
     pos: 1.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 115
   components:
@@ -1405,9 +942,6 @@ entities:
     pos: 0.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 116
   components:
@@ -1415,9 +949,6 @@ entities:
     pos: -0.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 117
   components:
@@ -1425,9 +956,6 @@ entities:
     pos: -1.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 118
   components:
@@ -1435,9 +963,6 @@ entities:
     pos: -2.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 119
   components:
@@ -1445,9 +970,6 @@ entities:
     pos: -3.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 120
   components:
@@ -1455,9 +977,6 @@ entities:
     pos: -4.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 121
   components:
@@ -1465,9 +984,6 @@ entities:
     pos: -5.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 122
   components:
@@ -1475,9 +991,6 @@ entities:
     pos: 1.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 123
   components:
@@ -1485,9 +998,6 @@ entities:
     pos: 1.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 124
   components:
@@ -1495,9 +1005,6 @@ entities:
     pos: 2.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 125
   components:
@@ -1505,9 +1012,6 @@ entities:
     pos: -2.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 126
   components:
@@ -1515,9 +1019,6 @@ entities:
     pos: -2.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 127
   components:
@@ -1525,9 +1026,6 @@ entities:
     pos: -3.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 128
   components:
@@ -1535,9 +1033,6 @@ entities:
     pos: -1.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Generator
   uid: 129
   components:
@@ -1545,12 +1040,6 @@ entities:
     pos: 2.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - type: Generator
   uid: 130
   components:
@@ -1558,12 +1047,6 @@ entities:
     pos: 1.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - type: smes_dry
   uid: 131
   components:
@@ -1571,11 +1054,6 @@ entities:
     pos: -1.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - charge: 3000
     type: PowerStorage
 - type: smes_dry
@@ -1585,11 +1063,6 @@ entities:
     pos: -2.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - charge: 3000
     type: PowerStorage
 - type: smes_dry
@@ -1599,11 +1072,6 @@ entities:
     pos: -3.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - charge: 3000
     type: PowerStorage
 - type: Multitool
@@ -1613,12 +1081,6 @@ entities:
     pos: -1.249865,-10.43489
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: catwalk
   uid: 135
   components:
@@ -1626,9 +1088,6 @@ entities:
     pos: -2.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 136
   components:
@@ -1636,9 +1095,6 @@ entities:
     pos: 1.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: spawn_point_latejoin
   uid: 137
   components:
@@ -1660,11 +1116,6 @@ entities:
     pos: -3.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 140
   components:
@@ -1672,11 +1123,6 @@ entities:
     pos: -2.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 141
   components:
@@ -1684,11 +1130,6 @@ entities:
     pos: -1.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 142
   components:
@@ -1696,11 +1137,6 @@ entities:
     pos: -0.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: solid_wall
   uid: 143
   components:
@@ -1708,10 +1144,6 @@ entities:
     pos: -7.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: spawn_point_latejoin
   uid: 144
   components:
@@ -1726,12 +1158,6 @@ entities:
     pos: 0.5223687,7.507263
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: locker_generic
   uid: 146
   components:
@@ -1739,12 +1165,6 @@ entities:
     pos: 1.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -1763,12 +1183,6 @@ entities:
     pos: -3.209215,-1.486604
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: MedkitFilled
   uid: 148
   components:
@@ -1776,12 +1190,6 @@ entities:
     pos: -4.146715,-1.408479
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: locker_generic
   uid: 149
   components:
@@ -1789,12 +1197,6 @@ entities:
     pos: 0.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -1813,12 +1215,6 @@ entities:
     pos: -1.297692,-5.396082
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: spawn_point_latejoin
   uid: 151
   components:
@@ -1840,12 +1236,6 @@ entities:
     pos: 0.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: computerSupplyOrdering
   uid: 154
   components:
@@ -1853,12 +1243,6 @@ entities:
     pos: 0.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: table
   uid: 155
   components:
@@ -1866,11 +1250,6 @@ entities:
     pos: -4.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 156
   components:
@@ -1878,11 +1257,6 @@ entities:
     pos: -1.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 157
   components:
@@ -1890,11 +1264,6 @@ entities:
     pos: -2.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 158
   components:
@@ -1902,11 +1271,6 @@ entities:
     pos: -3.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: WirelessMachine
   uid: 159
   components:
@@ -1914,12 +1278,6 @@ entities:
     pos: -6.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: catwalk
   uid: 160
   components:
@@ -1927,9 +1285,6 @@ entities:
     pos: 4.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 161
   components:
@@ -1937,9 +1292,6 @@ entities:
     pos: -5.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 162
   components:
@@ -1947,9 +1299,6 @@ entities:
     pos: -6.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 163
   components:
@@ -1957,9 +1306,6 @@ entities:
     pos: -6.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 164
   components:
@@ -1967,9 +1313,6 @@ entities:
     pos: 5.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 165
   components:
@@ -1977,9 +1320,6 @@ entities:
     pos: 5.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 166
   components:
@@ -1987,9 +1327,6 @@ entities:
     pos: 5.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: WiredMachine
   uid: 167
   components:
@@ -1997,12 +1334,6 @@ entities:
     pos: 5.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: WiredMachine
   uid: 168
   components:
@@ -2010,24 +1341,12 @@ entities:
     pos: -6.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: LightBulb
   uid: 169
   components:
   - parent: 28
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: wall_light
   uid: 170
   components:
@@ -2035,9 +1354,6 @@ entities:
     pos: -0.5,-14
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: spawn_point_latejoin
   uid: 171
   components:
@@ -2080,9 +1396,6 @@ entities:
     pos: 9.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 177
   components:
@@ -2090,9 +1403,6 @@ entities:
     pos: 9.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 178
   components:
@@ -2100,9 +1410,6 @@ entities:
     pos: 9.5,2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 179
   components:
@@ -2110,9 +1417,6 @@ entities:
     pos: 9.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 180
   components:
@@ -2120,9 +1424,6 @@ entities:
     pos: 9.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: vending_machine_youtool
   uid: 181
   components:
@@ -2132,12 +1433,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/youtool.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: Generator
   uid: 182
   components:
@@ -2145,12 +1440,6 @@ entities:
     pos: 0.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - type: Wire
   uid: 183
   components:
@@ -2158,9 +1447,6 @@ entities:
     pos: 3.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 184
   components:
@@ -2168,9 +1454,6 @@ entities:
     pos: 0.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Generator
   uid: 185
   components:
@@ -2178,12 +1461,6 @@ entities:
     pos: 3.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - type: table
   uid: 186
   components:
@@ -2191,11 +1468,6 @@ entities:
     pos: -6.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 187
   components:
@@ -2203,11 +1475,6 @@ entities:
     pos: -5.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 188
   components:
@@ -2215,11 +1482,6 @@ entities:
     pos: -4.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 189
   components:
@@ -2227,11 +1489,6 @@ entities:
     pos: -3.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 190
   components:
@@ -2239,11 +1496,6 @@ entities:
     pos: -2.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 191
   components:
@@ -2251,11 +1503,6 @@ entities:
     pos: -1.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 192
   components:
@@ -2263,11 +1510,6 @@ entities:
     pos: -0.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 193
   components:
@@ -2275,11 +1517,6 @@ entities:
     pos: 0.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 194
   components:
@@ -2287,11 +1524,6 @@ entities:
     pos: 1.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 195
   components:
@@ -2299,11 +1531,6 @@ entities:
     pos: -4.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 196
   components:
@@ -2311,11 +1538,6 @@ entities:
     pos: -3.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 197
   components:
@@ -2323,11 +1545,6 @@ entities:
     pos: -2.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 198
   components:
@@ -2335,11 +1552,6 @@ entities:
     pos: -1.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 199
   components:
@@ -2347,11 +1559,6 @@ entities:
     pos: -0.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: airlock_medical_glass
   uid: 200
   components:
@@ -2359,11 +1566,6 @@ entities:
     pos: 26.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_medical_glass
   uid: 201
   components:
@@ -2371,11 +1573,6 @@ entities:
     pos: 28.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: catwalk
   uid: 202
   components:
@@ -2383,9 +1580,6 @@ entities:
     pos: -9.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 203
   components:
@@ -2393,9 +1587,6 @@ entities:
     pos: -8.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 204
   components:
@@ -2403,9 +1594,6 @@ entities:
     pos: -8.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 205
   components:
@@ -2413,9 +1601,6 @@ entities:
     pos: -9.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 206
   components:
@@ -2423,9 +1608,6 @@ entities:
     pos: -9.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: solid_wall
   uid: 207
   components:
@@ -2433,10 +1615,6 @@ entities:
     pos: -10.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 208
   components:
@@ -2444,10 +1622,6 @@ entities:
     pos: -10.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: airlock
   uid: 209
   components:
@@ -2455,23 +1629,12 @@ entities:
     pos: -9.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: LightTube
   uid: 210
   components:
   - parent: 211
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 211
   components:
@@ -2479,9 +1642,6 @@ entities:
     pos: 0.5,1
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -2499,9 +1659,6 @@ entities:
     pos: -3.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chairOfficeDark
   uid: 213
   components:
@@ -2509,9 +1666,6 @@ entities:
     pos: 0.5,-6.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredlight
   uid: 214
   components:
@@ -2519,9 +1673,6 @@ entities:
     pos: -6.5,1
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -2539,12 +1690,6 @@ entities:
     pos: -15.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: stool
   uid: 216
   components:
@@ -2552,9 +1697,6 @@ entities:
     pos: -1.5,-9.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chairOfficeLight
   uid: 217
   components:
@@ -2562,9 +1704,6 @@ entities:
     pos: -3.5,-2.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chairOfficeLight
   uid: 218
   components:
@@ -2572,9 +1711,6 @@ entities:
     pos: -2.5,-2.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chairOfficeLight
   uid: 219
   components:
@@ -2582,9 +1718,6 @@ entities:
     pos: -2.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: stool
   uid: 220
   components:
@@ -2592,21 +1725,12 @@ entities:
     pos: -2.5,-6.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: LightBulb
   uid: 221
   components:
   - parent: 250
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: APC
   uid: 222
   components:
@@ -2614,10 +1738,6 @@ entities:
     pos: -6.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 223
   components:
@@ -2625,9 +1745,6 @@ entities:
     pos: -9.5,2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 224
   components:
@@ -2635,9 +1752,6 @@ entities:
     pos: -9.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 225
   components:
@@ -2645,9 +1759,6 @@ entities:
     pos: -8.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 226
   components:
@@ -2655,9 +1766,6 @@ entities:
     pos: -7.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 227
   components:
@@ -2665,9 +1773,6 @@ entities:
     pos: -6.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 228
   components:
@@ -2675,9 +1780,6 @@ entities:
     pos: -5.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 229
   components:
@@ -2685,9 +1787,6 @@ entities:
     pos: -4.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 230
   components:
@@ -2695,9 +1794,6 @@ entities:
     pos: -3.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 231
   components:
@@ -2705,9 +1801,6 @@ entities:
     pos: -2.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 232
   components:
@@ -2715,9 +1808,6 @@ entities:
     pos: -1.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 233
   components:
@@ -2725,9 +1815,6 @@ entities:
     pos: -0.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 234
   components:
@@ -2735,9 +1822,6 @@ entities:
     pos: 0.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: LargeBeaker
   uid: 235
   components:
@@ -2745,12 +1829,6 @@ entities:
     pos: 23.510572,7.7141185
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -2761,9 +1839,6 @@ entities:
     pos: 9.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 237
   components:
@@ -2771,9 +1846,6 @@ entities:
     pos: 9.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 238
   components:
@@ -2781,9 +1853,6 @@ entities:
     pos: 9.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 239
   components:
@@ -2791,9 +1860,6 @@ entities:
     pos: 9.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 240
   components:
@@ -2801,9 +1867,6 @@ entities:
     pos: 9.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 241
   components:
@@ -2811,9 +1874,6 @@ entities:
     pos: 9.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 242
   components:
@@ -2821,9 +1881,6 @@ entities:
     pos: 9.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 243
   components:
@@ -2831,9 +1888,6 @@ entities:
     pos: 9.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 244
   components:
@@ -2841,9 +1895,6 @@ entities:
     pos: 9.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 245
   components:
@@ -2851,9 +1902,6 @@ entities:
     pos: 9.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 246
   components:
@@ -2861,9 +1909,6 @@ entities:
     pos: 9.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 247
   components:
@@ -2871,9 +1916,6 @@ entities:
     pos: 9.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 248
   components:
@@ -2881,9 +1923,6 @@ entities:
     pos: 8.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: APC
   uid: 249
   components:
@@ -2891,19 +1930,12 @@ entities:
     pos: 4.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: poweredsmalllight
   uid: 250
   components:
   - grid: 0
     pos: 5,-9.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -2921,10 +1953,6 @@ entities:
     pos: 7.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: YellowToolboxItemFilled
   uid: 252
   components:
@@ -2932,12 +1960,6 @@ entities:
     pos: -0.8099712,-5.21454
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -2950,12 +1972,6 @@ entities:
     pos: -0.5597038,-5.679647
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -2968,12 +1984,6 @@ entities:
     pos: -1.934832,-5.154238
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       flashlight_cell_container:
         entities: []
@@ -2986,12 +1996,6 @@ entities:
     pos: -2.017696,-5.71715
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       flashlight_cell_container:
         entities: []
@@ -3004,12 +2008,6 @@ entities:
     pos: -2.861032,-5.524786
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: UniformEngineering
   uid: 257
   components:
@@ -3017,12 +2015,6 @@ entities:
     pos: -0.6474335,-10.27245
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: GasMaskClothing
   uid: 258
   components:
@@ -3030,12 +2022,6 @@ entities:
     pos: -0.2880585,-10.69432
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: OuterclothingVest
   uid: 259
   components:
@@ -3043,12 +2029,6 @@ entities:
     pos: -0.9130585,-10.66307
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: UtilityBeltClothingFilled
   uid: 260
   components:
@@ -3056,12 +2036,6 @@ entities:
     pos: -1.895102,-10.33495
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -3074,12 +2048,6 @@ entities:
     pos: -1.770102,-10.63182
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -3092,12 +2060,6 @@ entities:
     pos: -6.605512,7.638151
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       magazine_bullet_container:
         entities: []
@@ -3110,12 +2072,6 @@ entities:
     pos: -6.339887,7.669401
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       magazine_bullet_container:
         entities: []
@@ -3128,12 +2084,6 @@ entities:
     pos: -6.027387,7.622526
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       magazine_bullet_container:
         entities: []
@@ -3146,12 +2096,6 @@ entities:
     pos: -5.089887,7.591276
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -3164,12 +2108,6 @@ entities:
     pos: -4.683637,7.606901
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -3182,12 +2120,6 @@ entities:
     pos: -3.386762,7.466276
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: smg_c20r
   uid: 268
   components:
@@ -3195,12 +2127,6 @@ entities:
     pos: -2.524035,7.579326
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       ballistics_chamber_0:
         entities: []
@@ -3219,12 +2145,6 @@ entities:
     pos: -1.94591,7.485576
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       ballistics_chamber_0:
         entities: []
@@ -3243,10 +2163,6 @@ entities:
     pos: -10.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 271
   components:
@@ -3254,10 +2170,6 @@ entities:
     pos: -11.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 272
   components:
@@ -3265,10 +2177,6 @@ entities:
     pos: -10.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 273
   components:
@@ -3276,10 +2184,6 @@ entities:
     pos: -9.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 274
   components:
@@ -3287,10 +2191,6 @@ entities:
     pos: -8.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 275
   components:
@@ -3298,10 +2198,6 @@ entities:
     pos: -7.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 276
   components:
@@ -3309,10 +2205,6 @@ entities:
     pos: -8.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 277
   components:
@@ -3320,10 +2212,6 @@ entities:
     pos: -5.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 278
   components:
@@ -3331,10 +2219,6 @@ entities:
     pos: -6.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 279
   components:
@@ -3342,10 +2226,6 @@ entities:
     pos: -7.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 280
   components:
@@ -3353,10 +2233,6 @@ entities:
     pos: -0.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 281
   components:
@@ -3364,10 +2240,6 @@ entities:
     pos: 0.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 282
   components:
@@ -3375,10 +2247,6 @@ entities:
     pos: 1.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 283
   components:
@@ -3386,10 +2254,6 @@ entities:
     pos: 1.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 284
   components:
@@ -3397,10 +2261,6 @@ entities:
     pos: 1.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 285
   components:
@@ -3408,10 +2268,6 @@ entities:
     pos: 4.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 286
   components:
@@ -3419,10 +2275,6 @@ entities:
     pos: 4.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 287
   components:
@@ -3430,10 +2282,6 @@ entities:
     pos: 4.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 288
   components:
@@ -3441,10 +2289,6 @@ entities:
     pos: 4.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 289
   components:
@@ -3452,10 +2296,6 @@ entities:
     pos: 4.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 290
   components:
@@ -3463,10 +2303,6 @@ entities:
     pos: 4.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 291
   components:
@@ -3474,10 +2310,6 @@ entities:
     pos: 4.5,2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 292
   components:
@@ -3485,10 +2317,6 @@ entities:
     pos: 4.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 293
   components:
@@ -3496,10 +2324,6 @@ entities:
     pos: 4.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 294
   components:
@@ -3507,10 +2331,6 @@ entities:
     pos: 4.5,5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 295
   components:
@@ -3518,10 +2338,6 @@ entities:
     pos: 4.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 296
   components:
@@ -3529,10 +2345,6 @@ entities:
     pos: 4.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 297
   components:
@@ -3540,10 +2352,6 @@ entities:
     pos: 4.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 298
   components:
@@ -3551,10 +2359,6 @@ entities:
     pos: 1.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 299
   components:
@@ -3562,10 +2366,6 @@ entities:
     pos: 0.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 300
   components:
@@ -3573,10 +2373,6 @@ entities:
     pos: -0.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 301
   components:
@@ -3584,10 +2380,6 @@ entities:
     pos: -1.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 302
   components:
@@ -3595,10 +2387,6 @@ entities:
     pos: -2.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 303
   components:
@@ -3606,10 +2394,6 @@ entities:
     pos: -3.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 304
   components:
@@ -3617,10 +2401,6 @@ entities:
     pos: -4.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 305
   components:
@@ -3628,10 +2408,6 @@ entities:
     pos: -5.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 306
   components:
@@ -3639,10 +2415,6 @@ entities:
     pos: -6.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 307
   components:
@@ -3650,10 +2422,6 @@ entities:
     pos: -7.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 308
   components:
@@ -3661,10 +2429,6 @@ entities:
     pos: -7.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 309
   components:
@@ -3672,10 +2436,6 @@ entities:
     pos: -7.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 310
   components:
@@ -3683,10 +2443,6 @@ entities:
     pos: -7.5,5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: GlovesLeather
   uid: 311
   components:
@@ -3694,12 +2450,6 @@ entities:
     pos: -4.332221,4.64238
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: GlovesLeather
   uid: 312
   components:
@@ -3707,12 +2457,6 @@ entities:
     pos: -3.519721,4.64238
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: GlovesLeather
   uid: 313
   components:
@@ -3720,12 +2464,6 @@ entities:
     pos: -2.597846,4.61113
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: LedLightTube
   uid: 314
   components:
@@ -3735,24 +2473,12 @@ entities:
     type: Transform
   - color: '#EEEEFFFF'
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: LightTube
   uid: 315
   components:
   - parent: 214
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 316
   components:
@@ -3760,9 +2486,6 @@ entities:
     pos: -1.5,8
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -3779,12 +2502,6 @@ entities:
   - parent: 316
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 318
   components:
@@ -3792,9 +2509,6 @@ entities:
     pos: 4,3.5
     rot: 3.14159265358979 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -3811,21 +2525,12 @@ entities:
   - parent: 318
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: wall_light
   uid: 320
   components:
   - grid: 0
     pos: -7,-10.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredsmalllight
   uid: 321
   components:
@@ -3833,9 +2538,6 @@ entities:
     pos: -10,-5.5
     rot: 3.14159265358979 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -3852,12 +2554,6 @@ entities:
   - parent: 321
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: solid_wall
   uid: 323
   components:
@@ -3865,10 +2561,6 @@ entities:
     pos: -15.5,2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 324
   components:
@@ -3876,10 +2568,6 @@ entities:
     pos: -15.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 325
   components:
@@ -3887,10 +2575,6 @@ entities:
     pos: -15.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 326
   components:
@@ -3898,10 +2582,6 @@ entities:
     pos: -14.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 327
   components:
@@ -3909,10 +2589,6 @@ entities:
     pos: -12.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 328
   components:
@@ -3920,10 +2596,6 @@ entities:
     pos: -15.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 329
   components:
@@ -3931,10 +2603,6 @@ entities:
     pos: -14.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 330
   components:
@@ -3942,10 +2610,6 @@ entities:
     pos: -11.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 331
   components:
@@ -3953,10 +2617,6 @@ entities:
     pos: -14.5,5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 332
   components:
@@ -3964,10 +2624,6 @@ entities:
     pos: -14.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 333
   components:
@@ -3975,10 +2631,6 @@ entities:
     pos: -12.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 334
   components:
@@ -3986,10 +2638,6 @@ entities:
     pos: -12.5,5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 335
   components:
@@ -3997,10 +2645,6 @@ entities:
     pos: -16.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 336
   components:
@@ -4008,10 +2652,6 @@ entities:
     pos: -16.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 337
   components:
@@ -4019,10 +2659,6 @@ entities:
     pos: -16.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 338
   components:
@@ -4030,10 +2666,6 @@ entities:
     pos: -16.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 339
   components:
@@ -4041,10 +2673,6 @@ entities:
     pos: -16.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 340
   components:
@@ -4052,10 +2680,6 @@ entities:
     pos: -16.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 341
   components:
@@ -4063,10 +2687,6 @@ entities:
     pos: -16.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 342
   components:
@@ -4074,10 +2694,6 @@ entities:
     pos: -16.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 343
   components:
@@ -4085,10 +2701,6 @@ entities:
     pos: -16.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 344
   components:
@@ -4096,10 +2708,6 @@ entities:
     pos: -16.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 345
   components:
@@ -4107,10 +2715,6 @@ entities:
     pos: -16.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 346
   components:
@@ -4118,10 +2722,6 @@ entities:
     pos: -15.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 347
   components:
@@ -4129,10 +2729,6 @@ entities:
     pos: -14.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 348
   components:
@@ -4140,10 +2736,6 @@ entities:
     pos: -13.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 349
   components:
@@ -4151,10 +2743,6 @@ entities:
     pos: -12.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 350
   components:
@@ -4162,10 +2750,6 @@ entities:
     pos: -11.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: airlock_external
   uid: 351
   components:
@@ -4173,11 +2757,6 @@ entities:
     pos: -13.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_external
   uid: 352
   components:
@@ -4185,11 +2764,6 @@ entities:
     pos: -13.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_engineering
   uid: 353
   components:
@@ -4197,11 +2771,6 @@ entities:
     pos: -13.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: table
   uid: 354
   components:
@@ -4209,11 +2778,6 @@ entities:
     pos: -15.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 355
   components:
@@ -4221,11 +2785,6 @@ entities:
     pos: -15.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: Wire
   uid: 356
   components:
@@ -4233,9 +2792,6 @@ entities:
     pos: -9.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 357
   components:
@@ -4243,9 +2799,6 @@ entities:
     pos: -13.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 358
   components:
@@ -4253,9 +2806,6 @@ entities:
     pos: -9.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: table
   uid: 359
   components:
@@ -4263,11 +2813,6 @@ entities:
     pos: -15.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: catwalk
   uid: 360
   components:
@@ -4275,9 +2820,6 @@ entities:
     pos: -14.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 361
   components:
@@ -4285,9 +2827,6 @@ entities:
     pos: -13.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 362
   components:
@@ -4295,9 +2834,6 @@ entities:
     pos: -12.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: locker_tool_filled
   uid: 363
   components:
@@ -4305,12 +2841,6 @@ entities:
     pos: -11.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4323,12 +2853,6 @@ entities:
     pos: -11.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4341,12 +2865,6 @@ entities:
     pos: -11.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4359,12 +2877,6 @@ entities:
     pos: -11.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4377,12 +2889,6 @@ entities:
     pos: -11.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4395,12 +2901,6 @@ entities:
     pos: -15.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: airlock_engineering
   uid: 369
   components:
@@ -4408,11 +2908,6 @@ entities:
     pos: -10.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: autolathe
   uid: 370
   components:
@@ -4420,11 +2915,6 @@ entities:
     pos: -14.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -4447,11 +2937,6 @@ entities:
     pos: -13.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -4474,11 +2959,6 @@ entities:
     pos: -12.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -4501,9 +2981,6 @@ entities:
     pos: -11,-5.5
     rot: 3.14159265358979 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4520,12 +2997,6 @@ entities:
   - parent: 373
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 375
   components:
@@ -4533,9 +3004,6 @@ entities:
     pos: -11,-0.5
     rot: 3.14159265358979 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4552,21 +3020,12 @@ entities:
   - parent: 375
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 377
   components:
   - grid: 0
     pos: -16,-0.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4583,21 +3042,12 @@ entities:
   - parent: 377
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 379
   components:
   - grid: 0
     pos: -16,-5.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4614,21 +3064,12 @@ entities:
   - parent: 379
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 381
   components:
   - grid: 0
     pos: -15,3.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4645,12 +3086,6 @@ entities:
   - parent: 381
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredsmalllight
   uid: 383
   components:
@@ -4658,9 +3093,6 @@ entities:
     pos: -14.5,7
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4677,12 +3109,6 @@ entities:
   - parent: 383
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: CableStack
   uid: 385
   components:
@@ -4690,12 +3116,6 @@ entities:
     pos: -15.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: CableStack
   uid: 386
   components:
@@ -4703,12 +3123,6 @@ entities:
     pos: -15.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Wire
   uid: 387
   components:
@@ -4716,9 +3130,6 @@ entities:
     pos: -14.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 388
   components:
@@ -4726,9 +3137,6 @@ entities:
     pos: -12.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 389
   components:
@@ -4736,9 +3144,6 @@ entities:
     pos: -11.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 390
   components:
@@ -4746,9 +3151,6 @@ entities:
     pos: -9.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredlight
   uid: 391
   components:
@@ -4756,9 +3158,6 @@ entities:
     pos: -10.5,4
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4775,12 +3174,6 @@ entities:
   - parent: 391
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: MetalStack
   uid: 393
   components:
@@ -4788,12 +3181,6 @@ entities:
     pos: -15.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: MetalStack
   uid: 394
   components:
@@ -4801,12 +3188,6 @@ entities:
     pos: -15.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: APC
   uid: 395
   components:
@@ -4814,10 +3195,6 @@ entities:
     pos: -9.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: APC
   uid: 396
   components:
@@ -4825,10 +3202,6 @@ entities:
     pos: -16.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 397
   components:
@@ -4836,9 +3209,6 @@ entities:
     pos: -16.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 398
   components:
@@ -4846,9 +3216,6 @@ entities:
     pos: -15.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 399
   components:
@@ -4856,9 +3223,6 @@ entities:
     pos: -14.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 400
   components:
@@ -4866,9 +3230,6 @@ entities:
     pos: -13.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 401
   components:
@@ -4876,9 +3237,6 @@ entities:
     pos: -13.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 402
   components:
@@ -4886,9 +3244,6 @@ entities:
     pos: -13.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 403
   components:
@@ -4896,9 +3251,6 @@ entities:
     pos: -13.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 404
   components:
@@ -4906,9 +3258,6 @@ entities:
     pos: -13.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 405
   components:
@@ -4916,9 +3265,6 @@ entities:
     pos: -12.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 406
   components:
@@ -4926,9 +3272,6 @@ entities:
     pos: -11.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 407
   components:
@@ -4936,9 +3279,6 @@ entities:
     pos: -10.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 408
   components:
@@ -4946,9 +3286,6 @@ entities:
     pos: -9.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: table
   uid: 409
   components:
@@ -4956,11 +3293,6 @@ entities:
     pos: -15.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 410
   components:
@@ -4968,11 +3300,6 @@ entities:
     pos: -15.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 411
   components:
@@ -4980,11 +3307,6 @@ entities:
     pos: -15.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: CableStack
   uid: 412
   components:
@@ -4992,12 +3314,6 @@ entities:
     pos: -15.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: CableStack
   uid: 413
   components:
@@ -5005,12 +3321,6 @@ entities:
     pos: -15.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: GlassStack
   uid: 414
   components:
@@ -5018,12 +3328,6 @@ entities:
     pos: -15.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: GlassStack
   uid: 415
   components:
@@ -5031,12 +3335,6 @@ entities:
     pos: -15.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: GlassStack
   uid: 416
   components:
@@ -5044,12 +3342,6 @@ entities:
     pos: -15.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: vending_machine_engivend
   uid: 417
   components:
@@ -5059,12 +3351,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/engivend.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: table
   uid: 418
   components:
@@ -5072,11 +3358,6 @@ entities:
     pos: 18.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 419
   components:
@@ -5084,11 +3365,6 @@ entities:
     pos: 21.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 420
   components:
@@ -5096,11 +3372,6 @@ entities:
     pos: 20.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 421
   components:
@@ -5108,11 +3379,6 @@ entities:
     pos: 18.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 422
   components:
@@ -5120,11 +3386,6 @@ entities:
     pos: 19.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 423
   components:
@@ -5132,11 +3393,6 @@ entities:
     pos: 18.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 424
   components:
@@ -5144,11 +3400,6 @@ entities:
     pos: 22.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 425
   components:
@@ -5156,11 +3407,6 @@ entities:
     pos: 24.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: chairOfficeLight
   uid: 426
   components:
@@ -5168,9 +3414,6 @@ entities:
     pos: 19.5,4.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chairOfficeLight
   uid: 427
   components:
@@ -5178,9 +3421,6 @@ entities:
     pos: 20.5,5.5
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chairOfficeLight
   uid: 428
   components:
@@ -5188,9 +3428,6 @@ entities:
     pos: 23.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chairOfficeLight
   uid: 429
   components:
@@ -5198,48 +3435,30 @@ entities:
     pos: 24.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chair
   uid: 430
   components:
   - grid: 0
     pos: 14.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chair
   uid: 431
   components:
   - grid: 0
     pos: 14.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chair
   uid: 432
   components:
   - grid: 0
     pos: 14.5,7.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chem_dispenser
   uid: 433
   components:
   - grid: 0
     pos: 23.5,9.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.4,-0.25,0.4,0.25
-    type: Collidable
   - containers:
       ReagentDispenser-reagentContainerContainer:
         entities: []
@@ -5252,11 +3471,6 @@ entities:
     pos: 23.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: catwalk
   uid: 435
   components:
@@ -5264,9 +3478,6 @@ entities:
     pos: 0.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: table
   uid: 436
   components:
@@ -5274,11 +3485,6 @@ entities:
     pos: 25.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 437
   components:
@@ -5286,11 +3492,6 @@ entities:
     pos: 23.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 438
   components:
@@ -5298,11 +3499,6 @@ entities:
     pos: 24.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 439
   components:
@@ -5310,11 +3506,6 @@ entities:
     pos: 26.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 440
   components:
@@ -5322,11 +3513,6 @@ entities:
     pos: 27.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: computerMedicalRecords
   uid: 441
   components:
@@ -5334,12 +3520,6 @@ entities:
     pos: 21.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: medical_scanner
   uid: 442
   components:
@@ -5347,12 +3527,6 @@ entities:
     pos: 18.5,-1.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       MedicalScanner-bodyContainer:
         entities: []
@@ -5365,12 +3539,6 @@ entities:
     pos: 18.5,-5.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       MedicalScanner-bodyContainer:
         entities: []
@@ -5383,11 +3551,6 @@ entities:
     pos: 13.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 445
   components:
@@ -5395,11 +3558,6 @@ entities:
     pos: 13.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 446
   components:
@@ -5407,11 +3565,6 @@ entities:
     pos: 13.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: solid_wall
   uid: 447
   components:
@@ -5419,10 +3572,6 @@ entities:
     pos: 22.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 448
   components:
@@ -5430,10 +3579,6 @@ entities:
     pos: 17.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 449
   components:
@@ -5441,10 +3586,6 @@ entities:
     pos: 18.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 450
   components:
@@ -5452,10 +3593,6 @@ entities:
     pos: 20.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 451
   components:
@@ -5463,10 +3600,6 @@ entities:
     pos: 21.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 452
   components:
@@ -5474,10 +3607,6 @@ entities:
     pos: 19.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 453
   components:
@@ -5485,10 +3614,6 @@ entities:
     pos: 14.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 454
   components:
@@ -5496,10 +3621,6 @@ entities:
     pos: 13.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 455
   components:
@@ -5507,10 +3628,6 @@ entities:
     pos: 12.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 456
   components:
@@ -5518,10 +3635,6 @@ entities:
     pos: 12.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 457
   components:
@@ -5529,10 +3642,6 @@ entities:
     pos: 12.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 458
   components:
@@ -5540,10 +3649,6 @@ entities:
     pos: 12.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 459
   components:
@@ -5551,10 +3656,6 @@ entities:
     pos: 12.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 460
   components:
@@ -5562,10 +3663,6 @@ entities:
     pos: 13.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 461
   components:
@@ -5573,10 +3670,6 @@ entities:
     pos: 14.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 462
   components:
@@ -5584,10 +3677,6 @@ entities:
     pos: 13.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 463
   components:
@@ -5595,10 +3684,6 @@ entities:
     pos: 13.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 464
   components:
@@ -5606,10 +3691,6 @@ entities:
     pos: 13.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 465
   components:
@@ -5617,10 +3698,6 @@ entities:
     pos: 13.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 466
   components:
@@ -5628,10 +3705,6 @@ entities:
     pos: 13.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 467
   components:
@@ -5639,10 +3712,6 @@ entities:
     pos: 13.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 468
   components:
@@ -5650,10 +3719,6 @@ entities:
     pos: 14.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 469
   components:
@@ -5661,10 +3726,6 @@ entities:
     pos: 15.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 470
   components:
@@ -5672,10 +3733,6 @@ entities:
     pos: 16.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 471
   components:
@@ -5683,10 +3740,6 @@ entities:
     pos: 17.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 472
   components:
@@ -5694,10 +3747,6 @@ entities:
     pos: 18.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 473
   components:
@@ -5705,10 +3754,6 @@ entities:
     pos: 19.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 474
   components:
@@ -5716,10 +3761,6 @@ entities:
     pos: 20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 475
   components:
@@ -5727,10 +3768,6 @@ entities:
     pos: 21.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 476
   components:
@@ -5738,10 +3775,6 @@ entities:
     pos: 22.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 477
   components:
@@ -5749,10 +3782,6 @@ entities:
     pos: 23.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 478
   components:
@@ -5760,10 +3789,6 @@ entities:
     pos: 24.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 479
   components:
@@ -5771,10 +3796,6 @@ entities:
     pos: 25.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 480
   components:
@@ -5782,10 +3803,6 @@ entities:
     pos: 26.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 481
   components:
@@ -5793,10 +3810,6 @@ entities:
     pos: 26.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 482
   components:
@@ -5804,10 +3817,6 @@ entities:
     pos: 26.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 483
   components:
@@ -5815,10 +3824,6 @@ entities:
     pos: 27.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 484
   components:
@@ -5826,10 +3831,6 @@ entities:
     pos: 28.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 485
   components:
@@ -5837,10 +3838,6 @@ entities:
     pos: 29.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 486
   components:
@@ -5848,10 +3845,6 @@ entities:
     pos: 30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 487
   components:
@@ -5859,10 +3852,6 @@ entities:
     pos: 31.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 488
   components:
@@ -5870,10 +3859,6 @@ entities:
     pos: 32.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 489
   components:
@@ -5881,10 +3866,6 @@ entities:
     pos: 33.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 490
   components:
@@ -5892,10 +3873,6 @@ entities:
     pos: 34.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 491
   components:
@@ -5903,10 +3880,6 @@ entities:
     pos: 34.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 492
   components:
@@ -5914,10 +3887,6 @@ entities:
     pos: 34.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 493
   components:
@@ -5925,10 +3894,6 @@ entities:
     pos: 34.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 494
   components:
@@ -5936,10 +3901,6 @@ entities:
     pos: 34.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 495
   components:
@@ -5947,10 +3908,6 @@ entities:
     pos: 34.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 496
   components:
@@ -5958,10 +3915,6 @@ entities:
     pos: 34.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 497
   components:
@@ -5969,10 +3922,6 @@ entities:
     pos: 33.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 498
   components:
@@ -5980,10 +3929,6 @@ entities:
     pos: 32.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 499
   components:
@@ -5991,10 +3936,6 @@ entities:
     pos: 31.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 500
   components:
@@ -6002,10 +3943,6 @@ entities:
     pos: 30.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 501
   components:
@@ -6013,10 +3950,6 @@ entities:
     pos: 29.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 502
   components:
@@ -6024,10 +3957,6 @@ entities:
     pos: 30.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 503
   components:
@@ -6035,10 +3964,6 @@ entities:
     pos: 30.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 504
   components:
@@ -6046,10 +3971,6 @@ entities:
     pos: 30.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 505
   components:
@@ -6057,10 +3978,6 @@ entities:
     pos: 30.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 506
   components:
@@ -6068,10 +3985,6 @@ entities:
     pos: 30.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 507
   components:
@@ -6079,10 +3992,6 @@ entities:
     pos: 29.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 508
   components:
@@ -6090,10 +3999,6 @@ entities:
     pos: 28.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 509
   components:
@@ -6101,10 +4006,6 @@ entities:
     pos: 27.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 510
   components:
@@ -6112,10 +4013,6 @@ entities:
     pos: 27.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 511
   components:
@@ -6123,10 +4020,6 @@ entities:
     pos: 26.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 512
   components:
@@ -6134,10 +4027,6 @@ entities:
     pos: 25.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 513
   components:
@@ -6145,10 +4034,6 @@ entities:
     pos: 26.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 514
   components:
@@ -6156,10 +4041,6 @@ entities:
     pos: 26.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 515
   components:
@@ -6167,10 +4048,6 @@ entities:
     pos: 28.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 516
   components:
@@ -6178,10 +4055,6 @@ entities:
     pos: 28.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 517
   components:
@@ -6189,10 +4062,6 @@ entities:
     pos: 28.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 518
   components:
@@ -6200,10 +4069,6 @@ entities:
     pos: 28.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 519
   components:
@@ -6211,10 +4076,6 @@ entities:
     pos: 28.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 520
   components:
@@ -6222,10 +4083,6 @@ entities:
     pos: 28.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 521
   components:
@@ -6233,10 +4090,6 @@ entities:
     pos: 28.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 522
   components:
@@ -6244,10 +4097,6 @@ entities:
     pos: 27.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 523
   components:
@@ -6255,10 +4104,6 @@ entities:
     pos: 26.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 524
   components:
@@ -6266,10 +4111,6 @@ entities:
     pos: 25.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 525
   components:
@@ -6277,10 +4118,6 @@ entities:
     pos: 24.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 526
   components:
@@ -6288,10 +4125,6 @@ entities:
     pos: 23.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 527
   components:
@@ -6299,10 +4132,6 @@ entities:
     pos: 22.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 528
   components:
@@ -6310,10 +4139,6 @@ entities:
     pos: 21.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 529
   components:
@@ -6321,10 +4146,6 @@ entities:
     pos: 22.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 530
   components:
@@ -6332,10 +4153,6 @@ entities:
     pos: 22.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 531
   components:
@@ -6343,10 +4160,6 @@ entities:
     pos: 22.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 532
   components:
@@ -6354,10 +4167,6 @@ entities:
     pos: 22.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 533
   components:
@@ -6365,10 +4174,6 @@ entities:
     pos: 22.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 534
   components:
@@ -6376,10 +4181,6 @@ entities:
     pos: 22.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 535
   components:
@@ -6387,10 +4188,6 @@ entities:
     pos: 22.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 536
   components:
@@ -6398,10 +4195,6 @@ entities:
     pos: 21.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 537
   components:
@@ -6409,10 +4202,6 @@ entities:
     pos: 19.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 538
   components:
@@ -6420,10 +4209,6 @@ entities:
     pos: 18.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 539
   components:
@@ -6431,10 +4216,6 @@ entities:
     pos: 17.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 540
   components:
@@ -6442,10 +4223,6 @@ entities:
     pos: 23.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 541
   components:
@@ -6453,10 +4230,6 @@ entities:
     pos: 25.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 542
   components:
@@ -6464,10 +4237,6 @@ entities:
     pos: 13.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 543
   components:
@@ -6475,10 +4244,6 @@ entities:
     pos: 13.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 544
   components:
@@ -6486,10 +4251,6 @@ entities:
     pos: 13.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 545
   components:
@@ -6497,10 +4258,6 @@ entities:
     pos: 13.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 546
   components:
@@ -6508,10 +4265,6 @@ entities:
     pos: 13.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 547
   components:
@@ -6519,10 +4272,6 @@ entities:
     pos: 13.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 548
   components:
@@ -6530,10 +4279,6 @@ entities:
     pos: 14.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 549
   components:
@@ -6541,10 +4286,6 @@ entities:
     pos: 13.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 550
   components:
@@ -6552,10 +4293,6 @@ entities:
     pos: 12.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 551
   components:
@@ -6563,10 +4300,6 @@ entities:
     pos: 11.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 552
   components:
@@ -6574,10 +4307,6 @@ entities:
     pos: 10.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 553
   components:
@@ -6585,10 +4314,6 @@ entities:
     pos: 9.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 554
   components:
@@ -6596,10 +4321,6 @@ entities:
     pos: 8.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 555
   components:
@@ -6607,10 +4328,6 @@ entities:
     pos: 7.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 556
   components:
@@ -6618,10 +4335,6 @@ entities:
     pos: 6.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 557
   components:
@@ -6629,10 +4342,6 @@ entities:
     pos: 5.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 558
   components:
@@ -6640,10 +4349,6 @@ entities:
     pos: 4.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 559
   components:
@@ -6651,10 +4356,6 @@ entities:
     pos: 5.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 560
   components:
@@ -6662,10 +4363,6 @@ entities:
     pos: 6.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 561
   components:
@@ -6673,10 +4370,6 @@ entities:
     pos: 7.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 562
   components:
@@ -6684,10 +4377,6 @@ entities:
     pos: 8.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 563
   components:
@@ -6695,10 +4384,6 @@ entities:
     pos: 9.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 564
   components:
@@ -6706,10 +4391,6 @@ entities:
     pos: 10.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 565
   components:
@@ -6717,10 +4398,6 @@ entities:
     pos: 11.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 566
   components:
@@ -6728,10 +4405,6 @@ entities:
     pos: 12.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 567
   components:
@@ -6739,10 +4412,6 @@ entities:
     pos: 4.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 568
   components:
@@ -6750,10 +4419,6 @@ entities:
     pos: 1.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 569
   components:
@@ -6761,10 +4426,6 @@ entities:
     pos: 1.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 570
   components:
@@ -6772,10 +4433,6 @@ entities:
     pos: 0.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 571
   components:
@@ -6783,10 +4440,6 @@ entities:
     pos: -0.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 572
   components:
@@ -6794,10 +4447,6 @@ entities:
     pos: -1.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 573
   components:
@@ -6805,10 +4454,6 @@ entities:
     pos: -2.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 574
   components:
@@ -6816,10 +4461,6 @@ entities:
     pos: -3.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 575
   components:
@@ -6827,10 +4468,6 @@ entities:
     pos: -4.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 576
   components:
@@ -6838,10 +4475,6 @@ entities:
     pos: -5.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 577
   components:
@@ -6849,10 +4482,6 @@ entities:
     pos: -6.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 578
   components:
@@ -6860,10 +4489,6 @@ entities:
     pos: -7.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 579
   components:
@@ -6871,10 +4496,6 @@ entities:
     pos: 1.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 580
   components:
@@ -6882,10 +4503,6 @@ entities:
     pos: 1.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 581
   components:
@@ -6893,10 +4510,6 @@ entities:
     pos: 1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: catwalk
   uid: 582
   components:
@@ -6904,9 +4517,6 @@ entities:
     pos: 5.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 583
   components:
@@ -6914,9 +4524,6 @@ entities:
     pos: 12.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: table
   uid: 584
   components:
@@ -6924,11 +4531,6 @@ entities:
     pos: 23.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 585
   components:
@@ -6936,11 +4538,6 @@ entities:
     pos: 23.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: airlock_medical_glass
   uid: 586
   components:
@@ -6948,11 +4545,6 @@ entities:
     pos: 15.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_medical_glass
   uid: 587
   components:
@@ -6960,11 +4552,6 @@ entities:
     pos: 16.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_medical_glass
   uid: 588
   components:
@@ -6972,11 +4559,6 @@ entities:
     pos: 20.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_medical_glass
   uid: 589
   components:
@@ -6984,11 +4566,6 @@ entities:
     pos: 26.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: Beaker
   uid: 590
   components:
@@ -6996,12 +4573,6 @@ entities:
     pos: 26.416822,10.651619
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -7012,12 +4583,6 @@ entities:
     pos: 24.541822,10.635994
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -7028,12 +4593,6 @@ entities:
     pos: 25.291822,10.667244
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -7044,9 +4603,6 @@ entities:
     pos: 1.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 594
   components:
@@ -7054,9 +4610,6 @@ entities:
     pos: 2.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 595
   components:
@@ -7064,9 +4617,6 @@ entities:
     pos: 2.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 596
   components:
@@ -7074,9 +4624,6 @@ entities:
     pos: 2.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 597
   components:
@@ -7084,9 +4631,6 @@ entities:
     pos: 2.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 598
   components:
@@ -7094,9 +4638,6 @@ entities:
     pos: 2.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 599
   components:
@@ -7104,9 +4645,6 @@ entities:
     pos: 2.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 600
   components:
@@ -7114,9 +4652,6 @@ entities:
     pos: 2.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 601
   components:
@@ -7124,9 +4659,6 @@ entities:
     pos: 2.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 602
   components:
@@ -7134,9 +4666,6 @@ entities:
     pos: 3.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 603
   components:
@@ -7144,9 +4673,6 @@ entities:
     pos: 4.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 604
   components:
@@ -7154,9 +4680,6 @@ entities:
     pos: 5.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 605
   components:
@@ -7164,9 +4687,6 @@ entities:
     pos: 5.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 606
   components:
@@ -7174,9 +4694,6 @@ entities:
     pos: 6.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 607
   components:
@@ -7184,9 +4701,6 @@ entities:
     pos: 7.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 608
   components:
@@ -7194,9 +4708,6 @@ entities:
     pos: 8.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 609
   components:
@@ -7204,9 +4715,6 @@ entities:
     pos: 9.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 610
   components:
@@ -7214,9 +4722,6 @@ entities:
     pos: 10.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 611
   components:
@@ -7224,9 +4729,6 @@ entities:
     pos: 11.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 612
   components:
@@ -7234,9 +4736,6 @@ entities:
     pos: 12.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 613
   components:
@@ -7244,9 +4743,6 @@ entities:
     pos: 12.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 614
   components:
@@ -7254,9 +4750,6 @@ entities:
     pos: 13.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 615
   components:
@@ -7264,9 +4757,6 @@ entities:
     pos: 14.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 616
   components:
@@ -7274,9 +4764,6 @@ entities:
     pos: 15.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 617
   components:
@@ -7284,9 +4771,6 @@ entities:
     pos: 16.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 618
   components:
@@ -7294,9 +4778,6 @@ entities:
     pos: 16.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 619
   components:
@@ -7304,9 +4785,6 @@ entities:
     pos: 16.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 620
   components:
@@ -7314,9 +4792,6 @@ entities:
     pos: 16.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 621
   components:
@@ -7324,9 +4799,6 @@ entities:
     pos: 16.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 622
   components:
@@ -7334,9 +4806,6 @@ entities:
     pos: 16.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 623
   components:
@@ -7344,9 +4813,6 @@ entities:
     pos: 16.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 624
   components:
@@ -7354,9 +4820,6 @@ entities:
     pos: 16.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 625
   components:
@@ -7364,9 +4827,6 @@ entities:
     pos: 16.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 626
   components:
@@ -7374,9 +4834,6 @@ entities:
     pos: 17.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 627
   components:
@@ -7384,9 +4841,6 @@ entities:
     pos: 18.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 628
   components:
@@ -7394,9 +4848,6 @@ entities:
     pos: 18.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: APC
   uid: 629
   components:
@@ -7404,10 +4855,6 @@ entities:
     pos: 18.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 630
   components:
@@ -7415,9 +4862,6 @@ entities:
     pos: 1.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 631
   components:
@@ -7425,9 +4869,6 @@ entities:
     pos: 1.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: APC
   uid: 632
   components:
@@ -7435,10 +4876,6 @@ entities:
     pos: 1.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: airlock
   uid: 633
   components:
@@ -7446,11 +4883,6 @@ entities:
     pos: 1.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock
   uid: 634
   components:
@@ -7458,11 +4890,6 @@ entities:
     pos: 4.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock
   uid: 635
   components:
@@ -7470,49 +4897,30 @@ entities:
     pos: 13.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: APC
   uid: 636
   components:
   - grid: 0
     pos: 13.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 637
   components:
   - grid: 0
     pos: 13.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: APC
   uid: 638
   components:
   - grid: 0
     pos: 28.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 639
   components:
   - grid: 0
     pos: 25.5,4.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredlight
   uid: 640
   components:
@@ -7520,9 +4928,6 @@ entities:
     pos: 17.5,4
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7539,12 +4944,6 @@ entities:
   - parent: 640
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 642
   components:
@@ -7552,9 +4951,6 @@ entities:
     pos: 22.5,3
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7571,12 +4967,6 @@ entities:
   - parent: 642
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 644
   components:
@@ -7584,9 +4974,6 @@ entities:
     pos: 13.5,3
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7603,12 +4990,6 @@ entities:
   - parent: 644
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Wire
   uid: 646
   components:
@@ -7616,9 +4997,6 @@ entities:
     pos: 27.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 647
   components:
@@ -7626,54 +5004,36 @@ entities:
     pos: 26.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 648
   components:
   - grid: 0
     pos: 15.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 649
   components:
   - grid: 0
     pos: 14.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 650
   components:
   - grid: 0
     pos: 13.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 651
   components:
   - grid: 0
     pos: 15.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 652
   components:
   - grid: 0
     pos: 14.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: APC
   uid: 653
   components:
@@ -7681,91 +5041,60 @@ entities:
     pos: 30.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 654
   components:
   - grid: 0
     pos: 19.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 655
   components:
   - grid: 0
     pos: 20.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 656
   components:
   - grid: 0
     pos: 21.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 657
   components:
   - grid: 0
     pos: 22.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 658
   components:
   - grid: 0
     pos: 23.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 659
   components:
   - grid: 0
     pos: 24.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 660
   components:
   - grid: 0
     pos: 25.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 661
   components:
   - grid: 0
     pos: 25.5,3.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredlight
   uid: 662
   components:
   - grid: 0
     pos: 14,9.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7782,12 +5111,6 @@ entities:
   - parent: 662
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 664
   components:
@@ -7795,9 +5118,6 @@ entities:
     pos: 22,9.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7814,12 +5134,6 @@ entities:
   - parent: 664
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Wire
   uid: 666
   components:
@@ -7827,9 +5141,6 @@ entities:
     pos: 30.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 667
   components:
@@ -7837,9 +5148,6 @@ entities:
     pos: 29.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredlight
   uid: 668
   components:
@@ -7847,9 +5155,6 @@ entities:
     pos: 16.5,-6
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7866,12 +5171,6 @@ entities:
   - parent: 668
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: table
   uid: 670
   components:
@@ -7879,11 +5178,6 @@ entities:
     pos: 23.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 671
   components:
@@ -7891,11 +5185,6 @@ entities:
     pos: 24.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: APC
   uid: 672
   components:
@@ -7903,10 +5192,6 @@ entities:
     pos: 20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 673
   components:
@@ -7914,9 +5199,6 @@ entities:
     pos: 16.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 674
   components:
@@ -7924,9 +5206,6 @@ entities:
     pos: 16.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 675
   components:
@@ -7934,9 +5213,6 @@ entities:
     pos: 16.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 676
   components:
@@ -7944,9 +5220,6 @@ entities:
     pos: 16.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 677
   components:
@@ -7954,9 +5227,6 @@ entities:
     pos: 16.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 678
   components:
@@ -7964,9 +5234,6 @@ entities:
     pos: 16.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 679
   components:
@@ -7974,9 +5241,6 @@ entities:
     pos: 17.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 680
   components:
@@ -7984,9 +5248,6 @@ entities:
     pos: 18.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 681
   components:
@@ -7994,9 +5255,6 @@ entities:
     pos: 19.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 682
   components:
@@ -8004,9 +5262,6 @@ entities:
     pos: 20.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 683
   components:
@@ -8014,9 +5269,6 @@ entities:
     pos: 20.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 684
   components:
@@ -8024,9 +5276,6 @@ entities:
     pos: 20.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 685
   components:
@@ -8034,9 +5283,6 @@ entities:
     pos: 20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 686
   components:
@@ -8044,9 +5290,6 @@ entities:
     pos: 21.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 687
   components:
@@ -8054,9 +5297,6 @@ entities:
     pos: 22.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 688
   components:
@@ -8064,9 +5304,6 @@ entities:
     pos: 23.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 689
   components:
@@ -8074,9 +5311,6 @@ entities:
     pos: 24.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 690
   components:
@@ -8084,9 +5318,6 @@ entities:
     pos: 25.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 691
   components:
@@ -8094,9 +5325,6 @@ entities:
     pos: 26.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 692
   components:
@@ -8104,9 +5332,6 @@ entities:
     pos: 27.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 693
   components:
@@ -8114,9 +5339,6 @@ entities:
     pos: 28.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 694
   components:
@@ -8124,9 +5346,6 @@ entities:
     pos: 29.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 695
   components:
@@ -8134,9 +5353,6 @@ entities:
     pos: 30.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 696
   components:
@@ -8144,9 +5360,6 @@ entities:
     pos: 30.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 697
   components:
@@ -8154,9 +5367,6 @@ entities:
     pos: 30.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 698
   components:
@@ -8164,9 +5374,6 @@ entities:
     pos: 30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: APC
   uid: 699
   components:
@@ -8174,10 +5381,6 @@ entities:
     pos: 30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: poweredlight
   uid: 700
   components:
@@ -8185,9 +5388,6 @@ entities:
     pos: 31.5,-6
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -8204,12 +5404,6 @@ entities:
   - parent: 700
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 702
   components:
@@ -8217,9 +5411,6 @@ entities:
     pos: 30,1.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -8236,12 +5427,6 @@ entities:
   - parent: 702
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Wire
   uid: 704
   components:
@@ -8249,9 +5434,6 @@ entities:
     pos: 26.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 705
   components:
@@ -8259,9 +5441,6 @@ entities:
     pos: 27.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 706
   components:
@@ -8269,9 +5448,6 @@ entities:
     pos: 28.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 707
   components:
@@ -8279,9 +5455,6 @@ entities:
     pos: 28.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 708
   components:
@@ -8289,9 +5462,6 @@ entities:
     pos: 25.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 709
   components:
@@ -8299,9 +5469,6 @@ entities:
     pos: 25.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 710
   components:
@@ -8309,9 +5476,6 @@ entities:
     pos: 25.5,7.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 711
   components:
@@ -8319,9 +5483,6 @@ entities:
     pos: 25.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredlight
   uid: 712
   components:
@@ -8329,9 +5490,6 @@ entities:
     pos: 28,7.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -8348,12 +5506,6 @@ entities:
   - parent: 712
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: vending_machine_medical
   uid: 714
   components:
@@ -8363,12 +5515,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/medical.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: vending_machine_medical
   uid: 715
   components:
@@ -8378,12 +5524,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/medical.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: vending_machine_medical
   uid: 716
   components:
@@ -8393,12 +5533,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/medical.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: vending_machine_wallmed
   uid: 717
   components:
@@ -8408,12 +5542,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/wallmed.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: MedkitFilled
   uid: 718
   components:
@@ -8421,12 +5549,6 @@ entities:
     pos: 13.460339,0.6141751
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: MedkitFilled
   uid: 719
   components:
@@ -8434,12 +5556,6 @@ entities:
     pos: 13.632214,1.5673001
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: computerMedicalRecords
   uid: 720
   components:
@@ -8447,12 +5563,6 @@ entities:
     pos: 22.5,-5.5
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - type: poweredlight
   uid: 721
   components:
@@ -8460,9 +5570,6 @@ entities:
     pos: 23.5,-6
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -8479,12 +5586,6 @@ entities:
   - parent: 721
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Brutepack
   uid: 723
   components:
@@ -8492,12 +5593,6 @@ entities:
     pos: 18.476385,4.841032
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Brutepack
   uid: 724
   components:
@@ -8505,12 +5600,6 @@ entities:
     pos: 18.601385,5.512907
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Ointment
   uid: 725
   components:
@@ -8518,12 +5607,6 @@ entities:
     pos: 18.49201,6.059782
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: Ointment
   uid: 726
   components:
@@ -8531,12 +5614,6 @@ entities:
     pos: 18.77326,6.653532
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: spawn_point_latejoin
   uid: 727
   components:
@@ -8558,11 +5635,6 @@ entities:
     pos: 33.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 730
   components:
@@ -8570,11 +5642,6 @@ entities:
     pos: 33.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 731
   components:
@@ -8582,11 +5649,6 @@ entities:
     pos: 33.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 732
   components:
@@ -8594,11 +5656,6 @@ entities:
     pos: 33.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 733
   components:
@@ -8606,11 +5663,6 @@ entities:
     pos: 33.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: LargeBeaker
   uid: 734
   components:
@@ -8618,12 +5670,6 @@ entities:
     pos: 33.18525,-5.681699
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -8634,12 +5680,6 @@ entities:
     pos: 33.294624,-5.181699
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -8650,12 +5690,6 @@ entities:
     pos: 33.544624,-5.572324
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -8666,12 +5700,6 @@ entities:
     pos: 33.357124,-4.837949
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -8682,12 +5710,6 @@ entities:
     pos: 33.357124,-4.166074
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -8698,12 +5720,6 @@ entities:
     pos: 33.388374,-4.431699
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -8714,12 +5730,6 @@ entities:
     pos: 33.62275,-4.228574
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -8730,12 +5740,6 @@ entities:
     pos: 33.62275,-4.634824
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - contents:
       reagents: []
     type: Solution
@@ -8746,12 +5750,6 @@ entities:
     pos: 32.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.4,-0.4,0.4,0.4
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8764,12 +5762,6 @@ entities:
     pos: 31.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.4,-0.4,0.4,0.4
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8782,12 +5774,6 @@ entities:
     pos: 30.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8800,12 +5786,6 @@ entities:
     pos: 29.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8818,12 +5798,6 @@ entities:
     pos: 27.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8836,12 +5810,6 @@ entities:
     pos: 27.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8854,10 +5822,6 @@ entities:
     pos: 4.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 749
   components:
@@ -8865,10 +5829,6 @@ entities:
     pos: 4.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 750
   components:
@@ -8876,10 +5836,6 @@ entities:
     pos: 4.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 751
   components:
@@ -8887,10 +5843,6 @@ entities:
     pos: 4.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 752
   components:
@@ -8898,10 +5850,6 @@ entities:
     pos: 4.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 753
   components:
@@ -8909,10 +5857,6 @@ entities:
     pos: 4.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 754
   components:
@@ -8920,10 +5864,6 @@ entities:
     pos: 4.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 755
   components:
@@ -8931,10 +5871,6 @@ entities:
     pos: 4.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 756
   components:
@@ -8942,10 +5878,6 @@ entities:
     pos: 4.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 757
   components:
@@ -8953,10 +5885,6 @@ entities:
     pos: 4.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 758
   components:
@@ -8964,10 +5892,6 @@ entities:
     pos: 7.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 759
   components:
@@ -8975,10 +5899,6 @@ entities:
     pos: 7.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 760
   components:
@@ -8986,10 +5906,6 @@ entities:
     pos: 7.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 761
   components:
@@ -8997,10 +5913,6 @@ entities:
     pos: 7.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 762
   components:
@@ -9008,10 +5920,6 @@ entities:
     pos: 7.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 763
   components:
@@ -9019,10 +5927,6 @@ entities:
     pos: 8.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 764
   components:
@@ -9030,10 +5934,6 @@ entities:
     pos: 10.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 765
   components:
@@ -9041,10 +5941,6 @@ entities:
     pos: 11.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 766
   components:
@@ -9052,10 +5948,6 @@ entities:
     pos: 12.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 767
   components:
@@ -9063,10 +5955,6 @@ entities:
     pos: 13.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 768
   components:
@@ -9074,10 +5962,6 @@ entities:
     pos: 14.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 769
   components:
@@ -9085,10 +5969,6 @@ entities:
     pos: 15.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 770
   components:
@@ -9096,10 +5976,6 @@ entities:
     pos: 14.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 771
   components:
@@ -9107,10 +5983,6 @@ entities:
     pos: 14.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 772
   components:
@@ -9118,10 +5990,6 @@ entities:
     pos: 14.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 773
   components:
@@ -9129,10 +5997,6 @@ entities:
     pos: 14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 774
   components:
@@ -9140,10 +6004,6 @@ entities:
     pos: 15.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 775
   components:
@@ -9151,10 +6011,6 @@ entities:
     pos: 17.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 776
   components:
@@ -9162,10 +6018,6 @@ entities:
     pos: 17.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 777
   components:
@@ -9173,10 +6025,6 @@ entities:
     pos: 18.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 778
   components:
@@ -9184,10 +6032,6 @@ entities:
     pos: 18.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 779
   components:
@@ -9195,10 +6039,6 @@ entities:
     pos: 18.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 780
   components:
@@ -9206,10 +6046,6 @@ entities:
     pos: 18.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 781
   components:
@@ -9217,10 +6053,6 @@ entities:
     pos: 18.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 782
   components:
@@ -9228,10 +6060,6 @@ entities:
     pos: 18.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 783
   components:
@@ -9239,10 +6067,6 @@ entities:
     pos: 18.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 784
   components:
@@ -9250,10 +6074,6 @@ entities:
     pos: 18.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 785
   components:
@@ -9261,10 +6081,6 @@ entities:
     pos: 19.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 786
   components:
@@ -9272,10 +6088,6 @@ entities:
     pos: 20.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 787
   components:
@@ -9283,10 +6095,6 @@ entities:
     pos: 21.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 788
   components:
@@ -9294,10 +6102,6 @@ entities:
     pos: 22.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 789
   components:
@@ -9305,10 +6109,6 @@ entities:
     pos: 23.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 790
   components:
@@ -9316,10 +6116,6 @@ entities:
     pos: 24.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 791
   components:
@@ -9327,10 +6123,6 @@ entities:
     pos: 25.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 792
   components:
@@ -9338,10 +6130,6 @@ entities:
     pos: 26.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 793
   components:
@@ -9349,10 +6137,6 @@ entities:
     pos: 27.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 794
   components:
@@ -9360,10 +6144,6 @@ entities:
     pos: 28.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 795
   components:
@@ -9371,10 +6151,6 @@ entities:
     pos: 6.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 796
   components:
@@ -9382,10 +6158,6 @@ entities:
     pos: 7.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 797
   components:
@@ -9393,10 +6165,6 @@ entities:
     pos: 14.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 798
   components:
@@ -9404,10 +6172,6 @@ entities:
     pos: 14.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 799
   components:
@@ -9415,10 +6179,6 @@ entities:
     pos: 8.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 800
   components:
@@ -9426,10 +6186,6 @@ entities:
     pos: 9.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 801
   components:
@@ -9437,10 +6193,6 @@ entities:
     pos: 10.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 802
   components:
@@ -9448,10 +6200,6 @@ entities:
     pos: 11.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 803
   components:
@@ -9459,10 +6207,6 @@ entities:
     pos: 12.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 804
   components:
@@ -9470,10 +6214,6 @@ entities:
     pos: 13.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 805
   components:
@@ -9481,10 +6221,6 @@ entities:
     pos: 14.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 806
   components:
@@ -9492,10 +6228,6 @@ entities:
     pos: 14.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 807
   components:
@@ -9503,10 +6235,6 @@ entities:
     pos: 14.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 808
   components:
@@ -9514,10 +6242,6 @@ entities:
     pos: 14.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 809
   components:
@@ -9525,10 +6249,6 @@ entities:
     pos: 14.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 810
   components:
@@ -9536,10 +6256,6 @@ entities:
     pos: 18.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 811
   components:
@@ -9547,10 +6263,6 @@ entities:
     pos: 18.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 812
   components:
@@ -9558,10 +6270,6 @@ entities:
     pos: 18.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 813
   components:
@@ -9569,10 +6277,6 @@ entities:
     pos: 18.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 814
   components:
@@ -9580,10 +6284,6 @@ entities:
     pos: 18.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 815
   components:
@@ -9591,10 +6291,6 @@ entities:
     pos: 18.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 816
   components:
@@ -9602,10 +6298,6 @@ entities:
     pos: 13.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 817
   components:
@@ -9613,10 +6305,6 @@ entities:
     pos: 12.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 818
   components:
@@ -9624,10 +6312,6 @@ entities:
     pos: 11.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 819
   components:
@@ -9635,10 +6319,6 @@ entities:
     pos: 10.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 820
   components:
@@ -9646,10 +6326,6 @@ entities:
     pos: 9.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 821
   components:
@@ -9657,10 +6333,6 @@ entities:
     pos: 8.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 822
   components:
@@ -9668,10 +6340,6 @@ entities:
     pos: 4.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 823
   components:
@@ -9679,10 +6347,6 @@ entities:
     pos: 10.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 824
   components:
@@ -9690,10 +6354,6 @@ entities:
     pos: 10.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 825
   components:
@@ -9701,10 +6361,6 @@ entities:
     pos: 10.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 826
   components:
@@ -9712,10 +6368,6 @@ entities:
     pos: 4.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 827
   components:
@@ -9723,10 +6375,6 @@ entities:
     pos: 4.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 828
   components:
@@ -9734,10 +6382,6 @@ entities:
     pos: 4.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 829
   components:
@@ -9745,10 +6389,6 @@ entities:
     pos: 7.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 830
   components:
@@ -9756,10 +6396,6 @@ entities:
     pos: 7.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 831
   components:
@@ -9767,10 +6403,6 @@ entities:
     pos: 7.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 832
   components:
@@ -9778,10 +6410,6 @@ entities:
     pos: 7.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: catwalk
   uid: 833
   components:
@@ -9789,9 +6417,6 @@ entities:
     pos: 5.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 834
   components:
@@ -9799,9 +6424,6 @@ entities:
     pos: 6.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: catwalk
   uid: 835
   components:
@@ -9809,9 +6431,6 @@ entities:
     pos: 6.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: solid_wall
   uid: 836
   components:
@@ -9819,10 +6438,6 @@ entities:
     pos: 1.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 837
   components:
@@ -9830,10 +6445,6 @@ entities:
     pos: 1.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 838
   components:
@@ -9841,10 +6452,6 @@ entities:
     pos: 1.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 839
   components:
@@ -9852,10 +6459,6 @@ entities:
     pos: 1.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 840
   components:
@@ -9863,10 +6466,6 @@ entities:
     pos: 1.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 841
   components:
@@ -9874,10 +6473,6 @@ entities:
     pos: 1.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 842
   components:
@@ -9885,10 +6480,6 @@ entities:
     pos: 1.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 843
   components:
@@ -9896,10 +6487,6 @@ entities:
     pos: 1.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: solid_wall
   uid: 844
   components:
@@ -9907,10 +6494,6 @@ entities:
     pos: 1.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 1
-    type: Collidable
 - type: Wire
   uid: 845
   components:
@@ -9918,9 +6501,6 @@ entities:
     pos: 2.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 846
   components:
@@ -9928,9 +6508,6 @@ entities:
     pos: 2.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 847
   components:
@@ -9938,9 +6515,6 @@ entities:
     pos: 2.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 848
   components:
@@ -9948,9 +6522,6 @@ entities:
     pos: 3.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 849
   components:
@@ -9958,9 +6529,6 @@ entities:
     pos: 4.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 850
   components:
@@ -9968,9 +6536,6 @@ entities:
     pos: 6.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 851
   components:
@@ -9978,9 +6543,6 @@ entities:
     pos: 6.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 852
   components:
@@ -9988,9 +6550,6 @@ entities:
     pos: 5.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 853
   components:
@@ -9998,9 +6557,6 @@ entities:
     pos: 5.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 854
   components:
@@ -10008,9 +6564,6 @@ entities:
     pos: 5.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 855
   components:
@@ -10018,9 +6571,6 @@ entities:
     pos: 6.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 856
   components:
@@ -10028,9 +6578,6 @@ entities:
     pos: 6.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 857
   components:
@@ -10038,9 +6585,6 @@ entities:
     pos: 6.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 858
   components:
@@ -10048,9 +6592,6 @@ entities:
     pos: 6.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 859
   components:
@@ -10058,9 +6599,6 @@ entities:
     pos: 6.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 860
   components:
@@ -10068,9 +6606,6 @@ entities:
     pos: 6.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 861
   components:
@@ -10078,9 +6613,6 @@ entities:
     pos: 6.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 862
   components:
@@ -10088,9 +6620,6 @@ entities:
     pos: 6.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 863
   components:
@@ -10098,9 +6627,6 @@ entities:
     pos: 6.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 864
   components:
@@ -10108,9 +6634,6 @@ entities:
     pos: 6.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 865
   components:
@@ -10118,9 +6641,6 @@ entities:
     pos: 6.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 866
   components:
@@ -10128,9 +6648,6 @@ entities:
     pos: 5.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: airlock_science_glass
   uid: 867
   components:
@@ -10138,11 +6655,6 @@ entities:
     pos: 14.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_science
   uid: 868
   components:
@@ -10150,11 +6662,6 @@ entities:
     pos: 14.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_science
   uid: 869
   components:
@@ -10162,11 +6669,6 @@ entities:
     pos: 16.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock_science
   uid: 870
   components:
@@ -10174,11 +6676,6 @@ entities:
     pos: 16.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock
   uid: 871
   components:
@@ -10186,11 +6683,6 @@ entities:
     pos: 5.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: airlock
   uid: 872
   components:
@@ -10198,11 +6690,6 @@ entities:
     pos: 7.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 2
-    type: Collidable
 - type: table
   uid: 873
   components:
@@ -10210,11 +6697,6 @@ entities:
     pos: 9.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: poweredlight
   uid: 874
   components:
@@ -10222,9 +6704,6 @@ entities:
     pos: 6.5,12
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10241,12 +6720,6 @@ entities:
   - parent: 874
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 876
   components:
@@ -10254,9 +6727,6 @@ entities:
     pos: 12.5,12
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10273,24 +6743,12 @@ entities:
   - parent: 876
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: LightTube
   uid: 878
   components:
   - parent: 879
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 879
   components:
@@ -10298,9 +6756,6 @@ entities:
     pos: 14,18.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10318,9 +6773,6 @@ entities:
     pos: 3.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 881
   components:
@@ -10328,9 +6780,6 @@ entities:
     pos: 2.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredlight
   uid: 882
   components:
@@ -10338,9 +6787,6 @@ entities:
     pos: 18,22.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10357,12 +6803,6 @@ entities:
   - parent: 882
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 884
   components:
@@ -10370,9 +6810,6 @@ entities:
     pos: 18,27.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10389,21 +6826,12 @@ entities:
   - parent: 884
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredsmalllight
   uid: 886
   components:
   - grid: 0
     pos: 18,17.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10420,21 +6848,12 @@ entities:
   - parent: 886
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 888
   components:
   - grid: 0
     pos: 2,17.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10451,33 +6870,18 @@ entities:
   - parent: 888
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: LightTube
   uid: 890
   components:
   - parent: 891
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: poweredlight
   uid: 891
   components:
   - grid: 0
     pos: 2,23.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10495,9 +6899,6 @@ entities:
     pos: 11,24.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10514,12 +6915,6 @@ entities:
   - parent: 892
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: catwalk
   uid: 894
   components:
@@ -10527,9 +6922,6 @@ entities:
     pos: 13.5,24.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredsmalllight
   uid: 895
   components:
@@ -10537,9 +6929,6 @@ entities:
     pos: 7.5,26
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10556,12 +6945,6 @@ entities:
   - parent: 895
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: researchAndDevelopmentServer
   uid: 897
   components:
@@ -10569,9 +6952,6 @@ entities:
     pos: 11.5,24.5
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - points: 343000
     type: ResearchServer
   - technologies: []
@@ -10582,12 +6962,6 @@ entities:
   - grid: 0
     pos: 8.5,18.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - technologies: []
     type: TechnologyDatabase
 - type: baseResearchAndDevelopmentPointSource
@@ -10596,20 +6970,12 @@ entities:
   - grid: 0
     pos: 13.5,16.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: protolathe
   uid: 900
   components:
   - grid: 0
     pos: 8.5,17.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - recipes: []
     protolatherecipes:
     - Brutepack
@@ -10634,11 +7000,6 @@ entities:
   - grid: 0
     pos: 13.5,18.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -10660,11 +7021,6 @@ entities:
   - grid: 0
     pos: -4.5,-5.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -10687,11 +7043,6 @@ entities:
     pos: 8.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 904
   components:
@@ -10699,11 +7050,6 @@ entities:
     pos: 9.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 905
   components:
@@ -10711,11 +7057,6 @@ entities:
     pos: 10.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 906
   components:
@@ -10723,11 +7064,6 @@ entities:
     pos: 11.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: table
   uid: 907
   components:
@@ -10735,11 +7071,6 @@ entities:
     pos: 13.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-    type: Collidable
 - type: Wire
   uid: 908
   components:
@@ -10747,9 +7078,6 @@ entities:
     pos: 2.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 909
   components:
@@ -10757,9 +7085,6 @@ entities:
     pos: 1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: APC
   uid: 910
   components:
@@ -10767,10 +7092,6 @@ entities:
     pos: 1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: APC
   uid: 911
   components:
@@ -10778,10 +7099,6 @@ entities:
     pos: 14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: APC
   uid: 912
   components:
@@ -10789,10 +7106,6 @@ entities:
     pos: 18.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 913
   components:
@@ -10800,9 +7113,6 @@ entities:
     pos: 7.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 914
   components:
@@ -10810,9 +7120,6 @@ entities:
     pos: 8.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 915
   components:
@@ -10820,9 +7127,6 @@ entities:
     pos: 9.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 916
   components:
@@ -10830,9 +7134,6 @@ entities:
     pos: 10.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 917
   components:
@@ -10840,9 +7141,6 @@ entities:
     pos: 11.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 918
   components:
@@ -10850,9 +7148,6 @@ entities:
     pos: 12.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 919
   components:
@@ -10860,9 +7155,6 @@ entities:
     pos: 13.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 920
   components:
@@ -10870,9 +7162,6 @@ entities:
     pos: 14.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 921
   components:
@@ -10880,9 +7169,6 @@ entities:
     pos: 14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 922
   components:
@@ -10890,9 +7176,6 @@ entities:
     pos: 15.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 923
   components:
@@ -10900,9 +7183,6 @@ entities:
     pos: 16.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 924
   components:
@@ -10910,9 +7190,6 @@ entities:
     pos: 16.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 925
   components:
@@ -10920,9 +7197,6 @@ entities:
     pos: 16.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 926
   components:
@@ -10930,9 +7204,6 @@ entities:
     pos: 16.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 927
   components:
@@ -10940,9 +7211,6 @@ entities:
     pos: 16.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 928
   components:
@@ -10950,9 +7218,6 @@ entities:
     pos: 16.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 929
   components:
@@ -10960,9 +7225,6 @@ entities:
     pos: 16.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 930
   components:
@@ -10970,9 +7232,6 @@ entities:
     pos: 16.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 931
   components:
@@ -10980,9 +7239,6 @@ entities:
     pos: 17.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Wire
   uid: 932
   components:
@@ -10990,9 +7246,6 @@ entities:
     pos: 18.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: Generator
   uid: 933
   components:
@@ -11000,12 +7253,6 @@ entities:
     pos: 3.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - type: Generator
   uid: 934
   components:
@@ -11013,12 +7260,6 @@ entities:
     pos: 2.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - type: Generator
   uid: 935
   components:
@@ -11026,12 +7267,6 @@ entities:
     pos: 1.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - type: Generator
   uid: 936
   components:
@@ -11039,12 +7274,6 @@ entities:
     pos: 0.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - type: Wire
   uid: 937
   components:
@@ -11052,18 +7281,12 @@ entities:
     pos: 0.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: poweredlight
   uid: 938
   components:
   - grid: 0
     pos: 8,16.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -11080,103 +7303,54 @@ entities:
   - parent: 938
     grid: 0
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: APC
   uid: 940
   components:
   - grid: 0
     pos: 7.5,18.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - type: Wire
   uid: 941
   components:
   - grid: 0
     pos: 7.5,18.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: GlassStack
   uid: 942
   components:
   - grid: 0
     pos: 8.560405,21.456738
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: GlassStack
   uid: 943
   components:
   - grid: 0
     pos: 8.57603,21.566113
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: MetalStack
   uid: 944
   components:
   - grid: 0
     pos: 9.435405,21.503613
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: MetalStack
   uid: 945
   components:
   - grid: 0
     pos: 9.654155,21.628613
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: CableStack
   uid: 946
   components:
   - grid: 0
     pos: 10.561831,21.767809
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: CableStack
   uid: 947
   components:
   - grid: 0
     pos: 10.577456,21.424059
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 8
-      mask: 5
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - type: chairOfficeLight
   uid: 948
   components:
@@ -11184,9 +7358,6 @@ entities:
     pos: 9.5,18.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chairOfficeLight
   uid: 949
   components:
@@ -11194,18 +7365,12 @@ entities:
     pos: 9.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: chair
   uid: 950
   components:
   - grid: 0
     pos: 12.5,17.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - type: locker_science
   uid: 951
   components:
@@ -11213,12 +7378,6 @@ entities:
     pos: 12.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -11231,12 +7390,6 @@ entities:
     pos: 13.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 16
-      mask: 19
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []

--- a/Resources/Prototypes/Entities/Research.yml
+++ b/Resources/Prototypes/Entities/Research.yml
@@ -35,6 +35,9 @@
     state: tdoppler
   - type: Clickable
   - type: Collidable
+    shapes:
+    - !type:PhysShapeAabb
+      layer: 15
   - type: SnapGrid
     offset: Center
   - type: ResearchPointSource

--- a/Resources/Prototypes/Entities/Weapons/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Weapons/Projectiles/projectiles.yml
@@ -15,8 +15,8 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.2,-0.2,0.2,0.2"
-      layer: 1
-      mask: 3
+      layer: 32
+      mask: 30
   - type: Physics
     edgeslide: false
   - type: Projectile

--- a/Resources/Prototypes/Entities/buildings/airlock_base.yml
+++ b/Resources/Prototypes/Entities/buildings/airlock_base.yml
@@ -25,8 +25,9 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      mask: 2
-      layer: 16
+      bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+      mask: 4
+      layer: 31
   - type: Airlock
   - type: Appearance
     visuals:

--- a/Resources/Prototypes/Entities/buildings/asteroid.yml
+++ b/Resources/Prototypes/Entities/buildings/asteroid.yml
@@ -13,7 +13,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      layer: 1
+      layer: 31
   - type: Damageable
   - type: Destructible
     thresholdvalue: 100

--- a/Resources/Prototypes/Entities/buildings/computers.yml
+++ b/Resources/Prototypes/Entities/buildings/computers.yml
@@ -11,8 +11,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5,-0.25,0.5,0.25"
-      mask: 19
-      layer: 16
+      layer: 15
   - type: Icon
     sprite: Buildings/computer.rsi
     state: computer

--- a/Resources/Prototypes/Entities/buildings/fuel_tank.yml
+++ b/Resources/Prototypes/Entities/buildings/fuel_tank.yml
@@ -14,8 +14,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5,-0.25,0.5,0.25"
-      mask: 19
-      layer: 16
+      layer: 15
     IsScrapingFloor: true
   - type: Physics
     mass: 15

--- a/Resources/Prototypes/Entities/buildings/girder.yml
+++ b/Resources/Prototypes/Entities/buildings/girder.yml
@@ -11,8 +11,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      mask: 19
-      layer: 1
+      layer: 31
   - type: Damageable
   - type: Destructible
     thresholdvalue: 50

--- a/Resources/Prototypes/Entities/buildings/instruments.yml
+++ b/Resources/Prototypes/Entities/buildings/instruments.yml
@@ -10,8 +10,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      mask: 19
-      layer: 16
+      layer: 31
 
   - type: SnapGrid
     offset: Center

--- a/Resources/Prototypes/Entities/buildings/lathe.yml
+++ b/Resources/Prototypes/Entities/buildings/lathe.yml
@@ -32,8 +32,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      mask: 19
-      layer: 16
+      layer: 15
   - type: SnapGrid
     offset: Center
   - type: Lathe
@@ -75,8 +74,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      mask: 19
-      layer: 16
+      layer: 15
   - type: SnapGrid
     offset: Center
   - type: ResearchClient

--- a/Resources/Prototypes/Entities/buildings/low_wall.yml
+++ b/Resources/Prototypes/Entities/buildings/low_wall.yml
@@ -17,7 +17,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      layer: 1
+      layer: 20
   - type: Damageable
   - type: Destructible
     thresholdvalue: 100

--- a/Resources/Prototypes/Entities/buildings/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/buildings/medical_scanner.yml
@@ -21,8 +21,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5,-0.25,0.5,0.25"
-      mask: 19
-      layer: 16
+      layer: 15
     IsScrapingFloor: true
   - type: Physics
     mass: 25

--- a/Resources/Prototypes/Entities/buildings/mirror.yml
+++ b/Resources/Prototypes/Entities/buildings/mirror.yml
@@ -11,8 +11,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      mask: 19
-      layer: 16
+      layer: 32
   - type: Clickable
   - type: Physics
     mass: 25

--- a/Resources/Prototypes/Entities/buildings/power.yml
+++ b/Resources/Prototypes/Entities/buildings/power.yml
@@ -44,8 +44,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5, -0.5, 0.3, 0.5"
-      mask: 19
-      layer: 16
+      layer: 31
   - type: Sprite
     texture: Objects/Power/generator.png
   - type: Icon
@@ -61,8 +60,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      mask: 19
-      layer: 4
+      layer: 32
   - type: Sprite
     drawdepth: WallMountedItems
     texture: Objects/Power/provider.png
@@ -119,8 +117,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5, -0.5, 0.5, 0.5"
-      mask: 19
-      layer: 16
+      layer: 31
   - type: Sprite
     netsync: false
     sprite: Buildings/smes.rsi
@@ -159,8 +156,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5, -0.25, 0.5, 0.25"
-      mask: 19
-      layer: 16
+      layer: 31
   - type: Sprite
     texture: Objects/Power/wiredmachine.png
   - type: Icon
@@ -180,8 +176,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5, -0.25, 0.5, 0.25"
-      mask: 19
-      layer: 16
+      layer: 31
   - type: Sprite
     texture: Objects/Furniture/wirelessmachine.png
   - type: Icon

--- a/Resources/Prototypes/Entities/buildings/reagent_dispenser_base.yml
+++ b/Resources/Prototypes/Entities/buildings/reagent_dispenser_base.yml
@@ -7,8 +7,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.4,-0.25,0.4,0.25"
-      mask: 19
-      layer: 16
+      layer: 15
     IsScrapingFloor: true
   - type: Physics
     mass: 25

--- a/Resources/Prototypes/Entities/buildings/storage/closet_base.yml
+++ b/Resources/Prototypes/Entities/buildings/storage/closet_base.yml
@@ -20,8 +20,8 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5,-0.25,0.5,0.25"
-      mask: 19
-      layer: 16
+      mask: 30
+      layer: 31
     IsScrapingFloor: true
   - type: Physics
     mass: 25

--- a/Resources/Prototypes/Entities/buildings/storage/crate_base.yml
+++ b/Resources/Prototypes/Entities/buildings/storage/crate_base.yml
@@ -20,8 +20,8 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.4, -0.4, 0.4, 0.4"
-      layer: 16
-      mask: 19
+      layer: 31
+      mask: 30
     IsScrapingFloor: true
   - type: Physics
     mass: 25

--- a/Resources/Prototypes/Entities/buildings/table.yml
+++ b/Resources/Prototypes/Entities/buildings/table.yml
@@ -15,8 +15,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      mask: 19
-      layer: 16
+      layer: 20
 
   - type: SnapGrid
     offset: Center

--- a/Resources/Prototypes/Entities/buildings/vending_machines.yml
+++ b/Resources/Prototypes/Entities/buildings/vending_machines.yml
@@ -20,8 +20,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5,-0.25,0.5,0.25"
-      mask: 19
-      layer: 16
+      layer: 15
   - type: SnapGrid
     offset: Center
   - type: Damageable

--- a/Resources/Prototypes/Entities/buildings/walls.yml
+++ b/Resources/Prototypes/Entities/buildings/walls.yml
@@ -12,7 +12,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      layer: 1
+      layer: 31
   - type: Damageable
   - type: Destructible
     thresholdvalue: 100

--- a/Resources/Prototypes/Entities/buildings/windows.yml
+++ b/Resources/Prototypes/Entities/buildings/windows.yml
@@ -17,7 +17,7 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5, -0.5, 0.3, 0.5"
-      layer: 1
+      layer: 30
   - type: Damageable
   - type: Destructible
     thresholdvalue: 100

--- a/Resources/Prototypes/Entities/items/item_base.yml
+++ b/Resources/Prototypes/Entities/items/item_base.yml
@@ -9,8 +9,8 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.25,-0.25,0.25,0.25"
-      mask: 5
-      layer: 8
+      mask: 26
+      layer: 32
     IsScrapingFloor: true
   - type: Physics
     mass: 5

--- a/Resources/Prototypes/Entities/items/powercells.yml
+++ b/Resources/Prototypes/Entities/items/powercells.yml
@@ -122,8 +122,8 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.25,-0.25,0.25,0.25"
-      mask: 19
-      layer: 16
+      mask: 2
+      layer: 32
     IsScrapingFloor: true
 
 - type: entity
@@ -153,8 +153,8 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.25,-0.25,0.25,0.25"
-      mask: 19
-      layer: 16
+      mask: 2
+      layer: 32
     IsScrapingFloor: true
 
 - type: entity
@@ -183,6 +183,6 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.25,-0.25,0.25,0.25"
-      mask: 19
-      layer: 16
+      mask: 2
+      layer: 32
     IsScrapingFloor: true

--- a/Resources/Prototypes/Entities/mobs/human.yml
+++ b/Resources/Prototypes/Entities/mobs/human.yml
@@ -54,8 +54,8 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.5,-0.25,-0.05,0.25"
-      mask: 19
-      layer: 2
+      mask: 30
+      layer: 4
 
   - type: Input
     context: "human"

--- a/Resources/Prototypes/Entities/water_tank.yml
+++ b/Resources/Prototypes/Entities/water_tank.yml
@@ -12,8 +12,7 @@
 
   - type: Clickable
   - type: Collidable
-    mask: 3
-    layer: 1
+    layer: 31
     shape:
       bounds: "-0.5,-0.25,0.5,0.25"
     IsScrapingFloor: true


### PR DESCRIPTION
- New collision layering system based on passability (will be used for mobs crawling under things and whatnot)
- Removes layer overrides from map

Current issue is that saving maps still detects every collision component as different from the prototype and adds an override. Needs changes to IsValueDefault in MapLoader.cs to check lists against their prototype, which is its own issue that I don't know how to solve.
Another issue is that object interactibility is dependent on an object having a collision layer. I've added a clickable layer as a bandaid, but this needs to be fixed entirely so that objects can be interacted with even if they have no collision layer.

Still need to test collision cases I may not be aware of. I removed a lot of masks but I don't know if they're necessary for other reasons.