### PR TITLE
Map & Grid Entities

### DIFF
--- a/Content.Client/GameObjects/Components/SubFloorHideComponent.cs
+++ b/Content.Client/GameObjects/Components/SubFloorHideComponent.cs
@@ -40,6 +40,9 @@ namespace Content.Client.GameObjects.Components
         {
             base.Shutdown();
 
+            if(Owner.Transform.Running == false)
+                return;
+
             _snapGridComponent.OnPositionChanged -= SnapGridOnPositionChanged;
             Owner.EntityManager.EventBus.RaiseEvent(Owner, new SubFloorHideDirtyEvent());
         }

--- a/Content.Server/GameObjects/Components/Power/PowerNodeComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerNodeComponent.cs
@@ -37,9 +37,9 @@ namespace Content.Server.GameObjects.Components.Power
         /// </summary>
         public event EventHandler<PowernetEventArgs> OnPowernetRegenerate;
 
-        public override void Initialize()
+        protected override void Startup()
         {
-            base.Initialize();
+            base.Startup();
 
             TryCreatePowernetConnection();
         }

--- a/Content.Server/GameObjects/Components/Power/PowerTransferComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerTransferComponent.cs
@@ -27,9 +27,9 @@ namespace Content.Server.GameObjects.Components.Power
         [ViewVariables]
         public bool Regenerating { get; set; } = false;
 
-        public override void Initialize()
+        protected override void Startup()
         {
-            base.Initialize();
+            base.Startup();
 
             if (Parent == null)
             {


### PR DESCRIPTION
Power components were accessing another component (Transform) in it's `Initialize()` function, assuming that Transform was already initialized. Moves powernet creating call to `Startup()` so that Transform is guaranteed to be initialized.

SubFloorHideComponent assumed Transform was always running when its Shutdown function was called. Now it properly checks Transform.

Sibling PR to https://github.com/space-wizards/RobustToolbox/pull/916