### PR TITLE
Use hashcode comparison for string equality check

### DIFF
--- a/Content.Client/Parallax/ParallaxManager.cs
+++ b/Content.Client/Parallax/ParallaxManager.cs
@@ -64,7 +64,7 @@ namespace Content.Client.Parallax
                     using (var data = _resourceCache.UserData.Open(ParallaxConfigOld, FileMode.Open))
                     using (var reader = new StreamReader(data, EncodingHelpers.UTF8))
                     {
-                        match = reader.ReadToEnd() == contents;
+                        match = reader.ReadToEnd().GetHashCode() == contents.GetHashCode();
                     }
 
                     if (match)


### PR DESCRIPTION
Applies a tiny performance optimization for generation of the parallax generation which will be ran much more often in the future when resizing the game window