### PR TITLE
Add keybind for line edit delete key usage

### DIFF
--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -141,3 +141,7 @@ binds:
 - function: TextScrollToBottom
   type: state
   key: PageDown
+- function: TextDelete
+  type: state
+  key: Delete
+  canRepeat: true


### PR DESCRIPTION
Adds delete key keybind for `LineEdit`. Pressing the delete key with a line edit in focus will delete the character in front of your cursor. Requires [PR 934 on the engine repo](https://github.com/space-wizards/RobustToolbox/pull/934) which has the actual keybind code.

Fixes #507 