### PR TITLE
Add more client/server only components to registerIgnore lists

### DIFF
--- a/Content.Client/EntryPoint.cs
+++ b/Content.Client/EntryPoint.cs
@@ -125,7 +125,9 @@ namespace Content.Client
                 "MedkitFill",
                 "FloorTile",
                 "FootstepSound",
-                "UtilityBeltClothingFill"
+                "UtilityBeltClothingFill",
+                "ShuttleController",
+                "HumanInventoryController"
             };
 
             foreach (var ignoreName in registerIgnore)

--- a/Content.Server/EntryPoint.cs
+++ b/Content.Server/EntryPoint.cs
@@ -39,6 +39,7 @@ namespace Content.Server
                 "InteractionOutline",
                 "MeleeWeaponArcAnimation",
                 "AnimationsTest",
+                "ItemStatus"
             };
 
             foreach (var ignoreName in registerIgnore)


### PR DESCRIPTION
Fixes a few warnings from components not added to the ignore list on client/server.

![Robust Server_nAlvCKuP6c](https://user-images.githubusercontent.com/8206401/72771534-331c8e80-3bcf-11ea-957a-4e348776dc42.png)
![VsDebugConsole_lH4Zs8yPZs](https://user-images.githubusercontent.com/8206401/72771537-357ee880-3bcf-11ea-8ff6-09350bae410e.png)
