### PR TITLE
Fix crash / debug assertion failure from explosions

### DIFF
--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -34,10 +34,11 @@ namespace Content.Server.Explosions
 
             foreach (var entity in entitiesAll)
             {
-                //if (entity == Owner)
-                //    continue;
+                if (entity.Deleted)
+                    continue;
                 if (!entity.Transform.IsMapTransform)
                     continue;
+
                 var distanceFromEntity = (int)entity.Transform.GridPosition.Distance(mapManager, coords);
                 var exAct = entitySystemManager.GetEntitySystem<ActSystem>();
                 var severity = ExplosionSeverity.Destruction;


### PR DESCRIPTION
When explosions are spawned they grab all entities in range and interact with them. They don't check if entities are deleted before doing so which can cause a crash. 

To reproduce, place several grenades on the ground, pick one up and detonate it on top of the others so they detonate as well. The debug assertion in `ContainerHelpers.IsInContainer()` will fail due to one of the accessed entities having been deleted.

This fixes that by ignoring deleted entities when making explosions.