### PR TITLE
Makes players spawn on job spawn markers on roundstart

### DIFF
--- a/Content.Server/GameObjects/Components/Markers/SpawnPointComponent.cs
+++ b/Content.Server/GameObjects/Components/Markers/SpawnPointComponent.cs
@@ -22,7 +22,7 @@ namespace Content.Server.GameObjects.Components.Markers
         private string _jobId;
         public SpawnPointType SpawnType => _spawnType;
         public JobPrototype Job => string.IsNullOrEmpty(_jobId) ? null
-            : _prototypeManager.Index(typeof(JobPrototype), _jobId) as JobPrototype;
+            : _prototypeManager.Index<JobPrototype>(_jobId);
 
         public override void ExposeData(ObjectSerializer serializer)
         {

--- a/Content.Server/GameObjects/Components/Markers/SpawnPointComponent.cs
+++ b/Content.Server/GameObjects/Components/Markers/SpawnPointComponent.cs
@@ -1,5 +1,8 @@
 using Content.Shared.GameObjects.Components.Markers;
+using Content.Shared.Jobs;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
@@ -9,15 +12,24 @@ namespace Content.Server.GameObjects.Components.Markers
     [ComponentReference(typeof(SharedSpawnPointComponent))]
     public sealed class SpawnPointComponent : SharedSpawnPointComponent
     {
+#pragma warning disable 649
+        [Dependency] private IPrototypeManager _prototypeManager;
+#pragma warning restore 649
+
+        [ViewVariables(VVAccess.ReadWrite)]
         private SpawnPointType _spawnType;
-        [ViewVariables]
+        [ViewVariables(VVAccess.ReadWrite)]
+        private string _jobId;
         public SpawnPointType SpawnType => _spawnType;
+        public JobPrototype Job => string.IsNullOrEmpty(_jobId) ? null
+            : _prototypeManager.Index(typeof(JobPrototype), _jobId) as JobPrototype;
 
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);
 
             serializer.DataField(ref _spawnType, "spawn_type", SpawnPointType.Unset);
+            serializer.DataField(ref _jobId, "job_id", null);
         }
     }
 
@@ -25,5 +37,6 @@ namespace Content.Server.GameObjects.Components.Markers
     {
         Unset = 0,
         LateJoin,
+        Job,
     }
 }

--- a/Content.Server/Mobs/Roles/Job.cs
+++ b/Content.Server/Mobs/Roles/Job.cs
@@ -8,15 +8,15 @@ namespace Content.Server.Mobs.Roles
 {
     public class Job : Role
     {
-        private readonly JobPrototype _jobPrototype;
+        public JobPrototype Prototype { get; }
 
         public override string Name { get; }
 
-        public String StartingGear => _jobPrototype.StartingGear;
+        public String StartingGear => Prototype.StartingGear;
 
         public Job(Mind mind, JobPrototype jobPrototype) : base(mind)
         {
-            _jobPrototype = jobPrototype;
+            Prototype = jobPrototype;
             Name = jobPrototype.Name;
         }
 


### PR DESCRIPTION
Closes #531 

Already works, but I'd like to get some feedback on the changes I made.
Doesn't add any actual job spawn markers yet, but adding them should be quite simple.
You could add prototypes for each job's spawn marker, or just edit the spawn type and job Id with VV before saving the map.