### PR TITLE
Normalize wander AI's direction vector

### DIFF
--- a/Content.Server/AI/WanderProcessor.cs
+++ b/Content.Server/AI/WanderProcessor.cs
@@ -125,7 +125,7 @@ namespace Content.Server.AI
             var rngState = GenSeed();
             for (var i = 0; i < 3; i++) // you get 3 chances to find a place to walk
             {
-                var dir = new Vector2(Random01(ref rngState) * 2 - 1, Random01(ref rngState) *2 -1);
+                var dir = new Vector2(Random01(ref rngState) * 2 - 1, Random01(ref rngState) *2 -1).Normalized;
                 var ray = new Ray(entWorldPos, dir, (int) CollisionGroup.Impassable);
                 var rayResult = _physMan.IntersectRay(ray, MaxWalkDistance, SelfEntity);
 


### PR DESCRIPTION
Fixes this:
```
Unhandled exception. Robust.Shared.Utility.DebugAssertException: Exception of type 'Robust.Shared.Utility.DebugAssertException' was thrown.
   at Robust.Shared.Utility.DebugTools.Assert(Boolean condition) in D:\dev\space-station-14\RobustToolbox\Robust.Shared\Utility\DebugTools.cs:line 33
   at Robust.Shared.Maths.Ray..ctor(Vector2 position, Vector2 direction, Int32 collisionMask) in D:\dev\space-station-14\RobustToolbox\Robust.Shared\Physics\Ray.cs:line 40
   at Content.Server.AI.WanderProcessor.IdleState() in D:\dev\space-station-14\Content.Server\AI\WanderProcessor.cs:line 130
   at Content.Server.AI.WanderProcessor.ProcessState() in D:\dev\space-station-14\Content.Server\AI\WanderProcessor.cs:line 90
   at Content.Server.AI.WanderProcessor.Update(Single frameTime) in D:\dev\space-station-14\Content.Server\AI\WanderProcessor.cs:line 79
   at Content.Server.GameObjects.EntitySystems.AiSystem.Update(Single frameTime) in D:\dev\space-station-14\Content.Server\GameObjects\EntitySystems\AiSystem.cs:line 67
   at Robust.Shared.GameObjects.EntitySystemManager.Update(Single frameTime) in D:\dev\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntitySystemManager.cs:line 151
   at Robust.Shared.GameObjects.EntityManager.Update(Single frameTime) in D:\dev\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.cs:line 92
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in D:\dev\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 357
   at Robust.Server.BaseServer.<MainLoop>b__30_0(Object sender, FrameEventArgs args) in D:\dev\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 256
   at Robust.Shared.Timing.GameLoop.Run() in D:\dev\space-station-14\RobustToolbox\Robust.Shared\Timing\GameLoop.cs:line 180
   at Robust.Server.BaseServer.MainLoop() in D:\dev\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 259
   at Robust.Server.Program.ParsedMain(CommandLineArgs args) in D:\dev\space-station-14\RobustToolbox\Robust.Server\Program.cs:line 64
   at Robust.Server.Program.Start(String[] args) in D:\dev\space-station-14\RobustToolbox\Robust.Server\Program.cs:line 34
   at Robust.Server.Program.Main(String[] args) in D:\dev\space-station-14\RobustToolbox\Robust.Server\Program.cs:line 20
```