### PR TITLE
Fix PickUp verb showing up for entities in containers

### DIFF
--- a/Content.Server/GameObjects/Components/Items/Storage/ItemComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ItemComponent.cs
@@ -5,6 +5,7 @@ using Content.Shared.GameObjects;
 using Content.Shared.GameObjects.Components.Items;
 using Robust.Server.GameObjects;
 using Robust.Server.Interfaces.GameObjects;
+using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Random;
@@ -86,7 +87,7 @@ namespace Content.Server.GameObjects
 
             protected override VerbVisibility GetVisibility(IEntity user, ItemComponent component)
             {
-                if (user.TryGetComponent(out HandsComponent hands) && hands.IsHolding(component.Owner))
+                if (ContainerHelpers.IsInContainer(component.Owner))
                 {
                     return VerbVisibility.Invisible;
                 }


### PR DESCRIPTION
Fixes the PickUp verb showing up when right clicking on entities in the inventory.