### PR TITLE
Add solution pouring / click-transfer

### DIFF
--- a/Content.Client/EntryPoint.cs
+++ b/Content.Client/EntryPoint.cs
@@ -128,7 +128,8 @@ namespace Content.Client
                 "UtilityBeltClothingFill",
                 "ShuttleController",
                 "HumanInventoryController",
-                "UseDelay"
+                "UseDelay",
+                "Pourable"
             };
 
             foreach (var ignoreName in registerIgnore)

--- a/Content.Server/GameObjects/Components/Chemistry/PourableComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/PourableComponent.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Content.Server.GameObjects.Components.Nutrition;
+using Content.Server.GameObjects.EntitySystems;
+using Content.Server.Interfaces;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Serialization;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Server.GameObjects.Components.Chemistry
+{
+    /// <summary>
+    /// Gives an entity click behavior for pouring reagents into
+    /// other entities and being poured into. The entity must have
+    /// a SolutionComponent or DrinkComponent for this to work.
+    /// (DrinkComponent adds a SolutionComponent if one isn't present).
+    /// </summary>
+    [RegisterComponent]
+    [ComponentReference(typeof(IAttackBy))]
+    class PourableComponent : Component, IAttackBy
+    {
+#pragma warning disable 649
+        [Dependency] private readonly IServerNotifyManager _notifyManager;
+        [Dependency] private readonly ILocalizationManager _localizationManager;
+#pragma warning restore 649
+
+        public override string Name => "Pourable";
+
+        private int _transferAmount;
+
+        /// <summary>
+        ///     The amount of solution to be transferred from this solution when clicking on other solutions with it.
+        /// </summary>
+        [ViewVariables]
+        public int TransferAmount
+        {
+            get => _transferAmount;
+            set => _transferAmount = value;
+        }
+
+        public override void ExposeData(ObjectSerializer serializer)
+        {
+            base.ExposeData(serializer);
+            serializer.DataField(ref _transferAmount, "transferAmount", 5);
+        }
+
+        /// <summary>
+        /// Called when the owner of this component is clicked on with another entity.
+        /// The owner of this component is the target.
+        /// The entity used to click on this one is the attacker.
+        /// </summary>
+        /// <param name="eventArgs">Attack event args</param>
+        /// <returns></returns>
+        bool IAttackBy.AttackBy(AttackByEventArgs eventArgs)
+        {
+            //Get target and check if it can be poured into
+            if (!Owner.TryGetComponent<SolutionComponent>(out var targetSolution))
+                return false;
+            if (!targetSolution.CanPourIn)
+                return false;
+
+            //Get attack entity and check if it can pour out.
+            var attackEntity = eventArgs.AttackWith;
+            if (!attackEntity.TryGetComponent<SolutionComponent>(out var attackSolution) || !attackSolution.CanPourOut)
+                return false;
+            if (!attackEntity.TryGetComponent<PourableComponent>(out var attackPourable))
+                return false;
+
+            //Get transfer amount. May be smaller than _transferAmount if not enough room
+            int realTransferAmount = Math.Min(attackPourable.TransferAmount, targetSolution.EmptyVolume);
+            if (realTransferAmount <= 0) //Special message if container is full
+            {
+                _notifyManager.PopupMessage(Owner.Transform.GridPosition, eventArgs.User,
+                    _localizationManager.GetString("Container is full"));
+                return false;
+            }
+            //Remove transfer amount from attacker
+            if (!attackSolution.TryRemoveSolution(realTransferAmount, out var removedSolution))
+                return false;
+
+            //Add poured solution to this solution
+            if (!targetSolution.TryAddSolution(removedSolution))
+                return false;
+
+            _notifyManager.PopupMessage(Owner.Transform.GridPosition, eventArgs.User,
+                _localizationManager.GetString("Transferred {0}u", removedSolution.TotalVolume));
+
+            return true;
+        }
+    }
+}

--- a/Content.Server/GameObjects/Components/Chemistry/PourableComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/PourableComponent.cs
@@ -19,7 +19,6 @@ namespace Content.Server.GameObjects.Components.Chemistry
     /// (DrinkComponent adds a SolutionComponent if one isn't present).
     /// </summary>
     [RegisterComponent]
-    [ComponentReference(typeof(IAttackBy))]
     class PourableComponent : Component, IAttackBy
     {
 #pragma warning disable 649

--- a/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -21,15 +21,12 @@ namespace Content.Server.GameObjects.Components.Chemistry
     ///     Shared ECS component that manages a liquid solution of reagents.
     /// </summary>
     [RegisterComponent]
-    [ComponentReference(typeof(IAttackBy))]
-    internal class SolutionComponent : Shared.GameObjects.Components.Chemistry.SolutionComponent, IExamine, IAttackBy
+    internal class SolutionComponent : Shared.GameObjects.Components.Chemistry.SolutionComponent, IExamine
     {
 #pragma warning disable 649
         [Dependency] private readonly IPrototypeManager _prototypeManager;
         [Dependency] private readonly ILocalizationManager _loc;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager;
-        [Dependency] private readonly IServerNotifyManager _notifyManager;
-        [Dependency] private readonly ILocalizationManager _localizationManager;
 #pragma warning restore 649
 
         private IEnumerable<ReactionPrototype> _reactions;
@@ -322,46 +319,6 @@ namespace Content.Server.GameObjects.Components.Chemistry
 
             //Play reaction sound client-side
             _audioSystem.Play("/Audio/effects/chemistry/bubbles.ogg", Owner.Transform.GridPosition);
-        }
-
-        /// <summary>
-        /// Called when the owner of this component is attacked by
-        /// another entity. Currently used for click solution transfer behavior.
-        /// Eg: Clicking one beaker with another to transfer chems from one
-        /// to the other.
-        /// </summary>
-        /// <param name="eventArgs">Attack event args</param>
-        /// <returns></returns>
-        bool IAttackBy.AttackBy(AttackByEventArgs eventArgs)
-        {
-            //Check if this solution supports being poured into
-            if (!CanPourIn)
-                return false;
-
-            //Check if attack entity has a solution component, and can pour. Remove pour amount from attack entity if viable.
-            var attackEntity = eventArgs.AttackWith;
-            if (!attackEntity.TryGetComponent<SolutionComponent>(out var attackSolution))
-                return false;
-            if (!attackSolution.CanPourOut)
-                return false;
-            if (!attackSolution.TryRemoveSolution(attackSolution.TransferAmount, out var removedSolution))
-                return false;
-
-            //Add poured solution to this solution. Notify player with popup
-            _containedSolution.AddSolution(removedSolution);
-            _notifyManager.PopupMessage(Owner.Transform.GridPosition, eventArgs.User,
-                _localizationManager.GetString("Transferred {0}u", removedSolution.TotalVolume));
-
-            //Force drinks to update if they are empty. Without this empty drinks require an additional click before disappearing
-            if (attackSolution.CurrentVolume == 0)
-            {
-                if (attackEntity.TryGetComponent<DrinkComponent>(out var drinkComponent))
-                {
-                    drinkComponent.Finish(eventArgs.User);
-                }
-            }
-
-            return true;
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -350,8 +350,7 @@ namespace Content.Server.GameObjects.Components.Chemistry
             //Add poured solution to this solution. Notify player with popup
             _containedSolution.AddSolution(removedSolution);
             _notifyManager.PopupMessage(Owner.Transform.GridPosition, eventArgs.User,
-                _localizationManager.GetString("{0}u of solution transferred from {1} to {2}.",
-                    removedSolution.TotalVolume, attackEntity.Name, Owner.Name));
+                _localizationManager.GetString("Transferred {0}u", removedSolution.TotalVolume));
 
             //Force drinks to update if they are empty. Without this empty drinks require an additional click before disappearing
             if (attackSolution.CurrentVolume == 0)

--- a/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -358,7 +358,7 @@ namespace Content.Server.GameObjects.Components.Chemistry
             {
                 if (attackEntity.TryGetComponent<DrinkComponent>(out var drinkComponent))
                 {
-                    drinkComponent.UseDrink(eventArgs.User, false);
+                    drinkComponent.Finish(eventArgs.User);
                 }
             }
 

--- a/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
@@ -122,7 +122,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
             UseDrink(eventArgs.Attacked);
         }
 
-        public void UseDrink(IEntity user, bool useSoundOverride = true)
+        private void UseDrink(IEntity user)
         {
             if (user == null)
             {
@@ -141,7 +141,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
                 var split = _contents.SplitSolution(transferAmount);
                 if (stomachComponent.TryTransferSolution(split))
                 {
-                    if (_useSound != null && useSoundOverride)
+                    if (_useSound != null)
                     {
                         Owner.GetComponent<SoundComponent>()?.Play(_useSound);
                         user.PopupMessage(user, _localizationManager.GetString("Slurp"));
@@ -155,12 +155,20 @@ namespace Content.Server.GameObjects.Components.Nutrition
                 }
             }
 
+            Finish(user);
+        }
+
+        /// <summary>
+        /// Trigger finish behavior in the drink if applicable.
+        /// Depending on the drink this will either delete it,
+        /// or convert it to another entity, like an empty variant.
+        /// </summary>
+        /// <param name="user">The entity that is using the drink</param>
+        public void Finish(IEntity user)
+        {
             // Drink containers are mostly transient.
             if (!_despawnOnFinish || UsesLeft() > 0)
-            {
                 return;
-
-            }
 
             Owner.Delete();
 
@@ -181,7 +189,6 @@ namespace Content.Server.GameObjects.Components.Nutrition
                 {
                     drinkComponent.MaxVolume = MaxVolume;
                 }
-                return;
             }
         }
     }

--- a/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
@@ -80,6 +80,11 @@ namespace Content.Server.GameObjects.Components.Nutrition
                 else
                 {
                     _contents = Owner.AddComponent<SolutionComponent>();
+                    //Ensure SolutionComponent supports click transferring if custom one not set
+                    _contents.TransferAmount = 5;
+                    _contents.Capabilities = SolutionCaps.PourIn
+                                             | SolutionCaps.PourOut
+                                             | SolutionCaps.Injectable;
                 }
             }
 
@@ -117,7 +122,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
             UseDrink(eventArgs.Attacked);
         }
 
-        void UseDrink(IEntity user)
+        public void UseDrink(IEntity user, bool useSoundOverride = true)
         {
             if (user == null)
             {
@@ -136,7 +141,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
                 var split = _contents.SplitSolution(transferAmount);
                 if (stomachComponent.TryTransferSolution(split))
                 {
-                    if (_useSound != null)
+                    if (_useSound != null && useSoundOverride)
                     {
                         Owner.GetComponent<SoundComponent>()?.Play(_useSound);
                         user.PopupMessage(user, _localizationManager.GetString("Slurp"));

--- a/Content.Shared/Chemistry/Solution.cs
+++ b/Content.Shared/Chemistry/Solution.cs
@@ -125,15 +125,23 @@ namespace Content.Shared.Chemistry
             }
         }
 
-        public void RemoveSolution(int quantity)
+        /// <summary>
+        /// Remove the specified quantity from this solution.
+        /// </summary>
+        /// <param name="quantity">The quantity of this solution to remove</param>
+        /// <param name="removedSolution">Out arg. The removed solution. Useful for adding removed solution
+        /// into other solutions. For example, when pouring from one container to another.</param>
+        public void RemoveSolution(int quantity, out Solution removedSolution)
         {
-            if(quantity <=0)
+            removedSolution = new Solution();
+            if(quantity <= 0)
                 return;
 
             var ratio = (float)(TotalVolume - quantity) / TotalVolume;
 
             if (ratio <= 0)
             {
+                removedSolution = this.Clone(); //Todo: Check if clone necessary
                 RemoveAllSolution();
                 return;
             }
@@ -148,6 +156,7 @@ namespace Content.Shared.Chemistry
                 var newQuantity = (int)Math.Floor(oldQuantity * ratio);
 
                 _contents[i] = new ReagentQuantity(reagent.ReagentId, newQuantity);
+                removedSolution.AddReagent(reagent.ReagentId, oldQuantity - newQuantity);
             }
 
             TotalVolume = (int)Math.Floor(TotalVolume * ratio);

--- a/Content.Shared/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Shared/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -44,6 +44,12 @@ namespace Content.Shared.GameObjects.Components.Chemistry
         public int CurrentVolume => _containedSolution.TotalVolume;
 
         /// <summary>
+        ///     The volume without reagents remaining in the container.
+        /// </summary>
+        [ViewVariables]
+        public int EmptyVolume => MaxVolume - CurrentVolume;
+
+        /// <summary>
         ///     The current blended color of all the reagents in the container.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
@@ -57,16 +63,6 @@ namespace Content.Shared.GameObjects.Components.Chemistry
         {
             get => _capabilities;
             set => _capabilities = value;
-        }
-
-        /// <summary>
-        ///     The amount of solution to be transferred from this solution when clicking on other solutions with it.
-        /// </summary>
-        [ViewVariables]
-        public int TransferAmount
-        {
-            get => _transferAmount;
-            set => _transferAmount = value;
         }
 
         public IReadOnlyList<Solution.ReagentQuantity> ReagentList => _containedSolution.Contents;
@@ -94,7 +90,6 @@ namespace Content.Shared.GameObjects.Components.Chemistry
             serializer.DataField(ref _maxVolume, "maxVol", 0);
             serializer.DataField(ref _containedSolution, "contents", _containedSolution);
             serializer.DataField(ref _capabilities, "caps", SolutionCaps.None);
-            serializer.DataField(ref _transferAmount, "transferAmount", 5);
         }
 
         /// <inheritdoc />

--- a/Content.Shared/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Shared/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -20,7 +20,6 @@ namespace Content.Shared.GameObjects.Components.Chemistry
         protected Solution _containedSolution = new Solution();
         protected int _maxVolume;
         private SolutionCaps _capabilities;
-        private int _transferAmount;
 
         /// <summary>
         /// Triggered when the solution contents change.

--- a/Content.Shared/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Shared/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -20,6 +20,7 @@ namespace Content.Shared.GameObjects.Components.Chemistry
         protected Solution _containedSolution = new Solution();
         protected int _maxVolume;
         private SolutionCaps _capabilities;
+        private int _transferAmount;
 
         /// <summary>
         /// Triggered when the solution contents change.
@@ -58,7 +59,26 @@ namespace Content.Shared.GameObjects.Components.Chemistry
             set => _capabilities = value;
         }
 
+        /// <summary>
+        ///     The amount of solution to be transferred from this solution when clicking on other solutions with it.
+        /// </summary>
+        [ViewVariables]
+        public int TransferAmount
+        {
+            get => _transferAmount;
+            set => _transferAmount = value;
+        }
+
         public IReadOnlyList<Solution.ReagentQuantity> ReagentList => _containedSolution.Contents;
+
+        /// <summary>
+        /// Shortcut for Capabilities PourIn flag to avoid binary operators.
+        /// </summary>
+        public bool CanPourIn => (Capabilities & SolutionCaps.PourIn) != 0;
+        /// <summary>
+        /// Shortcut for Capabilities PourOut flag to avoid binary operators.
+        /// </summary>
+        public bool CanPourOut => (Capabilities & SolutionCaps.PourOut) != 0;
 
         /// <inheritdoc />
         public override string Name => "Solution";
@@ -74,6 +94,7 @@ namespace Content.Shared.GameObjects.Components.Chemistry
             serializer.DataField(ref _maxVolume, "maxVol", 0);
             serializer.DataField(ref _containedSolution, "contents", _containedSolution);
             serializer.DataField(ref _capabilities, "caps", SolutionCaps.None);
+            serializer.DataField(ref _transferAmount, "transferAmount", 5);
         }
 
         /// <inheritdoc />
@@ -108,11 +129,20 @@ namespace Content.Shared.GameObjects.Components.Chemistry
             return true;
         }
 
-        public bool TryRemoveSolution(int quantity)
+        /// <summary>
+        /// Attempt to remove the specified quantity from this solution
+        /// </summary>
+        /// <param name="quantity">Quantity of this solution to remove</param>
+        /// <param name="removedSolution">Out arg. The removed solution. Useful for adding removed solution
+        /// into other solutions. For example, when pouring from one container to another.</param>
+        /// <returns>Whether or not the solution was successfully removed</returns>
+        public bool TryRemoveSolution(int quantity, out Solution removedSolution)
         {
-            if (CurrentVolume == 0) return false;
+            removedSolution = new Solution();
+            if (CurrentVolume == 0)
+                return false;
 
-            _containedSolution.RemoveSolution(quantity);
+            _containedSolution.RemoveSolution(quantity, out removedSolution);
             OnSolutionChanged();
             return true;
         }

--- a/Content.Tests/Shared/Chemistry/Solution_Tests.cs
+++ b/Content.Tests/Shared/Chemistry/Solution_Tests.cs
@@ -141,10 +141,14 @@ namespace Content.Tests.Shared.Chemistry
         {
             var solution = new Solution("water", 700);
 
-            solution.RemoveSolution(500);
+            solution.RemoveSolution(500,  out var removedSolution);
 
+            //Check that edited solution is correct
             Assert.That(solution.GetReagentQuantity("water"), Is.EqualTo(200));
             Assert.That(solution.TotalVolume, Is.EqualTo(200));
+            //Check that removed solution is correct
+            Assert.That(removedSolution.GetReagentQuantity("water"), Is.EqualTo(500));
+            Assert.That(removedSolution.TotalVolume, Is.EqualTo(500));
         }
 
         [Test]
@@ -152,10 +156,14 @@ namespace Content.Tests.Shared.Chemistry
         {
             var solution = new Solution("water", 800);
 
-            solution.RemoveSolution(1000);
+            solution.RemoveSolution(1000, out var removedSolution);
 
+            //Check that edited solution is correct
             Assert.That(solution.GetReagentQuantity("water"), Is.EqualTo(0));
             Assert.That(solution.TotalVolume, Is.EqualTo(0));
+            //Check that removed solution is correct
+            Assert.That(removedSolution.GetReagentQuantity("water"), Is.EqualTo(800));
+            Assert.That(removedSolution.TotalVolume, Is.EqualTo(800));
         }
 
         [Test]
@@ -165,11 +173,15 @@ namespace Content.Tests.Shared.Chemistry
             solution.AddReagent("water", 1000);
             solution.AddReagent("fire", 2000);
 
-            solution.RemoveSolution(1500);
+            solution.RemoveSolution(1500, out var removedSolution);
 
             Assert.That(solution.GetReagentQuantity("water"), Is.EqualTo(500));
             Assert.That(solution.GetReagentQuantity("fire"), Is.EqualTo(1000));
             Assert.That(solution.TotalVolume, Is.EqualTo(1500));
+
+            Assert.That(removedSolution.GetReagentQuantity("water"), Is.EqualTo(500));
+            Assert.That(removedSolution.GetReagentQuantity("fire"), Is.EqualTo(1000));
+            Assert.That(removedSolution.TotalVolume, Is.EqualTo(1500));
         }
 
         [Test]
@@ -177,10 +189,13 @@ namespace Content.Tests.Shared.Chemistry
         {
             var solution = new Solution("water", 800);
 
-            solution.RemoveSolution(-200);
+            solution.RemoveSolution(-200, out var removedSolution);
 
             Assert.That(solution.GetReagentQuantity("water"), Is.EqualTo(800));
             Assert.That(solution.TotalVolume, Is.EqualTo(800));
+
+            Assert.That(removedSolution.GetReagentQuantity("water"), Is.EqualTo(0));
+            Assert.That(removedSolution.TotalVolume, Is.EqualTo(0));
         }
 
         [Test]

--- a/Resources/Prototypes/Entities/items/chemistry.yml
+++ b/Resources/Prototypes/Entities/items/chemistry.yml
@@ -11,6 +11,7 @@
   - type: Solution
     maxVol: 50
     caps: 19
+  - type: Pourable
     transferAmount: 5
 
 - type: entity
@@ -26,6 +27,7 @@
   - type: Solution
     maxVol: 100
     caps: 19
+  - type: Pourable
     transferAmount: 5
 
 - type: entity
@@ -41,4 +43,5 @@
   - type: Solution
     maxVol: 5
     caps: 19
+  - type: Pourable
     transferAmount: 5

--- a/Resources/Prototypes/Entities/items/chemistry.yml
+++ b/Resources/Prototypes/Entities/items/chemistry.yml
@@ -11,6 +11,7 @@
   - type: Solution
     maxVol: 50
     caps: 19
+    transferAmount: 5
 
 - type: entity
   name: Large Beaker
@@ -25,6 +26,7 @@
   - type: Solution
     maxVol: 100
     caps: 19
+    transferAmount: 5
 
 - type: entity
   name: Dropper
@@ -39,3 +41,4 @@
   - type: Solution
     maxVol: 5
     caps: 19
+    transferAmount: 5


### PR DESCRIPTION
For example, you can now click on a beaker with a soda can to transfer the soda to the beaker. Works on plain solution containers like beakers and also on open drink containers like soda cans as long as they have the `PourIn` and `PourOut` solution capabilities. 

If no `SolutionComponent` is added to a drink entity, the `DrinkComponent` will give the entity one. This PR extends that behavior slightly by also giving these default `SolutionComponent`'s the capabilities for pouring in/out.

![d5fDESaj7V](https://user-images.githubusercontent.com/8206401/73230558-b435d180-414b-11ea-850a-7700cfda9dbb.gif)