### PR TITLE
Add mask and layer to powercell items

### DIFF
--- a/Resources/Prototypes/Entities/items/powercells.yml
+++ b/Resources/Prototypes/Entities/items/powercells.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: PowerCellSmallBase
   abstract: true
   parent: BaseItem
@@ -7,6 +7,8 @@
     shapes:
     - !type:PhysShapeAabb
       bounds: "-0.15,-0.3,0.2,0.3"
+      mask: 26
+      layer: 32
   - type: PowerCell
   - type: Appearance
   - type: Sprite


### PR DESCRIPTION
Fix for #562. Not sure why the first line has a diff, but this is pretty simple. Looks like the mask/layer didn't get set, so it was just flinging through walls.