### PR TITLE
Implement antag role loading

### DIFF
--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Content.Server.GameTicking;
 using Content.Server.Interfaces.GameTicking;
@@ -66,6 +66,10 @@ namespace Content.IntegrationTests
         public IEnumerable<GameRule> ActiveGameRules { get; } = Array.Empty<GameRule>();
 
         public void SetStartPreset(Type type)
+        {
+        }
+
+        public void AddPresetRole(string presetId, int percent)
         {
         }
     }

--- a/Content.Server/GameTicking/GamePresets/PresetTraitor.cs
+++ b/Content.Server/GameTicking/GamePresets/PresetTraitor.cs
@@ -1,0 +1,19 @@
+﻿using Content.Server.Interfaces.GameTicking;
+using Robust.Shared.IoC;
+
+namespace Content.Server.GameTicking.GamePresets
+{
+    public sealed class PresetTraitor : GamePreset
+    {
+#pragma warning disable 649
+        [Dependency] private readonly IGameTicker _gameTicker;
+#pragma warning restore 649
+
+        public override void Start()
+        {
+            _gameTicker.AddPresetRole("Traitor", 25);
+        }
+
+        public override string Description => "There are Traitors in our midst.";
+    }
+}

--- a/Content.Server/GameTicking/GameTicker.AntagRoleController.cs
+++ b/Content.Server/GameTicking/GameTicker.AntagRoleController.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using Content.Shared.Preferences;
+using Robust.Server.Interfaces.Player;
+using Robust.Shared.Random;
+
+namespace Content.Server.GameTicking
+{
+    public partial class GameTicker
+    {
+        private Dictionary<string, int> _presetRoles = new Dictionary<string, int>();
+
+        public void AddPresetRole(string presetId, int percent)
+        {
+            _presetRoles.Add(presetId, percent);
+        }
+
+        private Dictionary<IPlayerSession, List<string>> AssignAntagRoles(List<IPlayerSession> available,
+            Dictionary<IPlayerSession, HumanoidCharacterProfile> profiles)
+        {
+            var gameModeRoles = new Dictionary<string, int>();
+            foreach (var role in _presetRoles)
+            {
+                gameModeRoles.Add(role.Key, Math.Max((int)(available.Count * (role.Value / 100f)), 1)); // 25% of players get traitor. Minimum is 1.
+            };
+
+            var assigned = new Dictionary<IPlayerSession, List<string>>();
+
+            var antagRoles = new Dictionary<string, List<IPlayerSession>>();
+
+            // TODO Replace with PlayerPrefs from profiles
+            var AntagPrefs = new List<string>
+            {
+                "Traitor"
+            };
+
+            foreach (var player in available)
+            {
+                foreach (var role in AntagPrefs) // TODO profiles[player].AntagPrefs)
+                {
+                    if (!antagRoles.ContainsKey(role))
+                        antagRoles.Add(role, new List<IPlayerSession> {
+                            player
+                        });
+                    else
+                        antagRoles[role].Add(player);
+                }
+            }
+
+            foreach (var (role, players) in antagRoles)
+            {
+                if (!gameModeRoles.ContainsKey(role))
+                    continue;
+
+                while (gameModeRoles[role] > 0)
+                {
+                    var picked = _robustRandom.Pick(players);
+                    if (!assigned.ContainsKey(picked))
+                        assigned.Add(picked, new List<string>
+                        {
+                            role
+                        });
+                    else
+                        assigned[picked].Add(role);
+                    gameModeRoles[role] -= 1;
+                }
+            }
+            return assigned;
+        }
+    }
+}

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Content.Server.GameTicking.GamePresets;
 using Content.Server.Interfaces.GameTicking;
 using Content.Server.Players;
@@ -192,6 +192,9 @@ namespace Content.Server.GameTicking
                     break;
                 case "Sandbox":
                     presetType = typeof(PresetSandbox);
+                    break;
+                case "Traitor":
+                    presetType = typeof(PresetTraitor);
                     break;
                 default:
                     shell.SendText(player, "That is not a valid game preset!");

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Content.Server.GameTicking;
 using Robust.Server.Interfaces.Player;
@@ -33,5 +33,6 @@ namespace Content.Server.Interfaces.GameTicking
         IEnumerable<GameRule> ActiveGameRules { get; }
 
         void SetStartPreset(Type type);
+        void AddPresetRole(string presetId, int percent);
     }
 }


### PR DESCRIPTION
This is a basic implementation for adding antag roles to players when they spawn.

There isn't much more to add until we design and begin implementing more antagonists without having to rewrite that stuff later.