### PR TITLE
Faster Power

### DIFF
--- a/Content.Server/GameObjects/Components/Power/PowerDevice.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerDevice.cs
@@ -26,7 +26,7 @@ namespace Content.Server.GameObjects.Components.Power
         protected override void Startup()
         {
             base.Startup();
-            if (_drawType != DrawTypes.Node)
+            if (DrawType != DrawTypes.Node)
             {
                 var componentMgr = IoCManager.Resolve<IComponentManager>();
                 AvailableProviders = componentMgr.GetAllComponents<PowerProviderComponent>().Where(x => x.CanServiceDevice(this)).ToList();
@@ -40,12 +40,16 @@ namespace Content.Server.GameObjects.Components.Power
         ///     The method of draw we will try to use to place our load set via component parameter, defaults to using power providers
         /// </summary>
         [ViewVariables]
-        public virtual DrawTypes DrawType
+        public DrawTypes DrawType
         {
-            get => _drawType;
+            get => _drawType ?? DefaultDrawType;
             protected set => _drawType = value;
         }
-        private DrawTypes _drawType = DrawTypes.Provider;
+
+        private DrawTypes? _drawType;
+
+        protected virtual DrawTypes DefaultDrawType => DrawTypes.Provider;
+
 
         /// <summary>
         ///     The power draw method we are currently connected to and using
@@ -206,7 +210,9 @@ namespace Content.Server.GameObjects.Components.Power
         {
             base.ExposeData(serializer);
 
-            serializer.DataField(ref _drawType, "drawtype", DrawTypes.Provider);
+            var drawType = DrawType;
+            serializer.DataField(ref drawType, "drawtype", DefaultDrawType);
+            DrawType = drawType;
             serializer.DataField(ref _priority, "priority", Powernet.Priority.Medium);
 
             if (SaveLoad)

--- a/Content.Server/GameObjects/Components/Power/PowerProviderComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerProviderComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Server.GameObjects.Components.Power
         public override string Name => "PowerProvider";
 
         /// <inheritdoc />
-        public override DrawTypes DrawType { get; protected set; } = DrawTypes.Node;
+        protected override DrawTypes DefaultDrawType => DrawTypes.Node;
 
         protected override bool SaveLoad => false;
 
@@ -198,9 +198,9 @@ namespace Content.Server.GameObjects.Components.Power
             base.PowernetConnect(sender, eventarg);
 
             //Find devices within range to take under our control
-            var _emanager = IoCManager.Resolve<IServerEntityManager>();
+            var entMgr = IoCManager.Resolve<IServerEntityManager>();
             var position = Owner.GetComponent<ITransformComponent>().WorldPosition;
-            var entities = _emanager.GetEntitiesInRange(Owner, PowerRange)
+            var entities = entMgr.GetEntitiesInRange(Owner, PowerRange)
                 .Where(x => x.HasComponent<PowerDeviceComponent>());
 
 
@@ -252,8 +252,7 @@ namespace Content.Server.GameObjects.Components.Power
         {
             if (DeviceLoadList.Contains(device))
             {
-                TheoreticalLoad -= oldLoad;
-                TheoreticalLoad += device.Load;
+                TheoreticalLoad = TheoreticalLoad - oldLoad + device.Load;
             }
         }
 


### PR DESCRIPTION
fixes incorrect DrawType for APCs due to deserialization and misuse of a virtual impl's field in a ctor

uses SnapGridComponent to select nearby wires instead of entity list (only marginally faster if entity queries are using DynamicTree)

TheoreticalLoad double dipping property setter, reduced to one update

minor refactoring

Benefits heavily from https://github.com/space-wizards/RobustToolbox/pull/951 changes to entity intersection queries

Lag-free wire cutting w/ both