### PR TITLE
Drink fixes

### DIFF
--- a/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
@@ -47,6 +47,8 @@ namespace Content.Server.GameObjects.Components.Nutrition
 
         private bool _despawnOnFinish;
 
+        private bool _drinking;
+
         public int UsesLeft()
         {
             // In case transfer amount exceeds volume left
@@ -92,6 +94,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
                 }
             }
 
+            _drinking = false;
             if (_maxVolume != 0)
                 _contents.MaxVolume = _maxVolume;
             else
@@ -145,6 +148,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
 
             if (user.TryGetComponent(out StomachComponent stomachComponent))
             {
+                _drinking = true;
                 var transferAmount = Math.Min(_transferAmount, _contents.CurrentVolume);
                 var split = _contents.SplitSolution(transferAmount);
                 if (stomachComponent.TryTransferSolution(split))
@@ -161,6 +165,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
                     _contents.TryAddSolution(split);
                     user.PopupMessage(user, _localizationManager.GetString("Can't drink"));
                 }
+                _drinking = false;
             }
 
             Finish(user);
@@ -175,7 +180,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
         public void Finish(IEntity user)
         {
             // Drink containers are mostly transient.
-            if (!_despawnOnFinish || UsesLeft() > 0)
+            if (_drinking || !_despawnOnFinish || UsesLeft() > 0)
                 return;
 
             var gridPos = Owner.Transform.GridPosition;

--- a/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
@@ -43,6 +43,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
         }
 
         private Solution _initialContents; // This is just for loading from yaml
+        private int _maxVolume;
 
         private bool _despawnOnFinish;
 
@@ -61,6 +62,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
         {
             base.ExposeData(serializer);
             serializer.DataField(ref _initialContents, "contents", null);
+            serializer.DataField(ref _maxVolume, "max_volume", 0);
             serializer.DataField(ref _useSound, "use_sound", "/Audio/items/drink.ogg");
             // E.g. cola can when done or clear bottle, whatever
             // Currently this will enforce it has the same volume but this may change.
@@ -90,7 +92,10 @@ namespace Content.Server.GameObjects.Components.Nutrition
                 }
             }
 
-            _contents.MaxVolume = _initialContents.TotalVolume;
+            if (_maxVolume != 0)
+                _contents.MaxVolume = _maxVolume;
+            else
+                _contents.MaxVolume = _initialContents.TotalVolume;
             _contents.SolutionChanged += HandleSolutionChangedEvent;
         }
 

--- a/Resources/Prototypes/Entities/items/Consumables/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/items/Consumables/drinks_cups.yml
@@ -5,9 +5,10 @@
   name: Base cup
   abstract: true
   components:
-  - type: Drink   
+  - type: Drink
     max_volume: 4
     despawn_empty: false
+  - type: Sound
   - type: Sprite
     state: icon
   - type: Icon
@@ -19,7 +20,7 @@
   name: Golden cup
   description: A golden cup
   components:
-  - type: Drink   
+  - type: Drink
     max_volume: 10
   - type: Sprite
     sprite: Objects/Drinks/golden_cup.rsi
@@ -32,7 +33,7 @@
   name: Insulated pitcher
   description: A stainless steel insulated pitcher. Everyone's best friend in the morning.
   components:
-  - type: Drink  
+  - type: Drink
     max_volume: 15
   - type: Sprite
     sprite: Objects/Drinks/pitcher.rsi
@@ -51,7 +52,7 @@
   name: Mug
   description: A plain white mug.
   components:
-  - type: Drink    
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug.rsi
@@ -70,7 +71,7 @@
   name: Mug Black
   description: A sleek black mug.
   components:
-  - type: Drink  
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_black.rsi
@@ -89,7 +90,7 @@
   name: Mug Blue
   description: A blue and black mug.
   components:
-  - type: Drink  
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_blue.rsi
@@ -108,7 +109,7 @@
   name: Mug Green
   description: A pale green and pink mug.
   components:
-  - type: Drink  
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_green.rsi
@@ -127,7 +128,7 @@
   name: Mug Heart
   description: A white mug, it prominently features a red heart.
   components:
-  - type: Drink 
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_heart.rsi
@@ -146,7 +147,7 @@
   name: Mug Metal
   description: A metal mug. You're not sure which metal.
   components:
-  - type: Drink  
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_metal.rsi
@@ -165,7 +166,7 @@
   name: Mug Moebius
   description: A mug with a Moebius Laboratories logo on it. Not even your morning coffee is safe from corporate advertising.
   components:
-  - type: Drink   
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_moebius.rsi
@@ -184,7 +185,7 @@
   name: "#1 mug"
   description: "A white mug, it prominently features a #1."
   components:
-  - type: Drink  
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_one.rsi
@@ -203,7 +204,7 @@
   name: Mug Rainbow
   description: A rainbow mug. The colors are almost as blinding as a welder.
   components:
-  - type: Drink   
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_rainbow.rsi
@@ -222,7 +223,7 @@
   name: Mug Red
   description: A red and black mug.
   components:
-  - type: Drink 
+  - type: Drink
     max_volume: 4
   - type: Sprite
     sprite: Objects/Drinks/mug_red.rsi


### PR DESCRIPTION
Fix all mugs crashing the game due to not having a `_contents.MaxVolume`

Fix crash from SoundComponent not existing on mugs.

Fix drinks that despawn when empty crashing due to deleting the Entity before trying to get SoundComponent.