### PR TITLE
Yaml fixes

### DIFF
--- a/Resources/Prototypes/Entities/Weapons/Ammunition/.32/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/.32/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_32_empty
   name: ".32 magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A32

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/.357/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/.357/ammunition.yml
@@ -1,110 +1,111 @@
-# Empty mags
-- type: entity
-  id: magazine_357_empty
-  name: ".357 magazine - empty"
-  parent: BaseItem
-  components:
-  - type: BallisticMagazine
-    caliber: A357
-    magazine: A357
-    capacity: 6
-  - type: Sprite
-    netsync: false
-
-# Magazines
-# Casings - magazines above here
-- type: entity
-  id: ammo_casing_357
-  name: ".357 casing"
-  parent: BaseItem
-  components:
-  - type: BallisticBullet
-    caliber: A357
-    projectile: bullet_357
-  - type: Sprite
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-    drawdepth: FloorObjects
-  - type: Icon
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-
-- type: entity
-  id: ammo_casing_357_flash
-  name: ".357 casing (Flash)"
-  parent: BaseItem
-  components:
-  - type: BallisticBullet
-    caliber: A357
-    projectile: bullet_357f
-  - type: Sprite
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-    drawdepth: FloorObjects
-  - type: Icon
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-
-- type: entity
-  id: ammo_casing_357_hv
-  name: ".357 casing (High Velocity)"
-  parent: BaseItem
-  components:
-  - type: BallisticBullet
-    caliber: A357
-    projectile: bullet_357hv
-  - type: Sprite
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-    drawdepth: FloorObjects
-  - type: Icon
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-
-- type: entity
-  id: ammo_casing_357_l
-  name: ".357 casing (L)"
-  parent: BaseItem
-  components:
-  - type: BallisticBullet
-    caliber: A357
-    projectile: bullet_357l
-  - type: Sprite
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-    drawdepth: FloorObjects
-  - type: Icon
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-
-- type: entity
-  id: ammo_casing_357_p
-  name: ".357 casing (Practice)"
-  parent: BaseItem
-  components:
-  - type: BallisticBullet
-    caliber: A357
-    projectile: bullet_357p
-  - type: Sprite
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-    drawdepth: FloorObjects
-  - type: Icon
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-
-- type: entity
-  id: ammo_casing_357_r
-  name: ".357 casing (Rubber)"
-  parent: BaseItem
-  components:
-  - type: BallisticBullet
-    caliber: A357
-    projectile: bullet_357r
-  - type: Sprite
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
-    drawdepth: FloorObjects
-  - type: Icon
-    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
-    state: s-casing
+## Empty mags
+#- type: entity
+#  id: magazine_357_empty
+#  name: ".357 magazine - empty"
+#  parent: BaseItem
+#  abstract: true
+#  components:
+#  - type: BallisticMagazine
+#    caliber: A357
+#    magazine: A357
+#    capacity: 6
+#  - type: Sprite
+#    netsync: false
+#
+## Magazines
+## Casings - magazines above here
+#- type: entity
+#  id: ammo_casing_357
+#  name: ".357 casing"
+#  parent: BaseItem
+#  components:
+#  - type: BallisticBullet
+#    caliber: A357
+#    projectile: bullet_357
+#  - type: Sprite
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#    drawdepth: FloorObjects
+#  - type: Icon
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#
+#- type: entity
+#  id: ammo_casing_357_flash
+#  name: ".357 casing (Flash)"
+#  parent: BaseItem
+#  components:
+#  - type: BallisticBullet
+#    caliber: A357
+#    projectile: bullet_357f
+#  - type: Sprite
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#    drawdepth: FloorObjects
+#  - type: Icon
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#
+#- type: entity
+#  id: ammo_casing_357_hv
+#  name: ".357 casing (High Velocity)"
+#  parent: BaseItem
+#  components:
+#  - type: BallisticBullet
+#    caliber: A357
+#    projectile: bullet_357hv
+#  - type: Sprite
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#    drawdepth: FloorObjects
+#  - type: Icon
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#
+#- type: entity
+#  id: ammo_casing_357_l
+#  name: ".357 casing (L)"
+#  parent: BaseItem
+#  components:
+#  - type: BallisticBullet
+#    caliber: A357
+#    projectile: bullet_357l
+#  - type: Sprite
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#    drawdepth: FloorObjects
+#  - type: Icon
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#
+#- type: entity
+#  id: ammo_casing_357_p
+#  name: ".357 casing (Practice)"
+#  parent: BaseItem
+#  components:
+#  - type: BallisticBullet
+#    caliber: A357
+#    projectile: bullet_357p
+#  - type: Sprite
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#    drawdepth: FloorObjects
+#  - type: Icon
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#
+#- type: entity
+#  id: ammo_casing_357_r
+#  name: ".357 casing (Rubber)"
+#  parent: BaseItem
+#  components:
+#  - type: BallisticBullet
+#    caliber: A357
+#    projectile: bullet_357r
+#  - type: Sprite
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing
+#    drawdepth: FloorObjects
+#  - type: Icon
+#    sprite: Objects/Guns/Ammunition/ammo_casing.rsi
+#    state: s-casing

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/.44/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/.44/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_44_empty
   name: ".44 magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A44

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/.45mm/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/.45mm/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_45mm_empty
   name: ".45mm magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A45mm
@@ -15,6 +16,7 @@
   id: magazine_45mm_smg_empty
   name: ".45mm SMG magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A45mm

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/.50/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/.50/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_50_empty
   name: ".50 cal magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A50

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/10mm/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/10mm/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_10mm_empty
   name: "10mm magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A10mm

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/20mm/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/20mm/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_20mm_empty
   name: "20mm magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A20mm

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/24mm/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/24mm/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_24mm_empty
   name: "24mm magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A24mm

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/5.56mm/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/5.56mm/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_556mm_empty
   name: "5.56mm magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A556mm

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/6.5mm/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/6.5mm/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_65mm_empty
   name: "6.5mm magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A65mm

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/7.62mm/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/7.62mm/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_762mm_empty
   name: "7.62mm magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A762mm

--- a/Resources/Prototypes/Entities/Weapons/Ammunition/9mm/ammunition.yml
+++ b/Resources/Prototypes/Entities/Weapons/Ammunition/9mm/ammunition.yml
@@ -3,6 +3,7 @@
   id: magazine_9mm_empty
   name: "9mm magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A9mm
@@ -15,6 +16,7 @@
   id: magazine_9mm_smg_empty
   name: "9mm SMG magazine - empty"
   parent: BaseItem
+  abstract: true
   components:
   - type: BallisticMagazine
     caliber: A9mm

--- a/Resources/Prototypes/Entities/buildings/low_wall.yml
+++ b/Resources/Prototypes/Entities/buildings/low_wall.yml
@@ -2,6 +2,10 @@
   id: low_wall
   name: Low Wall
   description: Goes up to about your waist.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wall
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -29,10 +33,6 @@
   - type: LowWall
     key: walls
     base: metal_
-
-  placement:
-    snap:
-    - Wall
 
 - type: entity
   id: low_wall_overlay

--- a/Resources/Prototypes/Entities/buildings/power.yml
+++ b/Resources/Prototypes/Entities/buildings/power.yml
@@ -2,6 +2,8 @@
   id: Wire
   name: Wire
   description: Transfers power, avoid letting things come down it
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -42,6 +44,8 @@
   id: Generator
   name: Generator
   description: A portal to hell which summons power from the nether
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -55,11 +59,15 @@
   - type: Icon
     texture: Objects/Power/generator.png
   - type: PowerGenerator
+  - type: SnapGrid
+    offset: Center
 
 - type: entity
   id: WPPnobattery
   name: WPPnobattery
   description: Supplies power directly to nearby objects
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -76,6 +84,8 @@
     range: 8
     priority: Provider
     load: 0
+  - type: SnapGrid
+    offset: Center
 
 - type: entity
   parent: WPPnobattery
@@ -117,6 +127,8 @@
   id: SMES
   name: Smes
   description: Stores power in its super-magnetic cells
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -145,6 +157,8 @@
   - type: Appearance
     visuals:
     - type: SmesVisualizer2D
+  - type: SnapGrid
+    offset: Center
 
 - type: entity
   id: smes_dry
@@ -157,6 +171,8 @@
   id: WiredMachine
   name: WiredMachine
   description: A monstrosity that does nothing but suck up power from the nearby wires
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -173,11 +189,15 @@
     drawtype: Node
     load: 100
     priority: High
+  - type: SnapGrid
+    offset: Center
 
 - type: entity
   id: WirelessMachine
   name: WirelessMachine
   description: A terrifying monstrosity that sucks up power from the wireless transmitters, Tesla would be proud
+  placement:
+    mode: SnapgridCenter
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -194,3 +214,5 @@
     drawtype: Both
     load: 200
     priority: Low
+  - type: SnapGrid
+    offset: Center

--- a/Resources/Prototypes/Entities/buildings/walls.yml
+++ b/Resources/Prototypes/Entities/buildings/walls.yml
@@ -3,6 +3,10 @@
   name: BaseWall
   description: Keeps the air in and the greytide out.
   abstract: true
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wall
   components:
   - type: Clickable
   - type: InteractionOutline
@@ -28,9 +32,6 @@
   - type: IconSmooth
     key: walls
     base: solid
-  placement:
-    snap:
-    - Wall
 
 - type: entity
   id: brick_wall


### PR DESCRIPTION
Change base magazines to abstract so that they don't show up in the Entity Spawn panel.

Comment out .357 ammo because the gun that uses it is also commented out.

Change walls, APCs, SMESes, and other power things to default to SnapGrid placement.

Fixes #607