### PR TITLE
Fix issues with exploding items from own hand

### DIFF
--- a/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Content.Shared.GameObjects.Components.Mobs;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
@@ -42,6 +42,9 @@ namespace Content.Client.GameObjects.Components.Mobs
 
         public override void Kick(Vector2 recoil)
         {
+            if(float.IsNaN(recoil.X) || float.IsNaN(recoil.Y))
+                return;
+
             // Use really bad math to "dampen" kicks when we're already kicked.
             var existing = _currentKick.Length;
             var dampen = existing/KickMagnitudeMax;

--- a/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
@@ -4,6 +4,7 @@ using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
+using Robust.Shared.Log;
 using Robust.Shared.Maths;
 
 namespace Content.Client.GameObjects.Components.Mobs
@@ -42,8 +43,11 @@ namespace Content.Client.GameObjects.Components.Mobs
 
         public override void Kick(Vector2 recoil)
         {
-            if(float.IsNaN(recoil.X) || float.IsNaN(recoil.Y))
+            if (float.IsNaN(recoil.X) || float.IsNaN(recoil.Y))
+            {
+                Logger.Error($"CameraRecoilComponent on entity {Owner.Uid} passed a NaN recoil value. Ignoring.");
                 return;
+            }
 
             // Use really bad math to "dampen" kicks when we're already kicked.
             var existing = _currentKick.Length;

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -20,6 +20,12 @@ namespace Content.Server.Explosions
 {
     public static class ExplosionHelper
     {
+        /// <summary>
+        /// Distance used for camera shake when distance from explosion is (0.0, 0.0).
+        /// Avoids getting NaN values down the line from doing math on (0.0, 0.0).
+        /// </summary>
+        private static Vector2 _epicenterDistance = (0.1f, 0.1f);
+
         public static void SpawnExplosion(GridCoordinates coords, int devastationRange, int heavyImpactRange, int lightImpactRange, int flashRange)
         {
             var tileDefinitionManager = IoCManager.Resolve<ITileDefinitionManager>();
@@ -130,8 +136,11 @@ namespace Content.Server.Explosions
 
                 var playerPos = player.AttachedEntity.Transform.WorldPosition;
                 var delta = coords.ToMapPos(mapManager) - playerPos;
-                var distance = delta.LengthSquared;
+                //Change if zero. Will result in a NaN later breaking camera shake if not changed
+                if (delta.EqualsApprox((0.0f, 0.0f)))
+                    delta = _epicenterDistance;
 
+                var distance = delta.LengthSquared;
                 var effect = 1 / (1 + 0.2f * distance);
                 if (effect > 0.01f)
                 {


### PR DESCRIPTION
Fixes #602.

`CameraRecoilComponent.Kick` returns early, logs an error, and doesn't shake camera if either component of recoil is NaN. Doesn't throw an exception since I think camera shake not working isn't crash-worthy. Also edited `ExplosionHelper.SpawnExplosion` to not send a NaN value over so explosion camera shake is fixed in this case.