### PR TITLE
Let stacks specify if they get thrown as one item, or individually

### DIFF
--- a/Content.Server/GameObjects/Components/Stack/StackComponent.cs
+++ b/Content.Server/GameObjects/Components/Stack/StackComponent.cs
@@ -26,6 +26,7 @@ namespace Content.Server.GameObjects.Components.Stack
         private const string SerializationCache = "stack";
         private int _count = 50;
         private int _maxCount = 50;
+        private bool _throwIndividually = false;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public int Count
@@ -49,6 +50,17 @@ namespace Content.Server.GameObjects.Components.Stack
             private set
             {
                 _maxCount = value;
+                Dirty();
+            }
+        }
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool ThrowIndividually
+        {
+            get => _throwIndividually;
+            private set
+            {
+                _throwIndividually = value;
                 Dirty();
             }
         }

--- a/Content.Server/GameObjects/EntitySystems/HandsSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/HandsSystem.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Content.Server.GameObjects.Components;
 using Content.Server.GameObjects.Components.Stack;
 using Content.Server.Interfaces.GameObjects;
@@ -166,8 +166,8 @@ namespace Content.Server.GameObjects.EntitySystems
             if (!handsComp.ThrowItem())
                 return false;
 
-            // pop off an item, or throw the single item in hand.
-            if (!throwEnt.TryGetComponent(out StackComponent stackComp) || stackComp.Count < 2)
+            // throw the item, split off from a stack if it's meant to be thrown individually
+            if (!throwEnt.TryGetComponent(out StackComponent stackComp) || stackComp.Count < 2 || !stackComp.ThrowIndividually)
             {
                 handsComp.Drop(handsComp.ActiveIndex);
             }


### PR DESCRIPTION
New variable added to the StackComponent called _throwIndividually, by default is false.
When false the stack is treated as a single item when throwing, otherwise the current behavior of throwing each item in the stack individually is used.

closes #677 