### PR TITLE
Unset FocusChat when returning to main menu

### DIFF
--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -92,6 +92,7 @@ namespace Content.Client.GameTicking
         {
             if (e.NewLevel != ClientRunLevel.Initialize)
             {
+                _inputManager.SetInputCommand(ContentKeyFunctions.FocusChat, null);
                 return;
             }
 
@@ -289,7 +290,7 @@ namespace Content.Client.GameTicking
 
         private void _focusChat(ChatBox chat)
         {
-            if (_userInterfaceManager.KeyboardFocused != null)
+            if (chat == null || _userInterfaceManager.KeyboardFocused != null)
             {
                 return;
             }


### PR DESCRIPTION
Fixes the error by unbinding the FocusChat keybind when returning to main menu. Added a check just in case so the crash doesn't happen again.

Fixes #403