### PR TITLE
Improve addai error handling and help message

### DIFF
--- a/Content.Server/GameObjects/EntitySystems/AiSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AiSystem.cs
@@ -84,12 +84,6 @@ namespace Content.Server.GameObjects.EntitySystems
 
         private class AddAiCommand : IClientCommand
         {
-#pragma warning disable 649
-            [Dependency] private readonly IEntitySystemManager _entitySystemManager;
-#pragma warning restore 649
-
-            public AddAiCommand() => IoCManager.InjectDependencies(this);
-
             public string Command => "addai";
             public string Description => "Add an ai component with a given processor to an entity.";
             public string Help => "Usage: addai <processorId> <entityId>"
@@ -107,7 +101,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 var processorId = args[0];
                 var entId = new EntityUid(int.Parse(args[1]));
                 var ent = IoCManager.Resolve<IEntityManager>().GetEntity(entId);
-                var aiSystem = _entitySystemManager.GetEntitySystem<AiSystem>();
+                var aiSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<AiSystem>();
 
                 if (!aiSystem.ProcessorTypeExists(processorId))
                 {

--- a/Content.Server/GameObjects/EntitySystems/AiSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AiSystem.cs
@@ -79,11 +79,23 @@ namespace Content.Server.GameObjects.EntitySystems
             throw new ArgumentException($"Processor type {name} could not be found.", nameof(name));
         }
 
+        public bool ProcessorTypeExists(string name) => _processorTypes.ContainsKey(name);
+
+
         private class AddAiCommand : IClientCommand
         {
+#pragma warning disable 649
+            [Dependency] private readonly IEntitySystemManager _entitySystemManager;
+#pragma warning restore 649
+
+            public AddAiCommand() => IoCManager.InjectDependencies(this);
+
             public string Command => "addai";
             public string Description => "Add an ai component with a given processor to an entity.";
-            public string Help => "addai <processorId> <entityId>";
+            public string Help => "Usage: addai <processorId> <entityId>"
+                                + "\n    processorId: Class that inherits AiLogicProcessor and has an AiLogicProcessor attribute."
+                                + "\n    entityID: Uid of entity to add the AiControllerComponent to. Open its VV menu to find this.";
+
             public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
             {
                 if(args.Length != 2)
@@ -95,7 +107,13 @@ namespace Content.Server.GameObjects.EntitySystems
                 var processorId = args[0];
                 var entId = new EntityUid(int.Parse(args[1]));
                 var ent = IoCManager.Resolve<IEntityManager>().GetEntity(entId);
+                var aiSystem = _entitySystemManager.GetEntitySystem<AiSystem>();
 
+                if (!aiSystem.ProcessorTypeExists(processorId))
+                {
+                    shell.SendText(player, "Invalid processor type. Processor must inherit AiLogicProcessor and have an AiLogicProcessor attribute.");
+                    return;
+                }
                 if (ent.HasComponent<AiControllerComponent>())
                 {
                     shell.SendText(player, "Entity already has an AI component.");


### PR DESCRIPTION
Fix client crash from giving `addai` console command an invalid `processorId` argument and improved it's help message to describe each parameter.

![Content Client_SwVsB2wyWi](https://user-images.githubusercontent.com/8206401/74575339-9b535b80-4f54-11ea-9fca-d4b24e03d043.png)
