### PR TITLE
Fixes 1 runtime error message

### DIFF
--- a/Resources/Prototypes/Cargo/products.yml
+++ b/Resources/Prototypes/Cargo/products.yml
@@ -48,8 +48,7 @@
   name: "Fire Extinguisher"
   id: cargo.fireextinguisher
   description: Puts out fires. Or propels you in space.
-  icon:
-    sprite: Objects/Misc/fire_extinguisher.png
+  icon: Objects/Misc/fire_extinguisher.png
   product: crate_fire_extinguisher
   cost: 300
   category: Other
@@ -71,8 +70,7 @@
   name: "Bike Horn"
   id: cargo.bikehorn
   description: HONK!
-  icon:
-    sprite: Objects/Fun/bikehorn.rsi
+  icon: Objects/Fun/bikehorn.rsi
   product: crate_bikehorn
   cost: 300
   category: Other
@@ -94,8 +92,7 @@
   name: "Fuel Tank"
   id: cargo.fueltank
   description: Movable fuel tank for welders. No boom boom.
-  icon:
-    sprite: Buildings/weldtank.png
+  icon: Buildings/weldtank.png
   product: crate_fueltank
   cost: 200
   category: Engineering
@@ -105,8 +102,7 @@
   name: "Medical Scanner"
   id: cargo.medscanner
   description: Scans patients. First we stick this probe...
-  icon:
-    sprite: Buildings/medical_scanner.rsi
+  icon: Buildings/medical_scanner.rsi
   product: crate_medscanner
   cost: 400
   category: Medical
@@ -116,8 +112,7 @@
   name: "Glass Crate"
   id: cargo.glass
   description: 50 sheets of glass.
-  icon:
-    sprite: Objects/Materials/sheet_glass.png
+  icon: Objects/Materials/sheet_glass.png
   product: crate_glass
   cost: 50
   category: Engineering
@@ -127,9 +122,7 @@
   name: "Cable Crate"
   id: cargo.cable
   description: 50 coils of cable.
-  icon:
-    sprite: Objects/Tools/cable_coil.png
-    color: yellow
+  icon: Objects/Tools/cable_coil.png
   product: crate_cable
   cost: 50
   category: Engineering


### PR DESCRIPTION
Fixes the error message from improper formatting in the cargo products YAML. Hopefully the icons display right. I wasn't able to check since apparently the cargo products actually have to be placed in the cargo console somewhere else and these were never added to them (100% tested to be not tested)
There are also some client-specific runtime errors from MovementSpeedModifierComponent and StorageFillComponent added recently. This is since the prototypes for both of these are loaded on both client and server but only server has these components. I'll leave these to whoever made them to fix since that would require making them inherit from a common shared class.