### PR TITLE
Fix vending machine eject animation being played twice

### DIFF
--- a/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
@@ -166,8 +166,8 @@ namespace Content.Server.GameObjects.Components.VendingMachines
 
             Timer.Spawn(_animationDuration, () =>
             {
-                TrySetVisualState(VendingMachineVisualState.Normal);
                 _ejecting = false;
+                TrySetVisualState(VendingMachineVisualState.Normal);
                 Owner.EntityManager.SpawnEntity(id, Owner.Transform.GridPosition);
             });
         }


### PR DESCRIPTION
Thought it would be fun to have a codebase to contribute again, so might start doing these small bug fixes while I familiarize myself with the project(s).

Fixes #675

The method that changes the current animation is checking for the `_ejecting` flag, so it would just play the animation again as opposed to setting it to the normal state.