### PR TITLE
Fixing map collisions

### DIFF
--- a/Resources/Maps/stationstation.yml
+++ b/Resources/Maps/stationstation.yml
@@ -101,10 +101,6 @@ entities:
     type: Transform
   - index: 0
     type: MapGrid
-  - shapes:
-    - !type:PhysShapeGrid
-      grid: 0
-    type: Collidable
 - uid: 1
   type: LaserGun
   components:
@@ -114,12 +110,6 @@ entities:
     type: Transform
   - charge: 1200
     type: HitscanWeaponCapacitor
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 2
   type: LaserGun
   components:
@@ -129,12 +119,6 @@ entities:
     type: Transform
   - charge: 1200
     type: HitscanWeaponCapacitor
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 3
   type: Brutepack
   components:
@@ -142,12 +126,6 @@ entities:
     pos: -2.106966,-1.457896
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 4
   type: Ointment
   components:
@@ -155,12 +133,6 @@ entities:
     pos: -1.481966,-1.317271
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 5
   type: Spear
   components:
@@ -168,12 +140,6 @@ entities:
     pos: -4.144312,7.499083
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 6
   type: Spear
   components:
@@ -181,12 +147,6 @@ entities:
     pos: -1.238062,7.436583
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 7
   type: PowerCellSmallHigh
   components:
@@ -194,10 +154,12 @@ entities:
     pos: -2.67511,-10.351
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
+  - type: Collidable
+    shapes:
     - !type:PhysShapeAabb
-      bounds: -0.15,-0.3,0.2,0.3
-    type: Collidable
+      bounds: "-0.15,-0.3,0.2,0.3"
+      mask: 26
+      layer: 32
 - uid: 8
   type: PowerCellSmallHigh
   components:
@@ -205,10 +167,12 @@ entities:
     pos: -2.55011,-10.6635
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
+  - type: Collidable
+    shapes:
     - !type:PhysShapeAabb
-      bounds: -0.15,-0.3,0.2,0.3
-    type: Collidable
+      bounds: "-0.15,-0.3,0.2,0.3"
+      mask: 26
+      layer: 32
 - uid: 9
   type: OuterclothingVest
   components:
@@ -216,12 +180,6 @@ entities:
     pos: 1.412994,7.507263
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 10
   type: solid_wall
   components:
@@ -229,10 +187,6 @@ entities:
     pos: -7.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 11
   type: solid_wall
   components:
@@ -240,10 +194,6 @@ entities:
     pos: -7.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 12
   type: solid_wall
   components:
@@ -251,10 +201,6 @@ entities:
     pos: -7.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 13
   type: solid_wall
   components:
@@ -262,10 +208,6 @@ entities:
     pos: -7.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 14
   type: solid_wall
   components:
@@ -273,10 +215,6 @@ entities:
     pos: -7.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 15
   type: solid_wall
   components:
@@ -284,10 +222,6 @@ entities:
     pos: 0.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 16
   type: solid_wall
   components:
@@ -295,10 +229,6 @@ entities:
     pos: -0.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 17
   type: solid_wall
   components:
@@ -306,10 +236,6 @@ entities:
     pos: 3.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 18
   type: solid_wall
   components:
@@ -317,10 +243,6 @@ entities:
     pos: 4.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 19
   type: solid_wall
   components:
@@ -328,10 +250,6 @@ entities:
     pos: -7.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 20
   type: solid_wall
   components:
@@ -339,10 +257,6 @@ entities:
     pos: -7.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 21
   type: solid_wall
   components:
@@ -350,10 +264,6 @@ entities:
     pos: -7.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 22
   type: solid_wall
   components:
@@ -361,10 +271,6 @@ entities:
     pos: -7.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 23
   type: solid_wall
   components:
@@ -372,10 +278,6 @@ entities:
     pos: 2.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 24
   type: solid_wall
   components:
@@ -383,10 +285,6 @@ entities:
     pos: 1.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 25
   type: solid_wall
   components:
@@ -394,10 +292,6 @@ entities:
     pos: -1.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 26
   type: poweredsmalllight
   components:
@@ -405,9 +299,6 @@ entities:
     pos: -4.5,-5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -425,12 +316,6 @@ entities:
     pos: -15.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 28
   type: Wire
   components:
@@ -438,9 +323,6 @@ entities:
     pos: 8.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 29
   type: poweredsmalllight
   components:
@@ -448,9 +330,6 @@ entities:
     pos: 0.5,-5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -466,12 +345,6 @@ entities:
   components:
   - parent: 26
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 31
   type: Wire
   components:
@@ -479,9 +352,6 @@ entities:
     pos: -6.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 32
   type: solid_wall
   components:
@@ -489,10 +359,6 @@ entities:
     pos: -7.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 33
   type: solid_wall
   components:
@@ -500,10 +366,6 @@ entities:
     pos: -10.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 34
   type: airlock_engineering
   components:
@@ -511,12 +373,6 @@ entities:
     pos: -12.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 35
   type: solid_wall
   components:
@@ -524,10 +380,6 @@ entities:
     pos: -10.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 36
   type: solid_wall
   components:
@@ -535,10 +387,6 @@ entities:
     pos: -10.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 37
   type: solid_wall
   components:
@@ -546,10 +394,6 @@ entities:
     pos: -10.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 38
   type: solid_wall
   components:
@@ -557,10 +401,6 @@ entities:
     pos: -10.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 39
   type: solid_wall
   components:
@@ -568,10 +408,6 @@ entities:
     pos: -10.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 40
   type: solid_wall
   components:
@@ -579,10 +415,6 @@ entities:
     pos: -3.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 41
   type: solid_wall
   components:
@@ -590,10 +422,6 @@ entities:
     pos: 1.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 42
   type: solid_wall
   components:
@@ -601,10 +429,6 @@ entities:
     pos: 0.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 43
   type: solid_wall
   components:
@@ -612,10 +436,6 @@ entities:
     pos: -0.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 44
   type: solid_wall
   components:
@@ -623,10 +443,6 @@ entities:
     pos: -1.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 45
   type: solid_wall
   components:
@@ -634,10 +450,6 @@ entities:
     pos: -2.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 46
   type: solid_wall
   components:
@@ -645,10 +457,6 @@ entities:
     pos: -3.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 47
   type: solid_wall
   components:
@@ -656,10 +464,6 @@ entities:
     pos: -4.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 48
   type: solid_wall
   components:
@@ -667,10 +471,6 @@ entities:
     pos: -5.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 49
   type: solid_wall
   components:
@@ -678,10 +478,6 @@ entities:
     pos: -6.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 50
   type: solid_wall
   components:
@@ -689,10 +485,6 @@ entities:
     pos: 4.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 51
   type: solid_wall
   components:
@@ -700,10 +492,6 @@ entities:
     pos: 5.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 52
   type: solid_wall
   components:
@@ -711,10 +499,6 @@ entities:
     pos: 6.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 53
   type: solid_wall
   components:
@@ -722,10 +506,6 @@ entities:
     pos: -7.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 54
   type: solid_wall
   components:
@@ -733,10 +513,6 @@ entities:
     pos: -2.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 55
   type: solid_wall
   components:
@@ -744,10 +520,6 @@ entities:
     pos: -6.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 56
   type: solid_wall
   components:
@@ -755,10 +527,6 @@ entities:
     pos: -5.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 57
   type: solid_wall
   components:
@@ -766,10 +534,6 @@ entities:
     pos: -4.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 58
   type: solid_wall
   components:
@@ -777,10 +541,6 @@ entities:
     pos: 6.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 59
   type: solid_wall
   components:
@@ -788,10 +548,6 @@ entities:
     pos: 6.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 60
   type: solid_wall
   components:
@@ -799,10 +555,6 @@ entities:
     pos: 6.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 61
   type: solid_wall
   components:
@@ -810,10 +562,6 @@ entities:
     pos: 6.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 62
   type: solid_wall
   components:
@@ -821,10 +569,6 @@ entities:
     pos: 6.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 63
   type: solid_wall
   components:
@@ -832,10 +576,6 @@ entities:
     pos: 5.5,-14.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 64
   type: solid_wall
   components:
@@ -843,10 +583,6 @@ entities:
     pos: -7.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 65
   type: solid_wall
   components:
@@ -854,10 +590,6 @@ entities:
     pos: -7.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 66
   type: solid_wall
   components:
@@ -865,10 +597,6 @@ entities:
     pos: -8.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 67
   type: solid_wall
   components:
@@ -876,10 +604,6 @@ entities:
     pos: -9.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 68
   type: solid_wall
   components:
@@ -887,10 +611,6 @@ entities:
     pos: -10.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 69
   type: solid_wall
   components:
@@ -898,10 +618,6 @@ entities:
     pos: -7.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 70
   type: catwalk
   components:
@@ -909,9 +625,6 @@ entities:
     pos: -6.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 71
   type: catwalk
   components:
@@ -919,9 +632,6 @@ entities:
     pos: -8.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 72
   type: solid_wall
   components:
@@ -929,10 +639,6 @@ entities:
     pos: 5.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 73
   type: solid_wall
   components:
@@ -940,10 +646,6 @@ entities:
     pos: 5.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 74
   type: solid_wall
   components:
@@ -951,10 +653,6 @@ entities:
     pos: 6.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 75
   type: solid_wall
   components:
@@ -962,10 +660,6 @@ entities:
     pos: 6.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 76
   type: catwalk
   components:
@@ -973,9 +667,6 @@ entities:
     pos: 4.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 77
   type: LargeBeaker
   components:
@@ -983,12 +674,6 @@ entities:
     pos: 23.494947,7.0422435
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 78
   type: solid_wall
   components:
@@ -996,10 +681,6 @@ entities:
     pos: 7.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 79
   type: airlock_external
   components:
@@ -1007,12 +688,6 @@ entities:
     pos: 7.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 80
   type: airlock_external
   components:
@@ -1020,12 +695,6 @@ entities:
     pos: 5.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 81
   type: airlock_engineering
   components:
@@ -1033,12 +702,6 @@ entities:
     pos: -7.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 82
   type: airlock_engineering
   components:
@@ -1046,12 +709,6 @@ entities:
     pos: 3.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 83
   type: airlock_engineering
   components:
@@ -1059,12 +716,6 @@ entities:
     pos: 2.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 84
   type: solid_wall
   components:
@@ -1072,10 +723,6 @@ entities:
     pos: 6.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 85
   type: solid_wall
   components:
@@ -1083,10 +730,6 @@ entities:
     pos: 6.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 86
   type: table
   components:
@@ -1094,10 +737,6 @@ entities:
     pos: -3.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 87
   type: table
   components:
@@ -1105,10 +744,6 @@ entities:
     pos: -2.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 88
   type: table
   components:
@@ -1116,10 +751,6 @@ entities:
     pos: -1.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 89
   type: table
   components:
@@ -1127,10 +758,6 @@ entities:
     pos: -0.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 90
   type: WirelessMachine
   components:
@@ -1138,11 +765,6 @@ entities:
     pos: 5.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 91
   type: crate_generic
   components:
@@ -1150,12 +772,6 @@ entities:
     pos: 5.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.4,-0.4,0.4,0.4
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -1171,9 +787,6 @@ entities:
     pos: -6.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 93
   type: Wire
   components:
@@ -1181,9 +794,6 @@ entities:
     pos: -7.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 94
   type: Wire
   components:
@@ -1191,9 +801,6 @@ entities:
     pos: -8.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 95
   type: Wire
   components:
@@ -1201,9 +808,6 @@ entities:
     pos: -8.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 96
   type: Wire
   components:
@@ -1211,9 +815,6 @@ entities:
     pos: -8.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 97
   type: Wire
   components:
@@ -1221,9 +822,6 @@ entities:
     pos: -8.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 98
   type: Wire
   components:
@@ -1231,9 +829,6 @@ entities:
     pos: -8.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 99
   type: Wire
   components:
@@ -1241,9 +836,6 @@ entities:
     pos: -8.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 100
   type: Wire
   components:
@@ -1251,9 +843,6 @@ entities:
     pos: -6.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 101
   type: Wire
   components:
@@ -1261,9 +850,6 @@ entities:
     pos: -6.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 102
   type: Wire
   components:
@@ -1271,9 +857,6 @@ entities:
     pos: -6.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 103
   type: Wire
   components:
@@ -1281,9 +864,6 @@ entities:
     pos: -6.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 104
   type: Wire
   components:
@@ -1291,9 +871,6 @@ entities:
     pos: 4.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 105
   type: Wire
   components:
@@ -1301,9 +878,6 @@ entities:
     pos: 4.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 106
   type: Wire
   components:
@@ -1311,9 +885,6 @@ entities:
     pos: 4.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 107
   type: Wire
   components:
@@ -1321,9 +892,6 @@ entities:
     pos: 4.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 108
   type: Wire
   components:
@@ -1331,9 +899,6 @@ entities:
     pos: 5.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 109
   type: Wire
   components:
@@ -1341,9 +906,6 @@ entities:
     pos: 6.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 110
   type: Wire
   components:
@@ -1351,9 +913,6 @@ entities:
     pos: 7.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 111
   type: catwalk
   components:
@@ -1361,9 +920,6 @@ entities:
     pos: 2.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 112
   type: catwalk
   components:
@@ -1371,9 +927,6 @@ entities:
     pos: -4.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 113
   type: Wire
   components:
@@ -1381,9 +934,6 @@ entities:
     pos: 3.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 114
   type: Wire
   components:
@@ -1391,9 +941,6 @@ entities:
     pos: 2.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 115
   type: Wire
   components:
@@ -1401,9 +948,6 @@ entities:
     pos: 1.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 116
   type: Wire
   components:
@@ -1411,9 +955,6 @@ entities:
     pos: 0.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 117
   type: Wire
   components:
@@ -1421,9 +962,6 @@ entities:
     pos: -0.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 118
   type: Wire
   components:
@@ -1431,9 +969,6 @@ entities:
     pos: -1.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 119
   type: Wire
   components:
@@ -1441,9 +976,6 @@ entities:
     pos: -2.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 120
   type: Wire
   components:
@@ -1451,9 +983,6 @@ entities:
     pos: -3.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 121
   type: Wire
   components:
@@ -1461,9 +990,6 @@ entities:
     pos: -4.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 122
   type: Wire
   components:
@@ -1471,9 +997,6 @@ entities:
     pos: -5.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 123
   type: Wire
   components:
@@ -1481,9 +1004,6 @@ entities:
     pos: 1.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 124
   type: Wire
   components:
@@ -1491,9 +1011,6 @@ entities:
     pos: 1.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 125
   type: Wire
   components:
@@ -1501,9 +1018,6 @@ entities:
     pos: 2.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 126
   type: Wire
   components:
@@ -1511,9 +1025,6 @@ entities:
     pos: -2.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 127
   type: Wire
   components:
@@ -1521,9 +1032,6 @@ entities:
     pos: -2.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 128
   type: Wire
   components:
@@ -1531,9 +1039,6 @@ entities:
     pos: -3.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 129
   type: Wire
   components:
@@ -1541,9 +1046,6 @@ entities:
     pos: -1.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 130
   type: Generator
   components:
@@ -1551,11 +1053,6 @@ entities:
     pos: 2.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - uid: 131
   type: Generator
   components:
@@ -1563,11 +1060,6 @@ entities:
     pos: 1.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - uid: 132
   type: smes_dry
   components:
@@ -1575,10 +1067,6 @@ entities:
     pos: -1.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
   - charge: 3000
     type: PowerStorage
 - uid: 133
@@ -1588,10 +1076,6 @@ entities:
     pos: -2.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
   - charge: 3000
     type: PowerStorage
 - uid: 134
@@ -1601,10 +1085,6 @@ entities:
     pos: -3.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
   - charge: 3000
     type: PowerStorage
 - uid: 135
@@ -1614,12 +1094,6 @@ entities:
     pos: -1.249865,-10.43489
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 136
   type: catwalk
   components:
@@ -1627,9 +1101,6 @@ entities:
     pos: -2.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 137
   type: catwalk
   components:
@@ -1637,9 +1108,6 @@ entities:
     pos: 1.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 138
   type: spawn_point_latejoin
   components:
@@ -1661,10 +1129,6 @@ entities:
     pos: -3.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 141
   type: table
   components:
@@ -1672,10 +1136,6 @@ entities:
     pos: -2.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 142
   type: table
   components:
@@ -1683,10 +1143,6 @@ entities:
     pos: -1.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 143
   type: table
   components:
@@ -1694,10 +1150,6 @@ entities:
     pos: -0.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 144
   type: solid_wall
   components:
@@ -1705,10 +1157,6 @@ entities:
     pos: -7.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 145
   type: spawn_point_latejoin
   components:
@@ -1723,12 +1171,6 @@ entities:
     pos: 0.5223687,7.507263
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 147
   type: locker_generic
   components:
@@ -1736,12 +1178,6 @@ entities:
     pos: 1.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -1760,12 +1196,6 @@ entities:
     pos: -3.209215,-1.486604
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -1778,12 +1208,6 @@ entities:
     pos: -4.146715,-1.408479
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -1796,12 +1220,6 @@ entities:
     pos: 0.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -1820,12 +1238,6 @@ entities:
     pos: -1.297692,-5.396082
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 152
   type: spawn_point_latejoin
   components:
@@ -1847,11 +1259,6 @@ entities:
     pos: 0.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - products:
     - cargo.dice
     - cargo.flashlight
@@ -1864,11 +1271,6 @@ entities:
     pos: 0.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - products:
     - cargo.dice
     - cargo.flashlight
@@ -1881,10 +1283,6 @@ entities:
     pos: -4.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 157
   type: table
   components:
@@ -1892,10 +1290,6 @@ entities:
     pos: -1.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 158
   type: table
   components:
@@ -1903,10 +1297,6 @@ entities:
     pos: -2.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 159
   type: table
   components:
@@ -1914,10 +1304,6 @@ entities:
     pos: -3.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 160
   type: WirelessMachine
   components:
@@ -1925,11 +1311,6 @@ entities:
     pos: -6.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 161
   type: catwalk
   components:
@@ -1937,9 +1318,6 @@ entities:
     pos: 4.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 162
   type: catwalk
   components:
@@ -1947,9 +1325,6 @@ entities:
     pos: -5.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 163
   type: Wire
   components:
@@ -1957,9 +1332,6 @@ entities:
     pos: -6.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 164
   type: Wire
   components:
@@ -1967,9 +1339,6 @@ entities:
     pos: -6.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 165
   type: Wire
   components:
@@ -1977,9 +1346,6 @@ entities:
     pos: 5.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 166
   type: Wire
   components:
@@ -1987,9 +1353,6 @@ entities:
     pos: 5.5,-12.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 167
   type: Wire
   components:
@@ -1997,9 +1360,6 @@ entities:
     pos: 5.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 168
   type: WiredMachine
   components:
@@ -2007,11 +1367,6 @@ entities:
     pos: 5.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 169
   type: WiredMachine
   components:
@@ -2019,22 +1374,11 @@ entities:
     pos: -6.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 170
   type: LightBulb
   components:
   - parent: 29
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 171
   type: wall_light
   components:
@@ -2042,9 +1386,6 @@ entities:
     pos: -0.5,-14
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 172
   type: spawn_point_latejoin
   components:
@@ -2087,9 +1428,6 @@ entities:
     pos: 9.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 178
   type: catwalk
   components:
@@ -2097,9 +1435,6 @@ entities:
     pos: 9.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 179
   type: catwalk
   components:
@@ -2107,9 +1442,6 @@ entities:
     pos: 9.5,2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 180
   type: catwalk
   components:
@@ -2117,9 +1449,6 @@ entities:
     pos: 9.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 181
   type: catwalk
   components:
@@ -2127,9 +1456,6 @@ entities:
     pos: 9.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 182
   type: vending_machine_youtool
   components:
@@ -2139,11 +1465,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/youtool.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 183
   type: Generator
   components:
@@ -2151,11 +1472,6 @@ entities:
     pos: 0.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - uid: 184
   type: Wire
   components:
@@ -2163,9 +1479,6 @@ entities:
     pos: 3.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 185
   type: Wire
   components:
@@ -2173,9 +1486,6 @@ entities:
     pos: 0.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 186
   type: Generator
   components:
@@ -2183,11 +1493,6 @@ entities:
     pos: 3.5,-13.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - uid: 187
   type: table
   components:
@@ -2195,10 +1500,6 @@ entities:
     pos: -6.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 188
   type: table
   components:
@@ -2206,10 +1507,6 @@ entities:
     pos: -5.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 189
   type: table
   components:
@@ -2217,10 +1514,6 @@ entities:
     pos: -4.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 190
   type: table
   components:
@@ -2228,10 +1521,6 @@ entities:
     pos: -3.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 191
   type: table
   components:
@@ -2239,10 +1528,6 @@ entities:
     pos: -2.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 192
   type: table
   components:
@@ -2250,10 +1535,6 @@ entities:
     pos: -1.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 193
   type: table
   components:
@@ -2261,10 +1542,6 @@ entities:
     pos: -0.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 194
   type: table
   components:
@@ -2272,10 +1549,6 @@ entities:
     pos: 0.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 195
   type: table
   components:
@@ -2283,10 +1556,6 @@ entities:
     pos: 1.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 196
   type: table
   components:
@@ -2294,10 +1563,6 @@ entities:
     pos: -4.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 197
   type: table
   components:
@@ -2305,10 +1570,6 @@ entities:
     pos: -3.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 198
   type: table
   components:
@@ -2316,10 +1577,6 @@ entities:
     pos: -2.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 199
   type: table
   components:
@@ -2327,10 +1584,6 @@ entities:
     pos: -1.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 200
   type: table
   components:
@@ -2338,10 +1591,6 @@ entities:
     pos: -0.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 201
   type: airlock_medical_glass
   components:
@@ -2349,12 +1598,6 @@ entities:
     pos: 26.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 202
   type: airlock_medical_glass
   components:
@@ -2362,12 +1605,6 @@ entities:
     pos: 28.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 203
   type: catwalk
   components:
@@ -2375,9 +1612,6 @@ entities:
     pos: -9.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 204
   type: Wire
   components:
@@ -2385,9 +1619,6 @@ entities:
     pos: -8.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 205
   type: Wire
   components:
@@ -2395,9 +1626,6 @@ entities:
     pos: -8.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 206
   type: Wire
   components:
@@ -2405,9 +1633,6 @@ entities:
     pos: -9.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 207
   type: Wire
   components:
@@ -2415,9 +1640,6 @@ entities:
     pos: -9.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 208
   type: solid_wall
   components:
@@ -2425,10 +1647,6 @@ entities:
     pos: -10.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 209
   type: solid_wall
   components:
@@ -2436,10 +1654,6 @@ entities:
     pos: -10.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 210
   type: airlock
   components:
@@ -2447,23 +1661,11 @@ entities:
     pos: -9.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 211
   type: LightTube
   components:
   - parent: 212
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 212
   type: poweredlight
   components:
@@ -2471,9 +1673,6 @@ entities:
     pos: 0.5,1
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -2491,9 +1690,6 @@ entities:
     pos: -3.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 214
   type: chairOfficeDark
   components:
@@ -2501,9 +1697,6 @@ entities:
     pos: 0.5,-6.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 215
   type: poweredlight
   components:
@@ -2511,9 +1704,6 @@ entities:
     pos: -6.5,1
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -2531,12 +1721,6 @@ entities:
     pos: -15.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 217
   type: stool
   components:
@@ -2544,9 +1728,6 @@ entities:
     pos: -1.5,-9.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 218
   type: chairOfficeLight
   components:
@@ -2554,9 +1735,6 @@ entities:
     pos: -3.5,-2.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 219
   type: chairOfficeLight
   components:
@@ -2564,9 +1742,6 @@ entities:
     pos: -2.5,-2.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 220
   type: chairOfficeLight
   components:
@@ -2574,9 +1749,6 @@ entities:
     pos: -2.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 221
   type: stool
   components:
@@ -2584,20 +1756,11 @@ entities:
     pos: -2.5,-6.5
     rot: 1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 222
   type: LightBulb
   components:
   - parent: 251
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 223
   type: APC
   components:
@@ -2605,10 +1768,6 @@ entities:
     pos: -6.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 224
   type: Wire
   components:
@@ -2616,9 +1775,6 @@ entities:
     pos: -9.5,2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 225
   type: Wire
   components:
@@ -2626,9 +1782,6 @@ entities:
     pos: -9.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 226
   type: Wire
   components:
@@ -2636,9 +1789,6 @@ entities:
     pos: -8.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 227
   type: Wire
   components:
@@ -2646,9 +1796,6 @@ entities:
     pos: -7.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 228
   type: Wire
   components:
@@ -2656,9 +1803,6 @@ entities:
     pos: -6.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 229
   type: Wire
   components:
@@ -2666,9 +1810,6 @@ entities:
     pos: -5.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 230
   type: Wire
   components:
@@ -2676,9 +1817,6 @@ entities:
     pos: -4.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 231
   type: Wire
   components:
@@ -2686,9 +1824,6 @@ entities:
     pos: -3.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 232
   type: Wire
   components:
@@ -2696,9 +1831,6 @@ entities:
     pos: -2.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 233
   type: Wire
   components:
@@ -2706,9 +1838,6 @@ entities:
     pos: -1.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 234
   type: Wire
   components:
@@ -2716,9 +1845,6 @@ entities:
     pos: -0.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 235
   type: Wire
   components:
@@ -2726,9 +1852,6 @@ entities:
     pos: 0.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 236
   type: LargeBeaker
   components:
@@ -2736,12 +1859,6 @@ entities:
     pos: 23.510572,7.7141185
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 237
   type: catwalk
   components:
@@ -2749,9 +1866,6 @@ entities:
     pos: 9.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 238
   type: catwalk
   components:
@@ -2759,9 +1873,6 @@ entities:
     pos: 9.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 239
   type: catwalk
   components:
@@ -2769,9 +1880,6 @@ entities:
     pos: 9.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 240
   type: catwalk
   components:
@@ -2779,9 +1887,6 @@ entities:
     pos: 9.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 241
   type: catwalk
   components:
@@ -2789,9 +1894,6 @@ entities:
     pos: 9.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 242
   type: catwalk
   components:
@@ -2799,9 +1901,6 @@ entities:
     pos: 9.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 243
   type: catwalk
   components:
@@ -2809,9 +1908,6 @@ entities:
     pos: 9.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 244
   type: catwalk
   components:
@@ -2819,9 +1915,6 @@ entities:
     pos: 9.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 245
   type: catwalk
   components:
@@ -2829,9 +1922,6 @@ entities:
     pos: 9.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 246
   type: catwalk
   components:
@@ -2839,9 +1929,6 @@ entities:
     pos: 9.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 247
   type: catwalk
   components:
@@ -2849,9 +1936,6 @@ entities:
     pos: 9.5,-10.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 248
   type: catwalk
   components:
@@ -2859,9 +1943,6 @@ entities:
     pos: 9.5,-11.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 249
   type: catwalk
   components:
@@ -2869,9 +1950,6 @@ entities:
     pos: 8.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 250
   type: APC
   components:
@@ -2879,19 +1957,12 @@ entities:
     pos: 4.5,-9.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 251
   type: poweredsmalllight
   components:
   - parent: 0
     pos: 5,-9.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -2909,10 +1980,6 @@ entities:
     pos: 7.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 253
   type: YellowToolboxItemFilled
   components:
@@ -2920,12 +1987,6 @@ entities:
     pos: -0.8099712,-5.21454
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -2938,12 +1999,6 @@ entities:
     pos: -0.5597038,-5.679647
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -2956,12 +2011,6 @@ entities:
     pos: -1.934832,-5.154238
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       flashlight_cell_container:
         entities: []
@@ -2974,12 +2023,6 @@ entities:
     pos: -2.017696,-5.71715
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       flashlight_cell_container:
         entities: []
@@ -2992,12 +2035,6 @@ entities:
     pos: -2.861032,-5.524786
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 258
   type: UniformEngineering
   components:
@@ -3005,12 +2042,6 @@ entities:
     pos: -0.6474335,-10.27245
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 259
   type: GasMaskClothing
   components:
@@ -3018,12 +2049,6 @@ entities:
     pos: -0.2880585,-10.69432
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 260
   type: OuterclothingVest
   components:
@@ -3031,12 +2056,6 @@ entities:
     pos: -0.9130585,-10.66307
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 261
   type: UtilityBeltClothingFilled
   components:
@@ -3044,12 +2063,6 @@ entities:
     pos: -1.895102,-10.33495
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -3062,12 +2075,6 @@ entities:
     pos: -1.770102,-10.63182
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -3080,12 +2087,6 @@ entities:
     pos: -6.605512,7.638151
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       magazine_bullet_container:
         entities: []
@@ -3098,12 +2099,6 @@ entities:
     pos: -6.339887,7.669401
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       magazine_bullet_container:
         entities: []
@@ -3116,12 +2111,6 @@ entities:
     pos: -6.027387,7.622526
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       magazine_bullet_container:
         entities: []
@@ -3134,12 +2123,6 @@ entities:
     pos: -5.089887,7.591276
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -3152,12 +2135,6 @@ entities:
     pos: -4.683637,7.606901
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -3170,12 +2147,6 @@ entities:
     pos: -3.386762,7.466276
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 269
   type: SmgC20r
   components:
@@ -3183,12 +2154,6 @@ entities:
     pos: -2.524035,7.579326
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       ballistics_chamber_0:
         entities: []
@@ -3207,12 +2172,6 @@ entities:
     pos: -1.94591,7.485576
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       ballistics_chamber_0:
         entities: []
@@ -3231,10 +2190,6 @@ entities:
     pos: -10.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 272
   type: solid_wall
   components:
@@ -3242,10 +2197,6 @@ entities:
     pos: -11.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 273
   type: solid_wall
   components:
@@ -3253,10 +2204,6 @@ entities:
     pos: -10.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 274
   type: solid_wall
   components:
@@ -3264,10 +2211,6 @@ entities:
     pos: -9.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 275
   type: solid_wall
   components:
@@ -3275,10 +2218,6 @@ entities:
     pos: -8.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 276
   type: solid_wall
   components:
@@ -3286,10 +2225,6 @@ entities:
     pos: -7.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 277
   type: solid_wall
   components:
@@ -3297,10 +2232,6 @@ entities:
     pos: -8.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 278
   type: solid_wall
   components:
@@ -3308,10 +2239,6 @@ entities:
     pos: -5.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 279
   type: solid_wall
   components:
@@ -3319,10 +2246,6 @@ entities:
     pos: -6.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 280
   type: solid_wall
   components:
@@ -3330,10 +2253,6 @@ entities:
     pos: -7.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 281
   type: solid_wall
   components:
@@ -3341,10 +2260,6 @@ entities:
     pos: -0.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 282
   type: solid_wall
   components:
@@ -3352,10 +2267,6 @@ entities:
     pos: 0.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 283
   type: solid_wall
   components:
@@ -3363,10 +2274,6 @@ entities:
     pos: 1.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 284
   type: solid_wall
   components:
@@ -3374,10 +2281,6 @@ entities:
     pos: 1.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 285
   type: solid_wall
   components:
@@ -3385,10 +2288,6 @@ entities:
     pos: 1.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 286
   type: solid_wall
   components:
@@ -3396,10 +2295,6 @@ entities:
     pos: 4.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 287
   type: solid_wall
   components:
@@ -3407,10 +2302,6 @@ entities:
     pos: 4.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 288
   type: solid_wall
   components:
@@ -3418,10 +2309,6 @@ entities:
     pos: 4.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 289
   type: solid_wall
   components:
@@ -3429,10 +2316,6 @@ entities:
     pos: 4.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 290
   type: solid_wall
   components:
@@ -3440,10 +2323,6 @@ entities:
     pos: 4.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 291
   type: solid_wall
   components:
@@ -3451,10 +2330,6 @@ entities:
     pos: 4.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 292
   type: solid_wall
   components:
@@ -3462,10 +2337,6 @@ entities:
     pos: 4.5,2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 293
   type: solid_wall
   components:
@@ -3473,10 +2344,6 @@ entities:
     pos: 4.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 294
   type: solid_wall
   components:
@@ -3484,10 +2351,6 @@ entities:
     pos: 4.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 295
   type: solid_wall
   components:
@@ -3495,10 +2358,6 @@ entities:
     pos: 4.5,5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 296
   type: solid_wall
   components:
@@ -3506,10 +2365,6 @@ entities:
     pos: 4.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 297
   type: solid_wall
   components:
@@ -3517,10 +2372,6 @@ entities:
     pos: 4.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 298
   type: solid_wall
   components:
@@ -3528,10 +2379,6 @@ entities:
     pos: 4.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 299
   type: solid_wall
   components:
@@ -3539,10 +2386,6 @@ entities:
     pos: 1.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 300
   type: solid_wall
   components:
@@ -3550,10 +2393,6 @@ entities:
     pos: 0.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 301
   type: solid_wall
   components:
@@ -3561,10 +2400,6 @@ entities:
     pos: -0.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 302
   type: solid_wall
   components:
@@ -3572,10 +2407,6 @@ entities:
     pos: -1.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 303
   type: solid_wall
   components:
@@ -3583,10 +2414,6 @@ entities:
     pos: -2.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 304
   type: solid_wall
   components:
@@ -3594,10 +2421,6 @@ entities:
     pos: -3.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 305
   type: solid_wall
   components:
@@ -3605,10 +2428,6 @@ entities:
     pos: -4.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 306
   type: solid_wall
   components:
@@ -3616,10 +2435,6 @@ entities:
     pos: -5.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 307
   type: solid_wall
   components:
@@ -3627,10 +2442,6 @@ entities:
     pos: -6.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 308
   type: solid_wall
   components:
@@ -3638,10 +2449,6 @@ entities:
     pos: -7.5,8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 309
   type: solid_wall
   components:
@@ -3649,10 +2456,6 @@ entities:
     pos: -7.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 310
   type: solid_wall
   components:
@@ -3660,10 +2463,6 @@ entities:
     pos: -7.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 311
   type: solid_wall
   components:
@@ -3671,10 +2470,6 @@ entities:
     pos: -7.5,5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 312
   type: GlovesLeather
   components:
@@ -3682,12 +2477,6 @@ entities:
     pos: -4.332221,4.64238
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 313
   type: GlovesLeather
   components:
@@ -3695,12 +2484,6 @@ entities:
     pos: -3.519721,4.64238
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 314
   type: GlovesLeather
   components:
@@ -3708,12 +2491,6 @@ entities:
     pos: -2.597846,4.61113
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 315
   type: LedLightTube
   components:
@@ -3723,23 +2500,11 @@ entities:
     type: Transform
   - color: '#EEEEFFFF'
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 316
   type: LightTube
   components:
   - parent: 215
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 317
   type: poweredlight
   components:
@@ -3747,9 +2512,6 @@ entities:
     pos: -1.5,8
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -3765,12 +2527,6 @@ entities:
   components:
   - parent: 317
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 319
   type: poweredlight
   components:
@@ -3778,9 +2534,6 @@ entities:
     pos: 4,3.5
     rot: 3.14159265358979 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -3796,21 +2549,12 @@ entities:
   components:
   - parent: 319
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 321
   type: wall_light
   components:
   - parent: 0
     pos: -7,-10.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 322
   type: poweredsmalllight
   components:
@@ -3818,9 +2562,6 @@ entities:
     pos: -10,-5.5
     rot: 3.14159265358979 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -3836,12 +2577,6 @@ entities:
   components:
   - parent: 322
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 324
   type: solid_wall
   components:
@@ -3849,10 +2584,6 @@ entities:
     pos: -15.5,2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 325
   type: solid_wall
   components:
@@ -3860,10 +2591,6 @@ entities:
     pos: -15.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 326
   type: solid_wall
   components:
@@ -3871,10 +2598,6 @@ entities:
     pos: -15.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 327
   type: solid_wall
   components:
@@ -3882,10 +2605,6 @@ entities:
     pos: -14.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 328
   type: solid_wall
   components:
@@ -3893,10 +2612,6 @@ entities:
     pos: -12.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 329
   type: solid_wall
   components:
@@ -3904,10 +2619,6 @@ entities:
     pos: -15.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 330
   type: solid_wall
   components:
@@ -3915,10 +2626,6 @@ entities:
     pos: -14.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 331
   type: solid_wall
   components:
@@ -3926,10 +2633,6 @@ entities:
     pos: -11.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 332
   type: solid_wall
   components:
@@ -3937,10 +2640,6 @@ entities:
     pos: -14.5,5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 333
   type: solid_wall
   components:
@@ -3948,10 +2647,6 @@ entities:
     pos: -14.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 334
   type: solid_wall
   components:
@@ -3959,10 +2654,6 @@ entities:
     pos: -12.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 335
   type: solid_wall
   components:
@@ -3970,10 +2661,6 @@ entities:
     pos: -12.5,5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 336
   type: solid_wall
   components:
@@ -3981,10 +2668,6 @@ entities:
     pos: -16.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 337
   type: solid_wall
   components:
@@ -3992,10 +2675,6 @@ entities:
     pos: -16.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 338
   type: solid_wall
   components:
@@ -4003,10 +2682,6 @@ entities:
     pos: -16.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 339
   type: solid_wall
   components:
@@ -4014,10 +2689,6 @@ entities:
     pos: -16.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 340
   type: solid_wall
   components:
@@ -4025,10 +2696,6 @@ entities:
     pos: -16.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 341
   type: solid_wall
   components:
@@ -4036,10 +2703,6 @@ entities:
     pos: -16.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 342
   type: solid_wall
   components:
@@ -4047,10 +2710,6 @@ entities:
     pos: -16.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 343
   type: solid_wall
   components:
@@ -4058,10 +2717,6 @@ entities:
     pos: -16.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 344
   type: solid_wall
   components:
@@ -4069,10 +2724,6 @@ entities:
     pos: -16.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 345
   type: solid_wall
   components:
@@ -4080,10 +2731,6 @@ entities:
     pos: -16.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 346
   type: solid_wall
   components:
@@ -4091,10 +2738,6 @@ entities:
     pos: -16.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 347
   type: solid_wall
   components:
@@ -4102,10 +2745,6 @@ entities:
     pos: -15.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 348
   type: solid_wall
   components:
@@ -4113,10 +2752,6 @@ entities:
     pos: -14.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 349
   type: solid_wall
   components:
@@ -4124,10 +2759,6 @@ entities:
     pos: -13.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 350
   type: solid_wall
   components:
@@ -4135,10 +2766,6 @@ entities:
     pos: -12.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 351
   type: solid_wall
   components:
@@ -4146,10 +2773,6 @@ entities:
     pos: -11.5,-8.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 352
   type: airlock_external
   components:
@@ -4157,12 +2780,6 @@ entities:
     pos: -13.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 353
   type: airlock_external
   components:
@@ -4170,12 +2787,6 @@ entities:
     pos: -13.5,6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 354
   type: airlock_engineering
   components:
@@ -4183,12 +2794,6 @@ entities:
     pos: -13.5,1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 355
   type: table
   components:
@@ -4196,10 +2801,6 @@ entities:
     pos: -15.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 356
   type: table
   components:
@@ -4207,10 +2808,6 @@ entities:
     pos: -15.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 357
   type: Wire
   components:
@@ -4218,9 +2815,6 @@ entities:
     pos: -9.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 358
   type: Wire
   components:
@@ -4228,9 +2822,6 @@ entities:
     pos: -13.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 359
   type: Wire
   components:
@@ -4238,9 +2829,6 @@ entities:
     pos: -9.5,3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 360
   type: table
   components:
@@ -4248,10 +2836,6 @@ entities:
     pos: -15.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 361
   type: catwalk
   components:
@@ -4259,9 +2843,6 @@ entities:
     pos: -14.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 362
   type: catwalk
   components:
@@ -4269,9 +2850,6 @@ entities:
     pos: -13.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 363
   type: catwalk
   components:
@@ -4279,9 +2857,6 @@ entities:
     pos: -12.5,7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 364
   type: locker_tool_filled
   components:
@@ -4289,12 +2864,6 @@ entities:
     pos: -11.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4307,12 +2876,6 @@ entities:
     pos: -11.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4325,12 +2888,6 @@ entities:
     pos: -11.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4343,12 +2900,6 @@ entities:
     pos: -11.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4361,12 +2912,6 @@ entities:
     pos: -11.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -4379,12 +2924,6 @@ entities:
     pos: -15.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 370
   type: airlock_engineering
   components:
@@ -4392,12 +2931,6 @@ entities:
     pos: -10.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 371
   type: autolathe
   components:
@@ -4405,10 +2938,6 @@ entities:
     pos: -14.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -4431,10 +2960,6 @@ entities:
     pos: -13.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -4457,10 +2982,6 @@ entities:
     pos: -12.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -4483,9 +3004,6 @@ entities:
     pos: -11,-5.5
     rot: 3.14159265358979 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4501,12 +3019,6 @@ entities:
   components:
   - parent: 374
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 376
   type: poweredlight
   components:
@@ -4514,9 +3026,6 @@ entities:
     pos: -11,-0.5
     rot: 3.14159265358979 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4532,21 +3041,12 @@ entities:
   components:
   - parent: 376
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 378
   type: poweredlight
   components:
   - parent: 0
     pos: -16,-0.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4562,21 +3062,12 @@ entities:
   components:
   - parent: 378
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 380
   type: poweredlight
   components:
   - parent: 0
     pos: -16,-5.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4592,21 +3083,12 @@ entities:
   components:
   - parent: 380
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 382
   type: poweredlight
   components:
   - parent: 0
     pos: -15,3.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4622,12 +3104,6 @@ entities:
   components:
   - parent: 382
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 384
   type: poweredsmalllight
   components:
@@ -4635,9 +3111,6 @@ entities:
     pos: -14.5,7
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4653,12 +3126,6 @@ entities:
   components:
   - parent: 384
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 386
   type: CableStack
   components:
@@ -4666,12 +3133,6 @@ entities:
     pos: -15.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 387
   type: CableStack
   components:
@@ -4679,12 +3140,6 @@ entities:
     pos: -15.5,-0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 388
   type: Wire
   components:
@@ -4692,9 +3147,6 @@ entities:
     pos: -14.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 389
   type: Wire
   components:
@@ -4702,9 +3154,6 @@ entities:
     pos: -12.5,-7.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 390
   type: catwalk
   components:
@@ -4712,9 +3161,6 @@ entities:
     pos: -11.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 391
   type: catwalk
   components:
@@ -4722,9 +3168,6 @@ entities:
     pos: -9.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 392
   type: poweredlight
   components:
@@ -4732,9 +3175,6 @@ entities:
     pos: -10.5,4
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -4750,12 +3190,6 @@ entities:
   components:
   - parent: 392
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 394
   type: MetalStack
   components:
@@ -4763,12 +3197,6 @@ entities:
     pos: -15.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 395
   type: MetalStack
   components:
@@ -4776,12 +3204,6 @@ entities:
     pos: -15.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 396
   type: APC
   components:
@@ -4789,10 +3211,6 @@ entities:
     pos: -9.5,4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 397
   type: APC
   components:
@@ -4800,10 +3218,6 @@ entities:
     pos: -16.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 398
   type: Wire
   components:
@@ -4811,9 +3225,6 @@ entities:
     pos: -16.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 399
   type: Wire
   components:
@@ -4821,9 +3232,6 @@ entities:
     pos: -15.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 400
   type: Wire
   components:
@@ -4831,9 +3239,6 @@ entities:
     pos: -14.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 401
   type: Wire
   components:
@@ -4841,9 +3246,6 @@ entities:
     pos: -13.5,-2.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 402
   type: Wire
   components:
@@ -4851,9 +3253,6 @@ entities:
     pos: -13.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 403
   type: Wire
   components:
@@ -4861,9 +3260,6 @@ entities:
     pos: -13.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 404
   type: Wire
   components:
@@ -4871,9 +3267,6 @@ entities:
     pos: -13.5,-5.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 405
   type: Wire
   components:
@@ -4881,9 +3274,6 @@ entities:
     pos: -13.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 406
   type: Wire
   components:
@@ -4891,9 +3281,6 @@ entities:
     pos: -12.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 407
   type: Wire
   components:
@@ -4901,9 +3288,6 @@ entities:
     pos: -11.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 408
   type: Wire
   components:
@@ -4911,9 +3295,6 @@ entities:
     pos: -10.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 409
   type: Wire
   components:
@@ -4921,9 +3302,6 @@ entities:
     pos: -9.5,-6.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 410
   type: table
   components:
@@ -4931,10 +3309,6 @@ entities:
     pos: -15.5,-4.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 411
   type: table
   components:
@@ -4942,10 +3316,6 @@ entities:
     pos: -15.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 412
   type: table
   components:
@@ -4953,10 +3323,6 @@ entities:
     pos: -15.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 413
   type: CableStack
   components:
@@ -4964,12 +3330,6 @@ entities:
     pos: -15.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 414
   type: CableStack
   components:
@@ -4977,12 +3337,6 @@ entities:
     pos: -15.5,0.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 415
   type: GlassStack
   components:
@@ -4990,12 +3344,6 @@ entities:
     pos: -15.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 416
   type: GlassStack
   components:
@@ -5003,12 +3351,6 @@ entities:
     pos: -15.5,-1.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 417
   type: GlassStack
   components:
@@ -5016,12 +3358,6 @@ entities:
     pos: -15.5,-3.5
     rot: -1.5707963267949 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 418
   type: vending_machine_engivend
   components:
@@ -5031,11 +3367,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/engivend.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 419
   type: table
   components:
@@ -5043,10 +3374,6 @@ entities:
     pos: 18.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 420
   type: table
   components:
@@ -5054,10 +3381,6 @@ entities:
     pos: 21.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 421
   type: table
   components:
@@ -5065,10 +3388,6 @@ entities:
     pos: 20.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 422
   type: table
   components:
@@ -5076,10 +3395,6 @@ entities:
     pos: 18.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 423
   type: table
   components:
@@ -5087,10 +3402,6 @@ entities:
     pos: 19.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 424
   type: table
   components:
@@ -5098,10 +3409,6 @@ entities:
     pos: 18.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 425
   type: table
   components:
@@ -5109,10 +3416,6 @@ entities:
     pos: 22.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 426
   type: table
   components:
@@ -5120,10 +3423,6 @@ entities:
     pos: 24.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 427
   type: chairOfficeLight
   components:
@@ -5131,9 +3430,6 @@ entities:
     pos: 19.5,4.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 428
   type: chairOfficeLight
   components:
@@ -5141,9 +3437,6 @@ entities:
     pos: 20.5,5.5
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 429
   type: chairOfficeLight
   components:
@@ -5151,9 +3444,6 @@ entities:
     pos: 23.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 430
   type: chairOfficeLight
   components:
@@ -5161,47 +3451,30 @@ entities:
     pos: 24.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 431
   type: chair
   components:
   - parent: 0
     pos: 14.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 432
   type: chair
   components:
   - parent: 0
     pos: 14.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 433
   type: chair
   components:
   - parent: 0
     pos: 14.5,7.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 434
   type: chem_dispenser
   components:
   - parent: 0
     pos: 23.5,9.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.4,-0.25,0.4,0.25
-    type: Collidable
   - containers:
       ReagentDispenser-reagentContainerContainer:
         entities: []
@@ -5214,10 +3487,6 @@ entities:
     pos: 23.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 436
   type: catwalk
   components:
@@ -5225,9 +3494,6 @@ entities:
     pos: 0.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 437
   type: table
   components:
@@ -5235,10 +3501,6 @@ entities:
     pos: 25.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 438
   type: table
   components:
@@ -5246,10 +3508,6 @@ entities:
     pos: 23.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 439
   type: table
   components:
@@ -5257,10 +3515,6 @@ entities:
     pos: 24.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 440
   type: table
   components:
@@ -5268,10 +3522,6 @@ entities:
     pos: 26.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 441
   type: table
   components:
@@ -5279,10 +3529,6 @@ entities:
     pos: 27.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 442
   type: computerMedicalRecords
   components:
@@ -5290,11 +3536,6 @@ entities:
     pos: 21.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 443
   type: medical_scanner
   components:
@@ -5302,11 +3543,6 @@ entities:
     pos: 18.5,-1.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       MedicalScanner-bodyContainer:
         entities: []
@@ -5319,11 +3555,6 @@ entities:
     pos: 18.5,-5.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       MedicalScanner-bodyContainer:
         entities: []
@@ -5336,10 +3567,6 @@ entities:
     pos: 13.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 446
   type: table
   components:
@@ -5347,10 +3574,6 @@ entities:
     pos: 13.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 447
   type: table
   components:
@@ -5358,10 +3581,6 @@ entities:
     pos: 13.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 448
   type: solid_wall
   components:
@@ -5369,10 +3588,6 @@ entities:
     pos: 22.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 449
   type: solid_wall
   components:
@@ -5380,10 +3595,6 @@ entities:
     pos: 17.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 450
   type: solid_wall
   components:
@@ -5391,10 +3602,6 @@ entities:
     pos: 18.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 451
   type: solid_wall
   components:
@@ -5402,10 +3609,6 @@ entities:
     pos: 20.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 452
   type: solid_wall
   components:
@@ -5413,10 +3616,6 @@ entities:
     pos: 21.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 453
   type: solid_wall
   components:
@@ -5424,10 +3623,6 @@ entities:
     pos: 19.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 454
   type: solid_wall
   components:
@@ -5435,10 +3630,6 @@ entities:
     pos: 14.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 455
   type: solid_wall
   components:
@@ -5446,10 +3637,6 @@ entities:
     pos: 13.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 456
   type: solid_wall
   components:
@@ -5457,10 +3644,6 @@ entities:
     pos: 12.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 457
   type: solid_wall
   components:
@@ -5468,10 +3651,6 @@ entities:
     pos: 12.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 458
   type: solid_wall
   components:
@@ -5479,10 +3658,6 @@ entities:
     pos: 12.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 459
   type: solid_wall
   components:
@@ -5490,10 +3665,6 @@ entities:
     pos: 12.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 460
   type: solid_wall
   components:
@@ -5501,10 +3672,6 @@ entities:
     pos: 12.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 461
   type: solid_wall
   components:
@@ -5512,10 +3679,6 @@ entities:
     pos: 13.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 462
   type: solid_wall
   components:
@@ -5523,10 +3686,6 @@ entities:
     pos: 14.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 463
   type: solid_wall
   components:
@@ -5534,10 +3693,6 @@ entities:
     pos: 13.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 464
   type: solid_wall
   components:
@@ -5545,10 +3700,6 @@ entities:
     pos: 13.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 465
   type: solid_wall
   components:
@@ -5556,10 +3707,6 @@ entities:
     pos: 13.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 466
   type: solid_wall
   components:
@@ -5567,10 +3714,6 @@ entities:
     pos: 13.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 467
   type: solid_wall
   components:
@@ -5578,10 +3721,6 @@ entities:
     pos: 13.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 468
   type: solid_wall
   components:
@@ -5589,10 +3728,6 @@ entities:
     pos: 13.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 469
   type: solid_wall
   components:
@@ -5600,10 +3735,6 @@ entities:
     pos: 14.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 470
   type: solid_wall
   components:
@@ -5611,10 +3742,6 @@ entities:
     pos: 15.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 471
   type: solid_wall
   components:
@@ -5622,10 +3749,6 @@ entities:
     pos: 16.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 472
   type: solid_wall
   components:
@@ -5633,10 +3756,6 @@ entities:
     pos: 17.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 473
   type: solid_wall
   components:
@@ -5644,10 +3763,6 @@ entities:
     pos: 18.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 474
   type: solid_wall
   components:
@@ -5655,10 +3770,6 @@ entities:
     pos: 19.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 475
   type: solid_wall
   components:
@@ -5666,10 +3777,6 @@ entities:
     pos: 20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 476
   type: solid_wall
   components:
@@ -5677,10 +3784,6 @@ entities:
     pos: 21.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 477
   type: solid_wall
   components:
@@ -5688,10 +3791,6 @@ entities:
     pos: 22.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 478
   type: solid_wall
   components:
@@ -5699,10 +3798,6 @@ entities:
     pos: 23.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 479
   type: solid_wall
   components:
@@ -5710,10 +3805,6 @@ entities:
     pos: 24.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 480
   type: solid_wall
   components:
@@ -5721,10 +3812,6 @@ entities:
     pos: 25.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 481
   type: solid_wall
   components:
@@ -5732,10 +3819,6 @@ entities:
     pos: 26.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 482
   type: solid_wall
   components:
@@ -5743,10 +3826,6 @@ entities:
     pos: 26.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 483
   type: solid_wall
   components:
@@ -5754,10 +3833,6 @@ entities:
     pos: 26.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 484
   type: solid_wall
   components:
@@ -5765,10 +3840,6 @@ entities:
     pos: 27.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 485
   type: solid_wall
   components:
@@ -5776,10 +3847,6 @@ entities:
     pos: 28.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 486
   type: solid_wall
   components:
@@ -5787,10 +3854,6 @@ entities:
     pos: 29.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 487
   type: solid_wall
   components:
@@ -5798,10 +3861,6 @@ entities:
     pos: 30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 488
   type: solid_wall
   components:
@@ -5809,10 +3868,6 @@ entities:
     pos: 31.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 489
   type: solid_wall
   components:
@@ -5820,10 +3875,6 @@ entities:
     pos: 32.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 490
   type: solid_wall
   components:
@@ -5831,10 +3882,6 @@ entities:
     pos: 33.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 491
   type: solid_wall
   components:
@@ -5842,10 +3889,6 @@ entities:
     pos: 34.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 492
   type: solid_wall
   components:
@@ -5853,10 +3896,6 @@ entities:
     pos: 34.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 493
   type: solid_wall
   components:
@@ -5864,10 +3903,6 @@ entities:
     pos: 34.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 494
   type: solid_wall
   components:
@@ -5875,10 +3910,6 @@ entities:
     pos: 34.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 495
   type: solid_wall
   components:
@@ -5886,10 +3917,6 @@ entities:
     pos: 34.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 496
   type: solid_wall
   components:
@@ -5897,10 +3924,6 @@ entities:
     pos: 34.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 497
   type: solid_wall
   components:
@@ -5908,10 +3931,6 @@ entities:
     pos: 34.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 498
   type: solid_wall
   components:
@@ -5919,10 +3938,6 @@ entities:
     pos: 33.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 499
   type: solid_wall
   components:
@@ -5930,10 +3945,6 @@ entities:
     pos: 32.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 500
   type: solid_wall
   components:
@@ -5941,10 +3952,6 @@ entities:
     pos: 31.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 501
   type: solid_wall
   components:
@@ -5952,10 +3959,6 @@ entities:
     pos: 30.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 502
   type: solid_wall
   components:
@@ -5963,10 +3966,6 @@ entities:
     pos: 29.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 503
   type: solid_wall
   components:
@@ -5974,10 +3973,6 @@ entities:
     pos: 30.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 504
   type: solid_wall
   components:
@@ -5985,10 +3980,6 @@ entities:
     pos: 30.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 505
   type: solid_wall
   components:
@@ -5996,10 +3987,6 @@ entities:
     pos: 30.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 506
   type: solid_wall
   components:
@@ -6007,10 +3994,6 @@ entities:
     pos: 30.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 507
   type: solid_wall
   components:
@@ -6018,10 +4001,6 @@ entities:
     pos: 30.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 508
   type: solid_wall
   components:
@@ -6029,10 +4008,6 @@ entities:
     pos: 29.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 509
   type: solid_wall
   components:
@@ -6040,10 +4015,6 @@ entities:
     pos: 28.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 510
   type: solid_wall
   components:
@@ -6051,10 +4022,6 @@ entities:
     pos: 27.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 511
   type: solid_wall
   components:
@@ -6062,10 +4029,6 @@ entities:
     pos: 27.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 512
   type: solid_wall
   components:
@@ -6073,10 +4036,6 @@ entities:
     pos: 26.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 513
   type: solid_wall
   components:
@@ -6084,10 +4043,6 @@ entities:
     pos: 25.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 514
   type: solid_wall
   components:
@@ -6095,10 +4050,6 @@ entities:
     pos: 26.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 515
   type: solid_wall
   components:
@@ -6106,10 +4057,6 @@ entities:
     pos: 26.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 516
   type: solid_wall
   components:
@@ -6117,10 +4064,6 @@ entities:
     pos: 28.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 517
   type: solid_wall
   components:
@@ -6128,10 +4071,6 @@ entities:
     pos: 28.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 518
   type: solid_wall
   components:
@@ -6139,10 +4078,6 @@ entities:
     pos: 28.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 519
   type: solid_wall
   components:
@@ -6150,10 +4085,6 @@ entities:
     pos: 28.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 520
   type: solid_wall
   components:
@@ -6161,10 +4092,6 @@ entities:
     pos: 28.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 521
   type: solid_wall
   components:
@@ -6172,10 +4099,6 @@ entities:
     pos: 28.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 522
   type: solid_wall
   components:
@@ -6183,10 +4106,6 @@ entities:
     pos: 28.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 523
   type: solid_wall
   components:
@@ -6194,10 +4113,6 @@ entities:
     pos: 27.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 524
   type: solid_wall
   components:
@@ -6205,10 +4120,6 @@ entities:
     pos: 26.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 525
   type: solid_wall
   components:
@@ -6216,10 +4127,6 @@ entities:
     pos: 25.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 526
   type: solid_wall
   components:
@@ -6227,10 +4134,6 @@ entities:
     pos: 24.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 527
   type: solid_wall
   components:
@@ -6238,10 +4141,6 @@ entities:
     pos: 23.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 528
   type: solid_wall
   components:
@@ -6249,10 +4148,6 @@ entities:
     pos: 22.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 529
   type: solid_wall
   components:
@@ -6260,10 +4155,6 @@ entities:
     pos: 21.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 530
   type: solid_wall
   components:
@@ -6271,10 +4162,6 @@ entities:
     pos: 22.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 531
   type: solid_wall
   components:
@@ -6282,10 +4169,6 @@ entities:
     pos: 22.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 532
   type: solid_wall
   components:
@@ -6293,10 +4176,6 @@ entities:
     pos: 22.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 533
   type: solid_wall
   components:
@@ -6304,10 +4183,6 @@ entities:
     pos: 22.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 534
   type: solid_wall
   components:
@@ -6315,10 +4190,6 @@ entities:
     pos: 22.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 535
   type: solid_wall
   components:
@@ -6326,10 +4197,6 @@ entities:
     pos: 22.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 536
   type: solid_wall
   components:
@@ -6337,10 +4204,6 @@ entities:
     pos: 22.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 537
   type: solid_wall
   components:
@@ -6348,10 +4211,6 @@ entities:
     pos: 21.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 538
   type: solid_wall
   components:
@@ -6359,10 +4218,6 @@ entities:
     pos: 19.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 539
   type: solid_wall
   components:
@@ -6370,10 +4225,6 @@ entities:
     pos: 18.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 540
   type: solid_wall
   components:
@@ -6381,10 +4232,6 @@ entities:
     pos: 17.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 541
   type: solid_wall
   components:
@@ -6392,10 +4239,6 @@ entities:
     pos: 23.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 542
   type: solid_wall
   components:
@@ -6403,10 +4246,6 @@ entities:
     pos: 25.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 543
   type: solid_wall
   components:
@@ -6414,10 +4253,6 @@ entities:
     pos: 13.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 544
   type: solid_wall
   components:
@@ -6425,10 +4260,6 @@ entities:
     pos: 13.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 545
   type: solid_wall
   components:
@@ -6436,10 +4267,6 @@ entities:
     pos: 13.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 546
   type: solid_wall
   components:
@@ -6447,10 +4274,6 @@ entities:
     pos: 13.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 547
   type: solid_wall
   components:
@@ -6458,10 +4281,6 @@ entities:
     pos: 13.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 548
   type: solid_wall
   components:
@@ -6469,10 +4288,6 @@ entities:
     pos: 13.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 549
   type: solid_wall
   components:
@@ -6480,10 +4295,6 @@ entities:
     pos: 14.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 550
   type: solid_wall
   components:
@@ -6491,10 +4302,6 @@ entities:
     pos: 13.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 551
   type: solid_wall
   components:
@@ -6502,10 +4309,6 @@ entities:
     pos: 12.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 552
   type: solid_wall
   components:
@@ -6513,10 +4316,6 @@ entities:
     pos: 11.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 553
   type: solid_wall
   components:
@@ -6524,10 +4323,6 @@ entities:
     pos: 10.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 554
   type: solid_wall
   components:
@@ -6535,10 +4330,6 @@ entities:
     pos: 9.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 555
   type: solid_wall
   components:
@@ -6546,10 +4337,6 @@ entities:
     pos: 8.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 556
   type: solid_wall
   components:
@@ -6557,10 +4344,6 @@ entities:
     pos: 7.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 557
   type: solid_wall
   components:
@@ -6568,10 +4351,6 @@ entities:
     pos: 6.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 558
   type: solid_wall
   components:
@@ -6579,10 +4358,6 @@ entities:
     pos: 5.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 559
   type: solid_wall
   components:
@@ -6590,10 +4365,6 @@ entities:
     pos: 4.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 560
   type: solid_wall
   components:
@@ -6601,10 +4372,6 @@ entities:
     pos: 5.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 561
   type: solid_wall
   components:
@@ -6612,10 +4379,6 @@ entities:
     pos: 6.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 562
   type: solid_wall
   components:
@@ -6623,10 +4386,6 @@ entities:
     pos: 7.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 563
   type: solid_wall
   components:
@@ -6634,10 +4393,6 @@ entities:
     pos: 8.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 564
   type: solid_wall
   components:
@@ -6645,10 +4400,6 @@ entities:
     pos: 9.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 565
   type: solid_wall
   components:
@@ -6656,10 +4407,6 @@ entities:
     pos: 10.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 566
   type: solid_wall
   components:
@@ -6667,10 +4414,6 @@ entities:
     pos: 11.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 567
   type: solid_wall
   components:
@@ -6678,10 +4421,6 @@ entities:
     pos: 12.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 568
   type: solid_wall
   components:
@@ -6689,10 +4428,6 @@ entities:
     pos: 4.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 569
   type: solid_wall
   components:
@@ -6700,10 +4435,6 @@ entities:
     pos: 1.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 570
   type: solid_wall
   components:
@@ -6711,10 +4442,6 @@ entities:
     pos: 1.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 571
   type: solid_wall
   components:
@@ -6722,10 +4449,6 @@ entities:
     pos: 0.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 572
   type: solid_wall
   components:
@@ -6733,10 +4456,6 @@ entities:
     pos: -0.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 573
   type: solid_wall
   components:
@@ -6744,10 +4463,6 @@ entities:
     pos: -1.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 574
   type: solid_wall
   components:
@@ -6755,10 +4470,6 @@ entities:
     pos: -2.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 575
   type: solid_wall
   components:
@@ -6766,10 +4477,6 @@ entities:
     pos: -3.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 576
   type: solid_wall
   components:
@@ -6777,10 +4484,6 @@ entities:
     pos: -4.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 577
   type: solid_wall
   components:
@@ -6788,10 +4491,6 @@ entities:
     pos: -5.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 578
   type: solid_wall
   components:
@@ -6799,10 +4498,6 @@ entities:
     pos: -6.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 579
   type: solid_wall
   components:
@@ -6810,10 +4505,6 @@ entities:
     pos: -7.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 580
   type: solid_wall
   components:
@@ -6821,10 +4512,6 @@ entities:
     pos: 1.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 581
   type: solid_wall
   components:
@@ -6832,10 +4519,6 @@ entities:
     pos: 1.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 582
   type: solid_wall
   components:
@@ -6843,10 +4526,6 @@ entities:
     pos: 1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 583
   type: catwalk
   components:
@@ -6854,9 +4533,6 @@ entities:
     pos: 5.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 584
   type: catwalk
   components:
@@ -6864,9 +4540,6 @@ entities:
     pos: 12.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 585
   type: table
   components:
@@ -6874,10 +4547,6 @@ entities:
     pos: 23.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 586
   type: table
   components:
@@ -6885,10 +4554,6 @@ entities:
     pos: 23.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 587
   type: airlock_medical_glass
   components:
@@ -6896,12 +4561,6 @@ entities:
     pos: 15.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 588
   type: airlock_medical_glass
   components:
@@ -6909,12 +4568,6 @@ entities:
     pos: 16.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 589
   type: airlock_medical_glass
   components:
@@ -6922,12 +4575,6 @@ entities:
     pos: 20.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 590
   type: airlock_medical_glass
   components:
@@ -6935,12 +4582,6 @@ entities:
     pos: 26.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 591
   type: Beaker
   components:
@@ -6948,12 +4589,6 @@ entities:
     pos: 26.416822,10.651619
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 592
   type: Beaker
   components:
@@ -6961,12 +4596,6 @@ entities:
     pos: 24.541822,10.635994
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 593
   type: Beaker
   components:
@@ -6974,12 +4603,6 @@ entities:
     pos: 25.291822,10.667244
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 594
   type: Wire
   components:
@@ -6987,9 +4610,6 @@ entities:
     pos: 1.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 595
   type: Wire
   components:
@@ -6997,9 +4617,6 @@ entities:
     pos: 2.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 596
   type: Wire
   components:
@@ -7007,9 +4624,6 @@ entities:
     pos: 2.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 597
   type: Wire
   components:
@@ -7017,9 +4631,6 @@ entities:
     pos: 2.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 598
   type: Wire
   components:
@@ -7027,9 +4638,6 @@ entities:
     pos: 2.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 599
   type: Wire
   components:
@@ -7037,9 +4645,6 @@ entities:
     pos: 2.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 600
   type: Wire
   components:
@@ -7047,9 +4652,6 @@ entities:
     pos: 2.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 601
   type: Wire
   components:
@@ -7057,9 +4659,6 @@ entities:
     pos: 2.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 602
   type: Wire
   components:
@@ -7067,9 +4666,6 @@ entities:
     pos: 2.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 603
   type: Wire
   components:
@@ -7077,9 +4673,6 @@ entities:
     pos: 3.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 604
   type: Wire
   components:
@@ -7087,9 +4680,6 @@ entities:
     pos: 4.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 605
   type: Wire
   components:
@@ -7097,9 +4687,6 @@ entities:
     pos: 5.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 606
   type: Wire
   components:
@@ -7107,9 +4694,6 @@ entities:
     pos: 5.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 607
   type: Wire
   components:
@@ -7117,9 +4701,6 @@ entities:
     pos: 6.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 608
   type: Wire
   components:
@@ -7127,9 +4708,6 @@ entities:
     pos: 7.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 609
   type: Wire
   components:
@@ -7137,9 +4715,6 @@ entities:
     pos: 8.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 610
   type: Wire
   components:
@@ -7147,9 +4722,6 @@ entities:
     pos: 9.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 611
   type: Wire
   components:
@@ -7157,9 +4729,6 @@ entities:
     pos: 10.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 612
   type: Wire
   components:
@@ -7167,9 +4736,6 @@ entities:
     pos: 11.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 613
   type: Wire
   components:
@@ -7177,9 +4743,6 @@ entities:
     pos: 12.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 614
   type: Wire
   components:
@@ -7187,9 +4750,6 @@ entities:
     pos: 12.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 615
   type: Wire
   components:
@@ -7197,9 +4757,6 @@ entities:
     pos: 13.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 616
   type: Wire
   components:
@@ -7207,9 +4764,6 @@ entities:
     pos: 14.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 617
   type: Wire
   components:
@@ -7217,9 +4771,6 @@ entities:
     pos: 15.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 618
   type: Wire
   components:
@@ -7227,9 +4778,6 @@ entities:
     pos: 16.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 619
   type: Wire
   components:
@@ -7237,9 +4785,6 @@ entities:
     pos: 16.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 620
   type: Wire
   components:
@@ -7247,9 +4792,6 @@ entities:
     pos: 16.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 621
   type: Wire
   components:
@@ -7257,9 +4799,6 @@ entities:
     pos: 16.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 622
   type: Wire
   components:
@@ -7267,9 +4806,6 @@ entities:
     pos: 16.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 623
   type: Wire
   components:
@@ -7277,9 +4813,6 @@ entities:
     pos: 16.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 624
   type: Wire
   components:
@@ -7287,9 +4820,6 @@ entities:
     pos: 16.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 625
   type: Wire
   components:
@@ -7297,9 +4827,6 @@ entities:
     pos: 16.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 626
   type: Wire
   components:
@@ -7307,9 +4834,6 @@ entities:
     pos: 16.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 627
   type: Wire
   components:
@@ -7317,9 +4841,6 @@ entities:
     pos: 17.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 628
   type: Wire
   components:
@@ -7327,9 +4848,6 @@ entities:
     pos: 18.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 629
   type: Wire
   components:
@@ -7337,9 +4855,6 @@ entities:
     pos: 18.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 630
   type: APC
   components:
@@ -7347,10 +4862,6 @@ entities:
     pos: 18.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 631
   type: Wire
   components:
@@ -7358,9 +4869,6 @@ entities:
     pos: 1.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 632
   type: Wire
   components:
@@ -7368,9 +4876,6 @@ entities:
     pos: 1.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 633
   type: APC
   components:
@@ -7378,10 +4883,6 @@ entities:
     pos: 1.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 634
   type: airlock
   components:
@@ -7389,12 +4890,6 @@ entities:
     pos: 1.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 635
   type: airlock
   components:
@@ -7402,12 +4897,6 @@ entities:
     pos: 4.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 636
   type: airlock
   components:
@@ -7415,50 +4904,30 @@ entities:
     pos: 13.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 637
   type: APC
   components:
   - parent: 0
     pos: 13.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 638
   type: Wire
   components:
   - parent: 0
     pos: 13.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 639
   type: APC
   components:
   - parent: 0
     pos: 28.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 640
   type: Wire
   components:
   - parent: 0
     pos: 25.5,4.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 641
   type: poweredlight
   components:
@@ -7466,9 +4935,6 @@ entities:
     pos: 17.5,4
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7484,12 +4950,6 @@ entities:
   components:
   - parent: 641
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 643
   type: poweredlight
   components:
@@ -7497,9 +4957,6 @@ entities:
     pos: 22.5,3
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7515,12 +4972,6 @@ entities:
   components:
   - parent: 643
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 645
   type: poweredlight
   components:
@@ -7528,9 +4979,6 @@ entities:
     pos: 13.5,3
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7546,12 +4994,6 @@ entities:
   components:
   - parent: 645
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 647
   type: Wire
   components:
@@ -7559,9 +5001,6 @@ entities:
     pos: 27.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 648
   type: Wire
   components:
@@ -7569,54 +5008,36 @@ entities:
     pos: 26.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 649
   type: Wire
   components:
   - parent: 0
     pos: 15.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 650
   type: Wire
   components:
   - parent: 0
     pos: 14.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 651
   type: Wire
   components:
   - parent: 0
     pos: 13.5,8.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 652
   type: Wire
   components:
   - parent: 0
     pos: 15.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 653
   type: Wire
   components:
   - parent: 0
     pos: 14.5,6.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 654
   type: APC
   components:
@@ -7624,91 +5045,60 @@ entities:
     pos: 30.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 655
   type: Wire
   components:
   - parent: 0
     pos: 19.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 656
   type: Wire
   components:
   - parent: 0
     pos: 20.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 657
   type: Wire
   components:
   - parent: 0
     pos: 21.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 658
   type: Wire
   components:
   - parent: 0
     pos: 22.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 659
   type: Wire
   components:
   - parent: 0
     pos: 23.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 660
   type: Wire
   components:
   - parent: 0
     pos: 24.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 661
   type: Wire
   components:
   - parent: 0
     pos: 25.5,2.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 662
   type: Wire
   components:
   - parent: 0
     pos: 25.5,3.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 663
   type: poweredlight
   components:
   - parent: 0
     pos: 14,9.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7724,12 +5114,6 @@ entities:
   components:
   - parent: 663
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 665
   type: poweredlight
   components:
@@ -7737,9 +5121,6 @@ entities:
     pos: 22,9.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7755,12 +5136,6 @@ entities:
   components:
   - parent: 665
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 667
   type: Wire
   components:
@@ -7768,9 +5143,6 @@ entities:
     pos: 30.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 668
   type: Wire
   components:
@@ -7778,9 +5150,6 @@ entities:
     pos: 29.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 669
   type: poweredlight
   components:
@@ -7788,9 +5157,6 @@ entities:
     pos: 16.5,-6
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -7806,12 +5172,6 @@ entities:
   components:
   - parent: 669
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 671
   type: table
   components:
@@ -7819,10 +5179,6 @@ entities:
     pos: 23.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 672
   type: table
   components:
@@ -7830,10 +5186,6 @@ entities:
     pos: 24.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 673
   type: APC
   components:
@@ -7841,10 +5193,6 @@ entities:
     pos: 20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 674
   type: Wire
   components:
@@ -7852,9 +5200,6 @@ entities:
     pos: 16.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 675
   type: Wire
   components:
@@ -7862,9 +5207,6 @@ entities:
     pos: 16.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 676
   type: Wire
   components:
@@ -7872,9 +5214,6 @@ entities:
     pos: 16.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 677
   type: Wire
   components:
@@ -7882,9 +5221,6 @@ entities:
     pos: 16.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 678
   type: Wire
   components:
@@ -7892,9 +5228,6 @@ entities:
     pos: 16.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 679
   type: Wire
   components:
@@ -7902,9 +5235,6 @@ entities:
     pos: 16.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 680
   type: Wire
   components:
@@ -7912,9 +5242,6 @@ entities:
     pos: 17.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 681
   type: Wire
   components:
@@ -7922,9 +5249,6 @@ entities:
     pos: 18.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 682
   type: Wire
   components:
@@ -7932,9 +5256,6 @@ entities:
     pos: 19.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 683
   type: Wire
   components:
@@ -7942,9 +5263,6 @@ entities:
     pos: 20.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 684
   type: Wire
   components:
@@ -7952,9 +5270,6 @@ entities:
     pos: 20.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 685
   type: Wire
   components:
@@ -7962,9 +5277,6 @@ entities:
     pos: 20.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 686
   type: Wire
   components:
@@ -7972,9 +5284,6 @@ entities:
     pos: 20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 687
   type: Wire
   components:
@@ -7982,9 +5291,6 @@ entities:
     pos: 21.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 688
   type: Wire
   components:
@@ -7992,9 +5298,6 @@ entities:
     pos: 22.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 689
   type: Wire
   components:
@@ -8002,9 +5305,6 @@ entities:
     pos: 23.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 690
   type: Wire
   components:
@@ -8012,9 +5312,6 @@ entities:
     pos: 24.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 691
   type: Wire
   components:
@@ -8022,9 +5319,6 @@ entities:
     pos: 25.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 692
   type: Wire
   components:
@@ -8032,9 +5326,6 @@ entities:
     pos: 26.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 693
   type: Wire
   components:
@@ -8042,9 +5333,6 @@ entities:
     pos: 27.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 694
   type: Wire
   components:
@@ -8052,9 +5340,6 @@ entities:
     pos: 28.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 695
   type: Wire
   components:
@@ -8062,9 +5347,6 @@ entities:
     pos: 29.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 696
   type: Wire
   components:
@@ -8072,9 +5354,6 @@ entities:
     pos: 30.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 697
   type: Wire
   components:
@@ -8082,9 +5361,6 @@ entities:
     pos: 30.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 698
   type: Wire
   components:
@@ -8092,9 +5368,6 @@ entities:
     pos: 30.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 699
   type: Wire
   components:
@@ -8102,9 +5375,6 @@ entities:
     pos: 30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 700
   type: APC
   components:
@@ -8112,10 +5382,6 @@ entities:
     pos: 30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 701
   type: poweredlight
   components:
@@ -8123,9 +5389,6 @@ entities:
     pos: 31.5,-6
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -8141,12 +5404,6 @@ entities:
   components:
   - parent: 701
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 703
   type: poweredlight
   components:
@@ -8154,9 +5411,6 @@ entities:
     pos: 30,1.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -8172,12 +5426,6 @@ entities:
   components:
   - parent: 703
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 705
   type: Wire
   components:
@@ -8185,9 +5433,6 @@ entities:
     pos: 26.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 706
   type: Wire
   components:
@@ -8195,9 +5440,6 @@ entities:
     pos: 27.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 707
   type: Wire
   components:
@@ -8205,9 +5447,6 @@ entities:
     pos: 28.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 708
   type: Wire
   components:
@@ -8215,9 +5454,6 @@ entities:
     pos: 28.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 709
   type: Wire
   components:
@@ -8225,9 +5461,6 @@ entities:
     pos: 25.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 710
   type: Wire
   components:
@@ -8235,9 +5468,6 @@ entities:
     pos: 25.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 711
   type: Wire
   components:
@@ -8245,9 +5475,6 @@ entities:
     pos: 25.5,7.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 712
   type: Wire
   components:
@@ -8255,9 +5482,6 @@ entities:
     pos: 25.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 713
   type: poweredlight
   components:
@@ -8265,9 +5489,6 @@ entities:
     pos: 28,7.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -8283,12 +5504,6 @@ entities:
   components:
   - parent: 713
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 715
   type: vending_machine_medical
   components:
@@ -8298,11 +5513,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/medical.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 716
   type: vending_machine_medical
   components:
@@ -8312,11 +5522,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/medical.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 717
   type: vending_machine_medical
   components:
@@ -8326,11 +5531,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/medical.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 718
   type: vending_machine_wallmed
   components:
@@ -8340,11 +5540,6 @@ entities:
     type: Transform
   - sprite: Buildings/VendingMachines/wallmed.rsi
     type: Sprite
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 719
   type: MedkitFilled
   components:
@@ -8352,12 +5547,6 @@ entities:
     pos: 13.460339,0.6141751
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -8370,12 +5559,6 @@ entities:
     pos: 13.632214,1.5673001
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
   - containers:
       storagebase:
         entities: []
@@ -8388,11 +5571,6 @@ entities:
     pos: 22.5,-5.5
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
 - uid: 722
   type: poweredlight
   components:
@@ -8400,9 +5578,6 @@ entities:
     pos: 23.5,-6
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -8418,12 +5593,6 @@ entities:
   components:
   - parent: 722
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 724
   type: Brutepack
   components:
@@ -8431,12 +5600,6 @@ entities:
     pos: 18.476385,4.841032
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 725
   type: Brutepack
   components:
@@ -8444,12 +5607,6 @@ entities:
     pos: 18.601385,5.512907
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 726
   type: Ointment
   components:
@@ -8457,12 +5614,6 @@ entities:
     pos: 18.49201,6.059782
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 727
   type: Ointment
   components:
@@ -8470,12 +5621,6 @@ entities:
     pos: 18.77326,6.653532
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 728
   type: spawn_point_latejoin
   components:
@@ -8497,10 +5642,6 @@ entities:
     pos: 33.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 731
   type: table
   components:
@@ -8508,10 +5649,6 @@ entities:
     pos: 33.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 732
   type: table
   components:
@@ -8519,10 +5656,6 @@ entities:
     pos: 33.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 733
   type: table
   components:
@@ -8530,10 +5663,6 @@ entities:
     pos: 33.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 734
   type: table
   components:
@@ -8541,10 +5670,6 @@ entities:
     pos: 33.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 735
   type: LargeBeaker
   components:
@@ -8552,12 +5677,6 @@ entities:
     pos: 33.18525,-5.681699
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 736
   type: LargeBeaker
   components:
@@ -8565,12 +5684,6 @@ entities:
     pos: 33.294624,-5.181699
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 737
   type: LargeBeaker
   components:
@@ -8578,12 +5691,6 @@ entities:
     pos: 33.544624,-5.572324
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 738
   type: Beaker
   components:
@@ -8591,12 +5698,6 @@ entities:
     pos: 33.357124,-4.837949
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 739
   type: Beaker
   components:
@@ -8604,12 +5705,6 @@ entities:
     pos: 33.357124,-4.166074
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 740
   type: Beaker
   components:
@@ -8617,12 +5712,6 @@ entities:
     pos: 33.388374,-4.431699
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 741
   type: Beaker
   components:
@@ -8630,12 +5719,6 @@ entities:
     pos: 33.62275,-4.228574
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 742
   type: Beaker
   components:
@@ -8643,12 +5726,6 @@ entities:
     pos: 33.62275,-4.634824
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 743
   type: crate_medical
   components:
@@ -8656,12 +5733,6 @@ entities:
     pos: 32.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.4,-0.4,0.4,0.4
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8674,12 +5745,6 @@ entities:
     pos: 31.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.4,-0.4,0.4,0.4
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8692,12 +5757,6 @@ entities:
     pos: 30.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8710,12 +5769,6 @@ entities:
     pos: 29.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8728,12 +5781,6 @@ entities:
     pos: 27.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8746,12 +5793,6 @@ entities:
     pos: 27.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -8764,10 +5805,6 @@ entities:
     pos: 4.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 750
   type: solid_wall
   components:
@@ -8775,10 +5812,6 @@ entities:
     pos: 4.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 751
   type: solid_wall
   components:
@@ -8786,10 +5819,6 @@ entities:
     pos: 4.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 752
   type: solid_wall
   components:
@@ -8797,10 +5826,6 @@ entities:
     pos: 4.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 753
   type: solid_wall
   components:
@@ -8808,10 +5833,6 @@ entities:
     pos: 4.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 754
   type: solid_wall
   components:
@@ -8819,10 +5840,6 @@ entities:
     pos: 4.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 755
   type: solid_wall
   components:
@@ -8830,10 +5847,6 @@ entities:
     pos: 4.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 756
   type: solid_wall
   components:
@@ -8841,10 +5854,6 @@ entities:
     pos: 4.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 757
   type: solid_wall
   components:
@@ -8852,10 +5861,6 @@ entities:
     pos: 4.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 758
   type: solid_wall
   components:
@@ -8863,10 +5868,6 @@ entities:
     pos: 4.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 759
   type: solid_wall
   components:
@@ -8874,10 +5875,6 @@ entities:
     pos: 7.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 760
   type: solid_wall
   components:
@@ -8885,10 +5882,6 @@ entities:
     pos: 7.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 761
   type: solid_wall
   components:
@@ -8896,10 +5889,6 @@ entities:
     pos: 7.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 762
   type: solid_wall
   components:
@@ -8907,10 +5896,6 @@ entities:
     pos: 7.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 763
   type: solid_wall
   components:
@@ -8918,10 +5903,6 @@ entities:
     pos: 7.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 764
   type: solid_wall
   components:
@@ -8929,10 +5910,6 @@ entities:
     pos: 8.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 765
   type: solid_wall
   components:
@@ -8940,10 +5917,6 @@ entities:
     pos: 10.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 766
   type: solid_wall
   components:
@@ -8951,10 +5924,6 @@ entities:
     pos: 11.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 767
   type: solid_wall
   components:
@@ -8962,10 +5931,6 @@ entities:
     pos: 12.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 768
   type: solid_wall
   components:
@@ -8973,10 +5938,6 @@ entities:
     pos: 13.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 769
   type: solid_wall
   components:
@@ -8984,10 +5945,6 @@ entities:
     pos: 14.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 770
   type: solid_wall
   components:
@@ -8995,10 +5952,6 @@ entities:
     pos: 15.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 771
   type: solid_wall
   components:
@@ -9006,10 +5959,6 @@ entities:
     pos: 14.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 772
   type: solid_wall
   components:
@@ -9017,10 +5966,6 @@ entities:
     pos: 14.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 773
   type: solid_wall
   components:
@@ -9028,10 +5973,6 @@ entities:
     pos: 14.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 774
   type: solid_wall
   components:
@@ -9039,10 +5980,6 @@ entities:
     pos: 14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 775
   type: solid_wall
   components:
@@ -9050,10 +5987,6 @@ entities:
     pos: 15.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 776
   type: solid_wall
   components:
@@ -9061,10 +5994,6 @@ entities:
     pos: 17.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 777
   type: solid_wall
   components:
@@ -9072,10 +6001,6 @@ entities:
     pos: 17.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 778
   type: solid_wall
   components:
@@ -9083,10 +6008,6 @@ entities:
     pos: 18.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 779
   type: solid_wall
   components:
@@ -9094,10 +6015,6 @@ entities:
     pos: 18.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 780
   type: solid_wall
   components:
@@ -9105,10 +6022,6 @@ entities:
     pos: 18.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 781
   type: solid_wall
   components:
@@ -9116,10 +6029,6 @@ entities:
     pos: 18.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 782
   type: solid_wall
   components:
@@ -9127,10 +6036,6 @@ entities:
     pos: 18.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 783
   type: solid_wall
   components:
@@ -9138,10 +6043,6 @@ entities:
     pos: 18.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 784
   type: solid_wall
   components:
@@ -9149,10 +6050,6 @@ entities:
     pos: 18.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 785
   type: solid_wall
   components:
@@ -9160,10 +6057,6 @@ entities:
     pos: 18.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 786
   type: solid_wall
   components:
@@ -9171,10 +6064,6 @@ entities:
     pos: 19.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 787
   type: solid_wall
   components:
@@ -9182,10 +6071,6 @@ entities:
     pos: 20.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 788
   type: solid_wall
   components:
@@ -9193,10 +6078,6 @@ entities:
     pos: 21.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 789
   type: solid_wall
   components:
@@ -9204,10 +6085,6 @@ entities:
     pos: 22.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 790
   type: solid_wall
   components:
@@ -9215,10 +6092,6 @@ entities:
     pos: 23.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 791
   type: solid_wall
   components:
@@ -9226,10 +6099,6 @@ entities:
     pos: 24.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 792
   type: solid_wall
   components:
@@ -9237,10 +6106,6 @@ entities:
     pos: 25.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 793
   type: solid_wall
   components:
@@ -9248,10 +6113,6 @@ entities:
     pos: 26.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 794
   type: solid_wall
   components:
@@ -9259,10 +6120,6 @@ entities:
     pos: 27.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 795
   type: solid_wall
   components:
@@ -9270,10 +6127,6 @@ entities:
     pos: 28.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 796
   type: solid_wall
   components:
@@ -9281,10 +6134,6 @@ entities:
     pos: 6.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 797
   type: solid_wall
   components:
@@ -9292,10 +6141,6 @@ entities:
     pos: 7.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 798
   type: solid_wall
   components:
@@ -9303,10 +6148,6 @@ entities:
     pos: 14.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 799
   type: solid_wall
   components:
@@ -9314,10 +6155,6 @@ entities:
     pos: 14.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 800
   type: solid_wall
   components:
@@ -9325,10 +6162,6 @@ entities:
     pos: 8.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 801
   type: solid_wall
   components:
@@ -9336,10 +6169,6 @@ entities:
     pos: 9.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 802
   type: solid_wall
   components:
@@ -9347,10 +6176,6 @@ entities:
     pos: 10.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 803
   type: solid_wall
   components:
@@ -9358,10 +6183,6 @@ entities:
     pos: 11.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 804
   type: solid_wall
   components:
@@ -9369,10 +6190,6 @@ entities:
     pos: 12.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 805
   type: solid_wall
   components:
@@ -9380,10 +6197,6 @@ entities:
     pos: 13.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 806
   type: solid_wall
   components:
@@ -9391,10 +6204,6 @@ entities:
     pos: 14.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 807
   type: solid_wall
   components:
@@ -9402,10 +6211,6 @@ entities:
     pos: 14.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 808
   type: solid_wall
   components:
@@ -9413,10 +6218,6 @@ entities:
     pos: 14.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 809
   type: solid_wall
   components:
@@ -9424,10 +6225,6 @@ entities:
     pos: 14.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 810
   type: solid_wall
   components:
@@ -9435,10 +6232,6 @@ entities:
     pos: 14.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 811
   type: solid_wall
   components:
@@ -9446,10 +6239,6 @@ entities:
     pos: 18.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 812
   type: solid_wall
   components:
@@ -9457,10 +6246,6 @@ entities:
     pos: 18.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 813
   type: solid_wall
   components:
@@ -9468,10 +6253,6 @@ entities:
     pos: 18.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 814
   type: solid_wall
   components:
@@ -9479,10 +6260,6 @@ entities:
     pos: 18.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 815
   type: solid_wall
   components:
@@ -9490,10 +6267,6 @@ entities:
     pos: 18.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 816
   type: solid_wall
   components:
@@ -9501,10 +6274,6 @@ entities:
     pos: 18.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 817
   type: solid_wall
   components:
@@ -9512,10 +6281,6 @@ entities:
     pos: 13.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 818
   type: solid_wall
   components:
@@ -9523,10 +6288,6 @@ entities:
     pos: 12.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 819
   type: solid_wall
   components:
@@ -9534,10 +6295,6 @@ entities:
     pos: 11.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 820
   type: solid_wall
   components:
@@ -9545,10 +6302,6 @@ entities:
     pos: 10.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 821
   type: solid_wall
   components:
@@ -9556,10 +6309,6 @@ entities:
     pos: 9.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 822
   type: solid_wall
   components:
@@ -9567,10 +6316,6 @@ entities:
     pos: 8.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 823
   type: solid_wall
   components:
@@ -9578,10 +6323,6 @@ entities:
     pos: 4.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 824
   type: solid_wall
   components:
@@ -9589,10 +6330,6 @@ entities:
     pos: 10.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 825
   type: solid_wall
   components:
@@ -9600,10 +6337,6 @@ entities:
     pos: 10.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 826
   type: solid_wall
   components:
@@ -9611,10 +6344,6 @@ entities:
     pos: 10.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 827
   type: solid_wall
   components:
@@ -9622,10 +6351,6 @@ entities:
     pos: 4.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 828
   type: solid_wall
   components:
@@ -9633,10 +6358,6 @@ entities:
     pos: 4.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 829
   type: solid_wall
   components:
@@ -9644,10 +6365,6 @@ entities:
     pos: 4.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 830
   type: solid_wall
   components:
@@ -9655,10 +6372,6 @@ entities:
     pos: 7.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 831
   type: solid_wall
   components:
@@ -9666,10 +6379,6 @@ entities:
     pos: 7.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 832
   type: solid_wall
   components:
@@ -9677,10 +6386,6 @@ entities:
     pos: 7.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 833
   type: solid_wall
   components:
@@ -9688,10 +6393,6 @@ entities:
     pos: 7.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 834
   type: catwalk
   components:
@@ -9699,9 +6400,6 @@ entities:
     pos: 5.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 835
   type: catwalk
   components:
@@ -9709,9 +6407,6 @@ entities:
     pos: 6.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 836
   type: catwalk
   components:
@@ -9719,9 +6414,6 @@ entities:
     pos: 6.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 837
   type: solid_wall
   components:
@@ -9729,10 +6421,6 @@ entities:
     pos: 1.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 838
   type: solid_wall
   components:
@@ -9740,10 +6428,6 @@ entities:
     pos: 1.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 839
   type: solid_wall
   components:
@@ -9751,10 +6435,6 @@ entities:
     pos: 1.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 840
   type: solid_wall
   components:
@@ -9762,10 +6442,6 @@ entities:
     pos: 1.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 841
   type: solid_wall
   components:
@@ -9773,10 +6449,6 @@ entities:
     pos: 1.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 842
   type: solid_wall
   components:
@@ -9784,10 +6456,6 @@ entities:
     pos: 1.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 843
   type: solid_wall
   components:
@@ -9795,10 +6463,6 @@ entities:
     pos: 1.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 844
   type: solid_wall
   components:
@@ -9806,10 +6470,6 @@ entities:
     pos: 1.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 845
   type: solid_wall
   components:
@@ -9817,10 +6477,6 @@ entities:
     pos: 1.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-    type: Collidable
 - uid: 846
   type: Wire
   components:
@@ -9828,9 +6484,6 @@ entities:
     pos: 2.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 847
   type: Wire
   components:
@@ -9838,9 +6491,6 @@ entities:
     pos: 2.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 848
   type: Wire
   components:
@@ -9848,9 +6498,6 @@ entities:
     pos: 2.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 849
   type: Wire
   components:
@@ -9858,9 +6505,6 @@ entities:
     pos: 3.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 850
   type: Wire
   components:
@@ -9868,9 +6512,6 @@ entities:
     pos: 4.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 851
   type: Wire
   components:
@@ -9878,9 +6519,6 @@ entities:
     pos: 6.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 852
   type: Wire
   components:
@@ -9888,9 +6526,6 @@ entities:
     pos: 6.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 853
   type: Wire
   components:
@@ -9898,9 +6533,6 @@ entities:
     pos: 5.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 854
   type: Wire
   components:
@@ -9908,9 +6540,6 @@ entities:
     pos: 5.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 855
   type: Wire
   components:
@@ -9918,9 +6547,6 @@ entities:
     pos: 5.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 856
   type: Wire
   components:
@@ -9928,9 +6554,6 @@ entities:
     pos: 6.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 857
   type: Wire
   components:
@@ -9938,9 +6561,6 @@ entities:
     pos: 6.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 858
   type: Wire
   components:
@@ -9948,9 +6568,6 @@ entities:
     pos: 6.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 859
   type: Wire
   components:
@@ -9958,9 +6575,6 @@ entities:
     pos: 6.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 860
   type: Wire
   components:
@@ -9968,9 +6582,6 @@ entities:
     pos: 6.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 861
   type: Wire
   components:
@@ -9978,9 +6589,6 @@ entities:
     pos: 6.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 862
   type: Wire
   components:
@@ -9988,9 +6596,6 @@ entities:
     pos: 6.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 863
   type: Wire
   components:
@@ -9998,9 +6603,6 @@ entities:
     pos: 6.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 864
   type: Wire
   components:
@@ -10008,9 +6610,6 @@ entities:
     pos: 6.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 865
   type: Wire
   components:
@@ -10018,9 +6617,6 @@ entities:
     pos: 6.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 866
   type: Wire
   components:
@@ -10028,9 +6624,6 @@ entities:
     pos: 6.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 867
   type: Wire
   components:
@@ -10038,9 +6631,6 @@ entities:
     pos: 5.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 868
   type: airlock_science_glass
   components:
@@ -10048,12 +6638,6 @@ entities:
     pos: 14.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 869
   type: airlock_science
   components:
@@ -10061,12 +6645,6 @@ entities:
     pos: 14.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 870
   type: airlock_science
   components:
@@ -10074,12 +6652,6 @@ entities:
     pos: 16.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 871
   type: airlock_science
   components:
@@ -10087,12 +6659,6 @@ entities:
     pos: 16.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 872
   type: airlock
   components:
@@ -10100,12 +6666,6 @@ entities:
     pos: 5.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 873
   type: airlock
   components:
@@ -10113,12 +6673,6 @@ entities:
     pos: 7.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 4
-      bounds: -0.49,-0.49,0.49,0.49
-    type: Collidable
 - uid: 874
   type: table
   components:
@@ -10126,10 +6680,6 @@ entities:
     pos: 9.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 875
   type: poweredlight
   components:
@@ -10137,9 +6687,6 @@ entities:
     pos: 6.5,12
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10155,12 +6702,6 @@ entities:
   components:
   - parent: 875
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 877
   type: poweredlight
   components:
@@ -10168,9 +6709,6 @@ entities:
     pos: 12.5,12
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10186,23 +6724,11 @@ entities:
   components:
   - parent: 877
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 879
   type: LightTube
   components:
   - parent: 880
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 880
   type: poweredlight
   components:
@@ -10210,9 +6736,6 @@ entities:
     pos: 14,18.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10230,9 +6753,6 @@ entities:
     pos: 3.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 882
   type: Wire
   components:
@@ -10240,9 +6760,6 @@ entities:
     pos: 2.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 883
   type: poweredlight
   components:
@@ -10250,9 +6767,6 @@ entities:
     pos: 18,22.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10268,12 +6782,6 @@ entities:
   components:
   - parent: 883
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 885
   type: poweredlight
   components:
@@ -10281,9 +6789,6 @@ entities:
     pos: 18,27.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10299,21 +6804,12 @@ entities:
   components:
   - parent: 885
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 887
   type: poweredsmalllight
   components:
   - parent: 0
     pos: 18,17.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10329,21 +6825,12 @@ entities:
   components:
   - parent: 887
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 889
   type: poweredlight
   components:
   - parent: 0
     pos: 2,17.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10359,32 +6846,17 @@ entities:
   components:
   - parent: 889
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 891
   type: LightTube
   components:
   - parent: 892
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 892
   type: poweredlight
   components:
   - parent: 0
     pos: 2,23.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10402,9 +6874,6 @@ entities:
     pos: 11,24.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10420,12 +6889,6 @@ entities:
   components:
   - parent: 893
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 895
   type: catwalk
   components:
@@ -10433,9 +6896,6 @@ entities:
     pos: 13.5,24.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 896
   type: poweredsmalllight
   components:
@@ -10443,9 +6903,6 @@ entities:
     pos: 7.5,26
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10461,12 +6918,6 @@ entities:
   components:
   - parent: 896
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 898
   type: researchAndDevelopmentServer
   components:
@@ -10474,9 +6925,6 @@ entities:
     pos: 11.5,24.5
     rot: 1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - points: 343000
     type: ResearchServer
   - technologies: []
@@ -10487,11 +6935,6 @@ entities:
   - parent: 0
     pos: 8.5,18.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - technologies: []
     type: TechnologyDatabase
 - uid: 900
@@ -10500,20 +6943,12 @@ entities:
   - parent: 0
     pos: 13.5,16.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-    type: Collidable
 - uid: 901
   type: protolathe
   components:
   - parent: 0
     pos: 8.5,17.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-    type: Collidable
   - recipes: []
     protolatherecipes:
     - Brutepack
@@ -10538,10 +6973,6 @@ entities:
   - parent: 0
     pos: 13.5,18.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -10563,10 +6994,6 @@ entities:
   - parent: 0
     pos: -4.5,-5.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 15
-    type: Collidable
   - recipes:
     - Brutepack
     - Ointment
@@ -10589,10 +7016,6 @@ entities:
     pos: 8.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 905
   type: table
   components:
@@ -10600,10 +7023,6 @@ entities:
     pos: 9.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 906
   type: table
   components:
@@ -10611,10 +7030,6 @@ entities:
     pos: 10.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 907
   type: table
   components:
@@ -10622,10 +7037,6 @@ entities:
     pos: 11.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 908
   type: table
   components:
@@ -10633,10 +7044,6 @@ entities:
     pos: 13.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 20
-    type: Collidable
 - uid: 909
   type: Wire
   components:
@@ -10644,9 +7051,6 @@ entities:
     pos: 2.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 910
   type: Wire
   components:
@@ -10654,9 +7058,6 @@ entities:
     pos: 1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 911
   type: APC
   components:
@@ -10664,10 +7065,6 @@ entities:
     pos: 1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 912
   type: APC
   components:
@@ -10675,10 +7072,6 @@ entities:
     pos: 14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 913
   type: APC
   components:
@@ -10686,10 +7079,6 @@ entities:
     pos: 18.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 914
   type: Wire
   components:
@@ -10697,9 +7086,6 @@ entities:
     pos: 7.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 915
   type: Wire
   components:
@@ -10707,9 +7093,6 @@ entities:
     pos: 8.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 916
   type: Wire
   components:
@@ -10717,9 +7100,6 @@ entities:
     pos: 9.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 917
   type: Wire
   components:
@@ -10727,9 +7107,6 @@ entities:
     pos: 10.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 918
   type: Wire
   components:
@@ -10737,9 +7114,6 @@ entities:
     pos: 11.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 919
   type: Wire
   components:
@@ -10747,9 +7121,6 @@ entities:
     pos: 12.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 920
   type: Wire
   components:
@@ -10757,9 +7128,6 @@ entities:
     pos: 13.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 921
   type: Wire
   components:
@@ -10767,9 +7135,6 @@ entities:
     pos: 14.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 922
   type: Wire
   components:
@@ -10777,9 +7142,6 @@ entities:
     pos: 14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 923
   type: Wire
   components:
@@ -10787,9 +7149,6 @@ entities:
     pos: 15.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 924
   type: Wire
   components:
@@ -10797,9 +7156,6 @@ entities:
     pos: 16.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 925
   type: Wire
   components:
@@ -10807,9 +7163,6 @@ entities:
     pos: 16.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 926
   type: Wire
   components:
@@ -10817,9 +7170,6 @@ entities:
     pos: 16.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 927
   type: Wire
   components:
@@ -10827,9 +7177,6 @@ entities:
     pos: 16.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 928
   type: Wire
   components:
@@ -10837,9 +7184,6 @@ entities:
     pos: 16.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 929
   type: Wire
   components:
@@ -10847,9 +7191,6 @@ entities:
     pos: 16.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 930
   type: Wire
   components:
@@ -10857,9 +7198,6 @@ entities:
     pos: 16.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 931
   type: Wire
   components:
@@ -10867,9 +7205,6 @@ entities:
     pos: 16.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 932
   type: Wire
   components:
@@ -10877,9 +7212,6 @@ entities:
     pos: 17.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 933
   type: Wire
   components:
@@ -10887,9 +7219,6 @@ entities:
     pos: 18.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 934
   type: Generator
   components:
@@ -10897,11 +7226,6 @@ entities:
     pos: 3.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - uid: 935
   type: Generator
   components:
@@ -10909,11 +7233,6 @@ entities:
     pos: 2.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - uid: 936
   type: Generator
   components:
@@ -10921,11 +7240,6 @@ entities:
     pos: 1.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - uid: 937
   type: Generator
   components:
@@ -10933,11 +7247,6 @@ entities:
     pos: 0.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      bounds: -0.5,-0.5,0.3,0.5
-    type: Collidable
 - uid: 938
   type: Wire
   components:
@@ -10945,18 +7254,12 @@ entities:
     pos: 0.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 939
   type: poweredlight
   components:
   - parent: 0
     pos: 8,16.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
   - color: '#FFFFFFFF'
     type: PointLight
   - load: 40
@@ -10972,103 +7275,54 @@ entities:
   components:
   - parent: 939
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 941
   type: APC
   components:
   - parent: 0
     pos: 7.5,18.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      bounds: -0.25,-0.25,0.25,0.3
-    type: Collidable
 - uid: 942
   type: Wire
   components:
   - parent: 0
     pos: 7.5,18.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 943
   type: GlassStack
   components:
   - parent: 0
     pos: 8.560405,21.456738
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 944
   type: GlassStack
   components:
   - parent: 0
     pos: 8.57603,21.566113
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 945
   type: MetalStack
   components:
   - parent: 0
     pos: 9.435405,21.503613
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 946
   type: MetalStack
   components:
   - parent: 0
     pos: 9.654155,21.628613
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 947
   type: CableStack
   components:
   - parent: 0
     pos: 10.561831,21.767809
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 948
   type: CableStack
   components:
   - parent: 0
     pos: 10.577456,21.424059
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 32
-      mask: 26
-      bounds: -0.25,-0.25,0.25,0.25
-    type: Collidable
 - uid: 949
   type: chairOfficeLight
   components:
@@ -11076,9 +7330,6 @@ entities:
     pos: 9.5,18.5
     rot: 3.141592653589793 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 950
   type: chairOfficeLight
   components:
@@ -11086,18 +7337,12 @@ entities:
     pos: 9.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 951
   type: chair
   components:
   - parent: 0
     pos: 12.5,17.5
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb {}
-    type: Collidable
 - uid: 952
   type: locker_science
   components:
@@ -11105,12 +7350,6 @@ entities:
     pos: 12.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []
@@ -11123,12 +7362,6 @@ entities:
     pos: 13.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - shapes:
-    - !type:PhysShapeAabb
-      layer: 31
-      mask: 30
-      bounds: -0.5,-0.25,0.5,0.25
-    type: Collidable
   - containers:
       EntityStorageComponent:
         entities: []

--- a/Resources/Maps/stationstation.yml
+++ b/Resources/Maps/stationstation.yml
@@ -154,12 +154,6 @@ entities:
     pos: -2.67511,-10.351
     rot: -1.5707963267949 rad
     type: Transform
-  - type: Collidable
-    shapes:
-    - !type:PhysShapeAabb
-      bounds: "-0.15,-0.3,0.2,0.3"
-      mask: 26
-      layer: 32
 - uid: 8
   type: PowerCellSmallHigh
   components:
@@ -167,12 +161,6 @@ entities:
     pos: -2.55011,-10.6635
     rot: -1.5707963267949 rad
     type: Transform
-  - type: Collidable
-    shapes:
-    - !type:PhysShapeAabb
-      bounds: "-0.15,-0.3,0.2,0.3"
-      mask: 26
-      layer: 32
 - uid: 9
   type: OuterclothingVest
   components:


### PR DESCRIPTION
Closes #647
Deletes all collision components from  `stationstation.yml`, so now it loads the entities physics as intended
God bless vim macros