### PR TITLE
Add CanAttack to IActionBlocker, prevent using guns when dead

### DIFF
--- a/Content.Server/GameObjects/Components/Mobs/DamageStates.cs
+++ b/Content.Server/GameObjects/Components/Mobs/DamageStates.cs
@@ -72,6 +72,11 @@ namespace Content.Server.GameObjects
         {
             return true;
         }
+
+        bool IActionBlocker.CanAttack()
+        {
+            return true;
+        }
     }
 
     /// <summary>
@@ -125,6 +130,11 @@ namespace Content.Server.GameObjects
         }
 
         bool IActionBlocker.CanEmote()
+        {
+            return false;
+        }
+
+        bool IActionBlocker.CanAttack()
         {
             return false;
         }
@@ -201,6 +211,11 @@ namespace Content.Server.GameObjects
         }
 
         bool IActionBlocker.CanEmote()
+        {
+            return false;
+        }
+
+        bool IActionBlocker.CanAttack()
         {
             return false;
         }

--- a/Content.Server/GameObjects/Components/Mobs/SpeciesComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/SpeciesComponent.cs
@@ -117,6 +117,11 @@ namespace Content.Server.GameObjects
             return CurrentDamageState.CanEmote();
         }
 
+        bool IActionBlocker.CanAttack()
+        {
+            return CurrentDamageState.CanAttack();
+        }
+
         List<DamageThreshold> IOnDamageBehavior.GetAllDamageThresholds()
         {
             var thresholdlist = DamageTemplate.DamageThresholds;

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/RangedWeapon.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/RangedWeapon.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Content.Server.GameObjects.Components.Mobs;
+using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.GameObjects.Components.Weapons.Ranged;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.GameObjects;
@@ -30,7 +31,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged
 
         private bool UserCanFire(IEntity user)
         {
-            return UserCanFireHandler == null || UserCanFireHandler(user);
+            return (UserCanFireHandler == null || UserCanFireHandler(user)) && ActionBlockerSystem.CanAttack(user);
         }
 
         private void Fire(IEntity user, GridCoordinates clickLocation)

--- a/Content.Server/GameObjects/EntitySystems/ActionBlockerSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ActionBlockerSystem.cs
@@ -20,6 +20,8 @@ namespace Content.Server.GameObjects.EntitySystems
         bool CanPickup();
 
         bool CanEmote();
+
+        bool CanAttack();
     }
 
     public class ActionBlockerSystem : EntitySystem
@@ -104,6 +106,18 @@ namespace Content.Server.GameObjects.EntitySystems
             }
 
             return canemote;
+        }
+
+        public static bool CanAttack(IEntity entity)
+        {
+            bool canattack = true;
+
+            foreach (var actionblockercomponents in entity.GetAllComponents<IActionBlocker>())
+            {
+                canattack &= actionblockercomponents.CanAttack();
+            }
+
+            return canattack;
         }
     }
 }

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -853,7 +853,7 @@ namespace Content.Server.GameObjects.EntitySystems
             var item = hands.GetActiveHand?.Owner;
 
             // TODO: If item is null we need some kinda unarmed combat.
-            if (!ActionBlockerSystem.CanInteract(player) || item == null)
+            if (!ActionBlockerSystem.CanAttack(player) || item == null)
             {
                 return;
             }


### PR DESCRIPTION
Closes #768 
I added yet another method to IActionBlocker to allow having mobs that can interact with items, but can't attack (something something, pacifism)