### PR TITLE
Basic Bound UI message sanitization

### DIFF
--- a/Content.Server/GameObjects/Components/Cargo/CargoConsoleComponent.cs
+++ b/Content.Server/GameObjects/Components/Cargo/CargoConsoleComponent.cs
@@ -63,6 +63,12 @@ namespace Content.Server.GameObjects.Components.Cargo
 
         private void UserInterfaceOnOnReceiveMessage(ServerBoundUserInterfaceMessage serverMsg)
         {
+            var playerEntity = serverMsg.Session.AttachedEntity;
+            if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
             var message = serverMsg.Message;
             if (!Orders.ConnectedToDatabase)
                 return;

--- a/Content.Server/GameObjects/Components/Cargo/CargoConsoleComponent.cs
+++ b/Content.Server/GameObjects/Components/Cargo/CargoConsoleComponent.cs
@@ -8,12 +8,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Robust.Shared.Map;
+using Robust.Shared.Interfaces.GameObjects;
 
 namespace Content.Server.GameObjects.Components.Cargo
 {
@@ -24,6 +19,7 @@ namespace Content.Server.GameObjects.Components.Cargo
 #pragma warning disable 649
         [Dependency] private readonly IGalacticBankManager _galacticBankManager;
         [Dependency] private readonly ICargoOrderDataManager _cargoOrderDataManager;
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager;
 #pragma warning restore 649
 
         [ViewVariables]
@@ -65,6 +61,12 @@ namespace Content.Server.GameObjects.Components.Cargo
         {
             var playerEntity = serverMsg.Session.AttachedEntity;
             if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
+            var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner))
             {
                 return;
             }

--- a/Content.Server/GameObjects/Components/Chemistry/ReagentDispenserComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/ReagentDispenserComponent.cs
@@ -34,6 +34,7 @@ namespace Content.Server.GameObjects.Components.Chemistry
 #pragma warning disable 649
         [Dependency] private readonly IServerNotifyManager _notifyManager;
         [Dependency] private readonly ILocalizationManager _localizationManager;
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager;
 #pragma warning restore 649
 
         [ViewVariables] private BoundUserInterface _userInterface;
@@ -159,7 +160,11 @@ namespace Content.Server.GameObjects.Components.Chemistry
             //Check if player can interact in their current state
             if (!ActionBlockerSystem.CanInteract(playerEntity))
                 return false;
-
+            var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner))
+            {
+                return false; ;
+            }
             return true;
         }
 

--- a/Content.Server/GameObjects/Components/Chemistry/ReagentDispenserComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/ReagentDispenserComponent.cs
@@ -157,7 +157,7 @@ namespace Content.Server.GameObjects.Components.Chemistry
             if (playerEntity == null) 
                 return false;
             //Check if player can interact in their current state
-            if (!ActionBlockerSystem.CanInteract(playerEntity) || !ActionBlockerSystem.CanUse(playerEntity))
+            if (!ActionBlockerSystem.CanInteract(playerEntity))
                 return false;
 
             return true;

--- a/Content.Server/GameObjects/Components/Power/ApcComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcComponent.cs
@@ -35,6 +35,12 @@ namespace Content.Server.GameObjects.Components.Power
 
         private void UserInterfaceOnOnReceiveMessage(ServerBoundUserInterfaceMessage serverMsg)
         {
+            var playerEntity = serverMsg.Session.AttachedEntity;
+            if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
             var obj = serverMsg.Message;
             if (obj is ApcToggleMainBreakerMessage)
             {

--- a/Content.Server/GameObjects/Components/Power/ApcComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcComponent.cs
@@ -6,6 +6,8 @@ using Robust.Server.GameObjects.Components.UserInterface;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.IoC;
 
 namespace Content.Server.GameObjects.Components.Power
 {
@@ -16,6 +18,10 @@ namespace Content.Server.GameObjects.Components.Power
         PowerStorageComponent Storage;
         AppearanceComponent Appearance;
         private PowerProviderComponent _provider;
+
+#pragma warning disable 649
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager;
+#pragma warning restore 649
 
         ApcChargeState LastChargeState;
         private float _lastCharge = 0f;
@@ -37,6 +43,12 @@ namespace Content.Server.GameObjects.Components.Power
         {
             var playerEntity = serverMsg.Session.AttachedEntity;
             if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
+            var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner, insideBlockerValid: true))
             {
                 return;
             }

--- a/Content.Server/GameObjects/Components/Research/LatheComponent.cs
+++ b/Content.Server/GameObjects/Components/Research/LatheComponent.cs
@@ -12,9 +12,10 @@ using Robust.Server.GameObjects.Components.UserInterface;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Map;
 using Robust.Shared.Timers;
 using Robust.Shared.ViewVariables;
+using Robust.Shared.IoC;
+using Robust.Shared.Interfaces.GameObjects;
 
 namespace Content.Server.GameObjects.Components.Research
 {
@@ -25,6 +26,9 @@ namespace Content.Server.GameObjects.Components.Research
         public const int VolumePerSheet = 3750;
 
         private BoundUserInterface _userInterface;
+#pragma warning disable 649
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager;
+#pragma warning restore 649
 
         [ViewVariables]
         public Queue<LatheRecipePrototype> Queue { get; } = new Queue<LatheRecipePrototype>();
@@ -48,6 +52,12 @@ namespace Content.Server.GameObjects.Components.Research
         {
             var playerEntity = message.Session.AttachedEntity;
             if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
+            var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner))
             {
                 return;
             }

--- a/Content.Server/GameObjects/Components/Research/LatheComponent.cs
+++ b/Content.Server/GameObjects/Components/Research/LatheComponent.cs
@@ -46,6 +46,12 @@ namespace Content.Server.GameObjects.Components.Research
 
         private void UserInterfaceOnOnReceiveMessage(ServerBoundUserInterfaceMessage message)
         {
+            var playerEntity = message.Session.AttachedEntity;
+            if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
             switch (message.Message)
             {
                 case LatheQueueRecipeMessage msg:

--- a/Content.Server/GameObjects/Components/Research/ResearchClientComponent.cs
+++ b/Content.Server/GameObjects/Components/Research/ResearchClientComponent.cs
@@ -78,6 +78,12 @@ namespace Content.Server.GameObjects.Components.Research
 
         private void UserInterfaceOnOnReceiveMessage(ServerBoundUserInterfaceMessage msg)
         {
+            var playerEntity = msg.Session.AttachedEntity;
+            if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
             switch (msg.Message)
             {
                 case ResearchClientSyncMessage _:

--- a/Content.Server/GameObjects/Components/Research/ResearchClientComponent.cs
+++ b/Content.Server/GameObjects/Components/Research/ResearchClientComponent.cs
@@ -84,6 +84,12 @@ namespace Content.Server.GameObjects.Components.Research
                 return;
             }
 
+            var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner))
+            {
+                return;
+            }
+
             switch (msg.Message)
             {
                 case ResearchClientSyncMessage _:

--- a/Content.Server/GameObjects/Components/Research/ResearchConsoleComponent.cs
+++ b/Content.Server/GameObjects/Components/Research/ResearchConsoleComponent.cs
@@ -51,6 +51,12 @@ namespace Content.Server.GameObjects.Components.Research
                 return;
             }
 
+            var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner))
+            {
+                return;
+            }
+
             if (!Owner.TryGetComponent(out TechnologyDatabaseComponent database)) return;
 
             switch (message.Message)

--- a/Content.Server/GameObjects/Components/Research/ResearchConsoleComponent.cs
+++ b/Content.Server/GameObjects/Components/Research/ResearchConsoleComponent.cs
@@ -45,6 +45,12 @@ namespace Content.Server.GameObjects.Components.Research
 
         private void UserInterfaceOnOnReceiveMessage(ServerBoundUserInterfaceMessage message)
         {
+            var playerEntity = message.Session.AttachedEntity;
+            if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
             if (!Owner.TryGetComponent(out TechnologyDatabaseComponent database)) return;
 
             switch (message.Message)

--- a/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
@@ -9,6 +9,7 @@ using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.Components.UserInterface;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Random;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -27,6 +28,7 @@ namespace Content.Server.GameObjects.Components.VendingMachines
     {
 #pragma warning disable 649
         [Dependency] private readonly IRobustRandom _random;
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager;
 #pragma warning restore 649
         private AppearanceComponent _appearance;
         private BoundUserInterface _userInterface;
@@ -123,6 +125,12 @@ namespace Content.Server.GameObjects.Components.VendingMachines
         {
             var playerEntity = serverMsg.Session.AttachedEntity;
             if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
+            var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner, insideBlockerValid: true))
             {
                 return;
             }

--- a/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
@@ -121,6 +121,12 @@ namespace Content.Server.GameObjects.Components.VendingMachines
 
         private void UserInterfaceOnOnReceiveMessage(ServerBoundUserInterfaceMessage serverMsg)
         {
+            var playerEntity = serverMsg.Session.AttachedEntity;
+            if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
             var message = serverMsg.Message;
             switch (message)
             {

--- a/Content.Server/GameObjects/Components/WiresComponent.cs
+++ b/Content.Server/GameObjects/Components/WiresComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Server.GameObjects.Components.Interactable.Tools;
@@ -223,6 +223,12 @@ namespace Content.Server.GameObjects.Components
 
         private void UserInterfaceOnReceiveMessage(ServerBoundUserInterfaceMessage serverMsg)
         {
+            var playerEntity = serverMsg.Session.AttachedEntity;
+            if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
             var message = serverMsg.Message;
             switch (message)
             {

--- a/Content.Server/GameObjects/Components/WiresComponent.cs
+++ b/Content.Server/GameObjects/Components/WiresComponent.cs
@@ -30,6 +30,7 @@ namespace Content.Server.GameObjects.Components
         [Dependency] private readonly IRobustRandom _random;
         [Dependency] private readonly IServerNotifyManager _notifyManager;
         [Dependency] private readonly ILocalizationManager _localizationManager;
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager;
 #pragma warning restore 649
         private AudioSystem _audioSystem;
         private AppearanceComponent _appearance;
@@ -225,6 +226,12 @@ namespace Content.Server.GameObjects.Components
         {
             var playerEntity = serverMsg.Session.AttachedEntity;
             if (playerEntity == null || !ActionBlockerSystem.CanInteract(playerEntity))
+            {
+                return;
+            }
+
+            var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner, insideBlockerValid: true))
             {
                 return;
             }

--- a/Content.Server/GameObjects/EntitySystems/HandsSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/HandsSystem.cs
@@ -126,7 +126,7 @@ namespace Content.Server.GameObjects.EntitySystems
 
             var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
 
-            if(interactionSystem.InRangeUnobstructed(coords.ToMap(_mapManager), ent.Transform.WorldPosition, 0f, ignoredEnt: ent))
+            if(interactionSystem.InRangeUnobstructed(coords.ToMap(_mapManager), ent.Transform.WorldPosition, 0f))
                 if (coords.InRange(_mapManager, ent.Transform.GridPosition, InteractionSystem.InteractionRange))
                 {
                     handsComp.Drop(handsComp.ActiveIndex, coords);


### PR DESCRIPTION
Adds sanitization checks to the existing bound UI's. I've decided to make CanInteract the main way for UI's to check for death/crit. 

InRangeUnobstructed checks for messages are set to ignore the wall they are on for apc, wires, and vending machines, since there are "wall mounted" entities that use them

Relates to #717. I'm not sure at the moment, but there might also be a need for checks on the Activate for each UI component, in a different PR.