### PR TITLE
Modify RD and Cargo to use Timers

### DIFF
--- a/Content.Server/Cargo/IGalacticBankManager.cs
+++ b/Content.Server/Cargo/IGalacticBankManager.cs
@@ -9,8 +9,6 @@ namespace Content.Server.Cargo
         IEnumerable<CargoBankAccount> GetAllBankAccounts();
 
         void Shutdown();
-        void Update(FrameEventArgs frameEventArgs);
-
         void CreateBankAccount(string name, int balance);
         CargoBankAccount GetBankAccount(int id);
         void AddComponent(CargoConsoleComponent cargoConsoleComponent);

--- a/Content.Server/EntryPoint.cs
+++ b/Content.Server/EntryPoint.cs
@@ -86,14 +86,6 @@ namespace Content.Server
             base.Update(level, frameEventArgs);
 
             _gameTicker.Update(frameEventArgs);
-            switch (level)
-            {
-                case ModUpdateLevel.PreEngine:
-                {
-                    IoCManager.Resolve<IGalacticBankManager>().Update(frameEventArgs);
-                    break;
-                }
-            }
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Research/ResearchServerComponent.cs
+++ b/Content.Server/GameObjects/Components/Research/ResearchServerComponent.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Content.Server.GameObjects.Components.Power;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.Research;
+using Robust.Server.Interfaces.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Timers;
@@ -19,6 +20,10 @@ namespace Content.Server.GameObjects.Components.Research
         public static int ServerCount = 0;
 
         public override string Name => "ResearchServer";
+
+#pragma warning disable 649
+        [Dependency] private IPauseManager _pauseManager;
+#pragma warning restore 649
 
         [ViewVariables(VVAccess.ReadWrite)] public string ServerName => _serverName;
 
@@ -169,7 +174,7 @@ namespace Content.Server.GameObjects.Components.Research
 
         private void OnResearchPointGet()
         {
-            if (!CanRun) return;
+            if (!CanRun || _pauseManager.IsEntityPaused(Owner)) return;
             _points += PointsPerSecond;
         }
     }


### PR DESCRIPTION
Needed for mapping
EDIT: This makes the RD server point collection stop when the entity is paused, preventing it from getting points while someone is editing the map.