### PR TITLE
Construction recipes can specify if they should be build-able inside impassables

### DIFF
--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Content.Server.GameObjects.Components.Interactable.Tools;
 using Content.Server.GameObjects.Components.Stack;
 using Content.Server.GameObjects.EntitySystems;
+using Content.Server.Interfaces;
 using Content.Shared.Construction;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.EntitySystems;
@@ -12,6 +13,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.Interfaces.Random;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Map;
 using Robust.Shared.ViewVariables;
 using static Content.Shared.Construction.ConstructionStepMaterial;
@@ -34,6 +36,8 @@ namespace Content.Server.GameObjects.Components.Construction
 #pragma warning disable 649
         [Dependency] private IRobustRandom _random;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager;
+        [Dependency] private readonly IServerNotifyManager _notifyManager;
+        [Dependency] private readonly ILocalizationManager _localizationManager;
 #pragma warning restore 649
 
         public override void Initialize()
@@ -49,8 +53,10 @@ namespace Content.Server.GameObjects.Components.Construction
         {
             var playerEntity = eventArgs.User;
             var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
-            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner, insideBlockerValid: true))
+            if (!interactionSystem.InRangeUnobstructed(playerEntity.Transform.MapPosition, Owner.Transform.WorldPosition, ignoredEnt: Owner, insideBlockerValid: Prototype.CanBuildInImpassable))
             {
+                _notifyManager.PopupMessage(Owner.Transform.GridPosition, playerEntity,
+                    _localizationManager.GetString("You can't reach there!"));
                 return false;
             }
 

--- a/Content.Server/GameObjects/Components/Construction/ConstructorComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructorComponent.cs
@@ -3,6 +3,7 @@ using Content.Server.GameObjects.Components.Stack;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.Construction;
 using Content.Shared.GameObjects.Components.Construction;
+using Content.Shared.Interfaces;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.GameObjects;
@@ -10,6 +11,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
@@ -24,6 +26,8 @@ namespace Content.Server.GameObjects.Components.Construction
         [Dependency] private readonly IMapManager _mapManager;
         [Dependency] private readonly IServerEntityManager _serverEntityManager;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager;
+        [Dependency] private readonly ISharedNotifyManager _notifyManager;
+        [Dependency] private readonly ILocalizationManager _localizationManager;
 #pragma warning restore 649
 
         public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
@@ -44,8 +48,10 @@ namespace Content.Server.GameObjects.Components.Construction
             var transform = Owner.Transform;
 
             var interactionSystem = _entitySystemManager.GetEntitySystem<InteractionSystem>();
-            if (!interactionSystem.InRangeUnobstructed(loc.ToMap(_mapManager), Owner.Transform.WorldPosition, ignoredEnt: Owner, insideBlockerValid: true))
+            if (!interactionSystem.InRangeUnobstructed(loc.ToMap(_mapManager), Owner.Transform.WorldPosition, ignoredEnt: Owner, insideBlockerValid: prototype.CanBuildInImpassable))
             {
+                _notifyManager.PopupMessage(transform.GridPosition, Owner,
+                        _localizationManager.GetString("You can't reach there!"));
                 return;
             }
 

--- a/Content.Shared/Construction/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/ConstructionPrototype.cs
@@ -21,6 +21,7 @@ namespace Content.Shared.Construction
         private string _id;
         private string _result;
         private string _placementMode;
+        private bool _canBuildInImpassable;
 
         /// <summary>
         ///     Friendly name displayed in the construction GUI.
@@ -36,6 +37,11 @@ namespace Content.Shared.Construction
         ///     Texture path inside the construction GUI.
         /// </summary>
         public SpriteSpecifier Icon => _icon;
+
+        /// <summary>
+        ///     If you can start building or complete steps on impassable terrain.
+        /// </summary>
+        public bool CanBuildInImpassable => _canBuildInImpassable;
 
         /// <summary>
         ///     A list of keywords that are used for searching.
@@ -81,6 +87,7 @@ namespace Content.Shared.Construction
             ser.DataField(ref _type, "objecttype", ConstructionType.Structure);
             ser.DataField(ref _result, "result", null);
             ser.DataField(ref _placementMode, "placementmode", "PlaceFree");
+            ser.DataField(ref _canBuildInImpassable, "canbuildinimpassable", false);
 
             _keywords = ser.ReadDataField<List<string>>("keywords", new List<string>());
             {

--- a/Resources/Prototypes/Construction/machines.yml
+++ b/Resources/Prototypes/Construction/machines.yml
@@ -5,6 +5,7 @@
   category: Machines
   description: A simple wall-mounted light fixture.
   placementmode: SnapgridBorder
+  canbuildinimpassable: true
   icon:
     sprite: Objects/Lighting/lighting.rsi
     state: on
@@ -16,6 +17,7 @@
     icon:
       sprite: Objects/Lighting/lighting.rsi
       state: construct
+
 
   - material: Cable
     amount: 1

--- a/Resources/Prototypes/Construction/power.yml
+++ b/Resources/Prototypes/Construction/power.yml
@@ -41,6 +41,7 @@
   category: Machines/Power
   placementmode: SnapgridCenter
   description: Provides power from the grid wirelessly to other machines in the area.
+  canbuildinimpassable: true
   icon:
     sprite: Buildings/apc.rsi
     state: apc0


### PR DESCRIPTION
Server-side check. Currently allowed for apcs and lights. Ghosts can still be placed in locations where you can't build, but I think that should be allowed for planning. 

Closes #741