### PR TITLE
Rewrite HandleMessage code for components

### DIFF
--- a/Content.Client/GameObjects/Components/Actor/CharacterInterface.cs
+++ b/Content.Client/GameObjects/Components/Actor/CharacterInterface.cs
@@ -78,10 +78,9 @@ namespace Content.Client.GameObjects.Components.Actor
             inputMgr.SetInputCommand(ContentKeyFunctions.OpenCharacterMenu, null);
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
 
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Construction/ConstructorComponent.cs
+++ b/Content.Client/GameObjects/Components/Construction/ConstructorComponent.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Players;
 
 namespace Content.Client.GameObjects.Components.Construction
 {
@@ -33,9 +34,9 @@ namespace Content.Client.GameObjects.Components.Construction
             Owner.GetComponent<ITransformComponent>();
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, channel, session);
 
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Construction/ConstructorComponent.cs
+++ b/Content.Client/GameObjects/Components/Construction/ConstructorComponent.cs
@@ -34,9 +34,9 @@ namespace Content.Client.GameObjects.Components.Construction
             Owner.GetComponent<ITransformComponent>();
         }
 
-        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleNetworkMessage(message, channel, session);
+            base.HandleMessage(message, component);
 
             switch (message)
             {
@@ -65,8 +65,22 @@ namespace Content.Client.GameObjects.Components.Construction
                     _gameHud.CraftingButtonVisible = false;
                     break;
 
+                default:
+                    break;
+            }
+        }
+
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
+        {
+            base.HandleNetworkMessage(message, channel, session);
+
+            switch (message)
+            {
                 case AckStructureConstructionMessage ackMsg:
                     ClearGhost(ackMsg.Ack);
+                    break;
+
+                default:
                     break;
             }
         }

--- a/Content.Client/GameObjects/Components/HUD/Inventory/ClientInventoryComponent.cs
+++ b/Content.Client/GameObjects/Components/HUD/Inventory/ClientInventoryComponent.cs
@@ -181,10 +181,9 @@ namespace Content.Client.GameObjects
             SendNetworkMessage(new OpenSlotStorageUIMessage(slot));
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
 
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Instruments/InstrumentComponent.cs
+++ b/Content.Client/GameObjects/Components/Instruments/InstrumentComponent.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 using Timer = Robust.Shared.Timers.Timer;
@@ -109,10 +110,9 @@ namespace Content.Client.GameObjects.Components.Instruments
             serializer.DataField(ref _instrumentProgram, "program", 1);
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, channel, session);
 
             if (_renderer == null)
             {

--- a/Content.Client/GameObjects/Components/Items/ClientHandsComponent.cs
+++ b/Content.Client/GameObjects/Components/Items/ClientHandsComponent.cs
@@ -12,6 +12,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
@@ -144,10 +145,35 @@ namespace Content.Client.GameObjects
             }
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
+
+            switch (message)
+            {
+                case PlayerAttachedMsg _:
+                    if (_gui == null)
+                    {
+                        _gui = new HandsGui();
+                    }
+                    else
+                    {
+                        _gui.Parent?.RemoveChild(_gui);
+                    }
+
+                    _gameHud.HandsContainer.AddChild(_gui);
+                    _gui.UpdateHandIcons();
+                    break;
+
+                case PlayerDetachedMsg _:
+                    _gui.Parent?.RemoveChild(_gui);
+                    break;
+            }
+        }
+
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
+        {
+            base.HandleNetworkMessage(message, channel, session);
 
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Items/ClientHandsComponent.cs
+++ b/Content.Client/GameObjects/Components/Items/ClientHandsComponent.cs
@@ -171,32 +171,6 @@ namespace Content.Client.GameObjects
             }
         }
 
-        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
-        {
-            base.HandleNetworkMessage(message, channel, session);
-
-            switch (message)
-            {
-                case PlayerAttachedMsg _:
-                    if (_gui == null)
-                    {
-                        _gui = new HandsGui();
-                    }
-                    else
-                    {
-                        _gui.Parent?.RemoveChild(_gui);
-                    }
-
-                    _gameHud.HandsContainer.AddChild(_gui);
-                    _gui.UpdateHandIcons();
-                    break;
-
-                case PlayerDetachedMsg _:
-                    _gui.Parent?.RemoveChild(_gui);
-                    break;
-            }
-        }
-
         public void SendChangeHand(string index)
         {
             SendNetworkMessage(new ClientChangedHandMsg(index));

--- a/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
@@ -63,18 +63,6 @@ namespace Content.Client.GameObjects.Components.Mobs
             _updateEye();
         }
 
-        public override void HandleMessage(ComponentMessage message, IComponent component)
-        {
-            base.HandleMessage(message, component);
-
-            switch (message)
-            {
-                case RecoilKickMessage msg:
-                    Kick(msg.Recoil);
-                    break;
-            }
-        }
-
         public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
             base.HandleNetworkMessage(message, channel, session);

--- a/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
+using Robust.Shared.Players;
 
 namespace Content.Client.GameObjects.Components.Mobs
 {
@@ -62,9 +63,21 @@ namespace Content.Client.GameObjects.Components.Mobs
             _updateEye();
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
+
+            switch (message)
+            {
+                case RecoilKickMessage msg:
+                    Kick(msg.Recoil);
+                    break;
+            }
+        }
+
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
+        {
+            base.HandleNetworkMessage(message, channel, session);
 
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Mobs/ClientOverlayEffectsComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/ClientOverlayEffectsComponent.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Players;
 
 namespace Content.Client.GameObjects
 {
@@ -53,7 +54,20 @@ namespace Content.Client.GameObjects
             };
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
+        {
+            switch (message)
+            {
+                case PlayerAttachedMsg _:
+                    SetOverlay(_currentEffect);
+                    break;
+                case PlayerDetachedMsg _:
+                    RemoveOverlay();
+                    break;
+            }
+        }
+
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Mobs/ClientOverlayEffectsComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/ClientOverlayEffectsComponent.cs
@@ -67,19 +67,6 @@ namespace Content.Client.GameObjects
             }
         }
 
-        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
-        {
-            switch (message)
-            {
-                case PlayerAttachedMsg _:
-                    SetOverlay(_currentEffect);
-                    break;
-                case PlayerDetachedMsg _:
-                    RemoveOverlay();
-                    break;
-            }
-        }
-
         public override void HandleComponentState(ComponentState curState, ComponentState nextState)
         {
             base.HandleComponentState(curState, nextState);

--- a/Content.Client/GameObjects/Components/Mobs/ClientStatusEffectsComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/ClientStatusEffectsComponent.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Players;
 
 namespace Content.Client.GameObjects.Components.Mobs
 {
@@ -40,10 +41,9 @@ namespace Content.Client.GameObjects.Components.Mobs
             PlayerDetached();
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
             switch (message)
             {
                 case PlayerAttachedMsg _:

--- a/Content.Client/GameObjects/Components/Mobs/CombatModeComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/CombatModeComponent.cs
@@ -7,6 +7,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
+using Robust.Shared.Players;
 
 namespace Content.Client.GameObjects.Components.Mobs
 {
@@ -39,9 +40,9 @@ namespace Content.Client.GameObjects.Components.Mobs
             }
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
 
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Observer/GhostComponent.cs
+++ b/Content.Client/GameObjects/Components/Observer/GhostComponent.cs
@@ -57,10 +57,9 @@ namespace Content.Client.GameObjects.Components.Observer
                 component.Visible = _playerManager.LocalPlayer.ControlledEntity?.HasComponent<GhostComponent>() ?? false;
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
 
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Power/PowerDebugTool.cs
+++ b/Content.Client/GameObjects/Components/Power/PowerDebugTool.cs
@@ -4,6 +4,7 @@ using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
+using Robust.Shared.Players;
 
 namespace Content.Client.GameObjects.Components.Power
 {
@@ -11,9 +12,9 @@ namespace Content.Client.GameObjects.Components.Power
     public class PowerDebugTool : SharedPowerDebugTool
     {
         SS14Window LastWindow;
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, channel, session);
 
             switch (message)
             {

--- a/Content.Client/GameObjects/Components/Sound/SoundComponent.cs
+++ b/Content.Client/GameObjects/Components/Sound/SoundComponent.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Interfaces.Random;
 using Robust.Shared.IoC;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timers;
 
@@ -68,9 +69,9 @@ namespace Content.Client.GameObjects.Components.Sound
                 });
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, channel, session);
             switch (message)
             {
                 case ScheduledSoundMessage msg:

--- a/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
+++ b/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
+using Robust.Shared.Players;
 
 namespace Content.Client.GameObjects.Components.Storage
 {
@@ -40,9 +41,10 @@ namespace Content.Client.GameObjects.Components.Storage
             base.OnRemove();
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
+            base.HandleNetworkMessage(message, channel, session);
+
             switch (message)
             {
                 //Updates what we are storing for the UI

--- a/Content.Client/GameObjects/Components/Weapons/Ranged/BallisticMagazineWeaponComponent.cs
+++ b/Content.Client/GameObjects/Components/Weapons/Ranged/BallisticMagazineWeaponComponent.cs
@@ -14,6 +14,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Maths;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 using static Content.Client.StaticIoC;
@@ -108,17 +109,16 @@ namespace Content.Client.GameObjects.Components.Weapons.Ranged
             _statusControl?.Update();
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
+            base.HandleNetworkMessage(message, channel, session);
+
             switch (message)
             {
                 case BmwComponentAutoEjectedMessage _:
                     _statusControl?.PlayAlarmAnimation();
                     return;
             }
-
-            base.HandleMessage(message, netChannel, component);
         }
 
         public Control MakeControl()

--- a/Content.Server/GameObjects/Components/Construction/ConstructorComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructorComponent.cs
@@ -14,6 +14,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Players;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.GameObjects.Components.Construction
@@ -30,9 +31,10 @@ namespace Content.Server.GameObjects.Components.Construction
         [Dependency] private readonly ILocalizationManager _localizationManager;
 #pragma warning restore 649
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, channel, session);
+
             switch (message)
             {
                 case TryStartStructureConstructionMessage tryStart:

--- a/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
@@ -85,9 +85,9 @@ namespace Content.Server.GameObjects
             ActivateImpl(eventArgs);
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
 
             switch (message)
             {

--- a/Content.Server/GameObjects/Components/GUI/HumanInventoryControllerComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/HumanInventoryControllerComponent.cs
@@ -51,9 +51,9 @@ namespace Content.Server.GameObjects
             return flagsCheck;
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
 
             switch (message)
             {

--- a/Content.Server/GameObjects/Components/GUI/ServerHandsComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/ServerHandsComponent.cs
@@ -17,6 +17,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
@@ -448,17 +449,19 @@ namespace Content.Server.GameObjects
             return false;
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, channel, session);
+
+            if (session == null)
+            {
+                throw new ArgumentNullException(nameof(session));
+            }
 
             switch (message)
             {
                 case ClientChangedHandMsg msg:
                 {
-                    var playerMan = IoCManager.Resolve<IPlayerManager>();
-                    var session = playerMan.GetSessionByChannel(netChannel);
                     var playerEntity = session.AttachedEntity;
 
                     if (playerEntity == Owner && HasHand(msg.Index))
@@ -475,8 +478,6 @@ namespace Content.Server.GameObjects
                         return;
                     }
 
-                    var playerMan = IoCManager.Resolve<IPlayerManager>();
-                    var session = playerMan.GetSessionByChannel(netChannel);
                     var playerEntity = session.AttachedEntity;
                     var used = GetActiveHand?.Owner;
 
@@ -502,8 +503,6 @@ namespace Content.Server.GameObjects
 
                 case UseInHandMsg msg:
                 {
-                    var playerMan = IoCManager.Resolve<IPlayerManager>();
-                    var session = playerMan.GetSessionByChannel(netChannel);
                     var playerEntity = session.AttachedEntity;
                     var used = GetActiveHand?.Owner;
 
@@ -518,8 +517,6 @@ namespace Content.Server.GameObjects
 
                 case ActivateInHandMsg msg:
                 {
-                    var playerMan = IoCManager.Resolve<IPlayerManager>();
-                    var session = playerMan.GetSessionByChannel(netChannel);
                     var playerEntity = session.AttachedEntity;
                     var used = GetHand(msg.Index)?.Owner;
 

--- a/Content.Server/GameObjects/Components/Instruments/InstrumentComponent.cs
+++ b/Content.Server/GameObjects/Components/Instruments/InstrumentComponent.cs
@@ -7,6 +7,7 @@ using Robust.Server.Interfaces.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
@@ -45,11 +46,11 @@ namespace Content.Server.GameObjects.Components.Instruments
             serializer.DataField(ref _handheld, "handheld", false);
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, channel, session);
             // If the client that sent the message isn't the client playing this instrument, we ignore it.
-            if (netChannel != _instrumentPlayer) return;
+            if (channel != _instrumentPlayer) return;
             switch (message)
             {
                 case InstrumentMidiEventMessage midiEventMsg:

--- a/Content.Server/GameObjects/Components/Items/Storage/EntityStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/EntityStorageComponent.cs
@@ -272,9 +272,9 @@ namespace Content.Server.GameObjects.Components
         }
 
         /// <inheritdoc />
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleMessage(message, component);
 
             switch (message)
             {

--- a/Content.Server/GameObjects/Components/Mobs/SpeciesComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/SpeciesComponent.cs
@@ -54,9 +54,10 @@ namespace Content.Server.GameObjects
             serializer.DataFieldCached(ref _heatResistance, "HeatResistance", 323);
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
+            base.HandleMessage(message, component);
+
             switch (message)
             {
                 case PlayerAttachedMsg _:

--- a/Content.Server/GameObjects/Components/Movement/ShuttleControllerComponent.cs
+++ b/Content.Server/GameObjects/Components/Movement/ShuttleControllerComponent.cs
@@ -105,12 +105,9 @@ namespace Content.Server.GameObjects.Components.Movement
         }
 
         /// <inheritdoc />
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null, IComponent component = null)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
-            base.HandleMessage(message, netChannel, component);
-
-            if(netChannel != null)
-                return;
+            base.HandleMessage(message, component);
 
             switch (message)
             {

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/RangedWeapon.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/RangedWeapon.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Players;
 using Robust.Shared.Timers;
 
 namespace Content.Server.GameObjects.Components.Weapon.Ranged
@@ -40,16 +41,18 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged
             FireHandler?.Invoke(user, clickLocation);
         }
 
-        public override void HandleMessage(ComponentMessage message, INetChannel netChannel = null,
-            IComponent component = null)
+        public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession session = null)
         {
-            base.HandleMessage(message, netChannel, component);
+            base.HandleNetworkMessage(message, channel, session);
+
+            if (session == null)
+            {
+                throw new ArgumentNullException(nameof(session));
+            }
 
             switch (message)
             {
                 case SyncFirePosMessage msg:
-                    var playerMgr = IoCManager.Resolve<IPlayerManager>();
-                    var session = playerMgr.GetSessionByChannel(netChannel);
                     var user = session.AttachedEntity;
                     if (user == null)
                     {


### PR DESCRIPTION
Corresponding PR for engine: https://github.com/space-wizards/RobustToolbox/pull/1028

### What this PR does
Reworks `HandleMessage` within component code, splitting it into two separate functions `HandleMessage` and `HandleNetworkMessage`. Also removes unused dependencies within components that no longer need to fetch the player session (since it is provided with `HandleNetworkMessage`).