### PR TITLE
Chat fix

### DIFF
--- a/Content.Server/Chat/ChatCommands.cs
+++ b/Content.Server/Chat/ChatCommands.cs
@@ -1,12 +1,10 @@
 ﻿using Content.Server.GameObjects.Components.Observer;
 using Content.Server.Interfaces.Chat;
-using Content.Server.Observer;
 using Content.Server.Players;
 using Robust.Server.Interfaces.Console;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 
 namespace Content.Server.Chat
 {
@@ -28,14 +26,11 @@ namespace Content.Server.Chat
 
             var message = string.Join(" ", args);
 
-
             if (player.AttachedEntity.HasComponent<GhostComponent>())
                 chat.SendDeadChat(player, message);
             else
             {
-                // This is a hacky way of getting the Players Mind
                 var mindComponent = player.ContentData().Mind;
-                // Say the message, as the Mind of the player.
                 chat.EntitySay(mindComponent.OwnedEntity, message);
             }
 
@@ -60,9 +55,7 @@ namespace Content.Server.Chat
 
             var action = string.Join(" ", args);
 
-            // As EntitySay, Hacky way of getting the Player's Mind
             var mindComponent = player.ContentData().Mind;
-            // Now do the /me as the Player's Mind.
             chat.EntityMe(mindComponent.OwnedEntity, action);
         }
     }

--- a/Content.Server/Chat/ChatCommands.cs
+++ b/Content.Server/Chat/ChatCommands.cs
@@ -1,10 +1,12 @@
 ﻿using Content.Server.GameObjects.Components.Observer;
 using Content.Server.Interfaces.Chat;
 using Content.Server.Observer;
+using Content.Server.Players;
 using Robust.Server.Interfaces.Console;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 
 namespace Content.Server.Chat
 {
@@ -26,10 +28,17 @@ namespace Content.Server.Chat
 
             var message = string.Join(" ", args);
 
+
             if (player.AttachedEntity.HasComponent<GhostComponent>())
                 chat.SendDeadChat(player, message);
             else
-                chat.EntitySay(player.AttachedEntity, message);
+            {
+                // This is a hacky way of getting the Players Mind
+                var mindComponent = player.ContentData().Mind;
+                // Say the message, as the Mind of the player.
+                chat.EntitySay(mindComponent.OwnedEntity, message);
+            }
+
         }
     }
 
@@ -51,14 +60,17 @@ namespace Content.Server.Chat
 
             var action = string.Join(" ", args);
 
-            chat.EntityMe(player.AttachedEntity, action);
+            // As EntitySay, Hacky way of getting the Player's Mind
+            var mindComponent = player.ContentData().Mind;
+            // Now do the /me as the Player's Mind.
+            chat.EntityMe(mindComponent.OwnedEntity, action);
         }
     }
 
     internal class OOCCommand : IClientCommand
     {
         public string Command => "ooc";
-        public string Description => "Send Out of Character chat messages.";
+        public string Description => "Send Out Of Character chat messages.";
         public string Help => "ooc <text>";
 
         public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)


### PR DESCRIPTION
This resolves #811.  Pulls the Character Name from "Mind" rather than AttachedEntity when using Say/Me, etc.