### PR TITLE
Clean up entity prototypes so that they don't define components twice

### DIFF
--- a/Resources/Prototypes/Entities/Buildings/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Buildings/medical_scanner.yml
@@ -36,7 +36,6 @@
   - type: Appearance
     visuals:
     - type: MedicalScannerVisualizer2D
-  - type: PowerDevice
   - type: UserInterface
     interfaces:
     - key: enum.MedicalScannerUiKey.Key

--- a/Resources/Prototypes/Entities/Weapons/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Weapons/Shotguns/shotguns.yml
@@ -42,6 +42,3 @@
   - type: Item
     Size: 24
     sprite: Objects/Guns/SMGs/c20r.rsi
-  - type: Item
-    Size: 24
-    sprite: Objects/Guns/SMGs/wt550.rsi

--- a/Resources/Prototypes/Entities/janitor.yml
+++ b/Resources/Prototypes/Entities/janitor.yml
@@ -34,7 +34,6 @@
     drawdepth: Objects
   - type: Icon
     texture: Objects/Janitorial/mopbucket.png
-  - type: Clickable
   - type: InteractionOutline
   - type: Bucket
   - type: Sound
@@ -51,7 +50,6 @@
   - type: Physics
     mass: 5
     Anchored: false
-  - type: Sound
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
Some entity prototypes needlessly define the same component twice. This PR removes the duplicates.