### PR TITLE
Add a style to the popup messages

### DIFF
--- a/Content.Client/ClientNotifyManager.cs
+++ b/Content.Client/ClientNotifyManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Content.Client.Interfaces;
+using Content.Client.UserInterface.Stylesheets;
 using Content.Shared;
 using Robust.Client.Interfaces.Console;
 using Robust.Client.Interfaces.Graphics.ClientEye;
@@ -57,7 +58,11 @@ namespace Content.Client
 
         public void PopupMessage(ScreenCoordinates coordinates, string message)
         {
-            var label = new PopupLabel {Text = message};
+            var label = new PopupLabel
+            {
+                Text = message,
+                StyleClasses = { StyleNano.StyleClassPopupMessage },
+            };
             var minimumSize = label.CombinedMinimumSize;
             LayoutContainer.SetPosition(label, label.InitialPos = coordinates.Position - minimumSize / 2);
             _userInterfaceManager.PopupRoot.AddChild(label);

--- a/Content.Client/UserInterface/Stylesheets/StyleNano.cs
+++ b/Content.Client/UserInterface/Stylesheets/StyleNano.cs
@@ -21,6 +21,7 @@ namespace Content.Client.UserInterface.Stylesheets
         public const string StyleClassLabelSecondaryColor = "LabelSecondaryColor";
         public const string StyleClassLabelBig = "LabelBig";
         public const string StyleClassButtonBig = "ButtonBig";
+        public const string StyleClassPopupMessage = "PopupMessage";
 
         public static readonly Color NanoGold = Color.FromHex("#A88B5E");
 
@@ -41,6 +42,7 @@ namespace Content.Client.UserInterface.Stylesheets
         public StyleNano(IResourceCache resCache) : base(resCache)
         {
             var notoSans10 = resCache.GetFont("/Nano/NotoSans/NotoSans-Regular.ttf", 10);
+            var notoSansItalic10 = resCache.GetFont("/Nano/NotoSans/NotoSans-Italic.ttf", 10);
             var notoSans12 = resCache.GetFont("/Nano/NotoSans/NotoSans-Regular.ttf", 12);
             var notoSansBold12 = resCache.GetFont("/Nano/NotoSans/NotoSans-Bold.ttf", 12);
             var notoSansDisplayBold14 = resCache.GetFont("/Fonts/NotoSansDisplay/NotoSansDisplay-Bold.ttf", 14);
@@ -550,6 +552,14 @@ namespace Content.Client.UserInterface.Stylesheets
                     new[]
                     {
                         new StyleProperty("font", notoSans16)
+                    }),
+
+                // Popup messages
+                new StyleRule(new SelectorElement(typeof(Label), new[] {StyleClassPopupMessage}, null, null),
+                    new[]
+                    {
+                        new StyleProperty("font", notoSansItalic10),
+                        new StyleProperty("font-color", Color.LightGray),
                     }),
 
                 //APC and SMES power state label colors


### PR DESCRIPTION
Make the popup message text light-gray, italic and size 10, so they are less aggressive.

Preview:
![preview of the stylized popup message](https://user-images.githubusercontent.com/9070803/80626802-48ffe200-8a4f-11ea-9219-fa73180456e1.png)
Related: #853