### PR TITLE
Begin to use text macros

### DIFF
--- a/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Map;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
+using Robust.Shared.Localization;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timers;
 using Robust.Shared.Utility;
@@ -124,13 +125,12 @@ namespace Content.Server.GameObjects.Components.Mobs
                 if (species.CurrentDamageState is DeadState)
                     dead = true;
 
-            // TODO: Use gendered pronouns depending on the entity
             if(!HasMind)
                 message.AddMarkup(!dead
-                    ? $"[color=red]They are totally catatonic. The stresses of life in deep-space must have been too much for them. Any recovery is unlikely.[/color]"
-                    : $"[color=purple]Their soul has departed.[/color]");
-            else if(Mind.Session == null)
-                message.AddMarkup("[color=yellow]They have a blank, absent-minded stare and appears completely unresponsive to anything. They may snap out of it soon.[/color]");
+                    ? $"[color=red]" + Loc.GetString("{0:They} are totally catatonic. The stresses of life in deep-space must have been too much for {0:them}. Any recovery is unlikely.", Owner) + "[/color]"
+                    : $"[color=purple]" + Loc.GetString("{0:Their} soul has departed.", Owner) + "[/color]");
+            else if (Mind.Session == null)
+                message.AddMarkup("[color=yellow]" + Loc.GetString("{0:They} have a blank, absent-minded stare and appears completely unresponsive to anything. {0:They} may snap out of it soon.", Owner) + "[/color]");
         }
     }
 }

--- a/Content.Shared/EntryPoint.cs
+++ b/Content.Shared/EntryPoint.cs
@@ -6,7 +6,8 @@
  using Robust.Shared.Interfaces.Map;
  using Robust.Shared.IoC;
  using Robust.Shared.Localization;
- using Robust.Shared.Prototypes;
+using Robust.Shared.Localization.Macros;
+using Robust.Shared.Prototypes;
 
  namespace Content.Shared
 {
@@ -24,6 +25,9 @@
         public override void PreInit()
         {
             IoCManager.InjectDependencies(this);
+
+            var textMacroFactory = IoCManager.Resolve<ITextMacroFactory>();
+            textMacroFactory.DoAutoRegistrations();
 
             // Default to en-US.
             _localizationManager.LoadCulture(new CultureInfo(Culture));

--- a/Content.Shared/EntryPoint.cs
+++ b/Content.Shared/EntryPoint.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using Content.Shared.Maps;
-using Robust.Shared.ContentPack;
-using Robust.Shared.Interfaces.Map;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Localization.Macros;
-using Robust.Shared.Prototypes;
+﻿﻿using System;
+ using System.Collections.Generic;
+ using System.Globalization;
+ using Content.Shared.Maps;
+ using Robust.Shared.ContentPack;
+ using Robust.Shared.Interfaces.Map;
+ using Robust.Shared.IoC;
+ using Robust.Shared.Localization;
+ using Robust.Shared.Prototypes;
 
-namespace Content.Shared
+ namespace Content.Shared
 {
     public class EntryPoint : GameShared
     {
@@ -27,16 +26,7 @@ namespace Content.Shared
             IoCManager.InjectDependencies(this);
 
             // Default to en-US.
-            // TODO Move this elsewhere, this definitely doesn't belong to here.
-            var macros = new Dictionary<string, ITextMacro>
-            {
-                { "they", new They() },
-                { "their", new Their() },
-                { "theirs", new Theirs() },
-                { "them", new Them() },
-                { "themself", new Themself() },
-            };
-            _localizationManager.LoadCulture(new MacroCultureInfoWrapper(new MacroFormatter(macros), Culture));
+            _localizationManager.LoadCulture(new CultureInfo(Culture));
         }
 
         public override void Init()

--- a/Content.Shared/EntryPoint.cs
+++ b/Content.Shared/EntryPoint.cs
@@ -1,14 +1,15 @@
-﻿﻿using System;
- using System.Collections.Generic;
- using System.Globalization;
- using Content.Shared.Maps;
- using Robust.Shared.ContentPack;
- using Robust.Shared.Interfaces.Map;
- using Robust.Shared.IoC;
- using Robust.Shared.Localization;
- using Robust.Shared.Prototypes;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Content.Shared.Maps;
+using Robust.Shared.ContentPack;
+using Robust.Shared.Interfaces.Map;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Localization.Macros;
+using Robust.Shared.Prototypes;
 
- namespace Content.Shared
+namespace Content.Shared
 {
     public class EntryPoint : GameShared
     {
@@ -26,7 +27,16 @@
             IoCManager.InjectDependencies(this);
 
             // Default to en-US.
-            _localizationManager.LoadCulture(new CultureInfo(Culture));
+            // TODO Move this elsewhere, this definitely doesn't belong to here.
+            var macros = new Dictionary<string, ITextMacro>
+            {
+                { "they", new They() },
+                { "their", new Their() },
+                { "theirs", new Theirs() },
+                { "them", new Them() },
+                { "themself", new Themself() },
+            };
+            _localizationManager.LoadCulture(new MacroCultureInfoWrapper(new MacroFormatter(macros), Culture));
         }
 
         public override void Init()

--- a/Content.Shared/GameObjects/Components/Mobs/SharedHumanoidAppearanceComponent.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/SharedHumanoidAppearanceComponent.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using Content.Shared.Preferences;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Localization.Macros;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Shared.GameObjects.Components.Mobs
 {
-    public abstract class SharedHumanoidAppearanceComponent : Component
+    public abstract class SharedHumanoidAppearanceComponent : Component, IGenderable
     {
         private HumanoidCharacterAppearance _appearance;
         private Sex _sex;
@@ -35,6 +36,13 @@ namespace Content.Shared.GameObjects.Components.Mobs
                 Dirty();
             }
         }
+
+        public Gender Gender => Sex switch
+        {
+            Sex.Female => Gender.Female,
+            Sex.Male => Gender.Male,
+            _ => Gender.Epicene,
+        };
 
         public override ComponentState GetComponentState()
         {


### PR DESCRIPTION
This is a draft work on text macros. English pronouns macros are implemented and work, but I am not happy with some design, but I need some help figuring how to do better:

- Hard-coded english macro in EntryPoint
- Humanoid**Appearance**Component is in charge of giving the gender of the person.
- Some other flaws mentioned in the [engine pull request](https://github.com/space-wizards/RobustToolbox/pull/1058).

Needs [engine update](https://github.com/space-wizards/RobustToolbox/pull/1058).