### PR TITLE
RotatableComponent: Fix "clockwise/counter-clockwise" verbs being swapped

### DIFF
--- a/Content.Server/GameObjects/Components/RotatableComponent.cs
+++ b/Content.Server/GameObjects/Components/RotatableComponent.cs
@@ -49,7 +49,7 @@ namespace Content.Server.GameObjects.Components
 
             protected override void Activate(IEntity user, RotatableComponent component)
             {
-                component.TryRotate(user, Angle.FromDegrees(90));
+                component.TryRotate(user, Angle.FromDegrees(-90));
             }
         }
 
@@ -70,7 +70,7 @@ namespace Content.Server.GameObjects.Components
 
             protected override void Activate(IEntity user, RotatableComponent component)
             {
-                component.TryRotate(user, Angle.FromDegrees(-90));
+                component.TryRotate(user, Angle.FromDegrees(90));
             }
         }
 


### PR DESCRIPTION
"Clockwise" actually rotated it counter-clockwise and vice versa.

See response to https://discord.com/channels/310555209753690112/310555209753690112/711331672485789718 for confirmation that this is correct