### PR TITLE
Split Powernet into Powernet and PowernetPowerManager

### DIFF
--- a/Content.Server/GameObjects/Components/Power/ApcComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcComponent.cs
@@ -97,7 +97,7 @@ namespace Content.Server.GameObjects.Components.Power
                 return ApcExternalPowerState.None;
             }
 
-            var net = node.Parent;
+            var net = node.Parent.GetManager<PowernetPowerManager>();
             if (net.LastTotalAvailable <= 0)
             {
                 return ApcExternalPowerState.None;

--- a/Content.Server/GameObjects/Components/Power/PowerDebugTool.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerDebugTool.cs
@@ -33,6 +33,7 @@ namespace Content.Server.GameObjects.Components.Power
                 else
                 {
                     var net = node.Parent;
+                    var mgr = net.GetManager<PowernetPowerManager>();
                     builder.AppendFormat(@"  Powernet: {0}
   Wires: {1}, Nodes: {2}
   Generators: {3}, Loaders: {4},
@@ -43,11 +44,11 @@ namespace Content.Server.GameObjects.Components.Power
 ",
                         net.Uid,
                         net.NodeList.Count, net.WireList.Count,
-                        net.GeneratorCount, net.DeviceCount,
-                        net.PowerStorageSupplierCount, net.PowerStorageConsumerCount,
-                        net.Load, net.Supply,
-                        net.LastTotalAvailable, net.LastTotalDraw,
-                        net.LastTotalDemand, net.LastTotalDemandWithSuppliers);
+                        mgr.GeneratorCount, mgr.DeviceCount,
+                        mgr.PowerStorageSupplierCount, mgr.PowerStorageConsumerCount,
+                        mgr.Load, mgr.Supply,
+                        mgr.LastTotalAvailable, mgr.LastTotalDraw,
+                        mgr.LastTotalDemand, mgr.LastTotalDemandWithSuppliers);
                 }
             }
 

--- a/Content.Server/GameObjects/Components/Power/PowerGeneratorComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerGeneratorComponent.cs
@@ -50,7 +50,7 @@ namespace Content.Server.GameObjects.Components.Power
             {
                 if (node.Parent != null)
                 {
-                    node.Parent.RemoveGenerator(this);
+                    node.Parent.GetManager<PowernetPowerManager>().RemoveGenerator(this);
                 }
 
                 node.OnPowernetConnect -= PowernetConnect;
@@ -65,7 +65,7 @@ namespace Content.Server.GameObjects.Components.Power
         {
             _supply = value;
             var node = Owner.GetComponent<PowerNodeComponent>();
-            node?.Parent?.UpdateGenerator(this);
+            node?.Parent?.GetManager<PowernetPowerManager>().UpdateGenerator(this);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Content.Server.GameObjects.Components.Power
         /// <param name="eventarg"></param>
         private void PowernetConnect(object sender, PowernetEventArgs eventarg)
         {
-            eventarg.Powernet.AddGenerator(this);
+            eventarg.Powernet.GetManager<PowernetPowerManager>().AddGenerator(this);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Content.Server.GameObjects.Components.Power
         /// <param name="eventarg"></param>
         private void PowernetRegenerate(object sender, PowernetEventArgs eventarg)
         {
-            eventarg.Powernet.AddGenerator(this);
+            eventarg.Powernet.GetManager<PowernetPowerManager>().AddGenerator(this);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Content.Server.GameObjects.Components.Power
         /// <param name="eventarg"></param>
         private void PowernetDisconnect(object sender, PowernetEventArgs eventarg)
         {
-            eventarg.Powernet.RemoveGenerator(this);
+            eventarg.Powernet.GetManager<PowernetPowerManager>().RemoveGenerator(this);
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Power/PowerProviderComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerProviderComponent.cs
@@ -44,7 +44,7 @@ namespace Content.Server.GameObjects.Components.Power
         /// List storing all the power devices that we are currently providing power to
         /// </summary>
         public SortedSet<PowerDeviceComponent> DeviceLoadList =
-            new SortedSet<PowerDeviceComponent>(new Powernet.DevicePriorityCompare());
+            new SortedSet<PowerDeviceComponent>(new PowernetPowerManager.DevicePriorityCompare());
 
         /// <summary>
         ///     List of devices in range that we "advertised" to.
@@ -53,7 +53,7 @@ namespace Content.Server.GameObjects.Components.Power
 
         public List<PowerDeviceComponent> DepoweredDevices = new List<PowerDeviceComponent>();
 
-        public override Powernet.Priority Priority { get; protected set; } = Powernet.Priority.Provider;
+        public override PowernetPowerManager.Priority Priority { get; protected set; } = PowernetPowerManager.Priority.Provider;
 
         private bool _mainBreaker = true;
 

--- a/Content.Server/GameObjects/Components/Power/PowerStorageNetComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerStorageNetComponent.cs
@@ -27,7 +27,7 @@ namespace Content.Server.GameObjects.Components.Power
                 _chargePowernet = value;
                 if (Owner.TryGetComponent(out PowerNodeComponent node))
                 {
-                    node.Parent?.UpdateStorageType(this);
+                    node.Parent?.GetManager<PowernetPowerManager>().UpdateStorageType(this);
                 }
             }
         }
@@ -57,10 +57,7 @@ namespace Content.Server.GameObjects.Components.Power
         {
             if (Owner.TryGetComponent(out PowerNodeComponent node))
             {
-                if (node.Parent != null)
-                {
-                    node.Parent.RemovePowerStorage(this);
-                }
+                node.Parent?.GetManager<PowernetPowerManager>().RemovePowerStorage(this);
 
                 node.OnPowernetConnect -= PowernetConnect;
                 node.OnPowernetDisconnect -= PowernetDisconnect;
@@ -77,7 +74,7 @@ namespace Content.Server.GameObjects.Components.Power
         /// <param name="eventarg"></param>
         private void PowernetConnect(object sender, PowernetEventArgs eventarg)
         {
-            eventarg.Powernet.AddPowerStorage(this);
+            eventarg.Powernet.GetManager<PowernetPowerManager>().AddPowerStorage(this);
         }
 
         /// <summary>
@@ -87,7 +84,7 @@ namespace Content.Server.GameObjects.Components.Power
         /// <param name="eventarg"></param>
         private void PowernetRegenerate(object sender, PowernetEventArgs eventarg)
         {
-            eventarg.Powernet.AddPowerStorage(this);
+            eventarg.Powernet.GetManager<PowernetPowerManager>().AddPowerStorage(this);
         }
 
         /// <summary>
@@ -97,7 +94,7 @@ namespace Content.Server.GameObjects.Components.Power
         /// <param name="eventarg"></param>
         private void PowernetDisconnect(object sender, PowernetEventArgs eventarg)
         {
-            eventarg.Powernet.RemovePowerStorage(this);
+            eventarg.Powernet.GetManager<PowernetPowerManager>().RemovePowerStorage(this);
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Power/Powernet.cs
+++ b/Content.Server/GameObjects/Components/Power/Powernet.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Reflection;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.ViewVariables;
@@ -9,7 +11,8 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Power
 {
     /// <summary>
-    /// Master class for group of <see cref="PowerTransferComponent"/>, takes in and distributes power via nodes
+    /// Master class for group of <see cref="PowerTransferComponent"/>, responsible for connecting devices and network-specific managers.
+    /// Like with other subsystems, the powernet managers are automatically created based on classes.
     /// </summary>
     public class Powernet
     {
@@ -19,10 +22,33 @@ namespace Content.Server.GameObjects.Components.Power
             var powerSystem = EntitySystemManager.GetEntitySystem<PowerSystem>();
             powerSystem.Powernets.Add(this);
             Uid = powerSystem.NewUid();
+
+            var ReflectionManager = IoCManager.Resolve<IReflectionManager>();
+            foreach (Type t in ReflectionManager.GetAllChildren<PowernetManager>())
+            {
+                ConstructorInfo c = t.GetConstructor(new Type[] {typeof(Powernet)});
+                if (c != null)
+                {
+                    Managers.Add((PowernetManager) c.Invoke(new object[] {this}));
+                }
+            }
+
+            foreach (PowernetManager manager in Managers)
+            {
+                manager.Initialize();
+            }
         }
 
         /// <summary>
-        ///     Unique identifier per powernet, used for debugging mostly.
+        /// Managers specific to this network.
+        /// An example would be <see cref="PowernetPowerManager"/>.
+        /// Do note that these managers expect to not be removed/added.
+        /// And users of these managers do not expect GetManager<>() to return null.
+        /// </summary>
+        public readonly List<PowernetManager> Managers = new List<PowernetManager>();
+
+        /// <summary>
+        ///     Unique identifier per wirenet, used for debugging mostly.
         /// </summary>
         [ViewVariables]
         public int Uid { get; }
@@ -38,266 +64,40 @@ namespace Content.Server.GameObjects.Components.Power
         public readonly List<PowerNodeComponent> NodeList = new List<PowerNodeComponent>();
 
         /// <summary>
-        ///     Subset of nodelist that adds a continuous power supply to the network
-        /// </summary>
-        private readonly Dictionary<PowerGeneratorComponent, float> GeneratorList =
-            new Dictionary<PowerGeneratorComponent, float>();
-
-        [ViewVariables]
-        public int GeneratorCount => GeneratorList.Count;
-
-        /// <summary>
-        ///     Subset of nodelist that draw power, stores information on current continuous powernet load
-        /// </summary>
-        private readonly SortedSet<PowerDeviceComponent> DeviceLoadList =
-            new SortedSet<PowerDeviceComponent>(new DevicePriorityCompare());
-
-        [ViewVariables]
-        public int DeviceCount => DeviceLoadList.Count;
-
-        /// <summary>
-        ///     All the devices that have been depowered by this powernet or depowered prior to being absorted into this powernet
-        /// </summary>
-        private readonly List<PowerDeviceComponent> DepoweredDevices = new List<PowerDeviceComponent>();
-
-        /// <summary>
-        ///     A list of the energy storage components that will feed the powernet if necessary, and if there is enough power feed itself
-        /// </summary>
-        private readonly List<PowerStorageNetComponent> PowerStorageSupplierList = new List<PowerStorageNetComponent>();
-
-        [ViewVariables]
-        public int PowerStorageSupplierCount => PowerStorageSupplierList.Count;
-
-        /// <summary>
-        ///     A list of energy storage components that will never feed the powernet, will try to draw energy to feed themselves if possible
-        /// </summary>
-        private readonly List<PowerStorageNetComponent> PowerStorageConsumerList = new List<PowerStorageNetComponent>();
-
-        [ViewVariables]
-        public int PowerStorageConsumerCount => PowerStorageConsumerList.Count;
-
-        /// <summary>
-        ///     Static counter of all continuous load placed from devices on this power network.
-        ///     In Watts.
-        /// </summary>
-        [ViewVariables]
-        public float Load { get; private set; } = 0;
-
-        /// <summary>
-        ///     Static counter of all continuous supply from generators on this power network.
-        ///     In Watts.
-        /// </summary>
-        [ViewVariables]
-        public float Supply { get; private set; } = 0;
-
-        /// <summary>
         ///     Variable that causes powernet to be regenerated from its wires during the next update cycle.
         /// </summary>
         [ViewVariables]
         public bool Dirty { get; set; } = false;
 
-        // These are stats for power monitoring equipment such as APCs.
-
         /// <summary>
-        ///     The total supply that was available to us last tick.
-        ///     This does not mean it was used.
+        /// Returns a powernet manager by type, or null.
+        /// Be aware that it isn't possible for this to return null for any
+        /// existing non-abstract constructable PowernetManager subclass.
+        /// Of course, if a PowernetManager subclass is abstract or unconstructable?
+        /// That's different...
         /// </summary>
-        [ViewVariables]
-        public float LastTotalAvailable { get; private set; }
-
-        /// <summary>
-        ///     The total power drawn last tick.
-        ///     This is how much power was actually, in practice, drawn.
-        ///     Not how much SHOULD have been drawn.
-        ///     If avail &lt; demand, this will be just &lt;= than the actual avail
-        ///     (e.g. if all machines need 100 W but there's 20 W excess, the 20 W will be avail but not drawn.)
-        /// </summary>
-        [ViewVariables]
-        public float LastTotalDraw { get; private set; }
-
-        /// <summary>
-        ///     The amount of power that was demanded last tick.
-        ///     This does not mean it was full filled in practice.
-        ///     This does not include the demand from storage suppliers until the suppliers are actually capable of drawing power.
-        ///     As such, this will quite abruptly shoot up if available rises to cover supplier charge demand too.
-        /// </summary>
-        /// <seealso cref="LastTotalDemandWithSuppliers"/>
-        [ViewVariables]
-        public float LastTotalDemand { get; private set; }
-
-        /// <summary>
-        ///     The amount of power that was demanded last tick, ALWAYS including storage supplier draw.
-        ///     This does not mean it was full filled in practice.
-        ///     See <see cref="LastTotalDemand"/> for the difference.
-        /// </summary>
-        [ViewVariables]
-        public float LastTotalDemandWithSuppliers { get; private set; }
-
-        /// <summary>
-        ///     The amount of power that we are lacking to properly power everything (excluding storage supplier charging).
-        /// </summary>
-        [ViewVariables]
-        public float Lack => Math.Max(0, LastTotalDemand - LastTotalAvailable);
-
-        /// <summary>
-        ///     The total amount of power that wasn't used last tick.
-        ///     This does not necessarily mean it went to waste, unused supply from storage is also counted.
-        ///     It is ALSO not implied that if this is &gt; 0, that we have sufficient power for everything.
-        ///     See the doc comment on <see cref="LastTotalDraw"/>.
-        /// </summary>
-        [ViewVariables]
-        public float Excess => Math.Max(0, LastTotalAvailable - LastTotalDraw);
+        public T GetManager<T>() where T : PowernetManager
+        {
+            foreach (PowernetManager manager in Managers)
+            {
+                if (manager is T)
+                {
+                    return (T) manager;
+                }
+            }
+            return null;
+        }
 
         public void Update(float frameTime)
         {
-            // The amount of energy that is supplied from generators that do not care if it's used or not.
-            var activeSupply = Supply * frameTime;
-            // The total load we need to fill for machines.
-            var activeLoad = Load * frameTime;
-
-            // The total load from storage consumers (batteries that do not supply like an SMES)
-            float storageConsumerDemand = 0;
-            foreach (var supply in PowerStorageConsumerList)
+            foreach (PowernetManager manager in Managers)
             {
-                storageConsumerDemand += supply.RequestCharge(frameTime);
-            }
-
-            // The total supply from storage suppliers.
-            float storageSupply = 0;
-            // The total load from storage suppliers (batteries that DO supply like an SMES)
-            float storageSupplierDemand = 0;
-            foreach (var supply in PowerStorageSupplierList)
-            {
-                storageSupply += supply.AvailableCharge(frameTime);
-                storageSupplierDemand += supply.RequestCharge(frameTime);
-            }
-
-            LastTotalAvailable = (storageSupply + activeSupply) / frameTime;
-            LastTotalDemandWithSuppliers = (activeLoad + storageConsumerDemand + storageSupplierDemand) / frameTime;
-
-            // The happy case.
-            // If we have enough power to feed all load and storage demand, then feed everything
-            if (activeSupply > activeLoad + storageConsumerDemand + storageSupplierDemand)
-            {
-                PowerAllDevices();
-                ChargeStorageConsumers(frameTime);
-                ChargeStorageSuppliers(frameTime);
-                LastTotalDraw = LastTotalDemand = LastTotalDemandWithSuppliers;
-                return;
-            }
-
-            LastTotalDemand = (activeLoad + storageConsumerDemand) / frameTime;
-
-            // We don't have enough power for the storage powernet suppliers, ignore powering them
-            // TODO: This is technically incorrect, it's totally possible to power *some* suppliers here,
-            // just not all.
-            if (activeSupply > activeLoad + storageConsumerDemand)
-            {
-                PowerAllDevices();
-                ChargeStorageConsumers(frameTime);
-                LastTotalDraw = LastTotalDemand;
-                return;
-            }
-
-            // The complex case: There is too little power to power everything without using storage suppliers (SMES).
-            // We have to keep track of power draw as to not incorrectly detract too much from storage suppliers.
-
-            // Calculate the total potential supply, then go through every normal load and detract.
-            var totalRemaining = activeSupply + storageSupply;
-            foreach (var device in DeviceLoadList)
-            {
-                var deviceLoad = device.Load * frameTime;
-                if (deviceLoad > totalRemaining)
-                {
-                    device.ExternalPowered = false;
-                    DepoweredDevices.Add(device);
-                }
-                else
-                {
-                    totalRemaining -= deviceLoad;
-                    if (!device.ExternalPowered)
-                    {
-                        DepoweredDevices.Remove(device);
-                        device.ExternalPowered = true;
-                    }
-                }
-            }
-
-            if (totalRemaining > 0)
-            {
-                // What we have left (if any) goes into storage consumers.
-                foreach (var consumer in PowerStorageConsumerList)
-                {
-                    if (totalRemaining < 0)
-                    {
-                        break;
-                    }
-
-                    var demand = consumer.RequestCharge(frameTime);
-                    if (demand == 0)
-                    {
-                        continue;
-                    }
-
-                    var taken = Math.Min(demand, totalRemaining);
-                    totalRemaining -= taken;
-                    consumer.AddCharge(taken);
-                }
-            }
-
-            LastTotalDraw = (activeSupply + storageSupply - totalRemaining) / frameTime;
-
-            // activeSupply is free to use, but storageSupply is not.
-            // Calculate how much of storageSupply, and deduct it from the storage suppliers.
-            var supplierUsed = storageSupply - totalRemaining;
-
-            // And deduct!
-            foreach (var supplier in PowerStorageSupplierList)
-            {
-                var load = supplier.AvailableCharge(frameTime);
-                if (load == 0)
-                {
-                    continue;
-                }
-
-                var added = Math.Min(load, supplierUsed);
-                supplierUsed -= added;
-                supplier.DeductCharge(added);
-                if (supplierUsed <= 0)
-                {
-                    return;
-                }
-            }
-        }
-
-        private void PowerAllDevices()
-        {
-            foreach (var device in DepoweredDevices)
-            {
-                device.ExternalPowered = true;
-            }
-
-            DepoweredDevices.Clear();
-        }
-
-        private void ChargeStorageConsumers(float frametime)
-        {
-            foreach (var storage in PowerStorageConsumerList)
-            {
-                storage.ChargePowerTick(frametime);
-            }
-        }
-
-        private void ChargeStorageSuppliers(float frametime)
-        {
-            foreach (var storage in PowerStorageSupplierList)
-            {
-                storage.ChargePowerTick(frametime);
+                manager.Update(frameTime);
             }
         }
 
         /// <summary>
-        /// Kills a powernet after it is marked dirty and its component have already been regenerated by the powernet system
+        /// Kills a wirenet after it is marked dirty and its component have already been regenerated by the powernet system
         /// </summary>
         public void DirtyKill()
         {
@@ -306,13 +106,6 @@ namespace Content.Server.GameObjects.Components.Power
             {
                 NodeList[0].DisconnectFromPowernet();
             }
-
-            GeneratorList.Clear();
-            DeviceLoadList.Clear();
-            DepoweredDevices.Clear();
-            PowerStorageSupplierList.Clear();
-            PowerStorageConsumerList.Clear();
-
             RemoveFromSystem();
         }
 
@@ -339,32 +132,10 @@ namespace Content.Server.GameObjects.Components.Power
             NodeList.AddRange(toMerge.NodeList);
             toMerge.NodeList.Clear();
 
-            foreach (var generator in toMerge.GeneratorList)
+            foreach (var manager in Managers)
             {
-                GeneratorList.Add(generator.Key, generator.Value);
+                manager.MergeFrom(toMerge);
             }
-
-            Supply += toMerge.Supply;
-            toMerge.Supply = 0;
-            toMerge.GeneratorList.Clear();
-
-            foreach (var device in toMerge.DeviceLoadList)
-            {
-                DeviceLoadList.Add(device);
-            }
-
-            Load += toMerge.Load;
-            toMerge.Load = 0;
-            toMerge.DeviceLoadList.Clear();
-
-            DepoweredDevices.AddRange(toMerge.DepoweredDevices);
-            toMerge.DepoweredDevices.Clear();
-
-            PowerStorageSupplierList.AddRange(toMerge.PowerStorageSupplierList);
-            toMerge.PowerStorageSupplierList.Clear();
-
-            PowerStorageConsumerList.AddRange(toMerge.PowerStorageConsumerList);
-            toMerge.PowerStorageConsumerList.Clear();
 
             toMerge.RemoveFromSystem();
         }
@@ -378,178 +149,9 @@ namespace Content.Server.GameObjects.Components.Power
             EntitySystemManager.GetEntitySystem<PowerSystem>().Powernets.Remove(this);
         }
 
-        #region Registration
-
-        /// <summary>
-        /// Register a continuous load from a device connected to the powernet
-        /// </summary>
-        public void AddDevice(PowerDeviceComponent device)
-        {
-            DeviceLoadList.Add(device);
-            Load += device.Load;
-            if (!device.Powered)
-                DepoweredDevices.Add(device);
-        }
-
-        /// <summary>
-        /// Update one of the loads from a deviceconnected to the powernet
-        /// </summary>
-        public void UpdateDevice(PowerDeviceComponent device, float oldLoad)
-        {
-            if (DeviceLoadList.Contains(device))
-            {
-                Load -= oldLoad;
-                Load += device.Load;
-            }
-        }
-
-        /// <summary>
-        ///     Returns whether or not a power device is in this powernet's load list.
-        /// </summary>
-        /// <param name="device">The device to check for.</param>
-        /// <returns>True if the device is in the load list, false otherwise.</returns>
-        public bool HasDevice(PowerDeviceComponent device)
-        {
-            return DeviceLoadList.Contains(device);
-        }
-
-        /// <summary>
-        ///     Remove a continuous load from a device connected to the powernet
-        /// </summary>
-        public void RemoveDevice(PowerDeviceComponent device)
-        {
-            if (DeviceLoadList.Contains(device))
-            {
-                Load -= device.Load;
-                DeviceLoadList.Remove(device);
-                if (DepoweredDevices.Contains(device))
-                    DepoweredDevices.Remove(device);
-            }
-            else
-            {
-                Logger.WarningS("power", "We tried to remove device {0} twice from {1}, somehow.", device.Owner, this);
-            }
-        }
-
-        /// <summary>
-        /// Register a power supply from a generator connected to the powernet
-        /// </summary>
-        public void AddGenerator(PowerGeneratorComponent generator)
-        {
-            GeneratorList.Add(generator, generator.Supply);
-            Supply += generator.Supply;
-        }
-
-        /// <summary>
-        /// Update the value supplied from a generator connected to the powernet
-        /// </summary>
-        public void UpdateGenerator(PowerGeneratorComponent generator)
-        {
-            if (GeneratorList.ContainsKey(generator))
-            {
-                Supply -= GeneratorList[generator];
-                GeneratorList[generator] = generator.Supply;
-                Supply += generator.Supply;
-            }
-        }
-
-        /// <summary>
-        /// Remove a power supply from a generator connected to the powernet
-        /// </summary>
-        public void RemoveGenerator(PowerGeneratorComponent generator)
-        {
-            if (GeneratorList.ContainsKey(generator))
-            {
-                Supply -= GeneratorList[generator];
-                GeneratorList.Remove(generator);
-            }
-            else
-            {
-                Logger.WarningS("power", "We tried to remove generator {0} twice from {1}, somehow.", generator.Owner,
-                    this);
-            }
-        }
-
-        /// <summary>
-        /// Register a power supply from a generator connected to the powernet
-        /// </summary>
-        public void AddPowerStorage(PowerStorageNetComponent storage)
-        {
-            if (storage.ChargePowernet)
-                PowerStorageSupplierList.Add(storage);
-            else
-                PowerStorageConsumerList.Add(storage);
-        }
-
-        //How do I even call this? TODO: fix
-        public void UpdateStorageType(PowerStorageNetComponent storage)
-        {
-            //If our chargepowernet settings change we need to tell the powernet of this new setting and remove traces of our old setting
-            if (PowerStorageSupplierList.Contains(storage))
-                PowerStorageSupplierList.Remove(storage);
-            if (PowerStorageConsumerList.Contains(storage))
-                PowerStorageConsumerList.Remove(storage);
-
-            //Apply new setting
-            if (storage.ChargePowernet)
-                PowerStorageSupplierList.Add(storage);
-            else
-                PowerStorageConsumerList.Add(storage);
-        }
-
-        /// <summary>
-        /// Remove a power supply from a generator connected to the powernet
-        /// </summary>
-        public void RemovePowerStorage(PowerStorageNetComponent storage)
-        {
-            if (PowerStorageSupplierList.Contains(storage))
-            {
-                PowerStorageSupplierList.Remove(storage);
-            }
-
-            if (PowerStorageConsumerList.Contains(storage))
-            {
-                PowerStorageSupplierList.Remove(storage);
-            }
-        }
-
-        #endregion Registration
-
         public override string ToString()
         {
             return $"Powernet {Uid}";
-        }
-
-        /// <summary>
-        ///     Priority that a device will receive power if powernet cannot supply every device
-        /// </summary>
-        public enum Priority
-        {
-            Necessary = 0,
-            High = 1,
-            Medium = 2,
-            Low = 3,
-            Provider = 4,
-            Unnecessary = 5
-        }
-
-        /// <summary>
-        ///     Comparer that keeps the device dictionary sorted by powernet priority
-        /// </summary>
-        public class DevicePriorityCompare : IComparer<PowerDeviceComponent>
-        {
-            public int Compare(PowerDeviceComponent x, PowerDeviceComponent y)
-            {
-                int compare = y.Priority.CompareTo(x.Priority);
-
-                //If the comparer returns 0 sortedset will believe it is a duplicate and return 0, so return 1 instead
-                if (compare == 0)
-                {
-                    return y.Owner.Uid.CompareTo(x.Owner.Uid);
-                }
-
-                return compare;
-            }
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Power/PowernetManager.cs
+++ b/Content.Server/GameObjects/Components/Power/PowernetManager.cs
@@ -1,0 +1,64 @@
+namespace Content.Server.GameObjects.Components.Power
+{
+    /// <summary>
+    /// Responsible for managing an aspect of a <see cref="Wirenet"/>.
+    /// For example, <see cref="PowernetPowerManager"/> manages the power network.
+    /// PowernetManagers are like components, but they're not directly connected to the world.
+    /// They are also like EntitySystems, in that they are automatically created when possible.
+    /// The expected constructor is the one provided by this class.
+    /// (An important side note is that PowernetManagers aren't aware of when nodes are added.
+    /// The node components have to manage this themselves via OnAdd/OnRemove,
+    ///  along with some events of PowerNodeComponent.
+    /// This likely has something to do with ensuring the runtime addition/removal of
+    /// components doesn't break, so I'm not modifying this part of the design. - 20kdc)
+    /// </summary>
+    public abstract class PowernetManager
+    {
+        /// <summary>
+        /// The Powernet this PowernetManager is responsible for.
+        /// </summary>
+        public readonly Powernet powernet;
+
+        public PowernetManager(Powernet net)
+        {
+            powernet = net;
+        }
+
+        /// <summary>
+        /// Called after all managers are connected to the powernet.
+        /// The network is guaranteed to be empty at this time.
+        /// </summary>
+        public virtual void Initialize()
+        {
+
+        }
+
+        /// <summary>
+        /// Called to update time-continuous activity (the usual reason for this to exist).
+        /// </summary>
+        public virtual void Update(float frameTime)
+        {
+
+        }
+
+        /// <summary>
+        /// Called to merge all of the devices from another powernet.
+        /// This is also responsible for cleaning up the correspondent manager
+        ///  in the other powernet.
+        /// </summary>
+        public virtual void MergeFrom(Powernet from)
+        {
+
+        }
+
+        /// <summary>
+        /// Called when the wirenet is being shutdown due to a wiring regeneration.
+        /// Every wire and node involved in the Wirenet has gone somewhere else.
+        /// *You will not have received any of the disconnection events.*
+        /// </summary>
+        public virtual void DirtyKill()
+        {
+
+        }
+    }
+}

--- a/Content.Server/GameObjects/Components/Power/PowernetPowerManager.cs
+++ b/Content.Server/GameObjects/Components/Power/PowernetPowerManager.cs
@@ -1,0 +1,500 @@
+﻿using System;
+using System.Collections.Generic;
+using Content.Shared.GameObjects.EntitySystems;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Log;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Server.GameObjects.Components.Power
+{
+    /// <summary>
+    /// Takes in and distributes power via the powernet system.
+    /// </summary>
+    public class PowernetPowerManager : PowernetManager
+    {
+        public PowernetPowerManager(Powernet net) : base(net)
+        {
+        }
+
+        /// <summary>
+        ///     Subset of nodelist that adds a continuous power supply to the network
+        /// </summary>
+        private readonly Dictionary<PowerGeneratorComponent, float> GeneratorList =
+            new Dictionary<PowerGeneratorComponent, float>();
+
+        [ViewVariables]
+        public int GeneratorCount => GeneratorList.Count;
+
+        /// <summary>
+        ///     Subset of nodelist that draw power, stores information on current continuous powernet load
+        /// </summary>
+        private readonly SortedSet<PowerDeviceComponent> DeviceLoadList =
+            new SortedSet<PowerDeviceComponent>(new DevicePriorityCompare());
+
+        [ViewVariables]
+        public int DeviceCount => DeviceLoadList.Count;
+
+        /// <summary>
+        ///     All the devices that have been depowered by this powernet or depowered prior to being absorted into this powernet
+        /// </summary>
+        private readonly List<PowerDeviceComponent> DepoweredDevices = new List<PowerDeviceComponent>();
+
+        /// <summary>
+        ///     A list of the energy storage components that will feed the powernet if necessary, and if there is enough power feed itself
+        /// </summary>
+        private readonly List<PowerStorageNetComponent> PowerStorageSupplierList = new List<PowerStorageNetComponent>();
+
+        [ViewVariables]
+        public int PowerStorageSupplierCount => PowerStorageSupplierList.Count;
+
+        /// <summary>
+        ///     A list of energy storage components that will never feed the powernet, will try to draw energy to feed themselves if possible
+        /// </summary>
+        private readonly List<PowerStorageNetComponent> PowerStorageConsumerList = new List<PowerStorageNetComponent>();
+
+        [ViewVariables]
+        public int PowerStorageConsumerCount => PowerStorageConsumerList.Count;
+
+        /// <summary>
+        ///     Static counter of all continuous load placed from devices on this power network.
+        ///     In Watts.
+        /// </summary>
+        [ViewVariables]
+        public float Load { get; private set; } = 0;
+
+        /// <summary>
+        ///     Static counter of all continuous supply from generators on this power network.
+        ///     In Watts.
+        /// </summary>
+        [ViewVariables]
+        public float Supply { get; private set; } = 0;
+
+        /// <summary>
+        ///     Variable that causes powernet to be regenerated from its wires during the next update cycle.
+        /// </summary>
+        [ViewVariables]
+        public bool Dirty { get; set; } = false;
+
+        // These are stats for power monitoring equipment such as APCs.
+
+        /// <summary>
+        ///     The total supply that was available to us last tick.
+        ///     This does not mean it was used.
+        /// </summary>
+        [ViewVariables]
+        public float LastTotalAvailable { get; private set; }
+
+        /// <summary>
+        ///     The total power drawn last tick.
+        ///     This is how much power was actually, in practice, drawn.
+        ///     Not how much SHOULD have been drawn.
+        ///     If avail &lt; demand, this will be just &lt;= than the actual avail
+        ///     (e.g. if all machines need 100 W but there's 20 W excess, the 20 W will be avail but not drawn.)
+        /// </summary>
+        [ViewVariables]
+        public float LastTotalDraw { get; private set; }
+
+        /// <summary>
+        ///     The amount of power that was demanded last tick.
+        ///     This does not mean it was full filled in practice.
+        ///     This does not include the demand from storage suppliers until the suppliers are actually capable of drawing power.
+        ///     As such, this will quite abruptly shoot up if available rises to cover supplier charge demand too.
+        /// </summary>
+        /// <seealso cref="LastTotalDemandWithSuppliers"/>
+        [ViewVariables]
+        public float LastTotalDemand { get; private set; }
+
+        /// <summary>
+        ///     The amount of power that was demanded last tick, ALWAYS including storage supplier draw.
+        ///     This does not mean it was full filled in practice.
+        ///     See <see cref="LastTotalDemand"/> for the difference.
+        /// </summary>
+        [ViewVariables]
+        public float LastTotalDemandWithSuppliers { get; private set; }
+
+        /// <summary>
+        ///     The amount of power that we are lacking to properly power everything (excluding storage supplier charging).
+        /// </summary>
+        [ViewVariables]
+        public float Lack => Math.Max(0, LastTotalDemand - LastTotalAvailable);
+
+        /// <summary>
+        ///     The total amount of power that wasn't used last tick.
+        ///     This does not necessarily mean it went to waste, unused supply from storage is also counted.
+        ///     It is ALSO not implied that if this is &gt; 0, that we have sufficient power for everything.
+        ///     See the doc comment on <see cref="LastTotalDraw"/>.
+        /// </summary>
+        [ViewVariables]
+        public float Excess => Math.Max(0, LastTotalAvailable - LastTotalDraw);
+
+        /// <inheritdoc/>
+        public override void Update(float frameTime)
+        {
+            base.Update(frameTime);
+
+            // The amount of energy that is supplied from generators that do not care if it's used or not.
+            var activeSupply = Supply * frameTime;
+            // The total load we need to fill for machines.
+            var activeLoad = Load * frameTime;
+
+            // The total load from storage consumers (batteries that do not supply like an SMES)
+            float storageConsumerDemand = 0;
+            foreach (var supply in PowerStorageConsumerList)
+            {
+                storageConsumerDemand += supply.RequestCharge(frameTime);
+            }
+
+            // The total supply from storage suppliers.
+            float storageSupply = 0;
+            // The total load from storage suppliers (batteries that DO supply like an SMES)
+            float storageSupplierDemand = 0;
+            foreach (var supply in PowerStorageSupplierList)
+            {
+                storageSupply += supply.AvailableCharge(frameTime);
+                storageSupplierDemand += supply.RequestCharge(frameTime);
+            }
+
+            LastTotalAvailable = (storageSupply + activeSupply) / frameTime;
+            LastTotalDemandWithSuppliers = (activeLoad + storageConsumerDemand + storageSupplierDemand) / frameTime;
+
+            // The happy case.
+            // If we have enough power to feed all load and storage demand, then feed everything
+            if (activeSupply > activeLoad + storageConsumerDemand + storageSupplierDemand)
+            {
+                PowerAllDevices();
+                ChargeStorageConsumers(frameTime);
+                ChargeStorageSuppliers(frameTime);
+                LastTotalDraw = LastTotalDemand = LastTotalDemandWithSuppliers;
+                return;
+            }
+
+            LastTotalDemand = (activeLoad + storageConsumerDemand) / frameTime;
+
+            // We don't have enough power for the storage powernet suppliers, ignore powering them
+            // TODO: This is technically incorrect, it's totally possible to power *some* suppliers here,
+            // just not all.
+            if (activeSupply > activeLoad + storageConsumerDemand)
+            {
+                PowerAllDevices();
+                ChargeStorageConsumers(frameTime);
+                LastTotalDraw = LastTotalDemand;
+                return;
+            }
+
+            // The complex case: There is too little power to power everything without using storage suppliers (SMES).
+            // We have to keep track of power draw as to not incorrectly detract too much from storage suppliers.
+
+            // Calculate the total potential supply, then go through every normal load and detract.
+            var totalRemaining = activeSupply + storageSupply;
+            foreach (var device in DeviceLoadList)
+            {
+                var deviceLoad = device.Load * frameTime;
+                if (deviceLoad > totalRemaining)
+                {
+                    device.ExternalPowered = false;
+                    DepoweredDevices.Add(device);
+                }
+                else
+                {
+                    totalRemaining -= deviceLoad;
+                    if (!device.ExternalPowered)
+                    {
+                        DepoweredDevices.Remove(device);
+                        device.ExternalPowered = true;
+                    }
+                }
+            }
+
+            if (totalRemaining > 0)
+            {
+                // What we have left (if any) goes into storage consumers.
+                foreach (var consumer in PowerStorageConsumerList)
+                {
+                    if (totalRemaining < 0)
+                    {
+                        break;
+                    }
+
+                    var demand = consumer.RequestCharge(frameTime);
+                    if (demand == 0)
+                    {
+                        continue;
+                    }
+
+                    var taken = Math.Min(demand, totalRemaining);
+                    totalRemaining -= taken;
+                    consumer.AddCharge(taken);
+                }
+            }
+
+            LastTotalDraw = (activeSupply + storageSupply - totalRemaining) / frameTime;
+
+            // activeSupply is free to use, but storageSupply is not.
+            // Calculate how much of storageSupply, and deduct it from the storage suppliers.
+            var supplierUsed = storageSupply - totalRemaining;
+
+            // And deduct!
+            foreach (var supplier in PowerStorageSupplierList)
+            {
+                var load = supplier.AvailableCharge(frameTime);
+                if (load == 0)
+                {
+                    continue;
+                }
+
+                var added = Math.Min(load, supplierUsed);
+                supplierUsed -= added;
+                supplier.DeductCharge(added);
+                if (supplierUsed <= 0)
+                {
+                    return;
+                }
+            }
+        }
+
+        private void PowerAllDevices()
+        {
+            foreach (var device in DepoweredDevices)
+            {
+                device.ExternalPowered = true;
+            }
+
+            DepoweredDevices.Clear();
+        }
+
+        private void ChargeStorageConsumers(float frametime)
+        {
+            foreach (var storage in PowerStorageConsumerList)
+            {
+                storage.ChargePowerTick(frametime);
+            }
+        }
+
+        private void ChargeStorageSuppliers(float frametime)
+        {
+            foreach (var storage in PowerStorageSupplierList)
+            {
+                storage.ChargePowerTick(frametime);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void DirtyKill()
+        {
+            base.DirtyKill();
+
+            GeneratorList.Clear();
+            DeviceLoadList.Clear();
+            DepoweredDevices.Clear();
+            PowerStorageSupplierList.Clear();
+            PowerStorageConsumerList.Clear();
+        }
+
+        /// <inheritdoc/>
+        public override void MergeFrom(Powernet toMerge)
+        {
+            base.MergeFrom(toMerge);
+
+            PowernetPowerManager toMergePM = toMerge.GetManager<PowernetPowerManager>();
+
+            //TODO: load balance reconciliation between powernets on merge tick here
+
+            foreach (var generator in toMergePM.GeneratorList)
+            {
+                GeneratorList.Add(generator.Key, generator.Value);
+            }
+
+            Supply += toMergePM.Supply;
+            toMergePM.Supply = 0;
+            toMergePM.GeneratorList.Clear();
+
+            foreach (var device in toMergePM.DeviceLoadList)
+            {
+                DeviceLoadList.Add(device);
+            }
+
+            Load += toMergePM.Load;
+            toMergePM.Load = 0;
+            toMergePM.DeviceLoadList.Clear();
+
+            DepoweredDevices.AddRange(toMergePM.DepoweredDevices);
+            toMergePM.DepoweredDevices.Clear();
+
+            PowerStorageSupplierList.AddRange(toMergePM.PowerStorageSupplierList);
+            toMergePM.PowerStorageSupplierList.Clear();
+
+            PowerStorageConsumerList.AddRange(toMergePM.PowerStorageConsumerList);
+            toMergePM.PowerStorageConsumerList.Clear();
+        }
+
+        #region Registration
+
+        /// <summary>
+        /// Register a continuous load from a device connected to the powernet
+        /// </summary>
+        public void AddDevice(PowerDeviceComponent device)
+        {
+            DeviceLoadList.Add(device);
+            Load += device.Load;
+            if (!device.Powered)
+                DepoweredDevices.Add(device);
+        }
+
+        /// <summary>
+        /// Update one of the loads from a deviceconnected to the powernet
+        /// </summary>
+        public void UpdateDevice(PowerDeviceComponent device, float oldLoad)
+        {
+            if (DeviceLoadList.Contains(device))
+            {
+                Load -= oldLoad;
+                Load += device.Load;
+            }
+        }
+
+        /// <summary>
+        ///     Returns whether or not a power device is in this powernet's load list.
+        /// </summary>
+        /// <param name="device">The device to check for.</param>
+        /// <returns>True if the device is in the load list, false otherwise.</returns>
+        public bool HasDevice(PowerDeviceComponent device)
+        {
+            return DeviceLoadList.Contains(device);
+        }
+
+        /// <summary>
+        ///     Remove a continuous load from a device connected to the powernet
+        /// </summary>
+        public void RemoveDevice(PowerDeviceComponent device)
+        {
+            if (DeviceLoadList.Contains(device))
+            {
+                Load -= device.Load;
+                DeviceLoadList.Remove(device);
+                if (DepoweredDevices.Contains(device))
+                    DepoweredDevices.Remove(device);
+            }
+            else
+            {
+                Logger.WarningS("power", "We tried to remove device {0} twice from {1}, somehow.", device.Owner, this);
+            }
+        }
+
+        /// <summary>
+        /// Register a power supply from a generator connected to the powernet
+        /// </summary>
+        public void AddGenerator(PowerGeneratorComponent generator)
+        {
+            GeneratorList.Add(generator, generator.Supply);
+            Supply += generator.Supply;
+        }
+
+        /// <summary>
+        /// Update the value supplied from a generator connected to the powernet
+        /// </summary>
+        public void UpdateGenerator(PowerGeneratorComponent generator)
+        {
+            if (GeneratorList.ContainsKey(generator))
+            {
+                Supply -= GeneratorList[generator];
+                GeneratorList[generator] = generator.Supply;
+                Supply += generator.Supply;
+            }
+        }
+
+        /// <summary>
+        /// Remove a power supply from a generator connected to the powernet
+        /// </summary>
+        public void RemoveGenerator(PowerGeneratorComponent generator)
+        {
+            if (GeneratorList.ContainsKey(generator))
+            {
+                Supply -= GeneratorList[generator];
+                GeneratorList.Remove(generator);
+            }
+            else
+            {
+                Logger.WarningS("power", "We tried to remove generator {0} twice from {1}, somehow.", generator.Owner,
+                    this);
+            }
+        }
+
+        /// <summary>
+        /// Register a power supply from a generator connected to the powernet
+        /// </summary>
+        public void AddPowerStorage(PowerStorageNetComponent storage)
+        {
+            if (storage.ChargePowernet)
+                PowerStorageSupplierList.Add(storage);
+            else
+                PowerStorageConsumerList.Add(storage);
+        }
+
+        //How do I even call this? TODO: fix
+        public void UpdateStorageType(PowerStorageNetComponent storage)
+        {
+            //If our chargepowernet settings change we need to tell the powernet of this new setting and remove traces of our old setting
+            if (PowerStorageSupplierList.Contains(storage))
+                PowerStorageSupplierList.Remove(storage);
+            if (PowerStorageConsumerList.Contains(storage))
+                PowerStorageConsumerList.Remove(storage);
+
+            //Apply new setting
+            if (storage.ChargePowernet)
+                PowerStorageSupplierList.Add(storage);
+            else
+                PowerStorageConsumerList.Add(storage);
+        }
+
+        /// <summary>
+        /// Remove a power supply from a generator connected to the powernet
+        /// </summary>
+        public void RemovePowerStorage(PowerStorageNetComponent storage)
+        {
+            if (PowerStorageSupplierList.Contains(storage))
+            {
+                PowerStorageSupplierList.Remove(storage);
+            }
+
+            if (PowerStorageConsumerList.Contains(storage))
+            {
+                PowerStorageSupplierList.Remove(storage);
+            }
+        }
+
+        #endregion Registration
+
+        /// <summary>
+        ///     Priority that a device will receive power if powernet cannot supply every device
+        /// </summary>
+        public enum Priority
+        {
+            Necessary = 0,
+            High = 1,
+            Medium = 2,
+            Low = 3,
+            Provider = 4,
+            Unnecessary = 5
+        }
+
+        /// <summary>
+        ///     Comparer that keeps the device dictionary sorted by powernet priority
+        /// </summary>
+        public class DevicePriorityCompare : IComparer<PowerDeviceComponent>
+        {
+            public int Compare(PowerDeviceComponent x, PowerDeviceComponent y)
+            {
+                int compare = y.Priority.CompareTo(x.Priority);
+
+                //If the comparer returns 0 sortedset will believe it is a duplicate and return 0, so return 1 instead
+                if (compare == 0)
+                {
+                    return y.Owner.Uid.CompareTo(x.Owner.Uid);
+                }
+
+                return compare;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This restructuring allows for arbitrary networks to be built on the powernet wires.
Still uses the same infrastructure, just moves the code around.

(Specifics: Actual power control has gone into PowernetPowerManager, while Powernet is responsible for holding the power networking data and auto-instantiating PowernetManagers.)

This may be a prerequisite of a future solar-panel related PR (for in-dev work, see solar-panels-occlusion-and-tracking, but at time of writing it's not using it *yet*)