### PR TITLE
Mark CollisionGroup as flag names for engine collision masks

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using JetBrains.Annotations;
 using Robust.Shared.Map;
+using RobustPhysics = Robust.Shared.Physics;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Physics
 {
@@ -8,6 +10,7 @@ namespace Content.Shared.Physics
     ///     Defined collision groups for the physics system.
     /// </summary>
     [Flags, PublicAPI]
+    [FlagsFor(typeof(RobustPhysics.CollisionLayer)), FlagsFor(typeof(RobustPhysics.CollisionMask))]
     public enum CollisionGroup
     {
 		None            = 0,

--- a/Resources/Prototypes/Entities/Buildings/walls.yml
+++ b/Resources/Prototypes/Entities/Buildings/walls.yml
@@ -20,7 +20,12 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      layer: 31
+      layer:
+      - Opaque
+      - Impassable
+      - MobImpassable
+      - VaultImpassable
+      - SmallImpassable
   - type: Damageable
   - type: Destructible
     thresholdvalue: 100


### PR DESCRIPTION
Fixes space-wizards/RobustToolbox#974.

Includes the example of walls, which now use the *new, fancy* flag names instead of a hardcoded number.

Depends on space-wizards/RobustToolbox#1072.