### PR TITLE
Adds ISuicideAct and support for Held Item and Environmental suicides

### DIFF
--- a/Content.Server/Chat/ChatCommands.cs
+++ b/Content.Server/Chat/ChatCommands.cs
@@ -1,10 +1,16 @@
-﻿using Content.Server.GameObjects.Components.Observer;
+﻿using Content.Server.GameObjects;
+using Content.Server.GameObjects.Components.Observer;
 using Content.Server.Interfaces.Chat;
+using Content.Server.Interfaces.GameObjects;
 using Content.Server.Players;
+using Content.Shared.GameObjects;
 using Robust.Server.Interfaces.Console;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Enums;
+using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using System.Linq;
 
 namespace Content.Server.Chat
 {
@@ -70,6 +76,83 @@ namespace Content.Server.Chat
         {
             var chat = IoCManager.Resolve<IChatManager>();
             chat.SendOOC(player, string.Join(" ", args));
+        }
+    }
+
+    internal class SuicideCommand : IClientCommand
+    {
+        public string Command => "suicide";
+
+        public string Description => "Commits suicide";
+
+        public string Help => "suicide";
+
+        private void DealDamage(ISuicideAct suicide, IChatManager chat, DamageableComponent damageableComponent, IEntity source, IEntity target)
+        {
+            SuicideKind kind = suicide.Suicide(target, chat);
+            if (kind != SuicideKind.Special && damageableComponent != null)
+            {
+                damageableComponent.TakeDamage(kind switch
+                {
+                    SuicideKind.Brute    => DamageType.Brute,
+                    SuicideKind.Heat     => DamageType.Heat,
+                    SuicideKind.Cold     => DamageType.Cold,
+                    SuicideKind.Acid     => DamageType.Acid,
+                    SuicideKind.Toxic    => DamageType.Toxic,
+                    SuicideKind.Electric => DamageType.Electric,
+                                       _ => DamageType.Brute
+                },
+                500, //TODO: needs to be a max damage of some sorts
+                source,
+                target);
+            }
+        }
+
+        public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
+        {
+            if (player.Status != SessionStatus.InGame)
+                return;
+
+            var chat = IoCManager.Resolve<IChatManager>();
+            var owner = player.ContentData().Mind.OwnedMob.Owner;
+            owner.TryGetComponent<DamageableComponent>(out var dmgComponent);
+            //TODO: needs to check if the mob is actually alive
+            //TODO: maybe set a suicided flag to prevent ressurection?
+
+            // Held item suicide
+            owner.TryGetComponent<HandsComponent>(out var handsComponent);
+            var itemComponent = handsComponent.GetActiveHand;
+            if (itemComponent != null)
+            {
+                ISuicideAct suicide = itemComponent.Owner.GetAllComponents<ISuicideAct>().FirstOrDefault();
+                if (suicide != null)
+                {
+                    DealDamage(suicide, chat, dmgComponent, itemComponent.Owner, owner);
+                    return;
+                }
+            }
+            // Get all entities in range of the suicider
+            var entities = owner.EntityManager.GetEntitiesInRange(owner, 1, true);
+            if (entities.Count() > 0)
+            {
+                foreach (var entity in entities)
+                {
+                    if (entity.HasComponent<ItemComponent>())
+                        continue;
+                    var suicide = entity.GetAllComponents<ISuicideAct>().FirstOrDefault();
+                    if (suicide != null)
+                    {
+                        DealDamage(suicide, chat, dmgComponent, entity, owner);
+                        return;
+                    }
+                }
+            }
+            // Default suicide, bite your tongue
+            if (dmgComponent != null)
+            {
+                chat.EntityMe(owner, Loc.GetString("is attempting to bite {0:their} own tongue, looks like {0:theyre} trying to commit suicide!", owner)); //TODO: theyre macro
+                dmgComponent.TakeDamage(DamageType.Brute, 500, owner, owner); //TODO: dmg value needs to be a max damage of some sorts
+            }
         }
     }
 }

--- a/Content.Server/Chat/ChatCommands.cs
+++ b/Content.Server/Chat/ChatCommands.cs
@@ -85,12 +85,15 @@ namespace Content.Server.Chat
 
         public string Description => "Commits suicide";
 
-        public string Help => "suicide";
+        public string Help => "The suicide command gives you a quick way out of a round while remaining in-character.\n" +
+            "The method varies, first it will attempt to use the held item in your active hand.\n" +
+            "If that fails, it will attempt to use an object in the environment.\n" +
+            "Finally, if neither of the above worked, you will die by biting your tongue.";
 
         private void DealDamage(ISuicideAct suicide, IChatManager chat, DamageableComponent damageableComponent, IEntity source, IEntity target)
         {
             SuicideKind kind = suicide.Suicide(target, chat);
-            if (kind != SuicideKind.Special && damageableComponent != null)
+            if (kind != SuicideKind.Special)
             {
                 damageableComponent.TakeDamage(kind switch
                 {
@@ -115,12 +118,12 @@ namespace Content.Server.Chat
 
             var chat = IoCManager.Resolve<IChatManager>();
             var owner = player.ContentData().Mind.OwnedMob.Owner;
-            owner.TryGetComponent<DamageableComponent>(out var dmgComponent);
+            var dmgComponent = owner.GetComponent<DamageableComponent>();
             //TODO: needs to check if the mob is actually alive
             //TODO: maybe set a suicided flag to prevent ressurection?
 
             // Held item suicide
-            owner.TryGetComponent<HandsComponent>(out var handsComponent);
+            var handsComponent = owner.GetComponent<HandsComponent>();
             var itemComponent = handsComponent.GetActiveHand;
             if (itemComponent != null)
             {
@@ -148,11 +151,8 @@ namespace Content.Server.Chat
                 }
             }
             // Default suicide, bite your tongue
-            if (dmgComponent != null)
-            {
-                chat.EntityMe(owner, Loc.GetString("is attempting to bite {0:their} own tongue, looks like {0:theyre} trying to commit suicide!", owner)); //TODO: theyre macro
-                dmgComponent.TakeDamage(DamageType.Brute, 500, owner, owner); //TODO: dmg value needs to be a max damage of some sorts
-            }
+            chat.EntityMe(owner, Loc.GetString("is attempting to bite {0:their} own tongue, looks like {0:theyre} trying to commit suicide!", owner)); //TODO: theyre macro
+            dmgComponent.TakeDamage(DamageType.Brute, 500, owner, owner); //TODO: dmg value needs to be a max damage of some sorts
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -1,10 +1,14 @@
 ﻿using System;
+using System.Runtime.Remoting;
 using Content.Server.GameObjects.Components.Chemistry;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Server.Interfaces;
+using Content.Server.Interfaces.Chat;
+using Content.Server.Interfaces.GameObjects;
 using Content.Shared.Chemistry;
 using Content.Shared.GameObjects;
 using Content.Shared.GameObjects.Components.Interactable;
+using Content.Shared.Interfaces;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
@@ -18,7 +22,7 @@ namespace Content.Server.GameObjects.Components.Interactable
 {
     [RegisterComponent]
     [ComponentReference(typeof(ToolComponent))]
-    public class WelderComponent : ToolComponent, IExamine, IUse
+    public class WelderComponent : ToolComponent, IExamine, IUse, ISuicideAct
     {
 #pragma warning disable 649
         [Dependency] private IEntitySystemManager _entitySystemManager;
@@ -92,17 +96,18 @@ namespace Content.Server.GameObjects.Components.Interactable
             return base.UseTool(user, target, toolQualityNeeded) && TryWeld(fuelConsumed, user);
         }
 
-        private bool TryWeld(float value, IEntity user = null)
+        private bool TryWeld(float value, IEntity user = null, bool silent = false)
         {
             if (!WelderLit)
             {
-                _notifyManager.PopupMessage(Owner, user, Loc.GetString("The welder is turned off!"));
+                if(!silent) _notifyManager.PopupMessage(Owner, user, Loc.GetString("The welder is turned off!"));
                 return false;
             }
 
             if (!CanWeld(value))
             {
-                _notifyManager.PopupMessage(Owner, user, Loc.GetString("The welder does not have enough fuel for that!"));
+                if(!silent) _notifyManager.PopupMessage(Owner, user, Loc.GetString("The welder does not have enough fuel for that!"));
+                return false;
             }
 
             if (_solutionComponent == null)
@@ -184,6 +189,18 @@ namespace Content.Server.GameObjects.Components.Interactable
                 ToggleWelderStatus();
 
             Dirty();
+        }
+
+        public SuicideKind Suicide(IEntity victim, IChatManager chat)
+        {
+            if (TryWeld(5, victim, silent: true))
+            {
+                PlaySoundCollection("Welder", -5);
+                chat.EntityMe(victim, Loc.GetString("welds {0:their} every orifice closed! It looks like {0:theyre} trying to commit suicide!", victim)); //TODO: theyre macro
+                return SuicideKind.Heat;
+            }
+            chat.EntityMe(victim, Loc.GetString("bashes {0:themselves} with the {1}!", victim, Owner.Name));
+            return SuicideKind.Brute;
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Kitchen/KitchenMicrowaveComponent.cs
+++ b/Content.Server/GameObjects/Components/Kitchen/KitchenMicrowaveComponent.cs
@@ -409,20 +409,18 @@ namespace Content.Server.GameObjects.Components.Kitchen
 
         public SuicideKind Suicide(IEntity victim, IChatManager chat)
         {
-            victim.TryGetComponent<BodyManagerComponent>(out var bodyManagerComponent);
-            if (bodyManagerComponent != null)
+            int headCount = 0;
+            if (victim.TryGetComponent<BodyManagerComponent>(out var bodyManagerComponent))
             {
                 var heads = bodyManagerComponent.GetBodyPartsOfType(BodyPartType.Head);
                 foreach (var head in heads)
                 {
                     var droppedHead = bodyManagerComponent.DisconnectBodyPart(head, true);
-                    _storage.Insert(droppedHead);   
+                    _storage.Insert(droppedHead);
+                    headCount++;
                 }
-                chat.EntityMe(victim, Loc.GetString("is trying to cook {0:their} " + (heads.Count() > 1 ? "heads!": "head!"), victim));
-            } else
-            {
-                chat.EntityMe(victim, Loc.GetString("is trying to cook {0:their} head!", victim));
             }
+            chat.EntityMe(victim, Loc.GetPluralString("is trying to cook {0:their} head!", "is trying to cook {0:their} heads!", headCount, victim));
             _currentCookTimerTime = 10;
             ClickSound();
             UpdateUserInterface();

--- a/Content.Server/Health/BodySystem/BodyManagerComponent.cs
+++ b/Content.Server/Health/BodySystem/BodyManagerComponent.cs
@@ -189,8 +189,9 @@ namespace Content.Server.BodySystem {
         }
 
         /// <summary>
-        ///     Disconnects the given BodyPart reference, potentially dropping other BodyParts if they were hanging off it. 
+        /// Disconnects the given BodyPart reference, potentially dropping other BodyParts if they were hanging off it. 
         /// </summary>
+        /// <returns>Returns the dropped entity, or null if no part is dropped</returns>
         public IEntity DisconnectBodyPart(BodyPart part, bool dropEntity)
         {
             if (!_partDictionary.ContainsValue(part))

--- a/Content.Server/Health/BodySystem/BodyManagerComponent.cs
+++ b/Content.Server/Health/BodySystem/BodyManagerComponent.cs
@@ -191,10 +191,10 @@ namespace Content.Server.BodySystem {
         /// <summary>
         ///     Disconnects the given BodyPart reference, potentially dropping other BodyParts if they were hanging off it. 
         /// </summary>
-        public void DisconnectBodyPart(BodyPart part, bool dropEntity)
+        public IEntity DisconnectBodyPart(BodyPart part, bool dropEntity)
         {
             if (!_partDictionary.ContainsValue(part))
-                return;
+                return null;
             if (part != null)
             {
                 string slotName = _partDictionary.FirstOrDefault(x => x.Value == part).Key;
@@ -213,8 +213,10 @@ namespace Content.Server.BodySystem {
                 {
                     var partEntity = Owner.EntityManager.SpawnEntity("BaseDroppedBodyPart", Owner.Transform.GridPosition);
                     partEntity.GetComponent<DroppedBodyPartComponent>().TransferBodyPartData(part);
+                    return partEntity;
                 }
             }
+            return null;
         }
 
         /// <summary>

--- a/Content.Server/Interfaces/GameObjects/ISuicideAct.cs
+++ b/Content.Server/Interfaces/GameObjects/ISuicideAct.cs
@@ -1,0 +1,26 @@
+﻿using Content.Server.Interfaces.Chat;
+using Robust.Shared.Interfaces.GameObjects;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Content.Server.Interfaces.GameObjects
+{
+    public interface ISuicideAct
+    {
+        public SuicideKind Suicide(IEntity victim, IChatManager chat);
+    }
+
+    public enum SuicideKind
+    {
+        Special, //Doesn't damage the mob, used for "weird" suicides like gibbing
+
+        //Damage type suicides
+        Brute,
+        Heat,
+        Cold,
+        Acid,
+        Toxic,
+        Electric
+    }
+}

--- a/Resources/Groups/groups.yml
+++ b/Resources/Groups/groups.yml
@@ -12,6 +12,7 @@
   - observe
   - toggleready
   - ghost
+  - suicide
 
 - Index: 50
   Name: Moderator
@@ -28,6 +29,7 @@
   - observe
   - toggleready
   - ghost
+  - suicide
   - kick
   - listplayers
   - loc
@@ -47,6 +49,7 @@
   - observe
   - toggleready
   - ghost
+  - suicide
   - spawn
   - delete
   - tp
@@ -89,6 +92,7 @@
   - observe
   - toggleready
   - ghost
+  - suicide
   - spawn
   - delete
   - tp


### PR DESCRIPTION
Closes #948
PR Co-Developed with @RemieRichards 
With the PR, you can now type `/suicide` in chat, which will let the player suicide. This will allow for the usual held item suicides, but also environmental suicides, and if all fails it will default to a "attempts to bite their own tongue" message.

Two suicides were added, one being the Welding Tool and the other being the microwave.