### PR TITLE
Fix laser collision logic wrt transparent entities

### DIFF
--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Hitscan/HitscanWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Hitscan/HitscanWeaponComponent.cs
@@ -93,10 +93,11 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Hitscan
             var userPosition = user.Transform.WorldPosition; //Remember world positions are ephemeral and can only be used instantaneously
             var angle = new Angle(clickLocation.Position - userPosition);
 
-            var ray = new CollisionRay(userPosition, angle.ToVec(), (int)(CollisionGroup.Impassable | CollisionGroup.MobImpassable));
-            var rayCastResults = IoCManager.Resolve<IPhysicsManager>().IntersectRay(user.Transform.MapID, ray, MaxLength, user).ToList();
+            var ray = new CollisionRay(userPosition, angle.ToVec(), (int)(CollisionGroup.Opaque));
+            var rayCastResults = IoCManager.Resolve<IPhysicsManager>().IntersectRay(user.Transform.MapID, ray, MaxLength, user, returnOnFirstHit: false).ToList();
 
-            if (rayCastResults.Count == 1)
+            //The first result is guaranteed to be the closest one
+            if (rayCastResults.Count >= 1)
             {
                 Hit(rayCastResults[0], energyModifier, user);
                 AfterEffects(user, rayCastResults[0], angle, energyModifier);

--- a/Resources/Prototypes/Entities/Mobs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/human.yml
@@ -109,6 +109,7 @@
       - VaultImpassable
       - SmallImpassable
       layer:
+      - Opaque
       - MobImpassable
   - type: Input
     context: "human"


### PR DESCRIPTION
Laser weapons now collide using Opaque, rather than Impassable | MobImpassable. This means they correctly go through windows and over tables.

Laser weapons now get all collisions along their path to ensure they stop at the closest one. This fixes space-wizards#1014, which was caused by the first collision not necessarily being the closest one.

Humans are now Opaque, both because they should be and because otherwise they cannot be shot with lasers.

Fixes #1014.