### PR TITLE
IExamine can now limit certain details behind a 'details' range check.

### DIFF
--- a/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -288,18 +288,18 @@ namespace Content.Server.GameObjects.Components.Chemistry
                     else
                     {
                         //This is trash but it shows the general idea 
-                        var colour = proto.SubstanceColor;
-                        var colourIsh = "Red";
-                        if (colour.G > colour.R)
+                        var color = proto.SubstanceColor;
+                        var colorIsh = "Red";
+                        if (color.G > color.R)
                         {
-                            colourIsh = "Green";
+                            colorIsh = "Green";
                         }
-                        if (colour.B > colour.G || colour.B > colour.R)
+                        if (color.B > color.G && color.B > color.R)
                         {
-                            colourIsh = "Blue";
+                            colorIsh = "Blue";
                         }
 
-                        message.AddText(_loc.GetString("A {0} liquid\n", colourIsh));
+                        message.AddText(_loc.GetString("A {0} liquid\n", colorIsh));
                     }
                 }
                 else

--- a/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/SolutionComponent.cs
@@ -265,7 +265,7 @@ namespace Content.Server.GameObjects.Components.Chemistry
             }
         }
 
-        void IExamine.Examine(FormattedMessage message)
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
             if (NoExamine)
             {
@@ -281,7 +281,26 @@ namespace Content.Server.GameObjects.Components.Chemistry
             {
                 if (_prototypeManager.TryIndex(reagent.ReagentId, out ReagentPrototype proto))
                 {
-                    message.AddText($"{proto.Name}: {reagent.Quantity}u\n");
+                    if (inDetailsRange)
+                    {
+                        message.AddText($"{proto.Name}: {reagent.Quantity}u\n");
+                    }
+                    else
+                    {
+                        //This is trash but it shows the general idea 
+                        var colour = proto.SubstanceColor;
+                        var colourIsh = "Red";
+                        if (colour.G > colour.R)
+                        {
+                            colourIsh = "Green";
+                        }
+                        if (colour.B > colour.G || colour.B > colour.R)
+                        {
+                            colourIsh = "Blue";
+                        }
+
+                        message.AddText(_loc.GetString("A {0} liquid\n", colourIsh));
+                    }
                 }
                 else
                 {

--- a/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
@@ -76,7 +76,7 @@ namespace Content.Server.GameObjects.Components.Interactable
             return true;
         }
 
-        void IExamine.Examine(FormattedMessage message)
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
             var loc = IoCManager.Resolve<ILocalizationManager>();
 

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -163,7 +163,7 @@ namespace Content.Server.GameObjects.Components.Interactable
             return ToggleWelderStatus(eventArgs.User);
         }
 
-        public void Examine(FormattedMessage message)
+        public void Examine(FormattedMessage message, bool inDetailsRange)
         {
             if (WelderLit)
             {
@@ -174,8 +174,11 @@ namespace Content.Server.GameObjects.Components.Interactable
                 message.AddText(Loc.GetString("Not lit\n"));
             }
 
-            message.AddMarkup(Loc.GetString("Fuel: [color={0}]{1}/{2}[/color].",
-                Fuel < FuelCapacity / 4f ? "darkorange" : "orange", Math.Round(Fuel), FuelCapacity));
+            if (inDetailsRange)
+            {
+                message.AddMarkup(Loc.GetString("Fuel: [color={0}]{1}/{2}[/color].",
+                    Fuel < FuelCapacity / 4f ? "darkorange" : "orange", Math.Round(Fuel), FuelCapacity));
+            }
         }
 
         public void OnUpdate(float frameTime)

--- a/Content.Server/GameObjects/Components/Items/DiceComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/DiceComponent.cs
@@ -1,4 +1,4 @@
-using Content.Server.GameObjects.Components.Sound;
+﻿using Content.Server.GameObjects.Components.Sound;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Server.Utility;
 using Content.Shared.Audio;
@@ -81,8 +81,9 @@ namespace Content.Server.GameObjects.Components.Items
             Roll();
         }
 
-        void IExamine.Examine(FormattedMessage message)
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
+            //No details check, since the sprite updates to show the side.
             var loc = IoCManager.Resolve<ILocalizationManager>();
             message.AddMarkup(loc.GetString("A dice with [color=lightgray]{0}[/color] sides.\n" +
                                             "It has landed on a [color=white]{1}[/color].", _sides, _currentSide));

--- a/Content.Server/GameObjects/Components/Markers/WarpPointComponent.cs
+++ b/Content.Server/GameObjects/Components/Markers/WarpPointComponent.cs
@@ -1,4 +1,4 @@
-using Content.Server.GameObjects.EntitySystems;
+﻿using Content.Server.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 using Robust.Shared.Serialization;
@@ -21,7 +21,7 @@ namespace Content.Server.GameObjects.Components.Markers
             serializer.DataField(this, x => x.Location, "location", null);
         }
 
-        public void Examine(FormattedMessage message)
+        public void Examine(FormattedMessage message, bool inDetailsRange)
         {
             var loc = Location == null ? "<null>" : $"'{Location}'";
             message.AddText(Loc.GetString("This one's location ID is {0}", loc));

--- a/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
@@ -114,9 +114,9 @@ namespace Content.Server.GameObjects.Components.Mobs
             serializer.DataField(ref _showExamineInfo, "show_examine_info", false);
         }
 
-        public void Examine(FormattedMessage message)
+        public void Examine(FormattedMessage message, bool inDetailsRange)
         {
-            if (!ShowExamineInfo)
+            if (!ShowExamineInfo || !inDetailsRange)
                 return;
 
             var dead = false;

--- a/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Content.Server.GameObjects.Components.Chemistry;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.Audio;
@@ -108,9 +108,9 @@ namespace Content.Server.GameObjects.Components.Nutrition
             TryUseDrink(eventArgs.Target);
         }
 
-        public void Examine(FormattedMessage message)
+        public void Examine(FormattedMessage message, bool inDetailsRange)
         {
-            if (!Opened)
+            if (!Opened || !inDetailsRange)
             {
                 return;
             }

--- a/Content.Server/GameObjects/Components/Paper/PaperComponent.cs
+++ b/Content.Server/GameObjects/Components/Paper/PaperComponent.cs
@@ -32,8 +32,11 @@ namespace Content.Server.GameObjects.Components.Interactable
             _userInterface.SetState(new PaperBoundUserInterfaceState(_content, _mode));
         }
 
-        public void Examine(FormattedMessage message)
+        public void Examine(FormattedMessage message, bool inDetailsRange)
         {
+            if (!inDetailsRange)
+                return;
+
             message.AddMarkup(_content);
         }
 

--- a/Content.Server/GameObjects/Components/Power/PowerDevice.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerDevice.cs
@@ -221,11 +221,11 @@ namespace Content.Server.GameObjects.Components.Power
             }
         }
 
-        void IExamine.Examine(FormattedMessage message)
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
             var loc = IoCManager.Resolve<ILocalizationManager>();
 
-            if (!Powered)
+            if (!Powered && inDetailsRange)
             {
                 message.AddMarkup(loc.GetString("The device is [color=orange]not powered[/color]."));
             }

--- a/Content.Server/GameObjects/Components/Power/PowerStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerStorageComponent.cs
@@ -166,7 +166,7 @@ namespace Content.Server.GameObjects.Components.Power
         }
 
         /// <inheritdoc />
-        public void Examine(FormattedMessage message)
+        public void Examine(FormattedMessage message, bool inDetailsRange)
         {
             var loc = IoCManager.Resolve<ILocalizationManager>();
 

--- a/Content.Server/GameObjects/Components/Stack/StackComponent.cs
+++ b/Content.Server/GameObjects/Components/Stack/StackComponent.cs
@@ -110,12 +110,15 @@ namespace Content.Server.GameObjects.Components.Stack
             return false;
         }
 
-        void IExamine.Examine(FormattedMessage message)
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
-            var loc = IoCManager.Resolve<ILocalizationManager>();
-            message.AddMarkup(loc.GetPluralString(
-                "There is [color=lightgray]1[/color] thing in the stack",
-                "There are [color=lightgray]{0}[/color] things in the stack.", Count, Count));
+            if (inDetailsRange)
+            {
+                var loc = IoCManager.Resolve<ILocalizationManager>();
+                message.AddMarkup(loc.GetPluralString(
+                    "There is [color=lightgray]1[/color] thing in the stack",
+                    "There are [color=lightgray]{0}[/color] things in the stack.", Count, Count));
+            }
         }
     }
 }

--- a/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
@@ -139,7 +139,7 @@ namespace Content.Server.GameObjects.Components.VendingMachines
             }
         }
 
-        public void Examine(FormattedMessage message)
+        public void Examine(FormattedMessage message, bool inDetailsRange)
         {
             if(_description == null) { return; }
             message.AddText(_description);

--- a/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
@@ -226,7 +226,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
             _entitySystemManager.GetEntitySystem<AudioSystem>().Play("/Audio/items/weapons/pistol_magout.ogg", Owner.Transform.GridPosition, AudioHelpers.WithVariation(0.25f));
         }
 
-        public void Examine(FormattedMessage message)
+        public void Examine(FormattedMessage message, bool inDetailsRange)
         {
             var loc = IoCManager.Resolve<ILocalizationManager>();
 

--- a/Content.Server/GameObjects/Components/WiresComponent.cs
+++ b/Content.Server/GameObjects/Components/WiresComponent.cs
@@ -481,9 +481,6 @@ namespace Content.Server.GameObjects.Components
 
         void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
-            if (!inDetailsRange)
-                return;
-
             var loc = IoCManager.Resolve<ILocalizationManager>();
 
             message.AddMarkup(loc.GetString(IsPanelOpen

--- a/Content.Server/GameObjects/Components/WiresComponent.cs
+++ b/Content.Server/GameObjects/Components/WiresComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Server.GameObjects.Components.Interactable;
@@ -479,8 +479,11 @@ namespace Content.Server.GameObjects.Components
             return true;
         }
 
-        void IExamine.Examine(FormattedMessage message)
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
+            if (!inDetailsRange)
+                return;
+
             var loc = IoCManager.Resolve<ILocalizationManager>();
 
             message.AddMarkup(loc.GetString(IsPanelOpen


### PR DESCRIPTION
## Premise:
Certain details should logically only be shown at certain distance, with either no info or lesser info (see SolutionComponent's example in this PR) being displayed otherwise.

**Note:**
I'd like feedback on the distance (it's 3 atm), I think that's fine but could maybe go up to 4 or even 5 and have it still "make sense" while being fairer to the examiner.