### PR TITLE
_necessaryTag null check for accessReaders #1038 fix

### DIFF
--- a/Content.Server/GameObjects/Components/Access/AccessReaderComponent.cs
+++ b/Content.Server/GameObjects/Components/Access/AccessReaderComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Content.Server.Interfaces;
 using Content.Server.Interfaces.GameObjects;
@@ -41,6 +41,12 @@ namespace Content.Server.GameObjects.Components.Access
                     return true;
                 }
             }
+
+            if (_necessaryTags.Count == 0) // If the list doesn't exist, or exists and only has [""], then deny access. Otherwise door would permitt access to all.
+            {
+                return false;
+            }
+
             foreach (var necessary in _necessaryTags)
             {
                 if (!accessTags.Contains(necessary))


### PR DESCRIPTION
If an airlock_access.yml (or really anything else that checks for access levels) had an empty `necessary:` component line entirely, or an empty `necessary: [""]` it would return true, therefore giving all levels access through the door.

This is basically a check to see if it's null and if it is, return false before it loops through the necessaryTag for each.

AKA a check in case someone forgets to add a line to a .yml, it doesn't break.