### PR TITLE
Adds damage on tool interaction component (#1060)

### DIFF
--- a/Content.Server/GameObjects/Components/Damage/DamageOnToolInteractComponent.cs
+++ b/Content.Server/GameObjects/Components/Damage/DamageOnToolInteractComponent.cs
@@ -1,0 +1,82 @@
+﻿using Content.Server.GameObjects.Components.Interactable;
+using Content.Server.GameObjects.EntitySystems;
+using Content.Shared.GameObjects.Components.Interactable;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Systems;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Log;
+using Robust.Shared.Serialization;
+using System;
+using System.Collections.Generic;
+
+namespace Content.Server.GameObjects.Components.Damage
+{
+    [RegisterComponent]
+    class DamageOnToolInteractComponent : Component, IInteractUsing
+    {
+        public override string Name => "DamageOnToolInteract";
+
+        /* Set in YAML */
+        protected int Damage;
+        private List<ToolQuality> _tools = new List<ToolQuality>();
+
+        public override void ExposeData(ObjectSerializer serializer)
+        {
+            base.ExposeData(serializer);
+
+            serializer.DataField(ref Damage, "damage", 0);
+
+            serializer.DataReadFunction("tools", new List<string>(0), parsedtools =>
+            {
+                foreach (string tool in parsedtools)
+                {
+                    _tools.Add((ToolQuality) Enum.Parse(typeof(ToolQuality), tool));
+                }
+            });
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            Owner.EnsureComponent<DamageableComponent>();
+        }
+
+        public bool InteractUsing(InteractUsingEventArgs eventArgs)
+        {
+            bool result = false; //assumes interaction can only be with one tool at one time.
+
+            if (eventArgs.Using.TryGetComponent<ToolComponent>(out var tool))
+                if (tool.HasQuality(ToolQuality.Welding))
+                {
+                    if (eventArgs.Using.TryGetComponent<WelderComponent>(out WelderComponent welder))
+                    {
+                        if (welder.WelderLit) return CallDamage(eventArgs);
+                    }
+
+                    //Should I add some error checking here for TryGet?
+                }
+            foreach (var toolQuality in _tools)
+            {
+                if (tool.HasQuality(toolQuality))
+                {
+                    result = CallDamage(eventArgs);
+                }
+
+                if (result is true) return true; //Should Break when return called automatically.
+            }             
+
+            return result;
+        }
+
+        protected bool CallDamage(InteractUsingEventArgs eventArgs)
+        {
+            if (eventArgs.Target.TryGetComponent<DamageableComponent>(out var damageable))
+            {
+                damageable.TakeDamage(Shared.GameObjects.DamageType.Heat, Damage, eventArgs.Using, eventArgs.User);
+                return true;
+            }
+                return false;
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Buildings/Storage/StorageTanks/fuel_tank.yml
+++ b/Resources/Prototypes/Entities/Buildings/Storage/StorageTanks/fuel_tank.yml
@@ -18,3 +18,8 @@
       reagents:
       - ReagentId: chem.WeldingFuel
         Quantity: 1500
+  - type: DamageOnToolInteract
+    damage: 200
+    tools:
+    - Welding
+


### PR DESCRIPTION
#### Goal:
Addressing #1060. Make the fuel tank explode if ignited with a welding tool.

#### Implementation: 
```
Created a new component -> DamageOnToolInteract.
When interacted with tool checks to see if interacted with a valid tool:
yes -> check for damageable component
    yes -> apply damage using takedamage function.
    no -> check if damage exceeds 0:
        yes -> call HandleDestruction system on Owner. (fallback)

```
#### Result:
fuel tank explodes if ignited with a welding tool. You can still fuel welder if the welder is turned off.

![Welder Blowup Fuel Tank when lit](https://user-images.githubusercontent.com/15194163/83944930-088a4580-a7ff-11ea-954c-f85e83b120c8.gif)

#### Supports:
- [x] All Tools supported
- [x] Multiple Tools causing damage to one entity

#### Why this method?
the component system isn’t designed for a single use case solutions. It is designed to be reused. Instead of creating a component with specific implementation in mind I created a more flexible component that adds damage when interacted with a tool and then lets other components handle events relating to that damage, such as an explosion on death.
