### PR TITLE
Re-adds ISuicideAct to microwave

### DIFF
--- a/Content.Server/GameObjects/Components/Kitchen/MicrowaveComponent.cs
+++ b/Content.Server/GameObjects/Components/Kitchen/MicrowaveComponent.cs
@@ -31,7 +31,7 @@ namespace Content.Server.GameObjects.Components.Kitchen
 {
     [RegisterComponent]
     [ComponentReference(typeof(IActivate))]
-    public class MicrowaveComponent : SharedMicrowaveComponent, IActivate, IInteractUsing, ISolutionChange
+    public class MicrowaveComponent : SharedMicrowaveComponent, IActivate, IInteractUsing, ISolutionChange, ISuicideAct
     {
 #pragma warning disable 649
         [Dependency] private readonly IEntityManager _entityManager;


### PR DESCRIPTION
The interface was accidently removed with the microwave refactor. This just re-adds the interface to the class, as the implementation is already there.