### PR TITLE
Virtualize all NetIDs to reduce network traffic

### DIFF
--- a/Content.Shared/GameObjects/Components/Cargo/SharedCargoOrderDatabaseComponent.cs
+++ b/Content.Shared/GameObjects/Components/Cargo/SharedCargoOrderDatabaseComponent.cs
@@ -16,7 +16,9 @@ namespace Content.Shared.GameObjects.Components.Cargo
     public class CargoOrderDatabaseState : ComponentState
     {
         public readonly List<CargoOrderData> Orders;
-        public CargoOrderDatabaseState(List<CargoOrderData> orders) : base(ContentNetIDs.CARGO_ORDER_DATABASE)
+        public override uint NetID => ContentNetIDs.CARGO_ORDER_DATABASE;
+
+        public CargoOrderDatabaseState(List<CargoOrderData> orders)
         {
             Orders = orders;
         }

--- a/Content.Shared/GameObjects/Components/Cargo/SharedGalacticMarketComponent.cs
+++ b/Content.Shared/GameObjects/Components/Cargo/SharedGalacticMarketComponent.cs
@@ -88,7 +88,9 @@ namespace Content.Shared.GameObjects.Components.Cargo
     public class GalacticMarketState : ComponentState
     {
         public List<string> Products;
-        public GalacticMarketState(List<string> technologies) : base(ContentNetIDs.GALACTIC_MARKET)
+        public override uint NetID => ContentNetIDs.GALACTIC_MARKET;
+
+        public GalacticMarketState(List<string> technologies)
         {
             Products = technologies;
         }

--- a/Content.Shared/GameObjects/Components/Chemistry/SharedInjectorComponent.cs
+++ b/Content.Shared/GameObjects/Components/Chemistry/SharedInjectorComponent.cs
@@ -22,8 +22,9 @@ namespace Content.Shared.GameObjects.Components.Chemistry
             public ReagentUnit CurrentVolume { get; }
             public ReagentUnit TotalVolume { get; }
             public InjectorToggleMode CurrentMode { get; }
+            public override uint NetID => ContentNetIDs.REAGENT_INJECTOR;
 
-            public InjectorComponentState(ReagentUnit currentVolume, ReagentUnit totalVolume, InjectorToggleMode currentMode) : base(ContentNetIDs.REAGENT_INJECTOR)
+            public InjectorComponentState(ReagentUnit currentVolume, ReagentUnit totalVolume, InjectorToggleMode currentMode)
             {
                 CurrentVolume = currentVolume;
                 TotalVolume = totalVolume;

--- a/Content.Shared/GameObjects/Components/Chemistry/SharedSolutionComponent.cs
+++ b/Content.Shared/GameObjects/Components/Chemistry/SharedSolutionComponent.cs
@@ -22,7 +22,7 @@ namespace Content.Shared.GameObjects.Components.Chemistry
         {
             public override uint NetID => ContentNetIDs.SOLUTION;
 
-        public SolutionComponentState() { }
+            public SolutionComponentState() { }
         }
 
         /// <inheritdoc />

--- a/Content.Shared/GameObjects/Components/Chemistry/SharedSolutionComponent.cs
+++ b/Content.Shared/GameObjects/Components/Chemistry/SharedSolutionComponent.cs
@@ -20,7 +20,9 @@ namespace Content.Shared.GameObjects.Components.Chemistry
         [Serializable, NetSerializable]
         public class SolutionComponentState : ComponentState
         {
-            public SolutionComponentState() : base(ContentNetIDs.SOLUTION) { }
+            public override uint NetID => ContentNetIDs.SOLUTION;
+
+        public SolutionComponentState() { }
         }
 
         /// <inheritdoc />

--- a/Content.Shared/GameObjects/Components/Damage/DamageableComponent.cs
+++ b/Content.Shared/GameObjects/Components/Damage/DamageableComponent.cs
@@ -16,8 +16,9 @@ namespace Content.Shared.GameObjects
     public class DamageComponentState : ComponentState
     {
         public Dictionary<DamageType, int> CurrentDamage = new Dictionary<DamageType, int>();
+        public override uint NetID => ContentNetIDs.DAMAGEABLE;
 
-        public DamageComponentState(Dictionary<DamageType, int> damage) : base(ContentNetIDs.DAMAGEABLE)
+        public DamageComponentState(Dictionary<DamageType, int> damage)
         {
             CurrentDamage = damage;
         }

--- a/Content.Shared/GameObjects/Components/Instruments/SharedInstrumentComponent.cs
+++ b/Content.Shared/GameObjects/Components/Instruments/SharedInstrumentComponent.cs
@@ -59,8 +59,9 @@ namespace Content.Shared.GameObjects.Components.Instruments
     public class InstrumentState : ComponentState
     {
         public bool Playing { get; }
+        public override uint NetID => ContentNetIDs.INSTRUMENTS;
 
-        public InstrumentState(bool playing, uint sequencerTick = 0) : base(ContentNetIDs.INSTRUMENTS)
+        public InstrumentState(bool playing, uint sequencerTick = 0)
         {
             Playing = playing;
         }

--- a/Content.Shared/GameObjects/Components/Interactable/SharedToolComponent.cs
+++ b/Content.Shared/GameObjects/Components/Interactable/SharedToolComponent.cs
@@ -27,8 +27,9 @@ namespace Content.Shared.GameObjects.Components.Interactable
     public class MultiToolComponentState : ComponentState
     {
         public ToolQuality Quality { get; }
+        public override uint NetID => ContentNetIDs.MULTITOOLS;
 
-        public MultiToolComponentState(ToolQuality quality) : base(ContentNetIDs.MULTITOOLS)
+        public MultiToolComponentState(ToolQuality quality)
         {
             Quality = quality;
         }
@@ -41,8 +42,9 @@ namespace Content.Shared.GameObjects.Components.Interactable
         public float Fuel { get; }
         public bool Activated { get; }
         public ToolQuality Quality { get; }
+        public override uint NetID => ContentNetIDs.WELDER;
 
-        public WelderComponentState(float fuelCapacity, float fuel, bool activated) : base(ContentNetIDs.WELDER)
+        public WelderComponentState(float fuelCapacity, float fuel, bool activated)
         {
             FuelCapacity = fuelCapacity;
             Fuel = fuel;

--- a/Content.Shared/GameObjects/Components/Inventory/SharedInventoryComponent.cs
+++ b/Content.Shared/GameObjects/Components/Inventory/SharedInventoryComponent.cs
@@ -51,8 +51,9 @@ namespace Content.Shared.GameObjects
         protected class InventoryComponentState : ComponentState
         {
             public List<KeyValuePair<Slots, EntityUid>> Entities { get; }
+            public override uint NetID => ContentNetIDs.STORAGE;
 
-            public InventoryComponentState(List<KeyValuePair<Slots, EntityUid>> entities) : base(ContentNetIDs.STORAGE)
+            public InventoryComponentState(List<KeyValuePair<Slots, EntityUid>> entities)
             {
                 Entities = entities;
             }

--- a/Content.Shared/GameObjects/Components/Items/ClothingComponentState.cs
+++ b/Content.Shared/GameObjects/Components/Items/ClothingComponentState.cs
@@ -7,8 +7,9 @@ namespace Content.Shared.GameObjects.Components.Items
     public class ClothingComponentState : ItemComponentState
     {
         public string ClothingEquippedPrefix { get; set; }
+        public override uint NetID => ContentNetIDs.CLOTHING;
 
-        public ClothingComponentState(string clothingEquippedPrefix, string equippedPrefix) : base(equippedPrefix, ContentNetIDs.CLOTHING)
+        public ClothingComponentState(string clothingEquippedPrefix, string equippedPrefix) : base(equippedPrefix)
         {
             ClothingEquippedPrefix = clothingEquippedPrefix;
         }

--- a/Content.Shared/GameObjects/Components/Items/ItemComponentState.cs
+++ b/Content.Shared/GameObjects/Components/Items/ItemComponentState.cs
@@ -8,15 +8,12 @@ namespace Content.Shared.GameObjects.Components.Items
     public class ItemComponentState : ComponentState
     {
         public string EquippedPrefix { get; set; }
+        public override uint NetID => ContentNetIDs.ITEM;
 
-        public ItemComponentState(string equippedPrefix) : base(ContentNetIDs.ITEM)
+        public ItemComponentState(string equippedPrefix)
         {
             EquippedPrefix = equippedPrefix;
         }
 
-        protected ItemComponentState(string equippedPrefix, uint netId) : base(netId)
-        {
-            EquippedPrefix = equippedPrefix;
-        }
     }
 }

--- a/Content.Shared/GameObjects/Components/Items/ItemCooldownComponent.cs
+++ b/Content.Shared/GameObjects/Components/Items/ItemCooldownComponent.cs
@@ -74,8 +74,9 @@ namespace Content.Shared.GameObjects.Components.Items
         {
             public TimeSpan? CooldownStart { get; set; }
             public TimeSpan? CooldownEnd { get; set; }
+            public override uint NetID => ContentNetIDs.ITEMCOOLDOWN;
 
-            public ItemCooldownComponentState() : base(ContentNetIDs.ITEMCOOLDOWN)
+        public ItemCooldownComponentState()
             {
             }
         }

--- a/Content.Shared/GameObjects/Components/Items/SharedHandsComponent.cs
+++ b/Content.Shared/GameObjects/Components/Items/SharedHandsComponent.cs
@@ -17,8 +17,9 @@ namespace Content.Shared.GameObjects
     {
         public readonly Dictionary<string, EntityUid> Hands;
         public readonly string ActiveIndex;
+        public override uint NetID => ContentNetIDs.HANDS;
 
-        public HandsComponentState(Dictionary<string, EntityUid> hands, string activeIndex) : base(ContentNetIDs.HANDS)
+        public HandsComponentState(Dictionary<string, EntityUid> hands, string activeIndex)
         {
             Hands = hands;
             ActiveIndex = activeIndex;

--- a/Content.Shared/GameObjects/Components/Mobs/SharedCombatModeComponent.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/SharedCombatModeComponent.cs
@@ -57,9 +57,9 @@ namespace Content.Shared.GameObjects.Components.Mobs
         {
             public bool IsInCombatMode { get; }
             public TargetingZone TargetingZone { get; }
+            public override uint NetID => ContentNetIDs.COMBATMODE;
 
             public CombatModeComponentState(bool isInCombatMode, TargetingZone targetingZone)
-                : base(ContentNetIDs.COMBATMODE)
             {
                 IsInCombatMode = isInCombatMode;
                 TargetingZone = targetingZone;

--- a/Content.Shared/GameObjects/Components/Mobs/SharedHumanoidAppearanceComponent.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/SharedHumanoidAppearanceComponent.cs
@@ -69,7 +69,9 @@ namespace Content.Shared.GameObjects.Components.Mobs
         [NetSerializable]
         private sealed class HumanoidAppearanceComponentState : ComponentState
         {
-            public HumanoidAppearanceComponentState(HumanoidCharacterAppearance appearance, Sex sex) : base(ContentNetIDs.HUMANOID_APPEARANCE)
+            public override uint NetID => ContentNetIDs.HUMANOID_APPEARANCE;
+
+            public HumanoidAppearanceComponentState(HumanoidCharacterAppearance appearance, Sex sex)
             {
                 Appearance = appearance;
                 Sex = sex;

--- a/Content.Shared/GameObjects/Components/Mobs/SharedOverlayEffectsComponent.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/SharedOverlayEffectsComponent.cs
@@ -24,8 +24,9 @@ namespace Content.Shared.GameObjects.Components.Mobs
     public class OverlayEffectComponentState : ComponentState
     {
         public ScreenEffects ScreenEffect;
+        public override uint NetID => ContentNetIDs.OVERLAYEFFECTS;
 
-        public OverlayEffectComponentState(ScreenEffects screenEffect) : base(ContentNetIDs.OVERLAYEFFECTS)
+        public OverlayEffectComponentState(ScreenEffects screenEffect)
         {
             ScreenEffect = screenEffect;
         }

--- a/Content.Shared/GameObjects/Components/Mobs/SharedStatusEffectsComponent.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/SharedStatusEffectsComponent.cs
@@ -19,8 +19,9 @@ namespace Content.Shared.GameObjects.Components.Mobs
     public class StatusEffectComponentState : ComponentState
     {
         public Dictionary<StatusEffect, string> StatusEffects;
+        public override uint NetID => ContentNetIDs.STATUSEFFECTS;
 
-        public StatusEffectComponentState(Dictionary<StatusEffect, string> statusEffects) : base(ContentNetIDs.STATUSEFFECTS)
+        public StatusEffectComponentState(Dictionary<StatusEffect, string> statusEffects)
         {
             StatusEffects = statusEffects;
         }

--- a/Content.Shared/GameObjects/Components/Observer/SharedGhostComponent.cs
+++ b/Content.Shared/GameObjects/Components/Observer/SharedGhostComponent.cs
@@ -14,8 +14,9 @@ namespace Content.Shared.GameObjects.Components.Observer
     public class GhostComponentState : ComponentState
     {
         public bool CanReturnToBody { get; }
+        public override uint NetID => ContentNetIDs.GHOST;
 
-        public GhostComponentState(bool canReturnToBody) : base(ContentNetIDs.GHOST)
+        public GhostComponentState(bool canReturnToBody)
         {
             CanReturnToBody = canReturnToBody;
         }

--- a/Content.Shared/GameObjects/Components/PDA/SharedPDAComponent.cs
+++ b/Content.Shared/GameObjects/Components/PDA/SharedPDAComponent.cs
@@ -166,10 +166,11 @@ namespace Content.Shared.GameObjects.Components.PDA
         public UplinkCategory Category;
         public string Description;
         public string ListingName;
+        public override uint NetID => ContentNetIDs.PDA;
 
         public UplinkListingData(string listingName,string itemId,
             int price, UplinkCategory category,
-            string description) : base(ContentNetIDs.PDA)
+            string description)
         {
             ListingName = listingName;
             Price = price;

--- a/Content.Shared/GameObjects/Components/Research/SharedLatheDatabaseComponent.cs
+++ b/Content.Shared/GameObjects/Components/Research/SharedLatheDatabaseComponent.cs
@@ -117,7 +117,9 @@ namespace Content.Shared.GameObjects.Components.Research
     public class LatheDatabaseState : ComponentState
     {
         public readonly List<string> Recipes;
-        public LatheDatabaseState(List<string> recipes) : base(ContentNetIDs.LATHE_DATABASE)
+        public override uint NetID => ContentNetIDs.LATHE_DATABASE;
+
+        public LatheDatabaseState(List<string> recipes)
         {
             Recipes = recipes;
         }

--- a/Content.Shared/GameObjects/Components/Research/SharedMaterialStorageComponent.cs
+++ b/Content.Shared/GameObjects/Components/Research/SharedMaterialStorageComponent.cs
@@ -69,7 +69,9 @@ namespace Content.Shared.GameObjects.Components.Research
     public class MaterialStorageState : ComponentState
     {
         public readonly Dictionary<string, int> Storage;
-        public MaterialStorageState(Dictionary<string, int> storage) : base(ContentNetIDs.MATERIAL_STORAGE)
+        public override uint NetID => ContentNetIDs.MATERIAL_STORAGE;
+
+        public MaterialStorageState(Dictionary<string, int> storage)
         {
             Storage = storage;
         }

--- a/Content.Shared/GameObjects/Components/Research/SharedProtolatheDatabaseComponent.cs
+++ b/Content.Shared/GameObjects/Components/Research/SharedProtolatheDatabaseComponent.cs
@@ -63,7 +63,9 @@ namespace Content.Shared.GameObjects.Components.Research
     public class ProtolatheDatabaseState : ComponentState
     {
         public readonly List<string> Recipes;
-        public ProtolatheDatabaseState(List<string> recipes) : base(ContentNetIDs.PROTOLATHE_DATABASE)
+        public override uint NetID => ContentNetIDs.PROTOLATHE_DATABASE;
+
+        public ProtolatheDatabaseState(List<string> recipes)
         {
             Recipes = recipes;
         }

--- a/Content.Shared/GameObjects/Components/Research/SharedTechnologyDatabaseComponent.cs
+++ b/Content.Shared/GameObjects/Components/Research/SharedTechnologyDatabaseComponent.cs
@@ -104,12 +104,14 @@ namespace Content.Shared.GameObjects.Components.Research
     public class TechnologyDatabaseState : ComponentState
     {
         public List<string> Technologies;
-        public TechnologyDatabaseState(List<string> technologies) : base(ContentNetIDs.TECHNOLOGY_DATABASE)
+        public override uint NetID => ContentNetIDs.TECHNOLOGY_DATABASE;
+
+        public TechnologyDatabaseState(List<string> technologies)
         {
             Technologies = technologies;
         }
 
-        public TechnologyDatabaseState(List<TechnologyPrototype> technologies) : base(ContentNetIDs.TECHNOLOGY_DATABASE)
+        public TechnologyDatabaseState(List<TechnologyPrototype> technologies)
         {
             Technologies = new List<string>();
             foreach (var technology in technologies)

--- a/Content.Shared/GameObjects/Components/SharedHandheldLightComponent.cs
+++ b/Content.Shared/GameObjects/Components/SharedHandheldLightComponent.cs
@@ -12,7 +12,9 @@ namespace Content.Shared.GameObjects.Components
         [Serializable, NetSerializable]
         protected sealed class HandheldLightComponentState : ComponentState
         {
-            public HandheldLightComponentState(float? charge) : base(ContentNetIDs.HANDHELD_LIGHT)
+            public override uint NetID => ContentNetIDs.HANDHELD_LIGHT;
+
+            public HandheldLightComponentState(float? charge)
             {
                 Charge = charge;
             }

--- a/Content.Shared/GameObjects/Components/SharedStackComponent.cs
+++ b/Content.Shared/GameObjects/Components/SharedStackComponent.cs
@@ -107,8 +107,9 @@ namespace Content.Shared.GameObjects.Components
         {
             public int Count { get; }
             public int MaxCount { get; }
+            public override uint NetID => ContentNetIDs.STACK;
 
-            public StackComponentState(int count, int maxCount) : base(ContentNetIDs.STACK)
+            public StackComponentState(int count, int maxCount)
             {
                 Count = count;
                 MaxCount = maxCount;

--- a/Content.Shared/GameObjects/Components/Weapons/Ranged/BallisticMagazineWeaponComponentState.cs
+++ b/Content.Shared/GameObjects/Components/Weapons/Ranged/BallisticMagazineWeaponComponentState.cs
@@ -20,7 +20,9 @@ namespace Content.Shared.GameObjects.Components.Weapons.Ranged
         /// </remarks>
         public (int count, int max)? MagazineCount { get; }
 
-        public BallisticMagazineWeaponComponentState(bool chambered, (int count, int max)? magazineCount) : base(ContentNetIDs.BALLISTIC_MAGAZINE_WEAPON)
+        public override uint NetID => ContentNetIDs.BALLISTIC_MAGAZINE_WEAPON;
+
+        public BallisticMagazineWeaponComponentState(bool chambered, (int count, int max)? magazineCount)
         {
             Chambered = chambered;
             MagazineCount = magazineCount;

--- a/Content.Shared/Materials/Material.cs
+++ b/Content.Shared/Materials/Material.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Materials
     ///     Materials are read-only storage for the properties of specific materials.
     ///     Properties should be intrinsic (or at least as much is necessary for game purposes).
     /// </summary>
-public class Material : IExposeData
+    public class Material : IExposeData
     {
         public string Name => _name;
         private string _name = "unobtanium";


### PR DESCRIPTION
The serializer encodes the runtime type, so we can take advantage of it to reduce network usage