### PR TITLE
Can only remove item from storage inventory if active hand is free

### DIFF
--- a/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
@@ -288,12 +288,12 @@ namespace Content.Server.GameObjects
                         var entity = _entityManager.GetEntity(remove.EntityUid);
                         if (entity != null && storage.Contains(entity))
                         {
-                            Remove(entity);
 
                             var item = entity.GetComponent<ItemComponent>();
                             if (item != null && playerentity.TryGetComponent(out HandsComponent hands))
                             {
-                                if (hands.PutInHand(item))
+                                if (hands.CanPutInHand(item) && hands.PutInHand(item))
+                                    Remove(entity);
                                     return;
                             }
 

--- a/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/ServerStorageComponent.cs
@@ -292,9 +292,9 @@ namespace Content.Server.GameObjects
                             var item = entity.GetComponent<ItemComponent>();
                             if (item != null && playerentity.TryGetComponent(out HandsComponent hands))
                             {
-                                if (hands.CanPutInHand(item) && hands.PutInHand(item))
-                                    Remove(entity);
-                                    return;
+                                    if (hands.CanPutInHand(item) && hands.PutInHand(item))
+                                        //Remove(entity);
+                                        return;
                             }
 
                             entity.GetComponent<ITransformComponent>().WorldPosition = ourtransform.WorldPosition;


### PR DESCRIPTION
Instead of dropping things at the floor when your hand is full, now it simply doesn't allow you to pick up the object. Also I removed the Remove() command now since it was redundant. accidentally deleted the PR but it's back now yayyyy
Fixes #1061