### PR TITLE
Silence ScreenToWorld warnings

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/RangedWeaponSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/RangedWeaponSystem.cs
@@ -6,6 +6,7 @@ using Robust.Client.Interfaces.Input;
 using Robust.Client.Player;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Input;
+using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -18,6 +19,7 @@ namespace Content.Client.GameObjects.EntitySystems
 #pragma warning disable 649
         [Dependency] private readonly IPlayerManager _playerManager;
         [Dependency] private readonly IEyeManager _eyeManager;
+        [Dependency] private readonly IMapManager _mapManager;
         [Dependency] private readonly IInputManager _inputManager;
         [Dependency] private readonly IGameTiming _gameTiming;
 #pragma warning restore 649
@@ -74,11 +76,14 @@ namespace Content.Client.GameObjects.EntitySystems
                 return;
             }
 
-            var worldPos = _eyeManager.ScreenToWorld(_inputManager.MouseScreenPosition);
+            var worldPos = _eyeManager.ScreenToMap(_inputManager.MouseScreenPosition);
+
+            if (!_mapManager.TryFindGridAt(worldPos, out var grid))
+                grid = _mapManager.GetDefaultGrid(worldPos.MapId);
 
             if (weapon.Automatic || canFireSemi)
             {
-                weapon.SyncFirePos(worldPos);
+                weapon.SyncFirePos(grid.MapToGrid(worldPos));
             }
         }
     }

--- a/Content.Client/UserInterface/ItemSlotManager.cs
+++ b/Content.Client/UserInterface/ItemSlotManager.cs
@@ -15,6 +15,7 @@ using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Shared.Input;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -30,6 +31,7 @@ namespace Content.Client.UserInterface
         [Dependency] private readonly IInputManager _inputManager;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager;
         [Dependency] private readonly IEyeManager _eyeManager;
+        [Dependency] private readonly IMapManager _mapManager;
 #pragma warning restore 0649
 
         public bool SetItemSlot(ItemSlotButton button, IEntity entity)
@@ -71,9 +73,12 @@ namespace Content.Client.UserInterface
                 var func = args.Function;
                 var funcId = _inputManager.NetworkBindMap.KeyFunctionID(args.Function);
 
-                var mousePosWorld = _eyeManager.ScreenToWorld(args.PointerLocation);
-                var message = new FullInputCmdMessage(_gameTiming.CurTick, funcId, BoundKeyState.Down, mousePosWorld,
-                    args.PointerLocation, item.Uid);
+                var mousePosWorld = _eyeManager.ScreenToMap(args.PointerLocation);
+                if (!_mapManager.TryFindGridAt(mousePosWorld, out var grid))
+                    grid = _mapManager.GetDefaultGrid(mousePosWorld.MapId);
+
+                var message = new FullInputCmdMessage(_gameTiming.CurTick, funcId, BoundKeyState.Down,
+                    grid.MapToGrid(mousePosWorld), args.PointerLocation, item.Uid);
 
                 // client side command handlers will always be sent the local player session.
                 var session = _playerManager.LocalPlayer.Session;


### PR DESCRIPTION
This fixes one case of GridCoordinates being used unnecessarily, inGameScreenBase.

It replaces other cases with explicit calls to TryFindGridAt and GetDefaultGrid.

Requires space-wizards/RobustToolbox#1120.