### PR TITLE
Adds Damage on tool interaction component (#1060)

### DIFF
--- a/Content.Server/GameObjects/Components/Damage/DamageOnToolInteractComponent.cs
+++ b/Content.Server/GameObjects/Components/Damage/DamageOnToolInteractComponent.cs
@@ -1,0 +1,67 @@
+﻿using Content.Server.GameObjects.Components.Interactable;
+using Content.Server.GameObjects.EntitySystems;
+using Content.Shared.GameObjects.Components.Interactable;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+using System.Collections.Generic;
+
+namespace Content.Server.GameObjects.Components.Damage
+{
+    [RegisterComponent]
+    class DamageOnToolInteractComponent : Component, IInteractUsing
+    {
+        public override string Name => "DamageOnToolInteract";
+
+        /* Set in YAML */
+        protected int Damage;
+        private List<ToolQuality> _tools = new List<ToolQuality>();
+
+        public override void ExposeData(ObjectSerializer serializer)
+        {
+            base.ExposeData(serializer);
+
+            serializer.DataField(ref Damage, "damage", 0);
+
+            serializer.DataField(ref _tools, "tools", new List<ToolQuality>());
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            Owner.EnsureComponent<DamageableComponent>();
+        }
+
+        public bool InteractUsing(InteractUsingEventArgs eventArgs)
+        {
+            if (eventArgs.Using.TryGetComponent<ToolComponent>(out var tool))
+            {
+                foreach (var toolQuality in _tools)
+                {
+                    if (tool.HasQuality(ToolQuality.Welding) && toolQuality == ToolQuality.Welding)
+                    {
+                    if (eventArgs.Using.TryGetComponent<WelderComponent>(out WelderComponent welder))
+                    {
+                            if (welder.WelderLit) return CallDamage(eventArgs, tool);
+                    }
+                        break; //If the tool quality is welding and its not lit or its not actually a welder that can be lit then its pointless to continue. 
+                }
+
+                    if (tool.HasQuality(toolQuality)) return CallDamage(eventArgs, tool);
+                }
+            }
+            return false;
+        }
+
+        protected bool CallDamage(InteractUsingEventArgs eventArgs, ToolComponent tool)
+        {
+            if (eventArgs.Target.TryGetComponent<DamageableComponent>(out var damageable))
+            {
+                if(tool.HasQuality(ToolQuality.Welding)) damageable.TakeDamage(Shared.GameObjects.DamageType.Heat, Damage, eventArgs.Using, eventArgs.User);
+                else
+                damageable.TakeDamage(Shared.GameObjects.DamageType.Brute, Damage, eventArgs.Using, eventArgs.User);
+                return true;
+            }
+                return false;
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Buildings/Storage/StorageTanks/fuel_tank.yml
+++ b/Resources/Prototypes/Entities/Buildings/Storage/StorageTanks/fuel_tank.yml
@@ -18,3 +18,8 @@
       reagents:
       - ReagentId: chem.WeldingFuel
         Quantity: 1500
+  - type: DamageOnToolInteract
+    damage: 200
+    tools:
+    - Welding
+


### PR DESCRIPTION
[Original](https://github.com/space-wizards/space-station-14/pull/1080). Sorry to everyone who has already submitted work to this issue. However I had some issues when I rebased to the latest version causing Github to also include already committed commits to this pull request. I couldn’t' resolve the issue. Unfortunately I’m going to open a new request which is much cleaner then the last. I'll avoid rebasing on master in the future when I have an active pull request.

#### Goal:
Addressing #1060. Make the fuel tank explode if ignited with a welding tool.

#### Result:
fuel tank explodes if ignited with a welding tool. You can still fuel welder if the welder is turned off.

![Welder Blowup Fuel Tank when lit](https://user-images.githubusercontent.com/15194163/83944930-088a4580-a7ff-11ea-954c-f85e83b120c8.gif)

#### Supports:
- [x] All Tools supported
- [x] Multiple Tools causing damage to one entity

#### Why this method?
the component system isn’t designed for a single use case solutions. It is designed to be reused. Instead of creating a component with specific implementation in mind I created a more flexible component that adds damage when interacted with a tool and then lets other components handle events relating to that damage, such as an explosion on death.
