### PR TITLE
Have RobustSerializer use a shared string dictionary

### DIFF
--- a/Content.Server/GameObjects/Components/Mobs/DamageThresholdTemplates/HumanTemplate.cs
+++ b/Content.Server/GameObjects/Components/Mobs/DamageThresholdTemplates/HumanTemplate.cs
@@ -35,6 +35,23 @@ namespace Content.Server.GameObjects
             }
         }
 
+        // for shared string dict, since we don't define these anywhere in content
+        [UsedImplicitly]
+        public static readonly string[] _humanStatusImages =
+        {
+            "/Textures/Mob/UI/Human/human0.png",
+            "/Textures/Mob/UI/Human/human1.png",
+            "/Textures/Mob/UI/Human/human2.png",
+            "/Textures/Mob/UI/Human/human3.png",
+            "/Textures/Mob/UI/Human/human4.png",
+            "/Textures/Mob/UI/Human/human5.png",
+            "/Textures/Mob/UI/Human/human6-0.png",
+            "/Textures/Mob/UI/Human/human6-1.png",
+            "/Textures/Mob/UI/Human/humancrit-0.png",
+            "/Textures/Mob/UI/Human/humancrit-1.png",
+            "/Textures/Mob/UI/Human/humandead.png",
+        };
+
         public override void ChangeHudState(DamageableComponent damage)
         {
             ThresholdType healthstate = CalculateDamageState(damage);

--- a/Content.Server/GameObjects/Components/Nutrition/HungerComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/HungerComponent.cs
@@ -4,6 +4,7 @@ using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.Components.Movement;
 using Content.Shared.GameObjects;
 using Content.Shared.GameObjects.Components.Mobs;
+using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.Random;
 using Robust.Shared.IoC;
@@ -51,6 +52,17 @@ namespace Content.Server.GameObjects.Components.Nutrition
             serializer.DataField(ref _baseDecayRate, "base_decay_rate", 0.1f);
         }
 
+        // for shared string dict, since we don't define these anywhere in content
+        [UsedImplicitly]
+        public static readonly string[] _hungerThresholdImages =
+        {
+            "/Textures/Mob/UI/Hunger/Overfed.png",
+            "/Textures/Mob/UI/Hunger/Okay.png",
+            "/Textures/Mob/UI/Hunger/Peckish.png",
+            "/Textures/Mob/UI/Hunger/Starving.png",
+            "/Textures/Mob/UI/Hunger/Dead.png",
+        };
+
         public void HungerThresholdEffect(bool force = false)
         {
             if (_currentHungerThreshold != _lastHungerThreshold || force)
@@ -66,8 +78,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
 
                 // Update UI
                 Owner.TryGetComponent(out ServerStatusEffectsComponent statusEffectsComponent);
-                statusEffectsComponent?.ChangeStatus(StatusEffect.Hunger, "/Textures/Mob/UI/Hunger/" +
-                                                                          _currentHungerThreshold + ".png");
+                statusEffectsComponent?.ChangeStatus(StatusEffect.Hunger, _hungerThresholdImages[ (int)_currentHungerThreshold ]);
 
                 switch (_currentHungerThreshold)
                 {

--- a/Content.Server/GameObjects/Components/Nutrition/ThirstComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/ThirstComponent.cs
@@ -4,6 +4,7 @@ using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.Components.Movement;
 using Content.Shared.GameObjects;
 using Content.Shared.GameObjects.Components.Mobs;
+using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.Random;
 using Robust.Shared.IoC;
@@ -45,6 +46,16 @@ namespace Content.Server.GameObjects.Components.Nutrition
             {ThirstThreshold.Dead, 0.0f},
         };
 
+        // for shared string dict, since we don't define these anywhere in content
+        [UsedImplicitly]
+        public static readonly string[] _thirstThresholdImages =
+        {
+            "/Textures/Mob/UI/Thirst/OverHydrated.png",
+            "/Textures/Mob/UI/Thirst/Okay.png",
+            "/Textures/Mob/UI/Thirst/Thirsty.png",
+            "/Textures/Mob/UI/Thirst/Parched.png",
+            "/Textures/Mob/UI/Thirst/Dead.png",
+        };
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);

--- a/Content.Server/GameObjects/Components/RandomPottedPlantComponent.cs
+++ b/Content.Server/GameObjects/Components/RandomPottedPlantComponent.cs
@@ -20,6 +20,16 @@ namespace Content.Server.GameObjects.Components
         private string _selectedState;
         private bool _plastic;
 
+        // for shared string dict, since we don't define these anywhere in content
+        public static readonly string[] plantIdStrings =
+        {
+            "plant-01", "plant-02", "plant-03", "plant-04", "plant-05",
+            "plant-06", "plant-07", "plant-08", "plant-09", "plant-10",
+            "plant-11", "plant-12", "plant-13", "plant-14", "plant-15",
+            "plant-16", "plant-17", "plant-18", "plant-19", "plant-20",
+            "plant-21", "plant-22", "plant-23", "plant-24", "plant-25",
+            "plant-26", "plant-27", "plant-28", "plant-29", "plant-30",
+        };
 
         static RandomPottedPlantComponent()
         {

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticMagazineWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticMagazineWeaponComponent.cs
@@ -6,6 +6,7 @@ using Content.Server.Utility;
 using Content.Shared.GameObjects;
 using Content.Shared.GameObjects.Components.Weapons.Ranged;
 using Content.Shared.Interfaces;
+using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.Components.Container;
 using Robust.Server.GameObjects.EntitySystems;
@@ -148,6 +149,15 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Projectile
             return false;
         }
 
+        // these are complete strings for the sake of the shared string dict
+        [UsedImplicitly]
+        private static readonly string[] _bulletDropSounds =
+        {
+            "/Audio/Guns/Casings/casingfall1.ogg",
+            "/Audio/Guns/Casings/casingfall2.ogg",
+            "/Audio/Guns/Casings/casingfall3.ogg"
+        };
+
         protected override void CycleChamberedBullet(int chamber)
         {
             DebugTools.Assert(chamber == 0);
@@ -161,7 +171,8 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Projectile
             var offsetPos = (CalcBulletOffset(), CalcBulletOffset());
             entity.Transform.GridPosition = Owner.Transform.GridPosition.Offset(offsetPos);
             entity.Transform.LocalRotation = _bulletDropRandom.Pick(RandomBulletDirs).ToAngle();
-            var effect = $"/Audio/Guns/Casings/casingfall{_bulletDropRandom.Next(1, 4)}.ogg";
+            var bulletDropNext = _bulletDropRandom.Next(1, 3);
+            var effect = _bulletDropSounds[bulletDropNext];
             EntitySystem.Get<AudioSystem>().PlayFromEntity(effect, Owner, AudioParams.Default.WithVolume(-3));
 
             if (Magazine != null)

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticWeapon.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Projectile/BallisticWeapon.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 using System;
+using JetBrains.Annotations;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.IoC;
@@ -67,6 +68,22 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Projectile
             serializer.DataField(ref _caliber, "caliber", BallisticCaliber.Unspecified);
             serializer.DataField(ref _chamberCount, "chambers", 1);
         }
+
+        // for shared string dict, since we don't define these anywhere in content
+        [UsedImplicitly]
+        private static readonly string[] _ballisticsChambersStrings =
+        {
+            "ballistics_chamber_0",
+            "ballistics_chamber_1",
+            "ballistics_chamber_2",
+            "ballistics_chamber_3",
+            "ballistics_chamber_4",
+            "ballistics_chamber_5",
+            "ballistics_chamber_6",
+            "ballistics_chamber_7",
+            "ballistics_chamber_8",
+            "ballistics_chamber_9",
+        };
 
         public override void Initialize()
         {

--- a/Content.Shared/GameObjects/Components/Inventory/EquipmentSlotDefinitions.cs
+++ b/Content.Shared/GameObjects/Components/Inventory/EquipmentSlotDefinitions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.GameObjects.Components.Inventory
@@ -128,5 +129,37 @@ namespace Content.Shared.GameObjects.Components.Inventory
             {Slots.EXOSUITSLOT1, SlotFlags.EXOSUITSTORAGE},
             {Slots.EXOSUITSLOT2, SlotFlags.EXOSUITSTORAGE}
         };
+
+        // for shared string dict, since we don't define these anywhere in content
+        [UsedImplicitly]
+        public static readonly string[] _inventorySlotStrings =
+        {
+            "Inventory_HEAD",
+            "Inventory_EYES",
+            "Inventory_EARS",
+            "Inventory_MASK",
+            "Inventory_OUTERCLOTHING",
+            "Inventory_INNERCLOTHING",
+            "Inventory_BACKPACK",
+            "Inventory_BELT",
+            "Inventory_GLOVES",
+            "Inventory_SHOES",
+            "Inventory_IDCARD",
+            "Inventory_POCKET1",
+            "Inventory_POCKET2",
+            "Inventory_POCKET3",
+            "Inventory_POCKET4",
+            "Inventory_EXOSUITSLOT1",
+            "Inventory_EXOSUITSLOT2",
+        };
+
+        // for shared string dict, since we don't define these anywhere in content
+        [UsedImplicitly]
+        public static readonly string[] _handsSlotStrings =
+        {
+            "Hands_left",
+            "Hands_right",
+        };
+
     }
 }


### PR DESCRIPTION
Add complete strings that aren't defined in content files to allow them to be mapped

Partial obsoletion by @metalgearsloth's PR that moves casing sounds to yml.

Depends on https://github.com/space-wizards/RobustToolbox/pull/1117