### PR TITLE
Add Anchorable to several objects

### DIFF
--- a/Resources/Prototypes/Entities/Buildings/Storage/Closets/wardrobe.yml
+++ b/Resources/Prototypes/Entities/Buildings/Storage/Closets/wardrobe.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: WardrobeBase
   parent: LockerGeneric
   abstract: true

--- a/Resources/Prototypes/Entities/Buildings/Storage/closet.yml
+++ b/Resources/Prototypes/Entities/Buildings/Storage/closet.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: LockerGeneric
   name: closet
   description: A standard-issue Nanotrasen storage unit.
@@ -48,6 +48,7 @@
       state_open: generic_open
       state_closed: generic_door
   - type: LoopingSound
+  - type: Anchorable
   placement:
     snap:
     - Wall

--- a/Resources/Prototypes/Entities/Buildings/chem_dispenser.yml
+++ b/Resources/Prototypes/Entities/Buildings/chem_dispenser.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: chem_dispenser
   name: chemical dispenser
   parent: ReagentDispenserBase

--- a/Resources/Prototypes/Entities/Buildings/instruments.yml
+++ b/Resources/Prototypes/Entities/Buildings/instruments.yml
@@ -1,4 +1,4 @@
- - type: entity
+﻿ - type: entity
    name: baseinstrument
    id: BaseInstrument
    abstract: true
@@ -40,6 +40,7 @@
    - type: Icon
      sprite: Objects/Instruments/otherinstruments.rsi
      state: piano
+   - type: Anchorable
 
  - type: entity
    name: minimoog

--- a/Resources/Prototypes/Entities/Buildings/lathe.yml
+++ b/Resources/Prototypes/Entities/Buildings/lathe.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: BaseLathe
   name: "lathe"
   abstract: true
@@ -6,10 +6,23 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Collidable
+    shapes:
+    - !type:PhysShapeAabb
+      bounds: "-0.4,-0.25,0.4,0.25"
+      layer:
+      - Opaque
+      - Impassable
+      - MobImpassable
+      - VaultImpassable
+    IsScrapingFloor: true
+  - type: Physics
+    mass: 25
+    Anchored: true
   - type: SnapGrid
     offset: Center
   - type: Lathe
   - type: MaterialStorage
+  - type: Anchorable
   - type: UserInterface
     interfaces:
     - key: enum.LatheUiKey.Key

--- a/Resources/Prototypes/Entities/Buildings/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Buildings/medical_scanner.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: MedicalScanner
   name: medical scanner
   description: A bulky medical scanner.
@@ -15,7 +15,7 @@
   - type: Icon
     sprite: Buildings/medical_scanner.rsi
     state: scanner_open
-
+  - type: Anchorable
   - type: Clickable
   - type: InteractionOutline
   - type: Collidable

--- a/Resources/Prototypes/Entities/Buildings/power.yml
+++ b/Resources/Prototypes/Entities/Buildings/power.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: Wire
   name: wire
   description: Transfers power, avoid letting things come down it
@@ -61,6 +61,7 @@
   - type: PowerGenerator
   - type: SnapGrid
     offset: Center
+  - type: Anchorable
 
 - type: entity
   id: SolarPanel
@@ -89,6 +90,7 @@
   - type: Damageable
   - type: Breakable
     thresholdvalue: 100
+  - type: Anchorable
 
 - type: entity
   id: WPPnobattery
@@ -187,6 +189,7 @@
     - type: SmesVisualizer2D
   - type: SnapGrid
     offset: Center
+  - type: Anchorable
 
 - type: entity
   id: SmesDry

--- a/Resources/Prototypes/Entities/Buildings/reagent_dispenser_base.yml
+++ b/Resources/Prototypes/Entities/Buildings/reagent_dispenser_base.yml
@@ -1,9 +1,10 @@
-- type: entity
+﻿- type: entity
   abstract: true
   id: ReagentDispenserBase
   components:
   - type: Clickable
   - type: InteractionOutline
+  - type: Anchorable
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb

--- a/Resources/Prototypes/Entities/research.yml
+++ b/Resources/Prototypes/Entities/research.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   id: ResearchAndDevelopmentServer
   name: "R&D server"
   components:
@@ -59,3 +59,7 @@
     visuals:
     - type: PowerDeviceVisualizer2D
   - type: PowerDevice
+  - type: Anchorable
+  - type: Physics
+    mass: 25
+    Anchored: true


### PR DESCRIPTION
updated ymls to add anchorable to things that it should apply to
something to consider is that a lot of these, including computers, don't collide with walls. i should probably update that as well. also, some of these are really floaty and move way too eagerly when bumped
- [x] protolathe
- [x] autolathe
- [x] base r&d point generator
- [x] medical scanner
- [x] chemical dispenser
- [x] generator 
- [x] locker