### PR TITLE
Add red outline to obstructed entities in range

### DIFF
--- a/Content.Client/State/GameScreenBase.cs
+++ b/Content.Client/State/GameScreenBase.cs
@@ -62,7 +62,7 @@ namespace Content.Client.State
                 var playerPos = _playerManager.LocalPlayer.ControlledEntity.Transform.MapPosition;
                 var entityPos = entityToClick.Transform.MapPosition;
                 inRange = _entitySystemManager.GetEntitySystem<SharedInteractionSystem>()
-                    .InRangeUnobstructed(playerPos, entityPos, predicate:entity => entity != _playerManager.LocalPlayer.ControlledEntity || entity != entityToClick);
+                    .InRangeUnobstructed(playerPos, entityPos, predicate:entity => entity == _playerManager.LocalPlayer.ControlledEntity || entity == entityToClick, insideBlockerValid:true);
             }
 
             InteractionOutlineComponent outline;


### PR DESCRIPTION
They couldn't be picked up or interacted with anyway, but items (and tiles) that were behind an impassable entity still showed a green outline, only showing that they couldn't be interacted with when clicked.
Fixes #944 