### PR TITLE
Make workflow pull in engine changes required by a PR

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup submodule
-      run: git submodule update --init --recursive
+      run: |
+        git submodule update --init --recursive
+        touch BuildChecker/DISABLE_SUBMODULE_AUTOUPDATE
+    - name: Pull engine updates
+      uses: ivanbakel/submodule-dependency@v0.1.0
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
Using a fancy new GitHub action, this makes the workflow prevent automatic submodule updates and allows for pulling engine changes in from a required engine PR.

The action can be found at: https://github.com/ivanbakel/submodule-dependency
It basically checks if the current run is because of a PR being opened, regexes the PR body for an submodule requirement, and then pulls the submodule.