### PR TITLE
Storage Windows now have the owner's name instead of Storage Item

### DIFF
--- a/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
+++ b/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
@@ -33,7 +33,7 @@ namespace Content.Client.GameObjects.Components.Storage
             base.OnAdd();
 
             Window = new StorageWindow()
-                {StorageEntity = this};
+                {StorageEntity = this, Title = Owner.Name};
         }
 
         public override void OnRemove()


### PR DESCRIPTION
Quick fix.
Now you can better see which window belongs to which item.

Dunno if you need an existence check for Owner