### PR TITLE
Allow examine through windows

### DIFF
--- a/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
+++ b/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
@@ -1,8 +1,8 @@
 using Content.Shared.GameObjects.Components.Mobs;
+using Content.Shared.Physics;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
-using Robust.Shared.Utility;
 
 namespace Content.Shared.GameObjects.EntitySystems
 {
@@ -31,7 +31,8 @@ namespace Content.Shared.GameObjects.EntitySystems
 
             return EntitySystem.Get<SharedInteractionSystem>()
                 .InRangeUnobstructed(examiner.Transform.MapPosition, examined.Transform.MapPosition,
-                    ExamineRange, predicate: entity => entity == examiner || entity == examined, insideBlockerValid:true);
+                    ExamineRange, (int)CollisionGroup.Opaque,
+                    entity => entity == examiner || entity == examined, true);
         }
     }
 }


### PR DESCRIPTION
Fixes #1134

Changes the collision layer of examine checks to be Opaque instead of Impassable (the default).

Of note, prototypes related to the Opaque layer:
- **Window**: Impassable but not Opaque
- **Human**: MobImpassable and Opaque
- **HumanMob_Content**: MobImpassable and Opaque
- **HumanMob_Dummy**: Only MobImpassable
- **MopBucket and Bucket**: Only Opaque