### PR TITLE
Fix crash when the round restarts

### DIFF
--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
@@ -198,6 +198,11 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding
             _mapManager.TileChanged -= QueueTileChange;
         }
 
+        public void ResettingCleanup()
+        {
+            _queuedGraphUpdates.Clear();
+        }
+
         private void QueueGridRemoval(GridId gridId)
         {
             _queuedGraphUpdates.Enqueue(new GridRemoval(gridId));

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -9,6 +9,7 @@ using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.Components.Observer;
 using Content.Server.GameObjects.Components.PDA;
 using Content.Server.GameObjects.EntitySystems;
+using Content.Server.GameObjects.EntitySystems.AI.Pathfinding;
 using Content.Server.GameTicking.GamePresets;
 using Content.Server.Interfaces;
 using Content.Server.Interfaces.Chat;
@@ -505,6 +506,9 @@ namespace Content.Server.GameTicking
 
                 _playerJoinLobby(player);
             }
+
+            // Reset pathing system
+            EntitySystem.Get<PathfindingSystem>().ResettingCleanup();
 
             _spawnedPositions.Clear();
             _manifest.Clear();


### PR DESCRIPTION
Fixes #1160 
Clears pathfinding graph updates in gameticker resetting cleanup
The AI does work after the restart as well
_Allegedly_