### PR TITLE
Add delaystart and forcepreset commands

### DIFF
--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -73,7 +73,7 @@ namespace Content.Client.GameTicking
 
         private void LobbyCountdown(MsgTickerLobbyCountdown message)
         {
-            StartTime = DateTime.UtcNow + TimeSpan.FromSeconds(message.Seconds);
+            StartTime = message.StartTime;
             Paused = message.Paused;
         }
 

--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -36,7 +36,7 @@ namespace Content.Client.GameTicking
             _netManager.RegisterNetMessage<MsgTickerJoinGame>(nameof(MsgTickerJoinGame), JoinGame);
             _netManager.RegisterNetMessage<MsgTickerLobbyStatus>(nameof(MsgTickerLobbyStatus), LobbyStatus);
             _netManager.RegisterNetMessage<MsgTickerLobbyInfo>(nameof(MsgTickerLobbyInfo), LobbyInfo);
-            _netManager.RegisterNetMessage<MsgTickerStartExtend>(nameof(MsgTickerStartExtend), StartExtend);
+            _netManager.RegisterNetMessage<MsgTickerDelayStart>(nameof(MsgTickerDelayStart), StartExtend);
             _netManager.RegisterNetMessage<MsgRoundEndMessage>(nameof(MsgRoundEndMessage), RoundEnd);
 
             _initialized = true;
@@ -70,9 +70,9 @@ namespace Content.Client.GameTicking
             _stateManager.RequestStateChange<GameScreen>();
         }
 
-        private void StartExtend(MsgTickerStartExtend message)
+        private void StartExtend(MsgTickerDelayStart message)
         {
-            StartTime += TimeSpan.FromSeconds(message.Time);
+            StartTime += TimeSpan.FromSeconds(message.Seconds);
         }
 
         private void RoundEnd(MsgRoundEndMessage message)

--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -36,6 +36,7 @@ namespace Content.Client.GameTicking
             _netManager.RegisterNetMessage<MsgTickerJoinGame>(nameof(MsgTickerJoinGame), JoinGame);
             _netManager.RegisterNetMessage<MsgTickerLobbyStatus>(nameof(MsgTickerLobbyStatus), LobbyStatus);
             _netManager.RegisterNetMessage<MsgTickerLobbyInfo>(nameof(MsgTickerLobbyInfo), LobbyInfo);
+            _netManager.RegisterNetMessage<MsgTickerStartExtend>(nameof(MsgTickerStartExtend), StartExtend);
             _netManager.RegisterNetMessage<MsgRoundEndMessage>(nameof(MsgRoundEndMessage), RoundEnd);
 
             _initialized = true;
@@ -67,6 +68,11 @@ namespace Content.Client.GameTicking
         private void JoinGame(MsgTickerJoinGame message)
         {
             _stateManager.RequestStateChange<GameScreen>();
+        }
+
+        private void StartExtend(MsgTickerStartExtend message)
+        {
+            StartTime += TimeSpan.FromSeconds(message.Time);
         }
 
         private void RoundEnd(MsgRoundEndMessage message)

--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -36,7 +36,7 @@ namespace Content.Client.GameTicking
             _netManager.RegisterNetMessage<MsgTickerJoinGame>(nameof(MsgTickerJoinGame), JoinGame);
             _netManager.RegisterNetMessage<MsgTickerLobbyStatus>(nameof(MsgTickerLobbyStatus), LobbyStatus);
             _netManager.RegisterNetMessage<MsgTickerLobbyInfo>(nameof(MsgTickerLobbyInfo), LobbyInfo);
-            _netManager.RegisterNetMessage<MsgTickerDelayStart>(nameof(MsgTickerDelayStart), StartExtend);
+            _netManager.RegisterNetMessage<MsgTickerDelayStart>(nameof(MsgTickerDelayStart), DelayStart);
             _netManager.RegisterNetMessage<MsgRoundEndMessage>(nameof(MsgRoundEndMessage), RoundEnd);
 
             _initialized = true;
@@ -70,7 +70,7 @@ namespace Content.Client.GameTicking
             _stateManager.RequestStateChange<GameScreen>();
         }
 
-        private void StartExtend(MsgTickerDelayStart message)
+        private void DelayStart(MsgTickerDelayStart message)
         {
             StartTime += TimeSpan.FromSeconds(message.Seconds);
         }

--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -24,6 +24,7 @@ namespace Content.Client.GameTicking
         [ViewVariables] public bool IsGameStarted { get; private set; }
         [ViewVariables] public string ServerInfoBlob { get; private set; }
         [ViewVariables] public DateTime StartTime { get; private set; }
+        [ViewVariables] public bool Paused { get; private set; }
 
         public event Action InfoBlobUpdated;
         public event Action LobbyStatusUpdated;
@@ -36,7 +37,7 @@ namespace Content.Client.GameTicking
             _netManager.RegisterNetMessage<MsgTickerJoinGame>(nameof(MsgTickerJoinGame), JoinGame);
             _netManager.RegisterNetMessage<MsgTickerLobbyStatus>(nameof(MsgTickerLobbyStatus), LobbyStatus);
             _netManager.RegisterNetMessage<MsgTickerLobbyInfo>(nameof(MsgTickerLobbyInfo), LobbyInfo);
-            _netManager.RegisterNetMessage<MsgTickerDelayStart>(nameof(MsgTickerDelayStart), DelayStart);
+            _netManager.RegisterNetMessage<MsgTickerLobbyCountdown>(nameof(MsgTickerLobbyCountdown), LobbyCountdown);
             _netManager.RegisterNetMessage<MsgRoundEndMessage>(nameof(MsgRoundEndMessage), RoundEnd);
 
             _initialized = true;
@@ -70,9 +71,10 @@ namespace Content.Client.GameTicking
             _stateManager.RequestStateChange<GameScreen>();
         }
 
-        private void DelayStart(MsgTickerDelayStart message)
+        private void LobbyCountdown(MsgTickerLobbyCountdown message)
         {
-            StartTime += TimeSpan.FromSeconds(message.Seconds);
+            StartTime = DateTime.UtcNow + TimeSpan.FromSeconds(message.Seconds);
+            Paused = message.Paused;
         }
 
         private void RoundEnd(MsgRoundEndMessage message)

--- a/Content.Client/Interfaces/IClientGameTicker.cs
+++ b/Content.Client/Interfaces/IClientGameTicker.cs
@@ -8,6 +8,7 @@ namespace Content.Client.Interfaces
         string ServerInfoBlob { get; }
         bool AreWeReady { get; }
         DateTime StartTime { get; }
+        bool Paused { get; }
 
         void Initialize();
         event Action InfoBlobUpdated;

--- a/Content.Client/State/LobbyState.cs
+++ b/Content.Client/State/LobbyState.cs
@@ -126,25 +126,26 @@ namespace Content.Client.State
 
             if (_clientGameTicker.Paused)
             {
-                _lobby.StartTime.Text = Loc.GetString("Paused");
-                return;
-            }
-
-            var difference = _clientGameTicker.StartTime - DateTime.UtcNow;
-            if (difference.Ticks < 0)
-            {
-                if (difference.TotalSeconds < -5)
-                {
-                    text = Loc.GetString("Right Now?");
-                }
-                else
-                {
-                    text = Loc.GetString("Right Now");
-                }
+                text = Loc.GetString("Paused");
             }
             else
             {
-                text = $"{(int) Math.Floor(difference.TotalMinutes)}:{difference.Seconds:D2}";
+                var difference = _clientGameTicker.StartTime - DateTime.UtcNow;
+                if (difference.Ticks < 0)
+                {
+                    if (difference.TotalSeconds < -5)
+                    {
+                        text = Loc.GetString("Right Now?");
+                    }
+                    else
+                    {
+                        text = Loc.GetString("Right Now");
+                    }
+                }
+                else
+                {
+                    text = $"{(int) Math.Floor(difference.TotalMinutes)}:{difference.Seconds:D2}";
+                }
             }
 
             _lobby.StartTime.Text = Loc.GetString("Round Starts In: {0}", text);

--- a/Content.Client/State/LobbyState.cs
+++ b/Content.Client/State/LobbyState.cs
@@ -123,6 +123,13 @@ namespace Content.Client.State
             }
 
             string text;
+
+            if (_clientGameTicker.Paused)
+            {
+                _lobby.StartTime.Text = Loc.GetString("Paused");
+                return;
+            }
+
             var difference = _clientGameTicker.StartTime - DateTime.UtcNow;
             if (difference.Ticks < 0)
             {

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -37,7 +37,7 @@ namespace Content.IntegrationTests
         {
         }
 
-        public void StartRound()
+        public void StartRound(bool force = false)
         {
         }
 
@@ -85,7 +85,15 @@ namespace Content.IntegrationTests
         {
         }
 
-        public void SetStartPreset(string type)
+        public void SetStartPreset(string name)
+        {
+        }
+
+        public void ForceStartPreset(Type type)
+        {
+        }
+
+        public void ForceStartPreset(string name)
         {
         }
 

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -81,6 +81,12 @@ namespace Content.IntegrationTests
 
         public IEnumerable<GameRule> ActiveGameRules { get; } = Array.Empty<GameRule>();
 
+        public bool TryGetPreset(string name, out Type type)
+        {
+            type = default;
+            return false;
+        }
+
         public void SetStartPreset(Type type, bool force = false)
         {
         }

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -81,19 +81,11 @@ namespace Content.IntegrationTests
 
         public IEnumerable<GameRule> ActiveGameRules { get; } = Array.Empty<GameRule>();
 
-        public void SetStartPreset(Type type)
+        public void SetStartPreset(Type type, bool force = false)
         {
         }
 
-        public void SetStartPreset(string name)
-        {
-        }
-
-        public void ForceStartPreset(Type type)
-        {
-        }
-
-        public void ForceStartPreset(string name)
+        public void SetStartPreset(string name, bool force = false)
         {
         }
 

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -88,5 +88,10 @@ namespace Content.IntegrationTests
         public void SetStartPreset(string type)
         {
         }
+
+        public bool ExtendStart(TimeSpan time)
+        {
+            return true;
+        }
     }
 }

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -99,5 +99,15 @@ namespace Content.IntegrationTests
         {
             return true;
         }
+
+        public bool PauseStart(bool pause = true)
+        {
+            return true;
+        }
+
+        public bool TogglePause()
+        {
+            return false;
+        }
     }
 }

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -89,7 +89,7 @@ namespace Content.IntegrationTests
         {
         }
 
-        public bool ExtendStart(TimeSpan time)
+        public bool DelayStart(TimeSpan time)
         {
             return true;
         }

--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
@@ -103,7 +103,7 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding
         {
             if (!_graph.ContainsKey(removal.GridId))
             {
-                throw new InvalidOperationException();
+                // throw new InvalidOperationException(); // TODO Yell at me in the pr review if I left this in
             }
 
             _graph.Remove(removal.GridId);

--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
@@ -103,7 +103,7 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding
         {
             if (!_graph.ContainsKey(removal.GridId))
             {
-                // throw new InvalidOperationException(); // TODO Yell at me in the pr review if I left this in
+                throw new InvalidOperationException();
             }
 
             _graph.Remove(removal.GridId);

--- a/Content.Server/GameTicking/GamePreset.cs
+++ b/Content.Server/GameTicking/GamePreset.cs
@@ -8,7 +8,7 @@ namespace Content.Server.GameTicking
     /// </summary>
     public abstract class GamePreset
     {
-        public abstract bool Start(IReadOnlyList<IPlayerSession> players);
+        public abstract bool Start(IReadOnlyList<IPlayerSession> readyPlayers, bool force = false);
         public virtual string ModeTitle => "Sandbox";
         public virtual string Description => "Secret!";
     }

--- a/Content.Server/GameTicking/GamePresets/PresetDeathMatch.cs
+++ b/Content.Server/GameTicking/GamePresets/PresetDeathMatch.cs
@@ -12,7 +12,7 @@ namespace Content.Server.GameTicking.GamePresets
         [Dependency] private readonly IGameTicker _gameTicker;
 #pragma warning restore 649
 
-        public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers)
+        public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers, bool force = false)
         {
             _gameTicker.AddGameRule<RuleDeathMatch>();
             return true;

--- a/Content.Server/GameTicking/GamePresets/PresetSandbox.cs
+++ b/Content.Server/GameTicking/GamePresets/PresetSandbox.cs
@@ -11,7 +11,7 @@ namespace Content.Server.GameTicking.GamePresets
         [Dependency] private readonly ISandboxManager _sandboxManager;
 #pragma warning restore 649
 
-        public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers)
+        public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers, bool force = false)
         {
             _sandboxManager.IsSandboxEnabled = true;
             return true;

--- a/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
+++ b/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Content.Server.GameTicking.GameRules;
 using Content.Server.Interfaces.Chat;
 using Content.Server.Interfaces.GameTicking;
@@ -28,16 +27,16 @@ namespace Content.Server.GameTicking.GamePresets
         public int MinTraitors { get; set; } = 2;
         public int PlayersPerTraitor { get; set; } = 5;
 
-        public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers)
+        public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers, bool force = false)
         {
-            if (readyPlayers.Count > MinPlayers) // TODO Yell at me in the pr review if I left this in
+            if (!force && readyPlayers.Count > MinPlayers || readyPlayers.Count == 0) // TODO Yell at me in the pr review if I left this in
             {
                 _chatManager.DispatchServerAnnouncement($"Not enough players readied up for the game! There were {readyPlayers.Count} players readied up out of {MinPlayers} needed.");
                 return false;
             }
 
             var list = new List<IPlayerSession>(readyPlayers);
-            var numTraitors = Math.Max(readyPlayers.Count() % PlayersPerTraitor, MinTraitors);
+            var numTraitors = Math.Max(readyPlayers.Count % PlayersPerTraitor, MinTraitors);
 
             for (var i = 0; i < numTraitors; i++)
             {

--- a/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
+++ b/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
@@ -30,7 +30,7 @@ namespace Content.Server.GameTicking.GamePresets
 
         public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers)
         {
-            if (readyPlayers.Count < MinPlayers)
+            if (readyPlayers.Count > MinPlayers) // TODO Yell at me in the pr review if I left this in
             {
                 _chatManager.DispatchServerAnnouncement($"Not enough players readied up for the game! There were {readyPlayers.Count} players readied up out of {MinPlayers} needed.");
                 return false;

--- a/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
+++ b/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
@@ -29,14 +29,16 @@ namespace Content.Server.GameTicking.GamePresets
 
         public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers, bool force = false)
         {
-            if (!force && readyPlayers.Count > MinPlayers || readyPlayers.Count == 0) // TODO Yell at me in the pr review if I left this in
+            if (!force && readyPlayers.Count > MinPlayers || readyPlayers.Count < 2) // TODO Yell at me in the pr review if I left this in
             {
-                _chatManager.DispatchServerAnnouncement($"Not enough players readied up for the game! There were {readyPlayers.Count} players readied up out of {MinPlayers} needed.");
+                _chatManager.DispatchServerAnnouncement($"Not enough players readied up for the game! There were {readyPlayers.Count} players readied up out of {(force ? 2 : MinPlayers)} needed.");
                 return false;
             }
 
             var list = new List<IPlayerSession>(readyPlayers);
-            var numTraitors = Math.Max(readyPlayers.Count % PlayersPerTraitor, MinTraitors);
+            var numTraitors = Math.Min(
+                Math.Max(readyPlayers.Count % PlayersPerTraitor, MinTraitors),
+                readyPlayers.Count);
 
             for (var i = 0; i < numTraitors; i++)
             {

--- a/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
+++ b/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
@@ -29,9 +29,9 @@ namespace Content.Server.GameTicking.GamePresets
 
         public override bool Start(IReadOnlyList<IPlayerSession> readyPlayers, bool force = false)
         {
-            if (!force && readyPlayers.Count > MinPlayers || readyPlayers.Count < 2) // TODO Yell at me in the pr review if I left this in
+            if (!force && readyPlayers.Count < MinPlayers)
             {
-                _chatManager.DispatchServerAnnouncement($"Not enough players readied up for the game! There were {readyPlayers.Count} players readied up out of {(force ? 2 : MinPlayers)} needed.");
+                _chatManager.DispatchServerAnnouncement($"Not enough players readied up for the game! There were {readyPlayers.Count} players readied up out of {MinPlayers} needed.");
                 return false;
             }
 

--- a/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
+++ b/Content.Server/GameTicking/GamePresets/PresetSuspicion.cs
@@ -36,9 +36,8 @@ namespace Content.Server.GameTicking.GamePresets
             }
 
             var list = new List<IPlayerSession>(readyPlayers);
-            var numTraitors = Math.Min(
-                Math.Max(readyPlayers.Count % PlayersPerTraitor, MinTraitors),
-                readyPlayers.Count);
+            var numTraitors = Math.Clamp(readyPlayers.Count % PlayersPerTraitor,
+                MinTraitors, readyPlayers.Count);
 
             for (var i = 0; i < numTraitors; i++)
             {

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -116,7 +116,7 @@ namespace Content.Server.GameTicking
         {
             DebugTools.Assert(!_initialized);
 
-            _configurationManager.RegisterCVar("game.lobbyenabled", true, CVar.ARCHIVE); // TODO Yell at me in the pr review if I left this in
+            _configurationManager.RegisterCVar("game.lobbyenabled", false, CVar.ARCHIVE);
             _configurationManager.RegisterCVar("game.lobbyduration", 20, CVar.ARCHIVE);
             _configurationManager.RegisterCVar("game.defaultpreset", "Suspicion", CVar.ARCHIVE);
             _configurationManager.RegisterCVar("game.fallbackpreset", "Sandbox", CVar.ARCHIVE);

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -127,7 +127,7 @@ namespace Content.Server.GameTicking
             _netManager.RegisterNetMessage<MsgTickerJoinGame>(nameof(MsgTickerJoinGame));
             _netManager.RegisterNetMessage<MsgTickerLobbyStatus>(nameof(MsgTickerLobbyStatus));
             _netManager.RegisterNetMessage<MsgTickerLobbyInfo>(nameof(MsgTickerLobbyInfo));
-            _netManager.RegisterNetMessage<MsgTickerStartExtend>(nameof(MsgTickerStartExtend));
+            _netManager.RegisterNetMessage<MsgTickerDelayStart>(nameof(MsgTickerDelayStart));
             _netManager.RegisterNetMessage<MsgRoundEndMessage>(nameof(MsgRoundEndMessage));
 
             SetStartPreset(_configurationManager.GetCVar<string>("game.defaultpreset"));
@@ -394,7 +394,7 @@ namespace Content.Server.GameTicking
                 _ => throw new NotSupportedException()
             });
 
-        public bool ExtendStart(TimeSpan time)
+        public bool DelayStart(TimeSpan time)
         {
             if (_runLevel != GameRunLevel.PreRoundLobby)
             {
@@ -403,8 +403,8 @@ namespace Content.Server.GameTicking
 
             _roundStartTimeUtc += time;
 
-            var roundEndMessage = _netManager.CreateNetMessage<MsgTickerStartExtend>();
-            roundEndMessage.Time = time.Seconds;
+            var roundEndMessage = _netManager.CreateNetMessage<MsgTickerDelayStart>();
+            roundEndMessage.Seconds = time.Seconds;
             _netManager.ServerSendToAll(roundEndMessage);
 
             return true;

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -404,7 +404,7 @@ namespace Content.Server.GameTicking
             _roundStartTimeUtc += time;
 
             var roundEndMessage = _netManager.CreateNetMessage<MsgTickerDelayStart>();
-            roundEndMessage.Seconds = (int) time.TotalSeconds;
+            roundEndMessage.Seconds = (uint) time.TotalSeconds;
             _netManager.ServerSendToAll(roundEndMessage);
 
             return true;

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -432,7 +432,7 @@ namespace Content.Server.GameTicking
             _roundStartTimeUtc += time;
 
             var lobbyCountdownMessage = _netManager.CreateNetMessage<MsgTickerLobbyCountdown>();
-            lobbyCountdownMessage.Seconds = (uint) time.TotalSeconds;
+            lobbyCountdownMessage.StartTime = _roundStartTimeUtc;
             lobbyCountdownMessage.Paused = Paused;
             _netManager.ServerSendToAll(lobbyCountdownMessage);
 
@@ -458,7 +458,7 @@ namespace Content.Server.GameTicking
             }
 
             var lobbyCountdownMessage = _netManager.CreateNetMessage<MsgTickerLobbyCountdown>();
-            lobbyCountdownMessage.Seconds = (uint) (_roundStartTimeUtc - DateTime.UtcNow).TotalSeconds;
+            lobbyCountdownMessage.StartTime = _roundStartTimeUtc;
             lobbyCountdownMessage.Paused = Paused;
             _netManager.ServerSendToAll(lobbyCountdownMessage);
 
@@ -469,18 +469,6 @@ namespace Content.Server.GameTicking
         {
             PauseStart(!Paused);
             return Paused;
-        }
-
-        public bool TryGetPauseTime(out DateTime time)
-        {
-            time = default;
-
-            if (Paused)
-            {
-                time = _pauseTime;
-            }
-
-            return time != default;
         }
 
         private IEntity _spawnPlayerMob(Job job, bool lateJoin = true)

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -381,11 +381,11 @@ namespace Content.Server.GameTicking
 
         private bool TryGetPreset(string name, out Type type)
         {
-            type = name switch
+            type = name.ToLower() switch
             {
-                "Sandbox" => typeof(PresetSandbox),
-                "DeathMatch" => typeof(PresetDeathMatch),
-                "Suspicion" => typeof(PresetSuspicion),
+                "sandbox" => typeof(PresetSandbox),
+                "deathmatch" => typeof(PresetDeathMatch),
+                "suspicion" => typeof(PresetSuspicion),
                 _ => default
             };
 

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -379,7 +379,7 @@ namespace Content.Server.GameTicking
 
         public IEnumerable<GameRule> ActiveGameRules => _gameRules;
 
-        private bool TryGetPreset(string name, out Type type)
+        public bool TryGetPreset(string name, out Type type)
         {
             type = name.ToLower() switch
             {

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -404,7 +404,7 @@ namespace Content.Server.GameTicking
             _roundStartTimeUtc += time;
 
             var roundEndMessage = _netManager.CreateNetMessage<MsgTickerDelayStart>();
-            roundEndMessage.Seconds = time.Seconds;
+            roundEndMessage.Seconds = (int) time.TotalSeconds;
             _netManager.ServerSendToAll(roundEndMessage);
 
             return true;

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -119,7 +119,7 @@ namespace Content.Server.GameTicking
         {
             DebugTools.Assert(!_initialized);
 
-            _configurationManager.RegisterCVar("game.lobbyenabled", true, CVar.ARCHIVE); // TODO throw me into the sun if I left this in
+            _configurationManager.RegisterCVar("game.lobbyenabled", false, CVar.ARCHIVE);
             _configurationManager.RegisterCVar("game.lobbyduration", 20, CVar.ARCHIVE);
             _configurationManager.RegisterCVar("game.defaultpreset", "Suspicion", CVar.ARCHIVE);
             _configurationManager.RegisterCVar("game.fallbackpreset", "Sandbox", CVar.ARCHIVE);

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -379,7 +379,7 @@ namespace Content.Server.GameTicking
 
         public IEnumerable<GameRule> ActiveGameRules => _gameRules;
 
-        public bool TryGetPreset(string name, out Type type)
+        private bool TryGetPreset(string name, out Type type)
         {
             type = name switch
             {
@@ -392,45 +392,27 @@ namespace Content.Server.GameTicking
             return type != default;
         }
 
-        public void SetStartPreset(Type type)
+        public void SetStartPreset(Type type, bool force = false)
         {
             if (!typeof(GamePreset).IsAssignableFrom(type)) throw new ArgumentException("type must inherit GamePreset");
 
             _presetType = type;
             UpdateInfoText();
+
+            if (force)
+            {
+                StartRound(true);
+            }
         }
 
-        public void SetStartPreset(string name)
+        public void SetStartPreset(string name, bool force = false)
         {
-            if (TryGetPreset(name, out var type))
-            {
-                SetStartPreset(type);
-            }
-            else
+            if (!TryGetPreset(name, out var type))
             {
                 throw new NotSupportedException();
             }
-        }
 
-        public void ForceStartPreset(Type type)
-        {
-            if (!typeof(GamePreset).IsAssignableFrom(type)) throw new ArgumentException("type must inherit GamePreset");
-
-            _presetType = type;
-            UpdateInfoText();
-            StartRound(true);
-        }
-
-        public void ForceStartPreset(string name)
-        {
-            if (TryGetPreset(name, out var type))
-            {
-                ForceStartPreset(type);
-            }
-            else
-            {
-                throw new NotSupportedException();
-            }
+            SetStartPreset(type, force);
         }
 
         public bool DelayStart(TimeSpan time)

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -19,7 +19,7 @@ namespace Content.Server.GameTicking
         {
             if (args.Length != 1)
             {
-                shell.SendText(player, "No time in seconds to extend the round start by has been specified.");
+                shell.SendText(player, "Need exactly one argument.");
                 return;
             }
 

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -264,7 +264,7 @@ namespace Content.Server.GameTicking
             }
 
             ticker.SetStartPreset(type, true);
-            shell.SendText(player, $"Forced the game to start with preset {name}");
+            shell.SendText(player, $"Forced the game to start with preset {name}.");
         }
     }
 }

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Network;
 
 namespace Content.Server.GameTicking
 {
-    class DelayStart : IClientCommand
+    class DelayStartCommand : IClientCommand
     {
         public string Command => "delaystart";
         public string Description => "Delays the round start.";
@@ -225,6 +225,26 @@ namespace Content.Server.GameTicking
             var ticker = IoCManager.Resolve<IGameTicker>();
 
             ticker.SetStartPreset(args[0]);
+        }
+    }
+
+    class ForceGamePresetCommand : IClientCommand
+    {
+        public string Command => "forcegamepreset";
+        public string Description => "Forces a specific game preset to start for the current lobby.";
+        public string Help => $"Usage: {Command} <preset>";
+
+        public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
+        {
+            if (args.Length != 1)
+            {
+                shell.SendText(player, "Need exactly one argument.");
+                return;
+            }
+
+            var ticker = IoCManager.Resolve<IGameTicker>();
+
+            ticker.ForceStartPreset(args[0]);
         }
     }
 }

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -23,7 +23,7 @@ namespace Content.Server.GameTicking
                 return;
             }
 
-            if (!int.TryParse(args[0], out var seconds))
+            if (!uint.TryParse(args[0], out var seconds))
             {
                 shell.SendText(player, $"{args[0]} isn't a valid amount of seconds.");
                 return;

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -13,7 +13,7 @@ namespace Content.Server.GameTicking
     {
         public string Command => "delaystart";
         public string Description => "Delays the round start.";
-        public string Help => $"Usage: {Command} <seconds>";
+        public string Help => $"Usage: {Command} <seconds>\nPauses/Resumes the countdown if no argument is provided.";
 
         public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
         {
@@ -24,9 +24,16 @@ namespace Content.Server.GameTicking
                 return;
             }
 
+            if (args.Length == 0)
+            {
+                var paused = ticker.TogglePause();
+                shell.SendText(player, paused ? "Paused the countdown." : "Resumed the countdown.");
+                return;
+            }
+
             if (args.Length != 1)
             {
-                shell.SendText(player, "Need exactly one argument.");
+                shell.SendText(player, "Need zero or one arguments.");
                 return;
             }
 
@@ -250,13 +257,14 @@ namespace Content.Server.GameTicking
             }
 
             var name = args[0];
-            if (!ticker.TryGetPreset(name, out _))
+            if (!ticker.TryGetPreset(name, out var type))
             {
                 shell.SendText(player, $"No preset exists with name {name}.");
                 return;
             }
 
-            ticker.SetStartPreset(args[0], true);
+            ticker.SetStartPreset(type, true);
+            shell.SendText(player, $"Forced the game to start with preset {name}");
         }
     }
 }

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -37,7 +37,7 @@ namespace Content.Server.GameTicking
                 return;
             }
 
-            if (!uint.TryParse(args[0], out var seconds))
+            if (!uint.TryParse(args[0], out var seconds) || seconds == 0)
             {
                 shell.SendText(player, $"{args[0]} isn't a valid amount of seconds.");
                 return;

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -228,9 +228,9 @@ namespace Content.Server.GameTicking
         }
     }
 
-    class ForceGamePresetCommand : IClientCommand
+    class ForcePresetCommand : IClientCommand
     {
-        public string Command => "forcegamepreset";
+        public string Command => "forcepreset";
         public string Description => "Forces a specific game preset to start for the current lobby.";
         public string Help => $"Usage: {Command} <preset>";
 
@@ -244,7 +244,7 @@ namespace Content.Server.GameTicking
 
             var ticker = IoCManager.Resolve<IGameTicker>();
 
-            ticker.ForceStartPreset(args[0]);
+            ticker.SetStartPreset(args[0], true);
         }
     }
 }

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -9,10 +9,10 @@ using Robust.Shared.Network;
 
 namespace Content.Server.GameTicking
 {
-    class ExtendRoundStart : IClientCommand
+    class DelayStart : IClientCommand
     {
-        public string Command => "extendroundstart";
-        public string Description => "Extends the round start timer.";
+        public string Command => "delaystart";
+        public string Description => "Delays the round start.";
         public string Help => $"Usage: {Command} <seconds>";
 
         public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
@@ -37,7 +37,7 @@ namespace Content.Server.GameTicking
             }
 
             var time = TimeSpan.FromSeconds(seconds);
-            if (!ticker.ExtendStart(time))
+            if (!ticker.DelayStart(time))
             {
                 shell.SendText(player, "An unknown error has occurred.");
             }

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -17,6 +17,13 @@ namespace Content.Server.GameTicking
 
         public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
         {
+            var ticker = IoCManager.Resolve<IGameTicker>();
+            if (ticker.RunLevel != GameRunLevel.PreRoundLobby)
+            {
+                shell.SendText(player, "This can only be executed while the game is in the pre-round lobby.");
+                return;
+            }
+
             if (args.Length != 1)
             {
                 shell.SendText(player, "Need exactly one argument.");
@@ -26,13 +33,6 @@ namespace Content.Server.GameTicking
             if (!uint.TryParse(args[0], out var seconds))
             {
                 shell.SendText(player, $"{args[0]} isn't a valid amount of seconds.");
-                return;
-            }
-
-            var ticker = IoCManager.Resolve<IGameTicker>();
-            if (ticker.RunLevel != GameRunLevel.PreRoundLobby)
-            {
-                shell.SendText(player, "This can only be executed while the game is in the pre-round lobby.");
                 return;
             }
 
@@ -236,6 +236,13 @@ namespace Content.Server.GameTicking
 
         public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
         {
+            var ticker = IoCManager.Resolve<IGameTicker>();
+            if (ticker.RunLevel != GameRunLevel.PreRoundLobby)
+            {
+                shell.SendText(player, "This can only be executed while the game is in the pre-round lobby.");
+                return;
+            }
+
             if (args.Length != 1)
             {
                 shell.SendText(player, "Need exactly one argument.");
@@ -243,8 +250,6 @@ namespace Content.Server.GameTicking
             }
 
             var name = args[0];
-            var ticker = IoCManager.Resolve<IGameTicker>();
-
             if (!ticker.TryGetPreset(name, out _))
             {
                 shell.SendText(player, $"No preset exists with name {name}.");

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -9,6 +9,40 @@ using Robust.Shared.Network;
 
 namespace Content.Server.GameTicking
 {
+    class ExtendRoundStart : IClientCommand
+    {
+        public string Command => "extendroundstart";
+        public string Description => "Extends the round start timer.";
+        public string Help => $"Usage: {Command} <seconds>";
+
+        public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
+        {
+            if (args.Length != 1)
+            {
+                shell.SendText(player, "No time in seconds to extend the round start by has been specified.");
+                return;
+            }
+
+            if (!int.TryParse(args[0], out var seconds))
+            {
+                shell.SendText(player, $"{args[0]} isn't a valid amount of seconds.");
+                return;
+            }
+
+            var ticker = IoCManager.Resolve<IGameTicker>();
+            if (ticker.RunLevel != GameRunLevel.PreRoundLobby)
+            {
+                shell.SendText(player, "This can only be executed while the game is in the pre-round lobby.");
+                return;
+            }
+
+            var time = TimeSpan.FromSeconds(seconds);
+            if (!ticker.ExtendStart(time))
+            {
+                shell.SendText(player, "An unknown error has occurred.");
+            }
+        }
+    }
 
     class StartRoundCommand : IClientCommand
     {

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -242,7 +242,14 @@ namespace Content.Server.GameTicking
                 return;
             }
 
+            var name = args[0];
             var ticker = IoCManager.Resolve<IGameTicker>();
+
+            if (!ticker.TryGetPreset(name, out _))
+            {
+                shell.SendText(player, $"No preset exists with name {name}.");
+                return;
+            }
 
             ticker.SetStartPreset(args[0], true);
         }

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Interfaces.GameTicking
         void Update(FrameEventArgs frameEventArgs);
 
         void RestartRound();
-        void StartRound();
+        void StartRound(bool force = false);
         void EndRound();
 
         void Respawn(IPlayerSession targetPlayer);
@@ -40,7 +40,9 @@ namespace Content.Server.Interfaces.GameTicking
         IEnumerable<GameRule> ActiveGameRules { get; }
 
         void SetStartPreset(Type type);
-        void SetStartPreset(string type);
+        void SetStartPreset(string name);
+        void ForceStartPreset(Type type);
+        void ForceStartPreset(string name);
 
         bool DelayStart(TimeSpan time);
     }

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -42,6 +42,6 @@ namespace Content.Server.Interfaces.GameTicking
         void SetStartPreset(Type type);
         void SetStartPreset(string type);
 
-        bool ExtendStart(TimeSpan time);
+        bool DelayStart(TimeSpan time);
     }
 }

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -39,10 +39,8 @@ namespace Content.Server.Interfaces.GameTicking
         void RemoveGameRule(GameRule rule);
         IEnumerable<GameRule> ActiveGameRules { get; }
 
-        void SetStartPreset(Type type);
-        void SetStartPreset(string name);
-        void ForceStartPreset(Type type);
-        void ForceStartPreset(string name);
+        void SetStartPreset(Type type, bool force = false);
+        void SetStartPreset(string name, bool force = false);
 
         bool DelayStart(TimeSpan time);
     }

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -39,6 +39,7 @@ namespace Content.Server.Interfaces.GameTicking
         void RemoveGameRule(GameRule rule);
         IEnumerable<GameRule> ActiveGameRules { get; }
 
+        bool TryGetPreset(string name, out Type type);
         void SetStartPreset(Type type, bool force = false);
         void SetStartPreset(string name, bool force = false);
 

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -43,6 +43,12 @@ namespace Content.Server.Interfaces.GameTicking
         void SetStartPreset(Type type, bool force = false);
         void SetStartPreset(string name, bool force = false);
 
+        /// <returns>true if changed, false otherwise</returns>
+        bool PauseStart(bool pause = true);
+
+        /// <returns>true if paused, false otherwise</returns>
+        bool TogglePause();
+
         bool DelayStart(TimeSpan time);
     }
 }

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -41,5 +41,7 @@ namespace Content.Server.Interfaces.GameTicking
 
         void SetStartPreset(Type type);
         void SetStartPreset(string type);
+
+        bool ExtendStart(TimeSpan time);
     }
 }

--- a/Content.Shared/SharedGameTicker.cs
+++ b/Content.Shared/SharedGameTicker.cs
@@ -130,7 +130,7 @@ namespace Content.Shared
             /// <summary>
             /// The total amount of seconds to go until the countdown finishes
             /// </summary>
-            public uint Seconds { get; set; }
+            public DateTime StartTime { get; set; }
 
             /// <summary>
             /// Whether or not the countdown is paused
@@ -139,13 +139,13 @@ namespace Content.Shared
 
             public override void ReadFromBuffer(NetIncomingMessage buffer)
             {
-                Seconds = buffer.ReadUInt32();
+                StartTime = new DateTime(buffer.ReadInt64(), DateTimeKind.Utc);
                 Paused = buffer.ReadBoolean();
             }
 
             public override void WriteToBuffer(NetOutgoingMessage buffer)
             {
-                buffer.Write(Seconds);
+                buffer.Write(StartTime.Ticks);
                 buffer.Write(Paused);
             }
         }

--- a/Content.Shared/SharedGameTicker.cs
+++ b/Content.Shared/SharedGameTicker.cs
@@ -127,11 +127,11 @@ namespace Content.Shared
 
             #endregion
 
-            public int Seconds { get; set; }
+            public uint Seconds { get; set; }
 
             public override void ReadFromBuffer(NetIncomingMessage buffer)
             {
-                Seconds = buffer.ReadInt32();
+                Seconds = buffer.ReadUInt32();
             }
 
             public override void WriteToBuffer(NetOutgoingMessage buffer)

--- a/Content.Shared/SharedGameTicker.cs
+++ b/Content.Shared/SharedGameTicker.cs
@@ -117,26 +117,36 @@ namespace Content.Shared
             }
         }
 
-        protected class MsgTickerDelayStart : NetMessage
+        protected class MsgTickerLobbyCountdown : NetMessage
         {
             #region REQUIRED
 
             public const MsgGroups GROUP = MsgGroups.Command;
-            public const string NAME = nameof(MsgTickerDelayStart);
-            public MsgTickerDelayStart(INetChannel channel) : base(NAME, GROUP) { }
+            public const string NAME = nameof(MsgTickerLobbyCountdown);
+            public MsgTickerLobbyCountdown(INetChannel channel) : base(NAME, GROUP) { }
 
             #endregion
 
+            /// <summary>
+            /// The total amount of seconds to go until the countdown finishes
+            /// </summary>
             public uint Seconds { get; set; }
+
+            /// <summary>
+            /// Whether or not the countdown is paused
+            /// </summary>
+            public bool Paused { get; set; }
 
             public override void ReadFromBuffer(NetIncomingMessage buffer)
             {
                 Seconds = buffer.ReadUInt32();
+                Paused = buffer.ReadBoolean();
             }
 
             public override void WriteToBuffer(NetOutgoingMessage buffer)
             {
                 buffer.Write(Seconds);
+                buffer.Write(Paused);
             }
         }
 

--- a/Content.Shared/SharedGameTicker.cs
+++ b/Content.Shared/SharedGameTicker.cs
@@ -116,6 +116,30 @@ namespace Content.Shared
                 buffer.Write(TextBlob);
             }
         }
+
+        protected class MsgTickerStartExtend : NetMessage
+        {
+            #region REQUIRED
+
+            public const MsgGroups GROUP = MsgGroups.Command;
+            public const string NAME = nameof(MsgTickerStartExtend);
+            public MsgTickerStartExtend(INetChannel channel) : base(NAME, GROUP) { }
+
+            #endregion
+
+            public int Time { get; set; }
+
+            public override void ReadFromBuffer(NetIncomingMessage buffer)
+            {
+                Time = buffer.ReadInt32();
+            }
+
+            public override void WriteToBuffer(NetOutgoingMessage buffer)
+            {
+                buffer.Write(Time);
+            }
+        }
+
         public struct RoundEndPlayerInfo
         {
             public string PlayerOOCName;

--- a/Content.Shared/SharedGameTicker.cs
+++ b/Content.Shared/SharedGameTicker.cs
@@ -117,26 +117,26 @@ namespace Content.Shared
             }
         }
 
-        protected class MsgTickerStartExtend : NetMessage
+        protected class MsgTickerDelayStart : NetMessage
         {
             #region REQUIRED
 
             public const MsgGroups GROUP = MsgGroups.Command;
-            public const string NAME = nameof(MsgTickerStartExtend);
-            public MsgTickerStartExtend(INetChannel channel) : base(NAME, GROUP) { }
+            public const string NAME = nameof(MsgTickerDelayStart);
+            public MsgTickerDelayStart(INetChannel channel) : base(NAME, GROUP) { }
 
             #endregion
 
-            public int Time { get; set; }
+            public int Seconds { get; set; }
 
             public override void ReadFromBuffer(NetIncomingMessage buffer)
             {
-                Time = buffer.ReadInt32();
+                Seconds = buffer.ReadInt32();
             }
 
             public override void WriteToBuffer(NetOutgoingMessage buffer)
             {
-                buffer.Write(Time);
+                buffer.Write(Seconds);
             }
         }
 

--- a/Resources/Groups/groups.yml
+++ b/Resources/Groups/groups.yml
@@ -55,7 +55,7 @@
   - tp
   - tpgrid
   - setgamepreset
-  - extendroundstart
+  - delaystart
   - startround
   - endround
   - restartround
@@ -99,7 +99,7 @@
   - tp
   - tpgrid
   - setgamepreset
-  - extendroundstart
+  - delaystart
   - startround
   - endround
   - restartround

--- a/Resources/Groups/groups.yml
+++ b/Resources/Groups/groups.yml
@@ -55,6 +55,7 @@
   - tp
   - tpgrid
   - setgamepreset
+  - extendroundstart
   - startround
   - endround
   - restartround
@@ -98,6 +99,7 @@
   - tp
   - tpgrid
   - setgamepreset
+  - extendroundstart
   - startround
   - endround
   - restartround

--- a/Resources/Groups/groups.yml
+++ b/Resources/Groups/groups.yml
@@ -55,6 +55,7 @@
   - tp
   - tpgrid
   - setgamepreset
+  - forcepreset
   - delaystart
   - startround
   - endround
@@ -99,6 +100,7 @@
   - tp
   - tpgrid
   - setgamepreset
+  - forcepreset
   - delaystart
   - startround
   - endround


### PR DESCRIPTION
Closes #1159 

- delaystart \<seconds\>: Delays the round starting while in a lobby. Negative seconds are not allowed because if the timer goes negative the game will never start. If no seconds are specified then the timer is paused until it is used again.
- forcepreset \<preset\>: Forces a preset to start immediately while in a lobby, even if it will end instantly (for example 1 player only in suspicion mode).

Even if forced, suspicion still only grabs the ready players as traitor candidates, not every player.