### PR TITLE
Fix a late joining client not knowing if the lobby has been paused

### DIFF
--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -55,6 +55,7 @@ namespace Content.Client.GameTicking
             StartTime = message.StartTime;
             IsGameStarted = message.IsRoundStarted;
             AreWeReady = message.YouAreReady;
+            Paused = message.Paused;
 
             LobbyStatusUpdated?.Invoke();
         }

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -437,6 +437,8 @@ namespace Content.Server.GameTicking
             lobbyCountdownMessage.Paused = Paused;
             _netManager.ServerSendToAll(lobbyCountdownMessage);
 
+            _chatManager.DispatchServerAnnouncement($"Round start has been delayed for {time.TotalSeconds} seconds.");
+
             return true;
         }
 
@@ -462,6 +464,10 @@ namespace Content.Server.GameTicking
             lobbyCountdownMessage.StartTime = _roundStartTimeUtc;
             lobbyCountdownMessage.Paused = Paused;
             _netManager.ServerSendToAll(lobbyCountdownMessage);
+
+            _chatManager.DispatchServerAnnouncement(Paused
+                ? "Round start has been paused."
+                : "Round start countdown is now resumed.");
 
             return true;
         }

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -838,6 +838,7 @@ namespace Content.Server.GameTicking
             msg.IsRoundStarted = RunLevel != GameRunLevel.PreRoundLobby;
             msg.StartTime = _roundStartTimeUtc;
             msg.YouAreReady = ready;
+            msg.Paused = Paused;
             return msg;
         }
 

--- a/Content.Shared/SharedGameTicker.cs
+++ b/Content.Shared/SharedGameTicker.cs
@@ -66,6 +66,7 @@ namespace Content.Shared
             public bool YouAreReady { get; set; }
             // UTC.
             public DateTime StartTime { get; set; }
+            public bool Paused { get; set; }
 
             public override void ReadFromBuffer(NetIncomingMessage buffer)
             {
@@ -78,6 +79,7 @@ namespace Content.Shared
 
                 YouAreReady = buffer.ReadBoolean();
                 StartTime = new DateTime(buffer.ReadInt64(), DateTimeKind.Utc);
+                Paused = buffer.ReadBoolean();
             }
 
             public override void WriteToBuffer(NetOutgoingMessage buffer)
@@ -91,6 +93,7 @@ namespace Content.Shared
 
                 buffer.Write(YouAreReady);
                 buffer.Write(StartTime.Ticks);
+                buffer.Write(Paused);
             }
         }
 


### PR DESCRIPTION
Fixes #1197 

Also adds a server announcement to pausing and delaying round start.