### PR TITLE
InventoryComponent now returns null if comp is deleted

### DIFF
--- a/Content.Server/GameObjects/Components/GUI/InventoryComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/InventoryComponent.cs
@@ -78,7 +78,13 @@ namespace Content.Server.GameObjects
         }
         public T GetSlotItem<T>(Slots slot) where T : ItemComponent
         {
-            return SlotContainers[slot].ContainedEntity?.GetComponent<T>();
+            var containedEntity = SlotContainers[slot].ContainedEntity;
+            if (containedEntity?.Deleted == true)
+            {
+                SlotContainers[slot] = null;
+                containedEntity = null;
+            }
+            return containedEntity?.GetComponent<T>();
         }
 
         public bool TryGetSlotItem<T>(Slots slot, out T itemComponent) where T : ItemComponent

--- a/Content.Server/GameObjects/Components/GUI/InventoryComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/InventoryComponent.cs
@@ -83,6 +83,7 @@ namespace Content.Server.GameObjects
             {
                 SlotContainers[slot] = null;
                 containedEntity = null;
+                Dirty();
             }
             return containedEntity?.GetComponent<T>();
         }


### PR DESCRIPTION
I think this is the intended behavior? OnRemove is being called in a test and it was throwing on this because the items were being deleted before the inventory was.