### PR TITLE
Deconstruction Features

### DIFF
--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -1,168 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using Content.Server.GameObjects.Components.Interactable;
-using Content.Server.GameObjects.Components.Stack;
-using Content.Server.GameObjects.EntitySystems;
-using Content.Server.Interfaces;
-using Content.Server.Utility;
-using Content.Shared.Construction;
-using Content.Shared.GameObjects.Components;
-using Content.Shared.GameObjects.Components.Interactable;
-using Robust.Server.GameObjects;
-using Robust.Server.GameObjects.EntitySystems;
-using Robust.Server.Interfaces.GameObjects;
+﻿using Content.Shared.Construction;
 using Robust.Shared.GameObjects;
-using Robust.Shared.GameObjects.Systems;
-using Robust.Shared.Interfaces.GameObjects;
-using Robust.Shared.Interfaces.GameObjects.Components;
-using Robust.Shared.Interfaces.Random;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
+using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
-using static Content.Shared.Construction.ConstructionStepMaterial;
 
 namespace Content.Server.GameObjects.Components.Construction
 {
+    /// <summary>
+    /// Holds data about an entity that is in the process of being constructed or destructed.
+    /// </summary>
     [RegisterComponent]
-    public class ConstructionComponent : Component, IInteractUsing
+    public class ConstructionComponent : Component
     {
+        /// <inheritdoc />
         public override string Name => "Construction";
 
+        /// <summary>
+        /// The current construction recipe being used to build this entity.
+        /// </summary>
         [ViewVariables]
-        public ConstructionPrototype Prototype { get; private set; }
+        public ConstructionPrototype Prototype { get; set; }
+
+        /// <summary>
+        /// The current stage of construction.
+        /// </summary>
         [ViewVariables]
-        public int Stage { get; private set; }
+        public int Stage { get; set; }
 
-        SpriteComponent Sprite;
-        ITransformComponent Transform;
-
-        public override void Initialize()
+        /// <inheritdoc />
+        public override void ExposeData(ObjectSerializer serializer)
         {
-            base.Initialize();
+            base.ExposeData(serializer);
 
-            Sprite = Owner.GetComponent<SpriteComponent>();
-            Transform = Owner.GetComponent<ITransformComponent>();
-        }
+            serializer.DataReadWriteFunction("prototype", null,
+                value => Prototype = value, () => Prototype);
 
-        public bool InteractUsing(InteractUsingEventArgs eventArgs)
-        {
-            // default interaction check for AttackBy allows inside blockers, so we will check if its blocked if
-            // we're not allowed to build on impassable stuff
-            if (Prototype.CanBuildInImpassable == false)
-            {
-                if (!InteractionChecks.InRangeUnobstructed(eventArgs, false))
-                    return false;
-            }
-
-            var stage = Prototype.Stages[Stage];
-
-            if (TryProcessStep(stage.Forward, eventArgs.Using, eventArgs.User))
-            {
-                Stage++;
-                if (Stage == Prototype.Stages.Count - 1)
-                {
-                    // Oh boy we get to finish construction!
-                    var entMgr = IoCManager.Resolve<IServerEntityManager>();
-                    var ent = entMgr.SpawnEntity(Prototype.Result, Transform.GridPosition);
-                    ent.GetComponent<ITransformComponent>().LocalRotation = Transform.LocalRotation;
-                    Owner.Delete();
-                    return true;
-                }
-
-                stage = Prototype.Stages[Stage];
-                if (stage.Icon != null)
-                {
-                    Sprite.LayerSetSprite(0, stage.Icon);
-                }
-            }
-
-            else if (TryProcessStep(stage.Backward, eventArgs.Using, eventArgs.User))
-            {
-                Stage--;
-                if (Stage == 0)
-                {
-                    // Deconstruction complete.
-                    Owner.Delete();
-                    return true;
-                }
-
-                stage = Prototype.Stages[Stage];
-                if (stage.Icon != null)
-                {
-                    Sprite.LayerSetSprite(0, stage.Icon);
-                }
-            }
-
-            return true;
-        }
-
-        public void Init(ConstructionPrototype prototype)
-        {
-            Prototype = prototype;
-            Stage = 1;
-            if(prototype.Stages[1].Icon != null)
-            {
-                Sprite.AddLayerWithSprite(prototype.Stages[1].Icon);
-            }
-            else
-            {
-                Sprite.AddLayerWithSprite(prototype.Icon);
-            }
-
-
-        }
-
-        bool TryProcessStep(ConstructionStep step, IEntity slapped, IEntity user)
-        {
-            if (step == null)
-            {
-                return false;
-            }
-            var sound = EntitySystem.Get<AudioSystem>();
-
-            switch (step)
-            {
-                case ConstructionStepMaterial matStep:
-                    if (!slapped.TryGetComponent(out StackComponent stack)
-                     || !MaterialStackValidFor(matStep, stack)
-                     || !stack.Use(matStep.Amount))
-                    {
-                        return false;
-                    }
-                    if (matStep.Material == MaterialType.Cable)
-                        sound.PlayAtCoords("/Audio/items/zip.ogg", Transform.GridPosition);
-                    else
-                        sound.PlayAtCoords("/Audio/items/deconstruct.ogg", Transform.GridPosition);
-                    return true;
-                case ConstructionStepTool toolStep:
-                    if (!slapped.TryGetComponent<ToolComponent>(out var tool))
-                        return false;
-
-                    // Handle welder manually since tool steps specify fuel amount needed, for some reason.
-                    if (toolStep.ToolQuality.HasFlag(ToolQuality.Welding))
-                        return slapped.TryGetComponent<WelderComponent>(out var welder)
-                               && welder.UseTool(user, Owner, toolStep.ToolQuality, toolStep.Amount);
-
-                    return tool.UseTool(user, Owner, toolStep.ToolQuality);
-
-                default:
-                    throw new NotImplementedException();
-            }
-        }
-
-        private static Dictionary<StackType, MaterialType> StackTypeMap
-        = new Dictionary<StackType, MaterialType>
-        {
-            { StackType.Cable, MaterialType.Cable },
-            { StackType.Gold, MaterialType.Gold },
-            { StackType.Glass, MaterialType.Glass },
-            { StackType.Metal, MaterialType.Metal }
-        };
-
-        // Really this should check the actual materials at play..
-        public static bool MaterialStackValidFor(ConstructionStepMaterial step, StackComponent stack)
-        {
-            return StackTypeMap.TryGetValue((StackType)stack.StackType, out var should) && should == step.Material;
+            serializer.DataReadWriteFunction("stage", 0,
+                value => Stage = value, () => Stage);
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Interactable/ToolComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/ToolComponent.cs
@@ -15,8 +15,14 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Interactable
 {
+    public interface IToolComponent
+    {
+        ToolQuality Qualities { get; set; }
+    }
+
     [RegisterComponent]
-    public class ToolComponent : SharedToolComponent
+    [ComponentReference(typeof(IToolComponent))]
+    public class ToolComponent : SharedToolComponent, IToolComponent
     {
         protected ToolQuality _qualities = ToolQuality.None;
 

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -22,6 +22,7 @@ namespace Content.Server.GameObjects.Components.Interactable
 {
     [RegisterComponent]
     [ComponentReference(typeof(ToolComponent))]
+    [ComponentReference(typeof(IToolComponent))]
     public class WelderComponent : ToolComponent, IExamine, IUse, ISuicideAct
     {
 #pragma warning disable 649

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/PoweredLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/PoweredLightComponent.cs
@@ -2,6 +2,7 @@
 using Content.Server.GameObjects.Components.Power.ApcNetComponents;
 using Content.Server.GameObjects.Components.Sound;
 using Content.Server.GameObjects.EntitySystems;
+using Content.Server.Interfaces;
 using Content.Server.Utility;
 using Content.Shared.GameObjects;
 using Robust.Server.GameObjects;
@@ -45,6 +46,23 @@ namespace Content.Server.GameObjects.Components.Power
                 _lightBulbContainer.ContainedEntity.TryGetComponent(out LightBulbComponent bulb);
 
                 return bulb;
+            }
+        }
+
+        public override void HandleMessage(ComponentMessage message, IComponent? component)
+        {
+            base.HandleMessage(message, component);
+
+            switch (message)
+            {
+                case BeginDeconstructCompMsg msg:
+                    if (!msg.BlockDeconstruct && !(_lightBulbContainer.ContainedEntity is null))
+                    {
+                        var notifyManager = IoCManager.Resolve<IServerNotifyManager>();
+                        notifyManager.PopupMessage(Owner, msg.User, "Remove the bulb.");
+                        msg.BlockDeconstruct = true;
+                    }
+                    break;
             }
         }
 

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/PoweredLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/PoweredLightComponent.cs
@@ -49,7 +49,7 @@ namespace Content.Server.GameObjects.Components.Power
             }
         }
 
-        public override void HandleMessage(ComponentMessage message, IComponent? component)
+        public override void HandleMessage(ComponentMessage message, IComponent component)
         {
             base.HandleMessage(message, component);
 

--- a/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
@@ -163,8 +163,10 @@ namespace Content.Server.GameObjects.EntitySystems
 
                     if (targetEnt.Prototype.Components.TryGetValue("Item", out var itemProtoComp))
                     {
-                        if (!frame.TryGetComponent<ItemComponent>(out var itemComp))
-                            itemComp = frame.AddComponent<ItemComponent>();
+                        if(frame.HasComponent<ItemComponent>())
+                            frame.RemoveComponent<ItemComponent>();
+
+                        var itemComp = frame.AddComponent<ItemComponent>();
 
                         var serializer = YamlObjectSerializer.NewReader(itemProtoComp);
                         itemComp.ExposeData(serializer);
@@ -339,8 +341,10 @@ namespace Content.Server.GameObjects.EntitySystems
                 var finalPrototype = _prototypeManager.Index<EntityPrototype>(prototype.Result);
                 if (finalPrototype.Components.TryGetValue("Item", out var itemProtoComp))
                 {
-                    if (!frame.TryGetComponent<ItemComponent>(out var itemComp))
-                        itemComp = frame.AddComponent<ItemComponent>();
+                    if(frame.HasComponent<ItemComponent>())
+                        frame.RemoveComponent<ItemComponent>();
+
+                    var itemComp = frame.AddComponent<ItemComponent>();
 
                     var serializer = YamlObjectSerializer.NewReader(itemProtoComp);
                     itemComp.ExposeData(serializer);

--- a/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
@@ -480,7 +480,7 @@ namespace Content.Server.GameObjects.EntitySystems
             return StackTypeMap.TryGetValue((StackType)stack.StackType, out var should) && should == step.Material;
         }
 
-        private static void SetupComponent(ConstructionComponent constructionComponent, ConstructionPrototype prototype)
+        private void SetupComponent(ConstructionComponent constructionComponent, ConstructionPrototype prototype)
         {
             constructionComponent.Prototype = prototype;
             constructionComponent.Stage = 1;
@@ -494,7 +494,10 @@ namespace Content.Server.GameObjects.EntitySystems
                 spriteComp.AddLayerWithSprite(prototype.Icon);
             }
 
+            var frame = constructionComponent.Owner;
+            var finalPrototype = _prototypeManager.Index<EntityPrototype>(prototype.Result);
 
+            frame.Name = $"Unfinished {finalPrototype.Name}";
         }
     }
 

--- a/Resources/Prototypes/Construction/structures.yml
+++ b/Resources/Prototypes/Construction/structures.yml
@@ -48,6 +48,8 @@
   steps:
   - material: Glass
     amount: 2
+    reverse:
+      tool: Screwing
 
 - type: construction
   name: low wall

--- a/Resources/Prototypes/Construction/weapons.yml
+++ b/Resources/Prototypes/Construction/weapons.yml
@@ -10,10 +10,16 @@
   steps:
   - material: Metal
     amount: 1
+    reverse:
+      tool: Screwing
 
   - material: Cable
     amount: 3
+    reverse:
+      tool: Screwing
 
   # Should probably use a shard but y'know.
   - material: Glass
     amount: 1
+    reverse:
+      tool: Screwing

--- a/Resources/Prototypes/Entities/Items/materials.yml
+++ b/Resources/Prototypes/Entities/Items/materials.yml
@@ -83,6 +83,14 @@
       all: -0.15,-0.15,0.15,0.15
 
 - type: entity
+  id: CableStack1
+  name: cable stack 1
+  parent: CableStack
+  components:
+  - type: Stack
+    count: 1
+
+- type: entity
   id: HVWireStack
   name: HV Wire Coil
   parent: CableStack


### PR DESCRIPTION
* Adds the ability to construct item entities directly in hand.
* Adds the ability to deconstruct entities in hand and in the world.
* Adds an event that allows entities to block deconstruction if some requirements are not met (no access, cover closed, bulb needs to be removed, etc.)
* Misc other issues in #88.

This PR resolves https://github.com/space-wizards/space-station-14/issues/779.
This PR closes https://github.com/space-wizards/space-station-14/pull/790. It basically does what was requested in the feedback.
This PR resolves https://github.com/space-wizards/space-station-14/issues/88. It does everything in the issue except integrate the material system, which is a fair amount of work, and therefore out of the scope of this PR. Another issue will be opened for this specifically.