### PR TITLE
Latejoin Job Selection

### DIFF
--- a/Content.Client/State/GameScreen.cs
+++ b/Content.Client/State/GameScreen.cs
@@ -26,7 +26,6 @@ namespace Content.Client.State
         [Dependency] private readonly IGameHud _gameHud;
         [Dependency] private readonly IInputManager _inputManager;
         [Dependency] private readonly IChatManager _chatManager;
-        [Dependency] private readonly IClientConGroupController _groupController = default!;
 #pragma warning restore 649
 
         [ViewVariables] private ChatBox _gameChat;

--- a/Content.Client/State/LobbyState.cs
+++ b/Content.Client/State/LobbyState.cs
@@ -9,6 +9,7 @@ using Robust.Client.Interfaces;
 using Robust.Client.Interfaces.Input;
 using Robust.Client.Interfaces.ResourceManagement;
 using Robust.Client.Interfaces.UserInterface;
+using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.Player;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Input;
@@ -87,7 +88,8 @@ namespace Content.Client.State
                     return;
                 }
 
-                _console.ProcessCommand("joingame");
+                new LateJoinGui().OpenCentered();
+                return;
             };
 
             _lobby.ReadyButton.OnToggled += args =>

--- a/Content.Client/UserInterface/LateJoinGui.cs
+++ b/Content.Client/UserInterface/LateJoinGui.cs
@@ -26,8 +26,6 @@ namespace Robust.Client.UserInterface.CustomControls
 
         public event Action<string> SelectedId;
 
-        private Dictionary<string, int> AvailablePositions;
-
         public LateJoinGui()
         {
             IoCManager.InjectDependencies(this);

--- a/Content.Client/UserInterface/LateJoinGui.cs
+++ b/Content.Client/UserInterface/LateJoinGui.cs
@@ -3,7 +3,6 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.Utility;
 using Content.Shared.Jobs;
 using Robust.Shared.IoC;
-using Robust.Shared.Interfaces.Network;
 using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
@@ -22,11 +21,6 @@ namespace Robust.Client.UserInterface.CustomControls
         [Dependency] private readonly IPrototypeManager _prototypeManager;
         [Dependency] private readonly IClientConsole _console;
 #pragma warning restore 649
-        /*private readonly Button ApplyButton;
-        private readonly CheckBox VSyncCheckBox;
-        private readonly CheckBox FullscreenCheckBox;
-        private readonly CheckBox HighResLightsCheckBox;*/
-        //private readonly IConfigurationManager configManager;
 
         protected override Vector2? CustomSize => (360, 560);
 
@@ -34,7 +28,7 @@ namespace Robust.Client.UserInterface.CustomControls
 
         private Dictionary<string, int> AvailablePositions;
 
-        public LateJoinGui(/*IConfigurationManager configMan*/)
+        public LateJoinGui()
         {
             IoCManager.InjectDependencies(this);
 
@@ -85,28 +79,15 @@ namespace Robust.Client.UserInterface.CustomControls
                 {
                     Text = job.Name
                 };
+
                 jobSelector.AddChild(jobLabel);
 
-                Logger.InfoS("latejoin", $"Job: {job.ID}, Positions: {job.TotalPositions}");
-                var jobPrototype = _prototypeManager.Index<JobPrototype>(job.ID);
-                Logger.InfoS("latejoin", $"Weird Job: {jobPrototype.ID}, Positions: {job.TotalPositions}");
-                if(jobPrototype.TotalPositions == 0) //TODO: Make this work. GetAvailablePositions() is serverside
-                {
-                    Logger.InfoS("latejoin", $"Disabling {job.ID}");
-                    jobButton.Disabled = true;
-                }
                 jobButton.AddChild(jobSelector);
                 jobList.AddChild(jobButton);
-                //jobButton.OnPressed += OnJobButtonPressed;
                 jobButton.OnPressed += args =>
                 {
                     SelectedId?.Invoke(jobButton.JobId);
                 };
-                /*jobButton.OnItemSelected += args =>
-                {
-                    _optionButton.SelectId(args.Id);
-                    PriorityChanged?.Invoke(Priority);
-                };*/
             }
 
             SelectedId += jobId =>

--- a/Content.Client/UserInterface/LateJoinGui.cs
+++ b/Content.Client/UserInterface/LateJoinGui.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.Utility;
+using Content.Shared.Jobs;
+using Robust.Shared.Interfaces.Configuration;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+using System.Linq;
+
+
+namespace Robust.Client.UserInterface.CustomControls
+{
+    public sealed class LateJoinGui : SS14Window
+    {
+#pragma warning disable 649
+        [Dependency] private readonly IPrototypeManager _prototypeManager;
+#pragma warning restore 649
+        /*private readonly Button ApplyButton;
+        private readonly CheckBox VSyncCheckBox;
+        private readonly CheckBox FullscreenCheckBox;
+        private readonly CheckBox HighResLightsCheckBox;*/
+        //private readonly IConfigurationManager configManager;
+
+        protected override Vector2? CustomSize => (360, 560);
+
+        public LateJoinGui(/*IConfigurationManager configMan*/)
+        {
+            IoCManager.InjectDependencies(this);
+            //configManager = configMan;
+
+            Title = "Late Join";
+            var jobList = new VBoxContainer();
+            var vBox = new VBoxContainer
+            {
+                    Children =
+                    {
+                        new ScrollContainer
+                        {
+                            SizeFlagsVertical = SizeFlags.FillExpand,
+                            Children =
+                            {
+                                jobList
+                            }
+                        }
+                    }
+                };
+            Contents.AddChild(vBox);
+
+            /*VSyncCheckBox = new CheckBox {Text = "VSync"};
+            vBox.AddChild(VSyncCheckBox);
+            VSyncCheckBox.OnToggled += OnCheckBoxToggled;
+
+            FullscreenCheckBox = new CheckBox {Text = "Fullscreen"};
+            vBox.AddChild(FullscreenCheckBox);
+            FullscreenCheckBox.OnToggled += OnCheckBoxToggled;
+
+            HighResLightsCheckBox = new CheckBox {Text = "High-Res Lights"};
+            vBox.AddChild(HighResLightsCheckBox);
+            HighResLightsCheckBox.OnToggled += OnCheckBoxToggled;
+
+            ApplyButton = new Button
+            {
+                Text = "Apply", TextAlign = Label.AlignMode.Center,
+                SizeFlagsVertical = SizeFlags.ShrinkCenter
+            };
+            vBox.AddChild(ApplyButton);
+            ApplyButton.OnPressed += OnApplyButtonPressed;
+
+            VSyncCheckBox.Pressed = configManager.GetCVar<bool>("display.vsync");
+            HighResLightsCheckBox.Pressed = configManager.GetCVar<bool>("display.highreslights");
+            FullscreenCheckBox.Pressed = ConfigIsFullscreen;*/
+
+            foreach (var job in _prototypeManager.EnumeratePrototypes<JobPrototype>().OrderBy(j => j.Name))
+            {
+                var jobSelector = new HBoxContainer();
+
+                var icon = new TextureRect
+                {
+                    TextureScale = (2, 2),
+                    Stretch = TextureRect.StretchMode.KeepCentered
+                };
+
+                if (job.Icon != null)
+                {
+                    var specifier = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/job_icons.rsi"), job.Icon);
+                    icon.Texture = specifier.Frame0();
+                }
+                jobSelector.AddChild(icon);
+
+                var jobLabel = new Label
+                {
+                    //SizeFlagsHorizontal = SizeFlags.ShrinkCenter,
+                    //SizeFlagsVertical = SizeFlags.ShrinkCenter,
+                    Text = job.Name
+                };
+                jobSelector.AddChild(jobLabel);
+
+                var button = new JobButton
+                {
+                    Text = Loc.GetString("Select"),
+                    ToolTip = Loc.GetString($"Join as {job.Name}."),
+                    TextAlign = Label.AlignMode.Center,
+                    JobId = job.ID
+                };
+                /*if(job.TotalPositions == 0) //TODO: Make this work. GetAvailablePositions() is serverside
+                {
+                    button.Disabled = true;
+                }*/
+                jobSelector.AddChild(button);
+                jobList.AddChild(jobSelector);
+            }
+        }
+
+        private void OnApplyButtonPressed(BaseButton.ButtonEventArgs args)
+        {
+            /*configManager.SetCVar("display.vsync", VSyncCheckBox.Pressed);
+            configManager.SetCVar("display.highreslights", HighResLightsCheckBox.Pressed);
+            configManager.SetCVar("display.windowmode",
+                (int) (FullscreenCheckBox.Pressed ? WindowMode.Fullscreen : WindowMode.Windowed));
+            configManager.SaveToFile();
+            UpdateApplyButton();*/
+        }
+
+        private void OnCheckBoxToggled(BaseButton.ButtonToggledEventArgs args)
+        {
+            UpdateApplyButton();
+        }
+
+        private void UpdateApplyButton()
+        {
+            //var isVSyncSame = VSyncCheckBox.Pressed == configManager.GetCVar<bool>("display.vsync");
+            //var isHighResLightsSame = HighResLightsCheckBox.Pressed == configManager.GetCVar<bool>("display.highreslights");
+            //var isFullscreenSame = FullscreenCheckBox.Pressed == ConfigIsFullscreen;
+            //ApplyButton.Disabled = isVSyncSame && isHighResLightsSame && isFullscreenSame;
+        }
+        private class JobButton : Button
+        {
+            public string JobId { get; set; }
+        }
+    }
+}

--- a/Content.Client/UserInterface/LateJoinGui.cs
+++ b/Content.Client/UserInterface/LateJoinGui.cs
@@ -55,6 +55,7 @@ namespace Robust.Client.UserInterface.CustomControls
                 {
                     JobId = job.ID
                 };
+
                 var jobSelector = new HBoxContainer
                 {
                     SizeFlagsHorizontal = SizeFlags.FillExpand
@@ -68,7 +69,7 @@ namespace Robust.Client.UserInterface.CustomControls
 
                 if (job.Icon != null)
                 {
-                    var specifier = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/job_icons.rsi"), job.Icon);
+                    var specifier = new SpriteSpecifier.Rsi(new ResourcePath("/Textures/Interface/Misc/job_icons.rsi"), job.Icon);
                     icon.Texture = specifier.Frame0();
                 }
                 jobSelector.AddChild(icon);

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -109,5 +109,10 @@ namespace Content.IntegrationTests
         {
             return false;
         }
+
+        public Dictionary<string, int> GetAvailablePositions()
+        {
+            return new Dictionary<string, int>();
+        }
     }
 }

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -53,7 +53,7 @@ namespace Content.IntegrationTests
         {
         }
 
-        public void MakeJoinGame(IPlayerSession player)
+        public void MakeJoinGame(IPlayerSession player, string jobId)
         {
         }
 

--- a/Content.Server/GameTicking/GameTicker.JobController.cs
+++ b/Content.Server/GameTicking/GameTicker.JobController.cs
@@ -124,7 +124,7 @@ namespace Content.Server.GameTicking
         /// <summary>
         ///     Gets the remaining available job positions in the current round.
         /// </summary>
-        private Dictionary<string, int> GetAvailablePositions()
+        public Dictionary<string, int> GetAvailablePositions()
         {
             var basePositions = GetBasePositions(false);
 

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -766,7 +766,6 @@ namespace Content.Server.GameTicking
             }
 
             var jobPrototype = _prototypeManager.Index<JobPrototype>(jobId);
-            jobPrototype.TotalPositions--;
             var job = new Job(data.Mind, jobPrototype);
             data.Mind.AddRole(job);
 

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -354,11 +354,11 @@ namespace Content.Server.GameTicking
             _spawnObserver(player);
         }
 
-        public void MakeJoinGame(IPlayerSession player)
+        public void MakeJoinGame(IPlayerSession player, string jobId = null)
         {
             if (!_playersInLobby.ContainsKey(player)) return;
 
-            SpawnPlayer(player);
+            SpawnPlayer(player, jobId);
         }
 
         public void ToggleReady(IPlayerSession player, bool ready)
@@ -766,6 +766,7 @@ namespace Content.Server.GameTicking
             }
 
             var jobPrototype = _prototypeManager.Index<JobPrototype>(jobId);
+            jobPrototype.TotalPositions--;
             var job = new Job(data.Mind, jobPrototype);
             data.Mind.AddRole(job);
 

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -209,7 +209,7 @@ namespace Content.Server.GameTicking
                 string ID = args[0];
                 var positions = ticker.GetAvailablePositions();
 
-                if(positions.GetValueOrDefault(ID, 0) == 0)
+                if(positions.GetValueOrDefault(ID, 0) == 0) //n < 0 is treated as infinite
                 {
                     var jobPrototype = _prototypeManager.Index<JobPrototype>(ID);
                     shell.SendText(player, $"{jobPrototype.Name} has no available slots.");

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Content.Server.GameTicking;
 using Content.Server.Interfaces.GameTicking;
 using Content.Server.Players;
@@ -206,9 +207,11 @@ namespace Content.Server.GameTicking
             else if(ticker.RunLevel == GameRunLevel.InRound)
             {
                 string ID = args[0];
-                var jobPrototype = _prototypeManager.Index<JobPrototype>(ID);
-                if(jobPrototype.TotalPositions == 0)
+                var positions = ticker.GetAvailablePositions();
+
+                if(positions.GetValueOrDefault(ID, 0) == 0)
                 {
+                    var jobPrototype = _prototypeManager.Index<JobPrototype>(ID);
                     shell.SendText(player, $"{jobPrototype.Name} has no available slots.");
                     return;
                 }

--- a/Content.Server/GameTicking/GameTickerCommands.cs
+++ b/Content.Server/GameTicking/GameTickerCommands.cs
@@ -1,11 +1,14 @@
 using System;
-using Content.Server.GameTicking.GamePresets;
+using Content.Server.GameTicking;
 using Content.Server.Interfaces.GameTicking;
 using Content.Server.Players;
+using Content.Shared.Jobs;
 using Robust.Server.Interfaces.Console;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Log;
 
 namespace Content.Server.GameTicking
 {
@@ -175,12 +178,20 @@ namespace Content.Server.GameTicking
 
     class JoinGameCommand : IClientCommand
     {
+#pragma warning disable 649
+        [Dependency] private IPrototypeManager _prototypeManager;
+#pragma warning restore 649
         public string Command => "joingame";
         public string Description => "";
         public string Help => "";
 
+        public JoinGameCommand()
+        {
+            IoCManager.InjectDependencies(this);
+        }
         public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
         {
+            var output = string.Join(".", args);
             if (player == null)
             {
                 return;
@@ -192,8 +203,20 @@ namespace Content.Server.GameTicking
                 shell.SendText(player, "Round has not started.");
                 return;
             }
+            else if(ticker.RunLevel == GameRunLevel.InRound)
+            {
+                string ID = args[0];
+                var jobPrototype = _prototypeManager.Index<JobPrototype>(ID);
+                if(jobPrototype.TotalPositions == 0)
+                {
+                    shell.SendText(player, $"{jobPrototype.Name} has no available slots.");
+                    return;
+                }
+                ticker.MakeJoinGame(player, args[0].ToString());
+                return;
+            }
 
-            ticker.MakeJoinGame(player);
+            ticker.MakeJoinGame(player, null);
         }
     }
 

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Interfaces.GameTicking
 
         void Respawn(IPlayerSession targetPlayer);
         void MakeObserve(IPlayerSession player);
-        void MakeJoinGame(IPlayerSession player);
+        void MakeJoinGame(IPlayerSession player, string jobId);
         void ToggleReady(IPlayerSession player, bool ready);
 
         GridCoordinates GetLateJoinSpawnPoint();

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -50,5 +50,7 @@ namespace Content.Server.Interfaces.GameTicking
         bool TogglePause();
 
         bool DelayStart(TimeSpan time);
+
+        Dictionary<string, int> GetAvailablePositions();
     }
 }

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -35,7 +35,7 @@ namespace Content.Shared.Jobs
         /// <summary>
         ///     The total amount of positions available.
         /// </summary>
-        public int TotalPositions { get; set; }
+        public int TotalPositions { get; private set; }
 
         public string StartingGear { get; private set; }
 

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -35,7 +35,7 @@ namespace Content.Shared.Jobs
         /// <summary>
         ///     The total amount of positions available.
         /// </summary>
-        public int TotalPositions { get; private set; }
+        public int TotalPositions { get; set; }
 
         public string StartingGear { get; private set; }
 


### PR DESCRIPTION
Allows players to select a job when they latejoin.

Demo: https://streamable.com/dzw795

It won't let you join as a job if it has no open positions, but this is only conveyed to the player via a console message at the moment because I can't wrap my head around netcode. Ideally the buttons would be disabled, but like I said I don't know how to get the available positions from the server to the client.