### PR TITLE
Admin chat

### DIFF
--- a/Content.Client/Chat/ChatBox.cs
+++ b/Content.Client/Chat/ChatBox.cs
@@ -26,6 +26,7 @@ namespace Content.Client.Chat
         public Button AllButton { get; }
         public Button LocalButton { get; }
         public Button OOCButton { get; }
+        public Button AdminButton { get; }
 
         /// <summary>
         ///     Default formatting string for the ClientChatConsole.
@@ -34,7 +35,7 @@ namespace Content.Client.Chat
 
         public bool ReleaseFocusOnEnter { get; set; } = true;
 
-        public ChatBox()
+        public ChatBox(bool admin = false)
         {
             /*MarginLeft = -475.0f;
             MarginTop = 10.0f;
@@ -95,6 +96,16 @@ namespace Content.Client.Chat
                 ToggleMode = true,
             };
 
+            if(admin)
+            {
+                AdminButton = new Button
+                {
+                    Text = _localize.GetString("Admin"),
+                    Name = "Admin",
+                    ToggleMode = true,
+                };
+            }
+
             AllButton.OnToggled += OnFilterToggled;
             LocalButton.OnToggled += OnFilterToggled;
             OOCButton.OnToggled += OnFilterToggled;
@@ -102,6 +113,11 @@ namespace Content.Client.Chat
             hBox.AddChild(AllButton);
             hBox.AddChild(LocalButton);
             hBox.AddChild(OOCButton);
+            if(AdminButton != null)
+            {
+                AdminButton.OnToggled += OnFilterToggled;
+                hBox.AddChild(AdminButton);
+            }
 
             AddChild(outerVBox);
         }

--- a/Content.Client/Chat/ChatBox.cs
+++ b/Content.Client/Chat/ChatBox.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Content.Shared.Chat;
+using Robust.Client.Console;
 using Robust.Client.Graphics.Drawing;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
@@ -35,7 +36,7 @@ namespace Content.Client.Chat
 
         public bool ReleaseFocusOnEnter { get; set; } = true;
 
-        public ChatBox(bool admin = false)
+        public ChatBox()
         {
             /*MarginLeft = -475.0f;
             MarginTop = 10.0f;
@@ -59,6 +60,7 @@ namespace Content.Client.Chat
 
             outerVBox.AddChild(panelContainer);
             outerVBox.AddChild(hBox);
+
 
             var contentMargin = new MarginContainer
             {
@@ -96,7 +98,8 @@ namespace Content.Client.Chat
                 ToggleMode = true,
             };
 
-            if(admin)
+            var groupController = IoCManager.Resolve<IClientConGroupController>();
+            if(groupController.CanCommand("asay"))
             {
                 AdminButton = new Button
                 {

--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -14,6 +14,7 @@ namespace Content.Client.Input
             var common = contexts.GetContext("common");
             common.AddFunction(ContentKeyFunctions.FocusChat);
             common.AddFunction(ContentKeyFunctions.FocusOOC);
+            common.AddFunction(ContentKeyFunctions.FocusAdminChat);
             common.AddFunction(ContentKeyFunctions.ExamineEntity);
             common.AddFunction(ContentKeyFunctions.OpenTutorial);
             common.AddFunction(ContentKeyFunctions.TakeScreenshot);

--- a/Content.Client/State/GameScreen.cs
+++ b/Content.Client/State/GameScreen.cs
@@ -29,14 +29,7 @@ namespace Content.Client.State
         {
             base.Startup();
 
-            if(_groupController.CanCommand("asay"))
-            {
-                _gameChat = new ChatBox(true);
-            }
-            else
-            {
-                _gameChat = new ChatBox(false);
-            }
+            _gameChat = new ChatBox();
 
             _userInterfaceManager.StateRoot.AddChild(_gameChat);
             LayoutContainer.SetAnchorAndMarginPreset(_gameChat, LayoutContainer.LayoutPreset.TopRight, margin: 10);

--- a/Content.Client/State/GameScreen.cs
+++ b/Content.Client/State/GameScreen.cs
@@ -2,6 +2,7 @@ using Content.Client.Chat;
 using Content.Client.Interfaces.Chat;
 using Content.Client.UserInterface;
 using Content.Shared.Input;
+using Robust.Client.Console;
 using Robust.Client.Interfaces.Input;
 using Robust.Client.Interfaces.UserInterface;
 using Robust.Client.UserInterface.Controls;
@@ -19,6 +20,7 @@ namespace Content.Client.State
         [Dependency] private readonly IGameHud _gameHud;
         [Dependency] private readonly IInputManager _inputManager;
         [Dependency] private readonly IChatManager _chatManager;
+        [Dependency] private readonly IClientConGroupController _groupController = default!;
 #pragma warning restore 649
 
         [ViewVariables] private ChatBox _gameChat;
@@ -27,7 +29,15 @@ namespace Content.Client.State
         {
             base.Startup();
 
-            _gameChat = new ChatBox();
+            if(_groupController.CanCommand("asay"))
+            {
+                _gameChat = new ChatBox(true);
+            }
+            else
+            {
+                _gameChat = new ChatBox(false);
+            }
+
             _userInterfaceManager.StateRoot.AddChild(_gameChat);
             LayoutContainer.SetAnchorAndMarginPreset(_gameChat, LayoutContainer.LayoutPreset.TopRight, margin: 10);
             LayoutContainer.SetAnchorAndMarginPreset(_gameChat, LayoutContainer.LayoutPreset.TopRight, margin: 10);
@@ -44,6 +54,9 @@ namespace Content.Client.State
 
             _inputManager.SetInputCommand(ContentKeyFunctions.FocusOOC,
                 InputCmdHandler.FromDelegate(s => FocusOOC(_gameChat)));
+
+            _inputManager.SetInputCommand(ContentKeyFunctions.FocusAdminChat,
+                InputCmdHandler.FromDelegate(s => FocusAdminChat(_gameChat)));
         }
 
         public override void Shutdown()
@@ -74,6 +87,18 @@ namespace Content.Client.State
             chat.Input.IgnoreNext = true;
             chat.Input.GrabKeyboardFocus();
             chat.Input.InsertAtCursor("[");
+        }
+
+        internal static void FocusAdminChat(ChatBox chat)
+        {
+            if (chat == null || chat.UserInterfaceManager.KeyboardFocused != null)
+            {
+                return;
+            }
+
+            chat.Input.IgnoreNext = true;
+            chat.Input.GrabKeyboardFocus();
+            chat.Input.InsertAtCursor("]");
         }
     }
 }

--- a/Content.Client/UserInterface/TutorialWindow.cs
+++ b/Content.Client/UserInterface/TutorialWindow.cs
@@ -76,6 +76,7 @@ Open character window: [color=#a4885c]{8}[/color]
 Open crafting window: [color=#a4885c]{9}[/color]
 Focus chat: [color=#a4885c]{10}[/color]
 Focus OOC: [color=#a4885c]{26}[/color]
+Focus Admin Chat: [color=#a4885c]{27}[/color]
 Use hand/object in hand: [color=#a4885c]{22}[/color]
 Do wide attack: [color=#a4885c]{23}[/color]
 Use targeted entity: [color=#a4885c]{11}[/color]
@@ -112,7 +113,8 @@ Toggle sandbox window: [color=#a4885c]{21}[/color]",
                 Key(WideAttack),
                 Key(SmartEquipBackpack),
                 Key(SmartEquipBelt),
-                Key(FocusOOC)));
+                Key(FocusOOC),
+                Key(FocusAdminChat)));
 
             //Gameplay
             VBox.AddChild(new Label { FontOverride = headerFont, Text = "\nGameplay" });

--- a/Content.Server/Chat/ChatCommands.cs
+++ b/Content.Server/Chat/ChatCommands.cs
@@ -4,6 +4,7 @@ using Content.Server.Interfaces.Chat;
 using Content.Server.Interfaces.GameObjects;
 using Content.Server.Players;
 using Content.Shared.GameObjects;
+using Robust.Server.Console;
 using Robust.Server.Interfaces.Console;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Enums;
@@ -76,6 +77,19 @@ namespace Content.Server.Chat
         {
             var chat = IoCManager.Resolve<IChatManager>();
             chat.SendOOC(player, string.Join(" ", args));
+        }
+    }
+
+    internal class AdminChatCommand : IClientCommand
+    {
+        public string Command => "asay";
+        public string Description => "Send chat messages to the private admin chat channel.";
+        public string Help => "asay <text>";
+
+        public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
+        {
+            var chat = IoCManager.Resolve<IChatManager>();
+            chat.SendAdminChat(player, string.Join(" ", args));
         }
     }
 

--- a/Content.Server/Chat/ChatManager.cs
+++ b/Content.Server/Chat/ChatManager.cs
@@ -127,7 +127,7 @@ namespace Content.Server.Chat
 
             msg.Channel = ChatChannel.AdminChat;
             msg.Message = message;
-            msg.MessageWrap = $"{_localizationManager.GetString("ADMIN")}: {player.AttachedEntity.Name}: {{0}}";
+            msg.MessageWrap = $"{_localizationManager.GetString("ADMIN")}: {player.SessionId}: {{0}}";
             msg.SenderEntity = player.AttachedEntityUid.GetValueOrDefault();
             _netManager.ServerSendToMany(msg, clients.ToList());
         }

--- a/Content.Server/Chat/ChatManager.cs
+++ b/Content.Server/Chat/ChatManager.cs
@@ -128,7 +128,6 @@ namespace Content.Server.Chat
             msg.Channel = ChatChannel.AdminChat;
             msg.Message = message;
             msg.MessageWrap = $"{_localizationManager.GetString("ADMIN")}: {player.SessionId}: {{0}}";
-            msg.SenderEntity = player.AttachedEntityUid.GetValueOrDefault();
             _netManager.ServerSendToMany(msg, clients.ToList());
         }
 

--- a/Content.Server/Chat/ChatManager.cs
+++ b/Content.Server/Chat/ChatManager.cs
@@ -7,6 +7,7 @@ using Content.Server.Observer;
 using Content.Server.Players;
 using Content.Shared.Chat;
 using Content.Shared.GameObjects.EntitySystems;
+using Robust.Server.Console;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
@@ -28,6 +29,7 @@ namespace Content.Server.Chat
         [Dependency] private readonly IPlayerManager _playerManager;
         [Dependency] private readonly ILocalizationManager _localizationManager;
         [Dependency] private readonly IMoMMILink _mommiLink;
+        [Dependency] private readonly IConGroupController _conGroupController;
 #pragma warning restore 649
 
         public void Initialize()
@@ -108,6 +110,24 @@ namespace Content.Server.Chat
             msg.Channel = ChatChannel.Dead;
             msg.Message = message;
             msg.MessageWrap = $"{_localizationManager.GetString("DEAD")}: {player.AttachedEntity.Name}: {{0}}";
+            msg.SenderEntity = player.AttachedEntityUid.GetValueOrDefault();
+            _netManager.ServerSendToMany(msg, clients.ToList());
+        }
+
+        public void SendAdminChat(IPlayerSession player, string message)
+        {
+            if(!_conGroupController.CanCommand(player, "asay"))
+            {
+                SendOOC(player, message);
+                return;
+            }
+            var clients = _playerManager.GetPlayersBy(x => _conGroupController.CanCommand(x, "asay")).Select(p => p.ConnectedClient);;
+
+            var msg = _netManager.CreateNetMessage<MsgChatMessage>();
+
+            msg.Channel = ChatChannel.AdminChat;
+            msg.Message = message;
+            msg.MessageWrap = $"{_localizationManager.GetString("ADMIN")}: {player.AttachedEntity.Name}: {{0}}";
             msg.SenderEntity = player.AttachedEntityUid.GetValueOrDefault();
             _netManager.ServerSendToMany(msg, clients.ToList());
         }

--- a/Content.Server/Interfaces/Chat/IChatManager.cs
+++ b/Content.Server/Interfaces/Chat/IChatManager.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Interfaces.Chat
         void EntityMe(IEntity source, string action);
 
         void SendOOC(IPlayerSession player, string message);
+        void SendAdminChat(IPlayerSession player, string message);
         void SendDeadChat(IPlayerSession player, string message);
 
         void SendHookOOC(string sender, string message);

--- a/Content.Shared/Chat/ChatChannel.cs
+++ b/Content.Shared/Chat/ChatChannel.cs
@@ -52,8 +52,13 @@ namespace Content.Shared.Chat
         Dead = 128,
 
         /// <summary>
+        ///     Admin chat
+        /// </summary>
+        AdminChat = 256,
+
+        /// <summary>
         ///     Unspecified.
         /// </summary>
-        Unspecified = 256,
+        Unspecified = 512,
     }
 }

--- a/Content.Shared/Chat/MsgChatMessage.cs
+++ b/Content.Shared/Chat/MsgChatMessage.cs
@@ -41,7 +41,7 @@ namespace Content.Shared.Chat
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
-            Channel = (ChatChannel) buffer.ReadByte();
+            Channel = (ChatChannel) buffer.ReadInt16();
             Message = buffer.ReadString();
             MessageWrap = buffer.ReadString();
 
@@ -49,6 +49,7 @@ namespace Content.Shared.Chat
             {
                 case ChatChannel.Local:
                 case ChatChannel.Dead:
+                case ChatChannel.AdminChat:
                 case ChatChannel.Emotes:
                     SenderEntity = buffer.ReadEntityUid();
                     break;
@@ -57,7 +58,7 @@ namespace Content.Shared.Chat
 
         public override void WriteToBuffer(NetOutgoingMessage buffer)
         {
-            buffer.Write((byte)Channel);
+            buffer.Write((short)Channel);
             buffer.Write(Message);
             buffer.Write(MessageWrap);
 
@@ -65,6 +66,7 @@ namespace Content.Shared.Chat
             {
                 case ChatChannel.Local:
                 case ChatChannel.Dead:
+                case ChatChannel.AdminChat:
                 case ChatChannel.Emotes:
                     buffer.Write(SenderEntity);
                     break;

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -12,6 +12,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction ExamineEntity = "ExamineEntity";
         public static readonly BoundKeyFunction FocusChat = "FocusChatWindow";
         public static readonly BoundKeyFunction FocusOOC = "FocusOOCWindow";
+        public static readonly BoundKeyFunction FocusAdminChat = "FocusAdminChatWindow";
         public static readonly BoundKeyFunction OpenCharacterMenu = "OpenCharacterMenu";
         public static readonly BoundKeyFunction OpenContextMenu = "OpenContextMenu";
         public static readonly BoundKeyFunction OpenCraftingMenu = "OpenCraftingMenu";

--- a/Resources/Groups/groups.yml
+++ b/Resources/Groups/groups.yml
@@ -80,6 +80,7 @@
   - warp
   - hostlogin
   - deleteewc
+  - asay
   CanViewVar: true
   CanAdminPlace: true
 
@@ -148,6 +149,7 @@
   - warp
   - deleteewc
   - sudo
+  - asay
   CanViewVar: true
   CanAdminPlace: true
   CanScript: true

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -46,6 +46,9 @@ binds:
 - function: FocusOOCWindow
   type: State
   key: LBracket
+- function: FocusAdminChatWindow
+  type: State
+  key: RBracket
 - function: EditorLinePlace
   type: State
   key: MouseLeft


### PR DESCRIPTION
Adds a chat channel for admins. Messages can be sent with the `asay` command or the `]` hotkey.

Admins also have a button to filter admin chat, the same as normal players filter Local/OOC. Regular players don't have the button.