### PR TITLE
Fixed Welding Tool Not Updating

### DIFF
--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -24,7 +24,7 @@ namespace Content.Server.GameObjects.Components.Interactable
     [RegisterComponent]
     [ComponentReference(typeof(ToolComponent))]
     [ComponentReference(typeof(IToolComponent))]
-    public class WelderComponent : ToolComponent, IExamine, IUse, ISuicideAct
+    public class WelderComponent : ToolComponent, IExamine, IUse, ISuicideAct, ISolutionChange
     {
 #pragma warning disable 649
         [Dependency] private IEntitySystemManager _entitySystemManager;
@@ -193,7 +193,7 @@ namespace Content.Server.GameObjects.Components.Interactable
             if (Fuel == 0)
                 ToggleWelderStatus();
 
-            Dirty();
+            //Dirty();
         }
 
         public SuicideKind Suicide(IEntity victim, IChatManager chat)
@@ -206,6 +206,11 @@ namespace Content.Server.GameObjects.Components.Interactable
             }
             chat.EntityMe(victim, Loc.GetString("bashes {0:themselves} with the {1}!", victim, Owner.Name));
             return SuicideKind.Brute;
+        }
+
+        public void SolutionChanged(SolutionChangeEventArgs eventArgs)
+        {
+            Dirty();
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -193,7 +193,6 @@ namespace Content.Server.GameObjects.Components.Interactable
             if (Fuel == 0)
                 ToggleWelderStatus();
 
-            //Dirty();
         }
 
         public SuicideKind Suicide(IEntity victim, IChatManager chat)


### PR DESCRIPTION
Fixes #1271 

- Added the ISolutionChange interface to the WelderComponent so that it dirties the entity any time the amount of welding fuel changes. This applies when it is lit and when it is unlit.
- I also removed some redundant code.