### PR TITLE
Fixes the ability to unweld inside containers

### DIFF
--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -101,12 +101,12 @@ namespace Content.Server.GameObjects.Components.Interactable
         public bool UseTool(IEntity user, IEntity target, ToolQuality toolQualityNeeded, float fuelConsumed)
         {
             // Checks to make sure the thing being welded is a container before checking contents
-            if (target.Prototype.Components.ContainsKey("EntityStorage"))
+            if (target.TryGetComponent<ContainerManagerComponent>(out ContainerManagerComponent container))
             {
                 // Checks if user is in the container before welding
-                if (target.GetComponent<ContainerManagerComponent>().ContainsEntity(user))
+                if (container.ContainsEntity(user))
                 {
-                   //_notifyManager.PopupMessage(Owner, user, Loc.GetString("You're too cramped!"));
+                   _notifyManager.PopupMessage(Owner, user, Loc.GetString("You're too cramped!"));
                     return false;
                 }
             }

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -99,6 +99,16 @@ namespace Content.Server.GameObjects.Components.Interactable
 
         public bool UseTool(IEntity user, IEntity target, ToolQuality toolQualityNeeded, float fuelConsumed)
         {
+            // Checks to make sure the thing being welded is a container before checking contents
+            if (target.Prototype.Components.ContainsKey("EntityStorage"))
+            {
+                // Checks if user is in the container before welding
+                if (target.GetComponent<ContainerManagerComponent>().ContainsEntity(user))
+                {
+                   _notifyManager.PopupMessage(Owner, user, Loc.GetString("Your too cramped!"));
+                    return false;
+                }
+            }
             return base.UseTool(user, target, toolQualityNeeded) && TryWeld(fuelConsumed, user);
         }
 

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -20,7 +20,6 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
-using Robust.Server.GameObjects.Components.Container;
 
 namespace Content.Server.GameObjects.Components.Interactable
 {
@@ -100,16 +99,6 @@ namespace Content.Server.GameObjects.Components.Interactable
 
         public bool UseTool(IEntity user, IEntity target, ToolQuality toolQualityNeeded, float fuelConsumed)
         {
-            // Checks to make sure the thing being welded is a container before checking contents
-            if (target.TryGetComponent<ContainerManagerComponent>(out ContainerManagerComponent container))
-            {
-                // Checks if user is in the container before welding
-                if (container.ContainsEntity(user))
-                {
-                   _notifyManager.PopupMessage(Owner, user, Loc.GetString("You're too cramped!"));
-                    return false;
-                }
-            }
             return base.UseTool(user, target, toolQualityNeeded) && TryWeld(fuelConsumed, user);
         }
 

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -20,6 +20,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
+using Robust.Server.GameObjects.Components.Container;
 
 namespace Content.Server.GameObjects.Components.Interactable
 {
@@ -105,7 +106,7 @@ namespace Content.Server.GameObjects.Components.Interactable
                 // Checks if user is in the container before welding
                 if (target.GetComponent<ContainerManagerComponent>().ContainsEntity(user))
                 {
-                   _notifyManager.PopupMessage(Owner, user, Loc.GetString("You're too cramped!"));
+                   //_notifyManager.PopupMessage(Owner, user, Loc.GetString("You're too cramped!"));
                     return false;
                 }
             }

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -105,7 +105,7 @@ namespace Content.Server.GameObjects.Components.Interactable
                 // Checks if user is in the container before welding
                 if (target.GetComponent<ContainerManagerComponent>().ContainsEntity(user))
                 {
-                   _notifyManager.PopupMessage(Owner, user, Loc.GetString("Your too cramped!"));
+                   _notifyManager.PopupMessage(Owner, user, Loc.GetString("You're too cramped!"));
                     return false;
                 }
             }

--- a/Content.Server/GameObjects/Components/Items/Storage/EntityStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/EntityStorageComponent.cs
@@ -356,16 +356,18 @@ namespace Content.Server.GameObjects.Components
             if (!CanWeldShut)
                 return false;
 
+            if (_contents.Contains(eventArgs.User))
+            {
+                Owner.PopupMessage(eventArgs.User, Loc.GetString("It's too Cramped!"));
+                return false;
+            }
+
             if (!eventArgs.Using.TryGetComponent(out WelderComponent tool))
                 return false;
 
             if (!tool.UseTool(eventArgs.User, Owner, ToolQuality.Welding, 1f))
                 return false;
-            if(_contents.Contains(eventArgs.User))
-            {
-                Owner.PopupMessage(eventArgs.User, Loc.GetString("It's too Cramped!"));
-                return false;
-            }
+
 
             IsWeldedShut ^= true;
             return true;

--- a/Content.Server/GameObjects/Components/Items/Storage/EntityStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/EntityStorageComponent.cs
@@ -361,6 +361,11 @@ namespace Content.Server.GameObjects.Components
 
             if (!tool.UseTool(eventArgs.User, Owner, ToolQuality.Welding, 1f))
                 return false;
+            if(_contents.Contains(eventArgs.User))
+            {
+                Owner.PopupMessage(eventArgs.User, Loc.GetString("It's too Cramped!"));
+                return false;
+            }
 
             IsWeldedShut ^= true;
             return true;


### PR DESCRIPTION
This fixes https://github.com/space-wizards/space-station-14/issues/1356 if it is decided that the user shouldn't be able to weld/un-weld themselves in a container.

Just recently started looking into ss14 codebase so let me know if something isn't named/coded correctly. Still learning how everything is.

![image](https://user-images.githubusercontent.com/43192081/87239162-e1183100-c3d9-11ea-8b95-4c2be2a7c4f5.png)
