### PR TITLE
fix #1192

### DIFF
--- a/Content.Client/GameObjects/Components/Mobs/ClientStatusEffectsComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/ClientStatusEffectsComponent.cs
@@ -85,6 +85,7 @@ namespace Content.Client.GameObjects.Components.Mobs
         {
             _ui?.Dispose();
             _ui = null;
+            _cooldown.Clear();
         }
 
         public void UpdateStatusEffects()


### PR DESCRIPTION
bug happens because `_status` and `_cooldown` get un-synced. imo they should be a single dictionary with a tuple value (StatusEffectStatus, CooldownGraphic), or a struct, but i'm a noob.