### PR TITLE
Projectiles Now check for Hard

### DIFF
--- a/Content.Server/GameObjects/Components/Projectiles/ProjectileComponent.cs
+++ b/Content.Server/GameObjects/Components/Projectiles/ProjectileComponent.cs
@@ -63,6 +63,15 @@ namespace Content.Server.GameObjects.Components.Projectiles
         /// <param name="entity"></param>
         void ICollideBehavior.CollideWith(IEntity entity)
         {
+            // This is so entities that shouldn't get a collision are ignored.
+            if (entity.TryGetComponent(out ICollidableComponent collidable) && collidable.Hard == false)
+            {
+                _deleteOnCollide = false;
+                return;
+            }
+            else
+                _deleteOnCollide = true;
+
             if (_soundHitSpecies != null && entity.HasComponent<SpeciesComponent>())
             {
                 EntitySystem.Get<AudioSystem>().PlayAtCoords(_soundHitSpecies, entity.Transform.GridPosition);


### PR DESCRIPTION
This PR Relates to the following issue where banana peels were ultimate bullet shields: https://github.com/space-wizards/space-station-14/issues/1354

Before these changes, banana peels were being calculated as a hit entity by projectiles: https://i.gyazo.com/66dc9fa1274789367a0ac4bb73879494.mp4

Now, projectiles will check to see if the collidable entity has the Hard value set to false so the entity will be ignored and the projectile isn't removed after the collision:
https://i.gyazo.com/e76197282ea50812b39170f36348e3e5.mp4

Still new to the codebase so let me know if I need to make other changes. I'm trying to help with the backlog of bug issues.

Edit: This should also make it so other slippery components aren't stopping bullets either. Slippery puddles for instance.