### PR TITLE
Examine text feedback for when things are powered

### DIFF
--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
@@ -8,7 +8,10 @@ using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 using System;
+using Content.Server.GameObjects.EntitySystems.Click;
 using Robust.Shared.GameObjects.Components;
+using Robust.Shared.Localization;
+using Robust.Shared.Utility;
 
 namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
 {
@@ -16,7 +19,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
     ///     Attempts to link with a nearby <see cref="IPowerProvider"/>s so that it can receive power from a <see cref="IApcNet"/>.
     /// </summary>
     [RegisterComponent]
-    public class PowerReceiverComponent : Component
+    public class PowerReceiverComponent : Component, IExamine
     {
         public override string Name => "PowerReceiver";
 
@@ -215,6 +218,14 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
             {
                 ClearProvider();
             }
+        }
+        ///<summary>
+        ///Adds some markup to the examine text of whatever object is using this component to tell you if it's powered or not, even if it doesn't have an icon state to do this for you.
+        ///</summary>
+
+        public void Examine(FormattedMessage message, bool inDetailsRange)
+        {
+            message.AddMarkup(Loc.GetString("It appears to be {0}.", this.Powered ? "[color=darkgreen]powered[/color]" : "[color=darkred]un-powered[/color]"));
         }
     }
 


### PR DESCRIPTION

![](https://cdn.discordapp.com/attachments/310555209753690112/735176979820576941/unknown.png)

Hopefully I understood this right, but should give some extra feedback for when things are powered.

fixes https://github.com/space-wizards/space-station-14/issues/1294