### PR TITLE
Set Handled for Deconstructing Items

### DIFF
--- a/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
@@ -120,6 +120,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 {
                     _notifyManager.PopupMessage(msg.Attacked, msg.User,
                         "Cannot be deconstructed.");
+                    msg.Handled = true;
                     return;
                 }
 
@@ -129,6 +130,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 {
                     _notifyManager.PopupMessage(msg.Attacked, msg.User,
                         "Cannot be deconstructed.");
+                    msg.Handled = true;
                     return;
                 }
 
@@ -138,6 +140,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 {
                     _notifyManager.PopupMessage(msg.Attacked, msg.User,
                         "Wrong tool to start deconstruct.");
+                    msg.Handled = true;
                     return;
                 }
 


### PR DESCRIPTION
Items that do not have a recipe will no longer deconstruct the floor instead.
Hopefully fixes https://github.com/space-wizards/space-station-14/issues/1403

Gif: https://gyazo.com/d2becef3fbd76dd5a2b25c33aa94742d