### PR TITLE
Moved audio playing for melee to be before damage calculation

### DIFF
--- a/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
@@ -100,6 +100,16 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
             // This should really be improved. GetEntitiesInArc uses pos instead of bounding boxes.
             var entities = ArcRayCast(eventArgs.User.Transform.WorldPosition, angle, eventArgs.User);
 
+            var audioSystem = EntitySystem.Get<AudioSystem>();
+            if (entities.Count() != 0)
+            {
+                audioSystem.PlayFromEntity( _hitSound, entities.First());
+            }
+            else
+            {
+                audioSystem.PlayFromEntity("/Audio/Weapons/punchmiss.ogg", eventArgs.User);
+            }
+
             var hitEntities = new List<IEntity>();
             foreach (var entity in entities)
             {
@@ -114,10 +124,6 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
             }
 
             if(!OnHitEntities(hitEntities, eventArgs)) return;
-
-            var audioSystem = EntitySystem.Get<AudioSystem>();
-            var emitter = hitEntities.Count == 0 ? eventArgs.User : hitEntities[0];
-            audioSystem.PlayFromEntity(hitEntities.Count > 0 ? _hitSound : "/Audio/Weapons/punchmiss.ogg", emitter);
 
             if (Arc != null)
             {


### PR DESCRIPTION
Fix for #1492.

There's another issue were audio on the client side won't play on destruction of an object, but that's a separate issue with RobustToolbox I'll have a PR out for shortly. 