### PR TITLE
Adds pullable component to multiple entities.

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Ground/furniture.yml
+++ b/Resources/Prototypes/Entities/Constructible/Ground/furniture.yml
@@ -14,6 +14,8 @@
     state: stool_base
   - type: Strap
     position: Stand
+  - type: Anchorable
+  - type: Pullable
 
 - type: entity
   name: bar stool
@@ -42,6 +44,8 @@
     state: officechair_white
   - type: Strap
     position: Stand
+  - type: Anchorable
+  - type: Pullable
 
 - type: entity
   name: dark office chair
@@ -59,6 +63,8 @@
     state: officechair_dark
   - type: Strap
     position: Stand
+  - type: Anchorable
+  - type: Pullable
 
 - type: entity
   name: chair
@@ -76,6 +82,8 @@
     state: chair
   - type: Strap
     position: Stand
+  - type: Anchorable
+  - type: Pullable
 
 - type: entity
   name: wooden chair
@@ -87,7 +95,9 @@
     color: "white"
   - type: Icon
     state: wooden_chair
-
+  - type: Anchorable
+  - type: Pullable
+  
 - type: entity
   name: bed
   id: Bed

--- a/Resources/Prototypes/Entities/Constructible/Ground/furniture.yml
+++ b/Resources/Prototypes/Entities/Constructible/Ground/furniture.yml
@@ -97,7 +97,7 @@
     state: wooden_chair
   - type: Anchorable
   - type: Pullable
-  
+
 - type: entity
   name: bed
   id: Bed

--- a/Resources/Prototypes/Entities/Constructible/Ground/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Constructible/Ground/potted_plants.yml
@@ -7,11 +7,10 @@
   - type: Collidable
   - type: Sprite
     sprite: Constructible/Misc/potted_plants.rsi
-
   - type: Icon
     sprite: Constructible/Misc/potted_plants.rsi
-
   - type: PottedPlantHide
+  - type: Pullable
 
 - type: entity
   id: PottedPlantRandom

--- a/Resources/Prototypes/Entities/Constructible/Power/arcade.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/arcade.yml
@@ -13,7 +13,6 @@
     - state: invaders
       shader: unshaded
       map: ["enum.ComputerVisualizer+Layers.Screen"]
-
   - type: Appearance
     visuals:
     - type: ComputerVisualizer
@@ -21,3 +20,5 @@
       key: ""
       body: arcade
       bodyBroken: arcade
+  - type: Anchorable
+  - type: Pullable

--- a/Resources/Prototypes/Entities/Constructible/Power/booze_dispenser.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/booze_dispenser.yml
@@ -10,7 +10,9 @@
     texture: Constructible/Power/dispensers.rsi/booze_dispenser.png
   - type: ReagentDispenser
     pack: BoozeDispenserInventory
-
+  - type: Anchorable
+  - type: Pullable
+  
 - type: reagentDispenserInventory
   id: BoozeDispenserInventory
   inventory:

--- a/Resources/Prototypes/Entities/Constructible/Power/chem_dispenser.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/chem_dispenser.yml
@@ -11,7 +11,9 @@
   - type: ReagentDispenser
     pack: ChemDispenserStandardInventory
   - type: PowerReceiver
-
+  - type: Anchorable
+  - type: Pullable
+  
 - type: reagentDispenserInventory
   id: ChemDispenserStandardInventory
   inventory:

--- a/Resources/Prototypes/Entities/Constructible/Power/chem_master.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/chem_master.yml
@@ -31,3 +31,4 @@
     interfaces:
     - key: enum.ChemMasterUiKey.Key
       type: ChemMasterBoundUserInterface
+  - type: Pullable

--- a/Resources/Prototypes/Entities/Constructible/Power/soda_dispenser.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/soda_dispenser.yml
@@ -10,7 +10,6 @@
     texture: Constructible/Power/dispensers.rsi/soda_dispenser.png
   - type: ReagentDispenser
     pack: SodaDispenserInventory
-
 - type: reagentDispenserInventory
   id: SodaDispenserInventory
   inventory:
@@ -20,3 +19,5 @@
   - chem.Ice
   - chem.H2O
   - chem.Cream
+  - type: Anchorable
+  - type: Pullable

--- a/Resources/Prototypes/Entities/Constructible/Power/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/vending_machines.yml
@@ -50,6 +50,7 @@
     BoardName: "Vending Machine"
     LayoutId: Vending
   - type: Anchorable
+  - type: Pullable
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Entities/Constructible/Storage/StorageTanks/fuel_tank.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/StorageTanks/fuel_tank.yml
@@ -22,4 +22,5 @@
     damage: 200
     tools:
     - Welding
-
+  - type: Anchorable
+  - type: Pullable

--- a/Resources/Prototypes/Entities/Constructible/Storage/StorageTanks/water_tank.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/StorageTanks/water_tank.yml
@@ -9,6 +9,8 @@
     texture: Constructible/Misc/watertank.png
   - type: Icon
     texture: Constructible/Misc/watertank.png
+  - type: Anchorable
+  - type: Pullable
 
 - type: entity
   parent: WaterTank

--- a/Resources/Prototypes/Entities/Objects/Specific/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/janitor.yml
@@ -7,15 +7,12 @@
   - type: Sprite
     sprite: Objects/Specific/Janitorial/mop.rsi
     state: mop
-
   - type: Icon
     sprite: Objects/Specific/Janitorial/mop.rsi
     state: mop
-
   - type: Item
     size: 10
     sprite: Objects/Specific/Janitorial/mop.rsi
-
   - type: Mop
   - type: Solution
     maxVol: 10
@@ -42,7 +39,7 @@
   - type: Collidable
     shapes:
     - !type:PhysShapeAabb
-      bounds: "-0.25,-0.25,0.25,0.25"
+      bounds: "-0.40,-0.25,0.25,0.25"
       mask:
       - Impassable
       - Opaque
@@ -53,6 +50,7 @@
     mass: 5
     Anchored: false
   - type: CanSpill
+  - type: Pullable
 
 - type: entity
   parent: BaseItem
@@ -92,11 +90,9 @@
   - type: Sprite
     sprite: Objects/Specific/Janitorial/wet_floor_sign.rsi
     state: caution
-
   - type: Icon
     sprite: Objects/Specific/Janitorial/wet_floor_sign.rsi
     state: caution
-
   - type: Item
     sprite: Objects/Specific/Janitorial/wet_floor_sign.rsi
 
@@ -109,14 +105,11 @@
     - type: Sprite
       sprite: Objects/Specific/Janitorial/soap.rsi
       state: soap
-
     - type: Icon
       sprite: Objects/Specific/Janitorial/soap.rsi
       state: soap
-
     - type: Item
       sprite: Objects/Specific/Janitorial/soap.rsi
-
     - type: Slippery
       paralyzeTime: 2.5
 
@@ -129,7 +122,6 @@
   components:
     - type: Sprite
       state: soapnt
-
     - type: Icon
       state: soapnt
 
@@ -141,7 +133,6 @@
   components:
     - type: Sprite
       state: soapdeluxe
-
     - type: Icon
       state: soapdeluxe
 
@@ -153,10 +144,8 @@
   components:
     - type: Sprite
       state: soapsyndie
-
     - type: Icon
       state: soapsyndie
-
     - type: Slippery
       paralyzeTime: 5
 
@@ -168,10 +157,8 @@
   components:
     - type: Sprite
       state: soapgibs
-
     - type: Icon
       state: soapgibs
-
     - type: Slippery
       paralyzeTime: 2
 
@@ -183,9 +170,7 @@
   components:
     - type: Sprite
       state: soapomega
-
     - type: Icon
       state: soapomega
-
     - type: Slippery
       paralyzeTime: 7


### PR DESCRIPTION
I added the pullable (and anchorable) component to 
- stools
- office chairs
- vending machines
- potted plants (not anchorable)
- arcade machines
- booze dispensers
- chem dispensers
- chem masters
- fuel/water tanks
- mop bucket

Some bugs I found
- You can't actually anchor the chem master, booze dispenser, or chem dispenser as it thinks you're trying to put the wrench in the chem dispenser. #1500 
- I was forced to add the anchorable component to office chairs, as it crashed when it didn't have it. Something to do with the physics component.
- Buckling someone to a chair and pulling the chair **works fine**. However, pulling them instead throws an exception. #1499 