### PR TITLE
Fix disposal units in general

### DIFF
--- a/Content.Client/GameObjects/Components/Disposal/DisposalUnitWindow.cs
+++ b/Content.Client/GameObjects/Components/Disposal/DisposalUnitWindow.cs
@@ -65,7 +65,11 @@ namespace Content.Client.GameObjects.Components.Disposal
                         Children =
                         {
                             new Label {Text = Loc.GetString("Handle:")},
-                            (Engage = new Button {Text = Loc.GetString("Engage")})
+                            (Engage = new Button
+                            {
+                                Text = Loc.GetString("Engage"),
+                                ToggleMode = true
+                            })
                         }
                     },
                     new Control {CustomMinimumSize = (0, 10)},
@@ -135,6 +139,7 @@ namespace Content.Client.GameObjects.Components.Disposal
             _unitState.Text = state.UnitState;
             UpdatePressureBar(state.Pressure);
             Power.Pressed = state.Powered;
+            Engage.Pressed = state.Engaged;
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -391,6 +391,11 @@ namespace Content.Server.GameObjects.Components.Disposal
             UpdateInterface();
         }
 
+        private void PowerStateChanged(object sender, PowerStateEventArgs args)
+        {
+
+        }
+
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);
@@ -431,14 +436,30 @@ namespace Content.Server.GameObjects.Components.Disposal
             base.Startup();
 
             Owner.EnsureComponent<AnchorableComponent>();
-            var collidable = Owner.EnsureComponent<CollidableComponent>();
 
+            var collidable = Owner.EnsureComponent<CollidableComponent>();
             collidable.AnchoredChanged += UpdateVisualState;
+
+            if (Owner.TryGetComponent(out PowerReceiverComponent receiver))
+            {
+                receiver.OnPowerStateChanged += PowerStateChanged;
+            }
+
             UpdateVisualState();
         }
 
         public override void OnRemove()
         {
+            if (Owner.TryGetComponent(out ICollidableComponent collidable))
+            {
+                collidable.AnchoredChanged -= UpdateVisualState;
+            }
+
+            if (Owner.TryGetComponent(out PowerReceiverComponent receiver))
+            {
+                receiver.OnPowerStateChanged -= PowerStateChanged;
+            }
+
             foreach (var entity in _container.ContainedEntities.ToArray())
             {
                 _container.ForceRemove(entity);

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -253,7 +253,8 @@ namespace Content.Server.GameObjects.Components.Disposal
 
         private DisposalUnitBoundUserInterfaceState GetInterfaceState()
         {
-            return new DisposalUnitBoundUserInterfaceState(Owner.Name, Loc.GetString($"{State}"), _pressure, Powered);
+            var state = Loc.GetString($"{State}");
+            return new DisposalUnitBoundUserInterfaceState(Owner.Name, state, _pressure, Powered, Engaged);
         }
 
         private void UpdateInterface()

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -192,11 +192,20 @@ namespace Content.Server.GameObjects.Components.Disposal
             return _pressure >= 1 && Powered && Anchored;
         }
 
+        private void ToggleEngage()
+        {
+            Engaged ^= true;
+
+            if (Engaged)
+            {
+                TryFlush();
+            }
+        }
+
         public bool TryFlush()
         {
             if (!CanFlush())
             {
-                Engaged = true;
                 return false;
             }
 
@@ -302,7 +311,7 @@ namespace Content.Server.GameObjects.Components.Disposal
                     TryEjectContents();
                     break;
                 case UiButton.Engage:
-                    TryFlush();
+                    ToggleEngage();
                     break;
                 case UiButton.Power:
                     TogglePower();
@@ -586,6 +595,7 @@ namespace Content.Server.GameObjects.Components.Disposal
 
             protected override void Activate(IEntity user, DisposalUnitComponent component)
             {
+                component.Engaged = true;
                 component.TryFlush();
             }
         }

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -116,7 +116,7 @@ namespace Content.Server.GameObjects.Components.Disposal
 
         public bool CanInsert(IEntity entity)
         {
-            if (!Powered || !Anchored)
+            if (!Anchored)
             {
                 return false;
             }

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -133,8 +133,6 @@ namespace Content.Server.GameObjects.Components.Disposal
 
         private void AfterInsert(IEntity entity)
         {
-            Engaged = true;
-
             _automaticEngageToken = new CancellationTokenSource();
 
             Timer.Spawn(_automaticEngageTime, () => TryFlush(), _automaticEngageToken.Token);

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -402,7 +402,7 @@ namespace Content.Server.GameObjects.Components.Disposal
             UpdateInterface();
         }
 
-        private void PowerStateChanged(object sender, PowerStateEventArgs args)
+        private void PowerStateChanged(object? sender, PowerStateEventArgs args)
         {
             UpdateVisualState();
         }

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -324,9 +324,6 @@ namespace Content.Server.GameObjects.Components.Disposal
                 return;
             }
 
-            appearance.SetData(Visuals.Handle, Engaged
-                ? HandleState.Engaged
-                : HandleState.Normal);
 
             if (!Anchored)
             {
@@ -335,26 +332,37 @@ namespace Content.Server.GameObjects.Components.Disposal
                 appearance.SetData(Visuals.Light, LightState.Off);
                 return;
             }
+            else
+            {
+                appearance.SetData(Visuals.VisualState, VisualState.Anchored);
+            }
+
+            appearance.SetData(Visuals.Handle, Engaged
+                ? HandleState.Engaged
+                : HandleState.Normal);
+
+            if (!Powered)
+            {
+                appearance.SetData(Visuals.Light, LightState.Off);
+                return;
+            }
 
             if (flush)
             {
                 appearance.SetData(Visuals.VisualState, VisualState.Flushing);
                 appearance.SetData(Visuals.Light, LightState.Off);
+                return;
             }
-            else
+
+            if (ContainedEntities.Count > 0)
             {
-                appearance.SetData(Visuals.VisualState, VisualState.Anchored);
-
-                if (ContainedEntities.Count > 0)
-                {
-                    appearance.SetData(Visuals.Light, LightState.Full);
-                    return;
-                }
-
-                appearance.SetData(Visuals.Light, _pressure < 1
-                    ? LightState.Charging
-                    : LightState.Ready);
+                appearance.SetData(Visuals.Light, LightState.Full);
+                return;
             }
+
+            appearance.SetData(Visuals.Light, _pressure < 1
+                ? LightState.Charging
+                : LightState.Ready);
         }
 
         public void Update(float frameTime)

--- a/Content.Shared/GameObjects/Components/Disposal/SharedDisposalUnitComponent.cs
+++ b/Content.Shared/GameObjects/Components/Disposal/SharedDisposalUnitComponent.cs
@@ -63,13 +63,16 @@ namespace Content.Shared.GameObjects.Components.Disposal
             public readonly string UnitState;
             public readonly float Pressure;
             public readonly bool Powered;
+            public readonly bool Engaged;
 
-            public DisposalUnitBoundUserInterfaceState(string unitName, string unitState, float pressure, bool powered)
+            public DisposalUnitBoundUserInterfaceState(string unitName, string unitState, float pressure, bool powered,
+                bool engaged)
             {
                 UnitName = unitName;
                 UnitState = unitState;
                 Pressure = pressure;
                 Powered = powered;
+                Engaged = engaged;
             }
         }
 


### PR DESCRIPTION
- Disposal units can be entered when unpowered.
- The light turns off when unpowered.
- Makes the engage button in the ui active when engaged.
- Makes the engage button toggleable.