### PR TITLE
Fix disposal unit power issues

### DIFF
--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -493,7 +493,8 @@ namespace Content.Server.GameObjects.Components.Disposal
             switch (message)
             {
                 case RelayMovementEntityMessage msg:
-                    if (!msg.Entity.HasComponent<HandsComponent>() ||
+                    if (!msg.Entity.TryGetComponent(out HandsComponent hands) ||
+                        hands.Count == 0 ||
                         _gameTiming.CurTime < _lastExitAttempt + ExitAttemptDelay)
                     {
                         break;

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -62,9 +62,6 @@ namespace Content.Server.GameObjects.Components.Disposal
         private bool _engaged;
 
         [ViewVariables]
-        private TimeSpan _engageTime;
-
-        [ViewVariables]
         private TimeSpan _automaticEngageTime;
 
         /// <summary>
@@ -423,10 +420,10 @@ namespace Content.Server.GameObjects.Components.Disposal
                 () => _pressure);
 
             serializer.DataReadWriteFunction(
-                "engageTime",
-                2,
-                seconds => _engageTime = TimeSpan.FromSeconds(seconds),
-                () => (int) _engageTime.TotalSeconds);
+                "automaticEngageTime",
+                30,
+                seconds => _automaticEngageTime = TimeSpan.FromSeconds(seconds),
+                () => (int) _automaticEngageTime.TotalSeconds);
 
             serializer.DataReadWriteFunction(
                 "automaticEngageTime",

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -493,8 +493,7 @@ namespace Content.Server.GameObjects.Components.Disposal
             switch (message)
             {
                 case RelayMovementEntityMessage msg:
-                    if (Engaged ||
-                        !msg.Entity.HasComponent<HandsComponent>() ||
+                    if (!msg.Entity.HasComponent<HandsComponent>() ||
                         _gameTiming.CurTime < _lastExitAttempt + ExitAttemptDelay)
                     {
                         break;

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -405,6 +405,11 @@ namespace Content.Server.GameObjects.Components.Disposal
         private void PowerStateChanged(object? sender, PowerStateEventArgs args)
         {
             UpdateVisualState();
+
+            if (Engaged)
+            {
+                TryFlush();
+            }
         }
 
         public override void ExposeData(ObjectSerializer serializer)

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -130,7 +130,7 @@ namespace Content.Server.GameObjects.Components.Disposal
 
         private void TryQueueEngage()
         {
-            if (!Powered)
+            if (!Powered && ContainedEntities.Count == 0)
             {
                 return;
             }

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -423,7 +423,7 @@ namespace Content.Server.GameObjects.Components.Disposal
                 _automaticEngageToken = null;
             }
 
-            if (Engaged && !TryFlush() && ContainedEntities.Count > 0)
+            if (Engaged && !TryFlush())
             {
                 TryQueueEngage();
             }

--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -423,12 +423,12 @@ namespace Content.Server.GameObjects.Components.Disposal
                 _automaticEngageToken = null;
             }
 
+            UpdateVisualState();
+
             if (Engaged && !TryFlush())
             {
                 TryQueueEngage();
             }
-
-            UpdateVisualState();
         }
 
         public override void ExposeData(ObjectSerializer serializer)


### PR DESCRIPTION
Fixes #1561 

- Fixes not being able to get out of an engaged and unpowered unit.
- Adds a check for no hands to getting out of a disposal unit.
- Makes units flush when they are engaged and their power is turned back on.
- Fixes disposal units not queueing an autoengage when they are engaged, turned back on and fail to flush with items inside.