### PR TITLE
Moves ExamineSystem to Shared & adds next step info to construction examine

### DIFF
--- a/Content.Client/GameObjects/Components/Construction/ConstructionGhostComponent.cs
+++ b/Content.Client/GameObjects/Components/Construction/ConstructionGhostComponent.cs
@@ -1,15 +1,29 @@
 ﻿using Content.Shared.Construction;
+using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Systems;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Client.GameObjects.Components.Construction
 {
     [RegisterComponent]
-    public class ConstructionGhostComponent : Component
+    public class ConstructionGhostComponent : Component, IExamine
     {
+#pragma warning disable 649
+        [Dependency] private readonly ILocalizationManager _loc;
+#pragma warning restore 649
         public override string Name => "ConstructionGhost";
 
         [ViewVariables] public ConstructionPrototype Prototype { get; set; }
         [ViewVariables] public int GhostID { get; set; }
+
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
+        {
+            message.AddText(_loc.GetString("Building: {0}\n", Prototype.Name));
+            EntitySystem.Get<ConstructionSystem>().DoExamine(message, Prototype, 0, inDetailsRange);
+        }
     }
 }

--- a/Content.Client/GameObjects/Components/Construction/ConstructionGhostComponent.cs
+++ b/Content.Client/GameObjects/Components/Construction/ConstructionGhostComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Client.GameObjects.Components.Construction
         void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
             message.AddText(_loc.GetString("Building: {0}\n", Prototype.Name));
-            EntitySystem.Get<ConstructionSystem>().DoExamine(message, Prototype, 0, inDetailsRange);
+            EntitySystem.Get<SharedConstructionSystem>().DoExamine(message, Prototype, 0, inDetailsRange);
         }
     }
 }

--- a/Content.Client/GameObjects/EntitySystems/ConstructionSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/ConstructionSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Client.GameObjects.EntitySystems
     /// The client-side implementation of the construction system, which is used for constructing entities in game.
     /// </summary>
     [UsedImplicitly]
-    public class ConstructionSystem : Shared.GameObjects.EntitySystems.ConstructionSystem
+    public class ConstructionSystem : Shared.GameObjects.EntitySystems.SharedConstructionSystem
     {
 #pragma warning disable 649
         [Dependency] private readonly IGameHud _gameHud;

--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -49,7 +49,7 @@ namespace Content.Server.GameObjects.Components.Construction
 
         void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
-            EntitySystem.Get<ConstructionSystem>().DoExamine(message, Prototype, Stage, inDetailsRange);
+            EntitySystem.Get<SharedConstructionSystem>().DoExamine(message, Prototype, Stage, inDetailsRange);
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -1,6 +1,10 @@
-﻿using Content.Shared.Construction;
+﻿using Content.Server.GameObjects.EntitySystems.Click;
+using Content.Shared.Construction;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Construction
@@ -9,8 +13,11 @@ namespace Content.Server.GameObjects.Components.Construction
     /// Holds data about an entity that is in the process of being constructed or destructed.
     /// </summary>
     [RegisterComponent]
-    public class ConstructionComponent : Component
+    public class ConstructionComponent : Component, IExamine
     {
+#pragma warning disable 649
+        [Dependency] private readonly ILocalizationManager _loc;
+#pragma warning restore 649
         /// <inheritdoc />
         public override string Name => "Construction";
 
@@ -36,6 +43,29 @@ namespace Content.Server.GameObjects.Components.Construction
 
             serializer.DataReadWriteFunction("stage", 0,
                 value => Stage = value, () => Stage);
+        }
+
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
+        {
+            var stages = Prototype.Stages;
+            if (Stage > 0 && Stage < stages.Count)
+            {
+                var curStage = stages[Stage];
+                if (curStage.Backward != null && curStage.Backward is ConstructionStepTool)
+                {
+                    var backward = (ConstructionStepTool) curStage.Backward;
+                    message.AddText(_loc.GetString("To deconstruct: {0}x {1} Tool", backward.Amount, backward.ToolQuality));
+                }
+                if (curStage.Forward != null && curStage.Forward is ConstructionStepMaterial)
+                {
+                    if (curStage.Backward != null)
+                    {
+                        message.AddText("\n");
+                    }
+                    var forward = (ConstructionStepMaterial) curStage.Forward;
+                    message.AddText(_loc.GetString("To construct: {0}x {1}", forward.Amount, forward.Material));
+                }
+            }
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Server.GameObjects.EntitySystems.Click;
 using Content.Shared.Construction;
+using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Serialization;
@@ -47,25 +49,7 @@ namespace Content.Server.GameObjects.Components.Construction
 
         void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
         {
-            var stages = Prototype.Stages;
-            if (Stage > 0 && Stage < stages.Count)
-            {
-                var curStage = stages[Stage];
-                if (curStage.Backward != null && curStage.Backward is ConstructionStepTool)
-                {
-                    var backward = (ConstructionStepTool) curStage.Backward;
-                    message.AddText(_loc.GetString("To deconstruct: {0}x {1} Tool", backward.Amount, backward.ToolQuality));
-                }
-                if (curStage.Forward != null && curStage.Forward is ConstructionStepMaterial)
-                {
-                    if (curStage.Backward != null)
-                    {
-                        message.AddText("\n");
-                    }
-                    var forward = (ConstructionStepMaterial) curStage.Forward;
-                    message.AddText(_loc.GetString("To construct: {0}x {1}", forward.Amount, forward.Material));
-                }
-            }
+            EntitySystem.Get<ConstructionSystem>().DoExamine(message, Prototype, Stage, inDetailsRange);
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Fluids/PuddleComponent.cs
+++ b/Content.Server/GameObjects/Components/Fluids/PuddleComponent.cs
@@ -24,6 +24,7 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using Timer = Robust.Shared.Timers.Timer;
+using Content.Shared.GameObjects.EntitySystems;
 
 namespace Content.Server.GameObjects.Components.Fluids
 {

--- a/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/WelderComponent.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Localization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using Robust.Shared.Serialization;
+using Content.Shared.GameObjects.EntitySystems;
 
 namespace Content.Server.GameObjects.Components.Interactable
 {

--- a/Content.Server/GameObjects/Components/Items/DiceComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/DiceComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.GameObjects.EntitySystems.Click;
 using Content.Shared.Audio;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.EntitySystems;

--- a/Content.Server/GameObjects/Components/Items/RCDComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/RCDComponent.cs
@@ -2,6 +2,7 @@
 using Content.Server.GameObjects.EntitySystems.Click;
 using Content.Server.Interfaces;
 using Content.Server.Utility;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Content.Shared.Maps;
 using Robust.Server.GameObjects.EntitySystems;

--- a/Content.Server/GameObjects/Components/Markers/WarpPointComponent.cs
+++ b/Content.Server/GameObjects/Components/Markers/WarpPointComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.GameObjects.EntitySystems.Click;
+using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 using Robust.Shared.Serialization;

--- a/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Timers;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
+using Content.Shared.GameObjects.EntitySystems;
 
 namespace Content.Server.GameObjects.Components.Mobs
 {

--- a/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/DrinkComponent.cs
@@ -5,6 +5,7 @@ using Content.Server.Interfaces.GameObjects.Components.Interaction;
 using Content.Shared.Audio;
 using Content.Shared.Chemistry;
 using Content.Shared.GameObjects.Components.Nutrition;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Server.GameObjects;
@@ -26,7 +27,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
 {
     [RegisterComponent]
     [ComponentReference(typeof(IAfterInteract))]
-    public class DrinkComponent : Component, IUse, IAfterInteract, ISolutionChange,IExamine, ILand
+    public class DrinkComponent : Component, IUse, IAfterInteract, ISolutionChange, IExamine, ILand
     {
 #pragma warning disable 649
         [Dependency] private readonly IPrototypeManager _prototypeManager;

--- a/Content.Server/GameObjects/Components/Paper/PaperComponent.cs
+++ b/Content.Server/GameObjects/Components/Paper/PaperComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.GameObjects.EntitySystems.Click;
 using Content.Shared.GameObjects.Components;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.Components.UserInterface;

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
@@ -12,6 +12,7 @@ using Content.Server.GameObjects.EntitySystems.Click;
 using Robust.Shared.GameObjects.Components;
 using Robust.Shared.Localization;
 using Robust.Shared.Utility;
+using Content.Shared.GameObjects.EntitySystems;
 
 namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
 {

--- a/Content.Server/GameObjects/Components/Stack/StackComponent.cs
+++ b/Content.Server/GameObjects/Components/Stack/StackComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Content.Server.GameObjects.EntitySystems.Click;
 using Content.Shared.GameObjects.Components;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.GameObjects;

--- a/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Server/GameObjects/Components/VendingMachines/VendingMachineComponent.cs
@@ -5,6 +5,7 @@ using Content.Server.GameObjects.Components.Power.ApcNetComponents;
 using Content.Server.GameObjects.EntitySystems.Click;
 using Content.Server.Interfaces.GameObjects.Components.Interaction;
 using Content.Shared.GameObjects.Components.VendingMachines;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Content.Shared.VendingMachines;
 using Robust.Server.GameObjects;

--- a/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
@@ -2,6 +2,7 @@
 using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.EntitySystems.Click;
 using Content.Shared.GameObjects.Components.Mobs;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Server.GameObjects;

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Barrels/ServerRangedBarrelComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Barrels/ServerRangedBarrelComponent.cs
@@ -28,6 +28,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Content.Server.Interfaces;
+using Content.Shared.GameObjects.EntitySystems;
 
 namespace Content.Server.GameObjects.Components.Weapon.Ranged.Barrels
 {

--- a/Content.Server/GameObjects/EntitySystems/Click/ExamineSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/ExamineSystem.cs
@@ -9,16 +9,6 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.GameObjects.EntitySystems.Click
 {
-    public interface IExamine
-    {
-        /// <summary>
-        /// Returns a status examine value for components appended to the end of the description of the entity
-        /// </summary>
-        /// <param name="message">The message to append to which will be displayed.</param>
-        /// <param name="inDetailsRange">Whether the examiner is within the 'Details' range, allowing you to show information logically only availabe when close to the examined entity.</param>
-        void Examine(FormattedMessage message, bool inDetailsRange);
-    }
-
     public class ExamineSystem : ExamineSystemShared
     {
 #pragma warning disable 649
@@ -26,8 +16,6 @@ namespace Content.Server.GameObjects.EntitySystems.Click
 #pragma warning restore 649
 
         private static readonly FormattedMessage _entityNotFoundMessage;
-
-        private const float ExamineDetailsRange = 3f;
 
         static ExamineSystem()
         {

--- a/Content.Server/GameObjects/EntitySystems/Click/ExamineSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/ExamineSystem.cs
@@ -32,45 +32,6 @@ namespace Content.Server.GameObjects.EntitySystems.Click
             IoCManager.InjectDependencies(this);
         }
 
-        private static FormattedMessage GetExamineText(IEntity entity, IEntity examiner)
-        {
-            var message = new FormattedMessage();
-
-            var doNewline = false;
-
-            //Add an entity description if one is declared
-            if (!string.IsNullOrEmpty(entity.Description))
-            {
-                message.AddText(entity.Description);
-                doNewline = true;
-            }
-
-            message.PushColor(Color.DarkGray);
-
-            var inDetailsRange = Get<SharedInteractionSystem>()
-                .InRangeUnobstructed(examiner.Transform.MapPosition, entity.Transform.MapPosition,
-                    ExamineDetailsRange, predicate: entity0 => entity0 == examiner || entity0 == entity, ignoreInsideBlocker: true);
-
-            //Add component statuses from components that report one
-            foreach (var examineComponent in entity.GetAllComponents<IExamine>())
-            {
-                var subMessage = new FormattedMessage();
-                examineComponent.Examine(subMessage, inDetailsRange);
-                if (subMessage.Tags.Count == 0)
-                    continue;
-
-                if (doNewline)
-                    message.AddText("\n");
-
-                message.AddMessage(subMessage);
-                doNewline = true;
-            }
-
-            message.Pop();
-
-            return message;
-        }
-
         private void ExamineInfoRequest(ExamineSystemMessages.RequestExamineInfoMessage request, EntitySessionEventArgs eventArgs)
         {
             var player = (IPlayerSession) eventArgs.SenderSession;

--- a/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
@@ -32,7 +32,7 @@ namespace Content.Server.GameObjects.EntitySystems
     /// The server-side implementation of the construction system, which is used for constructing entities in game.
     /// </summary>
     [UsedImplicitly]
-    internal class ConstructionSystem : Shared.GameObjects.EntitySystems.ConstructionSystem
+    internal class ConstructionSystem : Shared.GameObjects.EntitySystems.SharedConstructionSystem
     {
 #pragma warning disable 649
         [Dependency] private readonly IPrototypeManager _prototypeManager;

--- a/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
+++ b/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
@@ -1,14 +1,26 @@
-using Content.Shared.GameObjects.Components.Mobs;
+﻿using Content.Shared.GameObjects.Components.Mobs;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.GameObjects.EntitySystems
 {
+    public interface IExamine
+    {
+        /// <summary>
+        /// Returns a status examine value for components appended to the end of the description of the entity
+        /// </summary>
+        /// <param name="message">The message to append to which will be displayed.</param>
+        /// <param name="inDetailsRange">Whether the examiner is within the 'Details' range, allowing you to show information logically only availabe when close to the examined entity.</param>
+        void Examine(FormattedMessage message, bool inDetailsRange);
+    }
     public abstract class ExamineSystemShared : EntitySystem
     {
         public const float ExamineRange = 16f;
         public const float ExamineRangeSquared = ExamineRange * ExamineRange;
+        protected const float ExamineDetailsRange = 3f;
 
         [Pure]
         protected static bool CanExamine(IEntity examiner, IEntity examined)
@@ -31,6 +43,45 @@ namespace Content.Shared.GameObjects.EntitySystems
             return EntitySystem.Get<SharedInteractionSystem>()
                 .InRangeUnobstructed(examiner.Transform.MapPosition, examined.Transform.MapPosition,
                     ExamineRange, predicate: entity => entity == examiner || entity == examined, ignoreInsideBlocker:true);
+        }
+
+        public static FormattedMessage GetExamineText(IEntity entity, IEntity examiner)
+        {
+            var message = new FormattedMessage();
+
+            var doNewline = false;
+
+            //Add an entity description if one is declared
+            if (!string.IsNullOrEmpty(entity.Description))
+            {
+                message.AddText(entity.Description);
+                doNewline = true;
+            }
+
+            message.PushColor(Color.DarkGray);
+
+            var inDetailsRange = Get<SharedInteractionSystem>()
+                .InRangeUnobstructed(examiner.Transform.MapPosition, entity.Transform.MapPosition,
+                    ExamineDetailsRange, predicate: entity0 => entity0 == examiner || entity0 == entity, ignoreInsideBlocker: true);
+
+            //Add component statuses from components that report one
+            foreach (var examineComponent in entity.GetAllComponents<IExamine>())
+            {
+                var subMessage = new FormattedMessage();
+                examineComponent.Examine(subMessage, inDetailsRange);
+                if (subMessage.Tags.Count == 0)
+                    continue;
+
+                if (doNewline)
+                    message.AddText("\n");
+
+                message.AddMessage(subMessage);
+                doNewline = true;
+            }
+
+            message.Pop();
+
+            return message;
         }
     }
 }

--- a/Content.Shared/GameObjects/EntitySystems/SharedConstructionSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedConstructionSystem.cs
@@ -12,7 +12,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.GameObjects.EntitySystems
 {
-    public class ConstructionSystem : EntitySystem
+    public class SharedConstructionSystem : EntitySystem
     {
 #pragma warning disable 649
         [Dependency] private readonly ILocalizationManager _loc;


### PR DESCRIPTION
Kinda fixes 1563? It doesn't show on construction ghosts as those are client side and IExamine is on the server.

Could use the icon, but I don't think there is a way to add those in the ExamineText yet
![grafik](https://user-images.githubusercontent.com/17885980/89102222-2f33b980-d407-11ea-8b6c-5ee8dc643f89.png)
