### PR TITLE
Raises the screen-shake of explosions and fixes+changes how screenshake runs

### DIFF
--- a/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/CameraRecoilComponent.cs
@@ -14,16 +14,16 @@ namespace Content.Client.GameObjects.Components.Mobs
     public sealed class CameraRecoilComponent : SharedCameraRecoilComponent
     {
         // Maximum rate of magnitude restore towards 0 kick.
-        private const float RestoreRateMax = 2f;
+        private const float RestoreRateMax = 15f;
 
         // Minimum rate of magnitude restore towards 0 kick.
         private const float RestoreRateMin = 1f;
 
         // Time in seconds since the last kick that lerps RestoreRateMin and RestoreRateMax
-        private const float RestoreRateRamp = 0.05f;
+        private const float RestoreRateRamp = 0.1f;
 
         // The maximum magnitude of the kick applied to the camera at any point.
-        private const float KickMagnitudeMax = 0.25f;
+        private const float KickMagnitudeMax = 5f;
 
         private Vector2 _currentKick;
         private float _lastKickTime;
@@ -86,6 +86,7 @@ namespace Content.Client.GameObjects.Components.Mobs
 
             // Continually restore camera to 0.
             var normalized = _currentKick.Normalized;
+            _lastKickTime += frameTime;     
             var restoreRate = FloatMath.Lerp(RestoreRateMin, RestoreRateMax, Math.Min(1, _lastKickTime/RestoreRateRamp));
             var restore = normalized * restoreRate * frameTime;
             var (x, y) = _currentKick - restore;

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -141,7 +141,7 @@ namespace Content.Server.Explosions
                     delta = _epicenterDistance;
 
                 var distance = delta.LengthSquared;
-                var effect = 1 / (1 + 0.2f * distance);
+                var effect = 10 * (1 / (1 + distance));
                 if (effect > 0.01f)
                 {
                     var kick = -delta.Normalized * effect;


### PR DESCRIPTION
https://streamable.com/1jo82j

the time since last kick wasn't actually being changed so you'd always have the minimum restore speed. I fixed that and also changed the values of screen-shaking a bit.

closes #1281 