### PR TITLE
Added character limit for chat

### DIFF
--- a/Content.Client/Chat/ChatBox.cs
+++ b/Content.Client/Chat/ChatBox.cs
@@ -36,6 +36,8 @@ namespace Content.Client.Chat
 
         public bool ReleaseFocusOnEnter { get; set; } = true;
 
+        public bool ClearOnEnter { get; set; } = true;
+
         public ChatBox()
         {
             /*MarginLeft = -475.0f;
@@ -167,12 +169,18 @@ namespace Content.Client.Chat
 
         private void Input_OnTextEntered(LineEdit.LineEditEventArgs args)
         {
+            // We set it there to true so it's set to false by TextSubmitted.Invoke if necessary
+            ClearOnEnter = true;
+
             if (!string.IsNullOrWhiteSpace(args.Text))
             {
                 TextSubmitted?.Invoke(this, args.Text);
             }
 
-            Input.Clear();
+            if (ClearOnEnter)
+            {
+                Input.Clear();
+            }
 
             if (ReleaseFocusOnEnter)
             {

--- a/Content.Client/Chat/ChatManager.cs
+++ b/Content.Client/Chat/ChatManager.cs
@@ -1,17 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Content.Client.Interfaces.Chat;
 using Content.Shared.Chat;
 using Robust.Client.Console;
 using Robust.Client.Interfaces.Graphics.ClientEye;
 using Robust.Client.Interfaces.UserInterface;
+using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
+using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -44,6 +48,11 @@ namespace Content.Client.Chat
         ///     The max amount of speech bubbles over a single entity at once.
         /// </summary>
         private const int SpeechBubbleCap = 4;
+
+        /// <summary>
+        ///     The max amount of characters an entity can send in one message
+        /// </summary>
+        private int _maxMessageLength = 1000;
 
         private const char ConCmdSlash = '/';
         private const char OOCAlias = '[';
@@ -89,11 +98,15 @@ namespace Content.Client.Chat
         public void Initialize()
         {
             _netManager.RegisterNetMessage<MsgChatMessage>(MsgChatMessage.NAME, _onChatMessage);
+            _netManager.RegisterNetMessage<ChatMaxMsgLengthMessage>(ChatMaxMsgLengthMessage.NAME, _onMaxLengthReceived);
 
             _speechBubbleRoot = new LayoutContainer();
             LayoutContainer.SetAnchorPreset(_speechBubbleRoot, LayoutContainer.LayoutPreset.Wide);
             _userInterfaceManager.StateRoot.AddChild(_speechBubbleRoot);
             _speechBubbleRoot.SetPositionFirst();
+
+            // When connexion is achieved, request the max chat message length
+            _netManager.Connected += new EventHandler<NetChannelArgs>(RequestMaxLength);
         }
 
         public void FrameUpdate(FrameEventArgs delta)
@@ -212,6 +225,15 @@ namespace Content.Client.Chat
 
             if (string.IsNullOrWhiteSpace(text))
                 return;
+
+            // Check if message is longer than the character limit
+            if (text.Length > _maxMessageLength)
+            {
+                string locWarning = Loc.GetString("Your message exceeds {0} character limit", _maxMessageLength);
+                _currentChatBox?.AddLine(locWarning, ChatChannel.Server, Color.Orange);
+                _currentChatBox.ClearOnEnter = false;   // The text shouldn't be cleared if it hasn't been sent 
+                return;
+            }
 
             switch (text[0])
             {
@@ -344,6 +366,17 @@ namespace Content.Client.Chat
                     AddSpeechBubble(msg, SpeechBubble.SpeechType.Emote);
                     break;
             }
+        }
+
+        private void _onMaxLengthReceived(ChatMaxMsgLengthMessage msg)
+        {
+            _maxMessageLength = msg.MaxMessageLength;
+        }
+
+        private void RequestMaxLength(object sender, NetChannelArgs args)
+        {
+            ChatMaxMsgLengthMessage msg = _netManager.CreateNetMessage<ChatMaxMsgLengthMessage>();
+            _netManager.ClientSendMessage(msg);
         }
 
         private void AddSpeechBubble(MsgChatMessage msg, SpeechBubble.SpeechType speechType)

--- a/Content.Server/Chat/ChatManager.cs
+++ b/Content.Server/Chat/ChatManager.cs
@@ -4,7 +4,9 @@ using Content.Server.Interfaces;
 using Content.Server.Interfaces.Chat;
 using Content.Shared.Chat;
 using Content.Shared.GameObjects.EntitySystems;
+using NFluidsynth;
 using Robust.Server.Console;
+using Robust.Server.Interfaces.GameObjects;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Network;
@@ -27,7 +29,17 @@ namespace Content.Server.Chat
     /// </summary>
     internal sealed class ChatManager : IChatManager
     {
+        /// <summary>
+        /// The maximum length a player-sent message can be sent
+        /// </summary>
+        public int MaxMessageLength = 1000;
+
         private const int VoiceRange = 7; // how far voice goes in world units
+
+        /// <summary>
+        /// The message displayed to the player when it exceeds the chat character limit
+        /// </summary>
+        private const string MaxLengthExceededMessage = "Your message exceeded {0} character limit";
 
 #pragma warning disable 649
         [Dependency] private readonly IEntitySystemManager _entitySystemManager;
@@ -41,6 +53,12 @@ namespace Content.Server.Chat
         public void Initialize()
         {
             _netManager.RegisterNetMessage<MsgChatMessage>(MsgChatMessage.NAME);
+            _netManager.RegisterNetMessage<ChatMaxMsgLengthMessage>(ChatMaxMsgLengthMessage.NAME, _onMaxLengthRequest);
+
+            // Tell all the connected players the chat's character limit
+            var msg = _netManager.CreateNetMessage<ChatMaxMsgLengthMessage>();
+            msg.MaxMessageLength = MaxMessageLength;
+            _netManager.ServerSendToAll(msg);
         }
 
         public void DispatchServerAnnouncement(string message)
@@ -68,6 +86,17 @@ namespace Content.Server.Chat
                 return;
             }
 
+            // Get entity's PlayerSession
+            IPlayerSession playerSession = source.GetComponent<IActorComponent>().playerSession;
+
+            // Check if message exceeds the character limit if the sender is a player
+            if (playerSession != null)
+                if (message.Length > MaxMessageLength)
+                {
+                    DispatchServerMessage(playerSession, Loc.GetString(MaxLengthExceededMessage, MaxMessageLength));
+                    return;
+                }
+
             var pos = source.Transform.GridPosition;
             var clients = _playerManager.GetPlayersInRange(pos, VoiceRange).Select(p => p.ConnectedClient);
 
@@ -89,6 +118,17 @@ namespace Content.Server.Chat
                 return;
             }
 
+            // Check if entity is a player
+            IPlayerSession playerSession = source.GetComponent<IActorComponent>().playerSession;
+
+            // Check if message exceeds the character limit
+            if (playerSession != null)
+                if (action.Length > MaxMessageLength)
+                {
+                    DispatchServerMessage(playerSession, Loc.GetString(MaxLengthExceededMessage, MaxMessageLength));
+                    return;
+                }
+
             var pos = source.Transform.GridPosition;
             var clients = _playerManager.GetPlayersInRange(pos, VoiceRange).Select(p => p.ConnectedClient);
 
@@ -102,6 +142,13 @@ namespace Content.Server.Chat
 
         public void SendOOC(IPlayerSession player, string message)
         {
+            // Check if message exceeds the character limi
+            if (message.Length > MaxMessageLength)
+            {
+                DispatchServerMessage(player, Loc.GetString(MaxLengthExceededMessage, MaxMessageLength));
+                return;
+            }
+
             var msg = _netManager.CreateNetMessage<MsgChatMessage>();
             msg.Channel = ChatChannel.OOC;
             msg.Message = message;
@@ -113,6 +160,13 @@ namespace Content.Server.Chat
 
         public void SendDeadChat(IPlayerSession player, string message)
         {
+            // Check if message exceeds the character limit
+            if (message.Length > MaxMessageLength)
+            {
+                DispatchServerMessage(player, Loc.GetString(MaxLengthExceededMessage, MaxMessageLength));
+                return;
+            }
+
             var clients = _playerManager.GetPlayersBy(x => x.AttachedEntity != null && x.AttachedEntity.HasComponent<GhostComponent>()).Select(p => p.ConnectedClient);;
 
             var msg = _netManager.CreateNetMessage<MsgChatMessage>();
@@ -125,7 +179,14 @@ namespace Content.Server.Chat
 
         public void SendAdminChat(IPlayerSession player, string message)
         {
-            if(!_conGroupController.CanCommand(player, "asay"))
+            // Check if message exceeds the character limit
+            if (message.Length > MaxMessageLength)
+            {
+                DispatchServerMessage(player, Loc.GetString(MaxLengthExceededMessage, MaxMessageLength));
+                return;
+            }
+
+            if (!_conGroupController.CanCommand(player, "asay"))
             {
                 SendOOC(player, message);
                 return;
@@ -147,6 +208,13 @@ namespace Content.Server.Chat
             msg.Message = message;
             msg.MessageWrap = $"OOC: (D){sender}: {{0}}";
             _netManager.ServerSendToAll(msg);
+        }
+
+        private void _onMaxLengthRequest(ChatMaxMsgLengthMessage msg)
+        {
+            var response = _netManager.CreateNetMessage<ChatMaxMsgLengthMessage>();
+            response.MaxMessageLength = MaxMessageLength;
+            _netManager.ServerSendMessage(response, msg.MsgChannel);
         }
     }
 }

--- a/Content.Shared/Chat/ChatMaxMsgLengthMessage.cs
+++ b/Content.Shared/Chat/ChatMaxMsgLengthMessage.cs
@@ -28,7 +28,7 @@ namespace Content.Shared.Chat
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
-            MaxMessageLength = buffer.ReadInt16();
+            MaxMessageLength = buffer.ReadInt32();
         }
 
         public override void WriteToBuffer(NetOutgoingMessage buffer)

--- a/Content.Shared/Chat/ChatMaxMsgLengthMessage.cs
+++ b/Content.Shared/Chat/ChatMaxMsgLengthMessage.cs
@@ -1,0 +1,39 @@
+﻿using Lidgren.Network;
+using Robust.Shared.Interfaces.Network;
+using Robust.Shared.Network;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Content.Shared.Chat
+{
+    /// <summary>
+    /// This message is sent by the server to let clients know what is the chat's character limit for this server.
+    /// It is first sent by the client as a request
+    /// </summary>
+    public sealed class ChatMaxMsgLengthMessage : NetMessage
+    {
+        #region REQUIRED
+
+        public const MsgGroups GROUP = MsgGroups.Command;
+        public const string NAME = nameof(ChatMaxMsgLengthMessage);
+        public ChatMaxMsgLengthMessage(INetChannel channel) : base(NAME, GROUP) { }
+
+        #endregion
+
+        /// <summary>
+        /// The max length a player-sent message can get
+        /// </summary>
+        public int MaxMessageLength { get; set; }
+
+        public override void ReadFromBuffer(NetIncomingMessage buffer)
+        {
+            MaxMessageLength = buffer.ReadInt16();
+        }
+
+        public override void WriteToBuffer(NetOutgoingMessage buffer)
+        {
+            buffer.Write(MaxMessageLength);
+        }
+    }
+}


### PR DESCRIPTION
Fixes [#1301 ]
Related to [#526 ]

I had to recreate another pull request for technical problems. I'm sorry if it's not the good way to go.
So how it works is : when the server starts and when a client joins, the server tells the client the chat character limit. By default it's set to 1000.

Then there's a client-side check and in case the client is modded, the server also performs a check.

As we discussed on Discord, the NetMessage type I created for the purpose of communicating the MaxMessageLength to the client will become obsolete when the shared cvars between server and client are implemented.

