### PR TITLE
AI reachable deletion fix

### DIFF
--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/Accessible/PathfindingRegion.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/Accessible/PathfindingRegion.cs
@@ -34,7 +34,7 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Accessible
 
         public bool IsDoor { get; }
         public HashSet<PathfindingNode> Nodes => _nodes;
-        private HashSet<PathfindingNode> _nodes;
+        private readonly HashSet<PathfindingNode> _nodes;
 
         public bool Deleted { get; private set; }
 
@@ -55,6 +55,9 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Accessible
                 var neighbor = neighbors[i];
                 neighbor.Neighbors.Remove(this);
             }
+            
+            _nodes.Clear();
+            Neighbors.Clear();
 
             Deleted = true;
         }
@@ -127,7 +130,10 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Accessible
         {
             if (other == null) return false;
             if (ReferenceEquals(this, other)) return true;
-            return GetHashCode() == other.GetHashCode();
+            if (_nodes.Count != other.Nodes.Count) return false;
+            if (Deleted != other.Deleted) return false;
+            if (OriginNode != other.OriginNode) return false;
+            return true;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Deleted regions in some instances were being retained indefinitely.

I added some additional asserts + cleanup on region shutdown to try and stop / minimise further leaks as well. Long-term realistically large parts of this will likely be rewritten to be more performant anyway (e.g. rectangular-only regions using arrays instead of node hashsets), this is just to make sure it's stable for steam release (and this system is needed for the AI to actually be usable).