### PR TITLE
Fix OpenCentered by setting size before position

### DIFF
--- a/Content.Client/GameObjects/Components/Cargo/CargoConsoleBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Cargo/CargoConsoleBoundUserInterface.cs
@@ -69,7 +69,7 @@ namespace Content.Client.GameObjects.Components.Cargo
                 _orderMenu.Requester.Text = null;
                 _orderMenu.Reason.Text = null;
                 _orderMenu.Amount.Value = 1;
-                _orderMenu.OpenCenteredMinSize();
+                _orderMenu.OpenCentered();
             };
             _menu.OnOrderApproved += ApproveOrder;
             _menu.OnOrderCanceled += RemoveOrder;

--- a/Content.Client/GameObjects/Components/Chemistry/ReagentDispenser/ReagentDispenserBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Chemistry/ReagentDispenser/ReagentDispenserBoundUserInterface.cs
@@ -44,7 +44,7 @@ namespace Content.Client.GameObjects.Components.Chemistry
                 Title = _localizationManager.GetString("Reagent dispenser"),
             };
 
-            _window.OpenCenteredMinSize();
+            _window.OpenCentered();
             _window.OnClose += Close;
 
             //Setup static button actions.

--- a/Content.Client/GameObjects/Components/Disposal/DisposalUnitBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Disposal/DisposalUnitBoundUserInterface.cs
@@ -30,7 +30,7 @@ namespace Content.Client.GameObjects.Components.Disposal
 
             _window = new DisposalUnitWindow();
 
-            _window.OpenCenteredMinSize();
+            _window.OpenCentered();
             _window.OnClose += Close;
 
             _window.Eject.OnPressed += _ => ButtonPressed(UiButton.Eject);

--- a/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Power/ApcBoundUserInterface.cs
@@ -24,7 +24,7 @@ namespace Content.Client.GameObjects.Components.Power
 
             _window = new ApcWindow();
             _window.OnClose += Close;
-            _window.OpenCenteredMinSize();
+            _window.OpenCentered();
 
             _breakerButton = _window.BreakerButton;
             _breakerButton.OnPressed += _ => SendMessage(new ApcToggleMainBreakerMessage());

--- a/Content.Client/GameObjects/Components/Power/SolarControlConsoleBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Power/SolarControlConsoleBoundUserInterface.cs
@@ -48,7 +48,7 @@ namespace Content.Client.GameObjects.Components.Power
                     SendMessage(msg);
                 }
             };
-            _window.OpenCenteredMinSize();
+            _window.OpenCentered();
         }
 
         public SolarControlConsoleBoundUserInterface(ClientUserInterfaceComponent owner, object uiKey) : base(owner, uiKey)


### PR DESCRIPTION
Set Size to CombinedMinimumSize before opening BaseWindow.

Refactor all OpenCenteredMinSize to use OpenCentered.

Requires space-wizards/RobustToolbox#1211

Fixes #1603