### PR TITLE
Make devastation the only explosion type that removes tiles entirely

### DIFF
--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -83,29 +83,25 @@ namespace Content.Server.Explosions
                     continue;
                 }
                 var distanceFromTile = (int) tileLoc.Distance(mapManager, coords);
-                if (distanceFromTile < devastationRange)
-                {
-                    mapGrid.SetTile(tileLoc, new Tile(tileDefinitionManager[baseTurfs[0]].TileId));
-                }
 
-                else if (distanceFromTile < heavyImpactRange)
-                {
-                    if (robustRandom.Prob(0.8f))
-                    {
-                        mapGrid.SetTile(tileLoc, new Tile(tileDefinitionManager[baseTurfs[^1]].TileId));
-                    }
-                    else
-                    {
-                        mapGrid.SetTile(tileLoc, new Tile(tileDefinitionManager[baseTurfs[0]].TileId));
-                    }
-                }
+                var zeroTile = new Tile(tileDefinitionManager[baseTurfs[0]].TileId);
+                var previousTile = new Tile(tileDefinitionManager[baseTurfs[^1]].TileId);
 
-                else if (distanceFromTile < lightImpactRange)
+                switch (distanceFromTile)
                 {
-                    if (robustRandom.Prob(0.5f))
-                    {
-                        mapGrid.SetTile(tileLoc, new Tile(tileDefinitionManager[baseTurfs[^1]].TileId));
-                    }
+                    case var d when d < devastationRange:
+                        mapGrid.SetTile(tileLoc, zeroTile);
+                        break;
+                    case var d when d < heavyImpactRange
+                                    && !previousTile.IsEmpty
+                                    && robustRandom.Prob(0.8f):
+                        mapGrid.SetTile(tileLoc, previousTile);
+                        break;
+                    case var d when d < lightImpactRange
+                                    && !previousTile.IsEmpty
+                                    && robustRandom.Prob(0.5f):
+                        mapGrid.SetTile(tileLoc, previousTile);
+                        break;
                 }
             }
 

--- a/Resources/Prototypes/Entities/Constructible/Storage/StorageTanks/fuel_tank.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/StorageTanks/fuel_tank.yml
@@ -9,9 +9,9 @@
   - type: Icon
     texture: Constructible/Misc/weldtank.png
   - type: Explosive
-    devastationRange: 1
+    devastationRange: 0
     heavyImpactRange: 2
-    lightImpactRange: 4
+    lightImpactRange: 6
     flashRange: 5
   - type: Solution
     contents:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Explosives/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Explosives/grenades.yml
@@ -17,9 +17,9 @@
   - type: OnUseTimerTrigger
     delay: 3.5
   - type: Explosive
-    devastationRange: 1
-    heavyImpactRange: 3
-    lightImpactRange: 5
+    devastationRange: 0
+    heavyImpactRange: 2
+    lightImpactRange: 4
     flashRange: 7
   - type: Damageable
   - type: Destructible


### PR DESCRIPTION
Fixes #1279 

Also adjusts welding fuel tank and grenade explosion values.