### PR TITLE
Add total number of gases atmospherics test

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/ConstantsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/ConstantsTest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq;
+using Content.Shared.Atmos;
+using NUnit.Framework;
+
+namespace Content.IntegrationTests.Tests.Atmos
+{
+    [TestFixture]
+    [TestOf(typeof(Atmospherics))]
+    public class ConstantsTest : ContentIntegrationTest
+    {
+        [Test]
+        public void TotalGasesTest()
+        {
+            var server = StartServerDummyTicker();
+
+            server.Post(() =>
+            {
+                Assert.That(Atmospherics.Gases.Count(), Is.EqualTo(Atmospherics.TotalNumberOfGases));
+
+                Assert.That(Enum.GetValues(typeof(Gas)).Length, Is.EqualTo(Atmospherics.TotalNumberOfGases));
+            });
+        }
+    }
+}


### PR DESCRIPTION
Ensures that the amount of Gas enum entries and GasPrototypes are equal to the TotalNumberOfGases constant.
This is an integration test to make sure that all relevant atmos code is run, including IoC dependency injections.