### PR TITLE
Fix the pathfinding leak

### DIFF
--- a/Content.Server/GameObjects/Components/Access/AccessReaderChangeMessage.cs
+++ b/Content.Server/GameObjects/Components/Access/AccessReaderChangeMessage.cs
@@ -1,15 +1,17 @@
 using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
 
 namespace Content.Server.GameObjects.Components.Access
 {
     public sealed class AccessReaderChangeMessage : EntitySystemMessage
     {
-        public EntityUid Uid { get; }
+        public IEntity Sender { get; }
+
         public bool Enabled { get; }
 
-        public AccessReaderChangeMessage(EntityUid uid, bool enabled)
+        public AccessReaderChangeMessage(IEntity entity, bool enabled)
         {
-            Uid = uid;
+            Sender = entity;
             Enabled = enabled;
         }
     }

--- a/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
@@ -188,7 +188,7 @@ namespace Content.Server.GameObjects
                 SetAppearance(DoorVisualState.Open);
             }, _cancellationTokenSource.Token);
 
-            Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new AccessReaderChangeMessage(Owner.Uid, false));
+            Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new AccessReaderChangeMessage(Owner, false));
         }
 
         public virtual bool CanClose()
@@ -284,7 +284,7 @@ namespace Content.Server.GameObjects
                 State = DoorState.Closed;
                 SetAppearance(DoorVisualState.Closed);
             }, _cancellationTokenSource.Token);
-            Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new AccessReaderChangeMessage(Owner.Uid, true));
+            Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new AccessReaderChangeMessage(Owner, true));
             return true;
         }
 


### PR DESCRIPTION
I already outlined the issue in the discord but re-stated here for brevity:
As of one of the recent atmos commits tiles were being yeeted into space at a high-velocity which highlighted the existing pathfinding memory leak VERY quickly. This is because the tiles were still being tracked for the pathfinding chunks so they were being allocated and stored indefinitely.

Solutions:
1. Entities that aren't relevant for the graph no longer have their positions tracked even if the nodes ignore them (so the tiles are no longer tracked at all).
2. Any entity outside of its grid bounds is ignored (this seems like more of a band-aid to the potential entity parenting issue but it stops the source of the leak).

I also changed the EntityUids being used back to IEntities which is why there's so many lines committed.

I double-checked with a profiler that the issue didn't reoccur with and without playtesting and also checked that the AI was working.