### PR TITLE
Add test for non abstract entities without icons

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -19,16 +19,13 @@ namespace Content.IntegrationTests.Tests
     public class EntityTest : ContentIntegrationTest
     {
         [Test]
-        public async Task Test()
+        public async Task SpawnTest()
         {
             var server = StartServerDummyTicker();
-            var client = StartClient();
             await server.WaitIdleAsync();
-            await client.WaitIdleAsync();
             var mapMan = server.ResolveDependency<IMapManager>();
             var entityMan = server.ResolveDependency<IEntityManager>();
-            var serverPrototypeMan = server.ResolveDependency<IPrototypeManager>();
-            var clientPrototypeMan = client.ResolveDependency<IPrototypeManager>();
+            var prototypeMan = server.ResolveDependency<IPrototypeManager>();
             var mapLoader = server.ResolveDependency<IMapLoader>();
             var pauseMan = server.ResolveDependency<IPauseManager>();
             var prototypes = new List<EntityPrototype>();
@@ -43,56 +40,65 @@ namespace Content.IntegrationTests.Tests
                 grid = mapLoader.LoadBlueprint(mapId, "Maps/stationstation.yml");
             });
 
-            client.Assert(() =>
-                {
-                    foreach (var prototype in clientPrototypeMan.EnumeratePrototypes<EntityPrototype>())
-                    {
-                        if (prototype.Abstract)
-                        {
-                            continue;
-                        }
-
-                        Assert.That(prototype.Components.ContainsKey("Icon"), $"Entity {prototype.ID} does not have an Icon component, but is not abstract");
-                    }
-                });
-
             server.Assert(() =>
+            {
+                var testLocation = new GridCoordinates(new Vector2(0, 0), grid);
+
+                //Generate list of non-abstract prototypes to test
+                foreach (var prototype in prototypeMan.EnumeratePrototypes<EntityPrototype>())
                 {
-                    var testLocation = new GridCoordinates(new Vector2(0, 0), grid);
-
-                    //Generate list of non-abstract prototypes to test
-                    foreach (var prototype in serverPrototypeMan.EnumeratePrototypes<EntityPrototype>())
+                    if (prototype.Abstract)
                     {
-                        if (prototype.Abstract)
-                        {
-                            continue;
-                        }
-                        prototypes.Add(prototype);
+                        continue;
+                    }
+                    prototypes.Add(prototype);
+                }
+
+                //Iterate list of prototypes to spawn
+                foreach (var prototype in prototypes)
+                {
+                    try
+                    {
+                        Logger.LogS(LogLevel.Debug, "EntityTest", "Testing: " + prototype.ID);
+                        testEntity = entityMan.SpawnEntity(prototype.ID, testLocation);
+                        server.RunTicks(2);
+                        Assert.That(testEntity.Initialized);
+                        entityMan.DeleteEntity(testEntity.Uid);
                     }
 
-                    //Iterate list of prototypes to spawn
-                    foreach (var prototype in prototypes)
+                    //Fail any exceptions thrown on spawn
+                    catch (Exception e)
                     {
-                        try
-                        {
-                            Logger.LogS(LogLevel.Debug, "EntityTest", "Testing: " + prototype.ID);
-                            testEntity = entityMan.SpawnEntity(prototype.ID, testLocation);
-                            server.RunTicks(2);
-                            Assert.That(testEntity.Initialized);
-                            entityMan.DeleteEntity(testEntity.Uid);
-                        }
-
-                        //Fail any exceptions thrown on spawn
-                        catch (Exception e)
-                        {
-                            Logger.LogS(LogLevel.Error, "EntityTest", "Entity '" + prototype.ID + "' threw: " + e.Message);
-                            //Assert.Fail();
-                            throw;
-                        }
+                        Logger.LogS(LogLevel.Error, "EntityTest", "Entity '" + prototype.ID + "' threw: " + e.Message);
+                        //Assert.Fail();
+                        throw;
                     }
-                });
+                }
+            });
 
             await server.WaitIdleAsync();
+        }
+
+        [Test]
+        public async Task NotAbstractIconTest()
+        {
+            var client = StartClient();
+            await client.WaitIdleAsync();
+            var prototypeMan = client.ResolveDependency<IPrototypeManager>();
+
+            client.Assert(() =>
+            {
+                foreach (var prototype in prototypeMan.EnumeratePrototypes<EntityPrototype>())
+                {
+                    if (prototype.Abstract)
+                    {
+                        continue;
+                    }
+
+                    Assert.That(prototype.Components.ContainsKey("Icon"), $"Entity {prototype.ID} does not have an Icon component, but is not abstract");
+                }
+            });
+
             await client.WaitIdleAsync();
         }
     }

--- a/Resources/Prototypes/Entities/Constructible/Power/turret.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/turret.yml
@@ -9,6 +9,8 @@
   - type: Collidable
   - type: Sprite
     texture: Constructible/Misc/TurrBase.png
+  - type: Icon
+    texture: Constructible/Misc/TurrBase.png
 
 - type: entity
   id: TurretTopGun
@@ -23,6 +25,8 @@
     drawdepth: WallMountedItems
     texture: Constructible/Misc/TurrTop.png
     directional: false
+  - type: Icon
+    texture: Constructible/Misc/TurrTop.png
 
 - type: entity
   id: TurretTopLight
@@ -35,6 +39,8 @@
     drawdepth: WallMountedItems
     texture: Constructible/Misc/TurrLamp.png
     directional: false
+  - type: Icon
+    texture: Constructible/Misc/TurrLamp.png
   - type: PointLight
     radius: 512
     mask: flashlight_mask

--- a/Resources/Prototypes/Entities/Constructible/disposal.yml
+++ b/Resources/Prototypes/Entities/Constructible/disposal.yml
@@ -19,6 +19,7 @@
 
 - type: entity
   id: DisposalHolder
+  abstract: true
   name: disposal holder
   components:
   - type: DisposalHolder

--- a/Resources/Prototypes/Entities/Effects/Markers/construction_ghost.yml
+++ b/Resources/Prototypes/Entities/Effects/Markers/construction_ghost.yml
@@ -1,6 +1,7 @@
 - type: entity
-  name: spooky ghost
+  name: construction ghost
   id: constructionghost
+  abstract: true
   components:
   - type: Sprite
     color: '#3F38'
@@ -12,6 +13,7 @@
 - type: entity
   name: somebody-messed-up frame
   id: structureconstructionframe
+  abstract: true
   components:
   - type: Sprite
   - type: Construction

--- a/Resources/Prototypes/Entities/Effects/Markers/drag_shadow.yml
+++ b/Resources/Prototypes/Entities/Effects/Markers/drag_shadow.yml
@@ -1,6 +1,7 @@
 - type: entity
   name: drag shadow
   id: dragshadow
+  abstract: true
   components:
     - type: Sprite
       layers:

--- a/Resources/Prototypes/Entities/Effects/Markers/hover_entity.yml
+++ b/Resources/Prototypes/Entities/Effects/Markers/hover_entity.yml
@@ -1,6 +1,7 @@
 ﻿- type: entity
   name: hover entity
   id: hoverentity
+  abstract: true
   components:
     - type: Sprite
       layers:

--- a/Resources/Prototypes/Entities/Effects/Markers/pointing.yml
+++ b/Resources/Prototypes/Entities/Effects/Markers/pointing.yml
@@ -6,6 +6,9 @@
     netsync: false
     sprite: Interface/Misc/pointing.rsi
     state: pointing
+  - type: Icon
+    sprite: Interface/Misc/pointing.rsi
+    state: pointing
   - type: PointingArrow
     duration: 4
     step: 0.5

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -2,3 +2,5 @@
   parent: MobObserver
   save: false
   id: AdminObserver
+  name: admin observer
+  abstract: true

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -1,6 +1,7 @@
 - type: entity
   id: MobObserver
   name: observer
+  abstract: true
   save: false
   description: Boo!
   components:


### PR DESCRIPTION
Fixes #575.
Test will now fail if an entity is added that is not abstract but has no icon.
Also added icons or made entities abstract that failed the test.
No non abstract entities actually missed textures.

Some notes: Changed name of "constructionghost" from "spooky ghost" to "construction ghost", and changed name of "AdminObserver" from "observer" to "admin observer" to avoid overlap in names.