### PR TITLE
Observers are now shown in the Lobby as Observers

### DIFF
--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -30,7 +30,7 @@ namespace Content.Client.GameTicking
         [ViewVariables] public string ServerInfoBlob { get; private set; }
         [ViewVariables] public DateTime StartTime { get; private set; }
         [ViewVariables] public bool Paused { get; private set; }
-        [ViewVariables] public Dictionary<NetSessionId, bool> Ready { get; private set; }
+        [ViewVariables] public Dictionary<NetSessionId, PlayerStatus> Status { get; private set; }
 
         public event Action InfoBlobUpdated;
         public event Action LobbyStatusUpdated;
@@ -54,7 +54,7 @@ namespace Content.Client.GameTicking
             });
             _netManager.RegisterNetMessage<MsgTickerLateJoinStatus>(nameof(MsgTickerLateJoinStatus), LateJoinStatus);
 
-            Ready = new Dictionary<NetSessionId, bool>();
+            Status = new Dictionary<NetSessionId, PlayerStatus>();
             _initialized = true;
         }
 
@@ -77,7 +77,7 @@ namespace Content.Client.GameTicking
             AreWeReady = message.YouAreReady;
             Paused = message.Paused;
             if (IsGameStarted)
-                Ready.Clear();
+                Status.Clear();
 
             LobbyStatusUpdated?.Invoke();
         }
@@ -103,9 +103,9 @@ namespace Content.Client.GameTicking
         private void LobbyReady(MsgTickerLobbyReady message)
         {
             // Merge the Dictionaries
-            foreach (var p in message.PlayerReady)
+            foreach (var p in message.PlayerStatus)
             {
-                Ready[p.Key] = p.Value;
+                Status[p.Key] = p.Value;
             }
             LobbyReadyUpdated?.Invoke();
         }

--- a/Content.Client/Interfaces/IClientGameTicker.cs
+++ b/Content.Client/Interfaces/IClientGameTicker.cs
@@ -1,6 +1,7 @@
 ﻿using Robust.Shared.Network;
 using System;
 using System.Collections.Generic;
+using static Content.Shared.SharedGameTicker;
 
 namespace Content.Client.Interfaces
 {
@@ -12,7 +13,7 @@ namespace Content.Client.Interfaces
         bool DisallowedLateJoin { get; }
         DateTime StartTime { get; }
         bool Paused { get; }
-        Dictionary<NetSessionId, bool> Ready { get; }
+        Dictionary<NetSessionId, PlayerStatus> Status { get; }
 
         void Initialize();
         event Action InfoBlobUpdated;

--- a/Content.Client/State/LobbyState.cs
+++ b/Content.Client/State/LobbyState.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Localization;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.ViewVariables;
+using static Content.Shared.SharedGameTicker;
 
 namespace Content.Client.State
 {
@@ -112,7 +113,7 @@ namespace Content.Client.State
             _clientGameTicker.LobbyReadyUpdated -= LobbyReadyUpdated;
             _clientGameTicker.LobbyLateJoinStatusUpdated -= LobbyLateJoinStatusUpdated;
 
-            _clientGameTicker.Ready.Clear();
+            _clientGameTicker.Status.Clear();
 
             _lobby.Dispose();
             _characterSetup.Dispose();
@@ -157,12 +158,15 @@ namespace Content.Client.State
 
         private void PlayerManagerOnPlayerListUpdated(object sender, EventArgs e)
         {
-            // Remove disconnected sessions from the Ready Dict
-            foreach (var p in _clientGameTicker.Ready)
+            // Remove disconnected sessions from the Ready Dict //Question: Do we still need this? We clean the dict once we get ingame
+            foreach (var p in _clientGameTicker.Status)
             {
                 if (!_playerManager.SessionsDict.TryGetValue(p.Key, out _))
                 {
-                    _clientGameTicker.Ready.Remove(p.Key);
+                    // This is a shitty fix. Observers can rejoin because they are already in the game.
+                    // So we don't delete them, but keep them if they decide to rejoin
+                    if (p.Value != PlayerStatus.Observer)
+                        _clientGameTicker.Status.Remove(p.Key);
                 }
             }
             UpdatePlayerList();
@@ -218,12 +222,19 @@ namespace Content.Client.State
                 // Don't show ready state if we're ingame
                 if (!_clientGameTicker.IsGameStarted)
                 {
-                    var ready = false;
+                    var status = PlayerStatus.NotReady;
                     if (session.SessionId == _playerManager.LocalPlayer.SessionId)
-                        ready = _clientGameTicker.AreWeReady;
+                        status = _clientGameTicker.AreWeReady ? PlayerStatus.Ready : PlayerStatus.NotReady;
                     else
-                        _clientGameTicker.Ready.TryGetValue(session.SessionId, out ready);
-                    readyState = ready ? Loc.GetString("Ready") : Loc.GetString("Not Ready");
+                        _clientGameTicker.Status.TryGetValue(session.SessionId, out status);
+
+                    readyState = status switch
+                    {
+                        PlayerStatus.NotReady => Loc.GetString("Not Ready"),
+                        PlayerStatus.Ready => Loc.GetString("Ready"),
+                        PlayerStatus.Observer => Loc.GetString("Observer"),
+                        _ => "",
+                    };
                 }
                 _lobby.PlayerReadyList.AddItem(readyState, null, false);
             }

--- a/Content.Shared/SharedGameTicker.cs
+++ b/Content.Shared/SharedGameTicker.cs
@@ -191,13 +191,13 @@ namespace Content.Shared
             #endregion
 
             /// <summary>
-            /// The Players Ready (SessionID:ready)
+            /// The Status of the Player in the lobby (ready, observer, ...)
             /// </summary>
-            public Dictionary<NetSessionId, bool> PlayerReady { get; set; }
+            public Dictionary<NetSessionId, PlayerStatus> PlayerStatus { get; set; }
 
             public override void ReadFromBuffer(NetIncomingMessage buffer)
             {
-                PlayerReady = new Dictionary<NetSessionId, bool>();
+                PlayerStatus = new Dictionary<NetSessionId, PlayerStatus>();
                 var length = buffer.ReadInt32();
                 for (int i = 0; i < length; i++)
                 {
@@ -208,16 +208,16 @@ namespace Content.Shared
                     {
                         serializer.DeserializeDirect(stream, out sessionID);
                     }
-                    var ready = buffer.ReadBoolean();
-                    PlayerReady.Add(sessionID, ready);
+                    var status = (PlayerStatus)buffer.ReadByte();
+                    PlayerStatus.Add(sessionID, status);
                 }
             }
 
             public override void WriteToBuffer(NetOutgoingMessage buffer)
             {
                 var serializer = IoCManager.Resolve<IRobustSerializer>();
-                buffer.Write(PlayerReady.Count);
-                foreach (var p in PlayerReady)
+                buffer.Write(PlayerStatus.Count);
+                foreach (var p in PlayerStatus)
                 {
                     using (var stream = new MemoryStream())
                     {
@@ -226,7 +226,7 @@ namespace Content.Shared
                         stream.TryGetBuffer(out var segment);
                         buffer.Write(segment);
                     }
-                    buffer.Write(p.Value);
+                    buffer.Write((byte)p.Value);
                 }
             }
         }
@@ -238,7 +238,6 @@ namespace Content.Shared
             public string PlayerICName;
             public string Role;
             public bool Antag;
-
         }
 
         protected class MsgRoundEndMessage : NetMessage
@@ -307,6 +306,13 @@ namespace Content.Shared
                 }
             }
 
+        }
+
+        public enum PlayerStatus
+        {
+            NotReady = 0,
+            Ready,
+            Observer,
         }
     }
 }


### PR DESCRIPTION
Fixes #1821

This also makes the _playersInLobby in the Server GameTicker have the information if a player is a observer. This will make it easier to check if a player is a observer, instead of checking for ObserverMob