### PR TITLE
Slight DisposalUnit optimisation

### DIFF
--- a/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalUnitComponent.cs
@@ -117,6 +117,13 @@ namespace Content.Server.GameObjects.Components.Disposal
                 ? boundUi
                 : null;
 
+        private DisposalUnitBoundUserInterfaceState? _lastUiState;
+        
+        /// <summary>
+        ///     Store the translated state.
+        /// </summary>
+        private (PressureState State, string Localized) _locState;
+
         public bool CanInsert(IEntity entity)
         {
             if (!Anchored)
@@ -286,13 +293,31 @@ namespace Content.Server.GameObjects.Components.Disposal
 
         private DisposalUnitBoundUserInterfaceState GetInterfaceState()
         {
-            var state = Loc.GetString($"{State}");
-            return new DisposalUnitBoundUserInterfaceState(Owner.Name, state, _pressure, Powered, Engaged);
+            string stateString;
+            
+            if (_locState.State != State)
+            {
+                stateString = Loc.GetString($"{State}");
+                _locState = (State, stateString);
+            }
+            else
+            {
+                stateString = _locState.Localized;
+            }
+            
+            return new DisposalUnitBoundUserInterfaceState(Owner.Name, stateString, _pressure, Powered, Engaged);
         }
 
         private void UpdateInterface()
         {
             var state = GetInterfaceState();
+
+            if (_lastUiState != null && _lastUiState.Equals(state))
+            {
+                return;
+            }
+
+            _lastUiState = state;
             UserInterface?.SetState(state);
         }
 

--- a/Content.Shared/GameObjects/Components/Disposal/SharedDisposalUnitComponent.cs
+++ b/Content.Shared/GameObjects/Components/Disposal/SharedDisposalUnitComponent.cs
@@ -58,7 +58,7 @@ namespace Content.Shared.GameObjects.Components.Disposal
         }
 
         [Serializable, NetSerializable]
-        public class DisposalUnitBoundUserInterfaceState : BoundUserInterfaceState
+        public class DisposalUnitBoundUserInterfaceState : BoundUserInterfaceState, IEquatable<DisposalUnitBoundUserInterfaceState>
         {
             public readonly string UnitName;
             public readonly string UnitState;
@@ -74,6 +74,17 @@ namespace Content.Shared.GameObjects.Components.Disposal
                 Pressure = pressure;
                 Powered = powered;
                 Engaged = engaged;
+            }
+
+            public bool Equals(DisposalUnitBoundUserInterfaceState other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return UnitName == other.UnitName && 
+                       UnitState == other.UnitState && 
+                       Powered == other.Powered && 
+                       Engaged == other.Engaged && 
+                       Pressure.Equals(other.Pressure);
             }
         }
 


### PR DESCRIPTION
UI was being updated every tick even when not necessary. Ideally you'd just update the UI based on events but this should improve the idle perf.

The 2 main things were:
1. Localizing the state every time (this was like 2/3 of the update)
2. Calling SetState even when it hadn't changed.

Old:
![image](https://user-images.githubusercontent.com/31366439/90971954-2d699b80-e558-11ea-9762-fcc73a229be4.png)

New:
![image](https://user-images.githubusercontent.com/31366439/90971957-38bcc700-e558-11ea-87de-5577cc83fd51.png)

@DrSmugleaf 
