### PR TITLE
Fixes ghost NRE in lobby

### DIFF
--- a/Content.Server/Administration/AGhost.cs
+++ b/Content.Server/Administration/AGhost.cs
@@ -22,6 +22,12 @@ namespace Content.Server.Administration
             }
 
             var mind = player.ContentData().Mind;
+            if (mind == null)
+            {
+                shell.SendText(player, "You can't ghost here!");
+                return;
+            }
+
             if (mind.VisitingEntity != null && mind.VisitingEntity.Prototype.ID == "AdminObserver")
             {
                 var visiting = mind.VisitingEntity;

--- a/Content.Server/Observer/Ghost.cs
+++ b/Content.Server/Observer/Ghost.cs
@@ -28,6 +28,12 @@ namespace Content.Server.Observer
             }
 
             var mind = player.ContentData().Mind;
+            if (mind == null)
+            {
+                shell.SendText(player, "You can't ghost here!");
+                return;
+            }
+
             var canReturn = player.AttachedEntity != null && CanReturn;
             var name = player.AttachedEntity?.Name ?? player.Name;
 


### PR DESCRIPTION
Simply tells the player "You can't ghost here!" when they try it in the lobby, works for both normal ghost and aghost.
Closes #1891 