### PR TITLE
Bullet only damage the first entity it collided with

### DIFF
--- a/Content.Server/GameObjects/Components/Projectiles/ProjectileComponent.cs
+++ b/Content.Server/GameObjects/Components/Projectiles/ProjectileComponent.cs
@@ -36,6 +36,8 @@ namespace Content.Server.GameObjects.Components.Projectiles
         private string _soundHit;
         private string _soundHitSpecies;
 
+        private bool _damagedEntity;
+
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);
@@ -64,6 +66,11 @@ namespace Content.Server.GameObjects.Components.Projectiles
         /// <param name="entity"></param>
         void ICollideBehavior.CollideWith(IEntity entity)
         {
+            if (_damagedEntity)
+            {
+                return;
+            }
+
             // This is so entities that shouldn't get a collision are ignored.
             if (entity.TryGetComponent(out ICollidableComponent collidable) && collidable.Hard == false)
             {
@@ -91,6 +98,8 @@ namespace Content.Server.GameObjects.Components.Projectiles
                 {
                     damage.ChangeDamage(damageType, amount, false, shooter);
                 }
+
+                _damagedEntity = true;
             }
 
             if (!entity.Deleted && entity.TryGetComponent(out CameraRecoilComponent recoilComponent)


### PR DESCRIPTION
Used a boolean flag _damagedEntity to check for whether this projectile should damage an entity -- it should only damage the first entity it collided with.