### PR TITLE
Fix for missing loc strings in handcuffs.

### DIFF
--- a/Content.Server/GameObjects/Components/ActionBlocking/CuffableComponent.cs
+++ b/Content.Server/GameObjects/Components/ActionBlocking/CuffableComponent.cs
@@ -224,7 +224,7 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
 
             if (!isOwner && !ActionBlockerSystem.CanInteract(user))
             {
-                user.PopupMessage(user, "You can't do that!");
+                user.PopupMessage(user, Loc.GetString("You can't do that!"));
                 return;
             }
 
@@ -235,7 +235,7 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
                     _interactRange,
                     ignoredEnt: Owner))
             {
-                user.PopupMessage(user, "You are too far away to remove the cuffs.");
+                user.PopupMessage(user, Loc.GetString("You are too far away to remove the cuffs."));
                 return;
             }
 
@@ -249,7 +249,7 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
                 return;
             }
 
-            user.PopupMessage(user, "You start removing the cuffs.");
+            user.PopupMessage(user, Loc.GetString("You start removing the cuffs."));
 
             var audio = EntitySystem.Get<AudioSystem>();
             audio.PlayFromEntity(isOwner ? cuff.StartBreakoutSound : cuff.StartUncuffSound, Owner);
@@ -305,7 +305,7 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
                 {
                     if (!isOwner)
                     {
-                        _notifyManager.PopupMessage(user, user, Loc.GetString("You successfully remove the cuffs. {0} of {0:theName}'s hands remain cuffed.", CuffedHandCount, user));
+                        _notifyManager.PopupMessage(user, user, Loc.GetString("You successfully remove the cuffs. {0} of {1:theName}'s hands remain cuffed.", CuffedHandCount, user));
                         _notifyManager.PopupMessage(user, Owner, Loc.GetString("{0:theName} removes your cuffs. {1} of your hands remain cuffed.", user, CuffedHandCount));
                     }
                     else

--- a/Content.Server/GameObjects/Components/ActionBlocking/HandcuffComponent.cs
+++ b/Content.Server/GameObjects/Components/ActionBlocking/HandcuffComponent.cs
@@ -225,8 +225,8 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
             if (result != DoAfterStatus.Cancelled)
             {
                 _audioSystem.PlayFromEntity(EndCuffSound, Owner);
-                _notifyManager.PopupMessage(user, user, Loc.GetString("You successfully cuff {0}.", target.Name));
-                _notifyManager.PopupMessage(target, target, Loc.GetString("You have been cuffed by {0}!", user.Name));
+                _notifyManager.PopupMessage(user, user, Loc.GetString("You successfully cuff {0:theName}.", target));
+                _notifyManager.PopupMessage(target, target, Loc.GetString("You have been cuffed by {0:theName}!", user));
 
                 if (user.TryGetComponent<HandsComponent>(out var hands))
                 {
@@ -240,8 +240,8 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
             }
             else
             {
-                user.PopupMessage(user, Loc.GetString("You were interrupted while cuffing {0}!", target.Name));
-                target.PopupMessage(target, Loc.GetString("You interrupt {0} while they are cuffing you!", user.Name));
+                user.PopupMessage(user, Loc.GetString("You were interrupted while cuffing {0:theName}!", target));
+                target.PopupMessage(target, Loc.GetString("You interrupt {0:theName} while they are cuffing you!", user));
             }
         }
     }

--- a/Content.Shared/GameObjects/ContentNetIDs.cs
+++ b/Content.Shared/GameObjects/ContentNetIDs.cs
@@ -68,7 +68,7 @@
         public const uint BOLTACTION_BARREL = 1062;
         public const uint PUMP_BARREL = 1063;
         public const uint REVOLVER_BARREL = 1064;
-	    public const uint CUFFED = 1065;
+        public const uint CUFFED = 1065;
         public const uint HANDCUFFS = 1066;
 
         // Net IDs for integration tests.

--- a/Content.Shared/GameObjects/ContentNetIDs.cs
+++ b/Content.Shared/GameObjects/ContentNetIDs.cs
@@ -68,7 +68,7 @@
         public const uint BOLTACTION_BARREL = 1062;
         public const uint PUMP_BARREL = 1063;
         public const uint REVOLVER_BARREL = 1064;
-	public const uint CUFFED = 1065;
+	    public const uint CUFFED = 1065;
         public const uint HANDCUFFS = 1066;
 
         // Net IDs for integration tests.


### PR DESCRIPTION
Missing Loc.GetString in a few spots and also fixed some bad formatting on some strings.