### PR TITLE
No context menu through occluder

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
@@ -133,6 +133,7 @@ namespace Content.Client.GameObjects.EntitySystems
                 return false;
             }
             
+            // Check if we have LOS to the clicked-location, otherwise no popup.
             var vectorDiff = playerEntity.Transform.MapPosition.Position - mapCoordinates.Position;
             var direction = vectorDiff.Normalized;
             var distance = vectorDiff.Length;

--- a/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
@@ -136,7 +136,10 @@ namespace Content.Client.GameObjects.EntitySystems
             var vectorDiff = playerEntity.Transform.MapPosition.Position - mapCoordinates.Position;
             var direction = vectorDiff.Normalized;
             var distance = vectorDiff.Length;
-            Func<IEntity, bool> ignored = entity => entities.Contains(entity) || entity == playerEntity || !entity.HasComponent<OccluderComponent>();
+            Func<IEntity, bool> ignored = entity => entities.Contains(entity) || 
+                                                    entity == playerEntity || 
+                                                    !entity.TryGetComponent(out OccluderComponent occluder) ||
+                                                    !occluder.Enabled;
             
             var ray = _physicsManager
                 .IntersectRayWithPredicate(mapCoordinates.MapId, 

--- a/Content.Server/GameObjects/EntitySystems/VerbSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/VerbSystem.cs
@@ -12,7 +12,7 @@ using static Content.Shared.GameObjects.EntitySystemMessages.VerbSystemMessages;
 
 namespace Content.Server.GameObjects.EntitySystems
 {
-    public class VerbSystem : EntitySystem
+    public class VerbSystem : SharedVerbSystem
     {
         [Dependency] private readonly IEntityManager _entityManager = default!;
 
@@ -90,6 +90,11 @@ namespace Content.Server.GameObjects.EntitySystems
             if (userEntity == null)
             {
                 Logger.Warning($"{nameof(UseVerb)} called by player {player} with no attached entity.");
+                return;
+            }
+
+            if (!TryGetContextEntities(userEntity, entity.Transform.MapPosition, out var entities, true) || !entities.Contains(entity))
+            {
                 return;
             }
 

--- a/Content.Shared/GameObjects/Verbs/SharedVerbSystem.cs
+++ b/Content.Shared/GameObjects/Verbs/SharedVerbSystem.cs
@@ -1,0 +1,71 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.Physics;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Systems;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.Shared.GameObjects.Verbs
+{
+    public class SharedVerbSystem : EntitySystem
+    {
+        private SharedInteractionSystem _interactionSystem = null!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            _interactionSystem = Get<SharedInteractionSystem>();
+        }
+
+        /// <summary>
+        ///     Get all of the entities relevant for the contextmenu
+        /// </summary>
+        /// <param name="player"></param>
+        /// <param name="targetPos"></param>
+        /// <param name="contextEntities"></param>
+        /// <param name="buffer">Whether we should slightly extend out the ignored range for the ray predicated</param>
+        /// <returns></returns>
+        protected bool TryGetContextEntities(IEntity player, MapCoordinates targetPos, [NotNullWhen(true)] out List<IEntity>? contextEntities, bool buffer = false)
+        {
+            contextEntities = null;
+            var length = buffer ? 1.0f: 0.5f;
+            
+            var entities = EntityManager.GetEntitiesIntersecting(targetPos.MapId,
+                Box2.CenteredAround(targetPos.Position, (length, length))).ToList();
+            
+            if (entities.Count == 0)
+            {
+                return false;
+            }
+            
+            // Check if we have LOS to the clicked-location, otherwise no popup.
+            var vectorDiff = player.Transform.MapPosition.Position - targetPos.Position;
+            var distance = vectorDiff.Length + 0.01f;
+            Func<IEntity, bool> ignored = entity => entities.Contains(entity) || 
+                                                    entity == player || 
+                                                    !entity.TryGetComponent(out OccluderComponent? occluder) ||
+                                                    !occluder.Enabled;
+
+            var result = _interactionSystem.InRangeUnobstructed(
+                player.Transform.MapPosition, 
+                targetPos,
+                distance, 
+                (int) CollisionGroup.Opaque, 
+                ignored);
+
+            if (!result)
+            {
+                return false;
+            }
+
+            contextEntities = entities;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1933
@ancientpower how's this

It's not 100% perfect because it pulls out entities within a 1-1 box within the click (the default) which means it can still technically go slightly through walls (if you click the edge and something is next to it) though I'm not sure of the best way to deal with that.

Could maybe have it check if any of the entities are walls and fallback to a tile-based method / center it on the wall's tile and call GetEntitiesIntersecting again?