### PR TITLE
Change component tests to not use stationstation

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -121,18 +121,32 @@ namespace Content.IntegrationTests.Tests
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
-            var mapLoader = server.ResolveDependency<IMapLoader>();
             var pauseManager = server.ResolveDependency<IPauseManager>();
             var componentFactory = server.ResolveDependency<IComponentFactory>();
+            var tileDefinitionManager = server.ResolveDependency<ITileDefinitionManager>();
 
             IMapGrid grid = default;
 
             server.Post(() =>
             {
-                // Load test map
+                // Create a one tile grid to stave off the grid 0 monsters
                 var mapId = mapManager.CreateMap();
+
                 pauseManager.AddUninitializedMap(mapId);
-                grid = mapLoader.LoadBlueprint(mapId, "Maps/stationstation.yml");
+
+                var gridId = new GridId(1);
+
+                if (!mapManager.TryGetGrid(gridId, out grid))
+                {
+                    grid = mapManager.CreateGrid(mapId, gridId);
+                }
+
+                var tileDefinition = tileDefinitionManager["underplating"];
+                var tile = new Tile(tileDefinition.TileId);
+                var coordinates = new GridCoordinates(0, 0, gridId);
+
+                grid.SetTile(coordinates, tile);
+
                 pauseManager.DoMapInitialize(mapId);
             });
 
@@ -202,18 +216,32 @@ namespace Content.IntegrationTests.Tests
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
-            var mapLoader = server.ResolveDependency<IMapLoader>();
             var pauseManager = server.ResolveDependency<IPauseManager>();
             var componentFactory = server.ResolveDependency<IComponentFactory>();
+            var tileDefinitionManager = server.ResolveDependency<ITileDefinitionManager>();
 
             IMapGrid grid = default;
 
             server.Post(() =>
             {
-                // Load test map
+                // Create a one tile grid to stave off the grid 0 monsters
                 var mapId = mapManager.CreateMap();
+
                 pauseManager.AddUninitializedMap(mapId);
-                grid = mapLoader.LoadBlueprint(mapId, "Maps/stationstation.yml");
+
+                var gridId = new GridId(1);
+
+                if (!mapManager.TryGetGrid(gridId, out grid))
+                {
+                    grid = mapManager.CreateGrid(mapId, gridId);
+                }
+
+                var tileDefinition = tileDefinitionManager["underplating"];
+                var tile = new Tile(tileDefinition.TileId);
+                var coordinates = new GridCoordinates(0, 0, gridId);
+
+                grid.SetTile(coordinates, tile);
+
                 pauseManager.DoMapInitialize(mapId);
             });
 

--- a/Content.Server/GameObjects/Components/NodeContainer/NodeGroups/IPipeNet.cs
+++ b/Content.Server/GameObjects/Components/NodeContainer/NodeGroups/IPipeNet.cs
@@ -27,15 +27,16 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
         [ViewVariables]
         private readonly List<PipeNode> _pipes = new List<PipeNode>();
 
-        [ViewVariables]
-        private IGridAtmosphereComponent _gridAtmos;
+        [ViewVariables] private AtmosphereSystem _atmosphereSystem;
+
+        [ViewVariables] private IGridAtmosphereComponent GridAtmos => _atmosphereSystem.GetGridAtmosphere(GridId);
 
         public override void Initialize(Node sourceNode)
         {
             base.Initialize(sourceNode);
-            _gridAtmos = EntitySystem.Get<AtmosphereSystem>()
-                .GetGridAtmosphere(GridId);
-            _gridAtmos?.AddPipeNet(this);
+
+            _atmosphereSystem = EntitySystem.Get<AtmosphereSystem>();
+            GridAtmos?.AddPipeNet(this);
         }
 
         public void Update()
@@ -88,7 +89,7 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
 
         private void RemoveFromGridAtmos()
         {
-            _gridAtmos.RemovePipeNet(this);
+            GridAtmos?.RemovePipeNet(this);
         }
 
         private class NullPipeNet : IPipeNet


### PR DESCRIPTION
It was used as a dummy grid to spawn things into in order to avoid testing in grid 0, but that can be done by spawning a grid as well.