### PR TITLE
Tweaks damage types and classes

### DIFF
--- a/Content.Server/Chat/ChatCommands.cs
+++ b/Content.Server/Chat/ChatCommands.cs
@@ -139,12 +139,15 @@ namespace Content.Server.Chat
                 damageableComponent.ChangeDamage(kind switch
                     {
                         SuicideKind.Blunt => DamageType.Blunt,
+                        SuicideKind.Slash => DamageType.Slash,
                         SuicideKind.Piercing => DamageType.Piercing,
                         SuicideKind.Heat => DamageType.Heat,
-                        SuicideKind.Disintegration => DamageType.Disintegration,
-                        SuicideKind.Cellular => DamageType.Cellular,
-                        SuicideKind.DNA => DamageType.DNA,
+                        SuicideKind.Shock => DamageType.Shock,
+                        SuicideKind.Cold => DamageType.Cold,
+                        SuicideKind.Poison => DamageType.Poison,
+                        SuicideKind.Radiation => DamageType.Radiation,
                         SuicideKind.Asphyxiation => DamageType.Asphyxiation,
+                        SuicideKind.Bloodloss => DamageType.Bloodloss,
                         _ => DamageType.Blunt
                     },
                 500,

--- a/Content.Server/Interfaces/GameObjects/ISuicideAct.cs
+++ b/Content.Server/Interfaces/GameObjects/ISuicideAct.cs
@@ -14,12 +14,15 @@ namespace Content.Server.Interfaces.GameObjects
 
         //Damage type suicides
         Blunt,
+        Slash,
         Piercing,
         Heat,
-        Disintegration,
-        Cellular,
-        DNA,
-        Asphyxiation
+        Shock,
+        Cold,
+        Poison,
+        Radiation,
+        Asphyxiation,
+        Bloodloss
 
     }
 }

--- a/Content.Shared/Damage/DamageClass.cs
+++ b/Content.Shared/Damage/DamageClass.cs
@@ -12,7 +12,8 @@ namespace Content.Shared.Damage
         Brute,
         Burn,
         Toxin,
-        Airloss
+        Airloss,
+        Genetic
     }
 
     public static class DamageClassExtensions
@@ -20,10 +21,11 @@ namespace Content.Shared.Damage
         private static readonly ImmutableDictionary<DamageClass, List<DamageType>> ClassToType =
             new Dictionary<DamageClass, List<DamageType>>
             {
-                {DamageClass.Brute, new List<DamageType> {DamageType.Blunt, DamageType.Piercing}},
-                {DamageClass.Burn, new List<DamageType> {DamageType.Heat, DamageType.Disintegration}},
-                {DamageClass.Toxin, new List<DamageType> {DamageType.Cellular, DamageType.DNA}},
-                {DamageClass.Airloss, new List<DamageType> {DamageType.Asphyxiation}}
+                {DamageClass.Brute, new List<DamageType> {DamageType.Blunt, DamageType.Slash, DamageType.Piercing}},
+                {DamageClass.Burn, new List<DamageType> {DamageType.Heat, DamageType.Shock, DamageType.Cold}},
+                {DamageClass.Toxin, new List<DamageType> {DamageType.Poison, DamageType.Radiation}},
+                {DamageClass.Airloss, new List<DamageType> {DamageType.Asphyxiation, DamageType.Bloodloss}},
+                {DamageClass.Genetic, new List<DamageType> {DamageType.Cellular}}
             }.ToImmutableDictionary();
 
         public static List<DamageType> ToTypes(this DamageClass @class)

--- a/Content.Shared/Damage/DamageType.cs
+++ b/Content.Shared/Damage/DamageType.cs
@@ -10,12 +10,16 @@ namespace Content.Shared.Damage
     public enum DamageType
     {
         Blunt,
+        Slash,
         Piercing,
         Heat,
-        Disintegration,
-        Cellular,
-        DNA,
-        Asphyxiation
+        Shock,
+        Cold,
+        Poison,
+        Radiation,
+        Asphyxiation,
+        Bloodloss,
+        Cellular
     }
 
     public static class DamageTypeExtensions
@@ -25,12 +29,17 @@ namespace Content.Shared.Damage
             new Dictionary<DamageType, DamageClass>
             {
                 {DamageType.Blunt, DamageClass.Brute},
+                {DamageType.Slash, DamageClass.Brute},
                 {DamageType.Piercing, DamageClass.Brute},
                 {DamageType.Heat, DamageClass.Burn},
-                {DamageType.Disintegration, DamageClass.Burn},
-                {DamageType.Cellular, DamageClass.Toxin},
-                {DamageType.DNA, DamageClass.Toxin},
-                {DamageType.Asphyxiation, DamageClass.Airloss}
+                {DamageType.Shock, DamageClass.Burn},
+                {DamageType.Cold, DamageClass.Burn},
+                {DamageType.Poison, DamageClass.Toxin},
+                {DamageType.Radiation, DamageClass.Toxin},
+                {DamageType.Asphyxiation, DamageClass.Airloss},
+                {DamageType.Bloodloss, DamageClass.Airloss},
+                {DamageType.Cellular, DamageClass.Genetic }
+
             }.ToImmutableDictionary();
 
         public static DamageClass ToClass(this DamageType type)

--- a/Resources/Prototypes/Damage/damage_containers.yml
+++ b/Resources/Prototypes/Damage/damage_containers.yml
@@ -5,6 +5,7 @@
   - Burn
   - Toxin
   - Airloss
+  - Genetic
 
 - type: damageContainer
   id: metallicDamageContainer

--- a/Resources/Prototypes/Damage/resistance_sets.yml
+++ b/Resources/Prototypes/Damage/resistance_sets.yml
@@ -2,55 +2,79 @@
   id: defaultResistances
   coefficients:
     Blunt: 1.0
+    Slash: 1.0
     Piercing: 1.0
     Heat: 1.0
-    Disintegration: 1.0
-    Cellular: 1.0
-    DNA: 1.0
+    Shock: 1.0
+    Cold: 1.0
+    Poison: 1.0
+    Radiation: 1.0
     Asphyxiation: 1.0
+    Bloodloss: 1.0
+    Cellular: 1.0
   flatReductions:
     Blunt: 0
+    Slash: 0
     Piercing: 0
     Heat: 0
-    Disintegration: 0
+    Shock: 0
+    Cold: 0
+    Poison: 0
+    Radiation: 0
+    Asphyxiation: 0
+    Bloodloss: 0
     Cellular: 0
-    DNA: 0
-    Asphyxiation: 0 
    
 - type: resistanceSet
   id: dionaResistances
   coefficients:
     Blunt: 0.5
+    Slash: 1.2
     Piercing: 0.7
     Heat: 1.8
-    Disintegration: 1.8
-    Cellular: 1.0
-    DNA: 1.0
+    Shock: 0.5
+    Cold: 1.5
+    Poison: 0.8
+    Radiation: 0
     Asphyxiation: 1.0
+    Bloodloss: 1.0
+    Cellular: 1.0
   flatReductions:
     Blunt: 0
+    Slash: 0
     Piercing: 0
     Heat: 0
-    Disintegration: 0
-    Cellular: 0
-    DNA: 0
+    Shock: 0
+    Cold: 0
+    Poison: 0
+    Radiation: 0
     Asphyxiation: 0
+    Bloodloss: 0
+    Cellular: 0
     
 - type: resistanceSet
   id: metallicResistances
   coefficients:
     Blunt: 0.7
+    Slash: 0.5
     Piercing: 0.7
     Heat: 1.0
-    Disintegration: 1.0
-    Cellular: 0.0
-    DNA: 0.0
-    Asphyxiation: 0.0
+    Shock: 1.2
+    Cold: 0
+    Poison: 0
+    Radiation: 0
+    Asphyxiation: 0
+    Bloodloss: 0
+    Cellular: 0
   flatReductions:
     Blunt: 0
+    Slash: 0
     Piercing: 0
     Heat: 0
-    Disintegration: 0
-    Cellular: 0
-    DNA: 0
+    Shock: 0
+    Cold: 0
+    Poison: 0
+    Radiation: 0
     Asphyxiation: 0
+    Bloodloss: 0
+    Cellular: 0


### PR DESCRIPTION
Mainly to round them off to make sense and bring them to parity with SS13.

Brute -> Blunt, Slash, Piercing
Burn -> Heat, Shock, Cold
Toxin -> Poison, Radiation
Airloss -> Asphyxiation, Bloodloss
Genetic -> Cellular (aka clone damage)

Radiation is rolled into toxin until someone decides to make an actual radiation mechanic.