### PR TITLE
Removes exosuit slot (for now!!!) and rearranges inventory UI again.

### DIFF
--- a/Content.Client/GameObjects/Components/HUD/Inventory/HumanInventoryInterfaceController.cs
+++ b/Content.Client/GameObjects/Components/HUD/Inventory/HumanInventoryInterfaceController.cs
@@ -224,6 +224,7 @@ namespace Content.Client.GameObjects.Components.HUD.Inventory
                 AddButton(Slots.EYES, "glasses", (0, 0));
                 AddButton(Slots.NECK, "neck", (0, sizep));
                 AddButton(Slots.INNERCLOTHING, "uniform", (0, 2 * sizep));
+                AddButton(Slots.POCKET1, "pocket", (0, 3 * sizep));
 
                 // Middle column.
                 AddButton(Slots.HEAD, "head", (sizep, 0));
@@ -234,14 +235,12 @@ namespace Content.Client.GameObjects.Components.HUD.Inventory
                 // Right column
                 AddButton(Slots.EARS, "ears", (2 * sizep, 0));
                 AddButton(Slots.IDCARD, "id", (2 * sizep, sizep));
-                AddButton(Slots.EXOSUITSLOT1, "suit_storage", (2 * sizep, 2 * sizep));
-                AddButton(Slots.POCKET1, "pocket", (2 * sizep, 3 * sizep));
+                AddButton(Slots.GLOVES, "gloves", (2 * sizep, 2 * sizep));
+                AddButton(Slots.POCKET2, "pocket", (2 * sizep, 3 * sizep));
 
                 // Far right column.
                 AddButton(Slots.BACKPACK, "back", (3 * sizep, 0));
                 AddButton(Slots.BELT, "belt", (3 * sizep, sizep));
-                AddButton(Slots.GLOVES, "gloves", (3 * sizep, 2 * sizep));
-                AddButton(Slots.POCKET2, "pocket", (3 * sizep, 3 * sizep));
             }
         }
     }

--- a/Content.Shared/GameObjects/Components/Inventory/EquipmentSlotDefinitions.cs
+++ b/Content.Shared/GameObjects/Components/Inventory/EquipmentSlotDefinitions.cs
@@ -43,10 +43,6 @@ namespace Content.Shared.GameObjects.Components.Inventory
             IDCARD,
             POCKET1,
             POCKET2,
-            POCKET3,
-            POCKET4,
-            EXOSUITSLOT1,
-            EXOSUITSLOT2,
 
             /// <summary>
             ///     Not a real slot.
@@ -81,7 +77,6 @@ namespace Content.Shared.GameObjects.Components.Inventory
             LEGS = 1 << 13,
             SHOES = 1 << 14,
             FEET = 1 << 14,
-            EXOSUITSTORAGE = 1 << 15
         }
 
         public static readonly IReadOnlyDictionary<Slots, string> SlotNames = new Dictionary<Slots, string>()
@@ -100,10 +95,6 @@ namespace Content.Shared.GameObjects.Components.Inventory
             {Slots.IDCARD, "Id Card"},
             {Slots.POCKET1, "Left Pocket"},
             {Slots.POCKET2, "Right Pocket"},
-            {Slots.POCKET3, "Up Pocket"}, // What?
-            {Slots.POCKET4, "Down Pocket"}, // I, uh, what?
-            {Slots.EXOSUITSLOT1, "Suit Storage"},
-            {Slots.EXOSUITSLOT2, "Backup Storage"}
         };
 
         /// <summary>
@@ -128,10 +119,6 @@ namespace Content.Shared.GameObjects.Components.Inventory
             {Slots.IDCARD, SlotFlags.IDCARD},
             {Slots.POCKET1, SlotFlags.POCKET},
             {Slots.POCKET2, SlotFlags.POCKET},
-            {Slots.POCKET3, SlotFlags.POCKET},
-            {Slots.POCKET4, SlotFlags.POCKET},
-            {Slots.EXOSUITSLOT1, SlotFlags.EXOSUITSTORAGE},
-            {Slots.EXOSUITSLOT2, SlotFlags.EXOSUITSTORAGE}
         };
 
         // for shared string dict, since we don't define these anywhere in content
@@ -152,10 +139,6 @@ namespace Content.Shared.GameObjects.Components.Inventory
             "Inventory_IDCARD",
             "Inventory_POCKET1",
             "Inventory_POCKET2",
-            "Inventory_POCKET3",
-            "Inventory_POCKET4",
-            "Inventory_EXOSUITSLOT1",
-            "Inventory_EXOSUITSLOT2",
         };
 
         // for shared string dict, since we don't define these anywhere in content


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49448379/91774645-d0fe2000-ebd8-11ea-8474-3bfa0d901b3d.png)

I removed the exosuit slot because exosuits are in a sorry state right now and in my eyes they need hotbar to be merged before they'll have any functionality.

We don't even have anything that can clip onto the exosuit slot, and in SS13 it was mostly used for PDAs and O2 tanks anyway which is irrelevant since we don't even have tanks right now. The exosuit slot also doesn't even check if you're wearing an exosuit so you could equip stuff to it while not even wearing an exosuit.

It'll probably be added back later. I also removed the definitions for pocket 3 and 4 since that didn't make any sense.