### PR TITLE
Reduce power allocations

### DIFF
--- a/Content.Server/GameObjects/Components/NodeContainer/NodeGroups/ApcNetNodeGroup.cs
+++ b/Content.Server/GameObjects/Components/NodeContainer/NodeGroups/ApcNetNodeGroup.cs
@@ -35,8 +35,6 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
         [ViewVariables]
         private int TotalReceivers => _providerReceivers.SelectMany(kvp => kvp.Value).Count();
 
-        private IEnumerable<BatteryComponent> AvailableBatteries => _apcBatteries.Where(kvp => kvp.Key.MainBreakerEnabled).Select(kvp => kvp.Value);
-
         public static readonly IApcNet NullNet = new NullApcNet();
 
         #region IApcNet Methods
@@ -88,8 +86,11 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
         {
             var totalCharge = 0.0;
             var totalMaxCharge = 0;
-            foreach (var battery in AvailableBatteries)
+            foreach (var (apc, battery) in _apcBatteries)
             {
+                if (!apc.MainBreakerEnabled)
+                    continue;
+                
                 totalCharge += battery.CurrentCharge;
                 totalMaxCharge += battery.MaxCharge;
             }
@@ -102,8 +103,11 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
 
         private bool TryUsePower(float neededCharge)
         {
-            foreach (var battery in AvailableBatteries)
+            foreach (var (apc, battery) in _apcBatteries)
             {
+                if (!apc.MainBreakerEnabled)
+                    continue;
+                
                 if (battery.TryUseCharge(neededCharge)) //simplification - all power needed must come from one battery
                 {
                     return true;


### PR DESCRIPTION
I got sidetracked.

Death to linq.

Old allocs:
<img width="752" alt="old_allocs" src="https://user-images.githubusercontent.com/31366439/92099522-f465dc80-ee1d-11ea-8cb2-ffc9207d687e.PNG">

New allocs:
<img width="748" alt="new_allocs" src="https://user-images.githubusercontent.com/31366439/92099543-fa5bbd80-ee1d-11ea-904e-26d8f86a2d5a.PNG">
