### PR TITLE
Add UnsimulatedGridAtmosphereComponent and a command to add it

### DIFF
--- a/Content.Server/Atmos/AtmosCommands.cs
+++ b/Content.Server/Atmos/AtmosCommands.cs
@@ -17,11 +17,21 @@ namespace Content.Server.Atmos
     {
         public string Command => "addatmos";
         public string Description => "Adds atmos support to a grid.";
-        public string Help => "addatmos <GridId>";
+        public string Help => $"{Command} <GridId>";
+
         public void Execute(IConsoleShell shell, IPlayerSession? player, string[] args)
         {
-            if (args.Length < 1) return;
-            if(!int.TryParse(args[0], out var id)) return;
+            if (args.Length < 1)
+            {
+                shell.SendText(player, Help);
+                return;
+            }
+
+            if (!int.TryParse(args[0], out var id))
+            {
+                shell.SendText(player, $"{args[0]} is not a valid integer.");
+                return;
+            }
 
             var gridId = new GridId(id);
 
@@ -29,7 +39,7 @@ namespace Content.Server.Atmos
 
             if (!gridId.IsValid() || !mapMan.TryGetGrid(gridId, out var gridComp))
             {
-                shell.SendText(player, "Invalid grid ID.");
+                shell.SendText(player, $"{gridId} is not a valid grid id.");
                 return;
             }
 
@@ -41,7 +51,7 @@ namespace Content.Server.Atmos
                 return;
             }
 
-            if (grid.HasComponent<GridAtmosphereComponent>())
+            if (grid.HasComponent<IGridAtmosphereComponent>())
             {
                 shell.SendText(player, "Grid already has an atmosphere.");
                 return;
@@ -50,6 +60,56 @@ namespace Content.Server.Atmos
             grid.AddComponent<GridAtmosphereComponent>();
 
             shell.SendText(player, $"Added atmosphere to grid {id}.");
+        }
+    }
+
+    public class AddUnsimulatedAtmos : IClientCommand
+    {
+        public string Command => "addunsimulatedatmos";
+        public string Description => "Adds unimulated atmos support to a grid.";
+        public string Help => $"{Command} <GridId>";
+
+        public void Execute(IConsoleShell shell, IPlayerSession? player, string[] args)
+        {
+            if (args.Length < 1)
+            {
+                shell.SendText(player, Help);
+                return;
+            }
+
+            if (!int.TryParse(args[0], out var id))
+            {
+                shell.SendText(player, $"{args[0]} is not a valid integer.");
+                return;
+            }
+
+            var gridId = new GridId(id);
+
+            var mapMan = IoCManager.Resolve<IMapManager>();
+
+            if (!gridId.IsValid() || !mapMan.TryGetGrid(gridId, out var gridComp))
+            {
+                shell.SendText(player, $"{gridId} is not a valid grid id.");
+                return;
+            }
+
+            var entMan = IoCManager.Resolve<IEntityManager>();
+
+            if (!entMan.TryGetEntity(gridComp.GridEntityId, out var grid))
+            {
+                shell.SendText(player, "Failed to get grid entity.");
+                return;
+            }
+
+            if (grid.HasComponent<IGridAtmosphereComponent>())
+            {
+                shell.SendText(player, "Grid already has an atmosphere.");
+                return;
+            }
+
+            grid.AddComponent<UnsimulatedGridAtmosphereComponent>();
+
+            shell.SendText(player, $"Added unsimulated atmosphere to grid {id}.");
         }
     }
 

--- a/Content.Server/GameObjects/Components/Atmos/GridAtmosphereComponent.cs
+++ b/Content.Server/GameObjects/Components/Atmos/GridAtmosphereComponent.cs
@@ -14,10 +14,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components.Map;
 using Robust.Shared.GameObjects.Components.Transform;
 using Robust.Shared.Interfaces.Map;
-using Robust.Shared.Interfaces.Timing;
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
-using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.ViewVariables;
@@ -257,7 +254,7 @@ namespace Content.Server.GameObjects.Components.Atmos
         }
 
         /// <inheritdoc />
-        public void FixVacuum(MapIndices indices)
+        public virtual void FixVacuum(MapIndices indices)
         {
             if (!Owner.TryGetComponent(out IMapGridComponent? mapGrid)) return;
             var tile = GetTile(indices);
@@ -278,7 +275,7 @@ namespace Content.Server.GameObjects.Components.Atmos
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AddActiveTile(TileAtmosphere? tile)
+        public virtual void AddActiveTile(TileAtmosphere? tile)
         {
             if (!Owner.TryGetComponent(out IMapGridComponent? mapGrid)) return;
             if (tile?.GridIndex != mapGrid.Grid.Index) return;
@@ -288,7 +285,7 @@ namespace Content.Server.GameObjects.Components.Atmos
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void RemoveActiveTile(TileAtmosphere? tile)
+        public virtual void RemoveActiveTile(TileAtmosphere? tile)
         {
             if (tile == null) return;
             _activeTiles.Remove(tile);
@@ -298,7 +295,7 @@ namespace Content.Server.GameObjects.Components.Atmos
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AddHotspotTile(TileAtmosphere? tile)
+        public virtual void AddHotspotTile(TileAtmosphere? tile)
         {
             if (!Owner.TryGetComponent(out IMapGridComponent? mapGrid)) return;
             if (tile?.GridIndex != mapGrid.Grid.Index || tile?.Air == null) return;
@@ -307,20 +304,20 @@ namespace Content.Server.GameObjects.Components.Atmos
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void RemoveHotspotTile(TileAtmosphere? tile)
+        public virtual void RemoveHotspotTile(TileAtmosphere? tile)
         {
             if (tile == null) return;
             _hotspotTiles.Remove(tile);
         }
 
-        public void AddSuperconductivityTile(TileAtmosphere? tile)
+        public virtual void AddSuperconductivityTile(TileAtmosphere? tile)
         {
             if (!Owner.TryGetComponent(out IMapGridComponent? mapGrid)) return;
             if (tile?.GridIndex != mapGrid.Grid.Index) return;
             _superconductivityTiles.Add(tile);
         }
 
-        public void RemoveSuperconductivityTile(TileAtmosphere? tile)
+        public virtual void RemoveSuperconductivityTile(TileAtmosphere? tile)
         {
             if (tile == null) return;
             _superconductivityTiles.Remove(tile);
@@ -328,7 +325,7 @@ namespace Content.Server.GameObjects.Components.Atmos
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AddHighPressureDelta(TileAtmosphere? tile)
+        public virtual void AddHighPressureDelta(TileAtmosphere? tile)
         {
             if (!Owner.TryGetComponent(out IMapGridComponent? mapGrid)) return;
             if (tile?.GridIndex != mapGrid.Grid.Index) return;
@@ -337,21 +334,21 @@ namespace Content.Server.GameObjects.Components.Atmos
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool HasHighPressureDelta(TileAtmosphere tile)
+        public virtual bool HasHighPressureDelta(TileAtmosphere tile)
         {
             return _highPressureDelta.Contains(tile);
         }
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AddExcitedGroup(ExcitedGroup excitedGroup)
+        public virtual void AddExcitedGroup(ExcitedGroup excitedGroup)
         {
             _excitedGroups.Add(excitedGroup);
         }
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void RemoveExcitedGroup(ExcitedGroup excitedGroup)
+        public virtual void RemoveExcitedGroup(ExcitedGroup excitedGroup)
         {
             _excitedGroups.Remove(excitedGroup);
         }
@@ -440,7 +437,7 @@ namespace Content.Server.GameObjects.Components.Atmos
         }
 
         /// <inheritdoc />
-        public void Update(float frameTime)
+        public virtual void Update(float frameTime)
         {
             _timer += frameTime;
 
@@ -540,7 +537,7 @@ namespace Content.Server.GameObjects.Components.Atmos
             UpdateCounter++;
         }
 
-        public bool ProcessTileEqualize(bool resumed = false)
+        public virtual bool ProcessTileEqualize(bool resumed = false)
         {
             _stopwatch.Restart();
 
@@ -567,7 +564,7 @@ namespace Content.Server.GameObjects.Components.Atmos
             return true;
         }
 
-        public bool ProcessActiveTiles(bool resumed = false)
+        public virtual bool ProcessActiveTiles(bool resumed = false)
         {
             _stopwatch.Restart();
 
@@ -594,7 +591,7 @@ namespace Content.Server.GameObjects.Components.Atmos
             return true;
         }
 
-        public bool ProcessExcitedGroups(bool resumed = false)
+        public virtual bool ProcessExcitedGroups(bool resumed = false)
         {
             _stopwatch.Restart();
 
@@ -628,7 +625,7 @@ namespace Content.Server.GameObjects.Components.Atmos
             return true;
         }
 
-        public bool ProcessHighPressureDelta(bool resumed = false)
+        public virtual bool ProcessHighPressureDelta(bool resumed = false)
         {
             _stopwatch.Restart();
 
@@ -658,7 +655,7 @@ namespace Content.Server.GameObjects.Components.Atmos
             return true;
         }
 
-        private bool ProcessHotspots(bool resumed = false)
+        protected virtual bool ProcessHotspots(bool resumed = false)
         {
             _stopwatch.Restart();
 
@@ -685,7 +682,7 @@ namespace Content.Server.GameObjects.Components.Atmos
             return true;
         }
 
-        private bool ProcessSuperconductivity(bool resumed = false)
+        protected virtual bool ProcessSuperconductivity(bool resumed = false)
         {
             _stopwatch.Restart();
 
@@ -712,7 +709,7 @@ namespace Content.Server.GameObjects.Components.Atmos
             return true;
         }
 
-        private bool ProcessPipeNets(bool resumed = false)
+        protected virtual bool ProcessPipeNets(bool resumed = false)
         {
             _stopwatch.Restart();
 
@@ -739,7 +736,7 @@ namespace Content.Server.GameObjects.Components.Atmos
             return true;
         }
 
-        private bool ProcessPipeNetDevices(bool resumed = false)
+        protected virtual bool ProcessPipeNetDevices(bool resumed = false)
         {
             _stopwatch.Restart();
 
@@ -841,7 +838,7 @@ namespace Content.Server.GameObjects.Components.Atmos
         }
 
         /// <inheritdoc />
-        public void BurnTile(MapIndices gridIndices)
+        public virtual void BurnTile(MapIndices gridIndices)
         {
             // TODO ATMOS
         }

--- a/Content.Server/GameObjects/Components/Atmos/UnsimulatedGridAtmosphereComponent.cs
+++ b/Content.Server/GameObjects/Components/Atmos/UnsimulatedGridAtmosphereComponent.cs
@@ -1,0 +1,78 @@
+﻿#nullable enable
+using Content.Server.Atmos;
+using Robust.Shared.Map;
+
+namespace Content.Server.GameObjects.Components.Atmos
+{
+    public class UnsimulatedGridAtmosphereComponent : GridAtmosphereComponent, IGridAtmosphereComponent
+    {
+        public override string Name => "UnsimulatedGridAtmosphere";
+
+        public override void FixVacuum(MapIndices indices) { }
+
+        public override void AddActiveTile(TileAtmosphere? tile) { }
+
+        public override void RemoveActiveTile(TileAtmosphere? tile) { }
+
+        public override void AddHotspotTile(TileAtmosphere? tile) { }
+
+        public override void RemoveHotspotTile(TileAtmosphere? tile) { }
+
+        public override void AddSuperconductivityTile(TileAtmosphere? tile) { }
+
+        public override void RemoveSuperconductivityTile(TileAtmosphere? tile) { }
+
+        public override void AddHighPressureDelta(TileAtmosphere? tile) { }
+
+        public override bool HasHighPressureDelta(TileAtmosphere tile)
+        {
+            return false;
+        }
+
+        public override void AddExcitedGroup(ExcitedGroup excitedGroup) { }
+
+        public override void RemoveExcitedGroup(ExcitedGroup excitedGroup) { }
+
+        public override void Update(float frameTime) { }
+
+        public override bool ProcessTileEqualize(bool resumed = false)
+        {
+            return false;
+        }
+
+        public override bool ProcessActiveTiles(bool resumed = false)
+        {
+            return false;
+        }
+
+        public override bool ProcessExcitedGroups(bool resumed = false)
+        {
+            return false;
+        }
+
+        public override bool ProcessHighPressureDelta(bool resumed = false)
+        {
+            return false;
+        }
+
+        protected override bool ProcessHotspots(bool resumed = false)
+        {
+            return false;
+        }
+
+        protected override bool ProcessSuperconductivity(bool resumed = false)
+        {
+            return false;
+        }
+
+        protected override bool ProcessPipeNets(bool resumed = false)
+        {
+            return false;
+        }
+
+        protected override bool ProcessPipeNetDevices(bool resumed = false)
+        {
+            return false;
+        }
+    }
+}

--- a/Content.Server/GameObjects/Components/Atmos/UnsimulatedGridAtmosphereComponent.cs
+++ b/Content.Server/GameObjects/Components/Atmos/UnsimulatedGridAtmosphereComponent.cs
@@ -1,11 +1,17 @@
 ﻿#nullable enable
+using System;
 using Content.Server.Atmos;
 using Content.Shared.Atmos;
+using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components.Map;
 using Robust.Shared.Map;
 
 namespace Content.Server.GameObjects.Components.Atmos
 {
+    [RegisterComponent]
+    [ComponentReference(typeof(IGridAtmosphereComponent))]
+    [ComponentReference(typeof(GridAtmosphereComponent))]
+    [Serializable]
     public class UnsimulatedGridAtmosphereComponent : GridAtmosphereComponent, IGridAtmosphereComponent
     {
         public override string Name => "UnsimulatedGridAtmosphere";

--- a/Content.Server/GameObjects/Components/Atmos/UnsimulatedGridAtmosphereComponent.cs
+++ b/Content.Server/GameObjects/Components/Atmos/UnsimulatedGridAtmosphereComponent.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 using Content.Server.Atmos;
+using Content.Shared.Atmos;
+using Robust.Shared.GameObjects.Components.Map;
 using Robust.Shared.Map;
 
 namespace Content.Server.GameObjects.Components.Atmos
@@ -7,6 +9,23 @@ namespace Content.Server.GameObjects.Components.Atmos
     public class UnsimulatedGridAtmosphereComponent : GridAtmosphereComponent, IGridAtmosphereComponent
     {
         public override string Name => "UnsimulatedGridAtmosphere";
+
+        public override void PryTile(MapIndices indices) { }
+
+        public override void RepopulateTiles()
+        {
+            if (!Owner.TryGetComponent(out IMapGridComponent? mapGrid)) return;
+
+            foreach (var tile in mapGrid.Grid.GetAllTiles())
+            {
+                if(!Tiles.ContainsKey(tile.GridIndices))
+                    Tiles.Add(tile.GridIndices, new TileAtmosphere(this, tile.GridIndex, tile.GridIndices, new GasMixture(GetVolumeForCells(1)){Temperature = Atmospherics.T20C}));
+            }
+        }
+
+        public override void Invalidate(MapIndices indices) { }
+
+        protected override void Revalidate() { }
 
         public override void FixVacuum(MapIndices indices) { }
 


### PR DESCRIPTION
Fixes #1959 

Not overridden and still functional methods:
- AddPipeNet
- RemovePipeNet
- AddPipeNetDevice
- RemovePipeNetDevice
- GetTile
- IsAirBlocked
- IsSpace
- GetVolumeForCells
- GetEnumerator
- BurnTile