### PR TITLE
Removes camera jump on melee attack

### DIFF
--- a/Content.Client/GameObjects/Components/Mobs/MeleeLungeComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/MeleeLungeComponent.cs
@@ -1,4 +1,4 @@
-using Robust.Client.GameObjects;
+﻿using Robust.Client.GameObjects;
 using Robust.Client.Interfaces.GameObjects.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
@@ -37,15 +37,6 @@ namespace Content.Client.GameObjects.Components.Mobs
             {
                 offset = _angle.RotateVec((BaseOffset, 0));
                 offset *= (ResetTime - _time) / ResetTime;
-            }
-
-            if (Owner.TryGetComponent(out CameraRecoilComponent recoilComponent))
-            {
-                recoilComponent.BaseOffset = offset;
-            }
-            else if (Owner.TryGetComponent(out EyeComponent eyeComponent))
-            {
-                eyeComponent.Offset = offset;
             }
 
             if (Owner.TryGetComponent(out ISpriteComponent spriteComponent))


### PR DESCRIPTION
Was making me feel ill

![2020-09-17_06-34-51](https://user-images.githubusercontent.com/49448379/93477545-b02d0e80-f8ea-11ea-9f00-c40a40182dcc.gif)
![2020-09-17_06-43-15](https://user-images.githubusercontent.com/49448379/93479873-59283900-f8ec-11ea-95c5-b588ffb9f8d1.gif)

before
![2020-09-17_06-35-33](https://user-images.githubusercontent.com/49448379/93477548-b0c5a500-f8ea-11ea-8557-178f3a43ab23.gif)
after

I was going to also take away the red overlay on hitting something but Zumorica is against it.