### PR TITLE
Fixed flashlights staying enabled after taking the battery out of them

### DIFF
--- a/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
@@ -124,7 +124,7 @@ namespace Content.Server.GameObjects.Components.Interactable
             return true;
         }
 
-        private void TurnOff(bool makenoise = true)
+        private void TurnOff(bool makeNoise = true)
         {
             if (!Activated)
             {
@@ -134,7 +134,7 @@ namespace Content.Server.GameObjects.Components.Interactable
             SetState(false);
             Activated = false;
 
-            if (makenoise)
+            if (makeNoise)
             {
                 EntitySystem.Get<AudioSystem>().PlayFromEntity("/Audio/Items/flashlight_toggle.ogg", Owner);
             }


### PR DESCRIPTION
Fixes #2146, flashlights will now always get disabled after removing a battery from them successfully.