### PR TITLE
Adding Descriptions For a Few More Power Entities

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Power/arcade.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/arcade.yml
@@ -37,7 +37,7 @@
 
 - type: entity
   id: BlockGameArcade
-  description: A arcade cabinet with a strangely familiar game.
+  description: An arcade cabinet with a strangely familiar game.
   name: NT block game
   parent: ComputerBase
   components:

--- a/Resources/Prototypes/Entities/Constructible/Power/arcade.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/arcade.yml
@@ -1,5 +1,6 @@
 ﻿- type: entity
   id: Arcade
+  description: An arcade cabinet.
   name: arcade
   parent: ComputerBase
   components:
@@ -36,6 +37,7 @@
 
 - type: entity
   id: BlockGameArcade
+  description: A arcade cabinet with a strangely familiar game.
   name: NT block game
   parent: ComputerBase
   components:

--- a/Resources/Prototypes/Entities/Constructible/Power/power_base.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/power_base.yml
@@ -1,5 +1,6 @@
 ﻿- type: entity
   id: BaseGenerator
+  description: A high efficiency thermoelectric generator.
   name: Base Generator
   abstract: true
   placement:
@@ -27,6 +28,7 @@
 
 - type: entity
   id: BaseSmes
+  description: A high-capacity superconducting magnetic energy storage (SMES) unit.
   name: Base Smes
   abstract: true
   placement:
@@ -69,6 +71,7 @@
 
 - type: entity
   id: BaseSubstation
+  description: Reduces the voltage of electricity put into it. 
   name: Base Substation
   abstract: true
   placement:
@@ -106,6 +109,7 @@
 
 - type: entity
   id: BaseApc
+  description: A control terminal for the area's electrical systems.
   name: Base Apc
   abstract: true
   placement:

--- a/Resources/Prototypes/Entities/Constructible/Power/saltern_power.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/saltern_power.yml
@@ -1,5 +1,6 @@
 ﻿- type: entity
   id: SalternGenerator
+  description: A high efficiency thermoelectric generator.
   parent: BaseGenerator
   name: Generator
   components:
@@ -22,6 +23,7 @@
 
 - type: entity
   id: SalternSubstation
+  description: Reduces the voltage of electricity put into it. 
   parent: BaseSubstation
   name: Substation
   components:


### PR DESCRIPTION
Added descriptions for both arcade cabinets, added descriptions to the base items in `power_base.yml`, and added a description for the substation entity.