### PR TITLE
Optimise explosive depressurisation

### DIFF
--- a/Content.Server/Utility/GridTileLookupHelpers.cs
+++ b/Content.Server/Utility/GridTileLookupHelpers.cs
@@ -6,6 +6,7 @@ using Content.Shared.Maps;
 using Robust.Server.GameObjects.EntitySystems.TileLookup;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Map;
 
 namespace Content.Server.Utility
@@ -29,12 +30,8 @@ namespace Content.Server.Utility
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IEnumerable<IEntity> GetEntitiesInTileFast(this MapIndices indices, GridId gridId, GridTileLookupSystem? gridTileLookup = null)
         {
-            var turf = indices.GetTileRef(gridId);
-
-            if (turf == null)
-                return Enumerable.Empty<IEntity>();
-
-            return GetEntitiesInTileFast(turf.Value, gridTileLookup);
+            gridTileLookup ??= EntitySystem.Get<GridTileLookupSystem>();
+            return gridTileLookup.GetEntitiesIntersecting(gridId, indices);
         }
     }
 }

--- a/Content.Shared/Maps/TurfHelpers.cs
+++ b/Content.Shared/Maps/TurfHelpers.cs
@@ -29,12 +29,12 @@ namespace Content.Shared.Maps
         /// <summary>
         ///     Attempts to get the turf at map indices with grid id or null if no such turf is found.
         /// </summary>
-        public static TileRef? GetTileRef(this MapIndices mapIndices, GridId gridId)
+        public static TileRef? GetTileRef(this MapIndices mapIndices, GridId gridId, IMapManager mapManager = null)
         {
             if (!gridId.IsValid())
                 return null;
 
-            var mapManager = IoCManager.Resolve<IMapManager>();
+            mapManager ??= IoCManager.Resolve<IMapManager>();
 
             if (!mapManager.TryGetGrid(gridId, out var grid))
                 return null;


### PR DESCRIPTION
Slight increase, turns out IoCManager.Resolves ain't cheap when you do it a lot. Realistically it just makes ConsiderFirelocks ~a third quicker which is most of ExplosivelyDepressureize.

Old:
<img width="532" alt="old_explosive" src="https://user-images.githubusercontent.com/31366439/95468921-b767a980-09ca-11eb-9a10-f061d90abded.PNG">

New:
<img width="543" alt="new_explosive" src="https://user-images.githubusercontent.com/31366439/95468927-b9ca0380-09ca-11eb-8894-f754e187056d.PNG">