### PR TITLE
Welder can no longer start DoAfter on doors if unlit

### DIFF
--- a/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
@@ -477,7 +477,7 @@ namespace Content.Server.GameObjects.Components.Doors
                 return false;
             }
 
-            if (!eventArgs.Using.TryGetComponent(out WelderComponent? tool))
+            if (!eventArgs.Using.TryGetComponent(out WelderComponent? tool) || !tool.WelderLit)
             {
                 _beingWelded = false;
                 return false;


### PR DESCRIPTION
Fixes #2201 