### PR TITLE
Allow hitscan to go through open doors

### DIFF
--- a/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
@@ -17,6 +17,7 @@ using Content.Shared.GameObjects.Components.Doors;
 using Content.Shared.GameObjects.Components.Interactable;
 using Content.Shared.GameObjects.Components.Movement;
 using Content.Shared.Interfaces.GameObjects.Components;
+using Content.Shared.Physics;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Shared.Audio;
@@ -49,6 +50,32 @@ namespace Content.Server.GameObjects.Components.Doors
                     return;
 
                 _state = value;
+
+                // Didn't do in Open and Close as some stuff spawns as open so this is just easier.
+                if (Owner.TryGetComponent(out IPhysicsComponent? physicsComponent))
+                {
+                    switch (_state)
+                    {
+                        case DoorState.Closed:
+                        case DoorState.Closing:
+                            // WE should probably track what we updated but I doubt doors will get more than 1 physics shape anyway... right?
+                            foreach (var shape in physicsComponent.PhysicsShapes)
+                            {
+                                shape.CollisionLayer |= (int) CollisionGroup.Opaque;
+                            }
+                            break;
+                        case DoorState.Open:
+                        case DoorState.Opening:
+                            foreach (var shape in physicsComponent.PhysicsShapes)
+                            {
+                                shape.CollisionLayer &= (int) ~CollisionGroup.Opaque;
+                            }
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+
                 Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new DoorStateMessage(this, State));
             }
         }


### PR DESCRIPTION
So the door itself sets physics.Hard as false although that doesn't seem to include the opaque group which I guess makes sense.