### PR TITLE
Add IResettingEntitySystem for entity systems that do resetting cleanup

### DIFF
--- a/Content.Client/GameTicking/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/ClientGameTicker.cs
@@ -4,6 +4,7 @@ using Content.Client.Interfaces;
 using Content.Client.State;
 using Content.Client.UserInterface;
 using Content.Shared;
+using Content.Shared.GameTicking;
 using Content.Shared.Network.NetMessages;
 using Robust.Client.Interfaces.Graphics;
 using Robust.Client.Interfaces.State;

--- a/Content.Client/Interfaces/IClientGameTicker.cs
+++ b/Content.Client/Interfaces/IClientGameTicker.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Robust.Shared.Network;
-using static Content.Shared.SharedGameTicker;
+using static Content.Shared.GameTicking.SharedGameTicker;
 
 namespace Content.Client.Interfaces
 {

--- a/Content.Client/State/LobbyState.cs
+++ b/Content.Client/State/LobbyState.cs
@@ -18,7 +18,7 @@ using Robust.Shared.Localization;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.ViewVariables;
-using static Content.Shared.SharedGameTicker;
+using static Content.Shared.GameTicking.SharedGameTicker;
 
 namespace Content.Client.State
 {

--- a/Content.Client/UserInterface/HumanoidProfileEditor.cs
+++ b/Content.Client/UserInterface/HumanoidProfileEditor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Content.Client.GameObjects.Components;
 using Content.Client.Interfaces;
 using Content.Shared;
+using Content.Shared.GameTicking;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Client.Graphics.Drawing;

--- a/Content.Client/UserInterface/LobbyCharacterPreviewPanel.cs
+++ b/Content.Client/UserInterface/LobbyCharacterPreviewPanel.cs
@@ -3,6 +3,7 @@ using Content.Client.GameObjects.Components.HUD.Inventory;
 using Content.Client.GameObjects.Components.Mobs;
 using Content.Client.Interfaces;
 using Content.Shared;
+using Content.Shared.GameTicking;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Client.Interfaces.GameObjects.Components;

--- a/Content.Client/UserInterface/RoundEndSummaryWindow.cs
+++ b/Content.Client/UserInterface/RoundEndSummaryWindow.cs
@@ -7,7 +7,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
-using static Content.Shared.SharedGameTicker;
+using static Content.Shared.GameTicking.SharedGameTicker;
 
 namespace Content.Client.UserInterface
 {

--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/Accessible/AiReachableSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/Accessible/AiReachableSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Content.Server.GameObjects.Components.Access;
 using Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Pathfinders;
 using Content.Shared.AI;
+using Content.Shared.GameTicking;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects.Components;
@@ -22,7 +23,7 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Accessible
     /// </summary>
     /// Long-term can be used to do hierarchical pathfinding
     [UsedImplicitly]
-    public sealed class AiReachableSystem : EntitySystem
+    public sealed class AiReachableSystem : EntitySystem, IResettingEntitySystem
     {
         /*
          * The purpose of this is to provide a higher-level / hierarchical abstraction of the actual pathfinding graph
@@ -132,14 +133,6 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Accessible
             _cachedAccessible.Clear();
             _queuedCacheDeletions.Clear();
             _mapManager.OnGridRemoved -= GridRemoved;
-        }
-
-        public void ResettingCleanup()
-        {
-            _queuedUpdates.Clear();
-            _regions.Clear();
-            _cachedAccessible.Clear();
-            _queuedCacheDeletions.Clear();
         }
 
         private void RecalculateNodeRegions(PathfindingChunkUpdateMessage message)
@@ -681,6 +674,14 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Accessible
             DebugTools.Assert(chunkRegions.Count < Math.Pow(PathfindingChunk.ChunkSize, 2));
             SendRegionsDebugMessage(chunk.GridId);
 #endif
+        }
+
+        public void Reset()
+        {
+            _queuedUpdates.Clear();
+            _regions.Clear();
+            _cachedAccessible.Clear();
+            _queuedCacheDeletions.Clear();
         }
 
 #if DEBUG

--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.GameObjects.Components.Access;
 using Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Pathfinders;
 using Content.Server.GameObjects.EntitySystems.JobQueues;
 using Content.Server.GameObjects.EntitySystems.JobQueues.Queues;
+using Content.Shared.GameTicking;
 using Content.Shared.Physics;
 using Robust.Shared.GameObjects.Components;
 using Robust.Shared.GameObjects.Components.Transform;
@@ -28,7 +29,7 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding
     /// This system handles pathfinding graph updates as well as dispatches to the pathfinder
     /// (90% of what it's doing is graph updates so not much point splitting the 2 roles)
     /// </summary>
-    public class PathfindingSystem : EntitySystem
+    public class PathfindingSystem : EntitySystem, IResettingEntitySystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
@@ -230,16 +231,6 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding
             node.UpdateTile(tile);
         }
 
-        public void ResettingCleanup()
-        {
-            _graph.Clear();
-            _collidableUpdateQueue.Clear();
-            _moveUpdateQueue.Clear();
-            _accessReaderUpdateQueue.Clear();
-            _tileUpdateQueue.Clear();
-            _lastKnownPositions.Clear();
-        }
-
         private void HandleGridRemoval(GridId gridId)
         {
             if (_graph.ContainsKey(gridId))
@@ -388,6 +379,16 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding
             }
 
             return true;
+        }
+
+        public void Reset()
+        {
+            _graph.Clear();
+            _collidableUpdateQueue.Clear();
+            _moveUpdateQueue.Clear();
+            _accessReaderUpdateQueue.Clear();
+            _tileUpdateQueue.Clear();
+            _lastKnownPositions.Clear();
         }
     }
 }

--- a/Content.Server/GameObjects/EntitySystems/Atmos/GasTileOverlaySystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Atmos/GasTileOverlaySystem.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using Content.Server.GameObjects.Components.Atmos;
 using Content.Shared.Atmos;
 using Content.Shared.GameObjects.EntitySystems.Atmos;
+using Content.Shared.GameTicking;
 using JetBrains.Annotations;
 using Robust.Server.Interfaces.Player;
 using Robust.Server.Player;
@@ -21,7 +22,7 @@ using Robust.Shared.Timing;
 namespace Content.Server.GameObjects.EntitySystems.Atmos
 {
     [UsedImplicitly]
-    internal sealed class GasTileOverlaySystem : SharedGasTileOverlaySystem
+    internal sealed class GasTileOverlaySystem : SharedGasTileOverlaySystem, IResettingEntitySystem
     {
         [Robust.Shared.IoC.Dependency] private readonly IGameTiming _gameTiming = default!;
         [Robust.Shared.IoC.Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -110,17 +111,6 @@ namespace Content.Server.GameObjects.EntitySystems.Atmos
             if (_overlay.ContainsKey(gridId))
             {
                 _overlay.Remove(gridId);
-            }
-        }
-
-        public void ResettingCleanup()
-        {
-            _invalidTiles.Clear();
-            _overlay.Clear();
-
-            foreach (var (_, data) in _knownPlayerChunks)
-            {
-                data.Reset();
             }
         }
 
@@ -481,6 +471,17 @@ namespace Content.Server.GameObjects.EntitySystems.Atmos
                 }
 
                 return new GasOverlayMessage(chunk.GridIndices, tileData);
+            }
+        }
+
+        public void Reset()
+        {
+            _invalidTiles.Clear();
+            _overlay.Clear();
+
+            foreach (var (_, data) in _knownPlayerChunks)
+            {
+                data.Reset();
             }
         }
     }

--- a/Content.Server/GameObjects/EntitySystems/StationEvents/StationEventSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/StationEvents/StationEventSystem.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Content.Server.GameTicking;
 using Content.Server.Interfaces.GameTicking;
 using Content.Server.StationEvents;
+using Content.Shared.GameTicking;
 using JetBrains.Annotations;
 using Robust.Server.Console;
 using Robust.Server.Interfaces.Player;
@@ -20,7 +21,7 @@ namespace Content.Server.GameObjects.EntitySystems.StationEvents
 {
     [UsedImplicitly]
     // Somewhat based off of TG's implementation of events
-    public sealed class StationEventSystem : EntitySystem
+    public sealed class StationEventSystem : EntitySystem, IResettingEntitySystem
     {
         [Dependency] private readonly IServerNetManager _netManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -339,7 +340,13 @@ namespace Content.Server.GameObjects.EntitySystems.StationEvents
             return true;
         }
 
-        public void ResettingCleanup()
+        public override void Shutdown()
+        {
+            base.Shutdown();
+            CurrentEvent?.Shutdown();
+        }
+
+        public void Reset()
         {
             if (CurrentEvent != null && CurrentEvent.Running)
             {
@@ -353,12 +360,6 @@ namespace Content.Server.GameObjects.EntitySystems.StationEvents
             }
 
             _timeUntilNextEvent = MinimumTimeUntilFirstEvent;
-        }
-
-        public override void Shutdown()
-        {
-            base.Shutdown();
-            CurrentEvent?.Shutdown();
         }
     }
 }

--- a/Content.Server/GameObjects/EntitySystems/WireHackingSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/WireHackingSystem.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
+using Content.Shared.GameTicking;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.ViewVariables;
 using static Content.Shared.GameObjects.Components.SharedWiresComponent;
 
 namespace Content.Server.GameObjects.EntitySystems
 {
-    public class WireHackingSystem : EntitySystem
+    public class WireHackingSystem : EntitySystem, IResettingEntitySystem
     {
         [ViewVariables] private readonly Dictionary<string, WireLayout> _layouts =
             new Dictionary<string, WireLayout>();
@@ -20,7 +21,7 @@ namespace Content.Server.GameObjects.EntitySystems
             _layouts.Add(id, layout);
         }
 
-        public void ResetLayouts()
+        public void Reset()
         {
             _layouts.Clear();
         }

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -23,6 +23,7 @@ using Content.Server.Mobs.Roles;
 using Content.Server.Players;
 using Content.Shared;
 using Content.Shared.Chat;
+using Content.Shared.GameTicking;
 using Content.Shared.Network.NetMessages;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
@@ -99,9 +100,9 @@ namespace Content.Server.GameTicking
 
 
         [ViewVariables] public bool Paused { get; private set; }
-        
+
         [ViewVariables] public MapId DefaultMap { get; private set; }
-        
+
         [ViewVariables] public GridId DefaultGridId { get; private set; }
 
         [ViewVariables]
@@ -678,11 +679,13 @@ namespace Content.Server.GameTicking
                 _playerJoinLobby(player);
             }
 
-            EntitySystem.Get<GasTileOverlaySystem>().ResettingCleanup();
-            EntitySystem.Get<PathfindingSystem>().ResettingCleanup();
-            EntitySystem.Get<AiReachableSystem>().ResettingCleanup();
-            EntitySystem.Get<WireHackingSystem>().ResetLayouts();
-            EntitySystem.Get<StationEventSystem>().ResettingCleanup();
+            foreach (var system in _entitySystemManager.AllSystems)
+            {
+                if (system is IResettingEntitySystem resetting)
+                {
+                    resetting.Reset();
+                }
+            }
 
             _spawnedPositions.Clear();
             _manifest.Clear();
@@ -694,7 +697,7 @@ namespace Content.Server.GameTicking
             DefaultMap = _mapManager.CreateMap();
             var startTime = _gameTiming.RealTime;
             var grid = _mapLoader.LoadBlueprint(DefaultMap, MapFile);
-            
+
             DefaultGridId = grid.Index;
             _spawnPoint = grid.ToCoordinates();
 
@@ -1006,6 +1009,7 @@ The current game mode is: [color=white]{0}[/color].
         [Dependency] private readonly IServerPreferencesManager _prefsManager = default!;
         [Dependency] private readonly IBaseServer _baseServer = default!;
         [Dependency] private readonly IWatchdogApi _watchdogApi = default!;
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
     }
 
     public enum GameRunLevel

--- a/Content.Server/GameTicking/GameTickerBase.cs
+++ b/Content.Server/GameTicking/GameTickerBase.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Players;
 using Content.Shared;
+using Content.Shared.GameTicking;
 using Robust.Server.Interfaces.Player;
 using Robust.Server.Player;
 using Robust.Shared.Enums;

--- a/Content.Shared/GameTicking/IResettingEntitySystem.cs
+++ b/Content.Shared/GameTicking/IResettingEntitySystem.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Shared.GameTicking
+{
+    public interface IResettingEntitySystem
+    {
+        void Reset();
+    }
+}

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Interfaces.Serialization;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
 
-namespace Content.Shared
+namespace Content.Shared.GameTicking
 {
     public abstract class SharedGameTicker
     {

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Content.Shared.GameTicking;
 using Content.Shared.Roles;
 using Content.Shared.Text;
 using Robust.Shared.Interfaces.Random;

--- a/Content.Tests/Server/Preferences/ServerDbSqliteTests.cs
+++ b/Content.Tests/Server/Preferences/ServerDbSqliteTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Content.Server.Database;
 using Content.Shared;
+using Content.Shared.GameTicking;
 using Content.Shared.Preferences;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
Systems that previously manually reset:

- GasTileOverlaySystem
- PathfindingSystem
- AiReachableSystem
- WireHackingSystem
- StationEventSystem

Requires https://github.com/space-wizards/RobustToolbox/pull/1332