### PR TITLE
Add a toggle flashlight verb to the PDA

### DIFF
--- a/Content.Server/GameObjects/Components/PDA/PDAComponent.cs
+++ b/Content.Server/GameObjects/Components/PDA/PDAComponent.cs
@@ -303,7 +303,7 @@ namespace Content.Server.GameObjects.Components.PDA
                     return;
                 }
 
-                data.Text = Loc.GetString("Toggle Flashlight");
+                data.Text = Loc.GetString("Toggle flashlight");
                 data.Visibility = VerbVisibility.Visible;
             }
 

--- a/Content.Server/GameObjects/Components/PDA/PDAComponent.cs
+++ b/Content.Server/GameObjects/Components/PDA/PDAComponent.cs
@@ -293,6 +293,26 @@ namespace Content.Server.GameObjects.Components.PDA
             }
         }
 
+        public sealed class ToggleFlashlightVerb : Verb<PDAComponent>
+        {
+            protected override void GetData(IEntity user, PDAComponent component, VerbData data)
+            {
+                if (!ActionBlockerSystem.CanInteract(user))
+                {
+                    data.Visibility = VerbVisibility.Invisible;
+                    return;
+                }
+
+                data.Text = Loc.GetString("Toggle Flashlight");
+                data.Visibility = VerbVisibility.Visible;
+            }
+
+            protected override void Activate(IEntity user, PDAComponent component)
+            {
+                component.ToggleLight();
+            }
+        }
+
         private ISet<string>? GetContainedAccess()
         {
             return ContainedID?.Owner?.GetComponent<AccessComponent>()?.Tags;

--- a/Content.Server/GameObjects/Components/PDA/PDAComponent.cs
+++ b/Content.Server/GameObjects/Components/PDA/PDAComponent.cs
@@ -304,7 +304,6 @@ namespace Content.Server.GameObjects.Components.PDA
                 }
 
                 data.Text = Loc.GetString("Toggle flashlight");
-                data.Visibility = VerbVisibility.Visible;
             }
 
             protected override void Activate(IEntity user, PDAComponent component)


### PR DESCRIPTION
Adds a verb to toggle the flashlight on the PDA so you can do it from the right-click menu instead of having to open the interface.