### PR TITLE
Standardized colors between DoAfter and Cooldown progress

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/DoAfter/DoAfterBar.cs
+++ b/Content.Client/GameObjects/EntitySystems/DoAfter/DoAfterBar.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using Robust.Client.Graphics.Drawing;
 using Robust.Client.Graphics.Shaders;
@@ -70,8 +70,9 @@ namespace Content.Client.GameObjects.EntitySystems.DoAfter
         private const int XPixelDiff = 20 * DoAfterBarScale;
 
         public const byte DoAfterBarScale = 2;
-        private static readonly Color StartColor = new Color(0.8f, 0.0f, 0.2f);
-        private static readonly Color EndColor = new Color(0.2f, 0.4f, 1.0f);
+        private static readonly Color StartColor = new Color(0.8f, 0.0f, 0.2f); // red
+        private static readonly Color EndColor = new Color(0.92f, 0.77f, 0.34f); // yellow
+        private static readonly Color CompletedColor = new Color(0.0f, 0.8f, 0.27f); // green
 
         public DoAfterBar()
         {
@@ -110,15 +111,15 @@ namespace Content.Client.GameObjects.EntitySystems.DoAfter
             } 
             else if (Ratio >= 1.0f)
             {
-                color = new Color(0.92f, 0.77f, 0.34f);
+                color = CompletedColor;
             }
             else
             {
                 // lerp
                 color = new Color(
-                    StartColor.R + (EndColor.R - StartColor.R) * Ratio, 
-                    StartColor.G + (EndColor.G - StartColor.G) * Ratio, 
-                    StartColor.B + (EndColor.B - StartColor.B) * Ratio, 
+                    StartColor.R + (EndColor.R - StartColor.R) * Ratio,
+                    StartColor.G + (EndColor.G - StartColor.G) * Ratio,
+                    StartColor.B + (EndColor.B - StartColor.B) * Ratio,
                     StartColor.A);
             }
             

--- a/Content.Client/UserInterface/CooldownGraphic.cs
+++ b/Content.Client/UserInterface/CooldownGraphic.cs
@@ -27,6 +27,9 @@ namespace Content.Client.UserInterface
         ///     Possible values range from 1 to -1, where 1 to 0 is a depleting circle animation and 0 to -1 is a blink animation.
         /// </summary>
         public float Progress { get; set; }
+        private static readonly Color StartColor = new Color(0.8f, 0.0f, 0.2f); // red
+        private static readonly Color EndColor = new Color(0.92f, 0.77f, 0.34f); // yellow
+        private static readonly Color CompletedColor = new Color(0.0f, 0.8f, 0.27f); // green
 
         protected override void Draw(DrawingHandleScreen handle)
         {
@@ -37,13 +40,16 @@ namespace Content.Client.UserInterface
 
             if (Progress >= 0f)
             {
-                var hue = (5f / 18f) * lerp;
-                color = Color.FromHsv((hue, 0.75f, 0.75f, 0.50f));
+                color = new Color(
+                    EndColor.R + (StartColor.R - EndColor.R) * Progress,
+                    EndColor.G + (StartColor.G - EndColor.G) * Progress,
+                    EndColor.B + (StartColor.B - EndColor.B) * Progress,
+                    EndColor.A);
             }
             else
             {
                 var alpha = MathHelper.Clamp(0.5f * lerp, 0f, 0.5f);
-                color = new Color(1f, 1f, 1f, alpha);
+                color = CompletedColor.WithAlpha(alpha);
             }
 
             _shader.SetParameter("progress", Progress);


### PR DESCRIPTION
Fixes #2278

Progress starts at red, transitions to yellow, then ends at green.