### PR TITLE
Removes AtmosCooldown from TileAtmosphere, fixes various atmos issues

### DIFF
--- a/Content.Server/Atmos/ExcitedGroup.cs
+++ b/Content.Server/Atmos/ExcitedGroup.cs
@@ -30,6 +30,12 @@ namespace Content.Server.Atmos
             ResetCooldowns();
         }
 
+        public bool RemoveTile(TileAtmosphere tile)
+        {
+            tile.ExcitedGroup = null;
+            return _tile.Remove(tile);
+        }
+
         public void MergeGroups(ExcitedGroup other)
         {
             var ourSize = _tile.Count;
@@ -105,7 +111,6 @@ namespace Content.Server.Atmos
             {
                 if (tile?.Air == null) continue;
                 tile.Air.CopyFromMutable(combined);
-                tile.AtmosCooldown = 0;
                 tile.UpdateVisuals();
             }
 

--- a/Content.Server/Atmos/ExcitedGroup.cs
+++ b/Content.Server/Atmos/ExcitedGroup.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Atmos
         private bool _disposed = false;
 
         [ViewVariables]
-        private readonly HashSet<TileAtmosphere> _tile = new HashSet<TileAtmosphere>();
+        private readonly HashSet<TileAtmosphere> _tiles = new HashSet<TileAtmosphere>();
 
         [ViewVariables]
         private GridAtmosphereComponent _gridAtmosphereComponent;
@@ -25,7 +25,7 @@ namespace Content.Server.Atmos
 
         public void AddTile(TileAtmosphere tile)
         {
-            _tile.Add(tile);
+            _tiles.Add(tile);
             tile.ExcitedGroup = this;
             ResetCooldowns();
         }
@@ -33,33 +33,33 @@ namespace Content.Server.Atmos
         public bool RemoveTile(TileAtmosphere tile)
         {
             tile.ExcitedGroup = null;
-            return _tile.Remove(tile);
+            return _tiles.Remove(tile);
         }
 
         public void MergeGroups(ExcitedGroup other)
         {
-            var ourSize = _tile.Count;
-            var otherSize = other._tile.Count;
+            var ourSize = _tiles.Count;
+            var otherSize = other._tiles.Count;
 
             if (ourSize > otherSize)
             {
-                foreach (var tile in other._tile)
+                foreach (var tile in other._tiles)
                 {
                     tile.ExcitedGroup = this;
-                    _tile.Add(tile);
+                    _tiles.Add(tile);
                 }
-                other._tile.Clear();
+                other._tiles.Clear();
                 other.Dispose();
                 ResetCooldowns();
             }
             else
             {
-                foreach (var tile in _tile)
+                foreach (var tile in _tiles)
                 {
                     tile.ExcitedGroup = other;
-                    other._tile.Add(tile);
+                    other._tiles.Add(tile);
                 }
-                _tile.Clear();
+                _tiles.Clear();
                 Dispose();
                 other.ResetCooldowns();
             }
@@ -86,7 +86,7 @@ namespace Content.Server.Atmos
         {
             var combined = new GasMixture(Atmospherics.CellVolume);
 
-            var tileSize = _tile.Count;
+            var tileSize = _tiles.Count;
 
             if (_disposed) return;
 
@@ -96,7 +96,7 @@ namespace Content.Server.Atmos
                 return;
             }
 
-            foreach (var tile in _tile)
+            foreach (var tile in _tiles)
             {
                 if (tile?.Air == null) continue;
                 combined.Merge(tile.Air);
@@ -107,7 +107,7 @@ namespace Content.Server.Atmos
 
             combined.Multiply(1 / (float)tileSize);
 
-            foreach (var tile in _tile)
+            foreach (var tile in _tiles)
             {
                 if (tile?.Air == null) continue;
                 tile.Air.CopyFromMutable(combined);
@@ -119,7 +119,7 @@ namespace Content.Server.Atmos
 
         public void Dismantle(bool unexcite = true)
         {
-            foreach (var tile in _tile)
+            foreach (var tile in _tiles)
             {
                 if (tile == null) continue;
                 tile.ExcitedGroup = null;
@@ -128,7 +128,7 @@ namespace Content.Server.Atmos
                 _gridAtmosphereComponent.RemoveActiveTile(tile);
             }
 
-            _tile.Clear();
+            _tiles.Clear();
         }
 
         public void Dispose()

--- a/Content.Server/Atmos/IGridAtmosphereComponent.cs
+++ b/Content.Server/Atmos/IGridAtmosphereComponent.cs
@@ -63,7 +63,7 @@ namespace Content.Server.Atmos
         ///     Use with caution.
         /// </summary>
         /// <param name="tile"></param>
-        void RemoveActiveTile(TileAtmosphere tile);
+        void RemoveActiveTile(TileAtmosphere tile, bool disposeGroup = true);
 
         /// <summary>
         ///     Marks a tile as having a hotspot so it can be processed.

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -45,9 +45,6 @@ namespace Content.Server.Atmos
         private static GasTileOverlaySystem _gasTileOverlaySystem;
 
         [ViewVariables]
-        public int AtmosCooldown { get; set; } = 0;
-
-        [ViewVariables]
         public float Temperature {get; private set; } = Atmospherics.T20C;
 
         [ViewVariables]
@@ -647,7 +644,7 @@ namespace Content.Server.Atmos
             // Can't process a tile without air
             if (Air == null)
             {
-                _gridAtmosphereComponent.RemoveActiveTile(this);
+                Excited = false;
                 return;
             }
 
@@ -657,7 +654,6 @@ namespace Content.Server.Atmos
             _currentCycle = fireCount;
             var adjacentTileLength = 0;
 
-            AtmosCooldown++;
             for (var i = 0; i < Atmospherics.Directions; i++)
             {
                 var direction = (AtmosDirection) (1 << i);
@@ -738,7 +734,7 @@ namespace Content.Server.Atmos
                 if (ConsiderSuperconductivity(true))
                     remove = false;
 
-            if((ExcitedGroup == null && remove) || (AtmosCooldown > (Atmospherics.ExcitedGroupsDismantleCycles * 2)))
+            if(ExcitedGroup == null && remove)
                 _gridAtmosphereComponent.RemoveActiveTile(this);
         }
 
@@ -1187,11 +1183,9 @@ namespace Content.Server.Atmos
             if (lastShare > Atmospherics.MinimumAirToSuspend)
             {
                 ExcitedGroup.ResetCooldowns();
-                AtmosCooldown = 0;
             } else if (lastShare > Atmospherics.MinimumMolesDeltaToMove)
             {
                 ExcitedGroup.DismantleCooldown = 0;
-                AtmosCooldown = 0;
             }
         }
 

--- a/Content.Server/GameObjects/Components/Atmos/GridAtmosphereComponent.cs
+++ b/Content.Server/GameObjects/Components/Atmos/GridAtmosphereComponent.cs
@@ -241,6 +241,12 @@ namespace Content.Server.GameObjects.Components.Atmos
                         FixVacuum(tile.GridIndices);
                     }
 
+                    // Tile used to be space, but isn't anymore.
+                    if (tile.Air?.Immutable ?? false)
+                    {
+                        tile.Air = null;
+                    }
+
                     tile.Air ??= new GasMixture(GetVolumeForCells(1), AtmosphereSystem){Temperature = Atmospherics.T20C};
                 }
 

--- a/Content.Server/GameObjects/Components/Atmos/GridAtmosphereComponent.cs
+++ b/Content.Server/GameObjects/Components/Atmos/GridAtmosphereComponent.cs
@@ -300,12 +300,15 @@ namespace Content.Server.GameObjects.Components.Atmos
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public virtual void RemoveActiveTile(TileAtmosphere? tile)
+        public virtual void RemoveActiveTile(TileAtmosphere? tile, bool disposeGroup = true)
         {
             if (tile == null) return;
             _activeTiles.Remove(tile);
             tile.Excited = false;
-            tile.ExcitedGroup?.Dispose();
+            if(disposeGroup)
+                tile.ExcitedGroup?.Dispose();
+            else
+                tile.ExcitedGroup?.RemoveTile(tile);
         }
 
         /// <inheritdoc />

--- a/Content.Server/GameObjects/Components/Atmos/UnsimulatedGridAtmosphereComponent.cs
+++ b/Content.Server/GameObjects/Components/Atmos/UnsimulatedGridAtmosphereComponent.cs
@@ -40,7 +40,7 @@ namespace Content.Server.GameObjects.Components.Atmos
 
         public override void AddActiveTile(TileAtmosphere? tile) { }
 
-        public override void RemoveActiveTile(TileAtmosphere? tile) { }
+        public override void RemoveActiveTile(TileAtmosphere? tile, bool disposeGroup = true) { }
 
         public override void AddHotspotTile(TileAtmosphere? tile) { }
 

--- a/Content.Server/GameObjects/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AtmosphereSystem.cs
@@ -26,7 +26,6 @@ namespace Content.Server.GameObjects.EntitySystems
         [Dependency] private readonly IPrototypeManager _protoMan = default!;
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IPauseManager _pauseManager = default!;
-        [Dependency] private IEntityManager _entityManager = default!;
 
         private GasReactionPrototype[] _gasReactions = Array.Empty<GasReactionPrototype>();
 
@@ -37,11 +36,6 @@ namespace Content.Server.GameObjects.EntitySystems
         ///     List of gas reactions ordered by priority.
         /// </summary>
         public IEnumerable<GasReactionPrototype> GasReactions => _gasReactions!;
-
-        /// <summary>
-        ///     EventBus reference for gas reactions.
-        /// </summary>
-        public IEventBus EventBus => _entityManager.EventBus;
 
         public GridTileLookupSystem GridTileLookupSystem => _gridTileLookup ??= Get<GridTileLookupSystem>();
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -109,8 +109,8 @@
         /// <summary>
         ///     Minimum temperature for starting superconduction.
         /// </summary>
-        public const float MinimumTemperatureStartSuperConduction = (T20C + 200f);
-        public const float MinimumTemperatureForSuperconduction = (T20C + 10f);
+        public const float MinimumTemperatureStartSuperConduction = (T20C + 400f);
+        public const float MinimumTemperatureForSuperconduction = (T20C + 80f);
 
         /// <summary>
         ///     Minimum heat capacity.
@@ -233,7 +233,7 @@
     /// <summary>
     ///     Gases to Ids. Keep these updated with the prototypes!
     /// </summary>
-    public enum Gas
+    public enum Gas : sbyte
     {
         Oxygen = 0,
         Nitrogen = 1,


### PR DESCRIPTION
Fixes #2295. Turns out 6969b79c1c4b968f3910e7b15c0f64c3e56300d6 wasn't such an improvement, huh?
I might port the rest of changes from https://github.com/tgstation/tgstation/pull/52493 once that's merged.
Also turns out space tiles that stopped being space tiles never got their gas mixtures updated. Oops.
Special thanks to @LemonInTheDark for letting me know about this issue!