### PR TITLE
Fix throwing knockback when weightless

### DIFF
--- a/Content.Server/GameObjects/Components/Projectiles/ThrownItemComponent.cs
+++ b/Content.Server/GameObjects/Components/Projectiles/ThrownItemComponent.cs
@@ -120,12 +120,5 @@ namespace Content.Server.GameObjects.Components.Projectiles
 
             StopThrow();
         }
-
-        public override void Initialize()
-        {
-            base.Initialize();
-
-            Owner.EnsureComponent<PhysicsComponent>().EnsureController<ThrownController>();
-        }
     }
 }

--- a/Content.Server/Throw/ThrowHelper.cs
+++ b/Content.Server/Throw/ThrowHelper.cs
@@ -85,8 +85,7 @@ namespace Content.Server.Throw
             projComp.StartThrow(angle.ToVec(), spd);
 
             if (throwSourceEnt != null &&
-                throwSourceEnt.TryGetComponent<IPhysicsComponent>(out var physics) &&
-                physics.TryGetController(out ThrownController mover))
+                throwSourceEnt.TryGetComponent<IPhysicsComponent>(out var physics))
             {
                 if (throwSourceEnt.IsWeightless())
                 {
@@ -95,8 +94,9 @@ namespace Content.Server.Throw
                     // I got kinda lazy is the reason why. Also it makes a bit of sense.
                     // If somebody wants they can come along and make it so magboots completely hold you still.
                     // Would be a cool incentive to use them.
-                    const float ThrowFactor = 5.0f; // Break Newton's Third Law for better gameplay
-                    mover.Push(-angle.ToVec(), spd * ThrowFactor * physics.InvMass);
+                    const float throwFactor = 0.2f; // Break Newton's Third Law for better gameplay
+                    var mover = physics.EnsureController<ThrowKnockbackController>();
+                    mover.Push(-angle.ToVec(), spd * throwFactor);
                 }
             }
         }

--- a/Content.Shared/Physics/SlipController.cs
+++ b/Content.Shared/Physics/SlipController.cs
@@ -1,5 +1,6 @@
-using Robust.Shared.Interfaces.Physics;
+﻿using Robust.Shared.Interfaces.Physics;
 using Robust.Shared.IoC;
+using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 
 namespace Content.Shared.Physics
@@ -24,6 +25,11 @@ namespace Content.Shared.Physics
 
             if (_physicsManager.IsWeightless(ControlledComponent.Owner.Transform.Coordinates))
             {
+                if (ControlledComponent.IsColliding(Vector2.Zero, false))
+                {
+                    Stop();
+                }
+
                 return;
             }
 

--- a/Content.Shared/Physics/ThrowKnockbackController.cs
+++ b/Content.Shared/Physics/ThrowKnockbackController.cs
@@ -32,7 +32,7 @@ namespace Content.Shared.Physics
 
             if (ControlledComponent.Owner.IsWeightless())
             {
-                if (!ActionBlockerSystem.CanMove(ControlledComponent.Owner)
+                if (ActionBlockerSystem.CanMove(ControlledComponent.Owner)
                     && ControlledComponent.IsColliding(Vector2.Zero, false))
                 {
                     Stop();

--- a/Content.Shared/Physics/ThrowKnockbackController.cs
+++ b/Content.Shared/Physics/ThrowKnockbackController.cs
@@ -1,0 +1,52 @@
+﻿using Content.Shared.GameObjects.Components.Movement;
+using Content.Shared.GameObjects.EntitySystems;
+using Robust.Shared.Interfaces.Physics;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+
+namespace Content.Shared.Physics
+{
+    public class ThrowKnockbackController : VirtualController
+    {
+        [Dependency] private readonly IPhysicsManager _physicsManager = default!;
+
+        public ThrowKnockbackController()
+        {
+            IoCManager.InjectDependencies(this);
+        }
+
+        public void Push(Vector2 velocityDirection, float speed)
+        {
+            LinearVelocity = velocityDirection * speed;
+        }
+
+        private float Decay { get; set; } = 0.95f;
+
+        public override void UpdateAfterProcessing()
+        {
+            if (ControlledComponent == null)
+            {
+                return;
+            }
+
+            if (ControlledComponent.Owner.IsWeightless())
+            {
+                if (!ActionBlockerSystem.CanMove(ControlledComponent.Owner)
+                    && ControlledComponent.IsColliding(Vector2.Zero, false))
+                {
+                    Stop();
+                }
+
+                return;
+            }
+
+            LinearVelocity *= Decay;
+
+            if (LinearVelocity.Length < 0.001)
+            {
+                Stop();
+            }
+        }
+    }
+}


### PR DESCRIPTION
When weightless, players were not able to move by throwing something. This PR adds a ThrowKnockbackController and modifies the code to fix that.

It also modifies SlipController so that the player stops when they collide with something.