### PR TITLE
Rebind throw to shift+Q

### DIFF
--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -105,9 +105,9 @@ binds:
   key: E
 - function: ThrowItemInHand
   type: State
-  key: MouseLeft
+  key: Q
   canFocus: true
-  mod1: Alt
+  mod1: Shift
 - function: TryPullObject
   type: State
   canFocus: true


### PR DESCRIPTION
Throwing is currently bound to Alt+LeftClick. This is problematic because in SS13 there's lots of Alt+LeftClick interactions on items and objects and they're often quite handy.

Dropping and throwing are fairly similar interactions, so I think Q to drop and Shift+Q to throw makes kind of intuitive sense, plus it frees the Alt key free for Alt+Click functionality (which I believe we don't currently really have, but totally should).