### PR TITLE
Access lock lockers and add some more access types

### DIFF
--- a/Content.Server/GameObjects/Components/Items/Storage/SecureEntityStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/SecureEntityStorageComponent.cs
@@ -11,6 +11,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Localization;
+using Robust.Shared.Log;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
@@ -104,7 +105,7 @@ namespace Content.Server.GameObjects.Components.Items.Storage
 
         private void DoUnlock(IEntity user)
         {
-            if (CheckAccess(user)) return;
+            if (!CheckAccess(user)) return;
 
             Locked = false;
             EntitySystem.Get<AudioSystem>().PlayFromEntity("/Audio/Machines/door_lock_off.ogg", Owner, AudioParams.Default.WithVolume(-5));
@@ -112,7 +113,7 @@ namespace Content.Server.GameObjects.Components.Items.Storage
 
         private void DoLock(IEntity user)
         {
-            if (CheckAccess(user)) return;
+            if (!CheckAccess(user)) return;
 
             Locked = true;
             EntitySystem.Get<AudioSystem>().PlayFromEntity("/Audio/Machines/door_lock_on.ogg", Owner, AudioParams.Default.WithVolume(-5));
@@ -125,11 +126,11 @@ namespace Content.Server.GameObjects.Components.Items.Storage
                 if (!reader.IsAllowed(user))
                 {
                     Owner.PopupMessage(user, Loc.GetString("Access denied"));
-                    return true;
+                    return false;
                 }
             }
 
-            return false;
+            return true;
         }
 
         [Verb]

--- a/Resources/Prototypes/AccessLevels/cargo.yml
+++ b/Resources/Prototypes/AccessLevels/cargo.yml
@@ -1,2 +1,5 @@
 - type: accessLevel
+  id: Quartermaster
+
+- type: accessLevel
   id: Cargo

--- a/Resources/Prototypes/AccessLevels/engineering.yml
+++ b/Resources/Prototypes/AccessLevels/engineering.yml
@@ -1,2 +1,6 @@
 - type: accessLevel
+  id: ChiefEngineer
+  name: Chief Engineer
+
+- type: accessLevel
   id: Engineering

--- a/Resources/Prototypes/AccessLevels/medical.yml
+++ b/Resources/Prototypes/AccessLevels/medical.yml
@@ -1,2 +1,6 @@
 - type: accessLevel
+  id: ChiefMedicalOfficer
+  name: Chief Medical Officer
+
+- type: accessLevel
   id: Medical

--- a/Resources/Prototypes/AccessLevels/research.yml
+++ b/Resources/Prototypes/AccessLevels/research.yml
@@ -1,2 +1,6 @@
 - type: accessLevel
+  id: ResearchDirector
+  name: Research Director
+
+- type: accessLevel
   id: Research

--- a/Resources/Prototypes/AccessLevels/security.yml
+++ b/Resources/Prototypes/AccessLevels/security.yml
@@ -1,2 +1,12 @@
 - type: accessLevel
+  id: HeadOfSecurity
+  name: Head of Security
+
+- type: accessLevel
   id: Security
+
+- type: accessLevel
+  id: Brig
+
+- type: accessLevel
+  id: Detective

--- a/Resources/Prototypes/AccessLevels/service.yml
+++ b/Resources/Prototypes/AccessLevels/service.yml
@@ -1,4 +1,10 @@
 - type: accessLevel
+  id: Bar
+
+- type: accessLevel
+  id: Kitchen
+
+- type: accessLevel
   id: Service
 
 - type: accessLevel

--- a/Resources/Prototypes/AccessLevels/service.yml
+++ b/Resources/Prototypes/AccessLevels/service.yml
@@ -5,6 +5,9 @@
   id: Kitchen
 
 - type: accessLevel
+  id: Hydroponics
+
+- type: accessLevel
   id: Service
 
 - type: accessLevel

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/bar.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/bar.yml
@@ -9,3 +9,5 @@
       state: cabinet
   - type: Icon
     state: cabinet_icon
+  - type: AccessReader
+    access: [["Bar"]]

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/cargo.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/cargo.yml
@@ -9,3 +9,5 @@
       state: qm
   - type: Icon
     state: qm_icon
+  - type: AccessReader
+    access: [["Quartermaster"]]

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/command.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/command.yml
@@ -9,6 +9,8 @@
       state: cap
   - type: Icon
     state: cap_icon
+  - type: AccessReader
+    access: [["Captain"]]
 
 - type: entity
   id: LockerHeadOfPersonnel
@@ -21,3 +23,5 @@
       state: hop
   - type: Icon
     state: hop_icon
+  - type: AccessReader
+    access: [["HeadOfPersonnel"]]

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/engineering.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/engineering.yml
@@ -10,6 +10,8 @@
       state: ce
   - type: Icon
     state: ce_icon
+  - type: AccessReader
+    access: [ [ "ChiefEngineer" ] ]
 
 # Electrical supplies
 - type: entity
@@ -24,6 +26,8 @@
       state_closed: eng_elec_door
   - type: Icon
     state: eng_elec_icon
+  - type: AccessReader
+    access: [ [ "Engineering" ] ]
 
 # Welding supplies
 - type: entity
@@ -38,6 +42,8 @@
       state_closed: eng_weld_door
   - type: Icon
     state: eng_weld_icon
+  - type: AccessReader
+    access: [ [ "Engineering" ] ]
 
 # Atmos tech
 - type: entity
@@ -51,6 +57,8 @@
       state: atmos
   - type: Icon
     state: atmos_icon
+  - type: AccessReader
+    access: [ [ "Engineering" ] ]
 
 # Engineer
 - type: entity
@@ -64,3 +72,5 @@
       state: eng_secure
   - type: Icon
     state: eng_secure_icon
+  - type: AccessReader
+    access: [ [ "Engineering" ] ]

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/freezer.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/freezer.yml
@@ -9,3 +9,5 @@
       state: freezer
   - type: Icon
     state: freezer_icon
+  - type: AccessReader
+    access: [ [ "Service" ] ]

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/hydroponics.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/hydroponics.yml
@@ -9,3 +9,5 @@
       state: hydro
   - type: Icon
     state: hydro_icon
+  - type: AccessReader
+    access: [ [ "Hydroponics" ] ]

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/medical.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/medical.yml
@@ -11,6 +11,8 @@
       state: med
   - type: Icon
     state: med_icon
+  - type: AccessReader
+    access: [ [ "Medical" ] ]
 
 # Medical doctor
 - type: entity
@@ -24,6 +26,8 @@
       state: med_secure
   - type: Icon
     state: med_secure_icon
+  - type: AccessReader
+    access: [ [ "Medical" ] ]
 
 # Chemical
 - type: entity
@@ -38,6 +42,8 @@
       state_closed: chemical_door
   - type: Icon
     state: chemical_icon
+  - type: AccessReader
+    access: [ [ "Medical" ] ]
 
 # CMO
 - type: entity
@@ -51,3 +57,5 @@
       state: cmo
   - type: Icon
     state: cmo_icon
+  - type: AccessReader
+    access: [ [ "ChiefMedicalOfficer" ] ]

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/scientist.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/scientist.yml
@@ -9,3 +9,19 @@
       state: rd
   - type: Icon
     state: rd_icon
+  - type: AccessReader
+    access: [ [ "ResearchDirector" ] ]
+
+- type: entity
+  id: LockerResearchDirector
+  parent: LockerSecureBase
+  name: "scientist's locker"
+  components:
+    - type: Appearance
+      visuals:
+        - type: StorageVisualizer
+          state: rd
+    - type: Icon
+      state: rd_icon
+    - type: AccessReader
+      access: [ [ "Research" ] ]

--- a/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/security.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Closets/Secure/security.yml
@@ -10,6 +10,8 @@
       state: hos
   - type: Icon
     state: hos_icon
+  - type: AccessReader
+    access: [["HeadOfSecurity"]]
 
 # Warden
 - type: entity
@@ -23,6 +25,8 @@
       state: warden
   - type: Icon
     state: warden_icon
+  - type: AccessReader
+    access: [["Brig"]]
 
 # Security Officer
 - type: entity
@@ -36,6 +40,8 @@
       state: sec
   - type: Icon
     state: sec_icon
+  - type: AccessReader
+    access: [["Security"]]
 
 # Detective
 - type: entity
@@ -49,3 +55,5 @@
       state: cabinet
   - type: Icon
     state: cabinet_icon
+  - type: AccessReader
+    access: [["Detective"]]

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -302,6 +302,8 @@
     - External
     - HeadOfSecurity
     - HeadOfPersonnel
+    - Bar
+    - Hydroponics
     - Kitchen
     - Janitor
     - Theatre

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -284,4 +284,24 @@
   - type: IdCard
     jobTitle: Central Commander
   - type: Access
-    tags: ["Maintenance", "Cargo", "Engineering", "Medical", "Research", "Security", "Service", "Captain", "Command", "External", "HeadOfPersonnel", "Janitor", "Theatre"]
+    #GOD DEAR FUCKING GOD WE NEED AN ALL-ACCESS FLAG
+    tags:
+    - Maintenance
+    - Cargo
+    - Quartermaster
+    - Engineering
+    - ChiefEngineer
+    - Medical
+    - ChiefMedicalOfficer
+    - Research
+    - ResearchDirector
+    - Security
+    - Service
+    - Captain
+    - Command
+    - External
+    - HeadOfSecurity
+    - HeadOfPersonnel
+    - Kitchen
+    - Janitor
+    - Theatre

--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -8,6 +8,7 @@
   icon: "Bartender"
   access:
   - Service
+  - Bar
   - Maintenance
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -8,6 +8,7 @@
   icon: "Chef"
   access:
   - Service
+  - Kitchen
   - Maintenance
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -10,14 +10,24 @@
   access:
   # All of em.
   # Could probably do with some kind of wildcard or whatever to automate this.
+  # HELL FUCKING YEAH WE COULD
   - Captain
   - HeadOfPersonnel
   - Command
   - Security
+  - HeadOfSecurity
+  - Brig
+  - Detective
+  - ChiefEngineer
   - Engineering
+  - ChiefMedicalOfficer
   - Medical
+  - Quartermaster
   - Cargo
+  - ResearchDirector
   - Research
+  - Bar
+  - Kitchen
   - Service
   - Maintenance
   - External

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -29,6 +29,7 @@
   - Bar
   - Kitchen
   - Service
+  - Hydroponics
   - Maintenance
   - External
   - Janitor

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -11,6 +11,7 @@
   access:
   - Maintenance
   - Engineering
+  - ChiefEngineer
   - Command
   - External
 

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -12,6 +12,7 @@
   icon: "ChiefMedicalOfficer"
   access:
   - Medical
+  - ChiefMedicalOfficer
   - Command
   - Maintenance
 

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -10,6 +10,7 @@
   icon: "ResearchDirector"
   access:
   - Research
+  - ResearchDirector
   - Command
   - Maintenance
 

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -10,6 +10,9 @@
   icon: "HeadOfSecurity"
   access:
   - Command
+  - HeadOfSecurity
+  - Brig
+  - Detective
   - Security
   - Maintenance
   - Service


### PR DESCRIPTION
The code was there to access lock secure lockers but it wasn't being used. I added access to all the secure lockers and added some (but not all) missing types of access while I was at it.

PS: good christ we need an all access flag for job prototypes and possibly ID card definitions.