### PR TITLE
Implement PDA ID lights

### DIFF
--- a/Content.Client/GameObjects/Components/PDA/PDAVisualizer.cs
+++ b/Content.Client/GameObjects/Components/PDA/PDAVisualizer.cs
@@ -2,6 +2,7 @@
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Interfaces.GameObjects.Components;
+using Robust.Shared.Interfaces.GameObjects;
 
 namespace Content.Client.GameObjects.Components.PDA
 {
@@ -17,6 +18,17 @@ namespace Content.Client.GameObjects.Components.PDA
             IDLight
         }
 
+        public override void InitializeEntity(IEntity entity)
+        {
+            base.InitializeEntity(entity);
+            var sprite = entity.GetComponent<ISpriteComponent>();
+
+            sprite.LayerMapSet(PDAVisualLayers.Flashlight, sprite.AddLayerState("light_overlay"));
+            sprite.LayerSetShader(PDAVisualLayers.Flashlight, "unshaded");
+            sprite.LayerMapSet(PDAVisualLayers.IDLight, sprite.AddLayerState("id_overlay"));
+            sprite.LayerSetShader(PDAVisualLayers.IDLight, "unshaded");
+        }
+
 
         public override void OnChangeData(AppearanceComponent component)
         {
@@ -29,7 +41,6 @@ namespace Content.Client.GameObjects.Components.PDA
             sprite.LayerSetVisible(PDAVisualLayers.Flashlight, false);
             if (component.TryGetData(PDAVisuals.FlashlightLit, out bool isScreenLit))
             {
-                sprite.LayerSetState(PDAVisualLayers.Flashlight, "light_overlay");
                 sprite.LayerSetVisible(PDAVisualLayers.Flashlight, isScreenLit);
             }
 

--- a/Content.Client/GameObjects/Components/PDA/PDAVisualizer.cs
+++ b/Content.Client/GameObjects/Components/PDA/PDAVisualizer.cs
@@ -1,16 +1,20 @@
 ﻿using Content.Shared.GameObjects.Components.PDA;
+using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Interfaces.GameObjects.Components;
 
 namespace Content.Client.GameObjects.Components.PDA
 {
+    [UsedImplicitly]
+    // ReSharper disable once InconsistentNaming
     public class PDAVisualizer : AppearanceVisualizer
     {
 
         private enum PDAVisualLayers
         {
             Base,
-            Flashlight
+            Flashlight,
+            IDLight
         }
 
 
@@ -23,13 +27,16 @@ namespace Content.Client.GameObjects.Components.PDA
             }
             var sprite = component.Owner.GetComponent<ISpriteComponent>();
             sprite.LayerSetVisible(PDAVisualLayers.Flashlight, false);
-            if(!component.TryGetData<bool>(PDAVisuals.FlashlightLit, out var isScreenLit))
+            if (component.TryGetData(PDAVisuals.FlashlightLit, out bool isScreenLit))
             {
-                return;
+                sprite.LayerSetState(PDAVisualLayers.Flashlight, "light_overlay");
+                sprite.LayerSetVisible(PDAVisualLayers.Flashlight, isScreenLit);
             }
-            sprite.LayerSetState(PDAVisualLayers.Flashlight, "light_overlay");
-            sprite.LayerSetVisible(PDAVisualLayers.Flashlight, isScreenLit);
 
+            if (component.TryGetData(PDAVisuals.IDCardInserted, out bool isCardInserted))
+            {
+                sprite.LayerSetVisible(PDAVisualLayers.IDLight, isCardInserted);
+            }
 
         }
 

--- a/Content.Client/GameObjects/Components/PDA/PDAVisualizer.cs
+++ b/Content.Client/GameObjects/Components/PDA/PDAVisualizer.cs
@@ -3,6 +3,8 @@ using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Interfaces.GameObjects.Components;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Utility;
+using YamlDotNet.RepresentationModel;
 
 namespace Content.Client.GameObjects.Components.PDA
 {
@@ -10,6 +12,10 @@ namespace Content.Client.GameObjects.Components.PDA
     // ReSharper disable once InconsistentNaming
     public class PDAVisualizer : AppearanceVisualizer
     {
+        /// <summary>
+        /// The base PDA sprite state, eg. "pda", "pda-clown"
+        /// </summary>
+        private string _state;
 
         private enum PDAVisualLayers
         {
@@ -18,11 +24,21 @@ namespace Content.Client.GameObjects.Components.PDA
             IDLight
         }
 
+        public override void LoadData(YamlMappingNode node)
+        {
+            base.LoadData(node);
+            if (node.TryGetNode("state", out var child))
+            {
+                _state = child.AsString();
+            }
+        }
+
         public override void InitializeEntity(IEntity entity)
         {
             base.InitializeEntity(entity);
             var sprite = entity.GetComponent<ISpriteComponent>();
 
+            sprite.LayerMapSet(PDAVisualLayers.Base, sprite.AddLayerState(_state));
             sprite.LayerMapSet(PDAVisualLayers.Flashlight, sprite.AddLayerState("light_overlay"));
             sprite.LayerSetShader(PDAVisualLayers.Flashlight, "unshaded");
             sprite.LayerMapSet(PDAVisualLayers.IDLight, sprite.AddLayerState("id_overlay"));

--- a/Content.Server/GameObjects/Components/PDA/PDAComponent.cs
+++ b/Content.Server/GameObjects/Components/PDA/PDAComponent.cs
@@ -146,6 +146,7 @@ namespace Content.Server.GameObjects.Components.PDA
             if (Owner.TryGetComponent(out AppearanceComponent? appearance))
             {
                 appearance.SetData(PDAVisuals.FlashlightLit, _lightOn);
+                appearance.SetData(PDAVisuals.IDCardInserted, !IdSlotEmpty);
             }
         }
 

--- a/Content.Shared/GameObjects/Components/PDA/SharedPDAComponent.cs
+++ b/Content.Shared/GameObjects/Components/PDA/SharedPDAComponent.cs
@@ -108,6 +108,7 @@ namespace Content.Shared.GameObjects.Components.PDA
     public enum PDAVisuals
     {
         FlashlightLit,
+        IDCardInserted
     }
 
     [Serializable, NetSerializable]

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -20,15 +20,6 @@
     - key: enum.PDAUiKey.Key
       type: PDABoundUserInterface
   - type: LoopingSound
-
-- type: entity
-  name: Assistant PDA
-  parent: BasePDA
-  id: AssistantPDA
-  description: Why isn't it gray?
-  components:
-  - type: PDA
-    idCard: AssistantIDCard
   - type: Sprite
     sprite: Objects/Devices/pda.rsi
     netsync: false
@@ -38,6 +29,18 @@
     - state: light_overlay
       shader: unshaded
       map: ["enum.PDAVisualLayers.Flashlight"]
+    - state: id_overlay
+      shader: unshaded
+      map: ["enum.PDAVisualLayers.IDLight"]
+
+- type: entity
+  name: Assistant PDA
+  parent: BasePDA
+  id: AssistantPDA
+  description: Why isn't it gray?
+  components:
+  - type: PDA
+    idCard: AssistantIDCard
 
 - type: entity
   name: Chef PDA
@@ -53,9 +56,6 @@
     layers:
     - state: pda-cook
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: Clown PDA

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -26,12 +26,6 @@
     layers:
     - state: pda
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
-    - state: id_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.IDLight"]
 
 - type: entity
   name: Assistant PDA
@@ -71,9 +65,6 @@
     layers:
     - state: pda-clown
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
   - type: Slippery
     paralyzeTime: 4
   - type: Physics
@@ -97,9 +88,6 @@
     layers:
     - state: pda-mime
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: Cargo PDA
@@ -116,9 +104,6 @@
     layers:
     - state: pda-cargo
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: Bartender PDA
@@ -135,9 +120,6 @@
     layers:
     - state: pda-bartender
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 
 - type: entity
@@ -155,9 +137,6 @@
     layers:
     - state: pda-janitor
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: Captain PDA
@@ -174,9 +153,6 @@
     layers:
     - state: pda-captain
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: HoP PDA
@@ -192,9 +168,6 @@
     layers:
     - state: pda-hop
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: CE PDA
@@ -210,9 +183,6 @@
     layers:
     - state: pda-ce
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 
 - type: entity
@@ -229,9 +199,6 @@
     layers:
     - state: pda-engineer
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: CMO PDA
@@ -247,9 +214,6 @@
     layers:
     - state: pda-cmo
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: Medical PDA
@@ -265,9 +229,6 @@
     layers:
     - state: pda-medical
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: RnD PDA
@@ -276,16 +237,12 @@
   components:
   - type: PDA
     idCard: RDIDCard
-
   - type: Sprite
     sprite: Objects/Devices/pda.rsi
     netsync: false
     layers:
     - state: pda-rd
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: Science PDA
@@ -294,16 +251,12 @@
   components:
   - type: PDA
     idCard: ResearchIDCard
-
   - type: Sprite
     sprite: Objects/Devices/pda.rsi
     netsync: false
     layers:
     - state: pda-rd
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: HoS PDA
@@ -312,16 +265,12 @@
   components:
   - type: PDA
     idCard: HoSIDCard
-
   - type: Sprite
     sprite: Objects/Devices/pda.rsi
     netsync: false
     layers:
     - state: pda-hos
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]
 
 - type: entity
   name: Security PDA
@@ -330,13 +279,9 @@
   components:
   - type: PDA
     idCard: SecurityIDCard
-
   - type: Sprite
     sprite: Objects/Devices/pda.rsi
     netsync: false
     layers:
     - state: pda-security
       map: ["enum.PDAVisualLayers.Base"]
-    - state: light_overlay
-      shader: unshaded
-      map: ["enum.PDAVisualLayers.Flashlight"]

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -8,6 +8,13 @@
   - type: Appearance
     visuals:
     - type: PDAVisualizer
+      state: pda
+  - type: Sprite
+    sprite: Objects/Devices/pda.rsi
+    netsync: false
+  - type: Icon
+    sprite: Objects/Devices/pda.rsi
+    state: pda
   - type: Clothing
     QuickEquip: false
     Slots:
@@ -20,12 +27,6 @@
     - key: enum.PDAUiKey.Key
       type: PDABoundUserInterface
   - type: LoopingSound
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda
-      map: ["enum.PDAVisualLayers.Base"]
 
 - type: entity
   name: Assistant PDA
@@ -40,16 +41,16 @@
   name: Chef PDA
   parent: BasePDA
   id: ChefPDA
-  description: Why isn't it gray?
+  description: Covered in grease and flour.
   components:
   - type: PDA
     idCard: ChefIDCard
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-cook
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+    - type: PDAVisualizer
+      state: pda-cook
+  - type: Icon
+    state: pda-cook
 
 - type: entity
   name: Clown PDA
@@ -59,12 +60,12 @@
   components:
   - type: PDA
     idCard: ClownIDCard
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-clown
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-clown
+  - type: Icon
+    state: pda-clown
   - type: Slippery
     paralyzeTime: 4
   - type: Physics
@@ -82,12 +83,28 @@
   components:
   - type: PDA
     idCard: MimeIDCard
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-mime
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-mime
+  - type: Icon
+    state: pda-mime
+
+# TODO: uncomment this when the QM job gets added
+#- type: entity
+#  name: Quartermaster PDA
+#  parent: BasePDA
+#  id: QuartermasterPDA
+#  description: PDA for the guy that orders the guns.
+#  components:
+#    - type: PDA
+#      idCard: QuartermasterIDCard
+#    - type: Appearance
+#      visuals:
+#        - type: PDAVisualizer
+#          state: pda-qm
+#    - type: Icon
+#      state: pda-qm
 
 - type: entity
   name: Cargo PDA
@@ -97,13 +114,12 @@
   components:
   - type: PDA
     idCard: CargoIDCard
-
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-cargo
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-cargo
+  - type: Icon
+    state: pda-cargo
 
 - type: entity
   name: Bartender PDA
@@ -113,13 +129,12 @@
   components:
   - type: PDA
     idCard: BartenderIDCard
-
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-bartender
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-bartender
+  - type: Icon
+    state: pda-bartender
 
 
 - type: entity
@@ -130,158 +145,180 @@
   components:
   - type: PDA
     idCard: JanitorIDCard
-
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-janitor
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-janitor
+  - type: Icon
+    state: pda-janitor
 
 - type: entity
   name: Captain PDA
   parent: BasePDA
   id: CaptainPDA
-  description: Surprisingly no different than your PDA.
+  description: Surprisingly no different from your PDA.
   components:
   - type: PDA
     idCard: CaptainIDCard
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-captain
+  - type: Icon
+    state: pda-captain
 
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-captain
-      map: ["enum.PDAVisualLayers.Base"]
 
 - type: entity
-  name: HoP PDA
+  name: Head of Personnel PDA
   parent: BasePDA
   id: HoPPDA
+  description: Looks like it's been chewed on.
   components:
   - type: PDA
     idCard: HoPIDCard
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-hop
+  - type: Icon
+    state: pda-hop
 
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-hop
-      map: ["enum.PDAVisualLayers.Base"]
 
 - type: entity
-  name: CE PDA
+  name: Chief Engineer PDA
   parent: BasePDA
   id: CEPDA
+  description: Looks like it's barely been used.
   components:
   - type: PDA
     idCard: CEIDCard
-
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-ce
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-ce
+  - type: Icon
+    state: pda-ce
 
 
 - type: entity
   name: Engineer PDA
   parent: BasePDA
   id: EngineerPDA
+  description: Rugged and well-worn.
   components:
   - type: PDA
     idCard: EngineeringIDCard
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-engineer
+  - type: Icon
+    state: pda-engineer
 
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-engineer
-      map: ["enum.PDAVisualLayers.Base"]
 
 - type: entity
-  name: CMO PDA
+  name: Chief Medical Officer PDA
   parent: BasePDA
   id: CMOPDA
+  description: Extraordinarily shiny and sterile.
   components:
   - type: PDA
     idCard: CMOIDCard
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-cmo
+  - type: Icon
+    state: pda-cmo
 
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-cmo
-      map: ["enum.PDAVisualLayers.Base"]
 
 - type: entity
   name: Medical PDA
   parent: BasePDA
   id: MedicalPDA
+  description: Shiny and sterile.
   components:
   - type: PDA
     idCard: MedicalIDCard
-
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-medical
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-medical
+  - type: Icon
+    state: pda-medical
 
 - type: entity
-  name: RnD PDA
+  name: Research Director PDA
   parent: BasePDA
   id: RnDPDA
+  description: It appears surprisingly ordinary.
   components:
   - type: PDA
     idCard: RDIDCard
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-rd
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-rd
+  - type: Icon
+    state: pda-rd
 
 - type: entity
   name: Science PDA
   parent: BasePDA
   id: SciencePDA
+  description:
   components:
   - type: PDA
     idCard: ResearchIDCard
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-rd
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-science
+  - type: Icon
+    state: pda-science
 
 - type: entity
-  name: HoS PDA
+  name: Head of Security PDA
   parent: BasePDA
   id: HoSPDA
+  description: Whosoever bears this PDA is the law.
   components:
   - type: PDA
     idCard: HoSIDCard
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-hos
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-hos
+  - type: Icon
+    state: pda-hos
+
+# TODO: Uncomment this when the Warden job gets added
+#- type: entity
+#  name: Warden PDA
+#  parent: BasePDA
+#  id: WardenPDA
+#  description: The OS appears to have been jailbroken.
+#  components:
+#    - type: PDA
+#      idCard: WardenIDCard
+#    - type: Appearance
+#      visuals:
+#        - type: PDAVisualizer
+#          state: pda-warden
+#    - type: Icon
+#      state: pda-warden
 
 - type: entity
   name: Security PDA
   parent: BasePDA
   id: SecurityPDA
+  description: Red to hide the stains of assistant blood.
   components:
   - type: PDA
     idCard: SecurityIDCard
-  - type: Sprite
-    sprite: Objects/Devices/pda.rsi
-    netsync: false
-    layers:
-    - state: pda-security
-      map: ["enum.PDAVisualLayers.Base"]
+  - type: Appearance
+    visuals:
+      - type: PDAVisualizer
+        state: pda-security
+  - type: Icon
+    state: pda-security


### PR DESCRIPTION
Apparently this is a feature that's supposed to exist. Who knew?

I added some descriptions to PDAs that were missing them while I was fucking around in the YAML anyway.

![pda](https://user-images.githubusercontent.com/5822375/97200014-5a853500-17b9-11eb-86fd-9161d284f384.gif)


![pdas](https://user-images.githubusercontent.com/5822375/97199896-37f31c00-17b9-11eb-9383-fdd7c33372f0.gif)
