### PR TITLE
Fix reinforced table HP

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Furniture/tables.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/tables.yml
@@ -100,7 +100,7 @@
   - type: Icon
     sprite: Constructible/Structures/Tables/reinforced.rsi
   - type: Destructible
-    deadThreshold: 1
+    deadThreshold: 75
     destroySound: /Audio/Effects/metalbreak.ogg
     resistances: metallicResistances
     spawnOnDestroy: SteelSheet1


### PR DESCRIPTION
How I picked this number: regular tables have 15 health. Regular windows have 15 health. Reinforced windows have 75 health.