### PR TITLE
Fix ignoreInsideBlocker not working correctly for inRangeUnobstructed and inRangeUnoccluded

### DIFF
--- a/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
+++ b/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
@@ -92,12 +92,12 @@ namespace Content.Shared.GameObjects.EntitySystems
 
             foreach (var result in rayResults)
             {
-                if (!result.HitEntity.TryGetComponent(out IPhysicsComponent p))
+                if (!result.HitEntity.TryGetComponent(out OccluderComponent o))
                 {
                     continue;
                 }
 
-                var bBox = p.WorldAABB;
+                var bBox = o.BoundingBox.Translated(o.Owner.Transform.WorldPosition);
 
                 if (bBox.Contains(origin.Position) || bBox.Contains(other.Position))
                 {

--- a/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
+++ b/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
@@ -4,6 +4,8 @@ using Content.Shared.Interfaces.GameObjects.Components;
 using Content.Shared.Utility;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Map;
@@ -88,9 +90,24 @@ namespace Content.Shared.GameObjects.EntitySystems
 
             if (!ignoreInsideBlocker) return false;
 
-            if (rayResults.Count <= 0) return false;
+            foreach (var result in rayResults)
+            {
+                if (!result.HitEntity.TryGetComponent(out IPhysicsComponent p))
+                {
+                    continue;
+                }
 
-            return (rayResults[0].HitPos - other.Position).Length < 1f;
+                var bBox = p.WorldAABB;
+
+                if (bBox.Contains(origin.Position) || bBox.Contains(other.Position))
+                {
+                    continue;
+                }
+
+                return false;
+            }
+
+            return true;
         }
 
         public static bool InRangeUnOccluded(IEntity origin, IEntity other, float range, Ignored predicate, bool ignoreInsideBlocker = true)

--- a/Content.Shared/GameObjects/EntitySystems/SharedInteractionSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedInteractionSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Interfaces;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Content.Shared.Physics;
 using JetBrains.Annotations;
+using Robust.Shared.GameObjects.Components;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Physics;
@@ -134,12 +135,12 @@ namespace Content.Shared.GameObjects.EntitySystems
 
             foreach (var result in rayResults)
             {
-                if (!result.HitEntity.TryGetComponent(out OccluderComponent o))
+                if (!result.HitEntity.TryGetComponent(out IPhysicsComponent p))
                 {
                     continue;
                 }
 
-                var bBox = o.BoundingBox.Translated(o.Owner.Transform.WorldPosition);
+                var bBox = p.WorldAABB;
 
                 if (bBox.Contains(origin.Position) || bBox.Contains(other.Position))
                 {

--- a/Content.Shared/GameObjects/EntitySystems/SharedInteractionSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedInteractionSystem.cs
@@ -132,9 +132,24 @@ namespace Content.Shared.GameObjects.EntitySystems
 
             if (!ignoreInsideBlocker) return false;
 
-            if (rayResults.Count <= 0) return false;
+            foreach (var result in rayResults)
+            {
+                if (!result.HitEntity.TryGetComponent(out OccluderComponent o))
+                {
+                    continue;
+                }
 
-            return (rayResults[0].HitPos - other.Position).Length < 1f;
+                var bBox = o.BoundingBox.Translated(o.Owner.Transform.WorldPosition);
+
+                if (bBox.Contains(origin.Position) || bBox.Contains(other.Position))
+                {
+                    continue;
+                }
+
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Per the current summary:
> If true and origin or other are inside the obstruction, ignores the obstruction and considers the interaction unobstructed. Therefore, setting this to true makes this check more permissive, such as allowing an interaction to occur inside something impassable (like a wall). The default, false, makes the check more restrictive.

And the original one from April:
> if coordinates inside obstructions count as obstructed or not

It did neither of these things.
