### PR TITLE
Make InRangeUnoccluded methods consistent

### DIFF
--- a/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
+++ b/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿#nullable enable
+using System.Linq;
 using Content.Shared.GameObjects.Components.Mobs;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Content.Shared.Utility;
@@ -40,7 +41,7 @@ namespace Content.Shared.GameObjects.EntitySystems
         [Pure]
         protected static bool CanExamine(IEntity examiner, IEntity examined)
         {
-            if (!examiner.TryGetComponent(out ExaminerComponent examinerComponent))
+            if (!examiner.TryGetComponent(out ExaminerComponent? examinerComponent))
             {
                 return false;
             }
@@ -70,7 +71,7 @@ namespace Content.Shared.GameObjects.EntitySystems
                 ignoreInsideBlocker: true);
         }
 
-        public static bool InRangeUnOccluded(MapCoordinates origin, MapCoordinates other, float range, Ignored predicate, bool ignoreInsideBlocker = true)
+        public static bool InRangeUnOccluded(MapCoordinates origin, MapCoordinates other, float range, Ignored? predicate, bool ignoreInsideBlocker = true)
         {
             var occluderSystem = Get<OccluderSystem>();
             if (!origin.InRange(other, range)) return false;
@@ -110,7 +111,7 @@ namespace Content.Shared.GameObjects.EntitySystems
             return true;
         }
 
-        public static bool InRangeUnOccluded(IEntity origin, IEntity other, float range, Ignored predicate, bool ignoreInsideBlocker = true)
+        public static bool InRangeUnOccluded(IEntity origin, IEntity other, float range, Ignored? predicate, bool ignoreInsideBlocker = true)
         {
             var originPos = origin.Transform.MapPosition;
             var otherPos = other.Transform.MapPosition;
@@ -118,7 +119,7 @@ namespace Content.Shared.GameObjects.EntitySystems
             return InRangeUnOccluded(originPos, otherPos, range, predicate, ignoreInsideBlocker);
         }
 
-        public static bool InRangeUnOccluded(IEntity origin, IComponent other, float range, Ignored predicate, bool ignoreInsideBlocker = true)
+        public static bool InRangeUnOccluded(IEntity origin, IComponent other, float range, Ignored? predicate, bool ignoreInsideBlocker = true)
         {
             var originPos = origin.Transform.MapPosition;
             var otherPos = other.Owner.Transform.MapPosition;
@@ -126,7 +127,7 @@ namespace Content.Shared.GameObjects.EntitySystems
             return InRangeUnOccluded(originPos, otherPos, range, predicate, ignoreInsideBlocker);
         }
 
-        public static bool InRangeUnOccluded(IEntity origin, EntityCoordinates other, float range, Ignored predicate, bool ignoreInsideBlocker = true)
+        public static bool InRangeUnOccluded(IEntity origin, EntityCoordinates other, float range, Ignored? predicate, bool ignoreInsideBlocker = true)
         {
             var originPos = origin.Transform.MapPosition;
             var otherPos = other.ToMap(origin.EntityManager);
@@ -134,14 +135,14 @@ namespace Content.Shared.GameObjects.EntitySystems
             return InRangeUnOccluded(originPos, otherPos, range, predicate, ignoreInsideBlocker);
         }
 
-        public static bool InRangeUnOccluded(IEntity origin, MapCoordinates other, float range, Ignored predicate, bool ignoreInsideBlocker = true)
+        public static bool InRangeUnOccluded(IEntity origin, MapCoordinates other, float range, Ignored? predicate, bool ignoreInsideBlocker = true)
         {
             var originPos = origin.Transform.MapPosition;
 
             return InRangeUnOccluded(originPos, other, range, predicate, ignoreInsideBlocker);
         }
 
-        public static bool InRangeUnOccluded(ITargetedInteractEventArgs args, float range, Ignored predicate, bool ignoreInsideBlocker = true)
+        public static bool InRangeUnOccluded(ITargetedInteractEventArgs args, float range, Ignored? predicate, bool ignoreInsideBlocker = true)
         {
             var originPos = args.User.Transform.MapPosition;
             var otherPos = args.Target.Transform.MapPosition;
@@ -149,7 +150,7 @@ namespace Content.Shared.GameObjects.EntitySystems
             return InRangeUnOccluded(originPos, otherPos, range, predicate, ignoreInsideBlocker);
         }
 
-        public static bool InRangeUnOccluded(DragDropEventArgs args, float range, Ignored predicate, bool ignoreInsideBlocker = true)
+        public static bool InRangeUnOccluded(DragDropEventArgs args, float range, Ignored? predicate, bool ignoreInsideBlocker = true)
         {
             var originPos = args.User.Transform.MapPosition;
             var otherPos = args.DropLocation.ToMap(args.User.EntityManager);
@@ -157,7 +158,7 @@ namespace Content.Shared.GameObjects.EntitySystems
             return InRangeUnOccluded(originPos, otherPos, range, predicate, ignoreInsideBlocker);
         }
 
-        public static bool InRangeUnOccluded(AfterInteractEventArgs args, float range, Ignored predicate, bool ignoreInsideBlocker = true)
+        public static bool InRangeUnOccluded(AfterInteractEventArgs args, float range, Ignored? predicate, bool ignoreInsideBlocker = true)
         {
             var originPos = args.User.Transform.MapPosition;
             var otherPos = args.Target.Transform.MapPosition;

--- a/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
+++ b/Content.Shared/GameObjects/EntitySystems/ExamineSystemShared.cs
@@ -93,7 +93,7 @@ namespace Content.Shared.GameObjects.EntitySystems
 
             foreach (var result in rayResults)
             {
-                if (!result.HitEntity.TryGetComponent(out OccluderComponent o))
+                if (!result.HitEntity.TryGetComponent(out OccluderComponent? o))
                 {
                     continue;
                 }

--- a/Content.Shared/Utility/SharedUnoccludedExtensions.cs
+++ b/Content.Shared/Utility/SharedUnoccludedExtensions.cs
@@ -18,7 +18,7 @@ namespace Content.Shared.Utility
             IEntity other,
             float range = ExamineRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             return ExamineSystemShared.InRangeUnOccluded(origin, other, range, predicate, ignoreInsideBlocker);
         }
@@ -28,7 +28,7 @@ namespace Content.Shared.Utility
             IComponent other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             return ExamineSystemShared.InRangeUnOccluded(origin, other, range, predicate, ignoreInsideBlocker);
         }
@@ -38,7 +38,7 @@ namespace Content.Shared.Utility
             IContainer other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var otherEntity = other.Owner;
 
@@ -50,7 +50,7 @@ namespace Content.Shared.Utility
             EntityCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             return ExamineSystemShared.InRangeUnOccluded(origin, other, range, predicate, ignoreInsideBlocker);
         }
@@ -60,7 +60,7 @@ namespace Content.Shared.Utility
             MapCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             return ExamineSystemShared.InRangeUnOccluded(origin, other, range, predicate, ignoreInsideBlocker);
         }
@@ -72,7 +72,7 @@ namespace Content.Shared.Utility
             IEntity other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
 
@@ -84,7 +84,7 @@ namespace Content.Shared.Utility
             IComponent other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
 
@@ -96,7 +96,7 @@ namespace Content.Shared.Utility
             IContainer other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
             var otherEntity = other.Owner;
@@ -110,7 +110,7 @@ namespace Content.Shared.Utility
             EntityCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
 
@@ -122,7 +122,7 @@ namespace Content.Shared.Utility
             MapCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
 
@@ -137,7 +137,7 @@ namespace Content.Shared.Utility
             IEntity other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
 
@@ -150,7 +150,7 @@ namespace Content.Shared.Utility
             IComponent other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
 
@@ -162,7 +162,7 @@ namespace Content.Shared.Utility
             IContainer other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
             var otherEntity = other.Owner;
@@ -176,7 +176,7 @@ namespace Content.Shared.Utility
             EntityCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
 
@@ -188,7 +188,7 @@ namespace Content.Shared.Utility
             MapCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originEntity = origin.Owner;
 
@@ -202,7 +202,7 @@ namespace Content.Shared.Utility
             IEntity other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originPosition = origin.ToMap(other.EntityManager);
             var otherPosition = other.Transform.MapPosition;
@@ -216,7 +216,7 @@ namespace Content.Shared.Utility
             IComponent other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originPosition = origin.ToMap(other.Owner.EntityManager);
             var otherPosition = other.Owner.Transform.MapPosition;
@@ -230,7 +230,7 @@ namespace Content.Shared.Utility
             IContainer other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var originPosition = origin.ToMap(other.Owner.EntityManager);
             var otherPosition = other.Owner.Transform.MapPosition;
@@ -244,7 +244,7 @@ namespace Content.Shared.Utility
             EntityCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false,
+            bool ignoreInsideBlocker = true,
             IEntityManager? entityManager = null)
         {
             entityManager ??= IoCManager.Resolve<IEntityManager>();
@@ -261,7 +261,7 @@ namespace Content.Shared.Utility
             MapCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false,
+            bool ignoreInsideBlocker = true,
             IEntityManager? entityManager = null)
         {
             entityManager ??= IoCManager.Resolve<IEntityManager>();
@@ -279,7 +279,7 @@ namespace Content.Shared.Utility
             IEntity other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var otherPosition = other.Transform.MapPosition;
 
@@ -292,7 +292,7 @@ namespace Content.Shared.Utility
             IComponent other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var otherPosition = other.Owner.Transform.MapPosition;
 
@@ -305,7 +305,7 @@ namespace Content.Shared.Utility
             IContainer other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             var otherPosition = other.Owner.Transform.MapPosition;
 
@@ -318,7 +318,7 @@ namespace Content.Shared.Utility
             EntityCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false,
+            bool ignoreInsideBlocker = true,
             IEntityManager? entityManager = null)
         {
             entityManager ??= IoCManager.Resolve<IEntityManager>();
@@ -334,7 +334,7 @@ namespace Content.Shared.Utility
             MapCoordinates other,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             return ExamineSystemShared.InRangeUnOccluded(origin, other, range, predicate,
                 ignoreInsideBlocker);
@@ -346,7 +346,7 @@ namespace Content.Shared.Utility
             this ITargetedInteractEventArgs args,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             return ExamineSystemShared.InRangeUnOccluded(args, range, predicate,
                 ignoreInsideBlocker);
@@ -356,7 +356,7 @@ namespace Content.Shared.Utility
             this DragDropEventArgs args,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             return ExamineSystemShared.InRangeUnOccluded(args, range, predicate,
                 ignoreInsideBlocker);
@@ -366,7 +366,7 @@ namespace Content.Shared.Utility
             this AfterInteractEventArgs args,
             float range = InteractionRange,
             Ignored? predicate = null,
-            bool ignoreInsideBlocker = false)
+            bool ignoreInsideBlocker = true)
         {
             return ExamineSystemShared.InRangeUnOccluded(args, range, predicate,
                 ignoreInsideBlocker);


### PR DESCRIPTION
Required for https://github.com/space-wizards/space-station-14/pull/2253

- Makes ignoreInsideBlocker default to true, like the original InRangeUnoccluded method does since you can see "in" walls.
- Makes the Ignored predicate nullable.