### PR TITLE
Add admin teleport button

### DIFF
--- a/Content.Client/UserInterface/AdminMenu/AdminMenuWindow.cs
+++ b/Content.Client/UserInterface/AdminMenu/AdminMenuWindow.cs
@@ -37,7 +37,7 @@ namespace Content.Client.UserInterface.AdminMenu
         {
             new KickCommandButton(),
             new DirectCommandButton("Admin Ghost", "aghost"),
-            //TODO: teleport
+            new TeleportCommandButton(),
         };
         private readonly List<CommandButton> _adminbusButtons = new List<CommandButton>
         {
@@ -531,6 +531,30 @@ namespace Content.Client.UserInterface.AdminMenu
             public override void Submit()
             {
                 IoCManager.Resolve<IClientConsole>().ProcessCommand($"kick \"{_playerDropDown.GetValue()}\" \"{CommandParsing.Escape(_reason.GetValue())}\"");
+            }
+        }
+
+        private class TeleportCommandButton : UICommandButton
+        {
+            public override string Name => "Teleport";
+            public override string RequiredCommand => "tpto";
+
+            private readonly CommandUIDropDown _playerDropDown = new CommandUIDropDown
+            {
+                Name = "Player",
+                GetData = () => IoCManager.Resolve<IPlayerManager>().Sessions.ToList<object>(),
+                GetDisplayName = (obj) => $"{((IPlayerSession) obj).Name} ({((IPlayerSession) obj).AttachedEntity?.Name})",
+                GetValueFromData = (obj) => ((IPlayerSession) obj).Name,
+            };
+
+            public override List<CommandUIControl> UI => new List<CommandUIControl>
+            {
+                _playerDropDown
+            };
+
+            public override void Submit()
+            {
+                IoCManager.Resolve<IClientConsole>().ProcessCommand($"tpto \"{_playerDropDown.GetValue()}\"");
             }
         }
 

--- a/Resources/Groups/groups.yml
+++ b/Resources/Groups/groups.yml
@@ -60,6 +60,7 @@
   - spawn
   - delete
   - tp
+  - tpto
   - tpgrid
   - setgamepreset
   - forcepreset
@@ -142,6 +143,7 @@
   - spawn
   - delete
   - tp
+  - tpto
   - tpgrid
   - setgamepreset
   - forcepreset


### PR DESCRIPTION
Adds button to the admin menu that teleports you to another player's location.

Requires space-wizards/RobustToolbox#1366