### PR TITLE
Station Extension/Repair

### DIFF
--- a/Content.Server/Construction/Completions/SpawnTile.cs
+++ b/Content.Server/Construction/Completions/SpawnTile.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Map;
 using Robust.Shared.Map;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Serialization;
 
 namespace Content.Server.Construction.Completions
@@ -27,8 +28,14 @@ namespace Content.Server.Construction.Completions
             var mapManager = IoCManager.Resolve<IMapManager>();
             var tileDefinitionManager = IoCManager.Resolve<ITileDefinitionManager>();
 
-            var grid = mapManager.GetGrid(entity.Transform.GridID);
-            grid.SetTile(entity.Transform.Coordinates, new Tile(tileDefinitionManager[Tile].TileId));
+            if (mapManager.TryGetGrid(entity.Transform.GridID, out var grid))
+            {
+                grid.SetTile(entity.Transform.Coordinates, new Tile(tileDefinitionManager[Tile].TileId));
+            }
+            else
+            {
+                Logger.WarningS("construction", "Construction SpawnTile by {} on a non-existent grid at {}", user?.Name ?? "(null)", entity.Transform.ToString());
+            }
         }
     }
 }

--- a/Content.Server/Construction/Completions/SpawnTile.cs
+++ b/Content.Server/Construction/Completions/SpawnTile.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using Content.Shared.Construction;
+using JetBrains.Annotations;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
+using Robust.Shared.Map;
+using Robust.Shared.IoC;
+using Robust.Shared.Serialization;
+
+namespace Content.Server.Construction.Completions
+{
+    [UsedImplicitly]
+    public class SpawnTile : IGraphAction
+    {
+        public string Tile { get; private set; } = string.Empty;
+
+        public void ExposeData(ObjectSerializer serializer)
+        {
+            serializer.DataField(this, x => x.Tile, "tile", string.Empty);
+        }
+
+        public async Task PerformAction(IEntity entity, IEntity? user)
+        {
+            if (entity.Deleted) return;
+
+            var mapManager = IoCManager.Resolve<IMapManager>();
+            var tileDefinitionManager = IoCManager.Resolve<ITileDefinitionManager>();
+
+            var grid = mapManager.GetGrid(entity.Transform.GridID);
+            grid.SetTile(entity.Transform.Coordinates, new Tile(tileDefinitionManager[Tile].TileId));
+        }
+    }
+}

--- a/Content.Shared/Construction/ConstructionConditions/TileIsExactly.cs
+++ b/Content.Shared/Construction/ConstructionConditions/TileIsExactly.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Content.Shared.GameObjects.Components;
+using Content.Shared.Maps;
+using JetBrains.Annotations;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization;
+using Robust.Shared.IoC;
+using Robust.Shared.Interfaces.Map;
+
+namespace Content.Shared.Construction.ConstructionConditions
+{
+    [UsedImplicitly]
+    public class TileIsExactly : IConstructionCondition
+    {
+        public void ExposeData(ObjectSerializer serializer)
+        {
+            serializer.DataField(this, x => x.TileName, "tile", string.Empty);
+        }
+
+        /// <summary>
+        ///     The tile ID.
+        /// </summary>
+        public string TileName { get; private set; }
+
+        public bool Condition(IEntity user, EntityCoordinates location, Direction direction)
+        {
+            var tileRef = location.GetTileRef();
+            var tileIDNum = (tileRef?.Tile ?? Tile.Empty).TypeId;
+            var tileDefinitionManager = IoCManager.Resolve<ITileDefinitionManager>();
+            return tileIDNum == tileDefinitionManager[TileName].TileId;
+        }
+    }
+}

--- a/Resources/Prototypes/Catalog/LatheRecipes/misc.yml
+++ b/Resources/Prototypes/Catalog/LatheRecipes/misc.yml
@@ -15,3 +15,13 @@
   materials:
     steel: 30
     glass: 50
+
+- type: latheRecipe
+  id: MetalRod
+  icon:
+    sprite: Objects/Materials/materials.rsi
+    state: rods
+  result: MetalRod1
+  completetime: 250
+  materials:
+    steel: 1875

--- a/Resources/Prototypes/Entities/Constructible/Power/lathe.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/lathe.yml
@@ -57,6 +57,7 @@
       - LightTube
       - LightBulb
       - MetalStack
+      - MetalRod
       - GlassStack
       - Wirecutter
       - Screwdriver

--- a/Resources/Prototypes/Entities/Objects/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/materials.yml
@@ -214,3 +214,26 @@
   components:
     - type: Stack
       count: 1
+
+- type: entity
+  name: metal rod
+  id: MetalRodStack
+  parent: MaterialStack
+  suffix: Full
+  description: Some rods. Used for building things, or to extend the station.
+  components:
+    # TODO: This is metal, but it's half of a metal sheet per item in the stack.
+  - type: Stack
+    stacktype: enum.StackType.MetalRod
+  - type: Sprite
+    sprite: Objects/Materials/materials.rsi
+    state: rods
+
+- type: entity
+  id: MetalRod1
+  parent: MetalRodStack
+  suffix: 1
+  components:
+  - type: Stack
+    stacktype: enum.StackType.MetalRod
+    count: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/underplating.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/underplating.yml
@@ -7,9 +7,8 @@
         - to: underplating
           completed:
             - !type:SnapToGrid { }
-            - !type:SpawnPrototype
-              prototype: CarpMob_Content
-              amount: 1
+            - !type:SpawnTile
+              tile: underplating
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/underplating.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/underplating.yml
@@ -1,0 +1,18 @@
+﻿- type: constructionGraph
+  id: underplating
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: underplating
+          completed:
+            - !type:SnapToGrid { }
+            - !type:SpawnPrototype
+              prototype: CarpMob_Content
+              amount: 1
+          steps:
+            - material: MetalRod
+              amount: 2
+              doAfter: 1
+    - node: underplating
+

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1,4 +1,4 @@
-﻿- type: construction
+- type: construction
   name: girder
   id: girder
   graph: girder
@@ -24,6 +24,19 @@
   icon:
     sprite: Constructible/Structures/Walls/solid.rsi
     state: full
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: false
+
+- type: construction
+  name: underplating
+  id: underplating
+  graph: underplating
+  startNode: start
+  targetNode: underplating
+  category: Structures
+  description: The plating underneath the station.
+  icon: Constructible/Tiles/underplating.png
   objectType: Structure
   placementMode: SnapgridCenter
   canRotate: false

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -36,6 +36,9 @@
   targetNode: underplating
   category: Structures
   description: The plating underneath the station.
+  conditions:
+    - !type:TileIsExactly
+      tile: space
   icon: Constructible/Tiles/underplating.png
   objectType: Structure
   placementMode: SnapgridCenter


### PR DESCRIPTION
Adds metal rods and allows using them to place underplating.
Known bugs:
+ Attempting to build off the edge of the station doesn't work because GridCoordinates never truly died, it was just renamed EntityCoordinates, so when stuff can't find the station grid, it can't do anything. Trying anyway will print a warning and eat metal rods. Solution to this might be to allow construction placement to be more forgiving about which places it considers what grids and to add a condition for underplating to make sure that, yes, there is a grid (there doesn't necessarily have to be a tile there because SetTile will do that). This isn't the only problem related to stuff being off the station grid, though, there's also something unrelated to this PR involving not being able to pick up items.
+ Construction system issue: Conditions aren't checked after the do-after timer, and I'm not sure if pre-ghost-placement conditions are checked when materials are put into the construction ghost.