### PR TITLE
Add super synth that plays MIDIs without being restricted to one kind of sound

### DIFF
--- a/Content.Client/GameObjects/Components/Instruments/InstrumentComponent.cs
+++ b/Content.Client/GameObjects/Components/Instruments/InstrumentComponent.cs
@@ -41,6 +41,10 @@ namespace Content.Client.GameObjects.Components.Instruments
 
         private uint _sequenceStartTick;
 
+        private bool _allowPercussion;
+
+        private bool _allowProgramChange;
+
         /// <summary>
         ///     A queue of MidiEvents to be sent to the server.
         /// </summary>
@@ -97,6 +101,34 @@ namespace Content.Client.GameObjects.Components.Instruments
             }
         }
 
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool AllowPercussion
+        {
+            get => _allowPercussion;
+            set
+            {
+                _allowPercussion = value;
+                if (_renderer != null)
+                {
+                    _renderer.DisablePercussionChannel = !_allowPercussion;
+                }
+            }
+        }
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool AllowProgramChange
+        {
+            get => _allowProgramChange;
+            set
+            {
+                _allowProgramChange = value;
+                if (_renderer != null)
+                {
+                    _renderer.DisableProgramChangeEvent = !_allowProgramChange;
+                }
+            }
+        }
+
         /// <summary>
         ///     Whether this instrument is handheld or not.
         /// </summary>
@@ -127,7 +159,7 @@ namespace Content.Client.GameObjects.Components.Instruments
             IoCManager.InjectDependencies(this);
         }
 
-        protected void SetupRenderer(bool fromStateChange = false)
+        protected virtual void SetupRenderer(bool fromStateChange = false)
         {
             if (IsRendererAlive) return;
 
@@ -141,6 +173,8 @@ namespace Content.Client.GameObjects.Components.Instruments
                 _renderer.MidiBank = _instrumentBank;
                 _renderer.MidiProgram = _instrumentProgram;
                 _renderer.TrackingEntity = Owner;
+                _renderer.DisablePercussionChannel = !_allowPercussion;
+                _renderer.DisableProgramChangeEvent = !_allowProgramChange;
                 _renderer.OnMidiPlayerFinished += () =>
                 {
                     OnMidiPlaybackEnded?.Invoke();
@@ -195,6 +229,8 @@ namespace Content.Client.GameObjects.Components.Instruments
             serializer.DataField(this, x => Handheld, "handheld", false);
             serializer.DataField(ref _instrumentProgram, "program", (byte) 1);
             serializer.DataField(ref _instrumentBank, "bank", (byte) 0);
+            serializer.DataField(ref _allowPercussion, "allowPercussion", false);
+            serializer.DataField(ref _allowProgramChange, "allowProgramChange", false);
         }
 
         public override void HandleNetworkMessage(ComponentMessage message, INetChannel channel, ICommonSession? session = null)

--- a/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
@@ -206,3 +206,20 @@
   - type: Item
     size: 24
     sprite: Objects/Fun/Instruments/bike_horn.rsi
+
+- type: entity
+  name: super synthesizer
+  description: Blasting the ghetto with Touhou MIDIs since 2020.
+  parent: BaseHandheldInstrument
+  id: SuperSynthesizerInstrument
+  components:
+    - type: Instrument
+      allowPercussion: true
+      allowProgramChange: true
+    - type: Sprite
+      sprite: Objects/Fun/Instruments/h_synthesizer.rsi
+      state: icon
+
+    - type: Item
+      size: 24
+      sprite: Objects/Fun/Instruments/h_synthesizer.rsi


### PR DESCRIPTION
https://media.discordapp.net/attachments/675078881425752124/771519843144695838/simplescreenrecorder-2020-10-30_01.42.29.mp4

This is intended as an admin item because otherwise nobody would use the rest of the instruments.

It plays MIDIs as they're "supposed" to be played by allowing the percussion track and program change events. See the mp4 above for an example.

This requires https://github.com/space-wizards/RobustToolbox/pull/1369 -- oh wait that was already merged