### PR TITLE
Optimise flashlights

### DIFF
--- a/Content.Client/GameObjects/Components/Power/PowerCellVisualizer.cs
+++ b/Content.Client/GameObjects/Components/Power/PowerCellVisualizer.cs
@@ -34,10 +34,10 @@ namespace Content.Client.GameObjects.Components.Power
             base.OnChangeData(component);
 
             var sprite = component.Owner.GetComponent<ISpriteComponent>();
-            if (component.TryGetData(PowerCellVisuals.ChargeLevel, out float fraction))
+            if (component.TryGetData(PowerCellVisuals.ChargeLevel, out byte level))
             {
-                int level = ContentHelpers.RoundToNearestLevels(fraction, 1, 4) * 25;
-                sprite.LayerSetState(Layers.Charge, $"{_prefix}_{level}");
+                var adjustedLevel = level * 25;
+                sprite.LayerSetState(Layers.Charge, $"{_prefix}_{adjustedLevel}");
             }
         }
 

--- a/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
@@ -7,12 +7,14 @@ using Content.Shared.GameObjects.Components;
 using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces;
 using Content.Shared.Interfaces.GameObjects.Components;
+using Content.Shared.Utility;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Localization;
+using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -40,6 +42,11 @@ namespace Content.Server.GameObjects.Components.Interactable
         [ViewVariables(VVAccess.ReadWrite)] public string? TurnOnSound;
         [ViewVariables(VVAccess.ReadWrite)] public string? TurnOnFailSound;
         [ViewVariables(VVAccess.ReadWrite)] public string? TurnOffSound;
+
+        /// <summary>
+        ///     Client-side ItemStatus level
+        /// </summary>
+        private byte? _lastLevel;
 
         public override void ExposeData(ObjectSerializer serializer)
         {
@@ -190,24 +197,34 @@ namespace Content.Server.GameObjects.Components.Interactable
             }
 
             if (Activated && !Cell.TryUseCharge(Wattage * frameTime)) TurnOff(false);
-            Dirty();
+
+            var level = GetLevel();
+
+            if (level != _lastLevel)
+            {
+                _lastLevel = level;
+                Dirty();
+            }
+        }
+
+        // Curently every single flashlight has the same number of levels for status and that's all it uses the charge for
+        // Thus we'll just check if the level changes.
+        private byte? GetLevel()
+        {
+            if (Cell == null)
+                return null;
+
+            var currentCharge = Cell.CurrentCharge;
+
+            if (MathHelper.CloseTo(currentCharge, 0) || Wattage > currentCharge)
+                return 0;
+
+            return (byte?) ContentHelpers.RoundToNearestLevels(currentCharge / Cell.MaxCharge * 255, 255, StatusLevels);
         }
 
         public override ComponentState GetComponentState()
         {
-            if (Cell == null)
-            {
-                return new HandheldLightComponentState(null, false);
-            }
-
-            if (Wattage > Cell.CurrentCharge)
-            {
-                // Practically zero.
-                // This is so the item status works correctly.
-                return new HandheldLightComponentState(0, HasCell);
-            }
-
-            return new HandheldLightComponentState(Cell.CurrentCharge / Cell.MaxCharge, HasCell);
+            return new HandheldLightComponentState(GetLevel());
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Power/PowerCellComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerCellComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.GameObjects.Components.Power;
 using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.Utility;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
@@ -45,8 +46,13 @@ namespace Content.Server.GameObjects.Components.Power
         {
             if (Owner.TryGetComponent(out AppearanceComponent appearance))
             {
-                appearance.SetData(PowerCellVisuals.ChargeLevel, CurrentCharge / MaxCharge);
+                appearance.SetData(PowerCellVisuals.ChargeLevel, GetLevel(CurrentCharge / MaxCharge));
             }
+        }
+
+        private byte GetLevel(float fraction)
+        {
+            return (byte) ContentHelpers.RoundToNearestLevels(fraction, 1, SharedPowerCell.PowerCellVisualsLevels);
         }
 
         void IExamine.Examine(FormattedMessage message, bool inDetailsRange)

--- a/Content.Shared/GameObjects/Components/Power/SharedPowerCell.cs
+++ b/Content.Shared/GameObjects/Components/Power/SharedPowerCell.cs
@@ -3,6 +3,11 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.GameObjects.Components.Power
 {
+    public static class SharedPowerCell
+    {
+        public const int PowerCellVisualsLevels = 4;
+    }
+
     [Serializable, NetSerializable]
     public enum PowerCellVisuals
     {

--- a/Content.Shared/GameObjects/Components/SharedHandheldLightComponent.cs
+++ b/Content.Shared/GameObjects/Components/SharedHandheldLightComponent.cs
@@ -11,18 +11,17 @@ namespace Content.Shared.GameObjects.Components
 
         protected abstract bool HasCell { get; }
 
+        protected const int StatusLevels = 6;
+
         [Serializable, NetSerializable]
         protected sealed class HandheldLightComponentState : ComponentState
         {
-            public HandheldLightComponentState(float? charge, bool hasCell) : base(ContentNetIDs.HANDHELD_LIGHT)
+            public byte? Charge { get; }
+
+            public HandheldLightComponentState(byte? charge) : base(ContentNetIDs.HANDHELD_LIGHT)
             {
                 Charge = charge;
-                HasCell = hasCell;
             }
-
-            public float? Charge { get; }
-
-            public bool HasCell { get; }
         }
     }
 


### PR DESCRIPTION
Flashlights were calling dirty EVERY TICK so this just means they only call it when absolutely necessary which saves a lot of bandwidth. Even when it's on now it only sends the updated status in bytes which is a big saving.

Fixes #2467 