### PR TITLE
Fix block game causing server crash

### DIFF
--- a/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
+++ b/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
@@ -569,7 +569,7 @@ namespace Content.Server.GameObjects.Components.Arcade
                         break;
                     case BlockGamePlayerAction.Pause:
                         _running = false;
-                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause));
+                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause, IsRunning()));
                         break;
                     case BlockGamePlayerAction.Unpause:
                         if (!_gameOver)
@@ -583,7 +583,7 @@ namespace Content.Server.GameObjects.Components.Arcade
                         break;
                     case BlockGamePlayerAction.ShowHighscores:
                         _running = false;
-                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Highscores));
+                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Highscores, IsRunning()));
                         break;
                 }
             }
@@ -654,6 +654,12 @@ namespace Content.Server.GameObjects.Components.Arcade
             }
 
             private bool IsGameOver => _field.Any(block => block.Position.Y == 0);
+
+            private bool IsRunning()
+            {
+                return _component._game != null && _component._game._running;
+            }
+
             private void InvokeGameover()
             {
                 _running = false;

--- a/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
+++ b/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
@@ -572,7 +572,7 @@ namespace Content.Server.GameObjects.Components.Arcade
                         _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause, _started));
                         break;
                     case BlockGamePlayerAction.Unpause:
-                        if (!_gameOver)
+                        if (!_gameOver && _started)
                         {
                             _running = true;
                             _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Game));

--- a/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
+++ b/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
@@ -569,7 +569,7 @@ namespace Content.Server.GameObjects.Components.Arcade
                         break;
                     case BlockGamePlayerAction.Pause:
                         _running = false;
-                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause, IsRunning()));
+                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause, _running));
                         break;
                     case BlockGamePlayerAction.Unpause:
                         if (!_gameOver)
@@ -583,7 +583,7 @@ namespace Content.Server.GameObjects.Components.Arcade
                         break;
                     case BlockGamePlayerAction.ShowHighscores:
                         _running = false;
-                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Highscores, IsRunning()));
+                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Highscores, _running));
                         break;
                 }
             }
@@ -654,11 +654,6 @@ namespace Content.Server.GameObjects.Components.Arcade
             }
 
             private bool IsGameOver => _field.Any(block => block.Position.Y == 0);
-
-            private bool IsRunning()
-            {
-                return _component._game != null && _component._game._running;
-            }
 
             private void InvokeGameover()
             {

--- a/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
+++ b/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
@@ -569,7 +569,7 @@ namespace Content.Server.GameObjects.Components.Arcade
                         break;
                     case BlockGamePlayerAction.Pause:
                         _running = false;
-                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause, _running));
+                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause, _started));
                         break;
                     case BlockGamePlayerAction.Unpause:
                         if (!_gameOver)
@@ -583,7 +583,7 @@ namespace Content.Server.GameObjects.Components.Arcade
                         break;
                     case BlockGamePlayerAction.ShowHighscores:
                         _running = false;
-                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Highscores, _running));
+                        _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Highscores, _started));
                         break;
                 }
             }

--- a/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
+++ b/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
@@ -299,6 +299,7 @@ namespace Content.Server.GameObjects.Components.Arcade
                 _component = component;
                 _allBlockGamePieces = (BlockGamePieceType[]) Enum.GetValues(typeof(BlockGamePieceType));
                 _internalNextPiece = GetRandomBlockGamePiece(_component._random);
+                InitializeNewBlock();
             }
 
             private void SendHighscoreUpdate()
@@ -315,8 +316,6 @@ namespace Content.Server.GameObjects.Components.Arcade
 
             public void StartGame()
             {
-                InitializeNewBlock();
-
                 _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Game));
 
                 FullUpdate();


### PR DESCRIPTION
Viewing high scores before starting a game and going back would show an unpause button which causes a server crash when pressed.