### PR TITLE
Adds ContentBenchmark helper class for advanced benchmarks, adds Atmos benchmarks

### DIFF
--- a/Content.Benchmarks/AtmosBenchmark.cs
+++ b/Content.Benchmarks/AtmosBenchmark.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Maths;
 
 namespace Content.Benchmarks
 {
+    [SimpleJob(targetCount:50)]
     public class AtmosBenchmark : ContentBenchmark
     {
         private const string TileName = "floor_steel";

--- a/Content.Benchmarks/AtmosBenchmark.cs
+++ b/Content.Benchmarks/AtmosBenchmark.cs
@@ -46,7 +46,6 @@ namespace Content.Benchmarks
         public void PhoronFireBenchmarkNaive()
         {
             NumericsHelpers.Enabled = false;
-            NumericsHelpers.AvxEnabled = false;
             _server.Loop(AtmosFire, _ticks);
         }
 
@@ -59,20 +58,6 @@ namespace Content.Benchmarks
             }
 
             NumericsHelpers.Enabled = true;
-            NumericsHelpers.AvxEnabled = false;
-            _server.Loop(AtmosFire, _ticks);
-        }
-
-        [Benchmark]
-        public void PhoronFireBenchmarkAvx()
-        {
-            if (!Avx.IsSupported)
-            {
-                throw new NotSupportedException("AVX is not supported!");
-            }
-
-            NumericsHelpers.Enabled = true;
-            NumericsHelpers.AvxEnabled = true;
             _server.Loop(AtmosFire, _ticks);
         }
 

--- a/Content.Benchmarks/AtmosBenchmark.cs
+++ b/Content.Benchmarks/AtmosBenchmark.cs
@@ -18,7 +18,6 @@ using Robust.Shared.Maths;
 
 namespace Content.Benchmarks
 {
-    [SimpleJob(RunStrategy.Monitoring)]
     public class AtmosBenchmark : ContentBenchmark
     {
         private string _tileName = "floor_steel";
@@ -71,7 +70,7 @@ namespace Content.Benchmarks
         [IterationSetup]
         public void IterationSetup()
         {
-            _server = StartServer();
+            _server = StartServerDummyTicker();
         }
 
         [Benchmark(Baseline = true)]

--- a/Content.Benchmarks/AtmosBenchmark.cs
+++ b/Content.Benchmarks/AtmosBenchmark.cs
@@ -20,12 +20,12 @@ namespace Content.Benchmarks
 {
     public class AtmosBenchmark : ContentBenchmark
     {
-        private string _tileName = "floor_steel";
-        private string _wallPrototype = "reinforced_wall";
-        private int _squareSize = 32;
-        private int _ticks = 30 * 60; // 1 minute in 30 TPS
+        private const string TileName = "floor_steel";
+        private const string WallPrototype = "reinforced_wall";
+        private const int SquareSize = 32;
+        private const int Ticks = 30 * 60; // 1 minute in 30 TPS
 
-        private Dictionary<Gas, float> _gases = new Dictionary<Gas, float>()
+        private readonly Dictionary<Gas, float> _gases = new Dictionary<Gas, float>()
         {
             { Gas.Oxygen, 10000f },
             { Gas.Phoron, 10000f }
@@ -34,7 +34,7 @@ namespace Content.Benchmarks
         private float _temperature = 10000f;
         private ServerIntegrationInstance _server;
 
-        private int HalfSquareSize => _squareSize / 2;
+        private int HalfSquareSize => SquareSize / 2;
 
         [GlobalSetup(Target = nameof(PhoronFireBenchmarkNaive))]
         public void SetupNaive()
@@ -76,19 +76,19 @@ namespace Content.Benchmarks
         [Benchmark(Baseline = true)]
         public void PhoronFireBenchmarkNaive()
         {
-            _server.Loop(AtmosFire, _ticks);
+            _server.Loop(AtmosFire, Ticks);
         }
 
         [Benchmark]
         public void PhoronFireBenchmarkSse()
         {
-            _server.Loop(AtmosFire, _ticks);
+            _server.Loop(AtmosFire, Ticks);
         }
 
         [Benchmark]
         public void PhoronFireBenchmarkAvx()
         {
-            _server.Loop(AtmosFire, _ticks);
+            _server.Loop(AtmosFire, Ticks);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Content.Benchmarks
             var map = mapManager.GetMapEntity(newMap);
             var gridEnt = entityManager.GetEntity(grid.GridEntityId);
 
-            var tile = new Tile(tileDefinitionManager[_tileName].TileId);
+            var tile = new Tile(tileDefinitionManager[TileName].TileId);
 
             var gridAtmos = gridEnt.AddComponent<GridAtmosphereComponent>();
 
@@ -133,7 +133,7 @@ namespace Content.Benchmarks
 
                     if (CoordinateWall(x) || CoordinateWall(y))
                     {
-                        entityManager.SpawnEntity(_wallPrototype, new EntityCoordinates(gridEnt.Uid, vector));
+                        entityManager.SpawnEntity(WallPrototype, new EntityCoordinates(gridEnt.Uid, vector));
                     }
                 }
             }

--- a/Content.Benchmarks/AtmosBenchmark.cs
+++ b/Content.Benchmarks/AtmosBenchmark.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Disassemblers;
+using BenchmarkDotNet.Engines;
+using Content.Server.GameObjects.Components.Atmos;
+using Content.Shared.Atmos;
+using Content.Shared.Maps;
+using Robust.Server.Interfaces.Timing;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.Benchmarks
+{
+    public class AtmosBenchmark : ContentBenchmark
+    {
+        private string _tileName = "floor_steel";
+        private string _wallPrototype = "reinforced_wall";
+        private int _squareSize = 32;
+        private int _ticks = 30 * 60; // 1 minute in 30 TPS
+
+        private Dictionary<Gas, float> _gases = new Dictionary<Gas, float>()
+        {
+            { Gas.Oxygen, 10000f },
+            { Gas.Phoron, 10000f }
+        };
+
+        private float _temperature = 10000f;
+        private ServerIntegrationInstance _server;
+
+        private int HalfSquareSize => _squareSize / 2;
+
+        [Benchmark]
+        public void PhoronFireBenchmark()
+        {
+            bool CoordinateWall(int x) => x == -HalfSquareSize || x == (HalfSquareSize - 1);
+
+            _server.Loop(() =>
+            {
+                var mapManager = IoCManager.Resolve<IMapManager>();
+                var entityManager = IoCManager.Resolve<IEntityManager>();
+                var tileDefinitionManager = IoCManager.Resolve<ITileDefinitionManager>();
+                var pauseManager = IoCManager.Resolve<IPauseManager>();
+
+                foreach (var mapId in mapManager.GetAllMapIds())
+                {
+                    pauseManager.SetMapPaused(mapId, true);
+                }
+
+                var newMap = mapManager.CreateMap();
+                var grid = mapManager.CreateGrid(newMap);
+                var map = mapManager.GetMapEntity(newMap);
+                var gridEnt = entityManager.GetEntity(grid.GridEntityId);
+
+                var tile = new Tile(tileDefinitionManager[_tileName].TileId);
+
+                var gridAtmos = gridEnt.AddComponent<GridAtmosphereComponent>();
+
+                for (var x = -HalfSquareSize; x < HalfSquareSize; x++)
+                {
+                    for (var y = -HalfSquareSize; y < HalfSquareSize; y++)
+                    {
+                        var vector = new Vector2i(x, y);
+                        grid.SetTile(vector, tile);
+
+                        if (CoordinateWall(x) || CoordinateWall(y))
+                        {
+                            entityManager.SpawnEntity(_wallPrototype, new EntityCoordinates(gridEnt.Uid, vector));
+                        }
+                    }
+                }
+
+                gridAtmos.RepopulateTiles();
+                gridAtmos.Update(0f);
+
+                var zeroAtmos = gridAtmos.GetTile(Vector2i.Zero);
+
+                if (zeroAtmos == null)
+                    throw new NullReferenceException("Atmosphere at (0, 0) is null!");
+
+                foreach (var (gas, amount) in _gases)
+                {
+                    zeroAtmos.Air.AdjustMoles(gas, amount);
+                }
+
+                zeroAtmos.Air.Temperature = _temperature;
+
+                gridAtmos.AddActiveTile(zeroAtmos);
+
+                gridAtmos.Invalidate(Vector2i.Zero);
+            }, _ticks);
+        }
+    }
+}

--- a/Content.Benchmarks/Content.Benchmarks.csproj
+++ b/Content.Benchmarks/Content.Benchmarks.csproj
@@ -10,6 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
+  <Import Project="..\RobustToolbox\MSBuild\Robust.DefineConstants.targets" />
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
@@ -23,6 +24,7 @@
     <ProjectReference Include="..\RobustToolbox\Robust.Server\Robust.Server.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.Shared.Maths\Robust.Shared.Maths.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.Shared\Robust.Shared.csproj" />
-    <ProjectReference Include="..\RobustToolbox\Robust.UnitTesting\Robust.UnitTesting.csproj" />
   </ItemGroup>
+  <Import Project="..\RobustToolbox\MSBuild\Robust.Engine.targets" />
+  <Target Name="ContentAfterBuild" DependsOnTargets="ClientAfterBuild" AfterTargets="Build" />
 </Project>

--- a/Content.Benchmarks/ContentBenchmark.cs
+++ b/Content.Benchmarks/ContentBenchmark.cs
@@ -40,6 +40,13 @@ namespace Content.Benchmarks
             return base.StartServer(options);
         }
 
+        protected override ServerIntegrationInstance StartServerDummyTicker(ServerIntegrationOptions options = null)
+        {
+            options ??= new ServerContentIntegrationOption();
+            options.NotThreaded = true;
+            return base.StartServerDummyTicker(options);
+        }
+
         // I'm lazy and grabbed this method from here:
         // https://docs.microsoft.com/en-us/dotnet/standard/io/how-to-copy-directories
         private static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs = true)

--- a/Content.Benchmarks/ContentBenchmark.cs
+++ b/Content.Benchmarks/ContentBenchmark.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.IO;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 using Content.IntegrationTests;
+using NUnit.Framework;
 
 namespace Content.Benchmarks
 {

--- a/Content.Benchmarks/ContentBenchmark.cs
+++ b/Content.Benchmarks/ContentBenchmark.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Content.IntegrationTests;
+
+namespace Content.Benchmarks
+{
+    public class ContentBenchmark : ContentIntegrationTest
+    {
+        private string _robustResourceDest =
+            Path.Combine(Directory.GetCurrentDirectory(), "../../RobustToolbox/Resources/");
+        private string _resourceDest = Path.Combine(Directory.GetCurrentDirectory(), "../../Resources/");
+        private string _serverDest = Path.Combine(Directory.GetCurrentDirectory(), "../../bin/Content.Server/");
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            DirectoryCopy(Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../RobustToolbox/Resources"),
+                _robustResourceDest);
+            DirectoryCopy(Path.Combine(Directory.GetCurrentDirectory(), "../../../../../Content.Server"),
+                _serverDest);
+            DirectoryCopy(Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../Resources"),
+                _resourceDest);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            Directory.Delete(_robustResourceDest, true);
+            Directory.Delete(_serverDest, true);
+            Directory.Delete(_resourceDest, true);
+        }
+
+        protected override ServerIntegrationInstance StartServer(ServerIntegrationOptions options = null)
+        {
+            options ??= new ServerContentIntegrationOption();
+            options.NotThreaded = true;
+            return base.StartServer(options);
+        }
+
+        // I'm lazy and grabbed this method from here:
+        // https://docs.microsoft.com/en-us/dotnet/standard/io/how-to-copy-directories
+        private static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs = true)
+        {
+            // Get the subdirectories for the specified directory.
+            var dir = new DirectoryInfo(sourceDirName);
+
+            if (!dir.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    "Source directory does not exist or could not be found: "
+                    + sourceDirName);
+            }
+
+            var dirs = dir.GetDirectories();
+
+            // If the destination directory doesn't exist, create it.
+            Directory.CreateDirectory(destDirName);
+
+            // Get the files in the directory and copy them to the new location.
+            var files = dir.GetFiles();
+            foreach (var file in files)
+            {
+                var tempPath = Path.Combine(destDirName, file.Name);
+                file.CopyTo(tempPath, false);
+            }
+
+            // If copying subdirectories, copy them and their contents to new location.
+            if (copySubDirs)
+            {
+                foreach (var subdir in dirs)
+                {
+                    var tempPath = Path.Combine(destDirName, subdir.Name);
+                    DirectoryCopy(subdir.FullName, tempPath, copySubDirs);
+                }
+            }
+        }
+    }
+}

--- a/Content.Benchmarks/ContentBenchmark.cs
+++ b/Content.Benchmarks/ContentBenchmark.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Engines;
 using Content.IntegrationTests;
-using NUnit.Framework;
 
 namespace Content.Benchmarks
 {
@@ -14,7 +11,10 @@ namespace Content.Benchmarks
         private string _resourceDest = Path.Combine(Directory.GetCurrentDirectory(), "../../Resources/");
         private string _serverDest = Path.Combine(Directory.GetCurrentDirectory(), "../../bin/Content.Server/");
 
-        [GlobalSetup]
+        /// <summary>
+        ///     Copies all resources to the benchmark directory.
+        ///     Don't forget to call this in your GlobalSetup method!
+        /// </summary>
         public void Setup()
         {
             DirectoryCopy(Path.Combine(Directory.GetCurrentDirectory(), "../../../../../../RobustToolbox/Resources"),

--- a/Content.IntegrationTests/ContentIntegrationTest.cs
+++ b/Content.IntegrationTests/ContentIntegrationTest.cs
@@ -60,7 +60,7 @@ namespace Content.IntegrationTests
             return base.StartServer(options);
         }
 
-        protected ServerIntegrationInstance StartServerDummyTicker(ServerIntegrationOptions options = null)
+        protected virtual ServerIntegrationInstance StartServerDummyTicker(ServerIntegrationOptions options = null)
         {
             options ??= new ServerIntegrationOptions();
             options.BeforeStart += () =>


### PR DESCRIPTION
Requires space-wizards/RobustToolbox#1385
In the atmos benchmark, we create an empty 32x32 rectangle surrounded by airtight walls.
We then spawn a set amount of phoron and oxygen in the middle, and set it to a very high temperature so it catches fire.
We finally run the simulation for 1800 ticks and stop the server once afterwards.