### PR TITLE
Removed Mop Bucket from JanitorClosetFilled and added a Mop Bucket inside the janitor spawn room.

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -47577,4 +47577,11 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 4187
+  type: MopBucket
+  components:
+  - parent: 855
+    pos: -21.5,10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 ...

--- a/Resources/Prototypes/Catalog/Fills/lockers.yml
+++ b/Resources/Prototypes/Catalog/Fills/lockers.yml
@@ -199,7 +199,6 @@
   - type: StorageFill
     contents:
       - name: MopItem
-      - name: MopBucket
       - name: WetFloorSign
         amount: 3
       - name: TrashBag


### PR DESCRIPTION
Like title, removed the bucket from the locker and added one inside the janitor room.
Fixes #2514 