### PR TITLE
Use MousePositionScaled instead of absolute MousePosition to fix UI-scaling issues

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/ExamineSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/ExamineSystem.cs
@@ -25,7 +25,6 @@ namespace Content.Client.GameObjects.EntitySystems
     [UsedImplicitly]
     internal sealed class ExamineSystem : ExamineSystemShared
     {
-        [Dependency] private readonly IInputManager _inputManager = default!;
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;

--- a/Content.Client/GameObjects/EntitySystems/ExamineSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/ExamineSystem.cs
@@ -73,7 +73,7 @@ namespace Content.Client.GameObjects.EntitySystems
             const float minWidth = 300;
             CloseTooltip();
 
-            var popupPos = _inputManager.MouseScreenPosition;
+            var popupPos = _userInterfaceManager.MousePositionScaled;
 
             // Actually open the tooltip.
             _examineTooltipOpen = new Popup();

--- a/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
@@ -183,7 +183,7 @@ namespace Content.Client.GameObjects.EntitySystems
             _userInterfaceManager.ModalRoot.AddChild(_currentEntityList);
 
             var size = _currentEntityList.List.CombinedMinimumSize;
-            var box = UIBox2.FromDimensions(args.ScreenCoordinates.Position, size);
+            var box = UIBox2.FromDimensions(_userInterfaceManager.MousePositionScaled, size);
             _currentEntityList.Open(box);
 
             return true;
@@ -191,7 +191,7 @@ namespace Content.Client.GameObjects.EntitySystems
 
         private void OnContextButtonPressed(IEntity entity)
         {
-            OpenContextMenu(entity, new ScreenCoordinates(_inputManager.MouseScreenPosition));
+            OpenContextMenu(entity, new ScreenCoordinates(_userInterfaceManager.MousePositionScaled));
         }
 
         private void FillEntityPopup(VerbSystemMessages.VerbsResponseMessage msg)


### PR DESCRIPTION
https://streamable.com/bo9r6d

Specifically fixes the examine and right-click menus appearing in the wrong locations when using UI scaling.