### PR TITLE
Set requiredSlipSpeed default value to 0.1 to avoid slipping while still.

### DIFF
--- a/Content.Shared/GameObjects/Components/Movement/SharedSlipperyComponent.cs
+++ b/Content.Shared/GameObjects/Components/Movement/SharedSlipperyComponent.cs
@@ -149,7 +149,7 @@ namespace Content.Shared.GameObjects.Components.Movement
 
             serializer.DataField(this, x => x.ParalyzeTime, "paralyzeTime", 3f);
             serializer.DataField(this, x  => x.IntersectPercentage, "intersectPercentage", 0.3f);
-            serializer.DataField(this, x => x.RequiredSlipSpeed, "requiredSlipSpeed", 0f);
+            serializer.DataField(this, x => x.RequiredSlipSpeed, "requiredSlipSpeed", 0.1f);
             serializer.DataField(this, x => x.LaunchForwardsMultiplier, "launchForwardsMultiplier", 1f);
             serializer.DataField(this, x => x.Slippery, "slippery", true);
         }


### PR DESCRIPTION
Fixes #2569 
Sets the default slip speed to 0.1 in order to fix the character slipping if a SlipperyComponent spawns under its feets while not moving.