### PR TITLE
Added threshold to DoAfter's user and target movement checks

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/DoAfter/DoAfterSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/DoAfter/DoAfterSystem.cs
@@ -114,7 +114,7 @@ namespace Content.Client.GameObjects.EntitySystems.DoAfter
                     // Predictions
                     if (doAfter.BreakOnUserMove)
                     {
-                        if (userGrid != doAfter.UserGrid)
+                        if (!userGrid.InRange(EntityManager, doAfter.UserGrid, doAfter.MovementThreshold))
                         {
                             comp.Cancel(id, currentTime);
                             continue;
@@ -123,7 +123,7 @@ namespace Content.Client.GameObjects.EntitySystems.DoAfter
 
                     if (doAfter.BreakOnTargetMove)
                     {
-                        if (EntityManager.TryGetEntity(doAfter.TargetUid, out var targetEntity) && targetEntity.Transform.Coordinates != doAfter.TargetGrid)
+                        if (EntityManager.TryGetEntity(doAfter.TargetUid, out var targetEntity) && !targetEntity.Transform.Coordinates.InRange(EntityManager, doAfter.TargetGrid, doAfter.MovementThreshold))
                         {
                             comp.Cancel(id, currentTime);
                             continue;

--- a/Content.Server/GameObjects/Components/DoAfterComponent.cs
+++ b/Content.Server/GameObjects/Components/DoAfterComponent.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System.Collections.Generic;
 using Content.Server.GameObjects.EntitySystems.DoAfter;
 using Content.Shared.GameObjects.Components;
@@ -31,6 +31,7 @@ namespace Content.Server.GameObjects.Components
                     doAfter.EventArgs.Delay,
                     doAfter.EventArgs.BreakOnUserMove,
                     doAfter.EventArgs.BreakOnTargetMove,
+                    doAfter.EventArgs.MovementThreshold,
                     doAfter.EventArgs.Target?.Uid ?? EntityUid.Invalid);
                 
                 toAdd.Add(clientDoAfter);

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
@@ -119,7 +119,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
 
             // TODO :Handle inertia in space.
             if (EventArgs.BreakOnUserMove && !EventArgs.User.Transform.Coordinates.InRange(
-                EventArgs.User.EntityManager,UserGrid, EventArgs.MovementThreshold))
+                EventArgs.User.EntityManager, UserGrid, EventArgs.MovementThreshold))
             {
                 return true;
             }

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Threading.Tasks;
 using Content.Server.GameObjects.Components.GUI;
@@ -118,12 +118,14 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
             }
 
             // TODO :Handle inertia in space.
-            if (EventArgs.BreakOnUserMove && EventArgs.User.Transform.Coordinates != UserGrid)
+            if (EventArgs.BreakOnUserMove && !EventArgs.User.Transform.Coordinates.InRange(
+                EventArgs.User.EntityManager,UserGrid, EventArgs.MovementThreshold))
             {
                 return true;
             }
 
-            if (EventArgs.BreakOnTargetMove && EventArgs.Target!.Transform.Coordinates != TargetGrid)
+            if (EventArgs.BreakOnTargetMove && !EventArgs.Target!.Transform.Coordinates.InRange(
+                EventArgs.User.EntityManager, TargetGrid, EventArgs.MovementThreshold))
             {
                 return true;
             }

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterEventArgs.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Threading;
 using Content.Shared.Physics;
@@ -60,6 +60,11 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
         /// </summary>
         public bool BreakOnTargetMove { get; set; }
 
+        /// <summary>
+        ///     Threshold for user and target movement
+        /// </summary>
+        public float MovementThreshold { get; set; }
+
         public bool BreakOnDamage { get; set; }
         public bool BreakOnStun { get; set; }
 
@@ -86,6 +91,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
             Delay = delay;
             CancelToken = cancelToken;
             Target = target;
+            MovementThreshold = .1f;
 
             if (Target == null)
             {

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterEventArgs.cs
@@ -91,7 +91,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
             Delay = delay;
             CancelToken = cancelToken;
             Target = target;
-            MovementThreshold = .1f;
+            MovementThreshold = 0.1f;
 
             if (Target == null)
             {

--- a/Content.Shared/GameObjects/Components/SharedDoAfterComponent.cs
+++ b/Content.Shared/GameObjects/Components/SharedDoAfterComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -59,7 +59,9 @@ namespace Content.Shared.GameObjects.Components
 
         public bool BreakOnTargetMove { get; }
 
-        public ClientDoAfter(byte id, EntityCoordinates userGrid, EntityCoordinates targetGrid, TimeSpan startTime, float delay, bool breakOnUserMove, bool breakOnTargetMove, EntityUid targetUid = default)
+        public float MovementThreshold { get; }
+
+        public ClientDoAfter(byte id, EntityCoordinates userGrid, EntityCoordinates targetGrid, TimeSpan startTime, float delay, bool breakOnUserMove, bool breakOnTargetMove, float movementThreshold, EntityUid targetUid = default)
         {
             ID = id;
             UserGrid = userGrid;
@@ -68,6 +70,7 @@ namespace Content.Shared.GameObjects.Components
             Delay = delay;
             BreakOnUserMove = breakOnUserMove;
             BreakOnTargetMove = breakOnTargetMove;
+            MovementThreshold = movementThreshold;
             TargetUid = targetUid;
         }
     }


### PR DESCRIPTION
Fixes floating-point precision issues between client and server
Default value set to 0.1f in DoAfterEventArgs, value also sent to the client