### PR TITLE
Execute BlockGame game actions only if _running is true, added localization functions and italian strings to the blockgame UI

### DIFF
--- a/Content.Client/Arcade/BlockGameMenu.cs
+++ b/Content.Client/Arcade/BlockGameMenu.cs
@@ -11,6 +11,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
@@ -190,6 +191,7 @@ namespace Content.Client.Arcade
 
             _finalNewGameButton = new Button
             {
+                // Text = Loc.GetString("New Game"),
                 Text = "New Game",
                 TextAlign = Label.AlignMode.Center
             };

--- a/Content.Client/Arcade/BlockGameMenu.cs
+++ b/Content.Client/Arcade/BlockGameMenu.cs
@@ -56,7 +56,7 @@ namespace Content.Client.Arcade
 
         public BlockGameMenu(BlockGameBoundUserInterface owner)
         {
-            Title = "Nanotrasen Block Game";
+            Title = Loc.GetString("Nanotrasen Block Game");
             _owner = owner;
 
             var resourceCache = IoCManager.Resolve<IResourceCache>();
@@ -536,7 +536,7 @@ namespace Content.Client.Arcade
             List<BlockGameMessages.HighScoreEntry> globalHighscores)
         {
             var localHighscoreText = Loc.GetString("Station") + ":\n";
-            var globalHighscoreText = "Nanotrasen:\n";
+            var globalHighscoreText = Loc.GetString("Nanotrasen") + ":\n";
             for (int i = 0; i < 5; i++)
             {
                 localHighscoreText += $"#{i + 1} " + (localHighscores.Count > i

--- a/Content.Client/Arcade/BlockGameMenu.cs
+++ b/Content.Client/Arcade/BlockGameMenu.cs
@@ -116,7 +116,7 @@ namespace Content.Client.Arcade
                 SizeFlagsVertical = SizeFlags.ShrinkCenter
             };
 
-            menuContainer.AddChild(new Label{Text = "Highscores"});
+            menuContainer.AddChild(new Label{Text = Loc.GetString("Highscores")});
             menuContainer.AddChild(new Control{CustomMinimumSize = new Vector2(1,10)});
 
             var highScoreBox = new HBoxContainer();
@@ -136,7 +136,7 @@ namespace Content.Client.Arcade
             menuContainer.AddChild(new Control{CustomMinimumSize = new Vector2(1,10)});
             _highscoreBackButton = new Button
             {
-                Text = "Back",
+                Text = Loc.GetString("Back"),
                 TextAlign = Label.AlignMode.Center
             };
             _highscoreBackButton.OnPressed += (e) => _owner.SendAction(BlockGamePlayerAction.Pause);
@@ -181,7 +181,7 @@ namespace Content.Client.Arcade
                 SizeFlagsVertical = SizeFlags.ShrinkCenter
             };
 
-            menuContainer.AddChild(new Label{Text = "Gameover!",Align = Label.AlignMode.Center});
+            menuContainer.AddChild(new Label{Text = Loc.GetString("Gameover!"),Align = Label.AlignMode.Center});
             menuContainer.AddChild(new Control{CustomMinimumSize = new Vector2(1,10)});
 
 
@@ -191,8 +191,7 @@ namespace Content.Client.Arcade
 
             _finalNewGameButton = new Button
             {
-                // Text = Loc.GetString("New Game"),
-                Text = "New Game",
+                Text = Loc.GetString("New Game"),
                 TextAlign = Label.AlignMode.Center
             };
             _finalNewGameButton.OnPressed += (e) =>
@@ -243,7 +242,7 @@ namespace Content.Client.Arcade
 
             _newGameButton = new Button
             {
-                Text = "New Game",
+                Text = Loc.GetString("New Game"),
                 TextAlign = Label.AlignMode.Center
             };
             _newGameButton.OnPressed += (e) =>
@@ -255,7 +254,7 @@ namespace Content.Client.Arcade
 
             _scoreBoardButton = new Button
             {
-                Text = "Scoreboard",
+                Text = Loc.GetString("Scoreboard"),
                 TextAlign = Label.AlignMode.Center
             };
             _scoreBoardButton.OnPressed += (e) => _owner.SendAction(BlockGamePlayerAction.ShowHighscores);
@@ -265,7 +264,7 @@ namespace Content.Client.Arcade
 
             _unpauseButton = new Button
             {
-                Text = "Unpause",
+                Text = Loc.GetString("Unpause"),
                 TextAlign = Label.AlignMode.Center,
                 Visible = false
             };
@@ -343,7 +342,7 @@ namespace Content.Client.Arcade
 
             _pauseButton = new Button
             {
-                Text = "Pause",
+                Text = Loc.GetString("Pause"),
                 TextAlign = Label.AlignMode.Center
             };
             _pauseButton.OnPressed += (e) => TryPause();
@@ -415,7 +414,7 @@ namespace Content.Client.Arcade
             nextBlockPanel.AddChild(nextCenterContainer);
             grid.AddChild(nextBlockPanel);
 
-            grid.AddChild(new Label{Text = "Next", Align = Label.AlignMode.Center});
+            grid.AddChild(new Label{Text = Loc.GetString("Next"), Align = Label.AlignMode.Center});
 
             return grid;
         }
@@ -453,7 +452,7 @@ namespace Content.Client.Arcade
             holdBlockPanel.AddChild(holdCenterContainer);
             grid.AddChild(holdBlockPanel);
 
-            grid.AddChild(new Label{Text = "Hold", Align = Label.AlignMode.Center});
+            grid.AddChild(new Label{Text = Loc.GetString("Hold"), Align = Label.AlignMode.Center});
 
             return grid;
         }
@@ -520,23 +519,23 @@ namespace Content.Client.Arcade
         {
             var globalPlacementText = globalPlacement == null ? "-" : $"#{globalPlacement}";
             var localPlacementText = localPlacement == null ? "-" : $"#{localPlacement}";
-            _finalScoreLabel.Text = $"Global: {globalPlacementText}\nLocal: {localPlacementText}\nPoints: {amount}";
+            _finalScoreLabel.Text = Loc.GetString("Global") + $": {globalPlacementText}\n" + Loc.GetString("Local") + $": {localPlacementText}\n" + Loc.GetString("Points") + $": {amount}";
         }
 
         public void UpdatePoints(int points)
         {
-            _pointsLabel.Text = $"Points: {points}";
+            _pointsLabel.Text = Loc.GetString("Points") + $": {points}";
         }
 
         public void UpdateLevel(int level)
         {
-            _levelLabel.Text = $"Level {level + 1}";
+            _levelLabel.Text = Loc.GetString("Level") + $" { level + 1}";
         }
 
         public void UpdateHighscores(List<BlockGameMessages.HighScoreEntry> localHighscores,
             List<BlockGameMessages.HighScoreEntry> globalHighscores)
         {
-            var localHighscoreText = "Station:\n";
+            var localHighscoreText = Loc.GetString("Station") + ":\n";
             var globalHighscoreText = "Nanotrasen:\n";
             for (int i = 0; i < 5; i++)
             {

--- a/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
+++ b/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
@@ -226,7 +226,6 @@ namespace Content.Server.GameObjects.Components.Arcade
             private const float _pressCheckSpeed = 0.08f;
 
             private bool _running;
-            public bool Running => _running;
             public bool Paused => !(_running && _started);
             private bool _started;
             public bool Started => _started;

--- a/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
+++ b/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
@@ -545,14 +545,8 @@ namespace Content.Server.GameObjects.Components.Arcade
                         case BlockGamePlayerAction.StartLeft:
                             _leftPressed = true;
                             break;
-                        case BlockGamePlayerAction.EndLeft:
-                            _leftPressed = false;
-                            break;
                         case BlockGamePlayerAction.StartRight:
                             _rightPressed = true;
-                            break;
-                        case BlockGamePlayerAction.EndRight:
-                            _rightPressed = false;
                             break;
                         case BlockGamePlayerAction.Rotate:
                             TrySetRotation(Next(_currentRotation, false));
@@ -563,9 +557,6 @@ namespace Content.Server.GameObjects.Components.Arcade
                         case BlockGamePlayerAction.SoftdropStart:
                             _softDropPressed = true;
                             if (_accumulatedFieldFrameTime > Speed) _accumulatedFieldFrameTime = Speed; //to prevent jumps
-                            break;
-                        case BlockGamePlayerAction.SoftdropEnd:
-                            _softDropPressed = false;
                             break;
                         case BlockGamePlayerAction.Harddrop:
                             PerformHarddrop();
@@ -578,6 +569,15 @@ namespace Content.Server.GameObjects.Components.Arcade
 
                 switch (action)
                 {
+                    case BlockGamePlayerAction.EndLeft:
+                        _leftPressed = false;
+                        break;
+                    case BlockGamePlayerAction.EndRight:
+                        _rightPressed = false;
+                        break;
+                    case BlockGamePlayerAction.SoftdropEnd:
+                        _softDropPressed = false;
+                        break;
                     case BlockGamePlayerAction.Pause:
                         _running = false;
                         _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause, _started));

--- a/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
+++ b/Content.Server/GameObjects/Components/Arcade/BlockGameArcadeComponent.cs
@@ -226,6 +226,7 @@ namespace Content.Server.GameObjects.Components.Arcade
             private const float _pressCheckSpeed = 0.08f;
 
             private bool _running;
+            public bool Running => _running;
             public bool Paused => !(_running && _started);
             private bool _started;
             public bool Started => _started;
@@ -538,36 +539,46 @@ namespace Content.Server.GameObjects.Components.Arcade
 
             public void ProcessInput(BlockGamePlayerAction action)
             {
+                if (_running)
+                {
+                    switch (action)
+                    {
+                        case BlockGamePlayerAction.StartLeft:
+                            _leftPressed = true;
+                            break;
+                        case BlockGamePlayerAction.EndLeft:
+                            _leftPressed = false;
+                            break;
+                        case BlockGamePlayerAction.StartRight:
+                            _rightPressed = true;
+                            break;
+                        case BlockGamePlayerAction.EndRight:
+                            _rightPressed = false;
+                            break;
+                        case BlockGamePlayerAction.Rotate:
+                            TrySetRotation(Next(_currentRotation, false));
+                            break;
+                        case BlockGamePlayerAction.CounterRotate:
+                            TrySetRotation(Next(_currentRotation, true));
+                            break;
+                        case BlockGamePlayerAction.SoftdropStart:
+                            _softDropPressed = true;
+                            if (_accumulatedFieldFrameTime > Speed) _accumulatedFieldFrameTime = Speed; //to prevent jumps
+                            break;
+                        case BlockGamePlayerAction.SoftdropEnd:
+                            _softDropPressed = false;
+                            break;
+                        case BlockGamePlayerAction.Harddrop:
+                            PerformHarddrop();
+                            break;
+                        case BlockGamePlayerAction.Hold:
+                            HoldPiece();
+                            break;
+                    }
+                }
+
                 switch (action)
                 {
-                    case BlockGamePlayerAction.StartLeft:
-                        _leftPressed = true;
-                        break;
-                    case BlockGamePlayerAction.EndLeft:
-                        _leftPressed = false;
-                        break;
-                    case BlockGamePlayerAction.StartRight:
-                        _rightPressed = true;
-                        break;
-                    case BlockGamePlayerAction.EndRight:
-                        _rightPressed = false;
-                        break;
-                    case BlockGamePlayerAction.Rotate:
-                        TrySetRotation(Next(_currentRotation, false));
-                        break;
-                    case BlockGamePlayerAction.CounterRotate:
-                        TrySetRotation(Next(_currentRotation, true));
-                        break;
-                    case BlockGamePlayerAction.SoftdropStart:
-                        _softDropPressed = true;
-                        if (_accumulatedFieldFrameTime > Speed) _accumulatedFieldFrameTime = Speed; //to prevent jumps
-                        break;
-                    case BlockGamePlayerAction.SoftdropEnd:
-                        _softDropPressed = false;
-                        break;
-                    case BlockGamePlayerAction.Harddrop:
-                        PerformHarddrop();
-                        break;
                     case BlockGamePlayerAction.Pause:
                         _running = false;
                         _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Pause, _started));
@@ -578,9 +589,6 @@ namespace Content.Server.GameObjects.Components.Arcade
                             _running = true;
                             _component.UserInterface?.SendMessage(new BlockGameMessages.BlockGameSetScreenMessage(BlockGameMessages.BlockGameScreen.Game));
                         }
-                        break;
-                    case BlockGamePlayerAction.Hold:
-                        HoldPiece();
                         break;
                     case BlockGamePlayerAction.ShowHighscores:
                         _running = false;

--- a/Resources/Locale/it-IT/blockgame.yml
+++ b/Resources/Locale/it-IT/blockgame.yml
@@ -1,3 +1,42 @@
 
 - msgid: New Game
   msgstr: Nuova Partita
+  
+- msgid: Scoreboard
+  msgstr: Classifica
+  
+- msgid: Pause
+  msgstr: Pausa
+  
+- msgid: Unpause
+  msgstr: Riprendi
+  
+- msgid: Gameover!
+  msgstr: Partita Finita!
+
+- msgid: Highscores
+  msgstr: Record
+  
+- msgid: Back
+  msgstr: Indietro
+  
+- msgid: Next
+  msgstr: Prossimo
+
+- msgid: Hold
+  msgstr: Conservato
+  
+- msgid: Global
+  msgstr: Globale
+  
+- msgid: Local
+  msgstr: Locale
+  
+- msgid: Points
+  msgstr: Punti
+  
+- msgid: Level
+  msgstr: Livello
+  
+- msgid: Station
+  msgstr: Stazione

--- a/Resources/Locale/it-IT/blockgame.yml
+++ b/Resources/Locale/it-IT/blockgame.yml
@@ -1,0 +1,3 @@
+
+- msgid: New Game
+  msgstr: Nuova Partita


### PR DESCRIPTION
Fixes #2480 
Most of the BlockGamePlayerAction can now be executed only if "_running" is true, to avoid being able to control the game before its start.
Added Loc.GetString() to BlockGameMenu UI strings and Italian localization file for them.