### PR TITLE
Prevent ReagentUnit from having negative values using unsigned integer

### DIFF
--- a/Content.Client/GameObjects/Components/Chemistry/ReagentDispenser/ReagentDispenserWindow.cs
+++ b/Content.Client/GameObjects/Components/Chemistry/ReagentDispenser/ReagentDispenserWindow.cs
@@ -204,7 +204,7 @@ namespace Content.Client.GameObjects.Components.Chemistry.ReagentDispenser
                 EjectButton.Disabled = true;
             }
 
-            switch (castState.SelectedDispenseAmount.Int())
+            switch (castState.SelectedDispenseAmount.UInt())
             {
                 case 1:
                     DispenseButton1.Pressed = true;

--- a/Content.Client/GameObjects/EntitySystems/DoAfter/DoAfterSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/DoAfter/DoAfterSystem.cs
@@ -114,7 +114,7 @@ namespace Content.Client.GameObjects.EntitySystems.DoAfter
                     // Predictions
                     if (doAfter.BreakOnUserMove)
                     {
-                        if (userGrid != doAfter.UserGrid)
+                        if (!userGrid.InRange(EntityManager, doAfter.UserGrid, doAfter.MovementThreshold))
                         {
                             comp.Cancel(id, currentTime);
                             continue;
@@ -123,7 +123,7 @@ namespace Content.Client.GameObjects.EntitySystems.DoAfter
 
                     if (doAfter.BreakOnTargetMove)
                     {
-                        if (EntityManager.TryGetEntity(doAfter.TargetUid, out var targetEntity) && targetEntity.Transform.Coordinates != doAfter.TargetGrid)
+                        if (EntityManager.TryGetEntity(doAfter.TargetUid, out var targetEntity) && !targetEntity.Transform.Coordinates.InRange(EntityManager, doAfter.TargetGrid, doAfter.MovementThreshold))
                         {
                             comp.Cancel(id, currentTime);
                             continue;

--- a/Content.Server/AI/Utility/Considerations/Nutrition/Drink/DrinkValueCon.cs
+++ b/Content.Server/AI/Utility/Considerations/Nutrition/Drink/DrinkValueCon.cs
@@ -1,4 +1,4 @@
-using Content.Server.AI.WorldState;
+﻿using Content.Server.AI.WorldState;
 using Content.Server.AI.WorldState.States;
 using Content.Server.GameObjects.Components.Chemistry;
 
@@ -15,12 +15,12 @@ namespace Content.Server.AI.Utility.Considerations.Nutrition.Drink
                 return 0.0f;
             }
 
-            var nutritionValue = 0;
+            uint nutritionValue = 0;
 
             foreach (var reagent in drink.ReagentList)
             {
                 // TODO
-                nutritionValue += (reagent.Quantity * 30).Int();
+                nutritionValue += (reagent.Quantity * 30).UInt();
             }
 
             return nutritionValue / 1000.0f;

--- a/Content.Server/AI/Utility/Considerations/Nutrition/Food/FoodValueCon.cs
+++ b/Content.Server/AI/Utility/Considerations/Nutrition/Food/FoodValueCon.cs
@@ -1,4 +1,4 @@
-using Content.Server.AI.WorldState;
+﻿using Content.Server.AI.WorldState;
 using Content.Server.AI.WorldState.States;
 using Content.Server.GameObjects.Components.Chemistry;
 
@@ -15,12 +15,12 @@ namespace Content.Server.AI.Utility.Considerations.Nutrition.Food
                 return 0.0f;
             }
 
-            var nutritionValue = 0;
+            uint nutritionValue = 0;
 
             foreach (var reagent in food.ReagentList)
             {
                 // TODO
-                nutritionValue += (reagent.Quantity * 30).Int();
+                nutritionValue += (reagent.Quantity * 30).UInt();
             }
 
             return nutritionValue / 1000.0f;

--- a/Content.Server/GameObjects/Components/DoAfterComponent.cs
+++ b/Content.Server/GameObjects/Components/DoAfterComponent.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System.Collections.Generic;
 using Content.Server.GameObjects.EntitySystems.DoAfter;
 using Content.Shared.GameObjects.Components;
@@ -31,6 +31,7 @@ namespace Content.Server.GameObjects.Components
                     doAfter.EventArgs.Delay,
                     doAfter.EventArgs.BreakOnUserMove,
                     doAfter.EventArgs.BreakOnTargetMove,
+                    doAfter.EventArgs.MovementThreshold,
                     doAfter.EventArgs.Target?.Uid ?? EntityUid.Invalid);
                 
                 toAdd.Add(clientDoAfter);

--- a/Content.Server/GameObjects/Components/Fluids/SprayComponent.cs
+++ b/Content.Server/GameObjects/Components/Fluids/SprayComponent.cs
@@ -135,7 +135,7 @@ namespace Content.Server.GameObjects.Components.Fluids
             var threeQuarters = direction * 0.75f;
             var quarter = direction * 0.25f;
 
-            var amount = Math.Max(Math.Min((contents.CurrentVolume / _transferAmount).Int(), _vaporAmount), 1);
+            var amount = Math.Max(Math.Min((contents.CurrentVolume / _transferAmount).UInt(), _vaporAmount), 1);
 
             var spread = _vaporSpread / amount;
 

--- a/Content.Server/GameObjects/Components/Kitchen/MicrowaveComponent.cs
+++ b/Content.Server/GameObjects/Components/Kitchen/MicrowaveComponent.cs
@@ -446,7 +446,7 @@ namespace Content.Server.GameObjects.Components.Kitchen
                     return MicrowaveSuccessState.RecipeFail;
                 }
 
-                if (amount.Int() < reagent.Value)
+                if (amount.UInt() < reagent.Value)
                 {
                     return MicrowaveSuccessState.RecipeFail;
                 }

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
@@ -119,7 +119,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
 
             // TODO :Handle inertia in space.
             if (EventArgs.BreakOnUserMove && !EventArgs.User.Transform.Coordinates.InRange(
-                EventArgs.User.EntityManager,UserGrid, EventArgs.MovementThreshold))
+                EventArgs.User.EntityManager, UserGrid, EventArgs.MovementThreshold))
             {
                 return true;
             }

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Threading.Tasks;
 using Content.Server.GameObjects.Components.GUI;
@@ -118,12 +118,14 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
             }
 
             // TODO :Handle inertia in space.
-            if (EventArgs.BreakOnUserMove && EventArgs.User.Transform.Coordinates != UserGrid)
+            if (EventArgs.BreakOnUserMove && !EventArgs.User.Transform.Coordinates.InRange(
+                EventArgs.User.EntityManager,UserGrid, EventArgs.MovementThreshold))
             {
                 return true;
             }
 
-            if (EventArgs.BreakOnTargetMove && EventArgs.Target!.Transform.Coordinates != TargetGrid)
+            if (EventArgs.BreakOnTargetMove && !EventArgs.Target!.Transform.Coordinates.InRange(
+                EventArgs.User.EntityManager, TargetGrid, EventArgs.MovementThreshold))
             {
                 return true;
             }

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterEventArgs.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Threading;
 using Content.Shared.Physics;
@@ -60,6 +60,11 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
         /// </summary>
         public bool BreakOnTargetMove { get; set; }
 
+        /// <summary>
+        ///     Threshold for user and target movement
+        /// </summary>
+        public float MovementThreshold { get; set; }
+
         public bool BreakOnDamage { get; set; }
         public bool BreakOnStun { get; set; }
 
@@ -86,6 +91,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
             Delay = delay;
             CancelToken = cancelToken;
             Target = target;
+            MovementThreshold = .1f;
 
             if (Target == null)
             {

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterEventArgs.cs
@@ -91,7 +91,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
             Delay = delay;
             CancelToken = cancelToken;
             Target = target;
-            MovementThreshold = .1f;
+            MovementThreshold = 0.1f;
 
             if (Target == null)
             {

--- a/Content.Shared/Chemistry/ReagentUnit.cs
+++ b/Content.Shared/Chemistry/ReagentUnit.cs
@@ -8,10 +8,10 @@ namespace Content.Shared.Chemistry
     [Serializable]
     public struct ReagentUnit : ISelfSerialize, IComparable<ReagentUnit>, IEquatable<ReagentUnit>
     {
-        private int _value;
+        private uint _value;
         private static readonly int Shift = 2;
 
-        public static ReagentUnit MaxValue { get; } = new ReagentUnit(int.MaxValue);
+        public static ReagentUnit MaxValue { get; } = new ReagentUnit(uint.MaxValue);
         public static ReagentUnit Epsilon { get; } = new ReagentUnit(1);
         public static ReagentUnit Zero { get; } = new ReagentUnit(0);
 
@@ -20,14 +20,14 @@ namespace Content.Shared.Chemistry
             return _value / Math.Pow(10, Shift);
         }
 
-        private ReagentUnit(int value)
+        private ReagentUnit(uint value)
         {
             _value = value;
         }
 
-        public static ReagentUnit New(int value)
+        public static ReagentUnit New(uint value)
         {
-            return new ReagentUnit(value * (int) Math.Pow(10, Shift));
+            return new ReagentUnit(value * (uint) Math.Pow(10, Shift));
         }
 
         public static ReagentUnit New(float value)
@@ -35,14 +35,29 @@ namespace Content.Shared.Chemistry
             return new ReagentUnit(FromFloat(value));
         }
 
-        private static int FromFloat(float value)
+        private static uint FromFloat(float value)
         {
-            return (int) MathF.Round(value * MathF.Pow(10, Shift), MidpointRounding.AwayFromZero);
+            float v = MathF.Round(value * MathF.Pow(10, Shift), MidpointRounding.AwayFromZero);
+            if (v < 0)
+            {
+                return 0;
+            }
+            return (uint) v;
         }
 
         public static ReagentUnit New(double value)
         {
-            return new ReagentUnit((int) Math.Round(value * Math.Pow(10, Shift), MidpointRounding.AwayFromZero));
+            return new ReagentUnit(FromDouble(value));
+        }
+
+        private static uint FromDouble(double value)
+        {
+            double v = Math.Round(value * Math.Pow(10, Shift), MidpointRounding.AwayFromZero);
+            if (v < 0)
+            {
+                return 0;
+            }
+            return (uint) v;
         }
 
         public static ReagentUnit New(string value)
@@ -57,13 +72,18 @@ namespace Content.Shared.Chemistry
 
         public static ReagentUnit operator +(ReagentUnit a) => a;
 
-        public static ReagentUnit operator -(ReagentUnit a) => new ReagentUnit(-a._value);
-
         public static ReagentUnit operator +(ReagentUnit a, ReagentUnit b)
             => new ReagentUnit(a._value + b._value);
 
         public static ReagentUnit operator -(ReagentUnit a, ReagentUnit b)
-            => a + -b;
+        {
+            if (b._value > a._value)
+            {
+                // underflow
+                return ReagentUnit.Zero;
+            }
+            return new ReagentUnit(a._value - b._value);
+        }
 
         public static ReagentUnit operator *(ReagentUnit a, ReagentUnit b)
         {
@@ -84,7 +104,7 @@ namespace Content.Shared.Chemistry
             return New(aD * b);
         }
 
-        public static ReagentUnit operator *(ReagentUnit a, int b)
+        public static ReagentUnit operator *(ReagentUnit a, uint b)
         {
             return new ReagentUnit(a._value * b);
         }
@@ -100,34 +120,34 @@ namespace Content.Shared.Chemistry
             return New(aD / bD);
         }
 
-        public static bool operator <=(ReagentUnit a, int b)
+        public static bool operator <=(ReagentUnit a, uint b)
         {
             return a.ShiftDown() <= b;
         }
 
-        public static bool operator >=(ReagentUnit a, int b)
+        public static bool operator >=(ReagentUnit a, uint b)
         {
             return a.ShiftDown() >= b;
         }
 
-        public static bool operator <(ReagentUnit a, int b)
+        public static bool operator <(ReagentUnit a, uint b)
         {
             return a.ShiftDown() < b;
         }
 
-        public static bool operator >(ReagentUnit a, int b)
+        public static bool operator >(ReagentUnit a, uint b)
         {
             return a.ShiftDown() > b;
         }
 
-        public static bool operator ==(ReagentUnit a, int b)
+        public static bool operator ==(ReagentUnit a, uint b)
         {
-            return a.Int() == b;
+            return a.UInt() == b;
         }
 
-        public static bool operator !=(ReagentUnit a, int b)
+        public static bool operator !=(ReagentUnit a, uint b)
         {
-            return a.Int() != b;
+            return a.UInt() != b;
         }
 
         public static bool operator ==(ReagentUnit a, ReagentUnit b)
@@ -170,9 +190,9 @@ namespace Content.Shared.Chemistry
             return ShiftDown();
         }
 
-        public int Int()
+        public uint UInt()
         {
-            return (int) ShiftDown();
+            return (uint) ShiftDown();
         }
 
         public static ReagentUnit Min(params ReagentUnit[] reagentUnits)

--- a/Content.Shared/GameObjects/Components/SharedDoAfterComponent.cs
+++ b/Content.Shared/GameObjects/Components/SharedDoAfterComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -59,7 +59,9 @@ namespace Content.Shared.GameObjects.Components
 
         public bool BreakOnTargetMove { get; }
 
-        public ClientDoAfter(byte id, EntityCoordinates userGrid, EntityCoordinates targetGrid, TimeSpan startTime, float delay, bool breakOnUserMove, bool breakOnTargetMove, EntityUid targetUid = default)
+        public float MovementThreshold { get; }
+
+        public ClientDoAfter(byte id, EntityCoordinates userGrid, EntityCoordinates targetGrid, TimeSpan startTime, float delay, bool breakOnUserMove, bool breakOnTargetMove, float movementThreshold, EntityUid targetUid = default)
         {
             ID = id;
             UserGrid = userGrid;
@@ -68,6 +70,7 @@ namespace Content.Shared.GameObjects.Components
             Delay = delay;
             BreakOnUserMove = breakOnUserMove;
             BreakOnTargetMove = breakOnTargetMove;
+            MovementThreshold = movementThreshold;
             TargetUid = targetUid;
         }
     }

--- a/Content.Tests/Shared/Chemistry/ReagentUnit_Tests.cs
+++ b/Content.Tests/Shared/Chemistry/ReagentUnit_Tests.cs
@@ -10,8 +10,8 @@ namespace Content.Tests.Shared.Chemistry
         [Test]
         [TestCase(1, "1")]
         [TestCase(0, "0")]
-        [TestCase(-1, "-1")]
-        public void ReagentUnitIntegerTests(int value, string expected)
+        [TestCase(-1, "0")]
+        public void ReagentUnitUnsignedIntegerTests(int value, string expected)
         {
             var result = ReagentUnit.New(value);
             Assert.That($"{result}", Is.EqualTo(expected));
@@ -20,6 +20,7 @@ namespace Content.Tests.Shared.Chemistry
         [Test]
         [TestCase(1.001f, "1")]
         [TestCase(0.999f, "1")]
+        [TestCase(-0.001f, "0")]
         public void ReagentUnitFloatTests(float value, string expected)
         {
             var result = ReagentUnit.New(value);
@@ -29,6 +30,7 @@ namespace Content.Tests.Shared.Chemistry
         [Test]
         [TestCase(1.001d, "1")]
         [TestCase(0.999d, "1")]
+        [TestCase(-0.001d, "0")]
         public void ReagentUnitDoubleTests(double value, string expected)
         {
             var result = ReagentUnit.New(value);
@@ -38,6 +40,7 @@ namespace Content.Tests.Shared.Chemistry
         [Test]
         [TestCase("1.005", "1.01")]
         [TestCase("0.999", "1")]
+        [TestCase("-0.001", "0")]
         public void ReagentUnitStringTests(string value, string expected)
         {
             var result = ReagentUnit.New(value);
@@ -62,7 +65,7 @@ namespace Content.Tests.Shared.Chemistry
         [Test]
         [TestCase(1.001f, 1.001f, "0")]
         [TestCase(1.001f, 1.004f, "0")]
-        [TestCase(1f, 2.005f, "-1.01")]
+        [TestCase(1f, 2f, "0")]
         public void CalculusMinus(float aFloat, float bFloat, string expected)
         {
             var a = ReagentUnit.New(aFloat);
@@ -126,12 +129,10 @@ namespace Content.Tests.Shared.Chemistry
         }
 
         [Test]
-        [TestCase(1, 0, false)]
         [TestCase(0, 0, true)]
-        [TestCase(-1, 0, false)]
-        [TestCase(1, 1, true)]
         [TestCase(0, 1, false)]
-        [TestCase(-1, 1, false)]
+        [TestCase(1, 0, false)]
+        [TestCase(1, 1, true)]
         public void ReagentUnitEquals(int a, int b, bool expected)
         {
             var parameter = ReagentUnit.New(a);

--- a/Content.Tests/Shared/Chemistry/Solution_Tests.cs
+++ b/Content.Tests/Shared/Chemistry/Solution_Tests.cs
@@ -13,7 +13,7 @@ namespace Content.Tests.Shared.Chemistry
             solution.AddReagent("water", ReagentUnit.New(1000));
             var quantity = solution.GetReagentQuantity("water");
 
-            Assert.That(quantity.Int(), Is.EqualTo(1000));
+            Assert.That(quantity.UInt(), Is.EqualTo(1000));
         }
 
         [Test]
@@ -22,7 +22,7 @@ namespace Content.Tests.Shared.Chemistry
             var solution = new Solution("water", ReagentUnit.New(1000));
             var quantity = solution.GetReagentQuantity("water");
 
-            Assert.That(quantity.Int(), Is.EqualTo(1000));
+            Assert.That(quantity.UInt(), Is.EqualTo(1000));
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace Content.Tests.Shared.Chemistry
             var solution = new Solution();
             var quantity = solution.GetReagentQuantity("water");
 
-            Assert.That(quantity.Int(), Is.EqualTo(0));
+            Assert.That(quantity.UInt(), Is.EqualTo(0));
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace Content.Tests.Shared.Chemistry
             var solution = new Solution("water", ReagentUnit.New(-1000));
             var quantity = solution.GetReagentQuantity("water");
 
-            Assert.That(quantity.Int(), Is.EqualTo(0));
+            Assert.That(quantity.UInt(), Is.EqualTo(0));
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace Content.Tests.Shared.Chemistry
             solution.AddReagent("water", ReagentUnit.New(2000));
             var quantity = solution.GetReagentQuantity("water");
 
-            Assert.That(quantity.Int(), Is.EqualTo(3000));
+            Assert.That(quantity.UInt(), Is.EqualTo(3000));
         }
 
         [Test]
@@ -61,8 +61,8 @@ namespace Content.Tests.Shared.Chemistry
             solution.AddReagent("water", ReagentUnit.New(1000));
             solution.AddReagent("fire", ReagentUnit.New(2000));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(1000));
-            Assert.That(solution.GetReagentQuantity("fire").Int(), Is.EqualTo(2000));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(1000));
+            Assert.That(solution.GetReagentQuantity("fire").UInt(), Is.EqualTo(2000));
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace Content.Tests.Shared.Chemistry
             solution.AddReagent("water", ReagentUnit.New(1000));
             solution.AddReagent("fire", ReagentUnit.New(2000));
 
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(3000));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(3000));
         }
 
         [Test]
@@ -84,9 +84,9 @@ namespace Content.Tests.Shared.Chemistry
 
             var newSolution = solution.Clone();
 
-            Assert.That(newSolution.GetReagentQuantity("water").Int(), Is.EqualTo(1000));
-            Assert.That(newSolution.GetReagentQuantity("fire").Int(), Is.EqualTo(2000));
-            Assert.That(newSolution.TotalVolume.Int(), Is.EqualTo(3000));
+            Assert.That(newSolution.GetReagentQuantity("water").UInt(), Is.EqualTo(1000));
+            Assert.That(newSolution.GetReagentQuantity("fire").UInt(), Is.EqualTo(2000));
+            Assert.That(newSolution.TotalVolume.UInt(), Is.EqualTo(3000));
         }
 
         [Test]
@@ -98,9 +98,9 @@ namespace Content.Tests.Shared.Chemistry
 
             solution.RemoveReagent("water", ReagentUnit.New(500));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(500));
-            Assert.That(solution.GetReagentQuantity("fire").Int(), Is.EqualTo(2000));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(2500));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(500));
+            Assert.That(solution.GetReagentQuantity("fire").UInt(), Is.EqualTo(2000));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(2500));
         }
 
         [Test]
@@ -110,8 +110,8 @@ namespace Content.Tests.Shared.Chemistry
 
             solution.RemoveReagent("water", ReagentUnit.New(-100));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(100));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(100));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(100));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(100));
         }
 
         [Test]
@@ -121,8 +121,8 @@ namespace Content.Tests.Shared.Chemistry
 
             solution.RemoveReagent("water", ReagentUnit.New(1000));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(0));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(0));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(0));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(0));
         }
 
         [Test]
@@ -132,8 +132,8 @@ namespace Content.Tests.Shared.Chemistry
 
             solution.RemoveReagent("fire", ReagentUnit.New(1000));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(100));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(100));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(100));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(100));
         }
 
         [Test]
@@ -144,8 +144,8 @@ namespace Content.Tests.Shared.Chemistry
             solution.RemoveSolution(ReagentUnit.New(500));
 
             //Check that edited solution is correct
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(200));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(200));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(200));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(200));
         }
 
         [Test]
@@ -156,8 +156,8 @@ namespace Content.Tests.Shared.Chemistry
             solution.RemoveSolution(ReagentUnit.New(1000));
 
             //Check that edited solution is correct
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(0));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(0));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(0));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(0));
         }
 
         [Test]
@@ -169,9 +169,9 @@ namespace Content.Tests.Shared.Chemistry
 
             solution.RemoveSolution(ReagentUnit.New(1500));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(500));
-            Assert.That(solution.GetReagentQuantity("fire").Int(), Is.EqualTo(1000));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(1500));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(500));
+            Assert.That(solution.GetReagentQuantity("fire").UInt(), Is.EqualTo(1000));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(1500));
         }
 
         [Test]
@@ -181,8 +181,8 @@ namespace Content.Tests.Shared.Chemistry
 
             solution.RemoveSolution(ReagentUnit.New(-200));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(800));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(800));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(800));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(800));
         }
 
         [Test]
@@ -194,13 +194,13 @@ namespace Content.Tests.Shared.Chemistry
 
             var splitSolution = solution.SplitSolution(ReagentUnit.New(750));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(750));
-            Assert.That(solution.GetReagentQuantity("fire").Int(), Is.EqualTo(1500));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(2250));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(750));
+            Assert.That(solution.GetReagentQuantity("fire").UInt(), Is.EqualTo(1500));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(2250));
 
-            Assert.That(splitSolution.GetReagentQuantity("water").Int(), Is.EqualTo(250));
-            Assert.That(splitSolution.GetReagentQuantity("fire").Int(), Is.EqualTo(500));
-            Assert.That(splitSolution.TotalVolume.Int(), Is.EqualTo(750));
+            Assert.That(splitSolution.GetReagentQuantity("water").UInt(), Is.EqualTo(250));
+            Assert.That(splitSolution.GetReagentQuantity("fire").UInt(), Is.EqualTo(500));
+            Assert.That(splitSolution.TotalVolume.UInt(), Is.EqualTo(750));
         }
 
         [Test]
@@ -214,11 +214,11 @@ namespace Content.Tests.Shared.Chemistry
 
             Assert.That(solution.GetReagentQuantity("water").Float(), Is.EqualTo(0.67f));
             Assert.That(solution.GetReagentQuantity("fire").Float(), Is.EqualTo(1.33f));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(2));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(2));
 
             Assert.That(splitSolution.GetReagentQuantity("water").Float(), Is.EqualTo(0.33f));
             Assert.That(splitSolution.GetReagentQuantity("fire").Float(), Is.EqualTo(0.67f));
-            Assert.That(splitSolution.TotalVolume.Int(), Is.EqualTo(1));
+            Assert.That(splitSolution.TotalVolume.UInt(), Is.EqualTo(1));
         }
 
         [Test]
@@ -232,11 +232,11 @@ namespace Content.Tests.Shared.Chemistry
 
             Assert.That(solution.GetReagentQuantity("water").Float(), Is.EqualTo(0.33f));
             Assert.That(solution.GetReagentQuantity("fire").Float(), Is.EqualTo(0.67f));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(1));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(1));
 
             Assert.That(splitSolution.GetReagentQuantity("water").Float(), Is.EqualTo(0.67f));
             Assert.That(splitSolution.GetReagentQuantity("fire").Float(), Is.EqualTo(1.33f));
-            Assert.That(splitSolution.TotalVolume.Int(), Is.EqualTo(2));
+            Assert.That(splitSolution.TotalVolume.UInt(), Is.EqualTo(2));
         }
 
         [Test]
@@ -281,11 +281,11 @@ namespace Content.Tests.Shared.Chemistry
 
             var splitSolution = solution.SplitSolution(ReagentUnit.New(1000));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(0));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(0));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(0));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(0));
 
-            Assert.That(splitSolution.GetReagentQuantity("water").Int(), Is.EqualTo(800));
-            Assert.That(splitSolution.TotalVolume.Int(), Is.EqualTo(800));
+            Assert.That(splitSolution.GetReagentQuantity("water").UInt(), Is.EqualTo(800));
+            Assert.That(splitSolution.TotalVolume.UInt(), Is.EqualTo(800));
         }
 
         [Test]
@@ -295,11 +295,11 @@ namespace Content.Tests.Shared.Chemistry
 
             var splitSolution = solution.SplitSolution(ReagentUnit.New(-200));
 
-            Assert.That(solution.GetReagentQuantity("water").Int(), Is.EqualTo(800));
-            Assert.That(solution.TotalVolume.Int(), Is.EqualTo(800));
+            Assert.That(solution.GetReagentQuantity("water").UInt(), Is.EqualTo(800));
+            Assert.That(solution.TotalVolume.UInt(), Is.EqualTo(800));
 
-            Assert.That(splitSolution.GetReagentQuantity("water").Int(), Is.EqualTo(0));
-            Assert.That(splitSolution.TotalVolume.Int(), Is.EqualTo(0));
+            Assert.That(splitSolution.GetReagentQuantity("water").UInt(), Is.EqualTo(0));
+            Assert.That(splitSolution.TotalVolume.UInt(), Is.EqualTo(0));
         }
 
         [Test]
@@ -336,10 +336,10 @@ namespace Content.Tests.Shared.Chemistry
 
             solutionOne.AddSolution(solutionTwo);
 
-            Assert.That(solutionOne.GetReagentQuantity("water").Int(), Is.EqualTo(1500));
-            Assert.That(solutionOne.GetReagentQuantity("fire").Int(), Is.EqualTo(2000));
-            Assert.That(solutionOne.GetReagentQuantity("earth").Int(), Is.EqualTo(1000));
-            Assert.That(solutionOne.TotalVolume.Int(), Is.EqualTo(4500));
+            Assert.That(solutionOne.GetReagentQuantity("water").UInt(), Is.EqualTo(1500));
+            Assert.That(solutionOne.GetReagentQuantity("fire").UInt(), Is.EqualTo(2000));
+            Assert.That(solutionOne.GetReagentQuantity("earth").UInt(), Is.EqualTo(1000));
+            Assert.That(solutionOne.TotalVolume.UInt(), Is.EqualTo(4500));
         }
     }
 }


### PR DESCRIPTION
- Changed ReagentUnit's value to uint to prevent negative values
- Added underflow checks to various calculations
- Switched method name Int() to UInt()
- Edited ReagentUnit tests to match changes
- No overflow checks have been implemented (?)

Related to issue #2605 