### PR TITLE
Adds a semitone shifting AudioHelper

### DIFF
--- a/Content.Server/GameObjects/Components/Sound/EmitSoundOnUseComponent.cs
+++ b/Content.Server/GameObjects/Components/Sound/EmitSoundOnUseComponent.cs
@@ -20,12 +20,14 @@ namespace Content.Server.GameObjects.Components.Sound
 
         public string _soundName;
         public float _pitchVariation;
+        public int _semitoneVariation;
 
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);
             serializer.DataField(ref _soundName, "sound", string.Empty);
             serializer.DataField(ref _pitchVariation, "variation", 0.0f);
+            serializer.DataField(ref _semitoneVariation, "semitoneVariation", 0);
         }
 
         bool IUse.UseEntity(UseEntityEventArgs eventArgs)
@@ -35,6 +37,11 @@ namespace Content.Server.GameObjects.Components.Sound
                 if (_pitchVariation > 0.0)
                 {
                     EntitySystem.Get<AudioSystem>().PlayFromEntity(_soundName, Owner, AudioHelpers.WithVariation(_pitchVariation).WithVolume(-2f));
+                    return true;
+                }
+                if (_semitoneVariation > 0)
+                {
+                    EntitySystem.Get<AudioSystem>().PlayFromEntity(_soundName, Owner, AudioHelpers.WithSemitoneVariation(_semitoneVariation).WithVolume(-2f));
                     return true;
                 }
                 EntitySystem.Get<AudioSystem>().PlayFromEntity(_soundName, Owner, AudioParams.Default.WithVolume(-2f));

--- a/Content.Server/GameObjects/Components/Sound/EmitSoundOnUseComponent.cs
+++ b/Content.Server/GameObjects/Components/Sound/EmitSoundOnUseComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Serialization;
+using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Sound
 {
@@ -18,9 +19,9 @@ namespace Content.Server.GameObjects.Components.Sound
         ///
         public override string Name => "EmitSoundOnUse";
 
-        public string _soundName;
-        public float _pitchVariation;
-        public int _semitoneVariation;
+        [ViewVariables(VVAccess.ReadWrite)] public string _soundName;
+        [ViewVariables(VVAccess.ReadWrite)] public float _pitchVariation;
+        [ViewVariables(VVAccess.ReadWrite)] public int _semitoneVariation;
 
         public override void ExposeData(ObjectSerializer serializer)
         {

--- a/Content.Shared/Audio/AudioHelpers.cs
+++ b/Content.Shared/Audio/AudioHelpers.cs
@@ -1,6 +1,8 @@
+using System;
 using Robust.Shared.Audio;
 using Robust.Shared.Interfaces.Random;
 using Robust.Shared.IoC;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -14,6 +16,57 @@ namespace Content.Shared.Audio
         {
             var scale = (float)(IoCManager.Resolve<IRobustRandom>().NextGaussian(1, amplitude));
             return AudioParams.Default.WithPitchScale(scale);
+        }
+
+        private static float[] _semitoneMultipliers =
+        {
+            0.5f,
+            233.08f/440f,
+            246.94f/440f,
+            261.63f/440f,
+            277.18f/440f,
+            293.66f/440f,
+            311.13f/440f,
+            329.63f/440f,
+            349.23f/440f,
+            369.99f/440f,
+            392.00f/440f,
+            415.30f/440f,
+            1.0f,
+            466.16f/440f,
+            493.88f/440f,
+            523.25f/440f,
+            554.37f/440f,
+            587.33f/440f,
+            622.25f/440f,
+            659.26f/440f,
+            698.46f/440f,
+            739.99f/440f,
+            783.99f/440f,
+            830.61f/440f,
+            2.0f
+        };
+
+        /// <summary>
+        /// Returns a pitch multiplier that shifts by the given number of semitones.
+        /// </summary>
+        /// <param name="shift">Number of semitones to shift, positive or negative. Clamped between -12 and 12
+        /// which correspond to a pitch multiplier of 0.5 and 2.0 respectively.</param>
+        public static AudioParams ShiftSemitone(int shift)
+        {
+            shift = MathHelper.Clamp(shift, -12, 12);
+            float pitchMult = _semitoneMultipliers[shift + 12];
+            return AudioParams.Default.WithPitchScale(pitchMult);
+        }
+
+        /// <summary>
+        /// Returns a pitch multiplier shifted by a random number of semitones within variation.
+        /// </summary>
+        /// <param name="variation">Max number of semitones to shift in either direction. Values above 12 have no effect.</param>
+        public static AudioParams WithSemitoneVariation(int variation)
+        {
+            variation = Math.Min(variation, 12);
+            return ShiftSemitone(IoCManager.Resolve<IRobustRandom>().Next(-variation, variation));
         }
 
         public static string GetRandomFileFromSoundCollection(string name)

--- a/Content.Shared/Audio/AudioHelpers.cs
+++ b/Content.Shared/Audio/AudioHelpers.cs
@@ -18,33 +18,17 @@ namespace Content.Shared.Audio
             return AudioParams.Default.WithPitchScale(scale);
         }
 
-        private static float[] _semitoneMultipliers =
+        // Might as well just hardcode these because the audio system is limited to pitching up and down
+        // by 12 semitones anyway (ie. 0.5 to 2.0 multiplier).
+        private static readonly float[] SemitoneMultipliers =
         {
-            0.5f,
-            233.08f/440f,
-            246.94f/440f,
-            261.63f/440f,
-            277.18f/440f,
-            293.66f/440f,
-            311.13f/440f,
-            329.63f/440f,
-            349.23f/440f,
-            369.99f/440f,
-            392.00f/440f,
-            415.30f/440f,
+            0.5f, 233.08f/440f, 246.94f/440f, 261.63f/440f,
+            277.18f/440f, 293.66f/440f, 311.13f/440f, 329.63f/440f,
+            349.23f/440f, 369.99f/440f, 392.00f/440f, 415.30f/440f,
             1.0f,
-            466.16f/440f,
-            493.88f/440f,
-            523.25f/440f,
-            554.37f/440f,
-            587.33f/440f,
-            622.25f/440f,
-            659.26f/440f,
-            698.46f/440f,
-            739.99f/440f,
-            783.99f/440f,
-            830.61f/440f,
-            2.0f
+            466.16f/440f, 493.88f/440f, 523.25f/440f, 554.37f/440f,
+            587.33f/440f, 622.25f/440f, 659.26f/440f, 698.46f/440f,
+            739.99f/440f, 783.99f/440f, 830.61f/440f, 2.0f
         };
 
         /// <summary>
@@ -55,7 +39,7 @@ namespace Content.Shared.Audio
         public static AudioParams ShiftSemitone(int shift)
         {
             shift = MathHelper.Clamp(shift, -12, 12);
-            float pitchMult = _semitoneMultipliers[shift + 12];
+            float pitchMult = SemitoneMultipliers[shift + 12];
             return AudioParams.Default.WithPitchScale(pitchMult);
         }
 

--- a/Content.Shared/Audio/AudioHelpers.cs
+++ b/Content.Shared/Audio/AudioHelpers.cs
@@ -49,7 +49,7 @@ namespace Content.Shared.Audio
         /// <param name="variation">Max number of semitones to shift in either direction. Values above 12 have no effect.</param>
         public static AudioParams WithSemitoneVariation(int variation)
         {
-            variation = Math.Min(variation, 12);
+            variation = Math.Clamp(variation, 0, 12);
             return ShiftSemitone(IoCManager.Resolve<IRobustRandom>().Next(-variation, variation));
         }
 

--- a/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
@@ -17,7 +17,7 @@
 
   - type: EmitSoundOnUse
     sound: /Audio/Items/bikehorn.ogg
-    variation: 0.2
+    semitoneVariation: 6
 
   - type: UseDelay
     delay: 0.5


### PR DESCRIPTION
In a possibly naive application of musical theory, I thought it'd be funny if the clown horn randomly pitched up and down using semitones.

This adds an audio helper to get multipliers that shift a sound up or down by a given amount of semitones, in effect making the randomly shifted sound a different note (and if the sound file is in tune, the resultant note should also be in tune). I hope they work, because I'm not exactly a musical genius.

I put it on the bike horn. The difference is so subtle I can't be arsed to make a comparison, but I think it sounds slightly more maddening now. Plus this increases the chances of repeated honking playing an off-key "Mary Had A Little Lamb" from "astronomically low" to "still really very low indeed but it can happen".