### PR TITLE
Migrate pulling logic into SharedPullableComponent from PullController

### DIFF
--- a/Content.Server/GameObjects/Components/Pulling/PullableComponent.cs
+++ b/Content.Server/GameObjects/Components/Pulling/PullableComponent.cs
@@ -41,26 +41,17 @@ namespace Content.Server.GameObjects.Components.Pulling
                     return;
                 }
 
-                var controller = targetPhysics.EnsureController<PullController>();
-
                 data.Visibility = VerbVisibility.Visible;
-                data.Text = controller.Puller == userPhysics
+                data.Text = component.Puller == userPhysics
                     ? Loc.GetString("Stop pulling")
                     : Loc.GetString("Pull");
             }
 
             protected override void Activate(IEntity user, PullableComponent component)
             {
-                if (!user.TryGetComponent(out IPhysicsComponent? userCollidable) ||
-                    !component.Owner.TryGetComponent(out IPhysicsComponent? targetCollidable) ||
-                    targetCollidable.Anchored)
-                {
-                    return;
-                }
-
-                var controller = targetCollidable.EnsureController<PullController>();
-
-                if (controller.Puller == userCollidable)
+                // There used to be sanity checks here for no reason.
+                // Why no reason? Because they're supposed to be performed in TryStartPull.
+                if (component.Puller == user)
                 {
                     component.TryStopPull();
                 }

--- a/Content.Shared/GameObjects/Components/Pulling/SharedPullableComponent.cs
+++ b/Content.Shared/GameObjects/Components/Pulling/SharedPullableComponent.cs
@@ -41,8 +41,6 @@ namespace Content.Shared.GameObjects.Components.Pulling
             get => _puller;
             set
             {
-                // Debug stuff over
-
                 if (_puller == value)
                 {
                     return;
@@ -61,7 +59,6 @@ namespace Content.Shared.GameObjects.Components.Pulling
                     {
                         var message = new PullStoppedMessage(oldPullerPhysics, _physics);
 
-                        Logger.Debug("SEND STOP");
                         oldPuller.SendMessage(null, message);
                         Owner.SendMessage(null, message);
 
@@ -142,7 +139,6 @@ namespace Content.Shared.GameObjects.Components.Pulling
                     _physics.EnsureController<PullController>().Manager = this;
                     var message = new PullStartedMessage(_pullerPhysics, _physics);
 
-                    Logger.Debug("SEND START");
                     _puller.SendMessage(null, message);
                     Owner.SendMessage(null, message);
 

--- a/Content.Shared/GameObjects/Components/Pulling/SharedPullerComponent.cs
+++ b/Content.Shared/GameObjects/Components/Pulling/SharedPullerComponent.cs
@@ -1,9 +1,14 @@
 ﻿#nullable enable
+using Content.Shared.Alert;
+using Content.Shared.GameObjects.Components.Mobs;
 using Content.Shared.GameObjects.Components.Movement;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Physics.Pull;
 using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
 using Component = Robust.Shared.GameObjects.Component;
+using Robust.Shared.Log;
 
 namespace Content.Shared.GameObjects.Components.Pulling
 {
@@ -58,15 +63,34 @@ namespace Content.Shared.GameObjects.Components.Pulling
                 return;
             }
 
+            SharedAlertsComponent? ownerStatus = Owner.GetComponentOrNull<SharedAlertsComponent>();
+
             switch (message)
             {
                 case PullStartedMessage msg:
                     Pulling = msg.Pulled.Owner;
+                    if (ownerStatus != null)
+                    {
+                        ownerStatus.ShowAlert(AlertType.Pulling, onClickAlert: OnClickAlert);
+                    }
                     break;
                 case PullStoppedMessage _:
                     Pulling = null;
+                    if (ownerStatus != null)
+                    {
+                        ownerStatus.ClearAlert(AlertType.Pulling);
+                    }
                     break;
             }
+        }
+
+        private void OnClickAlert(ClickAlertEventArgs args)
+        {
+            EntitySystem
+                .Get<SharedPullingSystem>()
+                .GetPulled(args.Player)?
+                .GetComponentOrNull<SharedPullableComponent>()?
+                .TryStopPull();
         }
     }
 }

--- a/Content.Shared/Physics/Pull/PullStartedMessage.cs
+++ b/Content.Shared/Physics/Pull/PullStartedMessage.cs
@@ -4,7 +4,7 @@ namespace Content.Shared.Physics.Pull
 {
     public class PullStartedMessage : PullMessage
     {
-        public PullStartedMessage(PullController controller, IPhysicsComponent puller, IPhysicsComponent pulled) :
+        public PullStartedMessage(IPhysicsComponent puller, IPhysicsComponent pulled) :
             base(puller, pulled)
         {
         }


### PR DESCRIPTION
PullController containing the pulling mutex logic made no sense to me (it's a VirtualController), and it also indirectly caused #2619 because of the state duplication, so now it doesn't.
(There's still state duplication between pullable and pulling, but this can't really be solved. Luckily the only issue this caused was that the 1:1 constraint has to be manually maintained from within SharedPullableComponent's Puller setter, which at least centralizes the relation constraints into one place.)
Fixes #2619 and (if this occurs in master, unsure) would fix the pulling alert disappearing if pull is transferred to another object.