### PR TITLE
Make RoundEndSystem properly reset & CommunicationsConsoleComponent less crashy

### DIFF
--- a/Content.Server/GameObjects/Components/Command/CommunicationsConsoleComponent.cs
+++ b/Content.Server/GameObjects/Components/Command/CommunicationsConsoleComponent.cs
@@ -42,7 +42,16 @@ namespace Content.Server.GameObjects.Components.Command
 
         private void UpdateBoundInterface()
         {
-            UserInterface?.SetState(new CommunicationsConsoleInterfaceState(RoundEndSystem.ExpectedCountdownEnd));
+            if (!Deleted)
+                UserInterface?.SetState(new CommunicationsConsoleInterfaceState(RoundEndSystem.ExpectedCountdownEnd));
+        }
+
+        public override void OnRemove()
+        {
+            RoundEndSystem.OnRoundEndCountdownStarted -= UpdateBoundInterface;
+            RoundEndSystem.OnRoundEndCountdownCancelled -= UpdateBoundInterface;
+            RoundEndSystem.OnRoundEndCountdownFinished -= UpdateBoundInterface;
+            base.OnRemove();
         }
 
         private void UserInterfaceOnOnReceiveMessage(ServerBoundUserInterfaceMessage obj)

--- a/Content.Server/GameObjects/EntitySystems/RoundEndSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/RoundEndSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using Content.Server.Interfaces.Chat;
 using Content.Server.Interfaces.GameTicking;
+using Content.Shared.GameTicking;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
@@ -10,7 +11,7 @@ using Timer = Robust.Shared.Timers.Timer;
 
 namespace Content.Server.GameObjects.EntitySystems
 {
-    public class RoundEndSystem : EntitySystem
+    public class RoundEndSystem : EntitySystem, IResettingEntitySystem
     {
         [Dependency] private readonly IGameTicker _gameTicker = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
@@ -31,6 +32,14 @@ namespace Content.Server.GameObjects.EntitySystems
 
         public delegate void RoundEndCountdownFinished();
         public event RoundEndCountdownFinished OnRoundEndCountdownFinished;
+
+        void IResettingEntitySystem.Reset()
+        {
+            IsRoundEndCountdownStarted = false;
+            _roundEndCancellationTokenSource.Cancel();
+            _roundEndCancellationTokenSource = new CancellationTokenSource();
+            ExpectedCountdownEnd = null;
+        }
 
         public void RequestRoundEnd()
         {


### PR DESCRIPTION
+ Make RoundEndSystem properly reset (the shuttle remains called after reset otherwise)
+ Stop CommunicationsConsoleComponent event handlers sticking around too long (causes exceptions)
