### PR TITLE
Seed from toml object is converted by Convert.ToUInt32 method

### DIFF
--- a/Content.Client/Parallax/ParallaxGenerator.cs
+++ b/Content.Client/Parallax/ParallaxGenerator.cs
@@ -98,7 +98,7 @@ namespace Content.Client.Parallax
 
                 if (table.TryGetValue("seed", out tomlObject))
                 {
-                    Seed = (uint) ((TomlValue<int>) tomlObject).Value;
+                    Seed = Convert.ToUInt32(((TomlValue<int>) tomlObject).Value);
                 }
 
                 if (table.TryGetValue("persistence", out tomlObject))


### PR DESCRIPTION
The conversion of the tomlObject.Value element produce a runtime error: #2635 
This small patch was developed with no understanding of C# language. Please test and look for a better solution.