### PR TITLE
Added master volume slider in audio options

### DIFF
--- a/Content.Client/UserInterface/AudioSource.cs
+++ b/Content.Client/UserInterface/AudioSource.cs
@@ -1,0 +1,6 @@
+﻿namespace Content.Client.UserInterface
+{
+    internal class AudioSource
+    {
+    }
+}

--- a/Content.Client/UserInterface/AudioSource.cs
+++ b/Content.Client/UserInterface/AudioSource.cs
@@ -1,6 +1,0 @@
-﻿namespace Content.Client.UserInterface
-{
-    internal class AudioSource
-    {
-    }
-}

--- a/Content.Client/UserInterface/OptionsMenu.Audio.cs
+++ b/Content.Client/UserInterface/OptionsMenu.Audio.cs
@@ -20,9 +20,7 @@ namespace Content.Client.UserInterface
             private readonly Slider MasterVolumeSlider;
             private readonly Button ResetButton;
 
-            private const string SOUND_TEST_PATH = "/Audio/Machines/Keyboard.ogg";
-
-            public AudioControl(IConfigurationManager cfg, Robust.Client.Interfaces.Graphics.IClydeAudio clydeAudio)
+            public AudioControl(IConfigurationManager cfg, IClydeAudio clydeAudio)
             {
                 _cfg = cfg;
                 _clydeAudio = clydeAudio;
@@ -114,7 +112,7 @@ namespace Content.Client.UserInterface
                 });
 
                 MasterVolumeSlider.Value = _cfg.GetCVar(CVars.AudioMasterVolume) * 100.0f;
-                MasterVolumeLabel.Text = string.Format("{0:0}%", MasterVolumeSlider.Value);
+                MasterVolumeLabel.Text = string.Format(Loc.GetString("{0:0}%"), MasterVolumeSlider.Value);
 
                 ApplyButton.OnPressed += OnApplyButtonPressed;
                 ResetButton.OnPressed += OnResetButtonPressed;
@@ -124,9 +122,17 @@ namespace Content.Client.UserInterface
                 UpdateChanges();
             }
 
+            protected override void Dispose(bool disposing)
+            {
+                ApplyButton.OnPressed -= OnApplyButtonPressed;
+                ResetButton.OnPressed -= OnResetButtonPressed;
+                MasterVolumeSlider.OnValueChanged -= OnMasterVolumeSliderChanged;
+                base.Dispose(disposing);
+            }
+
             private void OnMasterVolumeSliderChanged(Range range)
             {
-                MasterVolumeLabel.Text = string.Format("{0:0}%", MasterVolumeSlider.Value);
+                MasterVolumeLabel.Text = string.Format(Loc.GetString("{0:0}%"), MasterVolumeSlider.Value);
                 _clydeAudio.SetMasterVolume(MasterVolumeSlider.Value / 100.0f);
                 UpdateChanges();
             }
@@ -141,7 +147,7 @@ namespace Content.Client.UserInterface
             private void OnResetButtonPressed(BaseButton.ButtonEventArgs args)
             {
                 MasterVolumeSlider.Value = _cfg.GetCVar(CVars.AudioMasterVolume) * 100.0f;
-                MasterVolumeLabel.Text = string.Format("{0:0}%", MasterVolumeSlider.Value);
+                MasterVolumeLabel.Text = string.Format(Loc.GetString("{0:0}%"), MasterVolumeSlider.Value);
                 UpdateChanges();
             }
 

--- a/Content.Client/UserInterface/OptionsMenu.Audio.cs
+++ b/Content.Client/UserInterface/OptionsMenu.Audio.cs
@@ -1,7 +1,10 @@
-﻿using Robust.Client.Interfaces.ResourceManagement;
+﻿using Content.Client.UserInterface.Stylesheets;
+using Robust.Client.Interfaces.Graphics;
 using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared;
 using Robust.Shared.Interfaces.Configuration;
-using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 
 namespace Content.Client.UserInterface
 {
@@ -9,12 +12,145 @@ namespace Content.Client.UserInterface
     {
         private sealed class AudioControl : Control
         {
-            public AudioControl(IConfigurationManager cfg)
+            private readonly IConfigurationManager _cfg;
+            private readonly IClydeAudio _clydeAudio;
+
+            private readonly Button ApplyButton;
+            private readonly Label MasterVolumeLabel;
+            private readonly Slider MasterVolumeSlider;
+            private readonly Button ResetButton;
+
+            private const string SOUND_TEST_PATH = "/Audio/Machines/Keyboard.ogg";
+
+            public AudioControl(IConfigurationManager cfg, Robust.Client.Interfaces.Graphics.IClydeAudio clydeAudio)
             {
-                AddChild(new Placeholder(IoCManager.Resolve<IResourceCache>())
+                _cfg = cfg;
+                _clydeAudio = clydeAudio;
+
+                var vBox = new VBoxContainer();
+
+                var contents = new VBoxContainer();
+
+                MasterVolumeSlider = new Slider
                 {
-                    PlaceholderText = "Pretend there's a bunch of volume sliders here."
+                    MinValue = 0.0f,
+                    MaxValue = 100.0f,
+                    SizeFlagsHorizontal = SizeFlags.FillExpand,
+                    CustomMinimumSize = (80, 8),
+                    Rounded = true
+                };
+
+                MasterVolumeLabel = new Label
+                {
+                    CustomMinimumSize = (48, 0),
+                    Align = Label.AlignMode.Right
+                };
+
+                contents.AddChild(new HBoxContainer
+                {
+                    Children =
+                    {
+                        new Control {CustomMinimumSize = (4, 0)},
+                        new Label {Text = Loc.GetString("Master Volume:")},
+                        new Control {CustomMinimumSize = (8, 0)},
+                        MasterVolumeSlider,
+                        new Control {CustomMinimumSize = (8, 0)},
+                        MasterVolumeLabel,
+                        new Control { CustomMinimumSize = (4, 0) },
+                    }
                 });
+
+                ApplyButton = new Button
+                {
+                    Text = Loc.GetString("Apply"), TextAlign = Label.AlignMode.Center,
+                    SizeFlagsHorizontal = SizeFlags.ShrinkEnd
+                };
+
+                vBox.AddChild(new Label
+                {
+                    Text = Loc.GetString("Volume Sliders"),
+                    FontColorOverride = StyleNano.NanoGold,
+                    StyleClasses = { StyleNano.StyleClassLabelKeyText }
+                });
+
+                vBox.AddChild(new MarginContainer
+                {
+                    MarginLeftOverride = 2,
+                    MarginTopOverride = 2,
+                    MarginRightOverride = 2,
+                    SizeFlagsVertical = SizeFlags.FillExpand,
+                    Children =
+                    {
+                        contents
+                    }
+                });
+
+                ResetButton = new Button
+                {
+                    Text = Loc.GetString("Reset all"),
+                    StyleClasses = { StyleBase.ButtonCaution },
+                    SizeFlagsHorizontal = SizeFlags.ShrinkEnd
+                };
+
+                vBox.AddChild(new StripeBack
+                {
+                    HasBottomEdge = false,
+                    HasMargins = false,
+                    Children =
+                    {
+                        new HBoxContainer
+                        {
+                            Align = BoxContainer.AlignMode.End,
+                            SizeFlagsHorizontal = SizeFlags.FillExpand,
+                            SizeFlagsVertical = SizeFlags.FillExpand,
+                            Children =
+                            {
+                                ResetButton,
+                                new Control { CustomMinimumSize = (2, 0) },
+                                ApplyButton
+                            }
+                        }
+                    }
+                });
+
+                MasterVolumeSlider.Value = _cfg.GetCVar(CVars.AudioMasterVolume) * 100.0f;
+                MasterVolumeLabel.Text = string.Format("{0:0}%", MasterVolumeSlider.Value);
+
+                ApplyButton.OnPressed += OnApplyButtonPressed;
+                ResetButton.OnPressed += OnResetButtonPressed;
+                MasterVolumeSlider.OnValueChanged += OnMasterVolumeSliderChanged;
+
+                AddChild(vBox);
+                UpdateChanges();
+            }
+
+            private void OnMasterVolumeSliderChanged(Range range)
+            {
+                MasterVolumeLabel.Text = string.Format("{0:0}%", MasterVolumeSlider.Value);
+                _clydeAudio.SetMasterVolume(MasterVolumeSlider.Value / 100.0f);
+                UpdateChanges();
+            }
+
+            private void OnApplyButtonPressed(BaseButton.ButtonEventArgs args)
+            {
+                _cfg.SetCVar(CVars.AudioMasterVolume, MasterVolumeSlider.Value / 100.0f);
+                _cfg.SaveToFile();
+                UpdateChanges();
+            }
+
+            private void OnResetButtonPressed(BaseButton.ButtonEventArgs args)
+            {
+                MasterVolumeSlider.Value = _cfg.GetCVar(CVars.AudioMasterVolume) * 100.0f;
+                MasterVolumeLabel.Text = string.Format("{0:0}%", MasterVolumeSlider.Value);
+                UpdateChanges();
+            }
+
+            private void UpdateChanges()
+            {
+                var isMasterVolumeSame = System.Math.Abs(MasterVolumeSlider.Value - _cfg.GetCVar(CVars.AudioMasterVolume) * 100.0f) < 0.01f;
+                var isEverythingSame = isMasterVolumeSame;
+                ApplyButton.Disabled = isEverythingSame;
+                ResetButton.Disabled = isEverythingSame;
             }
         }
     }

--- a/Content.Client/UserInterface/OptionsMenu.cs
+++ b/Content.Client/UserInterface/OptionsMenu.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Client.UserInterface.Controls;
+﻿using Robust.Client.Interfaces.Graphics;
+using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Interfaces.Configuration;
 using Robust.Shared.IoC;
@@ -12,6 +13,7 @@ namespace Content.Client.UserInterface
     public sealed partial class OptionsMenu : SS14Window
     {
         [Dependency] private readonly IConfigurationManager _configManager = default!;
+        [Dependency] private readonly IClydeAudio _clydeAudio = default!;
 
         protected override Vector2? CustomSize => (800, 450);
 
@@ -31,7 +33,7 @@ namespace Content.Client.UserInterface
                 {
                     (graphicsControl = new GraphicsControl(_configManager)),
                     (rebindControl = new KeyRebindControl()),
-                    (audioControl = new AudioControl(_configManager)),
+                    (audioControl = new AudioControl(_configManager, _clydeAudio)),
                 }
             };
 


### PR DESCRIPTION
- There is now a slider for changing the master volume
- The slider goes from 0% to 100% in 1% increments, being 0% setting the volume to 0.0f and 100% setting it to 1.0f

Requires space-wizards/RobustToolbox#1427
Fixes #2614