### PR TITLE
"Fix" doors getting stuck on deny

### DIFF
--- a/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
@@ -63,7 +63,7 @@ namespace Content.Server.GameObjects.Components.Doors
         [ViewVariables(VVAccess.ReadWrite)]
         protected float CloseSpeed = AutoCloseDelay;
 
-        private readonly CancellationTokenSource _cancellationTokenSource = new();
+        private CancellationTokenSource? _cancellationTokenSource;
 
         protected virtual TimeSpan CloseTimeOne => TimeSpan.FromSeconds(0.3f);
         protected virtual TimeSpan CloseTimeTwo => TimeSpan.FromSeconds(0.9f);
@@ -259,6 +259,9 @@ namespace Content.Server.GameObjects.Components.Doors
                 occluder.Enabled = false;
             }
 
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource = new();
+
             Owner.SpawnTimer(OpenTimeOne, async () =>
             {
                 if (Owner.TryGetComponent(out AirtightComponent? airtight))
@@ -412,6 +415,9 @@ namespace Content.Server.GameObjects.Components.Doors
                 occluder.Enabled = true;
             }
 
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource = new();
+
             Owner.SpawnTimer(CloseTimeOne, async () =>
             {
                 if (shouldCheckCrush && _canCrush)
@@ -444,6 +450,8 @@ namespace Content.Server.GameObjects.Components.Doors
             if (State == DoorState.Open || _isWeldedShut)
                 return;
 
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource = new();
             SetAppearance(DoorVisualState.Deny);
             Owner.SpawnTimer(DenyTime, () =>
             {


### PR DESCRIPTION
I say "fix" because if deny is getting spammed it'll stay in that state until the spam is over. This just means the noise won't get spammed which may be a good / bad thing depending on perspective. With door prediction you can probably change this to however you want (spammed vs not spammed).