### PR TITLE
Fix thrown throwing

### DIFF
--- a/Content.Server/GameObjects/Components/Nutrition/CreamPiedComponent.cs
+++ b/Content.Server/GameObjects/Components/Nutrition/CreamPiedComponent.cs
@@ -52,7 +52,7 @@ namespace Content.Server.GameObjects.Components.Nutrition
 
         public void HitBy(ThrowCollideEventArgs eventArgs)
         {
-            if (!eventArgs.Thrown.TryGetComponent(out CreamPieComponent creamPie) || CreamPied) return;
+            if (!eventArgs.Thrown.HasComponent<CreamPieComponent>() || CreamPied) return;
 
             CreamPied = true;
             Owner.PopupMessage(Loc.GetString("You have been creamed by {0:theName}!", eventArgs.Thrown));

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -624,11 +624,13 @@ namespace Content.Server.GameObjects.EntitySystems.Click
 
             foreach (var comp in thrown.GetAllComponents<IThrowCollide>().ToArray())
             {
+                if (thrown.Deleted) break;
                 comp.DoHit(eventArgs);
             }
 
             foreach (var comp in target.GetAllComponents<IThrowCollide>().ToArray())
             {
+                if (target.Deleted) break;
                 comp.HitBy(eventArgs);
             }
         }


### PR DESCRIPTION
Technically some stuff could be dependent upon the entity regardless of whether it's deleted but this is how ICollideBehavior does it (it was like that when I got there) so I figured we'd make it consistent (plus it fixes CreamPied throwing as well.)

If someone really needs the functionality even if it's deleted then they can refactor it.