### PR TITLE
Player post-spawn hook and player ghosting controlled by preset

### DIFF
--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -4,6 +4,7 @@ using Content.Server.GameTicking;
 using Content.Server.Interfaces.GameTicking;
 using Content.Shared.Roles;
 using Robust.Server.Interfaces.Player;
+using Robust.Server.Interfaces.Console;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
@@ -46,6 +47,10 @@ namespace Content.IntegrationTests
         }
 
         public void Respawn(IPlayerSession targetPlayer)
+        {
+        }
+
+        public void OnGhostAttempt(IConsoleShell shell, IPlayerSession session, bool canReturnGlobal)
         {
         }
 

--- a/Content.IntegrationTests/DummyGameTicker.cs
+++ b/Content.IntegrationTests/DummyGameTicker.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Content.Server.GameTicking;
 using Content.Server.Interfaces.GameTicking;
 using Content.Shared.Roles;
+using Content.Server.Mobs;
 using Robust.Server.Interfaces.Player;
 using Robust.Server.Interfaces.Console;
 using Robust.Shared.Interfaces.GameObjects;
@@ -50,8 +51,9 @@ namespace Content.IntegrationTests
         {
         }
 
-        public void OnGhostAttempt(IConsoleShell shell, IPlayerSession session, bool canReturnGlobal)
+        public bool OnGhostAttempt(Mind mind, bool canReturnGlobal)
         {
+            return false;
         }
 
         public void MakeObserve(IPlayerSession player)

--- a/Content.Server/Commands/Observer/Ghost.cs
+++ b/Content.Server/Commands/Observer/Ghost.cs
@@ -27,71 +27,11 @@ namespace Content.Server.Commands.Observer
         {
             if (player == null)
             {
-                shell.SendText(player, "Nah");
+                shell?.SendText((IPlayerSession?) null, "Nah");
                 return;
             }
 
-            var mind = player.ContentData()?.Mind;
-
-            if (mind == null)
-            {
-                shell.SendText(player, "You can't ghost here!");
-                return;
-            }
-
-            var playerEntity = player.AttachedEntity;
-
-            if (playerEntity != null && playerEntity.HasComponent<GhostComponent>())
-                return;
-
-            if (mind.VisitingEntity != null)
-            {
-                mind.UnVisit();
-                mind.VisitingEntity.Delete();
-            }
-
-            var position = playerEntity?.Transform.Coordinates ?? IoCManager.Resolve<IGameTicker>().GetObserverSpawnPoint();
-            var canReturn = false;
-
-            if (playerEntity != null && CanReturn && playerEntity.TryGetComponent(out IMobStateComponent? mobState))
-            {
-                if (mobState.IsDead())
-                {
-                    canReturn = true;
-                }
-                else if (mobState.IsCritical())
-                {
-                    canReturn = true;
-
-                    if (playerEntity.TryGetComponent(out IDamageableComponent? damageable))
-                    {
-                        //todo: what if they dont breathe lol
-                        damageable.ChangeDamage(DamageType.Asphyxiation, 100, true);
-                    }
-                }
-                else
-                {
-                    canReturn = false;
-                }
-            }
-
-            var entityManager = IoCManager.Resolve<IEntityManager>();
-            var ghost = entityManager.SpawnEntity("MobObserver", position);
-            ghost.Name = mind.CharacterName;
-
-            var ghostComponent = ghost.GetComponent<GhostComponent>();
-            ghostComponent.CanReturnToBody = canReturn;
-
-            if (playerEntity != null &&
-                playerEntity.TryGetComponent(out ServerOverlayEffectsComponent? overlayComponent))
-            {
-                overlayComponent.RemoveOverlay(SharedOverlayID.CircleMaskOverlay);
-            }
-
-            if (canReturn)
-                mind.Visit(ghost);
-            else
-                mind.TransferTo(ghost);
+            IoCManager.Resolve<IGameTicker>().OnGhostAttempt(shell, player, CanReturn);
         }
     }
 }

--- a/Content.Server/Commands/Observer/Ghost.cs
+++ b/Content.Server/Commands/Observer/Ghost.cs
@@ -27,11 +27,22 @@ namespace Content.Server.Commands.Observer
         {
             if (player == null)
             {
-                shell?.SendText((IPlayerSession?) null, "Nah");
+                shell?.SendText(player, "You have no session, you can't ghost.");
                 return;
             }
 
-            IoCManager.Resolve<IGameTicker>().OnGhostAttempt(shell, player, CanReturn);
+            var mind = player!.ContentData()?.Mind;
+            if (mind == null)
+            {
+                shell?.SendText(player, "You have no Mind, you can't ghost.");
+                return;
+            }
+
+            if (!IoCManager.Resolve<IGameTicker>().OnGhostAttempt(mind, CanReturn))
+            {
+                shell?.SendText(player, "You can't ghost right now.");
+                return;
+            }
         }
     }
 }

--- a/Content.Server/GameTicking/GamePreset.cs
+++ b/Content.Server/GameTicking/GamePreset.cs
@@ -1,8 +1,20 @@
+#nullable enable annotations
 ﻿using System.Collections.Generic;
 using Content.Shared.Preferences;
-using Robust.Server.Interfaces.Player;
+using Content.Server.Administration;
+using Content.Server.GameObjects.Components.Mobs;
+using Content.Server.GameObjects.Components.Observer;
+using Content.Server.Interfaces.GameTicking;
+using Content.Server.Players;
+using Content.Shared.Damage;
+using Content.Shared.GameObjects.Components.Damage;
+using Content.Shared.GameObjects.Components.Mobs;
+using Content.Shared.GameObjects.Components.Mobs.State;
 using Robust.Shared.Network;
 using Robust.Shared.Interfaces.GameObjects;
+using Robust.Server.Interfaces.Console;
+﻿using Robust.Server.Interfaces.Player;
+using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking
 {
@@ -23,6 +35,75 @@ namespace Content.Server.GameTicking
         /// Called when a player is spawned in (this includes, but is not limited to, before Start)
         /// </summary>
         public virtual void OnSpawnPlayerCompleted(IPlayerSession session, IEntity mob, bool lateJoin) { }
+
+        /// <summary>
+        /// Called when a player attempts to ghost.
+        /// </summary>
+        public virtual void OnGhostAttempt(IConsoleShell? shell, IPlayerSession player, bool canReturnGlobal)
+        {
+            var mind = player.ContentData().Mind;
+            if (mind == null)
+            {
+                shell?.SendText(player, "You can't ghost here!");
+                return;
+            }
+
+            var name = player.AttachedEntity?.Name ?? player.Name;
+
+            var playerEntity = player.AttachedEntity;
+
+            if (playerEntity != null && playerEntity.HasComponent<GhostComponent>())
+                return;
+
+            if (mind.VisitingEntity != null)
+            {
+                mind.UnVisit();
+                mind.VisitingEntity.Delete();
+            }
+
+            var position = playerEntity?.Transform.Coordinates ?? IoCManager.Resolve<IGameTicker>().GetObserverSpawnPoint();
+            var canReturn = false;
+
+            if (playerEntity != null && canReturnGlobal && playerEntity.TryGetComponent(out IMobStateComponent? mobState))
+            {
+                if (mobState.IsDead())
+                {
+                    canReturn = true;
+                }
+                else if (mobState.IsCritical())
+                {
+                    canReturn = true;
+
+                    if (playerEntity.TryGetComponent(out IDamageableComponent? damageable))
+                    {
+                        //todo: what if they dont breathe lol
+                        damageable.ChangeDamage(DamageType.Asphyxiation, 100, true);
+                    }
+                }
+                else
+                {
+                    canReturn = false;
+                }
+            }
+
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            var ghost = entityManager.SpawnEntity("MobObserver", position);
+            ghost.Name = mind.CharacterName;
+
+            var ghostComponent = ghost.GetComponent<GhostComponent>();
+            ghostComponent.CanReturnToBody = canReturn;
+
+            if (playerEntity != null &&
+                playerEntity.TryGetComponent(out ServerOverlayEffectsComponent? overlayComponent))
+            {
+                overlayComponent.RemoveOverlay(SharedOverlayID.CircleMaskOverlay);
+            }
+
+            if (canReturn)
+                mind.Visit(ghost);
+            else
+                mind.TransferTo(ghost);
+        }
 
         public virtual string GetRoundEndDescription() => "";
     }

--- a/Content.Server/GameTicking/GamePreset.cs
+++ b/Content.Server/GameTicking/GamePreset.cs
@@ -6,6 +6,7 @@ using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.Components.Observer;
 using Content.Server.Interfaces.GameTicking;
 using Content.Server.Players;
+using Content.Server.Mobs;
 using Content.Shared.Damage;
 using Content.Shared.GameObjects.Components.Damage;
 using Content.Shared.GameObjects.Components.Mobs;
@@ -39,21 +40,12 @@ namespace Content.Server.GameTicking
         /// <summary>
         /// Called when a player attempts to ghost.
         /// </summary>
-        public virtual void OnGhostAttempt(IConsoleShell? shell, IPlayerSession player, bool canReturnGlobal)
+        public virtual bool OnGhostAttempt(Mind mind, bool canReturnGlobal)
         {
-            var mind = player.ContentData().Mind;
-            if (mind == null)
-            {
-                shell?.SendText(player, "You can't ghost here!");
-                return;
-            }
-
-            var name = player.AttachedEntity?.Name ?? player.Name;
-
-            var playerEntity = player.AttachedEntity;
+            var playerEntity = mind.OwnedEntity;
 
             if (playerEntity != null && playerEntity.HasComponent<GhostComponent>())
-                return;
+                return false;
 
             if (mind.VisitingEntity != null)
             {
@@ -103,6 +95,7 @@ namespace Content.Server.GameTicking
                 mind.Visit(ghost);
             else
                 mind.TransferTo(ghost);
+            return true;
         }
 
         public virtual string GetRoundEndDescription() => "";

--- a/Content.Server/GameTicking/GamePreset.cs
+++ b/Content.Server/GameTicking/GamePreset.cs
@@ -2,6 +2,7 @@
 using Content.Shared.Preferences;
 using Robust.Server.Interfaces.Player;
 using Robust.Shared.Network;
+using Robust.Shared.Interfaces.GameObjects;
 
 namespace Content.Server.GameTicking
 {
@@ -17,6 +18,11 @@ namespace Content.Server.GameTicking
         public Dictionary<NetUserId, HumanoidCharacterProfile> readyProfiles;
 
         public virtual void OnGameStarted() { }
+
+        /// <summary>
+        /// Called when a player is spawned in (this includes, but is not limited to, before Start)
+        /// </summary>
+        public virtual void OnSpawnPlayerCompleted(IPlayerSession session, IEntity mob, bool lateJoin) { }
 
         public virtual string GetRoundEndDescription() => "";
     }

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -441,9 +441,9 @@ namespace Content.Server.GameTicking
             UpdateJobsAvailable();
         }
 
-        public void OnGhostAttempt(IConsoleShell shell, IPlayerSession session, bool canReturnGlobal)
+        public bool OnGhostAttempt(Mind mind, bool canReturnGlobal)
         {
-            Preset.OnGhostAttempt(shell, session, canReturnGlobal);
+            return Preset.OnGhostAttempt(mind, canReturnGlobal);
         }
 
         public T AddGameRule<T>() where T : GameRule, new()

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -31,6 +31,7 @@ using Robust.Server.Interfaces.Maps;
 using Robust.Server.Interfaces.Player;
 using Robust.Server.Player;
 using Robust.Server.ServerStatus;
+using Robust.Server.Interfaces.Console;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.Configuration;
@@ -438,6 +439,11 @@ namespace Content.Server.GameTicking
             DisallowLateJoin = disallowLateJoin;
             UpdateLateJoinStatus();
             UpdateJobsAvailable();
+        }
+
+        public void OnGhostAttempt(IConsoleShell shell, IPlayerSession session, bool canReturnGlobal)
+        {
+            Preset.OnGhostAttempt(shell, session, canReturnGlobal);
         }
 
         public T AddGameRule<T>() where T : GameRule, new()

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -887,6 +887,8 @@ namespace Content.Server.GameTicking
             AddSpawnedPosition(jobId);
             EquipIdCard(mob, character.Name, jobPrototype);
             jobPrototype.Special?.AfterEquip(mob);
+
+            Preset.OnSpawnPlayerCompleted(session, mob, lateJoin);
         }
 
         private void EquipIdCard(IEntity mob, string characterName, JobPrototype jobPrototype)

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Content.Server.GameTicking;
+using Content.Server.Mobs;
 using Content.Shared.Roles;
 using Robust.Server.Interfaces.Player;
 using Robust.Server.Interfaces.Console;
@@ -44,7 +45,7 @@ namespace Content.Server.Interfaces.GameTicking
         void ToggleDisallowLateJoin(bool disallowLateJoin);
 
         /// <summary>proxy to GamePreset (actual handler)</summary>
-        void OnGhostAttempt(IConsoleShell shell, IPlayerSession session, bool canReturnGlobal);
+        bool OnGhostAttempt(Mind mind, bool canReturnGlobal);
 
         EntityCoordinates GetLateJoinSpawnPoint();
         EntityCoordinates GetJobSpawnPoint(string jobId);

--- a/Content.Server/Interfaces/GameTicking/IGameTicker.cs
+++ b/Content.Server/Interfaces/GameTicking/IGameTicker.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Content.Server.GameTicking;
 using Content.Shared.Roles;
 using Robust.Server.Interfaces.Player;
+using Robust.Server.Interfaces.Console;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
@@ -41,6 +42,9 @@ namespace Content.Server.Interfaces.GameTicking
         void MakeJoinGame(IPlayerSession player, string jobId);
         void ToggleReady(IPlayerSession player, bool ready);
         void ToggleDisallowLateJoin(bool disallowLateJoin);
+
+        /// <summary>proxy to GamePreset (actual handler)</summary>
+        void OnGhostAttempt(IConsoleShell shell, IPlayerSession session, bool canReturnGlobal);
 
         EntityCoordinates GetLateJoinSpawnPoint();
         EntityCoordinates GetJobSpawnPoint(string jobId);


### PR DESCRIPTION
This allows the GamePreset to control players ghosting mid-round (including via death, but not via forced deletion as-of-yet) and to do things to players immediately after they spawn (read: teleport them somewhere else).

This was pulled out of #2719 and rebased because apparently the related code is a tad more under active change than I expected, so to reduce the amount of changes needed on #2719 I'm hoping to get this merged before that. (Less review needed and such.)
