### PR TITLE
Fix Antimatter engine maths and overplacing

### DIFF
--- a/Content.Server/GameObjects/Components/Power/AME/AMEControllerComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/AME/AMEControllerComponent.cs
@@ -85,11 +85,12 @@ namespace Content.Server.GameObjects.Components.Power.AME
             }
 
             _jarSlot.ContainedEntity.TryGetComponent<AMEFuelContainerComponent>(out var fuelJar);
-            if(fuelJar != null && _powerSupplier != null && fuelJar.FuelAmount > InjectionAmount)
+            if(fuelJar != null && _powerSupplier != null)
             {
-                _powerSupplier.SupplyRate = group.InjectFuel(InjectionAmount);
-                fuelJar.FuelAmount -= InjectionAmount;
-                InjectSound();
+                var availableInject = fuelJar.FuelAmount >= InjectionAmount ? InjectionAmount : fuelJar.FuelAmount;
+                _powerSupplier.SupplyRate = group.InjectFuel(availableInject, out var overloading);
+                fuelJar.FuelAmount -= availableInject;
+                InjectSound(overloading);
                 UpdateUserInterface();
             }
 
@@ -315,9 +316,9 @@ namespace Content.Server.GameObjects.Components.Power.AME
 
         }
 
-        private void InjectSound()
+        private void InjectSound(bool overloading)
         {
-            EntitySystem.Get<AudioSystem>().PlayFromEntity("/Audio/Effects/bang.ogg", Owner, AudioParams.Default.WithVolume(0f));
+            EntitySystem.Get<AudioSystem>().PlayFromEntity("/Audio/Effects/bang.ogg", Owner, AudioParams.Default.WithVolume(overloading ? 10f : 0f));
         }
 
         async Task<bool> IInteractUsing.InteractUsing(InteractUsingEventArgs args)

--- a/Content.Server/GameObjects/Components/Power/AME/AMEPartComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/AME/AMEPartComponent.cs
@@ -36,9 +36,8 @@ namespace Content.Server.GameObjects.Components.Power.AME
             {
 
                 var mapGrid = _mapManager.GetGrid(args.ClickLocation.GetGridId(_serverEntityManager));
-                var tile = mapGrid.GetTileRef(args.ClickLocation);
                 var snapPos = mapGrid.SnapGridCellFor(args.ClickLocation, SnapGridOffset.Center);
-                if (mapGrid.GetSnapGridCell(snapPos, SnapGridOffset.Center).Where(sc => sc.Owner.HasComponent<AMEShieldComponent>()).Count() > 0)
+                if (mapGrid.GetSnapGridCell(snapPos, SnapGridOffset.Center).Any(sc => sc.Owner.HasComponent<AMEShieldComponent>()))
                 {
                     Owner.PopupMessage(args.User, Loc.GetString("Shielding is already there!"));
                     return true;

--- a/Content.Server/GameObjects/Components/Power/AME/AMEPartComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/AME/AMEPartComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using System.Linq;
 using Content.Server.GameObjects.Components.Interactable;
 using Content.Server.Interfaces.GameObjects.Components.Items;
 using Content.Shared.GameObjects.Components.Interactable;
@@ -37,6 +38,11 @@ namespace Content.Server.GameObjects.Components.Power.AME
                 var mapGrid = _mapManager.GetGrid(args.ClickLocation.GetGridId(_serverEntityManager));
                 var tile = mapGrid.GetTileRef(args.ClickLocation);
                 var snapPos = mapGrid.SnapGridCellFor(args.ClickLocation, SnapGridOffset.Center);
+                if (mapGrid.GetSnapGridCell(snapPos, SnapGridOffset.Center).Where(sc => sc.Owner.HasComponent<AMEShieldComponent>()).Count() > 0)
+                {
+                    Owner.PopupMessage(args.User, Loc.GetString("Shielding is already there!"));
+                    return true;
+                }
 
                 var ent = _serverEntityManager.SpawnEntity("AMEShielding", mapGrid.GridTileToLocal(snapPos));
                 ent.Transform.LocalRotation = Owner.Transform.LocalRotation;

--- a/Content.Server/GameObjects/Components/Power/AME/AMEShieldComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/AME/AMEShieldComponent.cs
@@ -26,11 +26,6 @@ namespace Content.Server.GameObjects.Components.Power.AME
             Owner.TryGetComponent(out _pointLight);
         }
 
-        internal void OnUpdate(float frameTime)
-        {
-            throw new NotImplementedException();
-        }
-
         public void SetCore()
         {
             if(_isCore) { return; }


### PR DESCRIPTION
The antimatter engine maths in SS14 at present do not allow a stable 3x3 engine to be constructed.
This uses the vgstation13 rules for stability and power, which are stable for the basic 3x3 (1-core) and injection amount 2 configuration.
It also prevents antimatter engine parts being placed overlapping each other.

Possible considerations:
1. It may be better to have a generalized way of preventing snapgrid stuff being placed overlapping.
2. The power numbers being changed may or may not be a good idea.