### PR TITLE
Fix server NRE on clicking alerts with no OnClick

### DIFF
--- a/Content.Client/GameObjects/Components/Mobs/ClientAlertsComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/ClientAlertsComponent.cs
@@ -222,6 +222,7 @@ namespace Content.Client.GameObjects.Components.Mobs
                 return;
             }
 
+            if (!alert.Alert.HasOnClick) return;
             SendNetworkMessage(new ClickAlertMessage(alert.Alert.AlertType));
         }
 

--- a/Content.Server/GameObjects/Components/Mobs/ServerAlertsComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/ServerAlertsComponent.cs
@@ -71,7 +71,7 @@ namespace Content.Server.GameObjects.Components.Mobs
                         break;
                     }
 
-                    if (AlertManager.TryGet(msg.AlertType, out var alert))
+                    if (AlertManager.TryGet(msg.AlertType, out var alert) && alert.OnClick != null)
                     {
                         alert.OnClick.AlertClicked(new ClickAlertEventArgs(player, alert));
                     }

--- a/Content.Shared/Alert/AlertPrototype.cs
+++ b/Content.Shared/Alert/AlertPrototype.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Content.Shared.Interfaces;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -73,7 +74,13 @@ namespace Content.Shared.Alert
         public bool SupportsSeverity => MaxSeverity != -1;
 
         /// <summary>
+        /// Whether this alert is clickable. This is valid clientside.
+        /// </summary>
+        public bool HasOnClick { get; private set; }
+
+        /// <summary>
         /// Defines what to do when the alert is clicked.
+        /// This will always be null on clientside.
         /// </summary>
         public IAlertClick OnClick { get; private set; }
 
@@ -101,6 +108,8 @@ namespace Content.Shared.Alert
                 Category = alertCategory;
             }
             AlertKey = new AlertKey(AlertType, Category);
+
+            HasOnClick = serializer.TryReadDataField("onClick", out string _);
 
             if (IoCManager.Resolve<IModuleManager>().IsClientModule) return;
             serializer.DataField(this, x => x.OnClick, "onClick", null);

--- a/Content.Shared/Alert/AlertPrototype.cs
+++ b/Content.Shared/Alert/AlertPrototype.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Content.Shared.Interfaces;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;


### PR DESCRIPTION
Fixes #2744 

also makes it so the client won't send a click message unless there's an onclick for the alert.

note that there actually wasn't any pre-existing logic for uncuffing by clicking the alert, and this is not adding any such logic, it is just fixing the NRE