### PR TITLE
Shuttle can be called even when comms console is off.

### DIFF
--- a/Content.Server/GameObjects/Components/Command/CommunicationsConsoleComponent.cs
+++ b/Content.Server/GameObjects/Components/Command/CommunicationsConsoleComponent.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using Content.Server.GameObjects.Components.Power.ApcNetComponents;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Server.Utility;
@@ -77,11 +77,12 @@ namespace Content.Server.GameObjects.Components.Command
         {
             if (!eventArgs.User.TryGetComponent(out IActorComponent? actor))
                 return;
-
+/*
             if (!Powered)
             {
                 return;
             }
+*/
             OpenUserInterface(actor.playerSession);
         }
     }


### PR DESCRIPTION
Just to make restarting the round a little easier for players. 

(This will be rewritten anyway when shuttles are added.)