### PR TITLE
Fix low wall overlays

### DIFF
--- a/Content.Client/GameObjects/Components/LowWallComponent.cs
+++ b/Content.Client/GameObjects/Components/LowWallComponent.cs
@@ -39,6 +39,7 @@ namespace Content.Client.GameObjects.Components
 
             _overlayEntity = Owner.EntityManager.SpawnEntity("LowWallOverlay", Owner.Transform.Coordinates);
             _overlayEntity.Transform.AttachParent(Owner);
+            _overlayEntity.Transform.LocalPosition = Vector2.Zero;
 
             _overlaySprite = _overlayEntity.GetComponent<ISpriteComponent>();
 


### PR DESCRIPTION
Most noticeable when rotating walls I think which Saltern doesn't have.

@SweptWasTaken 