### PR TITLE
Adds missing gas canisters and improves the UI

### DIFF
--- a/Content.Client/GameObjects/Components/Atmos/GasCanisterBoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/Atmos/GasCanisterBoundUserInterface.cs
@@ -111,5 +111,12 @@ namespace Content.Client.GameObjects.Components.Atmos
 
             _window?.UpdateState(cast);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (!disposing) return;
+            _window?.Dispose();
+        }
     }
 }

--- a/Content.Client/GameObjects/Components/Atmos/GasCanisterWindow.cs
+++ b/Content.Client/GameObjects/Components/Atmos/GasCanisterWindow.cs
@@ -54,7 +54,7 @@ namespace Content.Client.GameObjects.Components.Atmos
                                     {
                                         Children =
                                         {
-                                            new Label(){ Text = Loc.GetString("Label") },
+                                            new Label(){ Text = Loc.GetString("Label: ") },
                                             (LabelInput = new LineEdit() { Text = Name, Editable = false,
                                                 CustomMinimumSize = new Vector2(200, 30)}),
                                             (EditLabelBtn = new Button()),

--- a/Content.Client/GameObjects/Components/Atmos/GasCanisterWindow.cs
+++ b/Content.Client/GameObjects/Components/Atmos/GasCanisterWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.GameObjects.Components.Disposal;
@@ -64,7 +64,7 @@ namespace Content.Client.GameObjects.Components.Atmos
                                     {
                                         Children =
                                         {
-                                            new Label {Text = Loc.GetString("Pressure:")},
+                                            new Label {Text = Loc.GetString("Pressure: ")},
                                             (_pressure = new Label())
                                         }
                                     },
@@ -76,7 +76,7 @@ namespace Content.Client.GameObjects.Components.Atmos
                                         {
                                             Children =
                                             {
-                                                new Label() {Text = Loc.GetString("Release pressure:")},
+                                                new Label() {Text = Loc.GetString("Release pressure: ")},
                                                 (_releasePressure = new Label())
                                             }
                                         },
@@ -100,8 +100,8 @@ namespace Content.Client.GameObjects.Components.Atmos
                                 {
                                     Children =
                                     {
-                                        new Label { Text = Loc.GetString("Valve") },
-                                        (ToggleValve = new CheckButton() { Text = Loc.GetString("Open") })
+                                        new Label { Text = Loc.GetString("Valve: ") },
+                                        (ToggleValve = new CheckButton() { Text = Loc.GetString("Closed") })
                                     }
                                 }
                             },
@@ -121,7 +121,6 @@ namespace Content.Client.GameObjects.Components.Atmos
             LabelInputEditable = false;
         }
 
-
         /// <summary>
         /// Update the UI based on <see cref="GasCanisterBoundUserInterfaceState"/>
         /// </summary>
@@ -140,6 +139,14 @@ namespace Content.Client.GameObjects.Components.Atmos
             LabelInputEditable = false;
 
             ToggleValve.Pressed = state.ValveOpened;
+            if (ToggleValve.Pressed)
+            {
+                ToggleValve.Text = Loc.GetString("Open");
+            }
+            else
+            {
+                ToggleValve.Text = Loc.GetString("Closed");
+            }
         }
     }
 

--- a/Resources/Prototypes/Entities/Constructible/Ground/gascanisters.yml
+++ b/Resources/Prototypes/Entities/Constructible/Ground/gascanisters.yml
@@ -60,6 +60,26 @@
           - VaultImpassable
           - SmallImpassable
 
+- type: entity
+  parent: GasCanister
+  id: StorageCanister
+  name: Storage Canister
+  components:
+    - type: Sprite
+      sprite: Constructible/Atmos/canister.rsi
+      state: yellow # Classic toxins canister
+    - type: GasCanister
+      gasMixture:
+        volume: 1000
+        moles: # List of gasses for easy reference
+          - 0 # oxygen
+          - 0 # nitrogen
+          - 0 # CO2
+          - 0 # Phoron
+          - 0 # Tritium
+          - 0 # Water vapor
+        temperature: 293.15
+
 # Filled canisters, contain 1871.71051 moles each
 
 - type: entity
@@ -95,6 +115,39 @@
 
 - type: entity
   parent: GasCanister
+  id: NitrogenCanister
+  name: Nitrogen Canister
+  components:
+    - type: Sprite
+      sprite: Constructible/Atmos/canister.rsi
+      state: red
+    - type: GasCanister
+      gasMixture:
+        volume: 1000
+        moles:
+          - 0 # oxygen
+          - 1871.71051 # nitrogen
+        temperature: 293.15
+
+- type: entity
+  parent: GasCanister
+  id: CarbonDioxideCanister
+  name: Carbon Dioxide Canister
+  components:
+    - type: Sprite
+      sprite: Constructible/Atmos/canister.rsi
+      state: black
+    - type: GasCanister
+      gasMixture:
+        volume: 1000
+        moles:
+          - 0 # oxygen
+          - 0 # nitrogen
+          - 1871.71051 # CO2
+        temperature: 293.15
+
+- type: entity
+  parent: GasCanister
   id: PhoronCanister
   name: Phoron Canister
   components:
@@ -109,4 +162,43 @@
           - 0 # nitrogen
           - 0 # carbon dioxide
           - 1871.71051 # phoron
+        temperature: 293.15
+
+- type: entity
+  parent: GasCanister
+  id: TritiumCanister
+  name: Tritium Canister
+  components:
+    - type: Sprite
+      sprite: Constructible/Atmos/canister.rsi
+      state: green
+    - type: GasCanister
+      gasMixture:
+        volume: 1000
+        moles:
+          - 0 # oxygen
+          - 0 # nitrogen
+          - 0 # CO2
+          - 0 # Phoron
+          - 1871.71051 # Tritium
+        temperature: 293.15
+
+- type: entity
+  parent: GasCanister
+  id: WaterVaporCanister
+  name: Water Vapor Canister
+  components:
+    - type: Sprite
+      sprite: Constructible/Atmos/canister.rsi
+      state: water_vapor
+    - type: GasCanister
+      gasMixture:
+        volume: 1000
+        moles:
+          - 0 # oxygen
+          - 0 # nitrogen
+          - 0 # CO2
+          - 0 # Phoron
+          - 0 # Tritium
+          - 1871.71051 # Water vapor
         temperature: 293.15


### PR DESCRIPTION
- Adds a canister for every implemented gas that was missing one.
- Adds the basic yellow Toxins canister.
- Makes the UI autoclose when you exit its range.
- Pretties up the UI a bit, and the valve label now properly shows its state.

![image](https://user-images.githubusercontent.com/5714543/102732070-4bc18700-42ff-11eb-9dbd-50539a8c2397.png)

![image](https://user-images.githubusercontent.com/5714543/102732090-5b40d000-42ff-11eb-83e1-041784ae2815.png)
