### PR TITLE
Make handheld explosives affect tiles

### DIFF
--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -77,7 +77,7 @@ namespace Content.Server.Explosions
             //TODO: make it into some sort of actual damage component or whatever the boys think is appropriate
             if (mapManager.TryGetGrid(coords.GetGridId(entityManager), out var mapGrid))
             {
-                var circle = new Circle(coords.Position, maxRange);
+                var circle = new Circle(coords.ToMapPos(entityManager), maxRange);
                 var tiles = mapGrid?.GetTilesIntersecting(circle);
                 foreach (var tile in tiles)
                 {


### PR DESCRIPTION
If you are holding the explosive in your hard or inventory, this makes it so the explosion affects the tiles around you. At the moment it only affects entities. I will refactor this more as there are other issues if none is doing it at the moment.