### PR TITLE
Fixes to explosionhelper

### DIFF
--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Explosions
         /// <summary>
         /// Chance of a tile breaking if the severity is Light and Heavy
         /// </summary>
-        private static readonly float LightBreakChance = 0.5f;
+        private static readonly float LightBreakChance = 0.3f;
         private static readonly float HeavyBreakChance = 0.8f;
 
         private static ExplosionSeverity CalculateSeverity(float distance, float devastationRange, float heaveyRange)
@@ -235,11 +235,11 @@ namespace Content.Server.Explosions
 
             var maxRange = MathHelper.Max(devastationRange, heavyImpactRange, lightImpactRange, 0);
 
-            var epicenter = source.Transform.Coordinates;
-            if (source.TryGetContainer(out var container) && container.Owner.HasComponent<EntityStorageComponent>())
+            while(source.TryGetContainer(out var cont))
             {
-                epicenter = container.Owner.Transform.Coordinates;
+                source = cont.Owner;
             }
+            var epicenter = source.Transform.Coordinates;
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
             var mapManager = IoCManager.Resolve<IMapManager>();

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -138,7 +138,7 @@ namespace Content.Server.Explosions
             // there are probably more ExplosivePassable entities around
             foreach (var (entity, distance) in nonImpassableEntities)
             {
-                if (!entity.InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: true, predicate: IgnoreExplosivePassable))
+                if (!entity.InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: false, predicate: IgnoreExplosivePassable))
                 {
                     continue;
                 }
@@ -185,11 +185,6 @@ namespace Content.Server.Explosions
                 }
 
                 if (!tileLoc.ToMap(entityManager).InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: false, predicate: IgnoreExplosivePassable))
-                {
-                    continue;
-                }
-
-                if (tile.IsBlockedTurf(false))
                 {
                     continue;
                 }

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -210,7 +210,6 @@ namespace Content.Server.Explosions
                 switch (severity)
                 {
                     case ExplosionSeverity.Light:
-                        mapGrid.SetTile(tileLoc, previousTile);
                         if (!previousTile.IsEmpty && robustRandom.Prob(LightBreakChance))
                         {
                             mapGrid.SetTile(tileLoc, previousTile);

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -138,7 +138,7 @@ namespace Content.Server.Explosions
             // there are probably more ExplosivePassable entities around
             foreach (var (entity, distance) in nonImpassableEntities)
             {
-                if (!entity.InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: false, predicate: IgnoreExplosivePassable))
+                if (!entity.InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: true, predicate: IgnoreExplosivePassable))
                 {
                     continue;
                 }

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -77,7 +77,7 @@ namespace Content.Server.Explosions
             //TODO: make it into some sort of actual damage component or whatever the boys think is appropriate
             if (mapManager.TryGetGrid(coords.GetGridId(entityManager), out var mapGrid))
             {
-                var circle = new Circle(coords.ToMapPos(entityManager), maxRange);
+                var circle = new Circle(coords.Position, maxRange);
                 var tiles = mapGrid?.GetTilesIntersecting(circle);
                 foreach (var tile in tiles)
                 {

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -47,7 +47,6 @@ namespace Content.Server.Explosions
 
         private static bool IgnoreExplosivePassable(IEntity e) => (e.GetComponent<IPhysicsComponent>().CollisionLayer & (int) CollisionGroup.ExplosivePassable) != 0;
 
-
         private static ExplosionSeverity CalculateSeverity(float distance, float devastationRange, float heaveyRange)
         {
             if (distance < devastationRange)
@@ -185,6 +184,11 @@ namespace Content.Server.Explosions
                 }
 
                 if (!tileLoc.ToMap(entityManager).InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: false, predicate: IgnoreExplosivePassable))
+                {
+                    continue;
+                }
+
+                if (tile.IsBlockedTurf(false))
                 {
                     continue;
                 }

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -124,9 +124,10 @@ namespace Content.Server.Explosions
             // Impassable entities are handled first. If they are damaged enough, they are destroyed and they may
             // be able to spawn a new entity. I.e Wall -> Girder.
             // Girder has a layer ExplosivePassable, and the predicate make it so the entities with this layer are ignored
+            var epicenterMapPos = epicenter.ToMap(entityManager);
             foreach (var (entity, distance) in impassableEntities)
             {
-                if (!entity.InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: true, predicate: IgnoreExplosivePassable))
+                if (!entity.InRangeUnobstructed(epicenterMapPos, maxRange, ignoreInsideBlocker: true, predicate: IgnoreExplosivePassable))
                 {
                     continue;
                 }
@@ -137,7 +138,7 @@ namespace Content.Server.Explosions
             // there are probably more ExplosivePassable entities around
             foreach (var (entity, distance) in nonImpassableEntities)
             {
-                if (!entity.InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: true, predicate: IgnoreExplosivePassable))
+                if (!entity.InRangeUnobstructed(epicenterMapPos, maxRange, ignoreInsideBlocker: true, predicate: IgnoreExplosivePassable))
                 {
                     continue;
                 }
@@ -175,6 +176,7 @@ namespace Content.Server.Explosions
 
             var tilesInGridAndCircle = mapGrid.GetTilesIntersecting(boundingBox);
 
+            var epicenterMapPos = epicenter.ToMap(entityManager);
             foreach (var tile in tilesInGridAndCircle)
             {
                 var tileLoc = mapGrid.GridTileToLocal(tile.GridIndices);
@@ -183,12 +185,12 @@ namespace Content.Server.Explosions
                     continue;
                 }
 
-                if (!tileLoc.ToMap(entityManager).InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: false, predicate: IgnoreExplosivePassable))
+                if (tile.IsBlockedTurf(false))
                 {
                     continue;
                 }
 
-                if (tile.IsBlockedTurf(false))
+                if (!tileLoc.ToMap(entityManager).InRangeUnobstructed(epicenterMapPos, maxRange, ignoreInsideBlocker: false, predicate: IgnoreExplosivePassable))
                 {
                     continue;
                 }
@@ -324,7 +326,6 @@ namespace Content.Server.Explosions
             }
             else
             {
-
                 Detonate(entity, devastationRange, heavyImpactRange, lightImpactRange, flashRange);
             }
         }

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -74,7 +74,7 @@ namespace Content.Server.Explosions
 
             var exAct = entitySystemManager.GetEntitySystem<ActSystem>();
             
-            var entitiesInRange = serverEntityManager.GetEntitiesInRange(mapId, boundingBox, maxRange).ToList();
+            var entitiesInRange = serverEntityManager.GetEntitiesInRange(mapId, boundingBox, 0).ToList();
 
             foreach (var entity in entitiesInRange)
             {
@@ -83,7 +83,7 @@ namespace Content.Server.Explosions
                     continue;
                 }
 
-                if (!entity.Transform.Coordinates.TryDistance(entityManager, epicenter, out var distance))
+                if (!entity.Transform.Coordinates.TryDistance(entityManager, epicenter, out var distance) || distance > maxRange)
                 {
                     continue;
                 }
@@ -243,7 +243,9 @@ namespace Content.Server.Explosions
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
             var mapManager = IoCManager.Resolve<IMapManager>();
-            var boundingBox = Box2.CenteredAround(epicenter.ToMapPos(entityManager), new Vector2(maxRange * 2, maxRange * 2));
+
+            var epicenterMapPos = epicenter.ToMapPos(entityManager);
+            var boundingBox = new Box2(epicenterMapPos - new Vector2(maxRange, maxRange), epicenterMapPos + new Vector2(maxRange, maxRange));
 
             DamageEntitiesInRange(epicenter, boundingBox, devastationRange, heavyImpactRange, maxRange, mapId);
 

--- a/Content.Server/Explosions/ExplosionHelper.cs
+++ b/Content.Server/Explosions/ExplosionHelper.cs
@@ -45,7 +45,7 @@ namespace Content.Server.Explosions
         private static readonly float LightBreakChance = 0.3f;
         private static readonly float HeavyBreakChance = 0.8f;
 
-        private static bool IgnoreExplosivePassable(IEntity e) =>(e.GetComponent<IPhysicsComponent>().CollisionLayer & (int) CollisionGroup.ExplosivePassable) != 0;
+        private static bool IgnoreExplosivePassable(IEntity e) => (e.GetComponent<IPhysicsComponent>().CollisionLayer & (int) CollisionGroup.ExplosivePassable) != 0;
 
 
         private static ExplosionSeverity CalculateSeverity(float distance, float devastationRange, float heaveyRange)
@@ -84,7 +84,7 @@ namespace Content.Server.Explosions
 
             var exAct = entitySystemManager.GetEntitySystem<ActSystem>();
 
-            var entitiesInRange = serverEntityManager.GetEntitiesInRange(mapId, boundingBox, 0);
+            var entitiesInRange = serverEntityManager.GetEntitiesInRange(mapId, boundingBox, 0).ToList();
 
             var impassableEntities = new List<Tuple<IEntity, float>>();
             var nonImpassableEntities = new List<Tuple<IEntity, float>>();
@@ -134,8 +134,8 @@ namespace Content.Server.Explosions
                 exAct.HandleExplosion(epicenter, entity, CalculateSeverity(distance, devastationRange, heaveyRange));
             }
 
-            // Impassable entities were handled first so NonImpassable entities had bigger chance to get hit if there
-            // was an unobstructed path
+            // Impassable entities were handled first so NonImpassable entities have a bigger chance to get hit. As now
+            // there are probably more ExplosivePassable entities around
             foreach (var (entity, distance) in nonImpassableEntities)
             {
                 if (!entity.InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: true, predicate: IgnoreExplosivePassable))
@@ -184,7 +184,7 @@ namespace Content.Server.Explosions
                     continue;
                 }
 
-                if (!tileLoc.ToMap(entityManager).InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: true, predicate: IgnoreExplosivePassable))
+                if (!tileLoc.ToMap(entityManager).InRangeUnobstructed(epicenter, maxRange, ignoreInsideBlocker: false, predicate: IgnoreExplosivePassable))
                 {
                     continue;
                 }

--- a/Content.Server/GameObjects/Components/Explosion/ExplosiveComponent.cs
+++ b/Content.Server/GameObjects/Components/Explosion/ExplosiveComponent.cs
@@ -1,23 +1,8 @@
-﻿using Content.Server.Explosions;
+using Content.Server.Explosions;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.GameObjects.EntitySystems;
-using Content.Shared.Maps;
-using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Interfaces.GameObjects;
-using Robust.Shared.Interfaces.Map;
-using Robust.Shared.Interfaces.Random;
-using Robust.Shared.IoC;
-using Robust.Shared.Map;
-using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
-using Robust.Shared.Random;
-using System;
-using Robust.Shared.GameObjects.EntitySystemMessages;
-using Robust.Shared.Interfaces.Timing;
-using Robust.Server.GameObjects.EntitySystems;
-using Robust.Server.Interfaces.Player;
-using Content.Server.GameObjects.Components.Mobs;
 
 namespace Content.Server.GameObjects.Components.Explosion
 {

--- a/Content.Server/GameObjects/Components/Explosion/ExplosiveComponent.cs
+++ b/Content.Server/GameObjects/Components/Explosion/ExplosiveComponent.cs
@@ -1,8 +1,23 @@
 ﻿using Content.Server.Explosions;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.Maps;
+using Robust.Server.Interfaces.GameObjects;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Interfaces.Map;
+using Robust.Shared.Interfaces.Random;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
+using Robust.Shared.Random;
+using System;
+using Robust.Shared.GameObjects.EntitySystemMessages;
+using Robust.Shared.Interfaces.Timing;
+using Robust.Server.GameObjects.EntitySystems;
+using Robust.Server.Interfaces.Player;
+using Content.Server.GameObjects.Components.Mobs;
 
 namespace Content.Server.GameObjects.Components.Explosion
 {
@@ -16,7 +31,7 @@ namespace Content.Server.GameObjects.Components.Explosion
         public int LightImpactRange = 0;
         public int FlashRange = 0;
 
-        private bool _beingExploded = false;
+        public bool Exploding { get; private set; } = false;
 
         public override void ExposeData(ObjectSerializer serializer)
         {
@@ -30,14 +45,16 @@ namespace Content.Server.GameObjects.Components.Explosion
 
         public bool Explosion()
         {
-            //Prevent adjacent explosives from infinitely blowing each other up.
-            if (_beingExploded) return true;
-            _beingExploded = true;
-
-            Owner.SpawnExplosion(DevastationRange, HeavyImpactRange, LightImpactRange, FlashRange);
-
-            Owner.Delete();
-            return true;
+            if (Exploding)
+            {
+                return false;
+            }
+            else
+            {
+                Exploding = true;
+                Owner.SpawnExplosion(DevastationRange, HeavyImpactRange, LightImpactRange, FlashRange);
+                return true;
+            }
         }
 
         bool ITimerTrigger.Trigger(TimerTriggerEventArgs eventArgs)

--- a/Content.Server/GameObjects/Components/Explosion/ExplosiveComponent.cs
+++ b/Content.Server/GameObjects/Components/Explosion/ExplosiveComponent.cs
@@ -38,6 +38,7 @@ namespace Content.Server.GameObjects.Components.Explosion
             {
                 Exploding = true;
                 Owner.SpawnExplosion(DevastationRange, HeavyImpactRange, LightImpactRange, FlashRange);
+                Owner.Delete();
                 return true;
             }
         }

--- a/Content.Server/GameObjects/Components/Items/Storage/EntityStorageComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/EntityStorageComponent.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Linq;
 using System.Threading;
@@ -470,7 +470,8 @@ namespace Content.Server.GameObjects.Components.Items.Storage
                 return;
             }
 
-            foreach (var entity in Contents.ContainedEntities)
+            var containedEntities = Contents.ContainedEntities.ToList();
+            foreach (var entity in containedEntities)
             {
                 var exActs = entity.GetAllComponents<IExAct>().ToArray();
                 foreach (var exAct in exActs)

--- a/Content.Server/GameObjects/Components/Projectiles/ThrownItemComponent.cs
+++ b/Content.Server/GameObjects/Components/Projectiles/ThrownItemComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.GameObjects.EntitySystems.Click;
+using Content.Server.GameObjects.EntitySystems.Click;
 using Content.Shared.Damage;
 using Content.Shared.GameObjects;
 using Content.Shared.GameObjects.Components.Damage;
@@ -33,7 +33,7 @@ namespace Content.Server.GameObjects.Components.Projectiles
 
         void ICollideBehavior.CollideWith(IEntity entity)
         {
-            if (!_shouldCollide) return;
+            if (!_shouldCollide || entity.Deleted) return;
             if (entity.TryGetComponent(out PhysicsComponent collid))
             {
                 if (!collid.Hard) // ignore non hard

--- a/Content.Server/Throw/ThrowHelper.cs
+++ b/Content.Server/Throw/ThrowHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Content.Server.GameObjects.Components.Projectiles;
 using Content.Shared.GameObjects.Components.Movement;
 using Content.Shared.GameObjects.EntitySystems;
@@ -43,6 +43,11 @@ namespace Content.Server.Throw
         /// </param>
         public static void Throw(this IEntity thrownEnt, float throwForce, EntityCoordinates targetLoc, EntityCoordinates sourceLoc, bool spread = false, IEntity throwSourceEnt = null)
         {
+            if (thrownEnt.Deleted)
+            {
+                return;
+            }
+
             if (!thrownEnt.TryGetComponent(out IPhysicsComponent colComp))
                 return;
 

--- a/Content.Server/Throw/ThrowHelper.cs
+++ b/Content.Server/Throw/ThrowHelper.cs
@@ -47,6 +47,12 @@ namespace Content.Server.Throw
                 return;
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
+            var direction_vector = targetLoc.ToMapPos(entityManager) - sourceLoc.ToMapPos(entityManager);
+
+            if (direction_vector.Length == 0)
+            {
+                return;
+            }
 
             colComp.CanCollide = true;
             // I can now collide with player, so that i can do damage.
@@ -61,8 +67,8 @@ namespace Content.Server.Throw
                 colComp.PhysicsShapes[0].CollisionMask |= (int) CollisionGroup.ThrownItem;
                 colComp.Status = BodyStatus.InAir;
             }
-            var angle = new Angle(targetLoc.ToMapPos(entityManager) - sourceLoc.ToMapPos(entityManager));
 
+            var angle = new Angle(direction_vector);
             if (spread)
             {
                 var spreadRandom = IoCManager.Resolve<IRobustRandom>();

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using JetBrains.Annotations;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
@@ -23,6 +23,7 @@ namespace Content.Shared.Physics
         GhostImpassable = 1 <<  6, // 64 Things impassible by ghosts/observers, ie blessed tiles or forcefields
         Underplating    = 1 <<  7, // 128 Things that are under plating
         Passable        = 1 <<  8, // 256 Things that are passable
+        ExplosivePassable = 1 << 9, // 512 Things that let the pressure of a explosion through
         MapGrid         = MapGridHelpers.CollisionGroup, // Map grids, like shuttles. This is the actual grid itself, not the walls or other entities connected to the grid.
 
         MobMask = Impassable | MobImpassable | VaultImpassable | SmallImpassable,

--- a/Resources/Prototypes/Entities/Constructible/Walls/girder.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/girder.yml
@@ -24,6 +24,7 @@
       - MobImpassable
       - VaultImpassable
       - SmallImpassable
+      - ExplosivePassable
   - type: Pullable
   - type: Damageable
     resistances: metallicResistances


### PR DESCRIPTION
- Tiles are not destroyed if after the explosion there is an entity with an airtightcomponent and airblocked, like most walls, on top of them 
- Fixed the range of the explosion, some entities were not getting damaged

