### PR TITLE
Fix "stuck" drag/drop controls using ControlFocusExited

### DIFF
--- a/Content.Client/Arcade/BlockGameMenu.cs
+++ b/Content.Client/Arcade/BlockGameMenu.cs
@@ -458,7 +458,7 @@ namespace Content.Client.Arcade
             return grid;
         }
 
-        protected override void FocusExited()
+        protected override void KeyboardFocusExited()
         {
             if (!IsOpen) return;
             if(_gameOver) return;

--- a/Content.Client/UserInterface/ActionMenu.cs
+++ b/Content.Client/UserInterface/ActionMenu.cs
@@ -280,6 +280,12 @@ namespace Content.Client.UserInterface
             _dragDropHelper.EndDrag();
         }
 
+        private void OnItemFocusExited(ActionMenuItem item)
+        {
+            // lost focus, cancel the drag if one is in progress
+            _dragDropHelper.EndDrag();
+        }
+
         private void OnItemPressed(BaseButton.ButtonEventArgs args)
         {
             if (args.Button is not ActionMenuItem actionMenuItem) return;
@@ -462,10 +468,9 @@ namespace Content.Client.UserInterface
             _actionList = actions.ToArray();
             foreach (var action in _actionList.OrderBy(act => act.Name.ToString()))
             {
-                var actionItem = new ActionMenuItem(action);
+                var actionItem = new ActionMenuItem(action, OnItemFocusExited);
                 _resultsGrid.Children.Add(actionItem);
                 actionItem.SetActionState(_actionsComponent.IsGranted(action));
-
                 actionItem.OnButtonDown += OnItemButtonDown;
                 actionItem.OnButtonUp += OnItemButtonUp;
                 actionItem.OnPressed += OnItemPressed;

--- a/Content.Client/UserInterface/ActionMenuItem.cs
+++ b/Content.Client/UserInterface/ActionMenuItem.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System;
+using Content.Client.GameObjects.Components.Mobs;
 using Content.Client.UserInterface.Stylesheets;
 using Content.Shared.Actions;
 using Robust.Client.UserInterface;
@@ -19,8 +21,11 @@ namespace Content.Client.UserInterface
 
         public BaseActionPrototype Action { get; private set; }
 
-        public ActionMenuItem(BaseActionPrototype action)
+        private Action<ActionMenuItem> _onControlFocusExited;
+
+        public ActionMenuItem(BaseActionPrototype action, Action<ActionMenuItem> onControlFocusExited)
         {
+            _onControlFocusExited = onControlFocusExited;
             Action = action;
 
             CustomMinimumSize = (64, 64);
@@ -36,6 +41,12 @@ namespace Content.Client.UserInterface
 
             TooltipDelay = CustomTooltipDelay;
             TooltipSupplier = SupplyTooltip;
+        }
+
+        protected override void ControlFocusExited()
+        {
+            base.ControlFocusExited();
+            _onControlFocusExited.Invoke(this);
         }
 
         private Control SupplyTooltip(Control? sender)

--- a/Content.Client/UserInterface/ActionMenuItem.cs
+++ b/Content.Client/UserInterface/ActionMenuItem.cs
@@ -46,7 +46,7 @@ namespace Content.Client.UserInterface
         protected override void ControlFocusExited()
         {
             base.ControlFocusExited();
-            _onControlFocusExited.Invoke(this);
+            _onControlFocusExited?.Invoke(this);
         }
 
         private Control SupplyTooltip(Control? sender)

--- a/Content.Client/UserInterface/ActionMenuItem.cs
+++ b/Content.Client/UserInterface/ActionMenuItem.cs
@@ -46,7 +46,7 @@ namespace Content.Client.UserInterface
         protected override void ControlFocusExited()
         {
             base.ControlFocusExited();
-            _onControlFocusExited?.Invoke(this);
+            _onControlFocusExited.Invoke(this);
         }
 
         private Control SupplyTooltip(Control? sender)

--- a/Content.Client/UserInterface/Controls/ActionSlot.cs
+++ b/Content.Client/UserInterface/Controls/ActionSlot.cs
@@ -325,6 +325,14 @@ namespace Content.Client.UserInterface.Controls
             DrawModeChanged();
         }
 
+        protected override void ControlFocusExited()
+        {
+            // lost focus for some reason, cancel the drag if there is one.
+            base.ControlFocusExited();
+            _actionsUI.DragDropHelper.EndDrag();
+            DrawModeChanged();
+        }
+
         /// <summary>
         /// Cancel current press without triggering the action
         /// </summary>


### PR DESCRIPTION
This fixes an issue where drag/dropping actions in slots or from actions menu would cause them to get "stuck" if you pressed RMB over a different control during the drag.

It also updates usages of the old FocusEntered/Exited based on the renaming.

EDIT: This can later be taken advantage of by other controls, such as Buttons. Currently, buttons also suffer from a similar issue - if you LMB down and drag off, then RMB another control, the button is stuck clicked down. By using this new hook they could revert to being unpressed when losing focus - see https://github.com/space-wizards/RobustToolbox/issues/1468 . I am planning to address that ticket next as I've been doing a lot of UI-related work lately.

Depends on space-wizards/RobustToolbox#1467