### PR TITLE
Maps in cargo teleporter.

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -46,7 +46,7 @@ grids:
   - ind: "0,0"
     tiles: FwAAABMAAAATAAAAEwAAABMAAAATAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABcAAAAaAAAAEwAAABMAAAATAAAAGgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAaAAAAFgAAABYAAAAaAAAAGgAAABMAAAATAAAAEwAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABoAAAATAAAAEwAAABMAAAAaAAAAGgAAABMAAAAaAAAAEwAAABoAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAAaAAAAEwAAABoAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAAaAAAAGgAAABoAAAAVAAAAGgAAABoAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAGgAAABkAAAAZAAAAGQAAABkAAAAZAAAAGgAAABoAAAAaAAAAGgAAABoAAAATAAAAGgAAABMAAAATAAAAEwAAABUAAAAZAAAAFQAAABUAAAAVAAAAGQAAABkAAAAZAAAAFQAAABUAAAAVAAAAGgAAABoAAAATAAAAEwAAABMAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGQAAABUAAAAaAAAAFQAAAA==
   - ind: "1,0"
-    tiles: FgAAABYAAAAWAAAAGgAAABkAAAAVAAAAFQAAABUAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABYAAAAWAAAAFgAAABoAAAAZAAAAGQAAABUAAAAVAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABUAAAAaAAAAGgAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABoAAAAaAAAAFQAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAGQAAABkAAAAZAAAAGgAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAFQAAABkAAAAVAAAAGQAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAAVAAAAFQAAABUAAAAVAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAFQAAABUAAAAVAAAAGgAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABUAAAAVAAAAFQAAABoAAAATAAAAEwAAABoAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAAZAAAAGQAAABkAAAAaAAAAEwAAABMAAAAVAAAAGgAAABoAAAAaAAAAFQAAABoAAAAVAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAATAAAAFQAAABoAAAAAAAAAGgAAABUAAAAaAAAAFQAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAAAGgAAAA==
+    tiles: FgAAABYAAAAWAAAAGgAAABkAAAAVAAAAFQAAABUAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABYAAAAWAAAAFgAAABoAAAAZAAAAGQAAABUAAAAVAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABUAAAAaAAAAGgAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABoAAAAaAAAAFQAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAGQAAABkAAAAZAAAAGgAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAFQAAABkAAAAVAAAAGQAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAAVAAAAFQAAABUAAAAVAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAFQAAABUAAAAVAAAAGgAAABMAAAATAAAAEwAAABoAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABUAAAAVAAAAFQAAABoAAAATAAAAEwAAABoAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAAZAAAAGQAAABkAAAAaAAAAEwAAABMAAAAVAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAATAAAAFQAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAAAGgAAAA==
   - ind: "0,1"
     tiles: GgAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABMAAAAaAAAAGQAAABUAAAAaAAAAFQAAABUAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABkAAAAVAAAAGgAAAAAAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAEwAAABoAAAAZAAAAFQAAABoAAAAAAAAAGgAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABMAAAATAAAAEwAAABMAAAAaAAAAGQAAABUAAAAaAAAAAAAAABUAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAFQAAABkAAAAVAAAAGgAAAAAAAAAaAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAEwAAABMAAAATAAAAEwAAABoAAAAVAAAAFQAAABoAAAAAAAAAGgAAABoAAAATAAAAGgAAABMAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAFQAAABoAAAAaAAAAAAAAAA0AAAAaAAAAEwAAABMAAAATAAAAGgAAABcAAAAXAAAAFwAAABcAAAAaAAAAFQAAABUAAAAVAAAAGgAAAAAAAAANAAAADQAAABMAAAATAAAAEwAAABoAAAAXAAAAFwAAABcAAAAXAAAAGgAAABkAAAAZAAAAGQAAABoAAAAAAAAADQAAAA0AAAATAAAAEwAAABMAAAATAAAAFwAAABcAAAAXAAAAFwAAABoAAAAaAAAAGgAAABoAAAAaAAAAAAAAAA0AAAAaAAAAEwAAABMAAAATAAAAGgAAABcAAAAXAAAAFwAAABcAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAAAGgAAABMAAAATAAAAEwAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAATAAAAGgAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
   - ind: "-2,0"
@@ -64,7 +64,7 @@ grids:
   - ind: "-1,2"
     tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABoAAAAaAAAAEwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
   - ind: "1,1"
-    tiles: GgAAABoAAAAAAAAAGgAAABUAAAAaAAAAFQAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    tiles: GgAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
   - ind: "0,2"
     tiles: EwAAABMAAAATAAAAEwAAABMAAAATAAAAEwAAABMAAAAaAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAABoAAAAaAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
   - ind: "2,0"
@@ -103,84 +103,84 @@ entities:
 - uid: 0
   type: SuspicionHitscanSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1
   type: SuspicionShotgunSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2
   type: SuspicionShotgunMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3
   type: SuspicionPistolMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4
   type: SuspicionRifleMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 5
   type: SuspicionRifleMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 6
   type: SuspicionShotgunMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 7
   type: SuspicionShotgunMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 8
   type: SuspicionGrenadesSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 9
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 10
   type: SpawnPointStationEngineer
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 11
   type: SuspicionLaunchersSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -189,35 +189,35 @@ entities:
   components:
   - name: Bar
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -7.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 13
   type: SuspicionShotgunSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 14
   type: SuspicionSMGSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 15
   type: BikeHornInstrument
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 16
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -226,231 +226,231 @@ entities:
 - uid: 17
   type: SuspicionRevolverSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 18
   type: SuspicionHitscanSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 19
   type: SuspicionPistolSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 20
   type: SuspicionPistolSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 21
   type: SuspicionPistolMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 22
   type: SuspicionPistolMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 23
   type: SuspicionPistolMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 24
   type: SuspicionPistolMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 25
   type: SuspicionPistolMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 26
   type: SuspicionShotgunMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 27
   type: SuspicionShotgunMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 28
   type: SuspicionShotgunSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 29
   type: SuspicionRifleMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 30
   type: SuspicionSMGSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 31
   type: SuspicionMagnumMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 32
   type: SuspicionRevolverSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 33
   type: SuspicionMagnumMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 34
   type: SuspicionGrenadesSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 35
   type: SuspicionGrenadesSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 36
   type: SuspicionHitscanSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 37
   type: SuspicionGrenadesSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 38
   type: SuspicionGrenadesSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 39
   type: SuspicionRifleMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 40
   type: SuspicionSniperSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 41
   type: SuspicionShotgunSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 42
   type: SuspicionShotgunMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 43
   type: SuspicionShotgunMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 44
   type: FoodBananaCreamPie
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.509874,-9.279623
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 45
   type: FoodBananaCreamPie
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.947374,-9.467123
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 46
   type: FoodBanana
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.463,-9.482748
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 47
   type: FoodBanana
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.603624,-9.388998
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 48
   type: FoodBanana
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.728624,-9.576498
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 49
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-7
     rot: -1.5707963267948966 rad
     type: Transform
@@ -463,28 +463,28 @@ entities:
 - uid: 50
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 51
   type: BoneSaw
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.49593,-21.552101
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 52
   type: ClothingUnderSocksCoder
   components:
-  - parent: 855
+  - parent: 854
     pos: 47.437466,-6.6893435
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 53
   type: JawsOfLife
   components:
-  - parent: 855
+  - parent: 854
     pos: 39.53893,-0.77325034
     rot: -1.5707963267948966 rad
     type: Transform
@@ -493,21 +493,21 @@ entities:
 - uid: 54
   type: ClothingHandsGlovesLatex
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.086878,-4.4133806
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 55
   type: ClothingHandsGlovesLatex
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.618128,-4.4133806
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 56
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -516,84 +516,84 @@ entities:
 - uid: 57
   type: ToyPhazon
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.449931,16.636608
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 58
   type: Scalpel
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.190952,-21.29313
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 59
   type: DrinkBottleRum
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.694785,24.608267
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 60
   type: DisgustingSweptSoup
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.96041,24.545767
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 61
   type: Retractor
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.482815,-21.853302
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 62
   type: ToyMouse
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.376545,-7.1625524
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 63
   type: SignSurgery
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.296293,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 64
   type: Drill
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.515043,-22.566078
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 65
   type: BedsheetMedical
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 66
   type: Bed
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 67
   type: Hemostat
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.655668,-21.300453
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 68
   type: LockerCursed
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -606,7 +606,7 @@ entities:
 - uid: 69
   type: PowerCellRecharger
   components:
-  - parent: 855
+  - parent: 854
     pos: 39.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -619,7 +619,7 @@ entities:
 - uid: 70
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -628,14 +628,14 @@ entities:
 - uid: 71
   type: SuspicionPistolSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 72
   type: ToolboxGoldFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.454914,18.643616
     rot: -1.5707963267948966 rad
     type: Transform
@@ -646,287 +646,287 @@ entities:
 - uid: 73
   type: DrinkGoldenCup
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.470539,16.956116
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 74
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 75
   type: FoodDonkPocket
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.274685,-1.5622956
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 76
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,-2.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 77
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 78
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 79
   type: FoodDonkPocket
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.66531,-1.3435456
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 80
   type: DrinkFlask
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.439846,26.712742
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 81
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 32.5,-2.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 82
   type: ClothingNeckBling
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.861164,18.612366
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 83
   type: ClothingNeckBling
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.564289,18.643616
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 84
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 85
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 86
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 87
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 88
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 89
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 90
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 91
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 92
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 93
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 94
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 95
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 96
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 97
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 98
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 99
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 100
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 101
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 102
   type: Brutepack
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.839255,-3.3712535
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 103
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 104
   type: RCD
   components:
-  - parent: 855
+  - parent: 854
     pos: 29.55875,-4.333219
     type: Transform
 - uid: 105
   type: RCD
   components:
-  - parent: 855
+  - parent: 854
     pos: 29.4025,-4.489469
     type: Transform
 - uid: 106
   type: WeldingFuelTank
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-11.5
     type: Transform
 - uid: 107
   type: WaterTankFull
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-11.5
     type: Transform
 - uid: 108
   type: Basketball
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5183675,-6.4951944
     type: Transform
 - uid: 109
   type: SignSomethingOld2
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.996767,-0.60842
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 110
   type: SignSomethingOld
   components:
-  - parent: 855
+  - parent: 854
     pos: 17.158585,-23.619913
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 111
   type: SignAtmos
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.498556,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 112
   type: Paper
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.379866,25.982151
     type: Transform
 - uid: 113
   type: DrinkHotCoffee
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.661116,25.513401
     type: Transform
 - uid: 114
   type: BoxDonkpocket
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.57156,-2.0622954
     rot: 1.5707963267948966 rad
     type: Transform
@@ -937,7 +937,7 @@ entities:
 - uid: 115
   type: FlashlightLantern
   components:
-  - parent: 855
+  - parent: 854
     pos: 30.248352,-4.36431
     type: Transform
   - containers:
@@ -949,7 +949,7 @@ entities:
 - uid: 116
   type: FlashlightLantern
   components:
-  - parent: 855
+  - parent: 854
     pos: 30.545227,-4.17681
     type: Transform
   - containers:
@@ -961,7 +961,7 @@ entities:
 - uid: 117
   type: ClothingHeadHatHardhatYellow
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.357727,-4.36431
     type: Transform
   - containers:
@@ -971,7 +971,7 @@ entities:
 - uid: 118
   type: ClothingHeadHatHardhatWhite
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.623352,-4.14556
     type: Transform
   - containers:
@@ -981,7 +981,7 @@ entities:
 - uid: 119
   type: ClothingHeadHatHardhatRed
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.201477,-4.05181
     type: Transform
   - containers:
@@ -991,35 +991,35 @@ entities:
 - uid: 120
   type: VendingMachineDinnerware
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 121
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 122
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 123
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 124
   type: Stunbaton
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.484581,20.641253
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1032,7 +1032,7 @@ entities:
 - uid: 125
   type: Stunbaton
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.609581,20.969378
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1050,7 +1050,7 @@ entities:
 - uid: 127
   type: TaserGun
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.515831,21.735003
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1070,7 +1070,7 @@ entities:
 - uid: 129
   type: TaserGun
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.672081,21.719378
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1085,35 +1085,35 @@ entities:
 - uid: 130
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 131
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 132
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 133
   type: SignEngineering
   components:
-  - parent: 855
+  - parent: 854
     pos: 30.305984,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 134
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 41.000477,14
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1126,7 +1126,7 @@ entities:
 - uid: 135
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -10,13.5
     type: Transform
   - powerLoad: 0
@@ -1138,7 +1138,7 @@ entities:
 - uid: 136
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -26,-3.5
     type: Transform
   - powerLoad: 0
@@ -1153,26 +1153,26 @@ entities:
   - name: Uhm
     desc: Uhm
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 33.498077,11.399912
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 138
   type: SignDirectionalEng
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.987236,6.2578936
     type: Transform
 - uid: 139
   type: SignBridge
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.6507263,22.5
     type: Transform
 - uid: 140
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.939785,7
     type: Transform
   - powerLoad: 0
@@ -1184,7 +1184,7 @@ entities:
 - uid: 141
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.231159,-17
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1197,35 +1197,35 @@ entities:
 - uid: 142
   type: SignRND
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.506548,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 143
   type: SignMedical
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.500677,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 144
   type: SignGravity
   components:
-  - parent: 855
+  - parent: 854
     pos: 48.325787,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 145
   type: SignToolStorage
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.694574,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 146
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.73304,7
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1238,96 +1238,96 @@ entities:
 - uid: 147
   type: SignEVA
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.691145,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 148
   type: SignChem
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.317627,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 149
   type: SignCargoDock
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.501179,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 150
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 151
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 152
-  type: LowWall
+  type: HVWire
   components:
-  - parent: 855
-    pos: 21.5,15.5
+  - parent: 854
+    pos: 58.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 153
-  type: LowWall
+  type: HVWire
   components:
-  - parent: 855
-    pos: 21.5,16.5
+  - parent: 854
+    pos: 58.5,-29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 154
   type: SignDirectionalEvac
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.488556,6.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 155
   type: SignDirectionalSupply
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.704908,7.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 156
   type: AirlockMaint
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,-12.5
     type: Transform
 - uid: 157
   type: ConveyorBelt
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,-13.5
     type: Transform
 - uid: 158
   type: LargeBeaker
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.611881,1.2455455
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 159
   type: Beaker
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.361881,1.6674205
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 160
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: 17.5,-0.5
     type: Transform
   - containers:
@@ -1337,7 +1337,7 @@ entities:
 - uid: 161
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: 17.5,-1.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1348,7 +1348,7 @@ entities:
 - uid: 162
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-1.5
     type: Transform
   - containers:
@@ -1358,7 +1358,7 @@ entities:
 - uid: 163
   type: TwoWayLever
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.467268,-14.347846
     rot: 3.141592653589793 rad
     type: Transform
@@ -1367,7 +1367,7 @@ entities:
 - uid: 164
   type: DisposalJunctionFlipped
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1378,7 +1378,7 @@ entities:
 - uid: 165
   type: DisposalJunction
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1389,7 +1389,7 @@ entities:
 - uid: 166
   type: DisposalJunction
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1400,7 +1400,7 @@ entities:
 - uid: 167
   type: DisposalJunctionFlipped
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1411,7 +1411,7 @@ entities:
 - uid: 168
   type: DisposalJunction
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1422,7 +1422,7 @@ entities:
 - uid: 169
   type: DisposalJunctionFlipped
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1433,7 +1433,7 @@ entities:
 - uid: 170
   type: DisposalJunctionFlipped
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-15.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1444,7 +1444,7 @@ entities:
 - uid: 171
   type: DisposalJunction
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-15.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1455,7 +1455,7 @@ entities:
 - uid: 172
   type: DisposalYJunction
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1466,7 +1466,7 @@ entities:
 - uid: 173
   type: DisposalJunctionFlipped
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,-10.5
     type: Transform
   - containers:
@@ -1476,7 +1476,7 @@ entities:
 - uid: 174
   type: DisposalJunction
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1487,7 +1487,7 @@ entities:
 - uid: 175
   type: DisposalJunction
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1498,7 +1498,7 @@ entities:
 - uid: 176
   type: DisposalJunctionFlipped
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1509,7 +1509,7 @@ entities:
 - uid: 177
   type: DisposalJunctionFlipped
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1520,7 +1520,7 @@ entities:
 - uid: 178
   type: DisposalJunction
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1531,7 +1531,7 @@ entities:
 - uid: 179
   type: DisposalJunctionFlipped
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1542,7 +1542,7 @@ entities:
 - uid: 180
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-14.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1553,7 +1553,7 @@ entities:
 - uid: 181
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-13.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1564,7 +1564,7 @@ entities:
 - uid: 182
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-12.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1575,7 +1575,7 @@ entities:
 - uid: 183
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-11.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1586,7 +1586,7 @@ entities:
 - uid: 184
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-22.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1597,7 +1597,7 @@ entities:
 - uid: 185
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-22.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1608,7 +1608,7 @@ entities:
 - uid: 186
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,-15.5
     type: Transform
   - containers:
@@ -1618,7 +1618,7 @@ entities:
 - uid: 187
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1629,7 +1629,7 @@ entities:
 - uid: 188
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1640,7 +1640,7 @@ entities:
 - uid: 189
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1651,7 +1651,7 @@ entities:
 - uid: 190
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1662,7 +1662,7 @@ entities:
 - uid: 191
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1673,14 +1673,14 @@ entities:
 - uid: 192
   type: VendingMachineYouTool
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 193
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1691,7 +1691,7 @@ entities:
 - uid: 194
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-15.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1702,7 +1702,7 @@ entities:
 - uid: 195
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-16.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1713,7 +1713,7 @@ entities:
 - uid: 196
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,17.5
     type: Transform
   - containers:
@@ -1723,7 +1723,7 @@ entities:
 - uid: 197
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,17.5
     type: Transform
   - containers:
@@ -1733,7 +1733,7 @@ entities:
 - uid: 198
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,17.5
     type: Transform
   - containers:
@@ -1743,7 +1743,7 @@ entities:
 - uid: 199
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,17.5
     type: Transform
   - containers:
@@ -1753,7 +1753,7 @@ entities:
 - uid: 200
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,17.5
     type: Transform
   - containers:
@@ -1763,7 +1763,7 @@ entities:
 - uid: 201
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,17.5
     type: Transform
   - containers:
@@ -1773,7 +1773,7 @@ entities:
 - uid: 202
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,17.5
     type: Transform
   - containers:
@@ -1783,7 +1783,7 @@ entities:
 - uid: 203
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1794,7 +1794,7 @@ entities:
 - uid: 204
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-17.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1805,7 +1805,7 @@ entities:
 - uid: 205
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 4.5,11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1816,7 +1816,7 @@ entities:
 - uid: 206
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1827,7 +1827,7 @@ entities:
 - uid: 207
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1838,7 +1838,7 @@ entities:
 - uid: 208
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -1849,7 +1849,7 @@ entities:
 - uid: 209
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-18.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1860,7 +1860,7 @@ entities:
 - uid: 210
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1871,7 +1871,7 @@ entities:
 - uid: 211
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1882,7 +1882,7 @@ entities:
 - uid: 212
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1893,7 +1893,7 @@ entities:
 - uid: 213
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1904,7 +1904,7 @@ entities:
 - uid: 214
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -1915,7 +1915,7 @@ entities:
 - uid: 215
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,-1.5
     type: Transform
   - containers:
@@ -1925,7 +1925,7 @@ entities:
 - uid: 216
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,-1.5
     type: Transform
   - containers:
@@ -1935,7 +1935,7 @@ entities:
 - uid: 217
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-1.5
     type: Transform
   - containers:
@@ -1945,7 +1945,7 @@ entities:
 - uid: 218
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-19.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1956,13 +1956,13 @@ entities:
 - uid: 219
   type: Recycler
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,-13.5
     type: Transform
 - uid: 220
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-20.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1973,7 +1973,7 @@ entities:
 - uid: 221
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,1.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1984,7 +1984,7 @@ entities:
 - uid: 222
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,0.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -1995,7 +1995,7 @@ entities:
 - uid: 223
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,-0.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2006,7 +2006,7 @@ entities:
 - uid: 224
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2017,7 +2017,7 @@ entities:
 - uid: 225
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,-2.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2028,7 +2028,7 @@ entities:
 - uid: 226
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,-3.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2039,7 +2039,7 @@ entities:
 - uid: 227
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,-4.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2050,7 +2050,7 @@ entities:
 - uid: 228
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,-4.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2061,7 +2061,7 @@ entities:
 - uid: 229
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 30.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2072,7 +2072,7 @@ entities:
 - uid: 230
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2083,7 +2083,7 @@ entities:
 - uid: 231
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 35.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2094,7 +2094,7 @@ entities:
 - uid: 232
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,2.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2105,7 +2105,7 @@ entities:
 - uid: 233
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2116,7 +2116,7 @@ entities:
 - uid: 234
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 32.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2127,7 +2127,7 @@ entities:
 - uid: 235
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2138,7 +2138,7 @@ entities:
 - uid: 236
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2149,7 +2149,7 @@ entities:
 - uid: 237
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2160,7 +2160,7 @@ entities:
 - uid: 238
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2171,7 +2171,7 @@ entities:
 - uid: 239
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2182,7 +2182,7 @@ entities:
 - uid: 240
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2193,7 +2193,7 @@ entities:
 - uid: 241
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,29.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2204,7 +2204,7 @@ entities:
 - uid: 242
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2215,7 +2215,7 @@ entities:
 - uid: 243
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2226,7 +2226,7 @@ entities:
 - uid: 244
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2237,7 +2237,7 @@ entities:
 - uid: 245
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2248,7 +2248,7 @@ entities:
 - uid: 246
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2259,7 +2259,7 @@ entities:
 - uid: 247
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2270,7 +2270,7 @@ entities:
 - uid: 248
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2281,7 +2281,7 @@ entities:
 - uid: 249
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2292,7 +2292,7 @@ entities:
 - uid: 250
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2303,7 +2303,7 @@ entities:
 - uid: 251
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2314,7 +2314,7 @@ entities:
 - uid: 252
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2325,7 +2325,7 @@ entities:
 - uid: 253
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2336,7 +2336,7 @@ entities:
 - uid: 254
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,17.5
     type: Transform
   - containers:
@@ -2346,7 +2346,7 @@ entities:
 - uid: 255
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2357,7 +2357,7 @@ entities:
 - uid: 256
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2368,7 +2368,7 @@ entities:
 - uid: 257
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2379,7 +2379,7 @@ entities:
 - uid: 258
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2390,7 +2390,7 @@ entities:
 - uid: 259
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2401,7 +2401,7 @@ entities:
 - uid: 260
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2412,7 +2412,7 @@ entities:
 - uid: 261
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2423,7 +2423,7 @@ entities:
 - uid: 262
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2434,7 +2434,7 @@ entities:
 - uid: 263
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2445,7 +2445,7 @@ entities:
 - uid: 264
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2456,14 +2456,14 @@ entities:
 - uid: 265
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 266
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -2474,7 +2474,7 @@ entities:
 - uid: 267
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-21.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2485,7 +2485,7 @@ entities:
 - uid: 268
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,29.5
     type: Transform
   - containers:
@@ -2495,7 +2495,7 @@ entities:
 - uid: 269
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,29.5
     type: Transform
   - containers:
@@ -2505,7 +2505,7 @@ entities:
 - uid: 270
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,29.5
     type: Transform
   - containers:
@@ -2515,7 +2515,7 @@ entities:
 - uid: 271
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,29.5
     type: Transform
   - containers:
@@ -2525,7 +2525,7 @@ entities:
 - uid: 272
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,29.5
     type: Transform
   - containers:
@@ -2535,7 +2535,7 @@ entities:
 - uid: 273
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,29.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2546,7 +2546,7 @@ entities:
 - uid: 274
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-10.5
     type: Transform
   - containers:
@@ -2556,7 +2556,7 @@ entities:
 - uid: 275
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-8.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2567,7 +2567,7 @@ entities:
 - uid: 276
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-7.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2578,7 +2578,7 @@ entities:
 - uid: 277
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-6.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2589,7 +2589,7 @@ entities:
 - uid: 278
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-5.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2600,7 +2600,7 @@ entities:
 - uid: 279
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-4.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2611,7 +2611,7 @@ entities:
 - uid: 280
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-3.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2622,7 +2622,7 @@ entities:
 - uid: 281
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-2.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2633,7 +2633,7 @@ entities:
 - uid: 282
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2644,7 +2644,7 @@ entities:
 - uid: 283
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-0.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2655,7 +2655,7 @@ entities:
 - uid: 284
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,0.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2666,7 +2666,7 @@ entities:
 - uid: 285
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,1.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2677,7 +2677,7 @@ entities:
 - uid: 286
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,2.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2688,7 +2688,7 @@ entities:
 - uid: 287
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-10.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2699,7 +2699,7 @@ entities:
 - uid: 288
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-11.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2710,7 +2710,7 @@ entities:
 - uid: 289
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2721,7 +2721,7 @@ entities:
 - uid: 290
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2732,7 +2732,7 @@ entities:
 - uid: 291
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2743,7 +2743,7 @@ entities:
 - uid: 292
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2754,7 +2754,7 @@ entities:
 - uid: 293
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 4.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2765,7 +2765,7 @@ entities:
 - uid: 294
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2776,7 +2776,7 @@ entities:
 - uid: 295
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2787,7 +2787,7 @@ entities:
 - uid: 296
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2798,7 +2798,7 @@ entities:
 - uid: 297
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2809,7 +2809,7 @@ entities:
 - uid: 298
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-10.5
     type: Transform
   - containers:
@@ -2819,7 +2819,7 @@ entities:
 - uid: 299
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,1.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2830,7 +2830,7 @@ entities:
 - uid: 300
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,0.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2841,7 +2841,7 @@ entities:
 - uid: 301
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-0.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2852,7 +2852,7 @@ entities:
 - uid: 302
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-2.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2863,7 +2863,7 @@ entities:
 - uid: 303
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-2.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2874,21 +2874,21 @@ entities:
 - uid: 304
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 305
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 306
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2899,7 +2899,7 @@ entities:
 - uid: 307
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2910,7 +2910,7 @@ entities:
 - uid: 308
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2921,7 +2921,7 @@ entities:
 - uid: 309
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2932,7 +2932,7 @@ entities:
 - uid: 310
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2943,7 +2943,7 @@ entities:
 - uid: 311
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2954,7 +2954,7 @@ entities:
 - uid: 312
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2965,7 +2965,7 @@ entities:
 - uid: 313
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,2.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -2976,7 +2976,7 @@ entities:
 - uid: 314
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2987,7 +2987,7 @@ entities:
 - uid: 315
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -2998,7 +2998,7 @@ entities:
 - uid: 316
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3009,7 +3009,7 @@ entities:
 - uid: 317
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3020,7 +3020,7 @@ entities:
 - uid: 318
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 17.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3031,7 +3031,7 @@ entities:
 - uid: 319
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3042,7 +3042,7 @@ entities:
 - uid: 320
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3053,7 +3053,7 @@ entities:
 - uid: 321
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3064,7 +3064,7 @@ entities:
 - uid: 322
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3075,7 +3075,7 @@ entities:
 - uid: 323
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3086,7 +3086,7 @@ entities:
 - uid: 324
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3097,7 +3097,7 @@ entities:
 - uid: 325
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3108,7 +3108,7 @@ entities:
 - uid: 326
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,14.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3117,7 +3117,7 @@ entities:
 - uid: 327
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3128,7 +3128,7 @@ entities:
 - uid: 328
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3139,7 +3139,7 @@ entities:
 - uid: 329
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3150,7 +3150,7 @@ entities:
 - uid: 330
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 29.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3161,7 +3161,7 @@ entities:
 - uid: 331
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 4.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3172,7 +3172,7 @@ entities:
 - uid: 332
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,-9.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -3183,7 +3183,7 @@ entities:
 - uid: 333
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3194,7 +3194,7 @@ entities:
 - uid: 334
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-10.5
     type: Transform
   - containers:
@@ -3204,7 +3204,7 @@ entities:
 - uid: 335
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,1.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -3215,7 +3215,7 @@ entities:
 - uid: 336
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3226,7 +3226,7 @@ entities:
 - uid: 337
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3237,7 +3237,7 @@ entities:
 - uid: 338
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3248,7 +3248,7 @@ entities:
 - uid: 339
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,-10.5
     type: Transform
   - containers:
@@ -3258,7 +3258,7 @@ entities:
 - uid: 340
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,2.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -3269,7 +3269,7 @@ entities:
 - uid: 341
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,1.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -3280,7 +3280,7 @@ entities:
 - uid: 342
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,-10.5
     type: Transform
   - containers:
@@ -3290,7 +3290,7 @@ entities:
 - uid: 343
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3301,7 +3301,7 @@ entities:
 - uid: 344
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3312,7 +3312,7 @@ entities:
 - uid: 345
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,3.5
     type: Transform
   - containers:
@@ -3322,7 +3322,7 @@ entities:
 - uid: 346
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3333,7 +3333,7 @@ entities:
 - uid: 347
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3344,7 +3344,7 @@ entities:
 - uid: 348
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3355,7 +3355,7 @@ entities:
 - uid: 349
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3366,7 +3366,7 @@ entities:
 - uid: 350
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3377,7 +3377,7 @@ entities:
 - uid: 351
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3388,7 +3388,7 @@ entities:
 - uid: 352
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3399,7 +3399,7 @@ entities:
 - uid: 353
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3410,7 +3410,7 @@ entities:
 - uid: 354
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3421,7 +3421,7 @@ entities:
 - uid: 355
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3432,7 +3432,7 @@ entities:
 - uid: 356
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3443,7 +3443,7 @@ entities:
 - uid: 357
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3454,7 +3454,7 @@ entities:
 - uid: 358
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,2.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -3465,7 +3465,7 @@ entities:
 - uid: 359
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3476,7 +3476,7 @@ entities:
 - uid: 360
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3487,7 +3487,7 @@ entities:
 - uid: 361
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3498,7 +3498,7 @@ entities:
 - uid: 362
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3509,7 +3509,7 @@ entities:
 - uid: 363
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3520,7 +3520,7 @@ entities:
 - uid: 364
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3531,7 +3531,7 @@ entities:
 - uid: 365
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3542,7 +3542,7 @@ entities:
 - uid: 366
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3553,7 +3553,7 @@ entities:
 - uid: 367
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3564,7 +3564,7 @@ entities:
 - uid: 368
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3575,7 +3575,7 @@ entities:
 - uid: 369
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3586,7 +3586,7 @@ entities:
 - uid: 370
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3597,7 +3597,7 @@ entities:
 - uid: 371
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3608,7 +3608,7 @@ entities:
 - uid: 372
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3619,7 +3619,7 @@ entities:
 - uid: 373
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3630,7 +3630,7 @@ entities:
 - uid: 374
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3641,7 +3641,7 @@ entities:
 - uid: 375
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3652,7 +3652,7 @@ entities:
 - uid: 376
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3663,7 +3663,7 @@ entities:
 - uid: 377
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3674,7 +3674,7 @@ entities:
 - uid: 378
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3685,7 +3685,7 @@ entities:
 - uid: 379
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3696,7 +3696,7 @@ entities:
 - uid: 380
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3707,7 +3707,7 @@ entities:
 - uid: 381
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3718,7 +3718,7 @@ entities:
 - uid: 382
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3729,7 +3729,7 @@ entities:
 - uid: 383
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3740,7 +3740,7 @@ entities:
 - uid: 384
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3751,7 +3751,7 @@ entities:
 - uid: 385
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3762,7 +3762,7 @@ entities:
 - uid: 386
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3773,7 +3773,7 @@ entities:
 - uid: 387
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3784,7 +3784,7 @@ entities:
 - uid: 388
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3795,7 +3795,7 @@ entities:
 - uid: 389
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3806,7 +3806,7 @@ entities:
 - uid: 390
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3817,7 +3817,7 @@ entities:
 - uid: 391
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3828,7 +3828,7 @@ entities:
 - uid: 392
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3839,7 +3839,7 @@ entities:
 - uid: 393
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3850,7 +3850,7 @@ entities:
 - uid: 394
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3861,7 +3861,7 @@ entities:
 - uid: 395
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3872,7 +3872,7 @@ entities:
 - uid: 396
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3883,7 +3883,7 @@ entities:
 - uid: 397
   type: DisposalBend
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-10.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -3894,7 +3894,7 @@ entities:
 - uid: 398
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,-10.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3905,7 +3905,7 @@ entities:
 - uid: 399
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,-10.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3916,7 +3916,7 @@ entities:
 - uid: 400
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,-10.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3927,7 +3927,7 @@ entities:
 - uid: 401
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,-10.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3938,7 +3938,7 @@ entities:
 - uid: 402
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,-8.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -3949,7 +3949,7 @@ entities:
 - uid: 403
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,-10.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3960,7 +3960,7 @@ entities:
 - uid: 404
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,-10.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3971,7 +3971,7 @@ entities:
 - uid: 405
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,-10.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -3982,7 +3982,7 @@ entities:
 - uid: 406
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -3993,7 +3993,7 @@ entities:
 - uid: 407
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -4002,672 +4002,672 @@ entities:
 - uid: 408
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 32.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 409
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 30.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 410
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 411
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 412
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 413
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 414
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 415
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 416
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 417
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 418
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 419
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 420
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 421
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 422
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 4.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 423
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 424
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 425
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 426
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 427
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 428
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 429
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 430
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 431
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 432
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 433
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 434
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 435
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 436
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 437
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 438
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 439
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 35.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 440
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 44.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 441
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 42.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 442
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 443
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 444
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 32.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 445
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 446
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 447
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 448
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 449
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 450
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 451
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 452
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 453
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 454
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 455
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 456
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 457
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 458
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 459
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 460
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 461
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 462
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 463
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 464
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 465
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 466
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 467
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 468
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 469
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 470
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 471
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 472
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 473
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 474
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 475
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 476
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 477
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 478
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 479
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 480
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 481
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 482
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 483
   type: SuspicionPistolMagazineSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 484
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 485
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 486
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 487
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -33.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 488
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -33.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 489
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 490
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 491
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 492
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 493
   type: SpawnPointMime
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 494
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 495
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 496
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -36.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 497
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 498
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 499
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 500
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 501
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 502
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 503
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -38.60578,1.9956734
     rot: 1.5707963267948966 rad
     type: Transform
@@ -4680,84 +4680,84 @@ entities:
 - uid: 504
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 505
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 506
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 507
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 508
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 509
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 510
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 511
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 512
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 513
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 514
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 515
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -16,-1.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -4770,7 +4770,7 @@ entities:
 - uid: 516
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-3
     rot: 1.5707963267948966 rad
     type: Transform
@@ -4783,7 +4783,7 @@ entities:
 - uid: 517
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,2
     rot: -1.5707963267948966 rad
     type: Transform
@@ -4796,35 +4796,35 @@ entities:
 - uid: 518
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 519
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 520
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 521
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 522
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -4833,224 +4833,224 @@ entities:
   components:
   - name: Hydroponics
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -16.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 524
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 525
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 526
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 527
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 528
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 529
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 530
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 531
   type: SuspicionPistolSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 532
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 533
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 534
   type: SuspicionPistolSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 535
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 536
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 537
   type: SuspicionPistolSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 538
   type: SuspicionPistolSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 539
   type: SuspicionPistolSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 540
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 541
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 542
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 543
   type: SuspicionRifleSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 544
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 545
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 17.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 546
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 547
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 548
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 549
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 550
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 551
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 552
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 553
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 554
   type: SuspicionMeleeSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -5059,7 +5059,7 @@ entities:
   components:
   - name: Cell 2
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 0.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -5068,28 +5068,28 @@ entities:
   components:
   - name: Cell 1
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -2.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 557
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 558
   type: reinforced_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 559
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 20,-17.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -5104,7 +5104,7 @@ entities:
 - uid: 560
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-18
     rot: 1.5707963267948966 rad
     type: Transform
@@ -5119,7 +5119,7 @@ entities:
 - uid: 561
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 17,-20.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -5135,7 +5135,7 @@ entities:
   components:
   - name: Head of Security's Office
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -8.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -5146,90 +5146,79 @@ entities:
 - uid: 563
   type: AirlockExternalLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 564
-  type: AirlockExternalLocked
+  type: SupplyComputerCircuitboard
   components:
-  - name: Supply Shuttle Dock
-    type: MetaData
-  - parent: 855
-    pos: 22.5,14.5
-    rot: -1.5707963267948966 rad
+  - parent: 565
     type: Transform
-  - access:
-    - - Cargo
-    type: AccessReader
 - uid: 565
-  type: AirlockExternalLocked
+  type: ComputerSupplyOrdering
   components:
-  - name: Supply Shuttle Dock
-    type: MetaData
-  - parent: 855
-    pos: 22.5,16.5
+  - parent: 854
+    pos: 21.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - access:
-    - - Cargo
-    type: AccessReader
+  - containers:
+      board:
+        entities:
+        - 564
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
 - uid: 566
-  type: AirlockExternalLocked
+  type: cargoTelepad
   components:
-  - name: Supply Shuttle Dock
-    type: MetaData
-  - parent: 855
-    pos: 20.5,16.5
+  - parent: 854
+    pos: 21.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - access:
-    - - Cargo
-    type: AccessReader
 - uid: 567
-  type: AirlockExternalLocked
+  type: AirlockCargoGlassLocked
   components:
-  - name: Supply Shuttle Dock
+  - name: Cargo Bay
     type: MetaData
-  - parent: 855
-    pos: 20.5,14.5
+  - parent: 854
+    pos: 17.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - access:
-    - - Cargo
-    type: AccessReader
 - uid: 568
   type: AirlockCargoGlassLocked
   components:
   - name: Cargo Bay
     type: MetaData
-  - parent: 855
-    pos: 17.5,11.5
+  - parent: 854
+    pos: 17.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 569
   type: AirlockCargoGlassLocked
   components:
-  - name: Cargo Bay
-    type: MetaData
-  - parent: 855
-    pos: 17.5,10.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 570
-  type: AirlockCargoGlassLocked
-  components:
   - name: Cargo Office
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 13.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 571
+- uid: 570
   type: AirlockMaintCommandLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,12.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - access:
+    - - External
+    type: AccessReader
+- uid: 571
+  type: AirlockCommandGlassLocked
+  components:
+  - name: EVA
+    type: MetaData
+  - parent: 854
+    pos: 9.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
@@ -5240,8 +5229,8 @@ entities:
   components:
   - name: EVA
     type: MetaData
-  - parent: 855
-    pos: 9.5,6.5
+  - parent: 854
+    pos: 7.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
@@ -5250,31 +5239,28 @@ entities:
 - uid: 573
   type: AirlockCommandGlassLocked
   components:
-  - name: EVA
+  - name: Bridge
     type: MetaData
-  - parent: 855
-    pos: 7.5,6.5
+  - parent: 854
+    pos: 4.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - access:
-    - - External
-    type: AccessReader
 - uid: 574
   type: AirlockCommandGlassLocked
   components:
   - name: Bridge
     type: MetaData
-  - parent: 855
-    pos: 4.5,22.5
+  - parent: 854
+    pos: 2.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 575
-  type: AirlockCommandGlassLocked
+  type: AirlockVaultLocked
   components:
-  - name: Bridge
+  - name: Armory
     type: MetaData
-  - parent: 855
-    pos: 2.5,22.5
+  - parent: 854
+    pos: -10.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 576
@@ -5282,172 +5268,176 @@ entities:
   components:
   - name: Armory
     type: MetaData
-  - parent: 855
-    pos: -10.5,20.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 577
-  type: AirlockVaultLocked
-  components:
-  - name: Armory
-    type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -12.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 578
+- uid: 577
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,8.5
     type: Transform
   - anchored: False
     type: Physics
-- uid: 579
+- uid: 578
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 580
+- uid: 579
   type: TableR
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 581
+- uid: 580
   type: TableR
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 582
+- uid: 581
   type: SuspicionHitscanSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 583
+- uid: 582
   type: SuspicionGrenadesSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 584
+- uid: 583
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 585
+- uid: 584
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 586
+- uid: 585
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - Service
     type: AccessReader
-- uid: 587
+- uid: 586
   type: Airlock
   components:
   - name: Showers
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -21.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 588
+- uid: 587
   type: StoolBar
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 589
+- uid: 588
   type: AirlockServiceLocked
   components:
   - name: Theatre
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -20.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - Theatre
     type: AccessReader
-- uid: 590
+- uid: 589
   type: TableGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 591
+- uid: 590
   type: AirlockServiceGlassLocked
   components:
   - name: Tool Storage
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -25.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - Maintenance
     type: AccessReader
-- uid: 592
+- uid: 591
   type: AirlockServiceGlassLocked
   components:
   - name: Tool Storage
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -25.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - Maintenance
     type: AccessReader
+- uid: 592
+  type: AirlockScienceLocked
+  components:
+  - name: Testing Area
+    type: MetaData
+  - parent: 854
+    pos: -12.5,-20.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 593
   type: AirlockScienceLocked
   components:
   - name: Testing Area
     type: MetaData
-  - parent: 855
-    pos: -12.5,-20.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 594
-  type: AirlockScienceLocked
-  components:
-  - name: Testing Area
-    type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -12.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 595
+- uid: 594
   type: AirlockCommandGlassLocked
   components:
   - name: Research Director's Office
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -3.5,-21.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - access:
+    - - Research
+      - Command
+    type: AccessReader
+- uid: 595
+  type: AirlockCommandGlassLocked
+  components:
+  - name: Server Room
+    type: MetaData
+  - parent: 854
+    pos: -8.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
@@ -5457,22 +5447,9 @@ entities:
 - uid: 596
   type: AirlockCommandGlassLocked
   components:
-  - name: Server Room
-    type: MetaData
-  - parent: 855
-    pos: -8.5,-21.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - access:
-    - - Research
-      - Command
-    type: AccessReader
-- uid: 597
-  type: AirlockCommandGlassLocked
-  components:
   - name: Chief Medical Officer's Office
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 20.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -5480,22 +5457,31 @@ entities:
     - - Medical
       - Command
     type: AccessReader
+- uid: 597
+  type: AirlockMedicalGlassLocked
+  components:
+  - name: Chemistry
+    type: MetaData
+  - parent: 854
+    pos: 17.5,-3.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 598
   type: AirlockMedicalGlassLocked
   components:
   - name: Chemistry
     type: MetaData
-  - parent: 855
-    pos: 17.5,-3.5
+  - parent: 854
+    pos: 7.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 599
-  type: AirlockMedicalGlassLocked
+  type: AirlockEngineeringGlassLocked
   components:
-  - name: Chemistry
+  - name: Engineering
     type: MetaData
-  - parent: 855
-    pos: 7.5,-6.5
+  - parent: 854
+    pos: 30.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 600
@@ -5503,182 +5489,173 @@ entities:
   components:
   - name: Engineering
     type: MetaData
-  - parent: 855
-    pos: 30.5,5.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 601
-  type: AirlockEngineeringGlassLocked
-  components:
-  - name: Engineering
-    type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 30.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 602
+- uid: 601
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - Janitor
     type: AccessReader
-- uid: 603
+- uid: 602
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,2.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 603
+  type: AirlockMaintIntLocked
+  components:
+  - parent: 854
+    pos: -13.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 604
   type: AirlockMaintIntLocked
   components:
-  - parent: 855
-    pos: -13.5,-13.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 605
-  type: AirlockMaintIntLocked
-  components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 606
+- uid: 605
   type: AirlockMaintRnDLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,-11.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 606
+  type: AirlockMaintCommonLocked
+  components:
+  - parent: 854
+    pos: 5.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 607
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
-    pos: 5.5,14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 608
-  type: AirlockMaintCommonLocked
-  components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 609
+- uid: 608
   type: AirlockSecurityGlassLocked
   components:
   - name: Brig
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -6.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 610
+- uid: 609
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,4.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 611
+- uid: 610
   type: AirlockMaintEngiLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 612
+- uid: 611
   type: AirlockServiceGlassLocked
   components:
   - name: Kitchen
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -10.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 613
+- uid: 612
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 614
+- uid: 613
   type: AirlockVaultLocked
   components:
   - name: Vault
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 0.5,17.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 614
+  type: AirlockMaintCommonLocked
+  components:
+  - parent: 854
+    pos: 1.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 615
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
-    pos: 1.5,-7.5
+  - parent: 854
+    pos: -23.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 616
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
-    pos: -23.5,-9.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 617
-  type: AirlockMaintCommonLocked
-  components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 618
+- uid: 617
   type: Airlock
   components:
   - name: Custodial Closet
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -22.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - Janitor
     type: AccessReader
-- uid: 619
+- uid: 618
   type: AirlockExternalLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 620
+- uid: 619
   type: AirlockMaintCommandLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - HeadOfPersonnel
     type: AccessReader
-- uid: 621
+- uid: 620
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 622
+- uid: 621
   type: AirlockCommandGlassLocked
   components:
   - name: Chief Engineer's Office
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 38.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -5686,20 +5663,29 @@ entities:
     - - Engineering
       - Command
     type: AccessReader
-- uid: 623
+- uid: 622
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -33.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 624
+- uid: 623
   type: AirlockScienceGlassLocked
   components:
   - name: Research and Development
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -3.5,-18.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 624
+  type: AirlockScienceLocked
+  components:
+  - name: Science
+    type: MetaData
+  - parent: 854
+    pos: 0.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 625
@@ -5707,90 +5693,90 @@ entities:
   components:
   - name: Science
     type: MetaData
-  - parent: 855
-    pos: 0.5,-20.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 626
-  type: AirlockScienceLocked
-  components:
-  - name: Science
-    type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 0.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 627
+- uid: 626
   type: AirlockMaintRnDLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-21.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 627
+  type: AirlockMaintMedLocked
+  components:
+  - parent: 854
+    pos: 20.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 628
   type: AirlockMaintMedLocked
   components:
-  - parent: 855
-    pos: 20.5,-10.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 629
-  type: AirlockMaintMedLocked
-  components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 630
+- uid: 629
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,20.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 630
+  type: AirlockSecurityGlassLocked
+  components:
+  - name: Reception Desk
+    type: MetaData
+  - parent: 854
+    pos: -9.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 631
   type: AirlockSecurityGlassLocked
   components:
-  - name: Reception Desk
+  - name: Security Equipment
     type: MetaData
-  - parent: 855
-    pos: -9.5,9.5
+  - parent: 854
+    pos: -10.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 632
-  type: AirlockSecurityGlassLocked
+  type: AirlockMedicalGlassLocked
   components:
-  - name: Security Equipment
+  - name: Cloning
     type: MetaData
-  - parent: 855
-    pos: -10.5,15.5
+  - parent: 854
+    pos: 8.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 633
   type: AirlockMedicalGlassLocked
   components:
-  - name: Cloning
+  - name: Surgery
     type: MetaData
-  - parent: 855
-    pos: 8.5,-12.5
+  - parent: 854
+    pos: 19.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 634
   type: AirlockMedicalGlassLocked
   components:
-  - name: Surgery
+  - name: Medical Storage
     type: MetaData
-  - parent: 855
-    pos: 19.5,-18.5
+  - parent: 854
+    pos: 20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 635
   type: AirlockMedicalGlassLocked
   components:
-  - name: Medical Storage
+  - name: Medical Bay
     type: MetaData
-  - parent: 855
-    pos: 20.5,-6.5
+  - parent: 854
+    pos: 11.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 636
@@ -5798,96 +5784,96 @@ entities:
   components:
   - name: Medical Bay
     type: MetaData
-  - parent: 855
-    pos: 11.5,-6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 637
-  type: AirlockMedicalGlassLocked
-  components:
-  - name: Medical Bay
-    type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 10.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 638
+- uid: 637
   type: AirlockMaintCommandLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,22.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 638
+  type: AirlockMaintCommonLocked
+  components:
+  - parent: 854
+    pos: 21.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 639
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
-    pos: 21.5,2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 640
-  type: AirlockMaintCommonLocked
-  components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 641
+- uid: 640
   type: AirlockCommandLocked
   components:
   - name: Captain's Office
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 5.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - Captain
     type: AccessReader
+- uid: 641
+  type: AirlockCommandGlassLocked
+  components:
+  - name: Heads of Staff Meeting Room
+    type: MetaData
+  - parent: 854
+    pos: 1.5,25.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 642
   type: AirlockCommandGlassLocked
   components:
   - name: Heads of Staff Meeting Room
     type: MetaData
-  - parent: 855
-    pos: 1.5,25.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 643
-  type: AirlockCommandGlassLocked
-  components:
-  - name: Heads of Staff Meeting Room
-    type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 1.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 644
+- uid: 643
   type: AirlockMaintRnDLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 645
+- uid: 644
   type: AirlockMaintCargoLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,9.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 645
+  type: AirlockMaintEngiLocked
+  components:
+  - parent: 854
+    pos: 43.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 646
   type: AirlockMaintEngiLocked
   components:
-  - parent: 855
-    pos: 43.5,0.5
+  - parent: 854
+    pos: 29.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 647
-  type: AirlockMaintEngiLocked
+  type: AirlockEngineeringLocked
   components:
-  - parent: 855
-    pos: 29.5,10.5
+  - name: Secure Storage
+    type: MetaData
+  - parent: 854
+    pos: 40.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 648
@@ -5895,44 +5881,44 @@ entities:
   components:
   - name: Secure Storage
     type: MetaData
-  - parent: 855
-    pos: 40.5,10.5
+  - parent: 854
+    pos: 41.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 649
-  type: AirlockEngineeringLocked
+  type: AirlockEngineeringGlassLocked
   components:
-  - name: Secure Storage
+  - name: Atmospherics
     type: MetaData
-  - parent: 855
-    pos: 41.5,10.5
+  - parent: 854
+    pos: 33.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 650
   type: AirlockEngineeringGlassLocked
   components:
-  - name: Atmospherics
-    type: MetaData
-  - parent: 855
-    pos: 33.5,7.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 651
-  type: AirlockEngineeringGlassLocked
-  components:
   - name: Engineering Equipment
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 33.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 652
+- uid: 651
   type: AirlockEngineeringLocked
   components:
   - name: Gravity Generator
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 49.5,-1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 652
+  type: AirlockSecurityGlassLocked
+  components:
+  - name: Brig
+    type: MetaData
+  - parent: 854
+    pos: -6.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 653
@@ -5940,8 +5926,8 @@ entities:
   components:
   - name: Brig
     type: MetaData
-  - parent: 855
-    pos: -6.5,9.5
+  - parent: 854
+    pos: -5.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 654
@@ -5949,17 +5935,17 @@ entities:
   components:
   - name: Brig
     type: MetaData
-  - parent: 855
-    pos: -5.5,9.5
+  - parent: 854
+    pos: -5.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 655
-  type: AirlockSecurityGlassLocked
+  type: AirlockExternalLocked
   components:
-  - name: Brig
+  - name: Arrivals Shuttle Dock
     type: MetaData
-  - parent: 855
-    pos: -5.5,6.5
+  - parent: 854
+    pos: -39.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 656
@@ -5967,40 +5953,40 @@ entities:
   components:
   - name: Arrivals Shuttle Dock
     type: MetaData
-  - parent: 855
-    pos: -39.5,-3.5
+  - parent: 854
+    pos: -37.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 657
   type: AirlockExternalLocked
   components:
-  - name: Arrivals Shuttle Dock
+  - name: Escape Shuttle Dock
     type: MetaData
-  - parent: 855
-    pos: -37.5,-3.5
+  - parent: 854
+    pos: -41.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 658
-  type: AirlockExternalLocked
+  type: LowWall
   components:
-  - name: Escape Shuttle Dock
-    type: MetaData
-  - parent: 855
-    pos: -41.5,8.5
+  - parent: 854
+    pos: -36.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 659
   type: LowWall
   components:
-  - parent: 855
-    pos: -36.5,11.5
+  - parent: 854
+    pos: -37.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 660
-  type: LowWall
+  type: AirlockExternalLocked
   components:
-  - parent: 855
-    pos: -37.5,11.5
+  - name: Escape Shuttle Dock
+    type: MetaData
+  - parent: 854
+    pos: -39.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 661
@@ -6008,8 +5994,8 @@ entities:
   components:
   - name: Escape Shuttle Dock
     type: MetaData
-  - parent: 855
-    pos: -39.5,8.5
+  - parent: 854
+    pos: -39.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 662
@@ -6017,23 +6003,14 @@ entities:
   components:
   - name: Escape Shuttle Dock
     type: MetaData
-  - parent: 855
-    pos: -39.5,4.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 663
-  type: AirlockExternalLocked
-  components:
-  - name: Escape Shuttle Dock
-    type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -41.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 664
+- uid: 663
   type: WardrobeWhite
   components:
-  - parent: 855
+  - parent: 854
     pos: 17.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6043,24 +6020,24 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 665
+- uid: 664
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 666
+- uid: 665
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -40.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 667
+- uid: 666
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -34.001373,10.342238
     rot: 3.141592653589793 rad
     type: Transform
@@ -6070,542 +6047,542 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 668
+- uid: 667
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -40.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 669
+- uid: 668
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.5,-21.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 669
+  type: Window
+  components:
+  - parent: 854
+    pos: 18.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 670
   type: Window
   components:
-  - parent: 855
-    pos: 18.5,-18.5
+  - parent: 854
+    pos: 17.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 671
-  type: Window
+  type: LowWall
   components:
-  - parent: 855
-    pos: 17.5,-18.5
+  - parent: 854
+    pos: 18.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 672
   type: LowWall
   components:
-  - parent: 855
-    pos: 18.5,-18.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 673
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 17.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 674
+- uid: 673
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 675
+- uid: 674
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -41.5,9.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 675
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 16.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 676
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,-20.5
+  - parent: 854
+    pos: 16.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 677
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,-21.5
+  - parent: 854
+    pos: 16.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 678
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,-22.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 679
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 680
+- uid: 679
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -40.5,9.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 680
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 17.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 681
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,-23.5
+  - parent: 854
+    pos: 20.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 682
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-23.5
+  - parent: 854
+    pos: 20.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 683
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-22.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 684
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 685
+- uid: 684
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -39.5,9.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 685
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 20.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 686
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-20.5
+  - parent: 854
+    pos: 20.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 687
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-19.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 688
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 689
+- uid: 688
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -39.5,7.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 689
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 13.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 690
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-24.5
+  - parent: 854
+    pos: 13.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 691
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-23.5
+  - parent: 854
+    pos: 13.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 692
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-22.5
+  - parent: 854
+    pos: 13.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 693
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-26.5
+  - parent: 854
+    pos: 14.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 694
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 14.5,-26.5
+  - parent: 854
+    pos: -41.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 695
   type: LowWall
   components:
-  - parent: 855
-    pos: -41.5,7.5
+  - parent: 854
+    pos: -40.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 696
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -40.5,7.5
+  - parent: 854
+    pos: 15.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 697
   type: solid_wall
   components:
-  - parent: 855
-    pos: 15.5,-26.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 698
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 699
+- uid: 698
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -40.5,6.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 699
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 17.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 700
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,-26.5
+  - parent: 854
+    pos: 18.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 701
   type: solid_wall
   components:
-  - parent: 855
-    pos: 18.5,-26.5
+  - parent: 854
+    pos: 19.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 702
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,-26.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 703
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 704
+- uid: 703
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -41.5,5.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 704
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 21.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 705
   type: solid_wall
   components:
-  - parent: 855
-    pos: 21.5,-26.5
+  - parent: 854
+    pos: 22.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 706
   type: solid_wall
   components:
-  - parent: 855
-    pos: 22.5,-26.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 707
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 708
+- uid: 707
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -40.5,5.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 708
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 23.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 709
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-25.5
+  - parent: 854
+    pos: 23.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 710
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-24.5
+  - parent: 854
+    pos: 23.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 711
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-23.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 712
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 713
+- uid: 712
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -39.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 714
+- uid: 713
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 45.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 715
+- uid: 714
   type: SpawnPointStationEngineer
   components:
-  - parent: 855
+  - parent: 854
     pos: 30.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 716
+- uid: 715
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -39.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 717
+- uid: 716
   type: SpawnPointChiefEngineer
   components:
-  - parent: 855
+  - parent: 854
     pos: 40.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 718
+- uid: 717
   type: SpawnPointHeadOfPersonnel
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 719
+- uid: 718
   type: SpawnPointCaptain
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 720
+- uid: 719
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -41.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 721
+- uid: 720
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,21.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 722
+- uid: 721
   type: SpawnPointJanitor
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 723
+- uid: 722
   type: SpawnPointClown
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 724
+- uid: 723
   type: SpawnPointBartender
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 725
+- uid: 724
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -40.5,3.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 725
+  type: SpawnPointScientist
+  components:
+  - parent: 854
+    pos: -15.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 726
   type: SpawnPointScientist
   components:
-  - parent: 855
-    pos: -15.5,-19.5
+  - parent: 854
+    pos: -4.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 727
   type: SpawnPointScientist
   components:
-  - parent: 855
-    pos: -4.5,-15.5
+  - parent: 854
+    pos: -0.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 728
   type: SpawnPointScientist
   components:
-  - parent: 855
-    pos: -0.5,-14.5
+  - parent: 854
+    pos: -8.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 729
   type: SpawnPointScientist
   components:
-  - parent: 855
-    pos: -8.5,-18.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 730
-  type: SpawnPointScientist
-  components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 731
+- uid: 730
   type: SpawnPointResearchDirector
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 732
+- uid: 731
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -40.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 733
+- uid: 732
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,-12.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 733
+  type: SpawnPointMedicalDoctor
+  components:
+  - parent: 854
+    pos: 11.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 734
   type: SpawnPointMedicalDoctor
   components:
-  - parent: 855
-    pos: 11.5,-9.5
+  - parent: 854
+    pos: 16.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 735
   type: SpawnPointMedicalDoctor
   components:
-  - parent: 855
-    pos: 16.5,-9.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 736
-  type: SpawnPointMedicalDoctor
-  components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 737
+- uid: 736
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -40.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 737
+  type: SpawnPointMedicalDoctor
+  components:
+  - parent: 854
+    pos: 14.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 738
   type: SpawnPointMedicalDoctor
   components:
-  - parent: 855
-    pos: 14.5,0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 739
-  type: SpawnPointMedicalDoctor
-  components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 740
+- uid: 739
   type: SpawnPointChiefMedicalOfficer
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,-14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 740
+  type: SpawnPointCargoTechnician
+  components:
+  - parent: 854
+    pos: 21.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 741
   type: SpawnPointCargoTechnician
   components:
-  - parent: 855
-    pos: 21.5,11.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 742
-  type: SpawnPointCargoTechnician
-  components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 743
+- uid: 742
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -39.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 744
+- uid: 743
   type: PottedPlantRandomPlastic
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6613,17 +6590,17 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 745
+- uid: 744
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: -37.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 746
+- uid: 745
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6631,10 +6608,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 747
+- uid: 746
   type: PottedPlantRandomPlastic
   components:
-  - parent: 855
+  - parent: 854
     pos: 29.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6642,10 +6619,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 748
+- uid: 747
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6653,59 +6630,59 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 748
+  type: LowWall
+  components:
+  - parent: 854
+    pos: -38.5,0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 749
   type: LowWall
   components:
-  - parent: 855
-    pos: -38.5,0.5
+  - parent: 854
+    pos: -38.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 750
   type: LowWall
   components:
-  - parent: 855
-    pos: -38.5,-0.5
+  - parent: 854
+    pos: -38.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 751
   type: LowWall
   components:
-  - parent: 855
-    pos: -38.5,-1.5
+  - parent: 854
+    pos: -37.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 752
   type: LowWall
   components:
-  - parent: 855
-    pos: -37.5,-2.5
+  - parent: 854
+    pos: -38.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 753
   type: LowWall
   components:
-  - parent: 855
-    pos: -38.5,-2.5
+  - parent: 854
+    pos: -39.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 754
   type: LowWall
   components:
-  - parent: 855
-    pos: -39.5,-2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 755
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -37.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 756
+- uid: 755
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6713,38 +6690,38 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 757
+- uid: 756
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -39.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 758
+- uid: 757
   type: reinforced_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,25.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 758
+  type: Table
+  components:
+  - parent: 854
+    pos: -5.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 759
   type: Table
   components:
-  - parent: 855
-    pos: -5.5,-3.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 760
-  type: Table
-  components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 761
+- uid: 760
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6752,10 +6729,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 762
+- uid: 761
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6765,10 +6742,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 763
+- uid: 762
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6776,10 +6753,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 764
+- uid: 763
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6789,10 +6766,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 765
+- uid: 764
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6802,10 +6779,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 766
+- uid: 765
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6813,10 +6790,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 767
+- uid: 766
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6824,11 +6801,24 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 767
+  type: LockerEmergencyFilledRandom
+  components:
+  - parent: 854
+    pos: -2.5,30.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
 - uid: 768
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
-    pos: -2.5,30.5
+  - parent: 854
+    pos: 9.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -6840,20 +6830,7 @@ entities:
 - uid: 769
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
-    pos: 9.5,30.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - IsPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 770
-  type: LockerEmergencyFilledRandom
-  components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6863,10 +6840,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 771
+- uid: 770
   type: PottedPlantRD
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6874,10 +6851,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 772
+- uid: 771
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6887,10 +6864,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 773
+- uid: 772
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6898,10 +6875,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 774
+- uid: 773
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: -39.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6909,10 +6886,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 775
+- uid: 774
   type: LockerFireFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -37.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6922,11 +6899,24 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 776
+- uid: 775
   type: LockerFireFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-11.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
+- uid: 776
+  type: LockerBombFilled
+  components:
+  - parent: 854
+    pos: -17.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -6938,20 +6928,7 @@ entities:
 - uid: 777
   type: LockerBombFilled
   components:
-  - parent: 855
-    pos: -17.5,-17.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - IsPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 778
-  type: LockerBombFilled
-  components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6961,10 +6938,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 779
+- uid: 778
   type: LockerFireFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6974,10 +6951,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 780
+- uid: 779
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -6987,10 +6964,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 781
+- uid: 780
   type: LockerFireFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7000,11 +6977,24 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 782
+- uid: 781
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 43.5,9.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
+- uid: 782
+  type: LockerFireFilled
+  components:
+  - parent: 854
+    pos: 44.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7016,20 +7006,7 @@ entities:
 - uid: 783
   type: LockerFireFilled
   components:
-  - parent: 855
-    pos: 44.5,9.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - IsPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 784
-  type: LockerFireFilled
-  components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7039,10 +7016,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 785
+- uid: 784
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7052,11 +7029,24 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 786
+- uid: 785
   type: LockerFireFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,-18.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
+- uid: 786
+  type: LockerEmergencyFilledRandom
+  components:
+  - parent: 854
+    pos: -15.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7068,8 +7058,8 @@ entities:
 - uid: 787
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
-    pos: -15.5,-17.5
+  - parent: 854
+    pos: -7.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7081,8 +7071,8 @@ entities:
 - uid: 788
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
-    pos: -7.5,-25.5
+  - parent: 854
+    pos: 26.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7094,20 +7084,7 @@ entities:
 - uid: 789
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
-    pos: 26.5,12.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - IsPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 790
-  type: LockerEmergencyFilledRandom
-  components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7117,11 +7094,24 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 791
+- uid: 790
   type: LockerFireFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-17.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
+- uid: 791
+  type: LockerEmergencyFilledRandom
+  components:
+  - parent: 854
+    pos: -11.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7133,8 +7123,8 @@ entities:
 - uid: 792
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
-    pos: -11.5,-10.5
+  - parent: 854
+    pos: -37.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7146,8 +7136,8 @@ entities:
 - uid: 793
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
-    pos: -37.5,-7.5
+  - parent: 854
+    pos: -39.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7159,20 +7149,7 @@ entities:
 - uid: 794
   type: LockerEmergencyFilledRandom
   components:
-  - parent: 855
-    pos: -39.5,2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - IsPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 795
-  type: LockerEmergencyFilledRandom
-  components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7182,10 +7159,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 796
+- uid: 795
   type: LockerCaptainFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7195,10 +7172,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 797
+- uid: 796
   type: WardrobeCargoFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7208,10 +7185,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 798
+- uid: 797
   type: PottedPlantRandom
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7219,10 +7196,10 @@ entities:
       potted_plant_hide:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 799
+- uid: 798
   type: WardrobePrisonFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7232,10 +7209,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 800
+- uid: 799
   type: LockerL3JanitorFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7245,10 +7222,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 801
+- uid: 800
   type: LockerJanitorFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7258,10 +7235,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 802
+- uid: 801
   type: LockerChefFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7271,10 +7248,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 803
+- uid: 802
   type: WardrobeWhiteFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7284,10 +7261,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 804
+- uid: 803
   type: LockerMedicineFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7297,11 +7274,24 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 805
+- uid: 804
   type: LockerL3VirologyFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,-7.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
+- uid: 805
+  type: LockerSecurityFilled
+  components:
+  - parent: 854
+    pos: -12.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7313,8 +7303,8 @@ entities:
 - uid: 806
   type: LockerSecurityFilled
   components:
-  - parent: 855
-    pos: -12.5,13.5
+  - parent: 854
+    pos: -13.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7326,20 +7316,7 @@ entities:
 - uid: 807
   type: LockerSecurityFilled
   components:
-  - parent: 855
-    pos: -13.5,13.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - IsPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 808
-  type: LockerSecurityFilled
-  components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7349,10 +7326,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 809
+- uid: 808
   type: WardrobeMedicalDoctorFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7362,10 +7339,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 810
+- uid: 809
   type: LockerL3SecurityFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7375,10 +7352,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 811
+- uid: 810
   type: LockerChiefMedicalOfficerFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7388,17 +7365,17 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 812
+- uid: 811
   type: TableGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 813
+- uid: 812
   type: LockerHeadOfPersonnelFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7408,17 +7385,17 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 814
+- uid: 813
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -38.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 815
+- uid: 814
   type: WardrobeEngineeringFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 32.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7428,11 +7405,24 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 816
+- uid: 815
   type: WardrobeAtmosphericsFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
+- uid: 816
+  type: LockerAtmosphericsFilled
+  components:
+  - parent: 854
+    pos: 36.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7444,20 +7434,7 @@ entities:
 - uid: 817
   type: LockerAtmosphericsFilled
   components:
-  - parent: 855
-    pos: 36.5,9.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - IsPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 818
-  type: LockerAtmosphericsFilled
-  components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7467,11 +7444,24 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 819
+- uid: 818
   type: LockerChiefEngineerFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,-1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
+- uid: 819
+  type: LockerEngineerFilled
+  components:
+  - parent: 854
+    pos: 35.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - IsPlaceable: False
@@ -7483,20 +7473,7 @@ entities:
 - uid: 820
   type: LockerEngineerFilled
   components:
-  - parent: 855
-    pos: 35.5,-1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - IsPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 821
-  type: LockerEngineerFilled
-  components:
-  - parent: 855
+  - parent: 854
     pos: 35.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7506,10 +7483,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 822
+- uid: 821
   type: LockerResearchDirectorFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7519,10 +7496,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 823
+- uid: 822
   type: WardrobeScienceFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7532,10 +7509,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 824
+- uid: 823
   type: LockerL3JanitorFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7545,10 +7522,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 825
+- uid: 824
   type: LockerGeneric
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7558,17 +7535,17 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 826
+- uid: 825
   type: TableGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 827
+- uid: 826
   type: soda_dispenser
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7576,94 +7553,94 @@ entities:
       ReagentDispenser-reagentContainerContainer:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 827
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: 47.5,-4.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 828
   type: Catwalk
   components:
-  - parent: 855
-    pos: 47.5,-4.5
+  - parent: 854
+    pos: 47.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 829
   type: Catwalk
   components:
-  - parent: 855
-    pos: 47.5,-5.5
+  - parent: 854
+    pos: 47.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 830
   type: Catwalk
   components:
-  - parent: 855
-    pos: 47.5,-6.5
+  - parent: 854
+    pos: 48.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 831
   type: Catwalk
   components:
-  - parent: 855
-    pos: 48.5,-6.5
+  - parent: 854
+    pos: 49.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 832
   type: Catwalk
   components:
-  - parent: 855
-    pos: 49.5,-6.5
+  - parent: 854
+    pos: 50.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 833
   type: Catwalk
   components:
-  - parent: 855
-    pos: 50.5,-6.5
+  - parent: 854
+    pos: 51.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 834
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-6.5
+  - parent: 854
+    pos: 51.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 835
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-5.5
+  - parent: 854
+    pos: 51.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 836
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-4.5
+  - parent: 854
+    pos: 51.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 837
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-3.5
+  - parent: 854
+    pos: 51.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 838
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 839
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: 50.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 840
+- uid: 839
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7671,12 +7648,23 @@ entities:
       DisposalEntry:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
+- uid: 840
+  type: DisposalBend
+  components:
+  - parent: 854
+    pos: -29.5,10.5
+    rot: 1.5707963267948966 rad
+    type: Transform
+  - containers:
+      DisposalBend:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
 - uid: 841
   type: DisposalBend
   components:
-  - parent: 855
-    pos: -29.5,10.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -28.5,10.5
+    rot: -1.5707963267948966 rad
     type: Transform
   - containers:
       DisposalBend:
@@ -7685,28 +7673,17 @@ entities:
 - uid: 842
   type: DisposalBend
   components:
-  - parent: 855
-    pos: -28.5,10.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - containers:
-      DisposalBend:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 843
-  type: DisposalBend
-  components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-14.5
     type: Transform
   - containers:
       DisposalBend:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 844
+- uid: 843
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-14.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -7714,10 +7691,10 @@ entities:
       DisposalTransit:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 845
+- uid: 844
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-14.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -7725,10 +7702,10 @@ entities:
       DisposalTransit:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 846
+- uid: 845
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-14.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -7736,10 +7713,10 @@ entities:
       DisposalEntry:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 847
+- uid: 846
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -7747,12 +7724,22 @@ entities:
       DisposalUnit:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
+- uid: 847
+  type: DisposalPipe
+  components:
+  - parent: 854
+    pos: -9.5,-15.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - containers:
+      DisposalTransit:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
 - uid: 848
   type: DisposalPipe
   components:
-  - parent: 855
-    pos: -9.5,-15.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -15.5,-15.5
     type: Transform
   - containers:
       DisposalTransit:
@@ -7761,8 +7748,8 @@ entities:
 - uid: 849
   type: DisposalPipe
   components:
-  - parent: 855
-    pos: -15.5,-15.5
+  - parent: 854
+    pos: -13.5,-15.5
     type: Transform
   - containers:
       DisposalTransit:
@@ -7771,8 +7758,8 @@ entities:
 - uid: 850
   type: DisposalPipe
   components:
-  - parent: 855
-    pos: -13.5,-15.5
+  - parent: 854
+    pos: -14.5,-15.5
     type: Transform
   - containers:
       DisposalTransit:
@@ -7781,8 +7768,8 @@ entities:
 - uid: 851
   type: DisposalPipe
   components:
-  - parent: 855
-    pos: -14.5,-15.5
+  - parent: 854
+    pos: -12.5,-15.5
     type: Transform
   - containers:
       DisposalTransit:
@@ -7791,8 +7778,8 @@ entities:
 - uid: 852
   type: DisposalPipe
   components:
-  - parent: 855
-    pos: -12.5,-15.5
+  - parent: 854
+    pos: -11.5,-15.5
     type: Transform
   - containers:
       DisposalTransit:
@@ -7801,17 +7788,7 @@ entities:
 - uid: 853
   type: DisposalPipe
   components:
-  - parent: 855
-    pos: -11.5,-15.5
-    type: Transform
-  - containers:
-      DisposalTransit:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 854
-  type: DisposalPipe
-  components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-16.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -7819,7 +7796,7 @@ entities:
       DisposalTransit:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 855
+- uid: 854
   components:
   - name: Saltern Station
     type: MetaData
@@ -19764,31 +19741,31 @@ entities:
         Y: -34
       : 0
     type: GridAtmosphere
+- uid: 855
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: 49.5,-2.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 856
   type: Catwalk
   components:
-  - parent: 855
-    pos: 49.5,-2.5
+  - parent: 854
+    pos: 48.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 857
   type: Catwalk
   components:
-  - parent: 855
-    pos: 48.5,-2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 858
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: 47.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 859
+- uid: 858
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 52,-4.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -19800,10 +19777,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 860
+- uid: 859
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 47,-4.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -19814,223 +19791,238 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 861
+- uid: 860
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -38.5,-5.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 861
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: 50.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 862
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 50.5,-1.5
+  - parent: 854
+    pos: 48.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 863
-  type: reinforced_wall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 48.5,-1.5
+  - parent: 854
+    pos: 51.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 864
   type: solid_wall
   components:
-  - parent: 855
-    pos: 51.5,5.5
+  - parent: 854
+    pos: 50.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 865
   type: solid_wall
   components:
-  - parent: 855
-    pos: 50.5,5.5
+  - parent: 854
+    pos: 47.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 866
   type: solid_wall
   components:
-  - parent: 855
-    pos: 47.5,0.5
+  - parent: 854
+    pos: 47.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 867
   type: solid_wall
   components:
-  - parent: 855
-    pos: 47.5,-0.5
+  - parent: 854
+    pos: 46.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 868
   type: solid_wall
   components:
-  - parent: 855
-    pos: 46.5,0.5
+  - parent: 854
+    pos: 49.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 869
   type: solid_wall
   components:
-  - parent: 855
-    pos: 49.5,5.5
+  - parent: 854
+    pos: 51.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 870
-  type: solid_wall
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: 51.5,4.5
+  - parent: 854
+    pos: 47.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 871
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 47.5,-1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 872
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 873
+- uid: 872
   type: AutolatheMachineCircuitboard
   components:
-  - parent: 1046
+  - parent: 1045
+    type: Transform
+- uid: 873
+  type: MatterBinStockPart
+  components:
+  - parent: 1045
     type: Transform
 - uid: 874
   type: MatterBinStockPart
   components:
-  - parent: 1046
+  - parent: 1045
     type: Transform
 - uid: 875
   type: MatterBinStockPart
   components:
-  - parent: 1046
+  - parent: 1045
     type: Transform
 - uid: 876
-  type: MatterBinStockPart
-  components:
-  - parent: 1046
-    type: Transform
-- uid: 877
   type: MicroManipulatorStockPart
   components:
-  - parent: 1046
+  - parent: 1045
     type: Transform
-- uid: 878
+- uid: 877
   type: GlassSheet1
   components:
-  - parent: 1046
+  - parent: 1045
+    type: Transform
+- uid: 878
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: 51.5,-7.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 879
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 51.5,-7.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 880
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 50.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 881
+- uid: 880
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: 43.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 881
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: 48.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 882
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 48.5,-7.5
+  - parent: 854
+    pos: 47.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 883
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 47.5,-7.5
+  - parent: 854
+    pos: 46.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 884
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-7.5
+  - parent: 854
+    pos: 46.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 885
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-6.5
+  - parent: 854
+    pos: 46.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 886
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-5.5
+  - parent: 854
+    pos: 46.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 887
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-4.5
+  - parent: 854
+    pos: 46.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 888
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-3.5
+  - parent: 854
+    pos: 46.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 889
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 890
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 46.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 891
+- uid: 890
   type: GravityGenerator
   components:
-  - parent: 855
+  - parent: 854
     pos: 49.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 892
+- uid: 891
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 893
+- uid: 892
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,-5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
+- uid: 893
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: -13.5,2
     rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -20044,22 +20036,7 @@ entities:
 - uid: 894
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -13.5,2
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 895
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,-2
     rot: 1.5707963267948966 rad
     type: Transform
@@ -20071,10 +20048,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 896
+- uid: 895
   type: KitchenMicrowave
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -20082,575 +20059,592 @@ entities:
       microwave_entity_container:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 897
+- uid: 896
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 898
+- uid: 897
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 899
+- uid: 898
   type: VendingMachineSnack
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 900
+- uid: 899
   type: VendingMachineCigs
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 901
+- uid: 900
   type: VendingMachineTheater
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 902
+- uid: 901
   type: SpawnPointSecurityOfficer
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,8.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 902
+  type: Table
+  components:
+  - parent: 854
+    pos: -10.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 903
   type: Table
   components:
-  - parent: 855
-    pos: -10.5,1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 904
-  type: Table
-  components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 905
+- uid: 904
   type: SpawnPointLatejoin
   components:
-  - parent: 855
+  - parent: 854
     pos: -36.5,-1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 905
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: -9.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 906
   type: Catwalk
   components:
-  - parent: 855
-    pos: -9.5,-7.5
+  - parent: 854
+    pos: -17.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 907
   type: Catwalk
   components:
-  - parent: 855
-    pos: -17.5,-14.5
+  - parent: 854
+    pos: -23.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 908
-  type: Catwalk
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -23.5,-10.5
+  - parent: 854
+    pos: -14.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 909
   type: solid_wall
   components:
-  - parent: 855
-    pos: -14.5,-5.5
+  - parent: 854
+    pos: -13.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 910
   type: solid_wall
   components:
-  - parent: 855
-    pos: -13.5,-5.5
+  - parent: 854
+    pos: -12.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 911
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-5.5
+  - parent: 854
+    pos: -11.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 912
   type: solid_wall
   components:
-  - parent: 855
-    pos: -11.5,-5.5
+  - parent: 854
+    pos: -10.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 913
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-3.5
+  - parent: 854
+    pos: -9.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 914
   type: solid_wall
   components:
-  - parent: 855
-    pos: -9.5,-3.5
+  - parent: 854
+    pos: -14.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 915
   type: solid_wall
   components:
-  - parent: 855
-    pos: -14.5,-2.5
+  - parent: 854
+    pos: -13.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 916
   type: solid_wall
   components:
-  - parent: 855
-    pos: -13.5,-2.5
+  - parent: 854
+    pos: -11.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 917
   type: solid_wall
   components:
-  - parent: 855
-    pos: -11.5,-2.5
+  - parent: 854
+    pos: -10.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 918
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-2.5
+  - parent: 854
+    pos: -15.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 919
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,-2.5
+  - parent: 854
+    pos: -15.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 920
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,-1.5
+  - parent: 854
+    pos: -15.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 921
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,-0.5
+  - parent: 854
+    pos: -15.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 922
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,-3.5
+  - parent: 854
+    pos: -15.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 923
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,1.5
+  - parent: 854
+    pos: -12.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 924
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,2.5
+  - parent: 854
+    pos: -13.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 925
   type: solid_wall
   components:
-  - parent: 855
-    pos: -13.5,2.5
+  - parent: 854
+    pos: -14.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 926
   type: solid_wall
   components:
-  - parent: 855
-    pos: -14.5,2.5
+  - parent: 854
+    pos: -15.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 927
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,2.5
+  - parent: 854
+    pos: -20.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 928
   type: solid_wall
   components:
-  - parent: 855
-    pos: -20.5,-8.5
+  - parent: 854
+    pos: -17.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 929
   type: solid_wall
   components:
-  - parent: 855
-    pos: -17.5,-10.5
+  - parent: 854
+    pos: -18.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 930
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-10.5
+  - parent: 854
+    pos: -19.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 931
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,-10.5
+  - parent: 854
+    pos: -20.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 932
   type: solid_wall
   components:
-  - parent: 855
-    pos: -20.5,-10.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 933
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 934
+- uid: 933
   type: Brutepack
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.370505,-3.4650035
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 935
+- uid: 934
   type: TrashSpawner
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 936
+- uid: 935
   type: Rack
   components:
-  - parent: 855
+  - parent: 854
     pos: 30.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 937
+- uid: 936
   type: SignSmoking
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.462582,6.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 937
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -16.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 938
   type: solid_wall
   components:
-  - parent: 855
-    pos: -16.5,-6.5
+  - parent: 854
+    pos: -0.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 939
   type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,-6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 940
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,11.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 941
+- uid: 940
   type: SignDirectionalBridge
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.641159,-12.7475605
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 942
+- uid: 941
   type: Brutepack
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.97988,-3.2306285
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 942
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -26.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 943
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,-12.5
+  - parent: 854
+    pos: -27.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 944
   type: solid_wall
   components:
-  - parent: 855
-    pos: -27.5,-12.5
+  - parent: 854
+    pos: -28.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 945
   type: solid_wall
   components:
-  - parent: 855
-    pos: -28.5,-12.5
+  - parent: 854
+    pos: -29.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 946
   type: solid_wall
   components:
-  - parent: 855
-    pos: -29.5,-12.5
+  - parent: 854
+    pos: -30.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 947
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,-12.5
+  - parent: 854
+    pos: -31.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 948
   type: solid_wall
   components:
-  - parent: 855
-    pos: -31.5,-12.5
+  - parent: 854
+    pos: -32.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 949
   type: solid_wall
   components:
-  - parent: 855
-    pos: -32.5,-12.5
+  - parent: 854
+    pos: -33.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 950
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,-12.5
+  - parent: 854
+    pos: -34.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 951
   type: solid_wall
   components:
-  - parent: 855
-    pos: -34.5,-12.5
+  - parent: 854
+    pos: -34.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 952
   type: solid_wall
   components:
-  - parent: 855
-    pos: -34.5,-11.5
+  - parent: 854
+    pos: -34.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 953
   type: solid_wall
   components:
-  - parent: 855
-    pos: -34.5,-10.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 954
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 955
+- uid: 954
   type: Paper
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.699392,17.630365
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 956
+- uid: 955
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,17.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 957
+- uid: 956
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,17.5
     type: Transform
   - anchored: False
     type: Physics
+- uid: 957
+  type: Table
+  components:
+  - parent: 854
+    pos: 9.5,17.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 958
   type: Table
   components:
-  - parent: 855
-    pos: 9.5,17.5
+  - parent: 854
+    pos: 9.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 959
   type: Table
   components:
-  - parent: 855
-    pos: 9.5,16.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 960
-  type: Table
-  components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 961
+- uid: 960
   type: ComputerSupplyRequest
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,31.5
     rot: 3.141592653589793 rad
     type: Transform
   - containers:
       board:
         entities:
-        - 4026
+        - 4025
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 962
+- uid: 961
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,31.5
     rot: 1.5707963267948966 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 963
+- uid: 962
   type: ComputerMedicalRecords
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 963
+  type: ChairOfficeDark
+  components:
+  - parent: 854
+    pos: 7.5,31.5
+    rot: 1.5707963267948966 rad
+    type: Transform
+  - anchored: False
+    type: Physics
 - uid: 964
   type: ChairOfficeDark
   components:
-  - parent: 855
-    pos: 7.5,31.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -2.5,25.5
     type: Transform
   - anchored: False
     type: Physics
 - uid: 965
   type: ChairOfficeDark
   components:
-  - parent: 855
-    pos: -2.5,25.5
+  - parent: 854
+    pos: -2.5,24.5
     type: Transform
   - anchored: False
     type: Physics
 - uid: 966
   type: ChairOfficeDark
   components:
-  - parent: 855
-    pos: -2.5,24.5
+  - parent: 854
+    pos: -0.5,25.5
+    rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
 - uid: 967
   type: ChairOfficeDark
   components:
-  - parent: 855
-    pos: -0.5,25.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - anchored: False
-    type: Physics
-- uid: 968
-  type: ChairOfficeDark
-  components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,24.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 969
+- uid: 968
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 970
+- uid: 969
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 971
+- uid: 970
   type: Pen
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.563138,24.568495
     type: Transform
-- uid: 972
+- uid: 971
   type: Paper
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.344388,25.58412
     type: Transform
-- uid: 973
+- uid: 972
   type: ComputerPowerMonitoring
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 974
+- uid: 973
   type: ComputerAlert
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 974
+  type: ComputerId
+  components:
+  - parent: 854
+    pos: 7.5,21.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - containers:
+      IdCardConsole-privilegedId:
+        type: Content.Server.GameObjects.ContainerSlot
+      IdCardConsole-targetId:
+        type: Content.Server.GameObjects.ContainerSlot
+      board:
+        entities:
+        - 3946
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
 - uid: 975
   type: ComputerId
   components:
-  - parent: 855
-    pos: 7.5,21.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 8.5,23.5
+    rot: 1.5707963267948966 rad
     type: Transform
   - containers:
       IdCardConsole-privilegedId:
@@ -20663,440 +20657,432 @@ entities:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
 - uid: 976
-  type: ComputerId
-  components:
-  - parent: 855
-    pos: 8.5,23.5
-    rot: 1.5707963267948966 rad
-    type: Transform
-  - containers:
-      IdCardConsole-privilegedId:
-        type: Content.Server.GameObjects.ContainerSlot
-      IdCardConsole-targetId:
-        type: Content.Server.GameObjects.ContainerSlot
-      board:
-        entities:
-        - 3948
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 977
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,20.5
     type: Transform
-- uid: 978
+- uid: 977
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,29.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: bridge
     type: WarpPoint
-- uid: 979
+- uid: 978
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: sec
     type: WarpPoint
-- uid: 980
+- uid: 979
   type: ChairWood
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,25.5
     type: Transform
   - anchored: False
     type: Physics
-- uid: 981
+- uid: 980
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,25.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 982
+- uid: 981
   type: ComputerComms
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,23.5
     rot: 1.5707963267948966 rad
     type: Transform
   - containers:
       board:
         entities:
-        - 3994
+        - 3993
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 983
+- uid: 982
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,31.5
     rot: 1.5707963267948966 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 984
+- uid: 983
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 985
+- uid: 984
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 986
+- uid: 985
   type: VendingMachineCigs
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 987
+- uid: 986
   type: VendingMachineCoffee
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 988
+- uid: 987
   type: VendingMachineCola
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 989
+- uid: 988
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 34.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: eng
     type: WarpPoint
-- uid: 990
+- uid: 989
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: cargo
     type: WarpPoint
-- uid: 991
+- uid: 990
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: med
     type: WarpPoint
-- uid: 992
+- uid: 991
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: sci
     type: WarpPoint
-- uid: 993
+- uid: 992
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: bar
     type: WarpPoint
-- uid: 994
+- uid: 993
   type: ComputerComms
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
   - containers:
       board:
         entities:
-        - 4034
+        - 4033
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 995
+- uid: 994
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 996
+- uid: 995
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,1.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 997
+- uid: 996
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 998
+- uid: 997
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-14.5
     type: Transform
   - anchored: False
     type: Physics
-- uid: 999
+- uid: 998
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1000
+- uid: 999
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,2.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1001
+- uid: 1000
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,2.5
     rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1001
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: 3.5,30.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 1002
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,30.5
+  - parent: 854
+    pos: 3.5,28.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 1003
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,28.5
+  - parent: 854
+    pos: 26.5,4.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 1004
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 26.5,4.5
+  - parent: 854
+    pos: 25.5,4.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 1005
-  type: ApcExtensionCable
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,4.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -5.5,2.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1006
   type: solid_wall
   components:
-  - parent: 855
-    pos: -5.5,2.5
+  - parent: 854
+    pos: -6.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1007
-  type: solid_wall
+  type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,2.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 27.5,4.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 1008
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,4.5
+  - parent: 854
+    pos: 27.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 1009
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,6.5
+  - parent: 854
+    pos: 27.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 1010
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,5.5
+  - parent: 854
+    pos: 3.5,29.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 1011
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,29.5
-    rot: 3.141592653589793 rad
-    type: Transform
-- uid: 1012
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-2.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1013
+- uid: 1012
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,2.5
     rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1013
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: 22.5,-18.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 1014
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-18.5
-    rot: 3.141592653589793 rad
-    type: Transform
-- uid: 1015
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-1.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1016
+- uid: 1015
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,-21.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1017
+- uid: 1016
   type: AirlockCommandGlassLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 2.5,27.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1018
+- uid: 1017
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 1019
+- uid: 1018
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 1020
+- uid: 1019
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,27.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1021
+- uid: 1020
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-26.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1021
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: 10.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1022
   type: Catwalk
   components:
-  - parent: 855
-    pos: 10.5,14.5
+  - parent: 854
+    pos: 12.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1023
   type: Catwalk
   components:
-  - parent: 855
-    pos: 12.5,14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1024
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1025
+- uid: 1024
   type: SpawnPointStationEngineer
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1026
+- uid: 1025
   type: SpawnPointAssistant
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1027
+- uid: 1026
   type: SpawnPointSecurityOfficer
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1028
+- uid: 1027
   type: SpawnPointAssistant
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1029
+- uid: 1028
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 39.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1030
+- uid: 1029
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-21.5
     rot: 1.5707963267948966 rad
     type: Transform
+- uid: 1030
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: 5.5,4.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
 - uid: 1031
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 5.5,4.5
+  - parent: 854
+    pos: 5.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -21104,46 +21090,37 @@ entities:
 - uid: 1032
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 5.5,3.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 1033
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 1034
+- uid: 1033
   type: TableR
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1035
+- uid: 1034
   type: TableR
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1036
+- uid: 1035
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,-21.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1037
+- uid: 1036
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -38.5,11
     rot: -1.5707963267948966 rad
     type: Transform
@@ -21155,59 +21132,59 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1038
+- uid: 1037
   type: SpawnPointSecurityOfficer
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1039
+- uid: 1038
   type: SpawnPointSecurityOfficer
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1040
+- uid: 1039
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1041
+- uid: 1040
   type: SpawnPointStationEngineer
   components:
-  - parent: 855
+  - parent: 854
     pos: 41.5,4.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1041
+  type: TableR
+  components:
+  - parent: 854
+    pos: 6.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1042
   type: TableR
   components:
-  - parent: 855
-    pos: 6.5,28.5
+  - parent: 854
+    pos: -2.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1043
   type: TableR
   components:
-  - parent: 855
-    pos: -2.5,28.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1044
-  type: TableR
-  components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1045
+- uid: 1044
   type: Protolathe
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,-12.5
     type: Transform
   - protolatherecipes:
@@ -21227,22 +21204,22 @@ entities:
   - containers:
       machine_board:
         entities:
-        - 4276
+        - 4274
         type: Robust.Server.GameObjects.Components.Container.Container
       machine_parts:
         entities:
+        - 4275
+        - 4276
         - 4277
         - 4278
         - 4279
         - 4280
-        - 4281
-        - 4282
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1046
+- uid: 1045
   type: Autolathe
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-12.5
     type: Transform
   - recipes:
@@ -21262,108 +21239,108 @@ entities:
   - containers:
       machine_board:
         entities:
-        - 873
+        - 872
         type: Robust.Server.GameObjects.Components.Container.Container
       machine_parts:
         entities:
+        - 873
         - 874
         - 875
         - 876
         - 877
-        - 878
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1047
+- uid: 1046
   type: ChairOfficeLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-18.5
     rot: 1.5707963267948966 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1048
+- uid: 1047
   type: ChairOfficeLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,-17.5
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1049
+- uid: 1048
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-17.5
     type: Transform
-- uid: 1050
+- uid: 1049
   type: VendingMachineCoffee
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-17.5
     type: Transform
-- uid: 1051
+- uid: 1050
   type: ChairOfficeLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-23.5
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1052
+- uid: 1051
   type: ChairOfficeLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-14.5
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1053
+- uid: 1052
   type: BaseResearchAndDevelopmentPointSource
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-17.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1053
+  type: TableR
+  components:
+  - parent: 854
+    pos: -7.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1054
   type: TableR
   components:
-  - parent: 855
-    pos: -7.5,7.5
+  - parent: 854
+    pos: -7.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1055
   type: TableR
   components:
-  - parent: 855
-    pos: -7.5,8.5
+  - parent: 854
+    pos: 9.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1056
   type: TableR
   components:
-  - parent: 855
-    pos: 9.5,28.5
+  - parent: 854
+    pos: 8.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1057
   type: TableR
   components:
-  - parent: 855
-    pos: 8.5,28.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1058
-  type: TableR
-  components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1059
+- uid: 1058
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-26
     rot: 1.5707963267948966 rad
     type: Transform
@@ -21375,37 +21352,52 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1060
+- uid: 1059
   type: ComputerResearchAndDevelopment
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-15.5
     type: Transform
   - containers:
       board:
         entities:
-        - 4011
+        - 4010
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1061
+- uid: 1060
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -38.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1062
+- uid: 1061
   type: SignScience
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.494434,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1062
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: -13,-25.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1063
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -13,-25.5
+  - parent: 854
+    pos: -13,-21.5
     rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -21419,9 +21411,8 @@ entities:
 - uid: 1064
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -13,-21.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -18,-21.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21434,21 +21425,7 @@ entities:
 - uid: 1065
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -18,-21.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1066
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -18,-25.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -21459,19 +21436,34 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1067
+- uid: 1066
   type: ResearchAndDevelopmentServer
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-23.5
     type: Transform
   - points: 136000
     type: ResearchServer
-- uid: 1068
+- uid: 1067
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -7,-23.5
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
+- uid: 1068
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: -2,-23.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21484,9 +21476,9 @@ entities:
 - uid: 1069
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -2,-23.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -1.5,-21
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21499,9 +21491,9 @@ entities:
 - uid: 1070
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -1.5,-21
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -9.5,-17
+    rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21514,9 +21506,9 @@ entities:
 - uid: 1071
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -9.5,-17
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -9.5,-21
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21529,9 +21521,9 @@ entities:
 - uid: 1072
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -9.5,-21
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -1.5,-13
+    rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21544,9 +21536,8 @@ entities:
 - uid: 1073
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -1.5,-13
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -6,-14.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21559,21 +21550,7 @@ entities:
 - uid: 1074
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -6,-14.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1075
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-18
     rot: 1.5707963267948966 rad
     type: Transform
@@ -21585,168 +21562,168 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 1075
+  type: ReinforcedWindow
+  components:
+  - parent: 854
+    pos: -6.5,-29.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1076
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -6.5,-29.5
+  - parent: 854
+    pos: -6.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1077
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -6.5,-30.5
+  - parent: 854
+    pos: -7.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1078
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -7.5,-30.5
+  - parent: 854
+    pos: -8.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1079
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -8.5,-30.5
+  - parent: 854
+    pos: -9.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1080
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -9.5,-30.5
+  - parent: 854
+    pos: -10.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1081
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -10.5,-30.5
+  - parent: 854
+    pos: -10.5,-29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1082
-  type: ReinforcedWindow
+  type: LowWall
   components:
-  - parent: 855
-    pos: -10.5,-29.5
+  - parent: 854
+    pos: -8.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1083
   type: LowWall
   components:
-  - parent: 855
-    pos: -8.5,-30.5
+  - parent: 854
+    pos: -6.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1084
   type: LowWall
   components:
-  - parent: 855
-    pos: -6.5,-30.5
+  - parent: 854
+    pos: -7.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1085
   type: LowWall
   components:
-  - parent: 855
-    pos: -7.5,-30.5
+  - parent: 854
+    pos: -6.5,-29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1086
   type: LowWall
   components:
-  - parent: 855
-    pos: -6.5,-29.5
+  - parent: 854
+    pos: -9.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1087
   type: LowWall
   components:
-  - parent: 855
-    pos: -9.5,-30.5
+  - parent: 854
+    pos: -10.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1088
   type: LowWall
   components:
-  - parent: 855
-    pos: -10.5,-30.5
+  - parent: 854
+    pos: -10.5,-29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1089
-  type: LowWall
+  type: Table
   components:
-  - parent: 855
-    pos: -10.5,-29.5
+  - parent: 854
+    pos: -4.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1090
   type: Table
   components:
-  - parent: 855
-    pos: -4.5,-24.5
+  - parent: 854
+    pos: -4.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1091
-  type: Table
+  type: SpawnPointAssistant
   components:
-  - parent: 855
-    pos: -4.5,-23.5
+  - parent: 854
+    pos: -23.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1092
   type: SpawnPointAssistant
   components:
-  - parent: 855
-    pos: -23.5,-2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1093
-  type: SpawnPointAssistant
-  components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1094
+- uid: 1093
   type: SpawnPointLatejoin
   components:
-  - parent: 855
+  - parent: 854
     pos: -36.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1095
+- uid: 1094
   type: SpawnPointChef
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1096
+- uid: 1095
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: -36.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: escape
     type: WarpPoint
-- uid: 1097
+- uid: 1096
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: dorms
     type: WarpPoint
-- uid: 1098
+- uid: 1097
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 25,-14.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -21758,61 +21735,61 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1099
+- uid: 1098
   type: ChairOfficeLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,-14.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
+- uid: 1099
+  type: Table
+  components:
+  - parent: 854
+    pos: 23.5,-15.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1100
   type: Table
   components:
-  - parent: 855
-    pos: 23.5,-15.5
+  - parent: 854
+    pos: 23.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1101
   type: Table
   components:
-  - parent: 855
-    pos: 23.5,-14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1102
-  type: Table
-  components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1103
+- uid: 1102
   type: ComputerMedicalRecords
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,-15.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1104
+- uid: 1103
   type: Beaker
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.48139,-0.43026757
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1105
+- uid: 1104
   type: LargeBeaker
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.528265,-0.44589257
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1106
+- uid: 1105
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,-0.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -21820,141 +21797,156 @@ entities:
       DisposalEntry:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1107
+- uid: 1106
   type: DisposalUnit
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,-0.5
     type: Transform
   - containers:
       DisposalUnit:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1108
+- uid: 1107
   type: SpawnPointBotanist
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1109
+- uid: 1108
   type: Scythe
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1110
+- uid: 1109
   type: Hatchet
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-2.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1110
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: -11.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1111
   type: Catwalk
   components:
-  - parent: 855
-    pos: -11.5,-22.5
+  - parent: 854
+    pos: -11.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1112
   type: Catwalk
   components:
-  - parent: 855
-    pos: -11.5,-23.5
+  - parent: 854
+    pos: -11.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1113
   type: Catwalk
   components:
-  - parent: 855
-    pos: -11.5,-24.5
+  - parent: 854
+    pos: -11.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1114
   type: Catwalk
   components:
-  - parent: 855
-    pos: -11.5,-25.5
+  - parent: 854
+    pos: -11.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1115
   type: Catwalk
   components:
-  - parent: 855
-    pos: -11.5,-26.5
+  - parent: 854
+    pos: -0.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1116
   type: Catwalk
   components:
-  - parent: 855
-    pos: -0.5,-26.5
+  - parent: 854
+    pos: -0.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1117
   type: Catwalk
   components:
-  - parent: 855
-    pos: -0.5,-25.5
+  - parent: 854
+    pos: -0.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1118
-  type: Catwalk
+  type: HVWire
   components:
-  - parent: 855
-    pos: -0.5,-24.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -6.5,-26.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 1119
   type: HVWire
   components:
-  - parent: 855
-    pos: -6.5,-26.5
+  - parent: 854
+    pos: -4.5,-26.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 1120
-  type: HVWire
+  type: Catwalk
   components:
-  - parent: 855
-    pos: -4.5,-26.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -9.5,-26.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1121
   type: Catwalk
   components:
-  - parent: 855
-    pos: -9.5,-26.5
+  - parent: 854
+    pos: -8.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1122
   type: Catwalk
   components:
-  - parent: 855
-    pos: -8.5,-26.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1123
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1124
+- uid: 1123
   type: MiniHoe
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1124
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 23.5,-8
+    rot: 1.5707963267948966 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1125
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 23.5,-8
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 23.5,-4
+    rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21967,9 +21959,8 @@ entities:
 - uid: 1126
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 23.5,-4
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 7,-14.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -21982,21 +21973,7 @@ entities:
 - uid: 1127
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 7,-14.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1128
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 20,-11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -22008,52 +21985,52 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1129
+- uid: 1128
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 17.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1130
+- uid: 1129
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1131
+- uid: 1130
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-17.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1131
+  type: LowWall
+  components:
+  - parent: 854
+    pos: 17.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1132
   type: LowWall
   components:
-  - parent: 855
-    pos: 17.5,-12.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1133
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1134
+- uid: 1133
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1135
+- uid: 1134
   type: WardrobeWhiteFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22063,17 +22040,17 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1136
+- uid: 1135
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -38.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1137
+- uid: 1136
   type: CloningPod
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22081,45 +22058,45 @@ entities:
       CloningPod-bodyContainer:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1138
+- uid: 1137
   type: VendingMachineSeeds
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1139
+- uid: 1138
   type: Beaker
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.07514,-0.38339257
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1140
+- uid: 1139
   type: VendingMachineMedical
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,-11.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1140
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: 29.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1141
   type: Catwalk
   components:
-  - parent: 855
-    pos: 29.5,-6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1142
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1143
+- uid: 1142
   type: LockerBotanistFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22129,38 +22106,38 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1144
+- uid: 1143
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1145
+- uid: 1144
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1146
+- uid: 1145
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1147
+- uid: 1146
   type: SeedExtractor
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1148
+- uid: 1147
   type: CrateMedical
   components:
-  - parent: 855
+  - parent: 854
     pos: 24.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22170,45 +22147,45 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
+- uid: 1148
+  type: Table
+  components:
+  - parent: 854
+    pos: 23.5,-4.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1149
   type: Table
   components:
-  - parent: 855
-    pos: 23.5,-4.5
+  - parent: 854
+    pos: 22.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1150
   type: Table
   components:
-  - parent: 855
-    pos: 22.5,-4.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1151
-  type: Table
-  components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1152
+- uid: 1151
   type: WaterTankFull
   components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1153
+- uid: 1152
   type: VendingMachineMedical
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1154
+- uid: 1153
   type: LockerMedical
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22218,17 +22195,17 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1155
+- uid: 1154
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 27.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1156
+- uid: 1155
   type: LockerMedical
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22238,62 +22215,62 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1157
+- uid: 1156
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 49.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: grav
     type: WarpPoint
-- uid: 1158
+- uid: 1157
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: hop
     type: WarpPoint
-- uid: 1159
+- uid: 1158
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: chem
     type: WarpPoint
-- uid: 1160
+- uid: 1159
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: cap
     type: WarpPoint
-- uid: 1161
+- uid: 1160
   type: WarpPoint
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
   - location: eva
     type: WarpPoint
-- uid: 1162
+- uid: 1161
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1163
+- uid: 1162
   type: LockerChemistry
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22303,10 +22280,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1164
+- uid: 1163
   type: LockerElectricalSupplies
   components:
-  - parent: 855
+  - parent: 854
     pos: 39.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22316,42 +22293,42 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1165
+- uid: 1164
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 47.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1166
+- uid: 1165
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1167
+- uid: 1166
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: 28.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1168
+- uid: 1167
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1169
+- uid: 1168
   type: LockerHeadOfSecurityFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22361,31 +22338,31 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1170
+- uid: 1169
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-3.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1170
+  type: TableGlassR
+  components:
+  - parent: 854
+    pos: 14.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1171
   type: TableGlassR
   components:
-  - parent: 855
-    pos: 14.5,-0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1172
-  type: TableGlassR
-  components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1173
+- uid: 1172
   type: chem_master
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22393,31 +22370,31 @@ entities:
       ChemMaster-reagentContainerContainer:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1174
+- uid: 1173
   type: TableGlassR
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1175
+- uid: 1174
   type: TableGlassR
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1176
+- uid: 1175
   type: TableR
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1177
+- uid: 1176
   type: chem_dispenser
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22425,103 +22402,103 @@ entities:
       ReagentDispenser-reagentContainerContainer:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1178
+- uid: 1177
   type: ComputerMedicalRecords
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,-5.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1179
+- uid: 1178
   type: ChairOfficeLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,-4.5
     rot: 1.5707963267948966 rad
     type: Transform
   - anchored: False
     type: Physics
+- uid: 1179
+  type: Table
+  components:
+  - parent: 854
+    pos: 6.5,-3.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1180
   type: Table
   components:
-  - parent: 855
-    pos: 6.5,-3.5
+  - parent: 854
+    pos: 7.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1181
   type: Table
   components:
-  - parent: 855
-    pos: 7.5,-3.5
+  - parent: 854
+    pos: 8.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1182
   type: Table
   components:
-  - parent: 855
-    pos: 8.5,-3.5
+  - parent: 854
+    pos: 8.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1183
   type: Table
   components:
-  - parent: 855
-    pos: 8.5,-4.5
+  - parent: 854
+    pos: 8.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1184
-  type: Table
+  type: LowWall
   components:
-  - parent: 855
-    pos: 8.5,-5.5
+  - parent: 854
+    pos: -38.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1185
   type: LowWall
   components:
-  - parent: 855
-    pos: -38.5,-8.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1186
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -37.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1187
+- uid: 1186
   type: SpawnPointSecurityOfficer
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1188
+- uid: 1187
   type: SpawnPointStationEngineer
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,4.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1188
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -34.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1189
   type: solid_wall
   components:
-  - parent: 855
-    pos: -34.5,11.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1190
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -38.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1191
+- uid: 1190
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -35,0.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -22533,19 +22510,19 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1192
+- uid: 1191
   type: EmergencyLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.166924,-3.5
     rot: 3.141592653589793 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
-- uid: 1193
+- uid: 1192
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -22,0.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -22557,45 +22534,45 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1194
+- uid: 1193
   type: SignShipDock
   components:
-  - parent: 855
+  - parent: 854
     pos: -33.298416,6.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1194
+  type: Window
+  components:
+  - parent: 854
+    pos: -18.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1195
   type: Window
   components:
-  - parent: 855
-    pos: -18.5,2.5
+  - parent: 854
+    pos: -19.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1196
-  type: Window
+  type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1197
   type: LowWall
   components:
-  - parent: 855
-    pos: -19.5,2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1198
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1199
+- uid: 1198
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -22,2.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -22607,10 +22584,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1200
+- uid: 1199
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,15
     rot: 1.5707963267948966 rad
     type: Transform
@@ -22622,24 +22599,24 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1201
+- uid: 1200
   type: TableCarpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1202
+- uid: 1201
   type: TableCarpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1203
+- uid: 1202
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -34,-0.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -22651,10 +22628,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1204
+- uid: 1203
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -18,-4.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -22665,24 +22642,24 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1205
+- uid: 1204
   type: Pen
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.652517,18.48974
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1206
+- uid: 1205
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,21.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1207
+- uid: 1206
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,15
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22694,50 +22671,50 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1208
+- uid: 1207
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1209
+- uid: 1208
   type: reinforced_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,23.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1210
+- uid: 1209
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1211
+- uid: 1210
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,8.5
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1212
+- uid: 1211
   type: Food4NoRaisins
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.7489221,25.142187
     rot: 3.141592653589793 rad
     type: Transform
   - fillingSteps: 0
     type: SolutionContainer
-- uid: 1213
+- uid: 1212
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,-9
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22749,17 +22726,17 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1214
+- uid: 1213
   type: TableR
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1215
+- uid: 1214
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -27,1.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -22771,25 +22748,40 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1216
+- uid: 1215
   type: CrowbarRed
   components:
-  - parent: 855
+  - parent: 854
     pos: -38.496082,2.6274996
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1217
+- uid: 1216
   type: ChairWood
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,0.5
     rot: 1.5707963267948966 rad
     type: Transform
+- uid: 1217
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: -20.5,3
+    rot: 1.5707963267948966 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1218
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -20.5,3
+  - parent: 854
+    pos: -30.5,3
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -22803,9 +22795,9 @@ entities:
 - uid: 1219
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -30.5,3
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -32.5,6
+    rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -22818,22 +22810,7 @@ entities:
 - uid: 1220
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -32.5,6
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1221
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -23,8.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -22845,10 +22822,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1222
+- uid: 1221
   type: LockerWeldingSupplies
   components:
-  - parent: 855
+  - parent: 854
     pos: 38.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22858,23 +22835,23 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1223
+- uid: 1222
   type: Welder
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.434454,8.191761
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1224
+- uid: 1223
   type: ComputerPowerMonitoring
   components:
-  - parent: 855
+  - parent: 854
     pos: 29.5,-1.5
     type: Transform
-- uid: 1225
+- uid: 1224
   type: LockerToolFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 35.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22884,17 +22861,17 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1226
+- uid: 1225
   type: Multitool
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.340704,7.4573865
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1227
+- uid: 1226
   type: LockerToolFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 35.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -22904,10 +22881,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1228
+- uid: 1227
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -30,9.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -22918,10 +22895,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1229
+- uid: 1228
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -19,9.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -22932,26 +22909,40 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 1229
+  type: Table
+  components:
+  - parent: 854
+    pos: 10.5,7.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1230
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1231
-  type: Table
+  type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 10.5,7.5
+  - parent: 854
+    pos: -14.5,-16
     rot: -1.5707963267948966 rad
     type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1232
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -14.5,-16
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -7,-12.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -22964,21 +22955,7 @@ entities:
 - uid: 1233
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -7,-12.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1234
-  type: PoweredSmallLight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -11,-10.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -22989,10 +22966,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1235
+- uid: 1234
   type: LockerToolFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -23002,10 +22979,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1236
+- uid: 1235
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,12
     rot: -1.5707963267948966 rad
     type: Transform
@@ -23017,47 +22994,49 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1237
+- uid: 1236
   type: VendingMachineCola
   components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1238
+- uid: 1237
   type: VendingMachineSnack
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1239
+- uid: 1238
   type: S
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.715853,24.118322
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1240
+- uid: 1239
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1241
+- uid: 1240
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5120974,-7.5
     rot: 1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.419
+  - startingCharge: 11998.838
     type: Battery
-- uid: 1242
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 1241
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -3,-6.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -23069,89 +23048,104 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1243
+- uid: 1242
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1244
+- uid: 1243
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,8.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1244
+  type: LowWall
+  components:
+  - parent: 854
+    pos: -36.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1245
   type: LowWall
   components:
-  - parent: 855
-    pos: -36.5,-8.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1246
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1247
+- uid: 1246
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-23.5
     rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1247
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -2.5,-15.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 1248
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,-15.5
-    rot: 3.141592653589793 rad
-    type: Transform
-- uid: 1249
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,-0.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1250
+- uid: 1249
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -33.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1251
+- uid: 1250
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,0.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1252
+- uid: 1251
   type: ComfyChair
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1253
+- uid: 1252
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -33.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1253
+  type: PoweredSmallLight
+  components:
+  - parent: 854
+    pos: -19,16.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1254
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -19,16.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -14.5,26
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23164,9 +23158,9 @@ entities:
 - uid: 1255
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -14.5,26
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -19,22.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23179,8 +23173,8 @@ entities:
 - uid: 1256
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -19,22.5
+  - parent: 854
+    pos: -18,9.5
     rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23194,22 +23188,7 @@ entities:
 - uid: 1257
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -18,9.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1258
-  type: PoweredSmallLight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-12
     rot: -1.5707963267948966 rad
     type: Transform
@@ -23221,18 +23200,33 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1259
+- uid: 1258
   type: Paper
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.598616,26.075901
     type: Transform
+- uid: 1259
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: -11,8.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1260
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -11,8.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -18.5,6
+    rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23245,8 +23239,8 @@ entities:
 - uid: 1261
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -18.5,6
+  - parent: 854
+    pos: -11.5,6
     rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23260,22 +23254,7 @@ entities:
 - uid: 1262
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -11.5,6
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1263
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,6
     rot: -1.5707963267948966 rad
     type: Transform
@@ -23287,40 +23266,55 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1264
+- uid: 1263
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -33.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1265
+- uid: 1264
   type: VendingMachineEngivend
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.5,-0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1265
+  type: Table
+  components:
+  - parent: 854
+    pos: 25.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1266
   type: Table
   components:
-  - parent: 855
-    pos: 25.5,0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1267
-  type: Table
-  components:
-  - parent: 855
+  - parent: 854
     pos: 29.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1267
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 6.0308504,2
+    type: Transform
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1268
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 6.0308504,2
+  - parent: 854
+    pos: -0.5,-5
+    rot: 1.5707963267948966 rad
     type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
   - powerLoad: 0
     type: PowerReceiver
   - containers:
@@ -23330,9 +23324,8 @@ entities:
 - uid: 1269
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -0.5,-5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 2,-9.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23345,21 +23338,7 @@ entities:
 - uid: 1270
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 2,-9.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1271
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 2,-4.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -23370,18 +23349,32 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1272
+- uid: 1271
   type: SignDirectionalSci
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.3437586,6.2515917
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1272
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 2,7.5
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1273
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 2,7.5
+  - parent: 854
+    pos: 2,12.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23394,8 +23387,9 @@ entities:
 - uid: 1274
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 2,12.5
+  - parent: 854
+    pos: -1.5,10
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23406,11 +23400,11 @@ entities:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
 - uid: 1275
-  type: Poweredlight
+  type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -1.5,10
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -1,8.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23423,8 +23417,8 @@ entities:
 - uid: 1276
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -1,8.5
+  - parent: 854
+    pos: -4,8.5
     rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23436,10 +23430,10 @@ entities:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
 - uid: 1277
-  type: PoweredSmallLight
+  type: Poweredlight
   components:
-  - parent: 855
-    pos: -4,8.5
+  - parent: 854
+    pos: -5,7.5
     rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23453,9 +23447,8 @@ entities:
 - uid: 1278
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -5,7.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -10,7.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23468,21 +23461,7 @@ entities:
 - uid: 1279
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -10,7.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1280
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,19
     rot: -1.5707963267948966 rad
     type: Transform
@@ -23492,10 +23471,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1281
+- uid: 1280
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -5,16.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -23507,10 +23486,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1282
+- uid: 1281
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.0158176,18
     rot: -1.5707963267948966 rad
     type: Transform
@@ -23520,10 +23499,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1283
+- uid: 1282
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -15,20.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -23534,38 +23513,38 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1284
+- uid: 1283
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1285
+- uid: 1284
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1285
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -10.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1286
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -10.5,22.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1287
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1288
+- uid: 1287
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,26
     rot: 1.5707963267948966 rad
     type: Transform
@@ -23577,19 +23556,33 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1289
+- uid: 1288
   type: AirlockMaintCommonLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1290
+- uid: 1289
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -4,17.5
     rot: 3.141592653589793 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
+- uid: 1290
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: -3,25.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23602,8 +23595,9 @@ entities:
 - uid: 1291
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -3,25.5
+  - parent: 854
+    pos: 10,30.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23616,9 +23610,8 @@ entities:
 - uid: 1292
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 10,30.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -3,30.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23631,8 +23624,9 @@ entities:
 - uid: 1293
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -3,30.5
+  - parent: 854
+    pos: 5.5,28
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23645,8 +23639,8 @@ entities:
 - uid: 1294
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 5.5,28
+  - parent: 854
+    pos: 1.5,28
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23660,9 +23654,9 @@ entities:
 - uid: 1295
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 1.5,28
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 10,25.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23675,8 +23669,8 @@ entities:
 - uid: 1296
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 10,25.5
+  - parent: 854
+    pos: 5,23.5
     rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23690,9 +23684,8 @@ entities:
 - uid: 1297
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 5,23.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 2,23.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23705,8 +23698,9 @@ entities:
 - uid: 1298
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 2,23.5
+  - parent: 854
+    pos: 5.5,16
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23719,8 +23713,8 @@ entities:
 - uid: 1299
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 5.5,16
+  - parent: 854
+    pos: 1.5,16
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23734,22 +23728,7 @@ entities:
 - uid: 1300
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 1.5,16
-    rot: 1.5707963267948966 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1301
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,16
     rot: 1.5707963267948966 rad
     type: Transform
@@ -23761,24 +23740,24 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1302
+- uid: 1301
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1303
+- uid: 1302
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1304
+- uid: 1303
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,22
     rot: -1.5707963267948966 rad
     type: Transform
@@ -23790,39 +23769,53 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 1304
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -34.5,-1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1305
   type: solid_wall
   components:
-  - parent: 855
-    pos: -34.5,-1.5
+  - parent: 854
+    pos: -34.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1306
   type: solid_wall
   components:
-  - parent: 855
-    pos: -34.5,-2.5
+  - parent: 854
+    pos: 8.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1307
   type: solid_wall
   components:
-  - parent: 855
-    pos: 8.5,15.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1308
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1308
+  type: PoweredSmallLight
+  components:
+  - parent: 854
+    pos: 17,15.5
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1309
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 17,15.5
+  - parent: 854
+    pos: 14,16.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23835,8 +23828,9 @@ entities:
 - uid: 1310
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 14,16.5
+  - parent: 854
+    pos: 8.5,15
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23847,11 +23841,10 @@ entities:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
 - uid: 1311
-  type: PoweredSmallLight
+  type: Poweredlight
   components:
-  - parent: 855
-    pos: 8.5,15
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 6,9.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23864,8 +23857,9 @@ entities:
 - uid: 1312
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 6,9.5
+  - parent: 854
+    pos: 11,9.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23878,9 +23872,9 @@ entities:
 - uid: 1313
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 11,9.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 13.5,3
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23893,8 +23887,8 @@ entities:
 - uid: 1314
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 13.5,3
+  - parent: 854
+    pos: 18.5,3
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23908,8 +23902,8 @@ entities:
 - uid: 1315
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 18.5,3
+  - parent: 854
+    pos: 23.5,3
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -23923,9 +23917,9 @@ entities:
 - uid: 1316
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 23.5,3
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 17,7.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23938,9 +23932,8 @@ entities:
 - uid: 1317
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 17,7.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 12,10.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23953,8 +23946,9 @@ entities:
 - uid: 1318
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 12,10.5
+  - parent: 854
+    pos: 15.5,13
+    rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23967,9 +23961,8 @@ entities:
 - uid: 1319
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 15.5,13
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 18,8.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -23982,21 +23975,7 @@ entities:
 - uid: 1320
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 18,8.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1321
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 18,13.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -24007,25 +23986,40 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1322
+- uid: 1321
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1323
+- uid: 1322
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1323
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 5.5,-22
+    rot: 1.5707963267948966 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1324
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 5.5,-22
+  - parent: 854
+    pos: 1.5,-22
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -24039,9 +24033,9 @@ entities:
 - uid: 1325
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 1.5,-22
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 6,-17.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24054,22 +24048,7 @@ entities:
 - uid: 1326
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 6,-17.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1327
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 1,-17.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -24080,17 +24059,17 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1328
+- uid: 1327
   type: SignCargo
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.688538,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1329
+- uid: 1328
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 13,-3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -24102,17 +24081,17 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1330
+- uid: 1329
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -34.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1331
+- uid: 1330
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,2
     rot: -1.5707963267948966 rad
     type: Transform
@@ -24124,25 +24103,40 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1332
+- uid: 1331
   type: SignDirectionalMed
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.768486,-12.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1333
+- uid: 1332
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1333
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 6,-4.5
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1334
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 6,-4.5
+  - parent: 854
+    pos: 6.5,-12
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24155,8 +24149,8 @@ entities:
 - uid: 1335
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 6.5,-12
+  - parent: 854
+    pos: 9.5,-17
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -24170,22 +24164,7 @@ entities:
 - uid: 1336
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 9.5,-17
-    rot: 1.5707963267948966 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1337
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 12,-12.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -24196,44 +24175,59 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1338
+- uid: 1337
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1339
+- uid: 1338
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 47.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1340
+- uid: 1339
   type: ChairOfficeLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,-16.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1341
+- uid: 1340
   type: ChairOfficeLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,0.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
+- uid: 1341
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 15.5,2
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1342
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 15.5,2
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 19,-0.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24246,8 +24240,8 @@ entities:
 - uid: 1343
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 19,-0.5
+  - parent: 854
+    pos: 20,-8.5
     rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -24261,22 +24255,7 @@ entities:
 - uid: 1344
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 20,-8.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1345
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 12.518894,-11
     rot: 1.5707963267948966 rad
     type: Transform
@@ -24286,10 +24265,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1346
+- uid: 1345
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 25,11.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -24301,18 +24280,33 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1347
+- uid: 1346
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1347
+  type: PoweredSmallLight
+  components:
+  - parent: 854
+    pos: 30.5,-6
+    rot: 1.5707963267948966 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1348
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 30.5,-6
+  - parent: 854
+    pos: 25.5,-1
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -24326,22 +24320,7 @@ entities:
 - uid: 1349
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 25.5,-1
-    rot: 1.5707963267948966 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1350
-  type: PoweredSmallLight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,-18
     rot: 1.5707963267948966 rad
     type: Transform
@@ -24353,38 +24332,38 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1351
+- uid: 1350
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1352
+- uid: 1351
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1353
+- uid: 1352
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1354
+- uid: 1353
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1355
+- uid: 1354
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-19
     rot: 1.5707963267948966 rad
     type: Transform
@@ -24396,17 +24375,17 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1356
+- uid: 1355
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 45.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1357
+- uid: 1356
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,-19
     rot: -1.5707963267948966 rad
     type: Transform
@@ -24418,10 +24397,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1358
+- uid: 1357
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 28,-15.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -24432,45 +24411,45 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 1358
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: 7.5,-19.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1359
   type: Catwalk
   components:
-  - parent: 855
-    pos: 7.5,-19.5
+  - parent: 854
+    pos: 14.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1360
   type: Catwalk
   components:
-  - parent: 855
-    pos: 14.5,-19.5
+  - parent: 854
+    pos: 21.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1361
   type: Catwalk
   components:
-  - parent: 855
-    pos: 21.5,-10.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1362
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1363
+- uid: 1362
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1364
+- uid: 1363
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 28,-10.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -24481,18 +24460,33 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1365
+- uid: 1364
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1365
+  type: PoweredSmallLight
+  components:
+  - parent: 854
+    pos: 24,0.5
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1366
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 24,0.5
+  - parent: 854
+    pos: 26,-4.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24505,9 +24499,9 @@ entities:
 - uid: 1367
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 26,-4.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 35.5,-6
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24520,8 +24514,8 @@ entities:
 - uid: 1368
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 35.5,-6
+  - parent: 854
+    pos: 38.5,-3
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -24535,9 +24529,9 @@ entities:
 - uid: 1369
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: 38.5,-3
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 26,11.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24548,10 +24542,10 @@ entities:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
 - uid: 1370
-  type: PoweredSmallLight
+  type: Poweredlight
   components:
-  - parent: 855
-    pos: 26,11.5
+  - parent: 854
+    pos: -35,-4.5
     rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -24565,9 +24559,8 @@ entities:
 - uid: 1371
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -35,-4.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 25,1.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24580,21 +24573,7 @@ entities:
 - uid: 1372
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 25,1.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1373
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 30,1.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -24606,18 +24585,33 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1374
+- uid: 1373
   type: SignEngineering
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.30795,7.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1374
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 31,0.5
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1375
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 31,0.5
+  - parent: 854
+    pos: 31.5,2
+    rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24630,9 +24624,9 @@ entities:
 - uid: 1376
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 31.5,2
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 35.5,7
+    rot: -1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24645,9 +24639,8 @@ entities:
 - uid: 1377
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 35.5,7
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 29,-2.5
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24660,21 +24653,7 @@ entities:
 - uid: 1378
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 29,-2.5
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1379
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 36,-2.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -24686,25 +24665,40 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1380
+- uid: 1379
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1381
+- uid: 1380
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1381
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 30,12.5
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1382
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 30,12.5
+  - parent: 854
+    pos: 37,12.5
+    rot: 3.141592653589793 rad
     type: Transform
   - color: '#FFFFFFFF'
     type: PointLight
@@ -24717,22 +24711,7 @@ entities:
 - uid: 1383
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 37,12.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1384
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,8
     rot: 1.5707963267948966 rad
     type: Transform
@@ -24744,10 +24723,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1385
+- uid: 1384
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 44,-1.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -24758,25 +24737,40 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1386
+- uid: 1385
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1387
+- uid: 1386
   type: reinforced_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 1387
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 30.5,8
+    rot: 1.5707963267948966 rad
+    type: Transform
+  - color: '#FFFFFFFF'
+    type: PointLight
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 1388
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 30.5,8
+  - parent: 854
+    pos: 38.5,-2
     rot: 1.5707963267948966 rad
     type: Transform
   - color: '#FFFFFFFF'
@@ -24790,22 +24784,7 @@ entities:
 - uid: 1389
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 38.5,-2
-    rot: 1.5707963267948966 rad
-    type: Transform
-  - color: '#FFFFFFFF'
-    type: PointLight
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 1390
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 37,2.5
     type: Transform
   - color: '#FFFFFFFF'
@@ -24816,1098 +24795,1098 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1391
+- uid: 1390
   type: SignDirectionalEng
   components:
-  - parent: 855
+  - parent: 854
     pos: 18.507353,6.5
+    type: Transform
+- uid: 1391
+  type: WaterTankFull
+  components:
+  - parent: 854
+    pos: 35.5,-3.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1392
   type: WaterTankFull
   components:
-  - parent: 855
-    pos: 35.5,-3.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1393
-  type: WaterTankFull
-  components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1394
+- uid: 1393
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1395
+- uid: 1394
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1396
+- uid: 1395
   type: TableGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1397
+- uid: 1396
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1398
+- uid: 1397
   type: AirlockCommandGlassLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 4.5,27.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1399
+- uid: 1398
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,27.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1400
+- uid: 1399
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,20.5
     rot: 1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
+- uid: 1400
+  type: ReinforcedWindow
+  components:
+  - parent: 854
+    pos: 5.5,-23.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1401
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 5.5,-23.5
+  - parent: 854
+    pos: 5.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1402
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 5.5,-24.5
+  - parent: 854
+    pos: 4.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1403
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 4.5,-24.5
+  - parent: 854
+    pos: 3.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1404
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 3.5,-24.5
+  - parent: 854
+    pos: 2.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1405
-  type: ReinforcedWindow
+  type: Window
   components:
-  - parent: 855
-    pos: 2.5,-24.5
+  - parent: 854
+    pos: -1.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1406
   type: Window
   components:
-  - parent: 855
-    pos: -1.5,27.5
+  - parent: 854
+    pos: -0.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1407
-  type: Window
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -0.5,27.5
+  - parent: 854
+    pos: 3.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1408
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 3.5,22.5
+  - parent: 854
+    pos: 10.5,29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1409
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 10.5,29.5
+  - parent: 854
+    pos: 9.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1410
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 9.5,32.5
+  - parent: 854
+    pos: 9.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1411
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 9.5,31.5
+  - parent: 854
+    pos: 8.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1412
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 8.5,32.5
+  - parent: 854
+    pos: 8.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1413
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 8.5,33.5
+  - parent: 854
+    pos: 7.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1414
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 7.5,33.5
+  - parent: 854
+    pos: 6.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1415
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 6.5,33.5
+  - parent: 854
+    pos: 5.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1416
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 5.5,33.5
+  - parent: 854
+    pos: 4.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1417
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 4.5,33.5
+  - parent: 854
+    pos: 3.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1418
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 3.5,33.5
+  - parent: 854
+    pos: 2.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1419
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 2.5,33.5
+  - parent: 854
+    pos: 1.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1420
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 1.5,33.5
+  - parent: 854
+    pos: 0.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1421
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 0.5,33.5
+  - parent: 854
+    pos: -0.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1422
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -0.5,33.5
+  - parent: 854
+    pos: -1.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1423
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -1.5,33.5
+  - parent: 854
+    pos: -1.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1424
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -1.5,32.5
+  - parent: 854
+    pos: -3.5,29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1425
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -3.5,29.5
+  - parent: 854
+    pos: -2.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1426
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -2.5,32.5
+  - parent: 854
+    pos: -2.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1427
-  type: ReinforcedWindow
+  type: Window
   components:
-  - parent: 855
-    pos: -2.5,31.5
+  - parent: 854
+    pos: -7.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1428
   type: Window
   components:
-  - parent: 855
-    pos: -7.5,18.5
+  - parent: 854
+    pos: -10.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1429
-  type: Window
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -10.5,14.5
+  - parent: 854
+    pos: -7.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1430
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -7.5,9.5
+  - parent: 854
+    pos: -8.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1431
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -8.5,9.5
+  - parent: 854
+    pos: -3.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1432
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -3.5,9.5
+  - parent: 854
+    pos: -0.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1433
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -0.5,9.5
+  - parent: 854
+    pos: 0.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1434
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 0.5,6.5
+  - parent: 854
+    pos: -0.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1435
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -0.5,6.5
+  - parent: 854
+    pos: -2.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1436
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -2.5,6.5
+  - parent: 854
+    pos: -3.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1437
-  type: ReinforcedWindow
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -3.5,6.5
+  - parent: 854
+    pos: -28.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1438
   type: solid_wall
   components:
-  - parent: 855
-    pos: -28.5,2.5
+  - parent: 854
+    pos: -29.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1439
-  type: solid_wall
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -29.5,2.5
+  - parent: 854
+    pos: -35.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1440
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -35.5,11.5
+  - parent: 854
+    pos: -36.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1441
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -36.5,11.5
+  - parent: 854
+    pos: -37.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1442
-  type: ReinforcedWindow
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -37.5,11.5
+  - parent: 854
+    pos: -39.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1443
   type: solid_wall
   components:
-  - parent: 855
-    pos: -39.5,11.5
+  - parent: 854
+    pos: -25.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1444
-  type: solid_wall
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -25.5,1.5
+  - parent: 854
+    pos: -40.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1445
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -40.5,10.5
+  - parent: 854
+    pos: -41.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1446
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -41.5,9.5
+  - parent: 854
+    pos: -40.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1447
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -40.5,9.5
+  - parent: 854
+    pos: -39.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1448
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -39.5,9.5
+  - parent: 854
+    pos: -39.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1449
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -39.5,7.5
+  - parent: 854
+    pos: -41.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1450
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -41.5,7.5
+  - parent: 854
+    pos: -40.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1451
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -40.5,7.5
+  - parent: 854
+    pos: -40.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1452
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -40.5,6.5
+  - parent: 854
+    pos: -41.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1453
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -41.5,5.5
+  - parent: 854
+    pos: -40.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1454
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -40.5,5.5
+  - parent: 854
+    pos: -39.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1455
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -39.5,5.5
+  - parent: 854
+    pos: -39.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1456
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -39.5,3.5
+  - parent: 854
+    pos: -41.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1457
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -41.5,3.5
+  - parent: 854
+    pos: -40.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1458
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -40.5,3.5
+  - parent: 854
+    pos: -40.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1459
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -40.5,2.5
+  - parent: 854
+    pos: -40.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1460
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -40.5,1.5
+  - parent: 854
+    pos: -39.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1461
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -39.5,1.5
+  - parent: 854
+    pos: -38.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1462
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -38.5,0.5
+  - parent: 854
+    pos: -38.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1463
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -38.5,-0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1464
-  type: ReinforcedWindow
-  components:
-  - parent: 855
+  - parent: 854
     pos: -38.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1465
+- uid: 1464
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -38.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1465
+  type: ReinforcedWindow
+  components:
+  - parent: 854
+    pos: -39.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1466
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -39.5,-2.5
+  - parent: 854
+    pos: -38.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1467
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -38.5,-2.5
+  - parent: 854
+    pos: -39.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1468
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -39.5,-4.5
+  - parent: 854
+    pos: -37.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1469
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -37.5,-4.5
+  - parent: 854
+    pos: -38.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1470
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -38.5,-4.5
+  - parent: 854
+    pos: -38.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1471
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -38.5,-5.5
+  - parent: 854
+    pos: -38.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1472
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -38.5,-6.5
+  - parent: 854
+    pos: -38.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1473
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -38.5,-7.5
+  - parent: 854
+    pos: -38.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1474
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -38.5,-8.5
+  - parent: 854
+    pos: -37.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1475
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -37.5,-8.5
+  - parent: 854
+    pos: -36.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1476
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -36.5,-8.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1477
-  type: ReinforcedWindow
-  components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1478
+- uid: 1477
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1479
+- uid: 1478
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,-6.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1480
+- uid: 1479
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
+    pos: -29.5,6.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1480
+  type: Window
+  components:
+  - parent: 854
     pos: -29.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1481
   type: Window
   components:
-  - parent: 855
-    pos: -29.5,6.5
+  - parent: 854
+    pos: -28.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1482
   type: Window
   components:
-  - parent: 855
-    pos: -28.5,6.5
+  - parent: 854
+    pos: -27.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1483
-  type: Window
+  type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -27.5,6.5
+  - parent: 854
+    pos: -7.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1484
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,-25.5
+  - parent: 854
+    pos: -7.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1485
-  type: ApcExtensionCable
+  type: Window
   components:
-  - parent: 855
-    pos: -7.5,-26.5
+  - parent: 854
+    pos: -2.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1486
   type: Window
   components:
-  - parent: 855
-    pos: -2.5,-21.5
+  - parent: 854
+    pos: -4.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1487
   type: Window
   components:
-  - parent: 855
-    pos: -4.5,-21.5
+  - parent: 854
+    pos: -5.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1488
   type: Window
   components:
-  - parent: 855
-    pos: -5.5,-21.5
+  - parent: 854
+    pos: -4.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1489
   type: Window
   components:
-  - parent: 855
-    pos: -4.5,-18.5
+  - parent: 854
+    pos: -2.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1490
   type: Window
   components:
-  - parent: 855
-    pos: -2.5,-18.5
+  - parent: 854
+    pos: 0.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1491
   type: Window
   components:
-  - parent: 855
-    pos: 0.5,-16.5
+  - parent: 854
+    pos: 5.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1492
   type: Window
   components:
-  - parent: 855
-    pos: 5.5,-8.5
+  - parent: 854
+    pos: 5.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1493
   type: Window
   components:
-  - parent: 855
-    pos: 5.5,-9.5
+  - parent: 854
+    pos: 5.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1494
   type: Window
   components:
-  - parent: 855
-    pos: 5.5,-10.5
+  - parent: 854
+    pos: 7.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1495
   type: Window
   components:
-  - parent: 855
-    pos: 7.5,-12.5
+  - parent: 854
+    pos: 10.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1496
   type: Window
   components:
-  - parent: 855
-    pos: 10.5,-12.5
+  - parent: 854
+    pos: 11.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1497
   type: Window
   components:
-  - parent: 855
-    pos: 11.5,-13.5
+  - parent: 854
+    pos: 11.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1498
-  type: Window
+  type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1499
   type: LowWall
   components:
-  - parent: 855
-    pos: 11.5,-16.5
+  - parent: 854
+    pos: 11.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1500
   type: LowWall
   components:
-  - parent: 855
-    pos: 11.5,-13.5
+  - parent: 854
+    pos: 7.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1501
   type: LowWall
   components:
-  - parent: 855
-    pos: 7.5,-12.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1502
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1503
+- uid: 1502
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-15.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1503
+  type: LowWall
+  components:
+  - parent: 854
+    pos: 20.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1504
   type: LowWall
   components:
-  - parent: 855
-    pos: 20.5,-12.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1505
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1506
+- uid: 1505
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,7.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1506
+  type: Window
+  components:
+  - parent: 854
+    pos: 18.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1507
   type: Window
   components:
-  - parent: 855
-    pos: 18.5,-3.5
+  - parent: 854
+    pos: 16.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1508
   type: Window
   components:
-  - parent: 855
-    pos: 16.5,-3.5
+  - parent: 854
+    pos: 13.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1509
   type: Window
   components:
-  - parent: 855
-    pos: 13.5,-4.5
+  - parent: 854
+    pos: 13.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1510
   type: Window
   components:
-  - parent: 855
-    pos: 13.5,-5.5
+  - parent: 854
+    pos: 12.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1511
   type: Window
   components:
-  - parent: 855
-    pos: 12.5,-6.5
+  - parent: 854
+    pos: 6.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1512
   type: Window
   components:
-  - parent: 855
-    pos: 6.5,-6.5
+  - parent: 854
+    pos: 9.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1513
   type: Window
   components:
-  - parent: 855
-    pos: 9.5,-6.5
+  - parent: 854
+    pos: 8.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1514
   type: Window
   components:
-  - parent: 855
-    pos: 8.5,-6.5
+  - parent: 854
+    pos: 7.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1515
   type: Window
   components:
-  - parent: 855
-    pos: 7.5,2.5
+  - parent: 854
+    pos: 8.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1516
   type: Window
   components:
-  - parent: 855
-    pos: 8.5,2.5
+  - parent: 854
+    pos: 9.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1517
   type: Window
   components:
-  - parent: 855
-    pos: 9.5,2.5
+  - parent: 854
+    pos: 10.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1518
   type: Window
   components:
-  - parent: 855
-    pos: 10.5,2.5
+  - parent: 854
+    pos: 11.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1519
   type: Window
   components:
-  - parent: 855
-    pos: 11.5,2.5
+  - parent: 854
+    pos: 13.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1520
   type: Window
   components:
-  - parent: 855
-    pos: 13.5,1.5
+  - parent: 854
+    pos: 13.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1521
   type: Window
   components:
-  - parent: 855
-    pos: 13.5,-1.5
+  - parent: 854
+    pos: 13.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1522
   type: Window
   components:
-  - parent: 855
-    pos: 13.5,-0.5
+  - parent: 854
+    pos: 22.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1523
   type: Window
   components:
-  - parent: 855
-    pos: 22.5,6.5
+  - parent: 854
+    pos: 21.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1524
   type: Window
   components:
-  - parent: 855
-    pos: 21.5,6.5
+  - parent: 854
+    pos: 20.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1525
   type: Window
   components:
-  - parent: 855
-    pos: 20.5,6.5
+  - parent: 854
+    pos: 19.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1526
   type: Window
   components:
-  - parent: 855
-    pos: 19.5,6.5
+  - parent: 854
+    pos: 14.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1527
-  type: Window
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 14.5,8.5
+  - parent: 854
+    pos: 8.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1528
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 8.5,6.5
+  - parent: 854
+    pos: 6.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1529
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 6.5,19.5
+  - parent: 854
+    pos: 6.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1530
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 6.5,18.5
+  - parent: 854
+    pos: 14.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1531
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 14.5,20.5
+  - parent: 854
+    pos: 14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1532
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 14.5,19.5
+  - parent: 854
+    pos: 14.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1533
-  type: ReinforcedWindow
+  type: LowWall
   components:
-  - parent: 855
-    pos: 14.5,18.5
+  - parent: 854
+    pos: 14.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1534
   type: LowWall
   components:
-  - parent: 855
-    pos: 14.5,20.5
+  - parent: 854
+    pos: 14.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1535
   type: LowWall
   components:
-  - parent: 855
-    pos: 14.5,19.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1536
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1537
+- uid: 1536
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,-23.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1538
+- uid: 1537
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: 38.5,-0.5
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1539
+- uid: 1538
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 39.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1540
+- uid: 1539
   type: VendingMachineYouTool
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1541
-  type: ReinforcedWindow
+- uid: 1540
+  type: HVWire
   components:
-  - parent: 855
-    pos: 21.5,16.5
+  - parent: 854
+    pos: 58.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1542
+- uid: 1541
   type: SignArmory
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.678196,17.5
     type: Transform
-- uid: 1543
+- uid: 1542
   type: SignConference
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.6767635,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1544
+- uid: 1543
   type: SignDirectionalBridge
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.3437586,6.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1545
+- uid: 1544
   type: WeldingFuelTank
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,12.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1546
+- uid: 1545
   type: MedicalScanner
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -25915,156 +25894,156 @@ entities:
       MedicalScanner-bodyContainer:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1547
+- uid: 1546
   type: ComputerAlert
   components:
-  - parent: 855
+  - parent: 854
     pos: 29.5,-2.5
     type: Transform
-- uid: 1548
-  type: ReinforcedWindow
+- uid: 1547
+  type: HVWire
   components:
-  - parent: 855
-    pos: 23.5,16.5
+  - parent: 854
+    pos: 58.5,-32.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1548
+  type: HVWire
+  components:
+  - parent: 854
+    pos: 57.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1549
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 23.5,15.5
+  - parent: 854
+    pos: 23.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1550
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 23.5,14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1551
-  type: ReinforcedWindow
-  components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1552
+- uid: 1551
   type: SignSmoking
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.2919803,-7.6148567
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1552
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -1.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1553
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-7.5
+  - parent: 854
+    pos: -20.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1554
-  type: solid_wall
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: -20.5,-16.5
+  - parent: 854
+    pos: 36.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1555
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 36.5,14.5
+  - parent: 854
+    pos: 36.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1556
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 36.5,15.5
+  - parent: 854
+    pos: 35.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1557
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 35.5,15.5
+  - parent: 854
+    pos: 34.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1558
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 34.5,15.5
+  - parent: 854
+    pos: 33.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1559
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 33.5,15.5
+  - parent: 854
+    pos: 32.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1560
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 32.5,15.5
+  - parent: 854
+    pos: 31.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1561
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 31.5,15.5
+  - parent: 854
+    pos: 30.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1562
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 30.5,15.5
+  - parent: 854
+    pos: 30.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1563
-  type: ReinforcedWindow
+  type: Window
   components:
-  - parent: 855
-    pos: 30.5,14.5
+  - parent: 854
+    pos: 34.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1564
   type: Window
   components:
-  - parent: 855
-    pos: 34.5,7.5
+  - parent: 854
+    pos: 32.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1565
-  type: Window
+  type: Catwalk
   components:
-  - parent: 855
-    pos: 32.5,7.5
+  - parent: 854
+    pos: -16.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1566
   type: Catwalk
   components:
-  - parent: 855
-    pos: -16.5,-15.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1567
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1568
+- uid: 1567
   type: ShotgunSawn
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.488487,-6.7298017
     rot: -1.5707963267948966 rad
     type: Transform
@@ -26074,54 +26053,54 @@ entities:
       BoltActionBarrel-chamber-container:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 1568
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: -8.5,-10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1569
   type: Catwalk
   components:
-  - parent: 855
-    pos: -8.5,-10.5
+  - parent: 854
+    pos: -9.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1570
   type: Catwalk
   components:
-  - parent: 855
-    pos: -9.5,-9.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1571
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1572
+- uid: 1571
   type: SignHead
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.687853,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1573
+- uid: 1572
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: 30.5,-2.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
-- uid: 1574
+- uid: 1573
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1575
+- uid: 1574
   type: CrateGeneric
   components:
-  - parent: 855
+  - parent: 854
     pos: 39.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -26131,10 +26110,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1576
+- uid: 1575
   type: CrateGeneric
   components:
-  - parent: 855
+  - parent: 854
     pos: 38.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -26144,332 +26123,332 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 1577
+- uid: 1576
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,8.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1577
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: -32.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1578
   type: Catwalk
   components:
-  - parent: 855
-    pos: -32.5,-6.5
+  - parent: 854
+    pos: -33.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1579
   type: Catwalk
   components:
-  - parent: 855
-    pos: -33.5,-6.5
+  - parent: 854
+    pos: -32.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1580
   type: Catwalk
   components:
-  - parent: 855
-    pos: -32.5,0.5
+  - parent: 854
+    pos: -32.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1581
   type: Catwalk
   components:
-  - parent: 855
-    pos: -32.5,1.5
+  - parent: 854
+    pos: -15.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1582
   type: Catwalk
   components:
-  - parent: 855
-    pos: -15.5,11.5
+  - parent: 854
+    pos: -16.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1583
   type: Catwalk
   components:
-  - parent: 855
-    pos: -16.5,7.5
+  - parent: 854
+    pos: -20.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1584
   type: Catwalk
   components:
-  - parent: 855
-    pos: -20.5,12.5
+  - parent: 854
+    pos: -16.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1585
   type: Catwalk
   components:
-  - parent: 855
-    pos: -16.5,11.5
+  - parent: 854
+    pos: -4.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1586
   type: Catwalk
   components:
-  - parent: 855
-    pos: -4.5,23.5
+  - parent: 854
+    pos: -4.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1587
   type: Catwalk
   components:
-  - parent: 855
-    pos: -4.5,22.5
+  - parent: 854
+    pos: -4.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1588
   type: Catwalk
   components:
-  - parent: 855
-    pos: -4.5,21.5
+  - parent: 854
+    pos: -0.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1589
   type: Catwalk
   components:
-  - parent: 855
-    pos: -0.5,20.5
+  - parent: 854
+    pos: 6.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1590
   type: Catwalk
   components:
-  - parent: 855
-    pos: 6.5,14.5
+  - parent: 854
+    pos: 8.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1591
   type: Catwalk
   components:
-  - parent: 855
-    pos: 8.5,13.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1592
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1593
+- uid: 1592
   type: AirlockMaintEngiLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 33.5,-5.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1593
+  type: Catwalk
+  components:
+  - parent: 854
+    pos: 27.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1594
   type: Catwalk
   components:
-  - parent: 855
-    pos: 27.5,8.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1595
-  type: Catwalk
-  components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1596
+- uid: 1595
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1597
+- uid: 1596
   type: SignSmoking
   components:
-  - parent: 855
+  - parent: 854
     pos: 42.70487,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1598
+- uid: 1597
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1598
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: 39.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1599
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 39.5,10.5
+  - parent: 854
+    pos: 38.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1600
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 38.5,10.5
+  - parent: 854
+    pos: 37.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1601
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 37.5,10.5
+  - parent: 854
+    pos: 37.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1602
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 37.5,11.5
+  - parent: 854
+    pos: 37.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1603
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 37.5,12.5
+  - parent: 854
+    pos: 37.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1604
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 37.5,13.5
+  - parent: 854
+    pos: 37.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1605
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 37.5,14.5
+  - parent: 854
+    pos: 38.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1606
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 38.5,14.5
+  - parent: 854
+    pos: 39.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1607
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 39.5,14.5
+  - parent: 854
+    pos: 40.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1608
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 40.5,14.5
+  - parent: 854
+    pos: 41.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1609
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 41.5,14.5
+  - parent: 854
+    pos: 42.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1610
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 42.5,14.5
+  - parent: 854
+    pos: 43.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1611
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,14.5
+  - parent: 854
+    pos: 44.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1612
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 44.5,14.5
+  - parent: 854
+    pos: 44.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1613
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 44.5,13.5
+  - parent: 854
+    pos: 44.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1614
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 44.5,12.5
+  - parent: 854
+    pos: 44.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1615
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 44.5,11.5
+  - parent: 854
+    pos: 44.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1616
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 44.5,10.5
+  - parent: 854
+    pos: 43.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1617
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,10.5
+  - parent: 854
+    pos: 42.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1618
-  type: reinforced_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 42.5,10.5
+  - parent: 854
+    pos: 40.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1619
   type: LowWall
   components:
-  - parent: 855
-    pos: 40.5,1.5
+  - parent: 854
+    pos: 39.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1620
   type: LowWall
   components:
-  - parent: 855
-    pos: 39.5,1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1621
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1622
+- uid: 1621
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1623
+- uid: 1622
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,-6
     rot: 1.5707963267948966 rad
     type: Transform
@@ -26481,10 +26460,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 1624
+- uid: 1623
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,-10
     rot: 1.5707963267948966 rad
     type: Transform
@@ -26496,1521 +26475,1521 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 1624
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -21.5,-0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1625
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,-0.5
+  - parent: 854
+    pos: 37.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1626
   type: solid_wall
   components:
-  - parent: 855
-    pos: 37.5,9.5
+  - parent: 854
+    pos: 37.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1627
   type: solid_wall
   components:
-  - parent: 855
-    pos: 37.5,8.5
+  - parent: 854
+    pos: 37.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1628
   type: solid_wall
   components:
-  - parent: 855
-    pos: 37.5,7.5
+  - parent: 854
+    pos: 36.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1629
   type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,7.5
+  - parent: 854
+    pos: 35.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1630
   type: solid_wall
   components:
-  - parent: 855
-    pos: 35.5,7.5
+  - parent: 854
+    pos: -8.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1631
   type: solid_wall
   components:
-  - parent: 855
-    pos: -8.5,-3.5
+  - parent: 854
+    pos: 36.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1632
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 36.5,6.5
+  - parent: 854
+    pos: 51.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1633
   type: LowWall
   components:
-  - parent: 855
-    pos: 51.5,1.5
+  - parent: 854
+    pos: 51.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1634
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 51.5,2.5
+  - parent: 854
+    pos: 41.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1635
   type: solid_wall
   components:
-  - parent: 855
-    pos: 41.5,1.5
+  - parent: 854
+    pos: 41.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1636
   type: solid_wall
   components:
-  - parent: 855
-    pos: 41.5,0.5
+  - parent: 854
+    pos: 41.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1637
   type: solid_wall
   components:
-  - parent: 855
-    pos: 41.5,-0.5
+  - parent: 854
+    pos: 41.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1638
   type: solid_wall
   components:
-  - parent: 855
-    pos: 41.5,-1.5
+  - parent: 854
+    pos: 41.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1639
   type: solid_wall
   components:
-  - parent: 855
-    pos: 41.5,-2.5
+  - parent: 854
+    pos: 40.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1640
   type: solid_wall
   components:
-  - parent: 855
-    pos: 40.5,-2.5
+  - parent: 854
+    pos: 39.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1641
   type: solid_wall
   components:
-  - parent: 855
-    pos: 39.5,-2.5
+  - parent: 854
+    pos: 38.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1642
   type: solid_wall
   components:
-  - parent: 855
-    pos: 38.5,-2.5
+  - parent: 854
+    pos: 37.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1643
   type: solid_wall
   components:
-  - parent: 855
-    pos: 37.5,-2.5
+  - parent: 854
+    pos: 36.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1644
   type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,-2.5
+  - parent: 854
+    pos: 36.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1645
   type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,-1.5
+  - parent: 854
+    pos: 36.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1646
   type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1647
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1648
+- uid: 1647
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1649
+- uid: 1648
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1650
+- uid: 1649
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,3.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1650
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 35.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1651
   type: solid_wall
   components:
-  - parent: 855
-    pos: 35.5,1.5
+  - parent: 854
+    pos: 31.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1652
   type: solid_wall
   components:
-  - parent: 855
-    pos: 31.5,1.5
+  - parent: 854
+    pos: 42.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1653
   type: solid_wall
   components:
-  - parent: 855
-    pos: 42.5,0.5
+  - parent: 854
+    pos: 45.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1654
   type: solid_wall
   components:
-  - parent: 855
-    pos: 45.5,0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1655
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 44.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1656
+- uid: 1655
   type: WaterTankFull
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,-18.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1656
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 44.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1657
   type: solid_wall
   components:
-  - parent: 855
-    pos: 44.5,-0.5
+  - parent: 854
+    pos: 44.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1658
   type: solid_wall
   components:
-  - parent: 855
-    pos: 44.5,-1.5
+  - parent: 854
+    pos: 44.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1659
   type: solid_wall
   components:
-  - parent: 855
-    pos: 44.5,-2.5
+  - parent: 854
+    pos: 44.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1660
   type: solid_wall
   components:
-  - parent: 855
-    pos: 44.5,-3.5
+  - parent: 854
+    pos: 44.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1661
   type: solid_wall
   components:
-  - parent: 855
-    pos: 44.5,-4.5
+  - parent: 854
+    pos: 44.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1662
   type: solid_wall
   components:
-  - parent: 855
-    pos: 44.5,-5.5
+  - parent: 854
+    pos: 43.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1663
   type: solid_wall
   components:
-  - parent: 855
-    pos: 43.5,-5.5
+  - parent: 854
+    pos: 42.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1664
   type: solid_wall
   components:
-  - parent: 855
-    pos: 42.5,-5.5
+  - parent: 854
+    pos: 41.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1665
   type: solid_wall
   components:
-  - parent: 855
-    pos: 41.5,-5.5
+  - parent: 854
+    pos: 40.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1666
   type: solid_wall
   components:
-  - parent: 855
-    pos: 40.5,-5.5
+  - parent: 854
+    pos: 39.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1667
   type: solid_wall
   components:
-  - parent: 855
-    pos: 39.5,-5.5
+  - parent: 854
+    pos: 39.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1668
   type: solid_wall
   components:
-  - parent: 855
-    pos: 39.5,-6.5
+  - parent: 854
+    pos: 39.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1669
   type: solid_wall
   components:
-  - parent: 855
-    pos: 39.5,-7.5
+  - parent: 854
+    pos: 39.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1670
   type: solid_wall
   components:
-  - parent: 855
-    pos: 39.5,-8.5
+  - parent: 854
+    pos: 38.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1671
   type: solid_wall
   components:
-  - parent: 855
-    pos: 38.5,-8.5
+  - parent: 854
+    pos: 37.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1672
   type: solid_wall
   components:
-  - parent: 855
-    pos: 37.5,-8.5
+  - parent: 854
+    pos: 36.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1673
   type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,-8.5
+  - parent: 854
+    pos: 35.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1674
   type: solid_wall
   components:
-  - parent: 855
-    pos: 35.5,-8.5
+  - parent: 854
+    pos: 34.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1675
   type: solid_wall
   components:
-  - parent: 855
-    pos: 34.5,-8.5
+  - parent: 854
+    pos: 33.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1676
   type: solid_wall
   components:
-  - parent: 855
-    pos: 33.5,-8.5
+  - parent: 854
+    pos: 32.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1677
   type: solid_wall
   components:
-  - parent: 855
-    pos: 32.5,-8.5
+  - parent: 854
+    pos: 31.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1678
   type: solid_wall
   components:
-  - parent: 855
-    pos: 31.5,-8.5
+  - parent: 854
+    pos: 30.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1679
   type: solid_wall
   components:
-  - parent: 855
-    pos: 30.5,-8.5
+  - parent: 854
+    pos: 29.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1680
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,-8.5
+  - parent: 854
+    pos: 28.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1681
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-8.5
+  - parent: 854
+    pos: 28.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1682
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-7.5
+  - parent: 854
+    pos: 28.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1683
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-9.5
+  - parent: 854
+    pos: 28.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1684
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-10.5
+  - parent: 854
+    pos: 28.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1685
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-11.5
+  - parent: 854
+    pos: 28.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1686
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-12.5
+  - parent: 854
+    pos: 28.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1687
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-13.5
+  - parent: 854
+    pos: 28.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1688
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-14.5
+  - parent: 854
+    pos: 28.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1689
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-15.5
+  - parent: 854
+    pos: 28.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1690
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-16.5
+  - parent: 854
+    pos: 28.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1691
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-17.5
+  - parent: 854
+    pos: 28.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1692
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-18.5
+  - parent: 854
+    pos: 28.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1693
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-19.5
+  - parent: 854
+    pos: 27.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1694
   type: solid_wall
   components:
-  - parent: 855
-    pos: 27.5,-19.5
+  - parent: 854
+    pos: 26.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1695
   type: solid_wall
   components:
-  - parent: 855
-    pos: 26.5,-19.5
+  - parent: 854
+    pos: 25.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1696
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-19.5
+  - parent: 854
+    pos: 24.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1697
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,-19.5
+  - parent: 854
+    pos: 23.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1698
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-19.5
+  - parent: 854
+    pos: 23.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1699
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-20.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1700
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1701
+- uid: 1700
   type: SignCloning
   components:
-  - parent: 855
+  - parent: 854
     pos: 7.326743,-12.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1701
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 0.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1702
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-28.5
+  - parent: 854
+    pos: 0.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1703
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-27.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1704
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1705
+- uid: 1704
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
+    pos: 51.5,0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1705
+  type: LowWall
+  components:
+  - parent: 854
     pos: 51.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1706
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 51.5,0.5
+  - parent: 854
+    pos: 18.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1707
   type: solid_wall
   components:
-  - parent: 855
-    pos: 18.5,-23.5
+  - parent: 854
+    pos: 19.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1708
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,-23.5
+  - parent: 854
+    pos: 13.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1709
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-21.5
+  - parent: 854
+    pos: 12.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1710
   type: solid_wall
   components:
-  - parent: 855
-    pos: 12.5,-21.5
+  - parent: 854
+    pos: 1.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1711
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-24.5
+  - parent: 854
+    pos: 0.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1712
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-24.5
+  - parent: 854
+    pos: 0.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1713
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-25.5
+  - parent: 854
+    pos: 8.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1714
   type: solid_wall
   components:
-  - parent: 855
-    pos: 8.5,-21.5
+  - parent: 854
+    pos: 7.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1715
   type: solid_wall
   components:
-  - parent: 855
-    pos: 7.5,-21.5
+  - parent: 854
+    pos: 6.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1716
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-21.5
+  - parent: 854
+    pos: 6.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1717
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-22.5
+  - parent: 854
+    pos: 5.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1718
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 5.5,-22.5
+  - parent: 854
+    pos: 5.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1719
   type: LowWall
   components:
-  - parent: 855
-    pos: 5.5,-23.5
+  - parent: 854
+    pos: 5.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1720
   type: LowWall
   components:
-  - parent: 855
-    pos: 5.5,-24.5
+  - parent: 854
+    pos: 4.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1721
   type: LowWall
   components:
-  - parent: 855
-    pos: 4.5,-24.5
+  - parent: 854
+    pos: 3.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1722
   type: LowWall
   components:
-  - parent: 855
-    pos: 3.5,-24.5
+  - parent: 854
+    pos: 2.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1723
   type: LowWall
   components:
-  - parent: 855
-    pos: 2.5,-24.5
+  - parent: 854
+    pos: 9.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1724
   type: LowWall
   components:
-  - parent: 855
-    pos: 9.5,-21.5
+  - parent: 854
+    pos: 10.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1725
   type: LowWall
   components:
-  - parent: 855
-    pos: 10.5,-21.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1726
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1727
+- uid: 1726
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 45.5,10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1727
+  type: LowWall
+  components:
+  - parent: 854
+    pos: 34.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1728
   type: LowWall
   components:
-  - parent: 855
-    pos: 34.5,7.5
+  - parent: 854
+    pos: 32.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1729
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 32.5,7.5
+  - parent: 854
+    pos: 31.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1730
   type: solid_wall
   components:
-  - parent: 855
-    pos: 31.5,7.5
+  - parent: 854
+    pos: 30.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1731
   type: solid_wall
   components:
-  - parent: 855
-    pos: 30.5,7.5
+  - parent: 854
+    pos: 29.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1732
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,7.5
+  - parent: 854
+    pos: 29.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1733
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,8.5
+  - parent: 854
+    pos: 29.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1734
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,9.5
+  - parent: 854
+    pos: 28.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1735
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,7.5
+  - parent: 854
+    pos: 30.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1736
   type: solid_wall
   components:
-  - parent: 855
-    pos: 30.5,6.5
+  - parent: 854
+    pos: 30.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1737
   type: solid_wall
   components:
-  - parent: 855
-    pos: 30.5,2.5
+  - parent: 854
+    pos: 30.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1738
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 30.5,1.5
+  - parent: 854
+    pos: 32.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1739
   type: LowWall
   components:
-  - parent: 855
-    pos: 32.5,1.5
+  - parent: 854
+    pos: 34.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1740
   type: LowWall
   components:
-  - parent: 855
-    pos: 34.5,1.5
+  - parent: 854
+    pos: 30.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1741
   type: LowWall
   components:
-  - parent: 855
-    pos: 30.5,4.5
+  - parent: 854
+    pos: 30.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1742
   type: LowWall
   components:
-  - parent: 855
-    pos: 30.5,14.5
+  - parent: 854
+    pos: 30.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1743
   type: LowWall
   components:
-  - parent: 855
-    pos: 30.5,15.5
+  - parent: 854
+    pos: 31.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1744
   type: LowWall
   components:
-  - parent: 855
-    pos: 31.5,15.5
+  - parent: 854
+    pos: 32.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1745
   type: LowWall
   components:
-  - parent: 855
-    pos: 32.5,15.5
+  - parent: 854
+    pos: 33.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1746
   type: LowWall
   components:
-  - parent: 855
-    pos: 33.5,15.5
+  - parent: 854
+    pos: 34.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1747
   type: LowWall
   components:
-  - parent: 855
-    pos: 34.5,15.5
+  - parent: 854
+    pos: 35.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1748
   type: LowWall
   components:
-  - parent: 855
-    pos: 35.5,15.5
+  - parent: 854
+    pos: 36.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1749
   type: LowWall
   components:
-  - parent: 855
-    pos: 36.5,15.5
+  - parent: 854
+    pos: 36.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1750
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,14.5
+  - parent: 854
+    pos: 29.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1751
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,11.5
+  - parent: 854
+    pos: 29.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1752
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,12.5
+  - parent: 854
+    pos: 29.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1753
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,13.5
+  - parent: 854
+    pos: 29.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1754
-  type: solid_wall
+  type: HVWire
   components:
-  - parent: 855
-    pos: 29.5,14.5
+  - parent: 854
+    pos: 54.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1755
   type: LowWall
   components:
-  - parent: 855
-    pos: 19.5,16.5
+  - parent: 854
+    pos: 21.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1756
   type: LowWall
   components:
-  - parent: 855
-    pos: 21.5,14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1757
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1758
+- uid: 1757
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1759
+- uid: 1758
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1760
-  type: ReinforcedWindow
+- uid: 1759
+  type: HVWire
   components:
-  - parent: 855
-    pos: 21.5,15.5
+  - parent: 854
+    pos: 58.5,-30.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1760
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 25.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1761
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,13.5
+  - parent: 854
+    pos: 25.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1762
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,12.5
+  - parent: 854
+    pos: 25.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1763
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,11.5
+  - parent: 854
+    pos: 25.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1764
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,10.5
+  - parent: 854
+    pos: 25.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1765
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,8.5
+  - parent: 854
+    pos: 25.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1766
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,7.5
+  - parent: 854
+    pos: 26.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1767
   type: solid_wall
   components:
-  - parent: 855
-    pos: 26.5,7.5
+  - parent: 854
+    pos: 24.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1768
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,7.5
+  - parent: 854
+    pos: 24.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1769
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,6.5
+  - parent: 854
+    pos: 23.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1770
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,6.5
+  - parent: 854
+    pos: 18.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1771
   type: solid_wall
   components:
-  - parent: 855
-    pos: 18.5,6.5
+  - parent: 854
+    pos: 17.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1772
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,6.5
+  - parent: 854
+    pos: 17.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1773
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,7.5
+  - parent: 854
+    pos: 17.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1774
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,8.5
+  - parent: 854
+    pos: 17.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1775
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,9.5
+  - parent: 854
+    pos: 16.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1776
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,8.5
+  - parent: 854
+    pos: 12.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1777
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 12.5,8.5
+  - parent: 854
+    pos: 19.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1778
   type: LowWall
   components:
-  - parent: 855
-    pos: 19.5,6.5
+  - parent: 854
+    pos: 20.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1779
   type: LowWall
   components:
-  - parent: 855
-    pos: 20.5,6.5
+  - parent: 854
+    pos: 21.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1780
   type: LowWall
   components:
-  - parent: 855
-    pos: 21.5,6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1781
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1782
-  type: LowWall
+- uid: 1781
+  type: HVWire
   components:
-  - parent: 855
-    pos: 23.5,15.5
+  - parent: 854
+    pos: 56.5,-33.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1782
+  type: HVWire
+  components:
+  - parent: 854
+    pos: 58.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1783
-  type: LowWall
-  components:
-  - parent: 855
-    pos: 23.5,16.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1784
   type: SignDirectionalBridge
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.49181,6.256847
     type: Transform
-- uid: 1785
+- uid: 1784
   type: SignDirectionalSec
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.9947615,6.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 1786
-  type: LowWall
+- uid: 1785
+  type: HVWire
   components:
-  - parent: 855
-    pos: 19.5,15.5
+  - parent: 854
+    pos: 52.5,-33.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1786
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -0.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1787
   type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,-7.5
+  - parent: 854
+    pos: -19.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1788
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,-16.5
+  - parent: 854
+    pos: -21.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1789
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,-16.5
+  - parent: 854
+    pos: 17.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1790
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,12.5
+  - parent: 854
+    pos: 17.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1791
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,13.5
+  - parent: 854
+    pos: 17.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1792
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,14.5
+  - parent: 854
+    pos: 17.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1793
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,15.5
+  - parent: 854
+    pos: 16.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1794
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,16.5
+  - parent: 854
+    pos: 17.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1795
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,16.5
+  - parent: 854
+    pos: 16.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1796
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,13.5
+  - parent: 854
+    pos: 15.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1797
   type: solid_wall
   components:
-  - parent: 855
-    pos: 15.5,13.5
+  - parent: 854
+    pos: 14.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1798
   type: solid_wall
   components:
-  - parent: 855
-    pos: 14.5,13.5
+  - parent: 854
+    pos: 13.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1799
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,13.5
+  - parent: 854
+    pos: 12.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1800
   type: solid_wall
   components:
-  - parent: 855
-    pos: 12.5,13.5
+  - parent: 854
+    pos: 11.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1801
-  type: solid_wall
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,13.5
+  - parent: 854
+    pos: 11.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1802
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,12.5
+  - parent: 854
+    pos: 10.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1803
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,12.5
+  - parent: 854
+    pos: 9.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1804
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 9.5,12.5
+  - parent: 854
+    pos: 7.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1805
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 7.5,12.5
+  - parent: 854
+    pos: 6.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1806
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 6.5,12.5
+  - parent: 854
+    pos: 5.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1807
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 5.5,12.5
+  - parent: 854
+    pos: 5.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1808
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 5.5,11.5
+  - parent: 854
+    pos: 5.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1809
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 5.5,10.5
+  - parent: 854
+    pos: 5.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1810
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 5.5,9.5
+  - parent: 854
+    pos: 5.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1811
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 5.5,8.5
+  - parent: 854
+    pos: 5.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1812
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 5.5,7.5
+  - parent: 854
+    pos: 5.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1813
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 5.5,6.5
+  - parent: 854
+    pos: 11.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1814
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,6.5
+  - parent: 854
+    pos: 11.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1815
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,11.5
+  - parent: 854
+    pos: 11.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1816
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,10.5
+  - parent: 854
+    pos: 11.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1817
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,9.5
+  - parent: 854
+    pos: 11.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1818
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,8.5
+  - parent: 854
+    pos: 11.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1819
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,7.5
+  - parent: 854
+    pos: 10.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1820
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1821
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1822
+- uid: 1821
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,6.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1822
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 14.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1823
   type: solid_wall
   components:
-  - parent: 855
-    pos: 14.5,15.5
+  - parent: 854
+    pos: 14.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1824
   type: solid_wall
   components:
-  - parent: 855
-    pos: 14.5,16.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1825
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 14.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1826
+- uid: 1825
   type: ReinforcedWindow
   components:
-  - parent: 855
+  - parent: 854
     pos: 19.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1827
-  type: ReinforcedWindow
+- uid: 1826
+  type: HVWire
   components:
-  - parent: 855
-    pos: 19.5,15.5
+  - parent: 854
+    pos: 53.5,-33.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1827
+  type: HVWire
+  components:
+  - parent: 854
+    pos: 55.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1828
-  type: ReinforcedWindow
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,16.5
+  - parent: 854
+    pos: 14.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1829
   type: solid_wall
   components:
-  - parent: 855
-    pos: 14.5,21.5
+  - parent: 854
+    pos: -17.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1830
   type: solid_wall
   components:
-  - parent: 855
-    pos: -17.5,2.5
+  - parent: 854
+    pos: -20.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1831
   type: solid_wall
   components:
-  - parent: 855
-    pos: -20.5,2.5
+  - parent: 854
+    pos: -21.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1832
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,2.5
+  - parent: 854
+    pos: 11.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1833
   type: solid_wall
   components:
-  - parent: 855
-    pos: 11.5,21.5
+  - parent: 854
+    pos: 11.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1834
   type: solid_wall
   components:
-  - parent: 855
-    pos: 11.5,19.5
+  - parent: 854
+    pos: 11.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1835
   type: solid_wall
   components:
-  - parent: 855
-    pos: 11.5,18.5
+  - parent: 854
+    pos: 11.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1836
   type: solid_wall
   components:
-  - parent: 855
-    pos: 11.5,17.5
+  - parent: 854
+    pos: 11.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1837
   type: solid_wall
   components:
-  - parent: 855
-    pos: 11.5,16.5
+  - parent: 854
+    pos: 11.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1838
   type: solid_wall
   components:
-  - parent: 855
-    pos: 11.5,15.5
+  - parent: 854
+    pos: 10.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1839
   type: solid_wall
   components:
-  - parent: 855
-    pos: 10.5,15.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1840
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1841
+- uid: 1840
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,-9
     rot: 1.5707963267948966 rad
     type: Transform
@@ -28022,3824 +28001,3824 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 1841
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -21.5,0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1842
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,0.5
+  - parent: 854
+    pos: 6.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1843
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,15.5
+  - parent: 854
+    pos: 5.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1844
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,15.5
+  - parent: 854
+    pos: 6.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1845
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,16.5
+  - parent: 854
+    pos: 5.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1846
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,13.5
+  - parent: 854
+    pos: 6.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1847
-  type: solid_wall
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: 6.5,21.5
+  - parent: 854
+    pos: 10.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1848
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,22.5
+  - parent: 854
+    pos: 9.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1849
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 9.5,22.5
+  - parent: 854
+    pos: 8.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1850
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 8.5,22.5
+  - parent: 854
+    pos: 7.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1851
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 7.5,22.5
+  - parent: 854
+    pos: 6.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1852
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 6.5,22.5
+  - parent: 854
+    pos: 5.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1853
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 5.5,22.5
+  - parent: 854
+    pos: 10.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1854
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,23.5
+  - parent: 854
+    pos: 10.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1855
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,24.5
+  - parent: 854
+    pos: 10.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1856
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,25.5
+  - parent: 854
+    pos: 10.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1857
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,26.5
+  - parent: 854
+    pos: 10.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1858
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,27.5
+  - parent: 854
+    pos: 10.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1859
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,28.5
+  - parent: 854
+    pos: 10.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1860
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,30.5
+  - parent: 854
+    pos: 10.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1861
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 10.5,31.5
+  - parent: 854
+    pos: -3.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1862
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,31.5
+  - parent: 854
+    pos: -3.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1863
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,30.5
+  - parent: 854
+    pos: -3.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1864
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,28.5
+  - parent: 854
+    pos: -3.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1865
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,27.5
+  - parent: 854
+    pos: -3.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1866
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,26.5
+  - parent: 854
+    pos: -3.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1867
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,25.5
+  - parent: 854
+    pos: 1.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1868
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,22.5
+  - parent: 854
+    pos: 0.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1869
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 0.5,22.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1870
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1871
+- uid: 1870
   type: AirlockCommandLocked
   components:
   - name: Head of Personnel's Office
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 6.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
   - access:
     - - HeadOfPersonnel
     type: AccessReader
+- uid: 1871
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -2.5,22.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 1872
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -2.5,22.5
+  - parent: 854
+    pos: -3.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1873
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,22.5
+  - parent: 854
+    pos: -3.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1874
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,23.5
+  - parent: 854
+    pos: -3.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1875
-  type: reinforced_wall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -3.5,24.5
+  - parent: 854
+    pos: 1.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1876
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,26.5
+  - parent: 854
+    pos: 1.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1877
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,27.5
+  - parent: 854
+    pos: 0.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1878
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,27.5
+  - parent: 854
+    pos: -2.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1879
   type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,27.5
+  - parent: 854
+    pos: 1.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1880
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,23.5
+  - parent: 854
+    pos: 5.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1881
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,23.5
+  - parent: 854
+    pos: 5.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1882
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,24.5
+  - parent: 854
+    pos: 5.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1883
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,26.5
+  - parent: 854
+    pos: 5.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1884
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,27.5
+  - parent: 854
+    pos: 6.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1885
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,27.5
+  - parent: 854
+    pos: 7.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1886
   type: solid_wall
   components:
-  - parent: 855
-    pos: 7.5,27.5
+  - parent: 854
+    pos: 8.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1887
   type: solid_wall
   components:
-  - parent: 855
-    pos: 8.5,27.5
+  - parent: 854
+    pos: 9.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1888
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 9.5,27.5
+  - parent: 854
+    pos: 3.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1889
   type: LowWall
   components:
-  - parent: 855
-    pos: 3.5,22.5
+  - parent: 854
+    pos: -1.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1890
   type: LowWall
   components:
-  - parent: 855
-    pos: -1.5,27.5
+  - parent: 854
+    pos: -0.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1891
   type: LowWall
   components:
-  - parent: 855
-    pos: -0.5,27.5
+  - parent: 854
+    pos: -3.5,29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1892
   type: LowWall
   components:
-  - parent: 855
-    pos: -3.5,29.5
+  - parent: 854
+    pos: 10.5,29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1893
   type: LowWall
   components:
-  - parent: 855
-    pos: 10.5,29.5
+  - parent: 854
+    pos: 9.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1894
   type: LowWall
   components:
-  - parent: 855
-    pos: 9.5,31.5
+  - parent: 854
+    pos: 9.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1895
   type: LowWall
   components:
-  - parent: 855
-    pos: 9.5,32.5
+  - parent: 854
+    pos: 8.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1896
   type: LowWall
   components:
-  - parent: 855
-    pos: 8.5,32.5
+  - parent: 854
+    pos: 8.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1897
   type: LowWall
   components:
-  - parent: 855
-    pos: 8.5,33.5
+  - parent: 854
+    pos: 7.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1898
   type: LowWall
   components:
-  - parent: 855
-    pos: 7.5,33.5
+  - parent: 854
+    pos: 6.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1899
   type: LowWall
   components:
-  - parent: 855
-    pos: 6.5,33.5
+  - parent: 854
+    pos: 5.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1900
   type: LowWall
   components:
-  - parent: 855
-    pos: 5.5,33.5
+  - parent: 854
+    pos: 4.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1901
   type: LowWall
   components:
-  - parent: 855
-    pos: 4.5,33.5
+  - parent: 854
+    pos: 3.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1902
   type: LowWall
   components:
-  - parent: 855
-    pos: 3.5,33.5
+  - parent: 854
+    pos: 2.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1903
   type: LowWall
   components:
-  - parent: 855
-    pos: 2.5,33.5
+  - parent: 854
+    pos: 1.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1904
   type: LowWall
   components:
-  - parent: 855
-    pos: 1.5,33.5
+  - parent: 854
+    pos: 0.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1905
   type: LowWall
   components:
-  - parent: 855
-    pos: 0.5,33.5
+  - parent: 854
+    pos: -0.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1906
   type: LowWall
   components:
-  - parent: 855
-    pos: -0.5,33.5
+  - parent: 854
+    pos: -1.5,33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1907
   type: LowWall
   components:
-  - parent: 855
-    pos: -1.5,33.5
+  - parent: 854
+    pos: -1.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1908
   type: LowWall
   components:
-  - parent: 855
-    pos: -1.5,32.5
+  - parent: 854
+    pos: -2.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1909
   type: LowWall
   components:
-  - parent: 855
-    pos: -2.5,31.5
+  - parent: 854
+    pos: -2.5,32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1910
   type: LowWall
   components:
-  - parent: 855
-    pos: -2.5,32.5
+  - parent: 854
+    pos: 6.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1911
   type: LowWall
   components:
-  - parent: 855
-    pos: 6.5,19.5
+  - parent: 854
+    pos: 6.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1912
-  type: LowWall
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: 6.5,18.5
+  - parent: 854
+    pos: 1.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1913
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,15.5
+  - parent: 854
+    pos: 0.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1914
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 0.5,15.5
+  - parent: 854
+    pos: -0.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1915
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -0.5,15.5
+  - parent: 854
+    pos: -1.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1916
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -1.5,15.5
+  - parent: 854
+    pos: -2.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1917
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -2.5,15.5
+  - parent: 854
+    pos: -3.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1918
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,15.5
+  - parent: 854
+    pos: -4.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1919
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -4.5,15.5
+  - parent: 854
+    pos: -4.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1920
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -4.5,16.5
+  - parent: 854
+    pos: -4.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1921
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -4.5,17.5
+  - parent: 854
+    pos: -4.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1922
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -4.5,18.5
+  - parent: 854
+    pos: -4.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1923
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -4.5,19.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1924
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1925
+- uid: 1924
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,18.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1925
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -3.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1926
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -3.5,19.5
+  - parent: 854
+    pos: -2.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1927
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -2.5,19.5
+  - parent: 854
+    pos: -1.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1928
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -1.5,19.5
+  - parent: 854
+    pos: -0.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1929
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -0.5,19.5
+  - parent: 854
+    pos: 0.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1930
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 0.5,19.5
+  - parent: 854
+    pos: 0.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1931
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 0.5,18.5
+  - parent: 854
+    pos: 0.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1932
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 0.5,16.5
+  - parent: 854
+    pos: -5.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1933
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -5.5,20.5
+  - parent: 854
+    pos: -5.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1934
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -5.5,21.5
+  - parent: 854
+    pos: -5.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1935
-  type: reinforced_wall
+  type: Carpet
   components:
-  - parent: 855
-    pos: -5.5,22.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -4.5,-1.5
+    rot: 1.5707963267948966 rad
     type: Transform
 - uid: 1936
   type: Carpet
   components:
-  - parent: 855
-    pos: -4.5,-1.5
+  - parent: 854
+    pos: -5.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 1937
   type: Carpet
   components:
-  - parent: 855
-    pos: -5.5,-1.5
-    rot: 1.5707963267948966 rad
-    type: Transform
-- uid: 1938
-  type: Carpet
-  components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1939
+- uid: 1938
   type: GoldStack
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.615473,16.701466
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 1940
+- uid: 1939
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 40.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1940
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -11.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1941
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -11.5,22.5
+  - parent: 854
+    pos: -12.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1942
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -12.5,22.5
+  - parent: 854
+    pos: -13.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1943
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -13.5,22.5
+  - parent: 854
+    pos: -14.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1944
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,22.5
+  - parent: 854
+    pos: -15.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1945
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,22.5
+  - parent: 854
+    pos: -16.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1946
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -16.5,22.5
+  - parent: 854
+    pos: -16.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1947
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -16.5,23.5
+  - parent: 854
+    pos: -15.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1948
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,23.5
+  - parent: 854
+    pos: -14.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1949
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,23.5
+  - parent: 854
+    pos: -13.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1950
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -13.5,23.5
+  - parent: 854
+    pos: -12.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1951
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -12.5,23.5
+  - parent: 854
+    pos: -11.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1952
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -11.5,23.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1953
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1954
+- uid: 1953
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 39.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1954
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -16.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1955
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -16.5,21.5
+  - parent: 854
+    pos: -16.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1956
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -16.5,20.5
+  - parent: 854
+    pos: -16.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1957
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -16.5,19.5
+  - parent: 854
+    pos: -16.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1958
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -16.5,18.5
+  - parent: 854
+    pos: -16.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1959
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -16.5,17.5
+  - parent: 854
+    pos: -15.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1960
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,21.5
+  - parent: 854
+    pos: -15.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1961
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,20.5
+  - parent: 854
+    pos: -15.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1962
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,19.5
+  - parent: 854
+    pos: -15.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1963
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,18.5
+  - parent: 854
+    pos: -15.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1964
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,17.5
+  - parent: 854
+    pos: -14.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1965
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,17.5
+  - parent: 854
+    pos: -13.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1966
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -13.5,17.5
+  - parent: 854
+    pos: -11.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1967
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -11.5,17.5
+  - parent: 854
+    pos: -10.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1968
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -10.5,17.5
+  - parent: 854
+    pos: -10.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1969
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -10.5,18.5
+  - parent: 854
+    pos: -10.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1970
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -10.5,19.5
+  - parent: 854
+    pos: -14.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1971
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,8.5
+  - parent: 854
+    pos: -14.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1972
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,7.5
+  - parent: 854
+    pos: -14.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1973
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,6.5
+  - parent: 854
+    pos: -13.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1974
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -13.5,6.5
+  - parent: 854
+    pos: -12.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1975
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -12.5,6.5
+  - parent: 854
+    pos: -11.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1976
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -11.5,6.5
+  - parent: 854
+    pos: -10.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1977
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -10.5,6.5
+  - parent: 854
+    pos: -10.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1978
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -10.5,7.5
+  - parent: 854
+    pos: -10.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1979
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -10.5,8.5
+  - parent: 854
+    pos: -10.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1980
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -10.5,9.5
+  - parent: 854
+    pos: -14.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1981
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,12.5
+  - parent: 854
+    pos: -15.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1982
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,12.5
+  - parent: 854
+    pos: -15.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1983
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,13.5
+  - parent: 854
+    pos: -15.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1984
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1985
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1986
+- uid: 1985
   type: AirlockMaintSecLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,11.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1986
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -14.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1987
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,10.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 1988
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1989
+- uid: 1988
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 1990
+- uid: 1989
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 1990
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -9.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1991
   type: solid_wall
   components:
-  - parent: 855
-    pos: -9.5,18.5
+  - parent: 854
+    pos: -10.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1992
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,16.5
+  - parent: 854
+    pos: -10.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1993
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,13.5
+  - parent: 854
+    pos: -10.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1994
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,12.5
+  - parent: 854
+    pos: -11.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1995
   type: solid_wall
   components:
-  - parent: 855
-    pos: -11.5,12.5
+  - parent: 854
+    pos: -12.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1996
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,12.5
+  - parent: 854
+    pos: -13.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1997
   type: solid_wall
   components:
-  - parent: 855
-    pos: -13.5,12.5
+  - parent: 854
+    pos: -5.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1998
-  type: solid_wall
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: -5.5,18.5
+  - parent: 854
+    pos: 1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 1999
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,14.5
+  - parent: 854
+    pos: 1.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2000
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,13.5
+  - parent: 854
+    pos: 1.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2001
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,12.5
+  - parent: 854
+    pos: 1.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2002
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,11.5
+  - parent: 854
+    pos: 1.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2003
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,10.5
+  - parent: 854
+    pos: 1.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2004
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,9.5
+  - parent: 854
+    pos: 1.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2005
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,8.5
+  - parent: 854
+    pos: 1.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2006
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,7.5
+  - parent: 854
+    pos: 1.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2007
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 1.5,6.5
+  - parent: 854
+    pos: -4.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2008
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -4.5,6.5
+  - parent: 854
+    pos: -1.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2009
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -1.5,6.5
+  - parent: 854
+    pos: -7.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2010
-  type: reinforced_wall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -7.5,6.5
+  - parent: 854
+    pos: -4.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2011
   type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,7.5
+  - parent: 854
+    pos: -4.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2012
   type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,8.5
+  - parent: 854
+    pos: -4.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2013
   type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,9.5
+  - parent: 854
+    pos: -1.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2014
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,9.5
+  - parent: 854
+    pos: -1.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2015
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,7.5
+  - parent: 854
+    pos: -1.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2016
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: -1.5,8.5
+  - parent: 854
+    pos: -0.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2017
   type: LowWall
   components:
-  - parent: 855
-    pos: -0.5,9.5
+  - parent: 854
+    pos: -3.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2018
   type: LowWall
   components:
-  - parent: 855
-    pos: -3.5,9.5
+  - parent: 854
+    pos: -7.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2019
   type: LowWall
   components:
-  - parent: 855
-    pos: -7.5,9.5
+  - parent: 854
+    pos: -8.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2020
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -8.5,9.5
+  - parent: 854
+    pos: -15.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2021
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,6.5
+  - parent: 854
+    pos: -17.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2022
   type: solid_wall
   components:
-  - parent: 855
-    pos: -17.5,6.5
+  - parent: 854
+    pos: -18.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2023
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,6.5
+  - parent: 854
+    pos: -18.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2024
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,7.5
+  - parent: 854
+    pos: -18.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2025
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,8.5
+  - parent: 854
+    pos: -18.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2026
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,9.5
+  - parent: 854
+    pos: -18.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2027
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,10.5
+  - parent: 854
+    pos: -18.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2028
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,11.5
+  - parent: 854
+    pos: -19.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2029
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,11.5
+  - parent: 854
+    pos: -18.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2030
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,14.5
+  - parent: 854
+    pos: -19.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2031
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,14.5
+  - parent: 854
+    pos: -19.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2032
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,15.5
+  - parent: 854
+    pos: -19.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2033
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,16.5
+  - parent: 854
+    pos: -19.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2034
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,17.5
+  - parent: 854
+    pos: -19.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2035
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,18.5
+  - parent: 854
+    pos: -19.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2036
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,19.5
+  - parent: 854
+    pos: -19.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2037
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,20.5
+  - parent: 854
+    pos: -19.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2038
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,21.5
+  - parent: 854
+    pos: -19.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2039
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,22.5
+  - parent: 854
+    pos: -19.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2040
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,23.5
+  - parent: 854
+    pos: -19.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2041
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,24.5
+  - parent: 854
+    pos: -19.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2042
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,25.5
+  - parent: 854
+    pos: -19.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2043
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,26.5
+  - parent: 854
+    pos: -18.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2044
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,26.5
+  - parent: 854
+    pos: -17.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2045
   type: solid_wall
   components:
-  - parent: 855
-    pos: -17.5,26.5
+  - parent: 854
+    pos: -16.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2046
   type: solid_wall
   components:
-  - parent: 855
-    pos: -16.5,26.5
+  - parent: 854
+    pos: -15.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2047
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,26.5
+  - parent: 854
+    pos: -14.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2048
   type: solid_wall
   components:
-  - parent: 855
-    pos: -14.5,26.5
+  - parent: 854
+    pos: -13.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2049
   type: solid_wall
   components:
-  - parent: 855
-    pos: -13.5,26.5
+  - parent: 854
+    pos: -12.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2050
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,26.5
+  - parent: 854
+    pos: -11.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2051
   type: solid_wall
   components:
-  - parent: 855
-    pos: -11.5,26.5
+  - parent: 854
+    pos: -10.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2052
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,26.5
+  - parent: 854
+    pos: -9.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2053
   type: solid_wall
   components:
-  - parent: 855
-    pos: -9.5,26.5
+  - parent: 854
+    pos: -8.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2054
   type: solid_wall
   components:
-  - parent: 855
-    pos: -8.5,26.5
+  - parent: 854
+    pos: -7.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2055
   type: solid_wall
   components:
-  - parent: 855
-    pos: -7.5,26.5
+  - parent: 854
+    pos: -6.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2056
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,26.5
+  - parent: 854
+    pos: -6.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2057
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,25.5
+  - parent: 854
+    pos: -4.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2058
   type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,25.5
+  - parent: 854
+    pos: -5.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2059
   type: solid_wall
   components:
-  - parent: 855
-    pos: -5.5,25.5
+  - parent: 854
+    pos: -20.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2060
   type: solid_wall
   components:
-  - parent: 855
-    pos: -20.5,15.5
+  - parent: 854
+    pos: -21.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2061
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,15.5
+  - parent: 854
+    pos: -22.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2062
   type: solid_wall
   components:
-  - parent: 855
-    pos: -22.5,15.5
+  - parent: 854
+    pos: -23.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2063
   type: solid_wall
   components:
-  - parent: 855
-    pos: -23.5,15.5
+  - parent: 854
+    pos: -24.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2064
   type: solid_wall
   components:
-  - parent: 855
-    pos: -24.5,15.5
+  - parent: 854
+    pos: -25.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2065
   type: solid_wall
   components:
-  - parent: 855
-    pos: -25.5,15.5
+  - parent: 854
+    pos: -26.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2066
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,15.5
+  - parent: 854
+    pos: -27.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2067
   type: solid_wall
   components:
-  - parent: 855
-    pos: -27.5,15.5
+  - parent: 854
+    pos: -28.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2068
   type: solid_wall
   components:
-  - parent: 855
-    pos: -28.5,15.5
+  - parent: 854
+    pos: -29.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2069
   type: solid_wall
   components:
-  - parent: 855
-    pos: -29.5,15.5
+  - parent: 854
+    pos: -30.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2070
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,15.5
+  - parent: 854
+    pos: -31.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2071
   type: solid_wall
   components:
-  - parent: 855
-    pos: -31.5,15.5
+  - parent: 854
+    pos: -32.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2072
   type: solid_wall
   components:
-  - parent: 855
-    pos: -32.5,15.5
+  - parent: 854
+    pos: -33.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2073
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,15.5
+  - parent: 854
+    pos: -33.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2074
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,14.5
+  - parent: 854
+    pos: -33.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2075
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,13.5
+  - parent: 854
+    pos: -33.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2076
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,12.5
+  - parent: 854
+    pos: -33.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2077
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,11.5
+  - parent: 854
+    pos: -33.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2078
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,10.5
+  - parent: 854
+    pos: -21.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2079
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,1.5
+  - parent: 854
+    pos: -33.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2080
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,7.5
+  - parent: 854
+    pos: -33.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2081
   type: solid_wall
   components:
-  - parent: 855
-    pos: -33.5,6.5
+  - parent: 854
+    pos: -32.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2082
   type: solid_wall
   components:
-  - parent: 855
-    pos: -32.5,6.5
+  - parent: 854
+    pos: -31.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2083
   type: solid_wall
   components:
-  - parent: 855
-    pos: -31.5,6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2084
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2085
+- uid: 2084
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2086
+- uid: 2085
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2087
+- uid: 2086
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-24.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2087
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -26.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2088
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2089
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2090
+- uid: 2089
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,6.5
     rot: 3.141592653589793 rad
+    type: Transform
+- uid: 2090
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -30.5,7.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2091
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,7.5
+  - parent: 854
+    pos: -30.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2092
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,8.5
+  - parent: 854
+    pos: -30.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2093
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,9.5
+  - parent: 854
+    pos: -30.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2094
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,10.5
+  - parent: 854
+    pos: -30.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2095
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,11.5
+  - parent: 854
+    pos: -30.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2096
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,12.5
+  - parent: 854
+    pos: -28.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2097
   type: solid_wall
   components:
-  - parent: 855
-    pos: -28.5,12.5
+  - parent: 854
+    pos: -27.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2098
   type: solid_wall
   components:
-  - parent: 855
-    pos: -27.5,12.5
+  - parent: 854
+    pos: -26.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2099
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,12.5
+  - parent: 854
+    pos: -25.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2100
   type: solid_wall
   components:
-  - parent: 855
-    pos: -25.5,12.5
+  - parent: 854
+    pos: -24.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2101
   type: solid_wall
   components:
-  - parent: 855
-    pos: -24.5,12.5
+  - parent: 854
+    pos: -23.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2102
   type: solid_wall
   components:
-  - parent: 855
-    pos: -23.5,12.5
+  - parent: 854
+    pos: -22.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2103
   type: solid_wall
   components:
-  - parent: 855
-    pos: -22.5,12.5
+  - parent: 854
+    pos: -29.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2104
   type: solid_wall
   components:
-  - parent: 855
-    pos: -29.5,12.5
+  - parent: 854
+    pos: -22.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2105
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2106
   type: solid_wall
   components:
-  - parent: 855
-    pos: -22.5,11.5
+  - parent: 854
+    pos: -21.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2107
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,11.5
+  - parent: 854
+    pos: -22.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2108
   type: solid_wall
   components:
-  - parent: 855
-    pos: -22.5,10.5
+  - parent: 854
+    pos: -22.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2109
   type: solid_wall
   components:
-  - parent: 855
-    pos: -22.5,8.5
+  - parent: 854
+    pos: -22.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2110
   type: solid_wall
   components:
-  - parent: 855
-    pos: -22.5,7.5
+  - parent: 854
+    pos: -21.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2111
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,7.5
+  - parent: 854
+    pos: -21.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2112
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,6.5
+  - parent: 854
+    pos: -20.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2113
   type: solid_wall
   components:
-  - parent: 855
-    pos: -20.5,6.5
+  - parent: 854
+    pos: -19.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2114
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,6.5
+  - parent: 854
+    pos: -25.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2115
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: -25.5,11.5
+  - parent: 854
+    pos: -25.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2116
   type: LowWall
   components:
-  - parent: 855
-    pos: -25.5,9.5
+  - parent: 854
+    pos: -2.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2117
   type: LowWall
   components:
-  - parent: 855
-    pos: -2.5,6.5
+  - parent: 854
+    pos: -3.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2118
   type: LowWall
   components:
-  - parent: 855
-    pos: -3.5,6.5
+  - parent: 854
+    pos: -0.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2119
   type: LowWall
   components:
-  - parent: 855
-    pos: -0.5,6.5
+  - parent: 854
+    pos: 0.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2120
   type: LowWall
   components:
-  - parent: 855
-    pos: 0.5,6.5
+  - parent: 854
+    pos: 14.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2121
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 14.5,8.5
+  - parent: 854
+    pos: 30.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2122
   type: solid_wall
   components:
-  - parent: 855
-    pos: 30.5,-0.5
+  - parent: 854
+    pos: 30.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2123
   type: solid_wall
   components:
-  - parent: 855
-    pos: 30.5,0.5
+  - parent: 854
+    pos: 29.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2124
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,-0.5
+  - parent: 854
+    pos: 28.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2125
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-0.5
+  - parent: 854
+    pos: 27.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2126
   type: solid_wall
   components:
-  - parent: 855
-    pos: 27.5,-0.5
+  - parent: 854
+    pos: 26.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2127
   type: solid_wall
   components:
-  - parent: 855
-    pos: 26.5,-0.5
+  - parent: 854
+    pos: 25.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2128
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-0.5
+  - parent: 854
+    pos: 24.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2129
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,-0.5
+  - parent: 854
+    pos: 24.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2130
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,0.5
+  - parent: 854
+    pos: 24.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2131
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,1.5
+  - parent: 854
+    pos: 24.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2132
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,2.5
+  - parent: 854
+    pos: 23.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2133
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,2.5
+  - parent: 854
+    pos: 22.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2134
   type: solid_wall
   components:
-  - parent: 855
-    pos: 22.5,2.5
+  - parent: 854
+    pos: 19.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2135
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,2.5
+  - parent: 854
+    pos: 18.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2136
   type: solid_wall
   components:
-  - parent: 855
-    pos: 18.5,2.5
+  - parent: 854
+    pos: 17.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2137
   type: solid_wall
   components:
-  - parent: 855
-    pos: 17.5,2.5
+  - parent: 854
+    pos: 16.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2138
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,2.5
+  - parent: 854
+    pos: 15.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2139
   type: solid_wall
   components:
-  - parent: 855
-    pos: 15.5,2.5
+  - parent: 854
+    pos: 14.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2140
   type: solid_wall
   components:
-  - parent: 855
-    pos: 14.5,2.5
+  - parent: 854
+    pos: 13.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2141
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,2.5
+  - parent: 854
+    pos: 12.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2142
   type: solid_wall
   components:
-  - parent: 855
-    pos: 12.5,2.5
+  - parent: 854
+    pos: 6.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2143
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,2.5
+  - parent: 854
+    pos: 5.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2144
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,2.5
+  - parent: 854
+    pos: 5.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2145
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,1.5
+  - parent: 854
+    pos: 20.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2146
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,2.5
+  - parent: 854
+    pos: 19.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2147
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,1.5
+  - parent: 854
+    pos: 19.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2148
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,0.5
+  - parent: 854
+    pos: 19.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2149
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,-0.5
+  - parent: 854
+    pos: 19.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2150
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,-1.5
+  - parent: 854
+    pos: 19.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2151
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,-2.5
+  - parent: 854
+    pos: 13.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2152
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-2.5
+  - parent: 854
+    pos: 13.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2153
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-3.5
+  - parent: 854
+    pos: 14.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2154
   type: solid_wall
   components:
-  - parent: 855
-    pos: 14.5,-3.5
+  - parent: 854
+    pos: 13.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2155
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-6.5
+  - parent: 854
+    pos: 5.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2156
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,-3.5
+  - parent: 854
+    pos: 5.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2157
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,-4.5
+  - parent: 854
+    pos: 5.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2158
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,-5.5
+  - parent: 854
+    pos: 5.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2159
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,-6.5
+  - parent: 854
+    pos: 5.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2160
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,-7.5
+  - parent: 854
+    pos: 5.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2161
   type: solid_wall
   components:
-  - parent: 855
-    pos: 5.5,-12.5
+  - parent: 854
+    pos: 5.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2162
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 5.5,-11.5
+  - parent: 854
+    pos: 5.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2163
   type: LowWall
   components:
-  - parent: 855
-    pos: 5.5,-8.5
+  - parent: 854
+    pos: 5.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2164
   type: LowWall
   components:
-  - parent: 855
-    pos: 5.5,-9.5
+  - parent: 854
+    pos: 5.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2165
   type: LowWall
   components:
-  - parent: 855
-    pos: 5.5,-10.5
+  - parent: 854
+    pos: 13.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2166
   type: LowWall
   components:
-  - parent: 855
-    pos: 13.5,-1.5
+  - parent: 854
+    pos: 13.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2167
   type: LowWall
   components:
-  - parent: 855
-    pos: 13.5,1.5
+  - parent: 854
+    pos: 13.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2168
   type: LowWall
   components:
-  - parent: 855
-    pos: 13.5,-0.5
+  - parent: 854
+    pos: 16.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2169
   type: LowWall
   components:
-  - parent: 855
-    pos: 16.5,-3.5
+  - parent: 854
+    pos: 11.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2170
   type: LowWall
   components:
-  - parent: 855
-    pos: 11.5,2.5
+  - parent: 854
+    pos: 10.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2171
   type: LowWall
   components:
-  - parent: 855
-    pos: 10.5,2.5
+  - parent: 854
+    pos: 9.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2172
   type: LowWall
   components:
-  - parent: 855
-    pos: 9.5,2.5
+  - parent: 854
+    pos: 8.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2173
   type: LowWall
   components:
-  - parent: 855
-    pos: 8.5,2.5
+  - parent: 854
+    pos: 7.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2174
   type: LowWall
   components:
-  - parent: 855
-    pos: 7.5,2.5
+  - parent: 854
+    pos: 6.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2175
   type: LowWall
   components:
-  - parent: 855
-    pos: 6.5,-6.5
+  - parent: 854
+    pos: 9.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2176
   type: LowWall
   components:
-  - parent: 855
-    pos: 9.5,-6.5
+  - parent: 854
+    pos: 8.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2177
   type: LowWall
   components:
-  - parent: 855
-    pos: 8.5,-6.5
+  - parent: 854
+    pos: 13.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2178
   type: LowWall
   components:
-  - parent: 855
-    pos: 13.5,-5.5
+  - parent: 854
+    pos: 13.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2179
   type: LowWall
   components:
-  - parent: 855
-    pos: 13.5,-4.5
+  - parent: 854
+    pos: 12.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2180
   type: LowWall
   components:
-  - parent: 855
-    pos: 12.5,-6.5
+  - parent: 854
+    pos: 18.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2181
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 18.5,-3.5
+  - parent: 854
+    pos: 19.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2182
   type: solid_wall
   components:
-  - parent: 855
-    pos: 19.5,-3.5
+  - parent: 854
+    pos: 20.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2183
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-3.5
+  - parent: 854
+    pos: 21.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2184
   type: solid_wall
   components:
-  - parent: 855
-    pos: 21.5,-3.5
+  - parent: 854
+    pos: 22.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2185
   type: solid_wall
   components:
-  - parent: 855
-    pos: 22.5,-3.5
+  - parent: 854
+    pos: 23.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2186
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-3.5
+  - parent: 854
+    pos: 24.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2187
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,-3.5
+  - parent: 854
+    pos: 25.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2188
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-3.5
+  - parent: 854
+    pos: 25.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2189
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-4.5
+  - parent: 854
+    pos: 25.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2190
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-5.5
+  - parent: 854
+    pos: 25.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2191
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-7.5
+  - parent: 854
+    pos: 25.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2192
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-8.5
+  - parent: 854
+    pos: 24.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2193
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,-8.5
+  - parent: 854
+    pos: 23.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2194
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-8.5
+  - parent: 854
+    pos: 22.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2195
   type: solid_wall
   components:
-  - parent: 855
-    pos: 22.5,-8.5
+  - parent: 854
+    pos: 21.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2196
   type: solid_wall
   components:
-  - parent: 855
-    pos: 21.5,-8.5
+  - parent: 854
+    pos: 20.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2197
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-8.5
+  - parent: 854
+    pos: 20.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2198
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-7.5
+  - parent: 854
+    pos: 16.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2199
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,-18.5
+  - parent: 854
+    pos: 20.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2200
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-4.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2201
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2202
+- uid: 2201
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2202
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 20.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2203
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-11.5
+  - parent: 854
+    pos: 21.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2204
   type: solid_wall
   components:
-  - parent: 855
-    pos: 21.5,-11.5
+  - parent: 854
+    pos: 22.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2205
   type: solid_wall
   components:
-  - parent: 855
-    pos: 22.5,-11.5
+  - parent: 854
+    pos: 23.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2206
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-11.5
+  - parent: 854
+    pos: 24.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2207
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,-11.5
+  - parent: 854
+    pos: 25.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2208
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-11.5
+  - parent: 854
+    pos: 25.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2209
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-12.5
+  - parent: 854
+    pos: 25.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2210
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-13.5
+  - parent: 854
+    pos: 25.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2211
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-14.5
+  - parent: 854
+    pos: 25.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2212
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-15.5
+  - parent: 854
+    pos: 25.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2213
   type: solid_wall
   components:
-  - parent: 855
-    pos: 25.5,-16.5
+  - parent: 854
+    pos: 24.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2214
   type: solid_wall
   components:
-  - parent: 855
-    pos: 24.5,-16.5
+  - parent: 854
+    pos: 23.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2215
   type: solid_wall
   components:
-  - parent: 855
-    pos: 23.5,-16.5
+  - parent: 854
+    pos: 22.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2216
   type: solid_wall
   components:
-  - parent: 855
-    pos: 22.5,-16.5
+  - parent: 854
+    pos: 21.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2217
   type: solid_wall
   components:
-  - parent: 855
-    pos: 21.5,-16.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2218
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2219
+- uid: 2218
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-5.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2219
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 15.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2220
   type: solid_wall
   components:
-  - parent: 855
-    pos: 15.5,-18.5
+  - parent: 854
+    pos: 20.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2221
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-17.5
+  - parent: 854
+    pos: 20.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2222
   type: solid_wall
   components:
-  - parent: 855
-    pos: 20.5,-18.5
+  - parent: 854
+    pos: 46.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2223
   type: solid_wall
   components:
-  - parent: 855
-    pos: 46.5,5.5
+  - parent: 854
+    pos: 45.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2224
   type: solid_wall
   components:
-  - parent: 855
-    pos: 45.5,5.5
+  - parent: 854
+    pos: 48.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2225
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 48.5,5.5
+  - parent: 854
+    pos: 20.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2226
   type: LowWall
   components:
-  - parent: 855
-    pos: 20.5,-14.5
+  - parent: 854
+    pos: 20.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2227
   type: LowWall
   components:
-  - parent: 855
-    pos: 20.5,-5.5
+  - parent: 854
+    pos: 11.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2228
   type: LowWall
   components:
-  - parent: 855
-    pos: 11.5,-14.5
+  - parent: 854
+    pos: 11.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2229
   type: LowWall
   components:
-  - parent: 855
-    pos: 11.5,-15.5
+  - parent: 854
+    pos: 9.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2230
-  type: LowWall
+  type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2231
-  type: Window
-  components:
-  - parent: 855
-    pos: 9.5,-12.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2232
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2233
+- uid: 2232
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2234
+- uid: 2233
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2235
+- uid: 2234
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,-12.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2235
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 6.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2236
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-13.5
+  - parent: 854
+    pos: 6.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2237
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-14.5
+  - parent: 854
+    pos: 6.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2238
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-15.5
+  - parent: 854
+    pos: 6.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2239
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-16.5
+  - parent: 854
+    pos: 6.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2240
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-17.5
+  - parent: 854
+    pos: 7.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2241
   type: solid_wall
   components:
-  - parent: 855
-    pos: 7.5,-17.5
+  - parent: 854
+    pos: 8.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2242
   type: solid_wall
   components:
-  - parent: 855
-    pos: 8.5,-17.5
+  - parent: 854
+    pos: 9.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2243
   type: solid_wall
   components:
-  - parent: 855
-    pos: 9.5,-17.5
+  - parent: 854
+    pos: 10.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2244
   type: solid_wall
   components:
-  - parent: 855
-    pos: 10.5,-17.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2245
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2246
+- uid: 2245
   type: Window
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,-14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2246
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: 11.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2247
   type: solid_wall
   components:
-  - parent: 855
-    pos: 11.5,-18.5
+  - parent: 854
+    pos: 12.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2248
   type: solid_wall
   components:
-  - parent: 855
-    pos: 12.5,-18.5
+  - parent: 854
+    pos: 13.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2249
   type: solid_wall
   components:
-  - parent: 855
-    pos: 13.5,-18.5
+  - parent: 854
+    pos: 6.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2250
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-18.5
+  - parent: 854
+    pos: 6.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2251
   type: solid_wall
   components:
-  - parent: 855
-    pos: 6.5,-20.5
+  - parent: 854
+    pos: 28.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2252
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-1.5
+  - parent: 854
+    pos: 28.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2253
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-2.5
+  - parent: 854
+    pos: 28.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2254
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-3.5
+  - parent: 854
+    pos: 28.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2255
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-4.5
+  - parent: 854
+    pos: 28.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2256
   type: solid_wall
   components:
-  - parent: 855
-    pos: 28.5,-5.5
+  - parent: 854
+    pos: 29.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2257
   type: solid_wall
   components:
-  - parent: 855
-    pos: 29.5,-5.5
+  - parent: 854
+    pos: 30.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2258
   type: solid_wall
   components:
-  - parent: 855
-    pos: 30.5,-5.5
+  - parent: 854
+    pos: 31.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2259
   type: solid_wall
   components:
-  - parent: 855
-    pos: 31.5,-5.5
+  - parent: 854
+    pos: 32.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2260
   type: solid_wall
   components:
-  - parent: 855
-    pos: 32.5,-5.5
+  - parent: 854
+    pos: 34.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2261
   type: solid_wall
   components:
-  - parent: 855
-    pos: 34.5,-5.5
+  - parent: 854
+    pos: 35.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2262
   type: solid_wall
   components:
-  - parent: 855
-    pos: 35.5,-5.5
+  - parent: 854
+    pos: 36.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2263
   type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,-5.5
+  - parent: 854
+    pos: 36.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2264
   type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,-4.5
+  - parent: 854
+    pos: 36.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2265
   type: solid_wall
   components:
-  - parent: 855
-    pos: 36.5,-3.5
+  - parent: 854
+    pos: 1.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2266
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,1.5
+  - parent: 854
+    pos: 1.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2267
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,2.5
+  - parent: 854
+    pos: 0.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2268
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,2.5
+  - parent: 854
+    pos: 1.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2269
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-3.5
+  - parent: 854
+    pos: 1.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2270
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-4.5
+  - parent: 854
+    pos: 1.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2271
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-5.5
+  - parent: 854
+    pos: 1.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2272
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-6.5
+  - parent: 854
+    pos: 0.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2273
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-5.5
+  - parent: 854
+    pos: -0.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2274
   type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,-5.5
+  - parent: 854
+    pos: -1.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2275
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-5.5
+  - parent: 854
+    pos: -2.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2276
   type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,-5.5
+  - parent: 854
+    pos: 1.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2277
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-9.5
+  - parent: 854
+    pos: 1.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2278
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-10.5
+  - parent: 854
+    pos: 1.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2279
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-11.5
+  - parent: 854
+    pos: 1.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2280
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-12.5
+  - parent: 854
+    pos: 1.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2281
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-8.5
+  - parent: 854
+    pos: 0.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2282
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-12.5
+  - parent: 854
+    pos: -0.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2283
   type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,-12.5
+  - parent: 854
+    pos: -1.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2284
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-12.5
+  - parent: 854
+    pos: -2.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2285
   type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,-12.5
+  - parent: 854
+    pos: 0.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2286
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-13.5
+  - parent: 854
+    pos: -5.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2287
   type: solid_wall
   components:
-  - parent: 855
-    pos: -5.5,-18.5
+  - parent: 854
+    pos: 0.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2288
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-17.5
+  - parent: 854
+    pos: 0.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2289
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-18.5
+  - parent: 854
+    pos: -0.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2290
   type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,-18.5
+  - parent: 854
+    pos: -6.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2291
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-18.5
+  - parent: 854
+    pos: -1.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2292
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-18.5
+  - parent: 854
+    pos: -2.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2293
   type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,-11.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2294
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2295
+- uid: 2294
   type: AirlockServiceLocked
   components:
   - name: Freezer
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -12.5,-2.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2295
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -5.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2296
   type: solid_wall
   components:
-  - parent: 855
-    pos: -5.5,-11.5
+  - parent: 854
+    pos: -6.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2297
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-11.5
+  - parent: 854
+    pos: -6.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2298
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-12.5
+  - parent: 854
+    pos: -6.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2299
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-13.5
+  - parent: 854
+    pos: -6.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2300
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-14.5
+  - parent: 854
+    pos: -6.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2301
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-15.5
+  - parent: 854
+    pos: -6.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2302
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-16.5
+  - parent: 854
+    pos: -6.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2303
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: -6.5,-17.5
+  - parent: 854
+    pos: -2.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2304
   type: LowWall
   components:
-  - parent: 855
-    pos: -2.5,-18.5
+  - parent: 854
+    pos: -4.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2305
   type: LowWall
   components:
-  - parent: 855
-    pos: -4.5,-18.5
+  - parent: 854
+    pos: 0.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2306
-  type: LowWall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-16.5
+  - parent: 854
+    pos: -7.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2307
   type: solid_wall
   components:
-  - parent: 855
-    pos: -7.5,-21.5
+  - parent: 854
+    pos: 1.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2308
   type: solid_wall
   components:
-  - parent: 855
-    pos: 1.5,-22.5
+  - parent: 854
+    pos: 0.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2309
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-22.5
+  - parent: 854
+    pos: 0.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2310
   type: solid_wall
   components:
-  - parent: 855
-    pos: 0.5,-21.5
+  - parent: 854
+    pos: -0.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2311
   type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,-21.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2312
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2313
+- uid: 2312
   type: LowWall
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,-21.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2313
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -1.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2314
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-22.5
+  - parent: 854
+    pos: -1.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2315
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-23.5
+  - parent: 854
+    pos: -1.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2316
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-24.5
+  - parent: 854
+    pos: -1.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2317
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-25.5
+  - parent: 854
+    pos: -2.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2318
   type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,-25.5
+  - parent: 854
+    pos: -3.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2319
   type: solid_wall
   components:
-  - parent: 855
-    pos: -3.5,-25.5
+  - parent: 854
+    pos: -4.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2320
   type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,-25.5
+  - parent: 854
+    pos: -5.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2321
   type: solid_wall
   components:
-  - parent: 855
-    pos: -5.5,-25.5
+  - parent: 854
+    pos: -6.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2322
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-25.5
+  - parent: 854
+    pos: -6.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2323
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-24.5
+  - parent: 854
+    pos: -6.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2324
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-23.5
+  - parent: 854
+    pos: -6.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2325
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-22.5
+  - parent: 854
+    pos: -6.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2326
-  type: solid_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: -6.5,-21.5
+  - parent: 854
+    pos: -2.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2327
   type: LowWall
   components:
-  - parent: 855
-    pos: -2.5,-21.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2328
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2329
+- uid: 2328
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,-21.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2329
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -12.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2330
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -12.5,-27.5
+  - parent: 854
+    pos: -13.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2331
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -13.5,-27.5
+  - parent: 854
+    pos: -14.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2332
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,-27.5
+  - parent: 854
+    pos: -15.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2333
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -15.5,-27.5
+  - parent: 854
+    pos: -16.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2334
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -16.5,-27.5
+  - parent: 854
+    pos: -17.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2335
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -17.5,-27.5
+  - parent: 854
+    pos: -18.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2336
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -18.5,-27.5
+  - parent: 854
+    pos: -18.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2337
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -18.5,-26.5
+  - parent: 854
+    pos: -18.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2338
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -18.5,-25.5
+  - parent: 854
+    pos: -18.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2339
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -18.5,-24.5
+  - parent: 854
+    pos: -18.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2340
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -18.5,-23.5
+  - parent: 854
+    pos: -17.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2341
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -17.5,-23.5
+  - parent: 854
+    pos: -13.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2342
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -13.5,-23.5
+  - parent: 854
+    pos: -12.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2343
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -12.5,-23.5
+  - parent: 854
+    pos: -12.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2344
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -12.5,-24.5
+  - parent: 854
+    pos: -12.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2345
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -12.5,-25.5
+  - parent: 854
+    pos: -12.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2346
-  type: reinforced_wall
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-26.5
+  - parent: 854
+    pos: -12.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2347
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-28.5
+  - parent: 854
+    pos: -11.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2348
   type: solid_wall
   components:
-  - parent: 855
-    pos: -11.5,-28.5
+  - parent: 854
+    pos: -10.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2349
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-28.5
+  - parent: 854
+    pos: -6.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2350
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-28.5
+  - parent: 854
+    pos: -5.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2351
   type: solid_wall
   components:
-  - parent: 855
-    pos: -5.5,-28.5
+  - parent: 854
+    pos: -4.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2352
   type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,-28.5
+  - parent: 854
+    pos: -3.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2353
   type: solid_wall
   components:
-  - parent: 855
-    pos: -3.5,-28.5
+  - parent: 854
+    pos: -2.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2354
   type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,-28.5
+  - parent: 854
+    pos: -1.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2355
   type: solid_wall
   components:
-  - parent: 855
-    pos: -1.5,-28.5
+  - parent: 854
+    pos: -0.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2356
   type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,-28.5
+  - parent: 854
+    pos: -10.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2357
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-21.5
+  - parent: 854
+    pos: -10.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2358
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-22.5
+  - parent: 854
+    pos: -10.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2359
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-23.5
+  - parent: 854
+    pos: -10.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2360
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-24.5
+  - parent: 854
+    pos: -10.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2361
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-25.5
+  - parent: 854
+    pos: -12.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2362
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-22.5
+  - parent: 854
+    pos: -12.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2363
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-21.5
+  - parent: 854
+    pos: -12.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2364
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-18.5
+  - parent: 854
+    pos: -12.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2365
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-17.5
+  - parent: 854
+    pos: -12.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2366
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-16.5
+  - parent: 854
+    pos: -11.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2367
   type: solid_wall
   components:
-  - parent: 855
-    pos: -11.5,-16.5
+  - parent: 854
+    pos: -10.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2368
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-16.5
+  - parent: 854
+    pos: -9.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2369
   type: solid_wall
   components:
-  - parent: 855
-    pos: -9.5,-16.5
+  - parent: 854
+    pos: -8.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2370
   type: solid_wall
   components:
-  - parent: 855
-    pos: -8.5,-16.5
+  - parent: 854
+    pos: -7.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2371
   type: solid_wall
   components:
-  - parent: 855
-    pos: -7.5,-16.5
+  - parent: 854
+    pos: -13.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2372
   type: solid_wall
   components:
-  - parent: 855
-    pos: -13.5,-16.5
+  - parent: 854
+    pos: -14.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2373
   type: solid_wall
   components:
-  - parent: 855
-    pos: -14.5,-16.5
+  - parent: 854
+    pos: -15.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2374
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,-16.5
+  - parent: 854
+    pos: -17.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2375
   type: solid_wall
   components:
-  - parent: 855
-    pos: -17.5,-16.5
+  - parent: 854
+    pos: -18.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2376
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-16.5
+  - parent: 854
+    pos: -18.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2377
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-17.5
+  - parent: 854
+    pos: -18.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2378
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-18.5
+  - parent: 854
+    pos: -18.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2379
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-19.5
+  - parent: 854
+    pos: -18.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2380
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-20.5
+  - parent: 854
+    pos: -18.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2381
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-21.5
+  - parent: 854
+    pos: -18.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2382
-  type: solid_wall
+  type: ChairWood
   components:
-  - parent: 855
-    pos: -18.5,-22.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -7.5,-0.5
     type: Transform
 - uid: 2383
   type: ChairWood
   components:
-  - parent: 855
-    pos: -7.5,-0.5
-    type: Transform
-- uid: 2384
-  type: ChairWood
-  components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-0.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 2385
+- uid: 2384
   type: VendingMachineCoffee
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2386
+- uid: 2385
   type: ToolboxElectricalFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.259691,28.555487
     rot: -1.5707963267948966 rad
     type: Transform
@@ -31847,294 +31826,294 @@ entities:
       storagebase:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
+- uid: 2386
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -16.5,-13.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 2387
   type: solid_wall
   components:
-  - parent: 855
-    pos: -16.5,-13.5
+  - parent: 854
+    pos: -15.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2388
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,-13.5
+  - parent: 854
+    pos: -14.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2389
   type: solid_wall
   components:
-  - parent: 855
-    pos: -14.5,-13.5
+  - parent: 854
+    pos: -12.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2390
   type: solid_wall
   components:
-  - parent: 855
-    pos: -12.5,-13.5
+  - parent: 854
+    pos: -11.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2391
   type: solid_wall
   components:
-  - parent: 855
-    pos: -11.5,-13.5
+  - parent: 854
+    pos: -10.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2392
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-13.5
+  - parent: 854
+    pos: -10.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2393
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-12.5
+  - parent: 854
+    pos: -10.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2394
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-11.5
+  - parent: 854
+    pos: -10.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2395
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-10.5
+  - parent: 854
+    pos: -10.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2396
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-9.5
+  - parent: 854
+    pos: -10.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2397
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,-8.5
+  - parent: 854
+    pos: -11.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2398
   type: solid_wall
   components:
-  - parent: 855
-    pos: -11.5,-8.5
+  - parent: 854
+    pos: -13.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2399
   type: solid_wall
   components:
-  - parent: 855
-    pos: -13.5,-8.5
+  - parent: 854
+    pos: -14.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2400
   type: solid_wall
   components:
-  - parent: 855
-    pos: -14.5,-8.5
+  - parent: 854
+    pos: -15.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2401
   type: solid_wall
   components:
-  - parent: 855
-    pos: -15.5,-8.5
+  - parent: 854
+    pos: -16.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2402
   type: solid_wall
   components:
-  - parent: 855
-    pos: -16.5,-8.5
+  - parent: 854
+    pos: -16.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2403
   type: solid_wall
   components:
-  - parent: 855
-    pos: -16.5,-9.5
+  - parent: 854
+    pos: -16.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2404
   type: solid_wall
   components:
-  - parent: 855
-    pos: -16.5,-10.5
+  - parent: 854
+    pos: -16.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2405
   type: solid_wall
   components:
-  - parent: 855
-    pos: -16.5,-11.5
+  - parent: 854
+    pos: -16.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2406
   type: solid_wall
   components:
-  - parent: 855
-    pos: -16.5,-12.5
+  - parent: 854
+    pos: -9.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2407
   type: solid_wall
   components:
-  - parent: 855
-    pos: -9.5,-24.5
+  - parent: 854
+    pos: -8.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2408
   type: solid_wall
   components:
-  - parent: 855
-    pos: -8.5,-24.5
+  - parent: 854
+    pos: -7.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2409
   type: solid_wall
   components:
-  - parent: 855
-    pos: -7.5,-24.5
+  - parent: 854
+    pos: -2.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2410
   type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,-6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2411
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2412
+- uid: 2411
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 2413
+- uid: 2412
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2414
+- uid: 2413
   type: BlockGameArcade
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - containers:
       board:
         entities:
-        - 2416
+        - 2415
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 2415
+- uid: 2414
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2416
+- uid: 2415
   type: BlockGameArcadeComputerCircuitboard
   components:
-  - parent: 2414
+  - parent: 2413
+    type: Transform
+- uid: 2416
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -3.5,6.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 2417
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,6.5
+  - parent: 854
+    pos: -2.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 2418
-  type: ApcExtensionCable
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,6.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -6.5,-7.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2419
   type: solid_wall
   components:
-  - parent: 855
-    pos: -6.5,-7.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2420
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2421
+- uid: 2420
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,6.5
     rot: 3.141592653589793 rad
+    type: Transform
+- uid: 2421
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -9.5,-5.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2422
   type: solid_wall
   components:
-  - parent: 855
-    pos: -9.5,-5.5
+  - parent: 854
+    pos: -10.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2423
-  type: solid_wall
+  type: Table
   components:
-  - parent: 855
-    pos: -10.5,-5.5
+  - parent: 854
+    pos: -15.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2424
   type: Table
   components:
-  - parent: 855
-    pos: -15.5,-11.5
+  - parent: 854
+    pos: -15.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2425
   type: Table
   components:
-  - parent: 855
-    pos: -15.5,-12.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2426
-  type: Table
-  components:
-  - parent: 855
+  - parent: 854
     pos: -29.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2427
+- uid: 2426
   type: DisposalTrunk
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-17.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -32142,68 +32121,68 @@ entities:
       DisposalEntry:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 2428
+- uid: 2427
   type: VendingMachineSovietSoda
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2429
+- uid: 2428
   type: ChairOfficeDark
   components:
-  - parent: 855
+  - parent: 854
     pos: 40.5,-0.5
     rot: 3.141592653589793 rad
     type: Transform
   - anchored: False
     type: Physics
+- uid: 2429
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -10.5,2.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 2430
   type: solid_wall
   components:
-  - parent: 855
-    pos: -10.5,2.5
+  - parent: 854
+    pos: -4.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2431
   type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,2.5
+  - parent: 854
+    pos: -9.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2432
   type: solid_wall
   components:
-  - parent: 855
-    pos: -9.5,2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2433
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2434
+- uid: 2433
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2435
+- uid: 2434
   type: Multitool
   components:
-  - parent: 855
+  - parent: 854
     pos: 6.259919,28.557344
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2436
+- uid: 2435
   type: Medkit
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.959059,28.524237
     rot: -1.5707963267948966 rad
     type: Transform
@@ -32211,275 +32190,275 @@ entities:
       storagebase:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 2437
+- uid: 2436
   type: VendingMachineCola
   components:
-  - parent: 855
+  - parent: 854
     pos: 29.5,6.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2437
+  type: Table
+  components:
+  - parent: 854
+    pos: 28.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2438
   type: Table
   components:
-  - parent: 855
-    pos: 28.5,0.5
+  - parent: 854
+    pos: 20.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2439
   type: Table
   components:
-  - parent: 855
-    pos: 20.5,7.5
+  - parent: 854
+    pos: 19.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2440
-  type: Table
+  type: WeldingFuelTank
   components:
-  - parent: 855
-    pos: 19.5,7.5
+  - parent: 854
+    pos: -26.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2441
   type: WeldingFuelTank
   components:
-  - parent: 855
-    pos: -26.5,11.5
+  - parent: 854
+    pos: 35.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2442
   type: WeldingFuelTank
   components:
-  - parent: 855
-    pos: 35.5,-4.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2443
-  type: WeldingFuelTank
-  components:
-  - parent: 855
+  - parent: 854
     pos: -15.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2444
+- uid: 2443
   type: DrinkMugMoebius
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.476567,-17.420076
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2445
+- uid: 2444
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,-0.5
     rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2445
+  type: ChairWood
+  components:
+  - parent: 854
+    pos: -0.5,-2.5
+    rot: 1.5707963267948966 rad
     type: Transform
 - uid: 2446
   type: ChairWood
   components:
-  - parent: 855
-    pos: -0.5,-2.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -0.5,0.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2447
-  type: ChairWood
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,0.5
+  - parent: 854
+    pos: -21.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2448
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,-9.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2449
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2450
+- uid: 2449
   type: Paper
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.543142,17.067865
     rot: 3.141592653589793 rad
+    type: Transform
+- uid: 2450
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -24.5,-9.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2451
   type: solid_wall
   components:
-  - parent: 855
-    pos: -24.5,-9.5
+  - parent: 854
+    pos: -25.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2452
   type: solid_wall
   components:
-  - parent: 855
-    pos: -25.5,-9.5
+  - parent: 854
+    pos: -26.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2453
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,-9.5
+  - parent: 854
+    pos: -27.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2454
   type: solid_wall
   components:
-  - parent: 855
-    pos: -27.5,-9.5
+  - parent: 854
+    pos: -28.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2455
   type: solid_wall
   components:
-  - parent: 855
-    pos: -28.5,-9.5
+  - parent: 854
+    pos: -29.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2456
   type: solid_wall
   components:
-  - parent: 855
-    pos: -29.5,-9.5
+  - parent: 854
+    pos: -30.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2457
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,-9.5
+  - parent: 854
+    pos: -31.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2458
   type: solid_wall
   components:
-  - parent: 855
-    pos: -31.5,-9.5
+  - parent: 854
+    pos: -30.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2459
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,-3.5
+  - parent: 854
+    pos: -31.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2460
-  type: solid_wall
+  type: ChairWood
   components:
-  - parent: 855
-    pos: -31.5,-8.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -2.5,-0.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 2461
   type: ChairWood
   components:
-  - parent: 855
-    pos: -2.5,-0.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -4.5,-0.5
     type: Transform
 - uid: 2462
-  type: ChairWood
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,-0.5
+  - parent: 854
+    pos: -34.5,-8.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2463
   type: solid_wall
   components:
-  - parent: 855
-    pos: -34.5,-8.5
+  - parent: 854
+    pos: -34.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2464
   type: solid_wall
   components:
-  - parent: 855
-    pos: -34.5,-7.5
+  - parent: 854
+    pos: -31.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2465
   type: solid_wall
   components:
-  - parent: 855
-    pos: -31.5,-5.5
+  - parent: 854
+    pos: -31.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2466
   type: solid_wall
   components:
-  - parent: 855
-    pos: -31.5,-4.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2467
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2468
+- uid: 2467
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2468
+  type: TableR
+  components:
+  - parent: 854
+    pos: 0.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2469
   type: TableR
   components:
-  - parent: 855
-    pos: 0.5,28.5
+  - parent: 854
+    pos: -0.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2470
   type: TableR
   components:
-  - parent: 855
-    pos: -0.5,28.5
+  - parent: 854
+    pos: -1.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2471
-  type: TableR
+  type: TableGlass
   components:
-  - parent: 855
-    pos: -1.5,28.5
+  - parent: 854
+    pos: -0.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2472
   type: TableGlass
   components:
-  - parent: 855
-    pos: -0.5,-13.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2473
-  type: TableGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2474
+- uid: 2473
   type: VendingMachineBooze
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2475
+- uid: 2474
   type: BoozeDispenser
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -32487,87 +32466,87 @@ entities:
       ReagentDispenser-reagentContainerContainer:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 2476
+- uid: 2475
   type: StoolBar
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2477
+- uid: 2476
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2478
+- uid: 2477
   type: reinforced_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,23.5
     rot: 1.5707963267948966 rad
+    type: Transform
+- uid: 2478
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -21.5,-5.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2479
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,-5.5
+  - parent: 854
+    pos: -21.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2480
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,-6.5
+  - parent: 854
+    pos: -20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2481
   type: solid_wall
   components:
-  - parent: 855
-    pos: -20.5,-6.5
+  - parent: 854
+    pos: -19.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2482
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,-6.5
+  - parent: 854
+    pos: -18.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2483
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-6.5
+  - parent: 854
+    pos: -17.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2484
-  type: solid_wall
+  type: SpawnPointLatejoin
   components:
-  - parent: 855
-    pos: -17.5,-6.5
+  - parent: 854
+    pos: -36.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2485
   type: SpawnPointLatejoin
   components:
-  - parent: 855
-    pos: -36.5,-5.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2486
-  type: SpawnPointLatejoin
-  components:
-  - parent: 855
+  - parent: 854
     pos: -36.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2487
+- uid: 2486
   type: CrateInternals
   components:
-  - parent: 855
+  - parent: 854
     pos: 42.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -32577,10 +32556,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 2488
+- uid: 2487
   type: CrateRadiation
   components:
-  - parent: 855
+  - parent: 854
     pos: 43.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -32590,237 +32569,261 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
+- uid: 2488
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -17.5,-4.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 2489
   type: solid_wall
   components:
-  - parent: 855
-    pos: -17.5,-4.5
+  - parent: 854
+    pos: -17.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2490
   type: solid_wall
   components:
-  - parent: 855
-    pos: -17.5,-5.5
+  - parent: 854
+    pos: -17.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2491
   type: solid_wall
   components:
-  - parent: 855
-    pos: -17.5,-3.5
+  - parent: 854
+    pos: -18.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2492
   type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-3.5
+  - parent: 854
+    pos: -19.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2493
   type: solid_wall
   components:
-  - parent: 855
-    pos: -19.5,-3.5
+  - parent: 854
+    pos: -20.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2494
   type: solid_wall
   components:
-  - parent: 855
-    pos: -20.5,-3.5
+  - parent: 854
+    pos: -21.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2495
   type: solid_wall
   components:
-  - parent: 855
-    pos: -21.5,-3.5
+  - parent: 854
+    pos: -21.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2496
-  type: solid_wall
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: -21.5,-2.5
+  - parent: 854
+    pos: 11.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2497
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 11.5,22.5
+  - parent: 854
+    pos: 14.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2498
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 14.5,23.5
+  - parent: 854
+    pos: 13.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2499
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 13.5,22.5
+  - parent: 854
+    pos: 14.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2500
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 14.5,22.5
+  - parent: 854
+    pos: 14.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2501
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 14.5,24.5
+  - parent: 854
+    pos: 14.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2502
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 14.5,25.5
+  - parent: 854
+    pos: -14.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2503
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,15.5
+  - parent: 854
+    pos: -14.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2504
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -14.5,16.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2505
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2506
+- uid: 2505
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,27.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11999.502
-    type: Battery
-- uid: 2507
-  type: SalternApc
-  components:
-  - parent: 855
-    pos: -2.5,27.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11999.17
-    type: Battery
-- uid: 2508
-  type: SalternApc
-  components:
-  - parent: 855
-    pos: 9.5,22.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11999.17
-    type: Battery
-- uid: 2509
-  type: SalternApc
-  components:
-  - parent: 855
-    pos: 24.5,14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11999.336
-    type: Battery
-- uid: 2510
-  type: SalternApc
-  components:
-  - parent: 855
-    pos: 28.5,14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11999.502
-    type: Battery
-- uid: 2511
-  type: SalternApc
-  components:
-  - parent: 855
-    pos: 47.5,-1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11991.086
-    type: Battery
-- uid: 2512
-  type: SalternApc
-  components:
-  - parent: 855
-    pos: 31.5,1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11999.253
-    type: Battery
-- uid: 2513
-  type: SalternApc
-  components:
-  - parent: 855
-    pos: 43.5,10.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11999.087
-    type: Battery
-- uid: 2514
-  type: SalternApc
-  components:
-  - parent: 855
-    pos: 12.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 11999.004
     type: Battery
-- uid: 2515
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2506
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
+    pos: -2.5,27.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11998.34
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2507
+  type: SalternApc
+  components:
+  - parent: 854
+    pos: 9.5,22.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11998.506
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2508
+  type: SalternApc
+  components:
+  - parent: 854
+    pos: 24.5,14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11999.303
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2509
+  type: SalternApc
+  components:
+  - parent: 854
+    pos: 28.5,14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11999.004
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2510
+  type: SalternApc
+  components:
+  - parent: 854
+    pos: 47.5,-1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11982.172
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2511
+  type: SalternApc
+  components:
+  - parent: 854
+    pos: 31.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11998.506
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2512
+  type: SalternApc
+  components:
+  - parent: 854
+    pos: 43.5,10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11998.174
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2513
+  type: SalternApc
+  components:
+  - parent: 854
+    pos: 12.5,13.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11998.008
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2514
+  type: SalternApc
+  components:
+  - parent: 854
     pos: 7.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.087
+  - startingCharge: 11998.506
     type: Battery
-- uid: 2516
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2515
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11998.838
+  - startingCharge: 11997.676
     type: Battery
-- uid: 2517
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2516
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.419
+  - startingCharge: 11998.672
     type: Battery
-- uid: 2518
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2517
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.498537,16.019438
     rot: -1.5707963267948966 rad
     type: Transform
@@ -32830,7706 +32833,7738 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 2519
+- uid: 2518
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.419
+  - startingCharge: 11998.672
     type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2519
+  type: SalternApc
+  components:
+  - parent: 854
+    pos: -28.5,12.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 11998.672
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
 - uid: 2520
   type: SalternApc
   components:
-  - parent: 855
-    pos: -28.5,12.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - startingCharge: 11999.336
-    type: Battery
-- uid: 2521
-  type: SalternApc
-  components:
-  - parent: 855
+  - parent: 854
     pos: -39.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.336
+  - startingCharge: 11998.672
     type: Battery
-- uid: 2522
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2521
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11998.257
+  - startingCharge: 11996.846
     type: Battery
-- uid: 2523
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2522
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2524
+- uid: 2523
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.668
+  - startingCharge: 11999.502
     type: Battery
-- uid: 2525
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2524
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2526
+- uid: 2525
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2527
+- uid: 2526
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.087
+  - startingCharge: 11998.008
     type: Battery
-- uid: 2528
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2527
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.75476,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11996.169
+  - startingCharge: 11992.006
     type: Battery
-- uid: 2529
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2528
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.585
+  - startingCharge: 11999.502
     type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2529
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -28.5,12.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 2530
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,12.5
+  - parent: 854
+    pos: -28.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2531
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,11.5
+  - parent: 854
+    pos: -28.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2532
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,10.5
+  - parent: 854
+    pos: -28.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2533
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,9.5
+  - parent: 854
+    pos: -28.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2534
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,8.5
+  - parent: 854
+    pos: -27.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2535
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -27.5,9.5
+  - parent: 854
+    pos: -26.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2536
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -26.5,9.5
+  - parent: 854
+    pos: -25.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2537
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -25.5,9.5
+  - parent: 854
+    pos: -26.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2538
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -26.5,8.5
+  - parent: 854
+    pos: -26.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2539
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -26.5,7.5
+  - parent: 854
+    pos: -24.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2540
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -24.5,9.5
+  - parent: 854
+    pos: -23.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2541
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -23.5,9.5
+  - parent: 854
+    pos: -22.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2542
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,9.5
+  - parent: 854
+    pos: -21.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2543
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -21.5,9.5
+  - parent: 854
+    pos: -20.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2544
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,9.5
+  - parent: 854
+    pos: -19.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2545
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -19.5,9.5
+  - parent: 854
+    pos: -23.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2546
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -23.5,8.5
+  - parent: 854
+    pos: -23.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2547
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2548
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -23.5,7.5
+  - parent: 854
+    pos: -23.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2549
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -23.5,6.5
+  - parent: 854
+    pos: -28.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2550
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,13.5
+  - parent: 854
+    pos: -28.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2551
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,14.5
+  - parent: 854
+    pos: -17.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2552
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,9.5
+  - parent: 854
+    pos: -16.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2553
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,9.5
+  - parent: 854
+    pos: -16.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2554
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,8.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2555
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2556
+- uid: 2555
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.302551,15.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.834
+  - startingCharge: 11999.668
     type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2556
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -16.5,15.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 2557
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,15.5
+  - parent: 854
+    pos: -17.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2558
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,15.5
+  - parent: 854
+    pos: -17.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2559
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,16.5
+  - parent: 854
+    pos: -17.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2560
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,17.5
+  - parent: 854
+    pos: -17.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2561
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,18.5
+  - parent: 854
+    pos: -17.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2562
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,19.5
+  - parent: 854
+    pos: -17.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2563
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,20.5
+  - parent: 854
+    pos: -17.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2564
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,21.5
+  - parent: 854
+    pos: -17.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2565
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,22.5
+  - parent: 854
+    pos: -17.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2566
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,23.5
+  - parent: 854
+    pos: -17.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2567
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,24.5
+  - parent: 854
+    pos: -16.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2568
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,24.5
+  - parent: 854
+    pos: -15.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2569
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -15.5,24.5
+  - parent: 854
+    pos: -14.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2570
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,24.5
+  - parent: 854
+    pos: -13.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2571
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -13.5,24.5
+  - parent: 854
+    pos: -12.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2572
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,24.5
+  - parent: 854
+    pos: -11.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2573
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,24.5
+  - parent: 854
+    pos: -10.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2574
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -10.5,24.5
+  - parent: 854
+    pos: -9.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2575
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,24.5
+  - parent: 854
+    pos: -8.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2576
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,24.5
+  - parent: 854
+    pos: -7.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2577
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,24.5
+  - parent: 854
+    pos: -12.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2578
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,12.5
+  - parent: 854
+    pos: -12.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2579
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,11.5
+  - parent: 854
+    pos: -13.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2580
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -13.5,11.5
+  - parent: 854
+    pos: -12.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2581
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,10.5
+  - parent: 854
+    pos: -12.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2582
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,9.5
+  - parent: 854
+    pos: -12.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2583
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,7.5
+  - parent: 854
+    pos: -12.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2584
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,8.5
+  - parent: 854
+    pos: -11.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2585
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,7.5
+  - parent: 854
+    pos: -11.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2586
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,10.5
+  - parent: 854
+    pos: -9.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2587
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,10.5
+  - parent: 854
+    pos: -10.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2588
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -10.5,10.5
+  - parent: 854
+    pos: -8.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2589
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,10.5
+  - parent: 854
+    pos: -7.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2590
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,10.5
+  - parent: 854
+    pos: -6.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2591
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,10.5
+  - parent: 854
+    pos: -5.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2592
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,10.5
+  - parent: 854
+    pos: -4.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2593
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,10.5
+  - parent: 854
+    pos: -3.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2594
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,10.5
+  - parent: 854
+    pos: -2.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2595
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,10.5
+  - parent: 854
+    pos: -1.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2596
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,10.5
+  - parent: 854
+    pos: -0.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2597
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,10.5
+  - parent: 854
+    pos: 0.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2598
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,10.5
+  - parent: 854
+    pos: -5.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2599
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,9.5
+  - parent: 854
+    pos: -5.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2600
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,8.5
+  - parent: 854
+    pos: -5.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2601
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,7.5
+  - parent: 854
+    pos: 0.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2602
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,9.5
+  - parent: 854
+    pos: 0.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2603
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,8.5
+  - parent: 854
+    pos: 0.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2604
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,7.5
+  - parent: 854
+    pos: 0.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2605
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2606
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,6.5
+  - parent: 854
+    pos: -0.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2607
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,6.5
+  - parent: 854
+    pos: -3.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2608
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,15.5
+  - parent: 854
+    pos: -3.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2609
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,16.5
+  - parent: 854
+    pos: -3.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2610
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,17.5
+  - parent: 854
+    pos: -3.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2611
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,18.5
+  - parent: 854
+    pos: -2.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2612
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,18.5
+  - parent: 854
+    pos: -1.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2613
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,18.5
+  - parent: 854
+    pos: -0.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2614
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,18.5
+  - parent: 854
+    pos: -3.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2615
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,15.5
+  - parent: 854
+    pos: -3.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2616
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,14.5
+  - parent: 854
+    pos: -4.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2617
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,14.5
+  - parent: 854
+    pos: -5.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2618
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,14.5
+  - parent: 854
+    pos: -6.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2619
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,14.5
+  - parent: 854
+    pos: -7.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2620
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,14.5
+  - parent: 854
+    pos: -8.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2621
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,14.5
+  - parent: 854
+    pos: -9.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2622
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,14.5
+  - parent: 854
+    pos: -10.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2623
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -10.5,14.5
+  - parent: 854
+    pos: -11.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2624
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,14.5
+  - parent: 854
+    pos: -12.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2625
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,14.5
+  - parent: 854
+    pos: -12.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2626
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,15.5
+  - parent: 854
+    pos: -12.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2627
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,16.5
+  - parent: 854
+    pos: -7.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2628
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,15.5
+  - parent: 854
+    pos: -7.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2629
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,16.5
+  - parent: 854
+    pos: -7.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2630
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,17.5
+  - parent: 854
+    pos: -6.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2631
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,17.5
+  - parent: 854
+    pos: -8.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2632
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,17.5
+  - parent: 854
+    pos: -8.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2633
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,18.5
+  - parent: 854
+    pos: -8.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2634
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,19.5
+  - parent: 854
+    pos: -8.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2635
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,20.5
+  - parent: 854
+    pos: -9.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2636
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,20.5
+  - parent: 854
+    pos: -8.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2637
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,21.5
+  - parent: 854
+    pos: -7.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2638
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,21.5
+  - parent: 854
+    pos: -12.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2639
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,17.5
+  - parent: 854
+    pos: -12.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2640
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,18.5
+  - parent: 854
+    pos: -12.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2641
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,19.5
+  - parent: 854
+    pos: -12.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2642
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,20.5
+  - parent: 854
+    pos: -13.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2643
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -13.5,20.5
+  - parent: 854
+    pos: -14.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2644
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,20.5
+  - parent: 854
+    pos: -3.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2645
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,14.5
+  - parent: 854
+    pos: -2.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2646
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,14.5
+  - parent: 854
+    pos: -1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2647
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,14.5
+  - parent: 854
+    pos: -0.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2648
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,14.5
+  - parent: 854
+    pos: 0.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2649
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,14.5
+  - parent: 854
+    pos: 1.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2650
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 1.5,14.5
+  - parent: 854
+    pos: 0.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2651
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,13.5
+  - parent: 854
+    pos: 0.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2652
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,12.5
+  - parent: 854
+    pos: -39.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2653
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -39.5,11.5
+  - parent: 854
+    pos: -39.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2654
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -39.5,10.5
+  - parent: 854
+    pos: -38.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2655
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -38.5,10.5
+  - parent: 854
+    pos: -37.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2656
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -37.5,10.5
+  - parent: 854
+    pos: -36.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2657
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,10.5
+  - parent: 854
+    pos: -36.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2658
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,9.5
+  - parent: 854
+    pos: -36.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2659
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,8.5
+  - parent: 854
+    pos: -36.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2660
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,7.5
+  - parent: 854
+    pos: -36.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2661
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,6.5
+  - parent: 854
+    pos: -36.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2662
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,5.5
+  - parent: 854
+    pos: -36.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2663
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,4.5
+  - parent: 854
+    pos: -36.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2664
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,3.5
+  - parent: 854
+    pos: -36.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2665
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,2.5
+  - parent: 854
+    pos: -36.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2666
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,1.5
+  - parent: 854
+    pos: -36.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2667
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,0.5
+  - parent: 854
+    pos: -36.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2668
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,-0.5
+  - parent: 854
+    pos: -36.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2669
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,-1.5
+  - parent: 854
+    pos: -36.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2670
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,-2.5
+  - parent: 854
+    pos: -36.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2671
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,-3.5
+  - parent: 854
+    pos: -36.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2672
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,-4.5
+  - parent: 854
+    pos: -36.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2673
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,-5.5
+  - parent: 854
+    pos: -36.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2674
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -36.5,-6.5
+  - parent: 854
+    pos: -35.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2675
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -35.5,-6.5
+  - parent: 854
+    pos: -35.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2676
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -35.5,2.5
+  - parent: 854
+    pos: -35.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2677
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -35.5,5.5
+  - parent: 854
+    pos: -34.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2678
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -34.5,5.5
+  - parent: 854
+    pos: -33.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2679
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -33.5,5.5
+  - parent: 854
+    pos: -32.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2680
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,5.5
+  - parent: 854
+    pos: -35.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2681
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -35.5,8.5
+  - parent: 854
+    pos: -34.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2682
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -34.5,8.5
+  - parent: 854
+    pos: -37.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2683
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -37.5,8.5
+  - parent: 854
+    pos: -38.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2684
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -38.5,8.5
+  - parent: 854
+    pos: -39.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2685
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -39.5,8.5
+  - parent: 854
+    pos: -40.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2686
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -40.5,8.5
+  - parent: 854
+    pos: -37.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2687
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -37.5,4.5
+  - parent: 854
+    pos: -38.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2688
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -38.5,4.5
+  - parent: 854
+    pos: -39.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2689
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -39.5,4.5
+  - parent: 854
+    pos: -40.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2690
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -40.5,4.5
+  - parent: 854
+    pos: -37.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2691
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -37.5,-3.5
+  - parent: 854
+    pos: -38.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2692
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -38.5,-3.5
+  - parent: 854
+    pos: -18.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2693
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -18.5,9.5
+  - parent: 854
+    pos: -17.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2694
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,7.5
+  - parent: 854
+    pos: -18.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2695
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -18.5,7.5
+  - parent: 854
+    pos: -30.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2696
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,-3.5
+  - parent: 854
+    pos: -30.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2697
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,-4.5
+  - parent: 854
+    pos: -30.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2698
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,-5.5
+  - parent: 854
+    pos: -30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2699
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,-6.5
+  - parent: 854
+    pos: -30.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2700
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,-7.5
+  - parent: 854
+    pos: -29.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2701
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -29.5,-7.5
+  - parent: 854
+    pos: -28.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2702
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,-7.5
+  - parent: 854
+    pos: -27.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2703
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -27.5,-7.5
+  - parent: 854
+    pos: -26.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2704
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -26.5,-7.5
+  - parent: 854
+    pos: -25.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2705
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -25.5,-7.5
+  - parent: 854
+    pos: -25.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2706
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -25.5,-8.5
+  - parent: 854
+    pos: -24.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2707
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -24.5,-7.5
+  - parent: 854
+    pos: -23.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2708
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -23.5,-7.5
+  - parent: 854
+    pos: -23.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2709
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -23.5,-8.5
+  - parent: 854
+    pos: -20.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2710
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-7.5
+  - parent: 854
+    pos: -30.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2711
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,-2.5
+  - parent: 854
+    pos: -30.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2712
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,-1.5
+  - parent: 854
+    pos: -30.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2713
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,-0.5
+  - parent: 854
+    pos: -30.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2714
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,0.5
+  - parent: 854
+    pos: -30.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2715
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -30.5,1.5
+  - parent: 854
+    pos: -29.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2716
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -29.5,0.5
+  - parent: 854
+    pos: -28.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2717
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -28.5,0.5
+  - parent: 854
+    pos: -27.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2718
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -27.5,0.5
+  - parent: 854
+    pos: -27.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2719
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -27.5,-0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2720
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: -27.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 2721
+- uid: 2720
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 2721
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -31.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2722
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -31.5,-6.5
+  - parent: 854
+    pos: -32.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2723
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,-6.5
+  - parent: 854
+    pos: -32.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2724
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,-5.5
+  - parent: 854
+    pos: -32.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2725
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,-4.5
+  - parent: 854
+    pos: -32.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2726
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,-3.5
+  - parent: 854
+    pos: -32.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2727
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,-2.5
+  - parent: 854
+    pos: -32.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2728
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,-1.5
+  - parent: 854
+    pos: -32.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2729
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,-0.5
+  - parent: 854
+    pos: -32.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2730
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,0.5
+  - parent: 854
+    pos: -32.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2731
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -32.5,1.5
+  - parent: 854
+    pos: -20.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2732
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-12.5
+  - parent: 854
+    pos: -20.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2733
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-13.5
+  - parent: 854
+    pos: -20.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2734
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-14.5
+  - parent: 854
+    pos: -21.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2735
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -21.5,-14.5
+  - parent: 854
+    pos: -22.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2736
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2737
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,-14.5
+  - parent: 854
+    pos: -23.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2738
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -23.5,-14.5
+  - parent: 854
+    pos: -24.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2739
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -24.5,-14.5
+  - parent: 854
+    pos: -24.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2740
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -24.5,-13.5
+  - parent: 854
+    pos: -14.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2741
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-8.5
+  - parent: 854
+    pos: -14.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2742
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-9.5
+  - parent: 854
+    pos: -14.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2743
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2744
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-10.5
+  - parent: 854
+    pos: -14.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2745
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-11.5
+  - parent: 854
+    pos: -13.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2746
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -13.5,-11.5
+  - parent: 854
+    pos: -12.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2747
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,-11.5
+  - parent: 854
+    pos: -11.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2748
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,-11.5
+  - parent: 854
+    pos: -12.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2749
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,-10.5
+  - parent: 854
+    pos: -12.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2750
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,-9.5
+  - parent: 854
+    pos: -13.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2751
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -13.5,-12.5
+  - parent: 854
+    pos: -12.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2752
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,-8.5
+  - parent: 854
+    pos: -16.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2753
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,-7.5
+  - parent: 854
+    pos: -15.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2754
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -15.5,-7.5
+  - parent: 854
+    pos: -14.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2755
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-7.5
+  - parent: 854
+    pos: -17.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2756
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,-7.5
+  - parent: 854
+    pos: -18.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2757
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -18.5,-7.5
+  - parent: 854
+    pos: -19.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2758
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -19.5,-7.5
+  - parent: 854
+    pos: -20.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2759
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-7.5
+  - parent: 854
+    pos: -18.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2760
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -18.5,-6.5
+  - parent: 854
+    pos: -18.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2761
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -18.5,-5.5
+  - parent: 854
+    pos: -18.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2762
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -18.5,-4.5
+  - parent: 854
+    pos: -19.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2763
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -19.5,-4.5
+  - parent: 854
+    pos: -20.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2764
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-4.5
+  - parent: 854
+    pos: -21.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2765
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -21.5,-4.5
+  - parent: 854
+    pos: -22.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2766
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,-4.5
+  - parent: 854
+    pos: -22.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2767
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,-3.5
+  - parent: 854
+    pos: -22.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2768
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2769
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,-2.5
+  - parent: 854
+    pos: -22.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2770
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,-1.5
+  - parent: 854
+    pos: -22.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2771
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,-0.5
+  - parent: 854
+    pos: -22.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2772
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,0.5
+  - parent: 854
+    pos: -22.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2773
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -22.5,1.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -23.5,0.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 2774
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -23.5,0.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -15.5,-6.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2775
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -15.5,-6.5
+  - parent: 854
+    pos: -15.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2776
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -15.5,-5.5
+  - parent: 854
+    pos: -15.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2777
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -15.5,-4.5
+  - parent: 854
+    pos: -11.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2778
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,2.5
+  - parent: 854
+    pos: -11.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2779
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,1.5
+  - parent: 854
+    pos: -11.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2780
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,0.5
+  - parent: 854
+    pos: -11.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2781
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,-0.5
+  - parent: 854
+    pos: -11.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2782
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,-1.5
+  - parent: 854
+    pos: -11.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2783
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,-2.5
+  - parent: 854
+    pos: -11.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2784
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,-3.5
+  - parent: 854
+    pos: -11.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2785
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,-4.5
+  - parent: 854
+    pos: -12.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2786
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,-4.5
+  - parent: 854
+    pos: -12.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2787
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,0.5
+  - parent: 854
+    pos: -13.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2788
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -13.5,0.5
+  - parent: 854
+    pos: -14.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2789
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2790
-  type: ApcExtensionCable
-  components:
-  - parent: 855
-    pos: -14.5,0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 2791
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.17
+  - startingCharge: 11998.008
     type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 2791
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -15.5,0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 2792
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -15.5,0.5
+  - parent: 854
+    pos: -16.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2793
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,0.5
+  - parent: 854
+    pos: -17.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2794
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,0.5
+  - parent: 854
+    pos: -18.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2795
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -18.5,0.5
+  - parent: 854
+    pos: -19.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2796
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -19.5,0.5
+  - parent: 854
+    pos: -20.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2797
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,0.5
+  - parent: 854
+    pos: -20.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2798
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,1.5
+  - parent: 854
+    pos: -16.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2799
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,-0.5
+  - parent: 854
+    pos: -16.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2800
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,-1.5
+  - parent: 854
+    pos: -12.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2801
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2802
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -12.5,-1.5
+  - parent: 854
+    pos: -13.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2803
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -13.5,-1.5
+  - parent: 854
+    pos: -20.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2804
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2805
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-0.5
+  - parent: 854
+    pos: -20.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2806
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-1.5
+  - parent: 854
+    pos: -20.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2807
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -20.5,-2.5
+  - parent: 854
+    pos: -10.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2808
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -10.5,0.5
+  - parent: 854
+    pos: -9.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2809
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,0.5
+  - parent: 854
+    pos: -8.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2810
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,0.5
+  - parent: 854
+    pos: -7.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2811
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,0.5
+  - parent: 854
+    pos: -6.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2812
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,0.5
+  - parent: 854
+    pos: -5.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2813
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,0.5
+  - parent: 854
+    pos: -4.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2814
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,0.5
+  - parent: 854
+    pos: -3.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2815
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,0.5
+  - parent: 854
+    pos: -2.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2816
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,0.5
+  - parent: 854
+    pos: -1.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2817
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,0.5
+  - parent: 854
+    pos: -0.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2818
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,0.5
+  - parent: 854
+    pos: 0.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2819
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,0.5
+  - parent: 854
+    pos: -0.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2820
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,0.5
+  - parent: 854
+    pos: -0.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2821
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-0.5
+  - parent: 854
+    pos: -0.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2822
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-1.5
+  - parent: 854
+    pos: -0.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2823
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-2.5
+  - parent: 854
+    pos: -0.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2824
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-3.5
+  - parent: 854
+    pos: -0.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2825
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-4.5
+  - parent: 854
+    pos: 0.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2826
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,-4.5
+  - parent: 854
+    pos: -5.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2827
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,-8.5
+  - parent: 854
+    pos: -5.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2828
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,-7.5
+  - parent: 854
+    pos: -4.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2829
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,-7.5
+  - parent: 854
+    pos: -3.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2830
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-7.5
+  - parent: 854
+    pos: -6.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2831
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2832
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,-7.5
+  - parent: 854
+    pos: -7.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2833
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,-7.5
+  - parent: 854
+    pos: -6.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2834
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,-6.5
+  - parent: 854
+    pos: -6.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2835
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,-5.5
+  - parent: 854
+    pos: -6.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2836
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,-4.5
+  - parent: 854
+    pos: -5.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2837
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,-9.5
+  - parent: 854
+    pos: -5.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2838
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,-10.5
+  - parent: 854
+    pos: -4.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2839
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2840
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,-10.5
+  - parent: 854
+    pos: -3.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2841
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-10.5
+  - parent: 854
+    pos: -2.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2842
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,-10.5
+  - parent: 854
+    pos: -1.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2843
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,-10.5
+  - parent: 854
+    pos: -0.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2844
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-10.5
+  - parent: 854
+    pos: 0.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2845
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,-10.5
+  - parent: 854
+    pos: 0.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2846
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,-9.5
+  - parent: 854
+    pos: 0.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2847
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,-8.5
+  - parent: 854
+    pos: 0.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2848
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,-7.5
+  - parent: 854
+    pos: -0.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2849
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-11.5
+  - parent: 854
+    pos: -1.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2850
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,-18.5
+  - parent: 854
+    pos: -1.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2851
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,-19.5
+  - parent: 854
+    pos: -1.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2852
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,-20.5
+  - parent: 854
+    pos: -0.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2853
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-19.5
+  - parent: 854
+    pos: -2.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2854
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,-19.5
+  - parent: 854
+    pos: -3.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2855
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-19.5
+  - parent: 854
+    pos: -4.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2856
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,-19.5
+  - parent: 854
+    pos: -3.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2857
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-20.5
+  - parent: 854
+    pos: -3.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2858
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-21.5
+  - parent: 854
+    pos: -3.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2859
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-23.5
+  - parent: 854
+    pos: -3.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2860
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-22.5
+  - parent: 854
+    pos: -2.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2861
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,-23.5
+  - parent: 854
+    pos: -9.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2862
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,-21.5
+  - parent: 854
+    pos: -9.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2863
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,-22.5
+  - parent: 854
+    pos: -9.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2864
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,-23.5
+  - parent: 854
+    pos: -8.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2865
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,-23.5
+  - parent: 854
+    pos: -7.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2866
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,-23.5
+  - parent: 854
+    pos: -7.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2867
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,-24.5
+  - parent: 854
+    pos: -7.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2868
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -7.5,-25.5
+  - parent: 854
+    pos: -9.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2869
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,-20.5
+  - parent: 854
+    pos: -10.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2870
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -10.5,-20.5
+  - parent: 854
+    pos: -11.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2871
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,-20.5
+  - parent: 854
+    pos: -11.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2872
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -11.5,-19.5
+  - parent: 854
+    pos: -9.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2873
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,-19.5
+  - parent: 854
+    pos: -9.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2874
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,-18.5
+  - parent: 854
+    pos: -9.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2875
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -9.5,-17.5
+  - parent: 854
+    pos: -8.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2876
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -8.5,-17.5
+  - parent: 854
+    pos: -3.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2877
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-18.5
+  - parent: 854
+    pos: -3.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2878
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2879
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-17.5
+  - parent: 854
+    pos: -3.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2880
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-16.5
+  - parent: 854
+    pos: -3.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2881
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-15.5
+  - parent: 854
+    pos: -3.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2882
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-14.5
+  - parent: 854
+    pos: -3.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2883
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-13.5
+  - parent: 854
+    pos: -3.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2884
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-12.5
+  - parent: 854
+    pos: -2.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2885
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,-13.5
+  - parent: 854
+    pos: -1.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2886
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,-13.5
+  - parent: 854
+    pos: -1.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2887
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,-17.5
+  - parent: 854
+    pos: -0.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2888
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-17.5
+  - parent: 854
+    pos: 0.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2889
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,-17.5
+  - parent: 854
+    pos: -4.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2890
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,-14.5
+  - parent: 854
+    pos: -4.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2891
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,-12.5
+  - parent: 854
+    pos: -4.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2892
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,-17.5
+  - parent: 854
+    pos: -5.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2893
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,-12.5
+  - parent: 854
+    pos: -6.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2894
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -6.5,-12.5
+  - parent: 854
+    pos: -5.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2895
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -5.5,-14.5
+  - parent: 854
+    pos: -14.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2896
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-16.5
+  - parent: 854
+    pos: -14.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2897
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-17.5
+  - parent: 854
+    pos: -14.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2898
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-18.5
+  - parent: 854
+    pos: -14.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2899
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-19.5
+  - parent: 854
+    pos: -14.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2900
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-20.5
+  - parent: 854
+    pos: -14.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2901
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-21.5
+  - parent: 854
+    pos: -14.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2902
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-22.5
+  - parent: 854
+    pos: -14.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2903
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-23.5
+  - parent: 854
+    pos: -14.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2904
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-24.5
+  - parent: 854
+    pos: -14.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2905
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -14.5,-25.5
+  - parent: 854
+    pos: -15.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2906
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -15.5,-25.5
+  - parent: 854
+    pos: -16.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2907
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,-25.5
+  - parent: 854
+    pos: -15.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2908
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -15.5,-22.5
+  - parent: 854
+    pos: -16.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2909
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -16.5,-22.5
+  - parent: 854
+    pos: -17.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2910
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,-22.5
+  - parent: 854
+    pos: -1.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2911
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,-23.5
+  - parent: 854
+    pos: -0.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2912
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-23.5
+  - parent: 854
+    pos: 0.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2913
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,-23.5
+  - parent: 854
+    pos: 7.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2914
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-17.5
+  - parent: 854
+    pos: 7.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2915
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-18.5
+  - parent: 854
+    pos: 7.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2916
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-19.5
+  - parent: 854
+    pos: 8.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2917
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,-18.5
+  - parent: 854
+    pos: 9.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2918
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-18.5
+  - parent: 854
+    pos: 10.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2919
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,-18.5
+  - parent: 854
+    pos: 10.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2920
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,-19.5
+  - parent: 854
+    pos: 11.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2921
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 11.5,-19.5
+  - parent: 854
+    pos: 12.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2922
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,-19.5
+  - parent: 854
+    pos: 13.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2923
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 13.5,-19.5
+  - parent: 854
+    pos: 14.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2924
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 14.5,-19.5
+  - parent: 854
+    pos: 15.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2925
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 15.5,-19.5
+  - parent: 854
+    pos: 7.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2926
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-16.5
+  - parent: 854
+    pos: 7.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2927
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-15.5
+  - parent: 854
+    pos: 7.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2928
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-14.5
+  - parent: 854
+    pos: 7.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2929
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-13.5
+  - parent: 854
+    pos: 6.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2930
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,-13.5
+  - parent: 854
+    pos: 5.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2931
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 5.5,-13.5
+  - parent: 854
+    pos: 8.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2932
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,-13.5
+  - parent: 854
+    pos: 9.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2933
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-13.5
+  - parent: 854
+    pos: 10.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2934
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,-13.5
+  - parent: 854
+    pos: 11.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2935
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 11.5,-13.5
+  - parent: 854
+    pos: 22.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2936
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-4.5
+  - parent: 854
+    pos: 22.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2937
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-5.5
+  - parent: 854
+    pos: 23.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2938
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 23.5,-4.5
+  - parent: 854
+    pos: 24.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2939
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 24.5,-4.5
+  - parent: 854
+    pos: 25.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2940
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 25.5,-4.5
+  - parent: 854
+    pos: 22.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2941
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-2.5
+  - parent: 854
+    pos: 22.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2942
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-1.5
+  - parent: 854
+    pos: 22.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2943
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-0.5
+  - parent: 854
+    pos: 22.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2944
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,0.5
+  - parent: 854
+    pos: 22.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2945
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,1.5
+  - parent: 854
+    pos: 21.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2946
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,1.5
+  - parent: 854
+    pos: 23.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2947
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 23.5,0.5
+  - parent: 854
+    pos: 23.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2948
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 23.5,-1.5
+  - parent: 854
+    pos: 24.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2949
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 24.5,-1.5
+  - parent: 854
+    pos: 25.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2950
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 25.5,-1.5
+  - parent: 854
+    pos: 22.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2951
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-6.5
+  - parent: 854
+    pos: 21.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2952
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,-6.5
+  - parent: 854
+    pos: 20.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2953
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 20.5,-6.5
+  - parent: 854
+    pos: 19.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2954
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 19.5,-6.5
+  - parent: 854
+    pos: 18.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2955
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-6.5
+  - parent: 854
+    pos: 18.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2956
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-5.5
+  - parent: 854
+    pos: 18.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2957
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-4.5
+  - parent: 854
+    pos: 18.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2958
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-7.5
+  - parent: 854
+    pos: 18.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2959
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-8.5
+  - parent: 854
+    pos: 18.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2960
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-9.5
+  - parent: 854
+    pos: 18.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2961
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-10.5
+  - parent: 854
+    pos: 18.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2962
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-11.5
+  - parent: 854
+    pos: 18.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2963
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-12.5
+  - parent: 854
+    pos: 18.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2964
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-13.5
+  - parent: 854
+    pos: 18.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2965
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-14.5
+  - parent: 854
+    pos: 18.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2966
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-15.5
+  - parent: 854
+    pos: 18.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2967
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-16.5
+  - parent: 854
+    pos: 18.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2968
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-17.5
+  - parent: 854
+    pos: 18.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2969
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-18.5
+  - parent: 854
+    pos: 18.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2970
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-19.5
+  - parent: 854
+    pos: 18.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2971
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-20.5
+  - parent: 854
+    pos: 19.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2972
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 19.5,-13.5
+  - parent: 854
+    pos: 20.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2973
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 20.5,-13.5
+  - parent: 854
+    pos: 21.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2974
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,-13.5
+  - parent: 854
+    pos: 22.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2975
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2976
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-13.5
+  - parent: 854
+    pos: 23.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2977
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 23.5,-13.5
+  - parent: 854
+    pos: 23.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2978
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 23.5,-14.5
+  - parent: 854
+    pos: 8.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2979
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,-12.5
+  - parent: 854
+    pos: 8.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2980
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,-11.5
+  - parent: 854
+    pos: 7.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2981
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-11.5
+  - parent: 854
+    pos: 9.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2982
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-11.5
+  - parent: 854
+    pos: 10.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2983
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,-11.5
+  - parent: 854
+    pos: 7.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2984
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-7.5
+  - parent: 854
+    pos: 8.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2985
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,-7.5
+  - parent: 854
+    pos: 9.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2986
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-7.5
+  - parent: 854
+    pos: 10.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2987
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,-7.5
+  - parent: 854
+    pos: 11.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2988
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 11.5,-7.5
+  - parent: 854
+    pos: 12.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2989
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,-7.5
+  - parent: 854
+    pos: 13.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2990
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 13.5,-7.5
+  - parent: 854
+    pos: 14.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2991
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 14.5,-7.5
+  - parent: 854
+    pos: 15.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2992
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 15.5,-7.5
+  - parent: 854
+    pos: 16.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2993
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 16.5,-7.5
+  - parent: 854
+    pos: 17.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2994
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 17.5,-7.5
+  - parent: 854
+    pos: 18.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2995
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-7.5
+  - parent: 854
+    pos: 17.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2996
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 17.5,-17.5
+  - parent: 854
+    pos: 16.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2997
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 16.5,-17.5
+  - parent: 854
+    pos: 15.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2998
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 15.5,-17.5
+  - parent: 854
+    pos: 16.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 2999
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 16.5,2.5
+  - parent: 854
+    pos: 16.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3000
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 16.5,1.5
+  - parent: 854
+    pos: 17.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3001
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 17.5,1.5
+  - parent: 854
+    pos: 18.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3002
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,1.5
+  - parent: 854
+    pos: 15.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3003
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 15.5,1.5
+  - parent: 854
+    pos: 14.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3004
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 14.5,1.5
+  - parent: 854
+    pos: 13.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3005
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 13.5,1.5
+  - parent: 854
+    pos: 12.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3006
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,1.5
+  - parent: 854
+    pos: 11.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3007
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 11.5,1.5
+  - parent: 854
+    pos: 10.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3008
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,1.5
+  - parent: 854
+    pos: 9.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3009
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,1.5
+  - parent: 854
+    pos: 8.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3010
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,1.5
+  - parent: 854
+    pos: 7.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3011
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,1.5
+  - parent: 854
+    pos: 6.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3012
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,1.5
+  - parent: 854
+    pos: 16.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3013
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 16.5,0.5
+  - parent: 854
+    pos: 16.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3014
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 16.5,-0.5
+  - parent: 854
+    pos: 17.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3015
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 17.5,-0.5
+  - parent: 854
+    pos: 18.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3016
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,-0.5
+  - parent: 854
+    pos: 9.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3017
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,0.5
+  - parent: 854
+    pos: 9.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3018
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-0.5
+  - parent: 854
+    pos: 9.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3019
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-1.5
+  - parent: 854
+    pos: 9.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3020
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-2.5
+  - parent: 854
+    pos: 9.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3021
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-3.5
+  - parent: 854
+    pos: 9.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3022
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,-4.5
+  - parent: 854
+    pos: 8.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3023
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,-4.5
+  - parent: 854
+    pos: 7.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3024
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,-4.5
+  - parent: 854
+    pos: 6.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3025
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,-4.5
+  - parent: 854
+    pos: 10.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3026
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,-2.5
+  - parent: 854
+    pos: 11.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3027
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 11.5,-2.5
+  - parent: 854
+    pos: 6.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3028
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,-17.5
+  - parent: 854
+    pos: 1.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3029
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 1.5,-23.5
+  - parent: 854
+    pos: 2.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3030
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 2.5,-23.5
+  - parent: 854
+    pos: 3.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3031
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,-23.5
+  - parent: 854
+    pos: 3.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3032
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,-22.5
+  - parent: 854
+    pos: 3.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3033
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,-21.5
+  - parent: 854
+    pos: 2.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3034
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 2.5,-21.5
+  - parent: 854
+    pos: 4.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3035
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 4.5,-21.5
+  - parent: 854
+    pos: 22.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3036
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,-3.5
+  - parent: 854
+    pos: 31.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3037
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,1.5
+  - parent: 854
+    pos: 31.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3038
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,0.5
+  - parent: 854
+    pos: 31.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3039
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,-0.5
+  - parent: 854
+    pos: 31.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3040
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,-1.5
+  - parent: 854
+    pos: 31.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3041
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,-3.5
+  - parent: 854
+    pos: 31.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3042
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,-2.5
+  - parent: 854
+    pos: 30.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3043
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 30.5,-2.5
+  - parent: 854
+    pos: 29.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3044
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 29.5,-2.5
+  - parent: 854
+    pos: 32.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3045
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 32.5,-2.5
+  - parent: 854
+    pos: 33.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3046
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 33.5,-2.5
+  - parent: 854
+    pos: 34.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3047
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 34.5,-2.5
+  - parent: 854
+    pos: 35.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3048
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 35.5,-2.5
+  - parent: 854
+    pos: 31.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3049
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,1.5
+  - parent: 854
+    pos: 31.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3050
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,2.5
+  - parent: 854
+    pos: 31.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3051
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,3.5
+  - parent: 854
+    pos: 31.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3052
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,4.5
+  - parent: 854
+    pos: 32.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3053
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 32.5,4.5
+  - parent: 854
+    pos: 33.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3054
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 33.5,4.5
+  - parent: 854
+    pos: 34.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3055
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 34.5,4.5
+  - parent: 854
+    pos: 35.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3056
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 35.5,4.5
+  - parent: 854
+    pos: 36.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3057
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 36.5,4.5
+  - parent: 854
+    pos: 37.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3058
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 37.5,4.5
+  - parent: 854
+    pos: 38.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3059
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,4.5
+  - parent: 854
+    pos: 38.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3060
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,3.5
+  - parent: 854
+    pos: 38.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3061
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,2.5
+  - parent: 854
+    pos: 38.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3062
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,1.5
+  - parent: 854
+    pos: 38.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3063
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,0.5
+  - parent: 854
+    pos: 38.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3064
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,-0.5
+  - parent: 854
+    pos: 38.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3065
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,-1.5
+  - parent: 854
+    pos: 43.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3066
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,10.5
+  - parent: 854
+    pos: 43.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3067
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,9.5
+  - parent: 854
+    pos: 42.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3068
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 42.5,9.5
+  - parent: 854
+    pos: 41.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3069
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 41.5,9.5
+  - parent: 854
+    pos: 39.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3070
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 39.5,9.5
+  - parent: 854
+    pos: 38.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3071
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,9.5
+  - parent: 854
+    pos: 40.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3072
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 40.5,9.5
+  - parent: 854
+    pos: 38.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3073
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,8.5
+  - parent: 854
+    pos: 38.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3074
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,7.5
+  - parent: 854
+    pos: 38.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3075
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,6.5
+  - parent: 854
+    pos: 44.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3076
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,9.5
+  - parent: 854
+    pos: 44.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3077
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,8.5
+  - parent: 854
+    pos: 44.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3078
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,7.5
+  - parent: 854
+    pos: 44.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3079
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,6.5
+  - parent: 854
+    pos: 44.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3080
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,5.5
+  - parent: 854
+    pos: 44.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3081
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,4.5
+  - parent: 854
+    pos: 45.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3082
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 45.5,4.5
+  - parent: 854
+    pos: 46.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3083
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 46.5,4.5
+  - parent: 854
+    pos: 47.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3084
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,4.5
+  - parent: 854
+    pos: 48.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3085
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 48.5,4.5
+  - parent: 854
+    pos: 49.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3086
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,4.5
+  - parent: 854
+    pos: 33.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3087
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 33.5,-3.5
+  - parent: 854
+    pos: 33.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3088
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 33.5,-4.5
+  - parent: 854
+    pos: 43.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3089
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,4.5
+  - parent: 854
+    pos: 43.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3090
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,3.5
+  - parent: 854
+    pos: 43.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3091
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,2.5
+  - parent: 854
+    pos: 43.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3092
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,1.5
+  - parent: 854
+    pos: 43.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3093
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,0.5
+  - parent: 854
+    pos: 43.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3094
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,-0.5
+  - parent: 854
+    pos: 43.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3095
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,-1.5
+  - parent: 854
+    pos: 43.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3096
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,-2.5
+  - parent: 854
+    pos: 43.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3097
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 43.5,-3.5
+  - parent: 854
+    pos: 42.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3098
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 42.5,-3.5
+  - parent: 854
+    pos: 41.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3099
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 41.5,-3.5
+  - parent: 854
+    pos: 40.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3100
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 40.5,-3.5
+  - parent: 854
+    pos: 39.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3101
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 39.5,-3.5
+  - parent: 854
+    pos: 38.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3102
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 38.5,-3.5
+  - parent: 854
+    pos: 37.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3103
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 37.5,-3.5
+  - parent: 854
+    pos: 37.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3104
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 37.5,-4.5
+  - parent: 854
+    pos: 37.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3105
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 37.5,-5.5
+  - parent: 854
+    pos: 37.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3106
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 37.5,-6.5
+  - parent: 854
+    pos: 36.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3107
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 36.5,-6.5
+  - parent: 854
+    pos: 35.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3108
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 35.5,-6.5
+  - parent: 854
+    pos: 34.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3109
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 34.5,-6.5
+  - parent: 854
+    pos: 33.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3110
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 33.5,-6.5
+  - parent: 854
+    pos: 32.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3111
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 32.5,-6.5
+  - parent: 854
+    pos: 31.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3112
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,-6.5
+  - parent: 854
+    pos: 30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3113
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 30.5,-6.5
+  - parent: 854
+    pos: 29.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3114
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 29.5,-6.5
+  - parent: 854
+    pos: 28.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3115
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 28.5,-6.5
+  - parent: 854
+    pos: 27.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3116
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-6.5
+  - parent: 854
+    pos: 27.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3117
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-7.5
+  - parent: 854
+    pos: 27.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3118
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-8.5
+  - parent: 854
+    pos: 27.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3119
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-9.5
+  - parent: 854
+    pos: 27.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3120
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-10.5
+  - parent: 854
+    pos: 27.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3121
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-11.5
+  - parent: 854
+    pos: 27.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3122
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-12.5
+  - parent: 854
+    pos: 27.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3123
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-13.5
+  - parent: 854
+    pos: 27.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3124
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-14.5
+  - parent: 854
+    pos: 27.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3125
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-15.5
+  - parent: 854
+    pos: 27.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3126
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-16.5
+  - parent: 854
+    pos: 27.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3127
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-17.5
+  - parent: 854
+    pos: 27.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3128
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,-18.5
+  - parent: 854
+    pos: 26.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3129
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 26.5,-18.5
+  - parent: 854
+    pos: 25.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3130
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 25.5,-18.5
+  - parent: 854
+    pos: 24.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3131
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 24.5,-18.5
+  - parent: 854
+    pos: 47.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3132
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,-1.5
+  - parent: 854
+    pos: 47.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3133
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,-2.5
+  - parent: 854
+    pos: 47.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3134
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,-3.5
+  - parent: 854
+    pos: 48.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3135
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 48.5,-2.5
+  - parent: 854
+    pos: 49.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3136
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,-2.5
+  - parent: 854
+    pos: 50.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3137
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 50.5,-2.5
+  - parent: 854
+    pos: 51.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3138
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 51.5,-2.5
+  - parent: 854
+    pos: 51.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3139
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 51.5,-3.5
+  - parent: 854
+    pos: 51.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3140
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 51.5,-4.5
+  - parent: 854
+    pos: 41.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3141
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 41.5,10.5
+  - parent: 854
+    pos: 41.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3142
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 41.5,11.5
+  - parent: 854
+    pos: 41.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3143
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 41.5,12.5
+  - parent: 854
+    pos: 41.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3144
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 41.5,13.5
+  - parent: 854
+    pos: 28.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3145
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 28.5,14.5
+  - parent: 854
+    pos: 28.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3146
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 28.5,13.5
+  - parent: 854
+    pos: 28.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3147
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 28.5,12.5
+  - parent: 854
+    pos: 28.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3148
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 28.5,11.5
+  - parent: 854
+    pos: 28.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3149
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 28.5,10.5
+  - parent: 854
+    pos: 29.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3150
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 29.5,10.5
+  - parent: 854
+    pos: 28.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3151
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 28.5,9.5
+  - parent: 854
+    pos: 27.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3152
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,9.5
+  - parent: 854
+    pos: 26.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3153
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 26.5,9.5
+  - parent: 854
+    pos: 25.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3154
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 25.5,9.5
+  - parent: 854
+    pos: 26.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3155
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 26.5,10.5
+  - parent: 854
+    pos: 26.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3156
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 26.5,11.5
+  - parent: 854
+    pos: 27.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3157
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,8.5
+  - parent: 854
+    pos: 27.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3158
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 27.5,7.5
+  - parent: 854
+    pos: 30.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3159
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 30.5,10.5
+  - parent: 854
+    pos: 31.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3160
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 31.5,10.5
+  - parent: 854
+    pos: 32.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3161
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 32.5,10.5
+  - parent: 854
+    pos: 33.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3162
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 33.5,10.5
+  - parent: 854
+    pos: 34.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3163
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 34.5,10.5
+  - parent: 854
+    pos: 35.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3164
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 35.5,10.5
+  - parent: 854
+    pos: 36.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3165
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 36.5,10.5
+  - parent: 854
+    pos: 30.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3166
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 30.5,9.5
+  - parent: 854
+    pos: 33.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3167
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 33.5,9.5
+  - parent: 854
+    pos: 35.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3168
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 35.5,9.5
+  - parent: 854
+    pos: 35.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3169
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 35.5,8.5
+  - parent: 854
+    pos: 35.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3170
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 35.5,7.5
+  - parent: 854
+    pos: 36.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3171
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 36.5,11.5
+  - parent: 854
+    pos: 36.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3172
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 36.5,12.5
+  - parent: 854
+    pos: 30.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3173
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 30.5,11.5
+  - parent: 854
+    pos: 30.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3174
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 30.5,12.5
+  - parent: 854
+    pos: 24.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3175
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 24.5,14.5
+  - parent: 854
+    pos: 24.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3176
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 24.5,13.5
+  - parent: 854
+    pos: 23.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3177
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 23.5,13.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3178
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3179
-  type: ApcExtensionCable
+- uid: 3178
+  type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,14.5
+  - parent: 854
+    pos: 58.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3180
-  type: ApcExtensionCable
+- uid: 3179
+  type: Emitter
   components:
-  - parent: 855
-    pos: 22.5,14.5
+  - parent: 854
+    pos: 43.5,11.5
+    type: Transform
+- uid: 3180
+  type: AMEJar
+  components:
+  - parent: 854
+    pos: 38.25703,11.473667
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3181
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,15.5
+  - parent: 854
+    pos: 21.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3182
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,13.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3183
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 20.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3184
-  type: ApcExtensionCable
+- uid: 3183
+  type: HVWire
   components:
-  - parent: 855
-    pos: 20.5,14.5
+  - parent: 854
+    pos: 58.5,-26.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 3184
+  type: HVWire
+  components:
+  - parent: 854
+    pos: 58.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3185
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 20.5,15.5
+  - parent: 854
+    pos: 19.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3186
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 19.5,13.5
+  - parent: 854
+    pos: 18.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3187
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,13.5
+  - parent: 854
+    pos: 21.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3188
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,12.5
+  - parent: 854
+    pos: 21.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3189
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,11.5
+  - parent: 854
+    pos: 21.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3190
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,10.5
+  - parent: 854
+    pos: 21.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3191
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,9.5
+  - parent: 854
+    pos: 21.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3192
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 21.5,8.5
+  - parent: 854
+    pos: 22.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3193
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 22.5,8.5
+  - parent: 854
+    pos: 23.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3194
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 23.5,8.5
+  - parent: 854
+    pos: 20.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3195
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 20.5,8.5
+  - parent: 854
+    pos: 19.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3196
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 19.5,8.5
+  - parent: 854
+    pos: 18.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3197
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,8.5
+  - parent: 854
+    pos: 17.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3198
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 17.5,8.5
+  - parent: 854
+    pos: 18.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3199
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,12.5
+  - parent: 854
+    pos: 18.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3200
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 18.5,11.5
+  - parent: 854
+    pos: 12.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3201
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,13.5
+  - parent: 854
+    pos: 12.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3202
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,12.5
+  - parent: 854
+    pos: 12.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3203
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,11.5
+  - parent: 854
+    pos: 12.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3204
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,10.5
+  - parent: 854
+    pos: 13.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3205
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 13.5,10.5
+  - parent: 854
+    pos: 14.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3206
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 14.5,10.5
+  - parent: 854
+    pos: 15.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3207
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 15.5,10.5
+  - parent: 854
+    pos: 16.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3208
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 16.5,10.5
+  - parent: 854
+    pos: 15.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3209
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 15.5,11.5
+  - parent: 854
+    pos: 13.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3210
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 13.5,9.5
+  - parent: 854
+    pos: 11.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3211
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 11.5,10.5
+  - parent: 854
+    pos: 10.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3212
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,10.5
+  - parent: 854
+    pos: 9.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3213
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,10.5
+  - parent: 854
+    pos: 8.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3214
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,10.5
+  - parent: 854
+    pos: 7.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3215
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,10.5
+  - parent: 854
+    pos: 6.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3216
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,10.5
+  - parent: 854
+    pos: 8.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3217
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,11.5
+  - parent: 854
+    pos: 8.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3218
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,9.5
+  - parent: 854
+    pos: 8.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3219
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,8.5
+  - parent: 854
+    pos: 8.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3220
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,7.5
+  - parent: 854
+    pos: 8.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3221
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,6.5
+  - parent: 854
+    pos: 12.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3222
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,13.5
+  - parent: 854
+    pos: 12.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3223
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,14.5
+  - parent: 854
+    pos: 11.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3224
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 11.5,14.5
+  - parent: 854
+    pos: 10.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3225
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,14.5
+  - parent: 854
+    pos: 9.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3226
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,14.5
+  - parent: 854
+    pos: 8.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3227
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,14.5
+  - parent: 854
+    pos: 7.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3228
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,14.5
+  - parent: 854
+    pos: 6.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3229
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,14.5
+  - parent: 854
+    pos: 12.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3230
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 12.5,14.5
+  - parent: 854
+    pos: 13.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3231
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 13.5,14.5
+  - parent: 854
+    pos: 14.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3232
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 14.5,14.5
+  - parent: 854
+    pos: 15.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3233
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 15.5,14.5
+  - parent: 854
+    pos: 15.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3234
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 15.5,15.5
+  - parent: 854
+    pos: 13.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3235
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 13.5,16.5
+  - parent: 854
+    pos: 13.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3236
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 13.5,15.5
+  - parent: 854
+    pos: 9.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3237
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,22.5
+  - parent: 854
+    pos: 9.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3238
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,21.5
+  - parent: 854
+    pos: 9.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3239
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,20.5
+  - parent: 854
+    pos: 9.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3240
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,19.5
+  - parent: 854
+    pos: 9.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3241
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,18.5
+  - parent: 854
+    pos: 9.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3242
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,17.5
+  - parent: 854
+    pos: 9.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3243
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,16.5
+  - parent: 854
+    pos: 10.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3244
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 10.5,20.5
+  - parent: 854
+    pos: 8.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3245
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3246
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,17.5
+  - parent: 854
+    pos: 7.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3247
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,17.5
+  - parent: 854
+    pos: 8.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3248
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,20.5
+  - parent: 854
+    pos: 6.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3249
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,17.5
+  - parent: 854
+    pos: 5.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3250
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 5.5,17.5
+  - parent: 854
+    pos: 5.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3251
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 5.5,16.5
+  - parent: 854
+    pos: 4.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3252
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 4.5,17.5
+  - parent: 854
+    pos: 3.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3253
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,17.5
+  - parent: 854
+    pos: 3.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3254
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,18.5
+  - parent: 854
+    pos: 3.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3255
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,19.5
+  - parent: 854
+    pos: 3.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3256
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3257
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,20.5
+  - parent: 854
+    pos: 3.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3258
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,21.5
+  - parent: 854
+    pos: 3.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3259
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,22.5
+  - parent: 854
+    pos: 2.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3260
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 2.5,20.5
+  - parent: 854
+    pos: 1.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3261
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 1.5,20.5
+  - parent: 854
+    pos: 9.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3262
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,27.5
+  - parent: 854
+    pos: 9.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3263
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,26.5
+  - parent: 854
+    pos: 9.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3264
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,25.5
+  - parent: 854
+    pos: 9.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3265
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,24.5
+  - parent: 854
+    pos: 8.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3266
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,24.5
+  - parent: 854
+    pos: 7.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3267
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,24.5
+  - parent: 854
+    pos: 6.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3268
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,24.5
+  - parent: 854
+    pos: 9.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3269
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,28.5
+  - parent: 854
+    pos: 9.5,29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3270
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,29.5
+  - parent: 854
+    pos: 9.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3271
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 9.5,30.5
+  - parent: 854
+    pos: 8.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3272
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 8.5,30.5
+  - parent: 854
+    pos: 7.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3273
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 7.5,30.5
+  - parent: 854
+    pos: 6.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3274
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,30.5
+  - parent: 854
+    pos: 6.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3275
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 6.5,31.5
+  - parent: 854
+    pos: -2.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3276
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,27.5
+  - parent: 854
+    pos: -2.5,28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3277
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,28.5
+  - parent: 854
+    pos: -2.5,29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3278
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,29.5
+  - parent: 854
+    pos: -2.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3279
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,30.5
+  - parent: 854
+    pos: -1.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3280
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,30.5
+  - parent: 854
+    pos: -0.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3281
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,30.5
+  - parent: 854
+    pos: 0.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3282
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,30.5
+  - parent: 854
+    pos: 1.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3283
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 1.5,30.5
+  - parent: 854
+    pos: 2.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3284
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 2.5,30.5
+  - parent: 854
+    pos: 3.5,30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3285
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,30.5
+  - parent: 854
+    pos: 0.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3286
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,31.5
+  - parent: 854
+    pos: 3.5,31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3287
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,31.5
+  - parent: 854
+    pos: -2.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3288
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,26.5
+  - parent: 854
+    pos: -2.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3289
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,25.5
+  - parent: 854
+    pos: -1.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3290
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -1.5,25.5
+  - parent: 854
+    pos: -0.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3291
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,25.5
+  - parent: 854
+    pos: 0.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3292
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,25.5
+  - parent: 854
+    pos: 0.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3293
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,24.5
+  - parent: 854
+    pos: -2.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3294
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,24.5
+  - parent: 854
+    pos: -2.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3295
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -2.5,23.5
+  - parent: 854
+    pos: -1.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3296
-  type: ApcExtensionCable
+  type: SalternSmes
   components:
-  - parent: 855
-    pos: -1.5,23.5
+  - parent: 854
+    pos: 42.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3297
   type: SalternSmes
   components:
-  - parent: 855
-    pos: 42.5,5.5
+  - parent: 854
+    pos: 40.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3298
-  type: SalternSmes
+  type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,5.5
+  - parent: 854
+    pos: 41.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3299
   type: HVWire
   components:
-  - parent: 855
-    pos: 41.5,6.5
+  - parent: 854
+    pos: 41.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3300
   type: HVWire
   components:
-  - parent: 855
-    pos: 41.5,5.5
+  - parent: 854
+    pos: 42.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3301
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,4.5
+  - parent: 854
+    pos: 42.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3302
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,3.5
+  - parent: 854
+    pos: 42.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3303
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,2.5
+  - parent: 854
+    pos: 42.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3304
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,1.5
+  - parent: 854
+    pos: 42.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3305
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,0.5
+  - parent: 854
+    pos: 42.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3306
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-0.5
+  - parent: 854
+    pos: 42.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3307
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-1.5
+  - parent: 854
+    pos: 42.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3308
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-2.5
+  - parent: 854
+    pos: 42.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3309
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-3.5
+  - parent: 854
+    pos: 42.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3310
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: 42.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3311
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-4.5
+  - parent: 854
+    pos: 41.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3312
   type: HVWire
   components:
-  - parent: 855
-    pos: 41.5,-4.5
+  - parent: 854
+    pos: 40.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3313
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-4.5
+  - parent: 854
+    pos: 39.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3314
   type: HVWire
   components:
-  - parent: 855
-    pos: 39.5,-4.5
+  - parent: 854
+    pos: 38.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3315
   type: HVWire
   components:
-  - parent: 855
-    pos: 38.5,-4.5
+  - parent: 854
+    pos: 38.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3316
   type: HVWire
   components:
-  - parent: 855
-    pos: 38.5,-5.5
+  - parent: 854
+    pos: 38.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3317
   type: HVWire
   components:
-  - parent: 855
-    pos: 38.5,-6.5
+  - parent: 854
+    pos: 38.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3318
   type: HVWire
   components:
-  - parent: 855
-    pos: 38.5,-7.5
+  - parent: 854
+    pos: 37.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3319
   type: HVWire
   components:
-  - parent: 855
-    pos: 37.5,-7.5
+  - parent: 854
+    pos: 36.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3320
   type: HVWire
   components:
-  - parent: 855
-    pos: 36.5,-7.5
+  - parent: 854
+    pos: 35.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3321
   type: HVWire
   components:
-  - parent: 855
-    pos: 35.5,-7.5
+  - parent: 854
+    pos: 34.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3322
   type: HVWire
   components:
-  - parent: 855
-    pos: 34.5,-7.5
+  - parent: 854
+    pos: 33.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3323
   type: HVWire
   components:
-  - parent: 855
-    pos: 33.5,-7.5
+  - parent: 854
+    pos: 32.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3324
   type: HVWire
   components:
-  - parent: 855
-    pos: 32.5,-7.5
+  - parent: 854
+    pos: 31.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3325
   type: HVWire
   components:
-  - parent: 855
-    pos: 31.5,-7.5
+  - parent: 854
+    pos: 30.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3326
   type: HVWire
   components:
-  - parent: 855
-    pos: 30.5,-7.5
+  - parent: 854
+    pos: 29.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3327
   type: HVWire
   components:
-  - parent: 855
-    pos: 29.5,-7.5
+  - parent: 854
+    pos: 28.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3328
   type: HVWire
   components:
-  - parent: 855
-    pos: 28.5,-7.5
+  - parent: 854
+    pos: 27.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3329
   type: HVWire
   components:
-  - parent: 855
-    pos: 27.5,-7.5
+  - parent: 854
+    pos: 26.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3330
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-7.5
+  - parent: 854
+    pos: 26.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3331
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-8.5
+  - parent: 854
+    pos: 26.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3332
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-9.5
+  - parent: 854
+    pos: 26.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3333
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-10.5
+  - parent: 854
+    pos: 26.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3334
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-11.5
+  - parent: 854
+    pos: 26.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3335
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-12.5
+  - parent: 854
+    pos: 26.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3336
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-13.5
+  - parent: 854
+    pos: 26.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3337
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-14.5
+  - parent: 854
+    pos: 26.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3338
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-15.5
+  - parent: 854
+    pos: 26.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3339
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-16.5
+  - parent: 854
+    pos: 26.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3340
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,-17.5
+  - parent: 854
+    pos: 25.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3341
   type: HVWire
   components:
-  - parent: 855
-    pos: 25.5,-9.5
+  - parent: 854
+    pos: 24.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3342
   type: HVWire
   components:
-  - parent: 855
-    pos: 24.5,-9.5
+  - parent: 854
+    pos: 23.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3343
   type: HVWire
   components:
-  - parent: 855
-    pos: 23.5,-9.5
+  - parent: 854
+    pos: 22.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3344
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-9.5
+  - parent: 854
+    pos: 21.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3345
   type: HVWire
   components:
-  - parent: 855
-    pos: 21.5,-9.5
+  - parent: 854
+    pos: 25.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3346
   type: HVWire
   components:
-  - parent: 855
-    pos: 25.5,-17.5
+  - parent: 854
+    pos: 24.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3347
   type: HVWire
   components:
-  - parent: 855
-    pos: 24.5,-17.5
+  - parent: 854
+    pos: 23.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3348
   type: HVWire
   components:
-  - parent: 855
-    pos: 23.5,-17.5
+  - parent: 854
+    pos: 22.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3349
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-17.5
+  - parent: 854
+    pos: 22.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3350
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-18.5
+  - parent: 854
+    pos: 22.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3351
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-19.5
+  - parent: 854
+    pos: 22.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3352
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-20.5
+  - parent: 854
+    pos: 22.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3353
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-21.5
+  - parent: 854
+    pos: 22.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3354
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-22.5
+  - parent: 854
+    pos: 22.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3355
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-23.5
+  - parent: 854
+    pos: 22.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3356
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-24.5
+  - parent: 854
+    pos: 22.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3357
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,-25.5
+  - parent: 854
+    pos: 21.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3358
   type: HVWire
   components:
-  - parent: 855
-    pos: 21.5,-25.5
+  - parent: 854
+    pos: 20.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3359
   type: HVWire
   components:
-  - parent: 855
-    pos: 20.5,-25.5
+  - parent: 854
+    pos: 19.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3360
   type: HVWire
   components:
-  - parent: 855
-    pos: 19.5,-25.5
+  - parent: 854
+    pos: 18.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3361
   type: HVWire
   components:
-  - parent: 855
-    pos: 18.5,-25.5
+  - parent: 854
+    pos: 17.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3362
   type: HVWire
   components:
-  - parent: 855
-    pos: 17.5,-25.5
+  - parent: 854
+    pos: 16.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3363
   type: HVWire
   components:
-  - parent: 855
-    pos: 16.5,-25.5
+  - parent: 854
+    pos: 15.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3364
   type: HVWire
   components:
-  - parent: 855
-    pos: 15.5,-25.5
+  - parent: 854
+    pos: 14.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3365
   type: HVWire
   components:
-  - parent: 855
-    pos: 14.5,-25.5
+  - parent: 854
+    pos: 14.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3366
   type: HVWire
   components:
-  - parent: 855
-    pos: 14.5,-24.5
+  - parent: 854
+    pos: 14.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3367
   type: HVWire
   components:
-  - parent: 855
-    pos: 14.5,-23.5
+  - parent: 854
+    pos: 14.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3368
   type: HVWire
   components:
-  - parent: 855
-    pos: 14.5,-22.5
+  - parent: 854
+    pos: 14.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3369
   type: HVWire
   components:
-  - parent: 855
-    pos: 14.5,-21.5
+  - parent: 854
+    pos: 14.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3370
   type: HVWire
   components:
-  - parent: 855
-    pos: 14.5,-20.5
+  - parent: 854
+    pos: 13.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3371
   type: HVWire
   components:
-  - parent: 855
-    pos: 13.5,-20.5
+  - parent: 854
+    pos: 12.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3372
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,-20.5
+  - parent: 854
+    pos: 11.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3373
   type: HVWire
   components:
-  - parent: 855
-    pos: 11.5,-20.5
+  - parent: 854
+    pos: 10.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3374
   type: HVWire
   components:
-  - parent: 855
-    pos: 10.5,-20.5
+  - parent: 854
+    pos: 9.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3375
   type: HVWire
   components:
-  - parent: 855
-    pos: 9.5,-20.5
+  - parent: 854
+    pos: 8.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3376
   type: HVWire
   components:
-  - parent: 855
-    pos: 8.5,-20.5
+  - parent: 854
+    pos: 7.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3377
   type: HVWire
   components:
-  - parent: 855
-    pos: 7.5,-20.5
+  - parent: 854
+    pos: 6.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3378
   type: HVWire
   components:
-  - parent: 855
-    pos: 6.5,-20.5
+  - parent: 854
+    pos: 5.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3379
   type: HVWire
   components:
-  - parent: 855
-    pos: 5.5,-20.5
+  - parent: 854
+    pos: 4.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3380
   type: HVWire
   components:
-  - parent: 855
-    pos: 4.5,-20.5
+  - parent: 854
+    pos: 3.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3381
   type: HVWire
   components:
-  - parent: 855
-    pos: 3.5,-20.5
+  - parent: 854
+    pos: 2.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3382
   type: HVWire
   components:
-  - parent: 855
-    pos: 2.5,-20.5
+  - parent: 854
+    pos: 2.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3383
   type: HVWire
   components:
-  - parent: 855
-    pos: 2.5,-21.5
+  - parent: 854
+    pos: 2.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3384
   type: HVWire
   components:
-  - parent: 855
-    pos: 2.5,-22.5
+  - parent: 854
+    pos: 2.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3385
   type: HVWire
   components:
-  - parent: 855
-    pos: 2.5,-23.5
+  - parent: 854
+    pos: 1.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3386
   type: HVWire
   components:
-  - parent: 855
-    pos: 1.5,-23.5
+  - parent: 854
+    pos: -0.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3387
   type: HVWire
   components:
-  - parent: 855
-    pos: -0.5,-23.5
+  - parent: 854
+    pos: 0.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3388
   type: HVWire
   components:
-  - parent: 855
-    pos: 0.5,-23.5
+  - parent: 854
+    pos: -0.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3389
   type: HVWire
   components:
-  - parent: 855
-    pos: -0.5,-24.5
+  - parent: 854
+    pos: -0.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3390
   type: HVWire
   components:
-  - parent: 855
-    pos: -0.5,-25.5
+  - parent: 854
+    pos: -0.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3391
   type: HVWire
   components:
-  - parent: 855
-    pos: -0.5,-26.5
+  - parent: 854
+    pos: -1.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3392
   type: HVWire
   components:
-  - parent: 855
-    pos: -1.5,-26.5
+  - parent: 854
+    pos: -2.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3393
   type: HVWire
   components:
-  - parent: 855
-    pos: -2.5,-26.5
+  - parent: 854
+    pos: -3.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3394
-  type: HVWire
+  type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -3.5,-26.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -0.5,-15.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 3395
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -0.5,-15.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -4.5,-26.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3396
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -4.5,-26.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3397
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,-15.5
     rot: 3.141592653589793 rad
+    type: Transform
+- uid: 3397
+  type: HVWire
+  components:
+  - parent: 854
+    pos: -7.5,-26.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3398
   type: HVWire
   components:
-  - parent: 855
-    pos: -7.5,-26.5
+  - parent: 854
+    pos: -8.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3399
   type: HVWire
   components:
-  - parent: 855
-    pos: -8.5,-26.5
+  - parent: 854
+    pos: -9.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3400
   type: HVWire
   components:
-  - parent: 855
-    pos: -9.5,-26.5
+  - parent: 854
+    pos: -10.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3401
   type: HVWire
   components:
-  - parent: 855
-    pos: -10.5,-26.5
+  - parent: 854
+    pos: -11.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3402
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3403
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-26.5
+  - parent: 854
+    pos: -11.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3404
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-25.5
+  - parent: 854
+    pos: -11.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3405
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-24.5
+  - parent: 854
+    pos: -11.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3406
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-23.5
+  - parent: 854
+    pos: -11.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3407
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-22.5
+  - parent: 854
+    pos: -11.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3408
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-21.5
+  - parent: 854
+    pos: -11.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3409
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-20.5
+  - parent: 854
+    pos: -11.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3410
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-19.5
+  - parent: 854
+    pos: -11.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3411
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-18.5
+  - parent: 854
+    pos: -11.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3412
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-17.5
+  - parent: 854
+    pos: -11.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3413
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-16.5
+  - parent: 854
+    pos: -11.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3414
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-15.5
+  - parent: 854
+    pos: -11.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3415
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,-14.5
+  - parent: 854
+    pos: -10.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3416
   type: HVWire
   components:
-  - parent: 855
-    pos: -10.5,-14.5
+  - parent: 854
+    pos: -9.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3417
   type: HVWire
   components:
-  - parent: 855
-    pos: -9.5,-14.5
+  - parent: 854
+    pos: -9.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3418
   type: HVWire
   components:
-  - parent: 855
-    pos: -9.5,-13.5
+  - parent: 854
+    pos: -9.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3419
   type: HVWire
   components:
-  - parent: 855
-    pos: -9.5,-12.5
+  - parent: 854
+    pos: -9.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3420
   type: HVWire
   components:
-  - parent: 855
-    pos: -9.5,-11.5
+  - parent: 854
+    pos: -9.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3421
   type: HVWire
   components:
-  - parent: 855
-    pos: -9.5,-10.5
+  - parent: 854
+    pos: -8.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3422
   type: HVWire
   components:
-  - parent: 855
-    pos: -8.5,-10.5
+  - parent: 854
+    pos: -7.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3423
   type: HVWire
   components:
-  - parent: 855
-    pos: -7.5,-10.5
+  - parent: 854
+    pos: -6.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3424
   type: HVWire
   components:
-  - parent: 855
-    pos: -6.5,-10.5
+  - parent: 854
+    pos: -5.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3425
   type: HVWire
   components:
-  - parent: 855
-    pos: -5.5,-10.5
+  - parent: 854
+    pos: -4.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3426
   type: HVWire
   components:
-  - parent: 855
-    pos: -4.5,-10.5
+  - parent: 854
+    pos: -3.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3427
   type: HVWire
   components:
-  - parent: 855
-    pos: -3.5,-10.5
+  - parent: 854
+    pos: -2.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3428
   type: HVWire
   components:
-  - parent: 855
-    pos: -2.5,-10.5
+  - parent: 854
+    pos: -1.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3429
   type: HVWire
   components:
-  - parent: 855
-    pos: -1.5,-10.5
+  - parent: 854
+    pos: -0.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3430
   type: HVWire
   components:
-  - parent: 855
-    pos: -0.5,-10.5
+  - parent: 854
+    pos: 0.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3431
   type: HVWire
   components:
-  - parent: 855
-    pos: 0.5,-10.5
+  - parent: 854
+    pos: 0.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3432
   type: HVWire
   components:
-  - parent: 855
-    pos: 0.5,-9.5
+  - parent: 854
+    pos: 0.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3433
   type: HVWire
   components:
-  - parent: 855
-    pos: 0.5,-8.5
+  - parent: 854
+    pos: 0.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3434
   type: HVWire
   components:
-  - parent: 855
-    pos: 0.5,-7.5
+  - parent: 854
+    pos: 0.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3435
   type: HVWire
   components:
-  - parent: 855
-    pos: 0.5,-6.5
+  - parent: 854
+    pos: -12.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3436
   type: HVWire
   components:
-  - parent: 855
-    pos: -12.5,-14.5
+  - parent: 854
+    pos: -13.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3437
   type: HVWire
   components:
-  - parent: 855
-    pos: -13.5,-14.5
+  - parent: 854
+    pos: -14.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3438
   type: HVWire
   components:
-  - parent: 855
-    pos: -14.5,-14.5
+  - parent: 854
+    pos: -15.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3439
   type: HVWire
   components:
-  - parent: 855
-    pos: -15.5,-14.5
+  - parent: 854
+    pos: -16.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3440
   type: HVWire
   components:
-  - parent: 855
-    pos: -16.5,-14.5
+  - parent: 854
+    pos: -17.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3441
   type: HVWire
   components:
-  - parent: 855
-    pos: -17.5,-14.5
+  - parent: 854
+    pos: -18.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3442
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,-14.5
+  - parent: 854
+    pos: -18.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3443
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,-13.5
+  - parent: 854
+    pos: -18.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3444
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,-12.5
+  - parent: 854
+    pos: -18.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3445
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3446
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,-11.5
+  - parent: 854
+    pos: -19.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3447
   type: HVWire
   components:
-  - parent: 855
-    pos: -19.5,-11.5
+  - parent: 854
+    pos: -20.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3448
   type: HVWire
   components:
-  - parent: 855
-    pos: -20.5,-11.5
+  - parent: 854
+    pos: -21.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3449
   type: HVWire
   components:
-  - parent: 855
-    pos: -21.5,-11.5
+  - parent: 854
+    pos: -22.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3450
   type: HVWire
   components:
-  - parent: 855
-    pos: -22.5,-11.5
+  - parent: 854
+    pos: -23.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3451
   type: HVWire
   components:
-  - parent: 855
-    pos: -23.5,-11.5
+  - parent: 854
+    pos: -24.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3452
   type: HVWire
   components:
-  - parent: 855
-    pos: -24.5,-11.5
+  - parent: 854
+    pos: -25.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3453
   type: HVWire
   components:
-  - parent: 855
-    pos: -25.5,-11.5
+  - parent: 854
+    pos: -26.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3454
   type: HVWire
   components:
-  - parent: 855
-    pos: -26.5,-11.5
+  - parent: 854
+    pos: -27.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3455
   type: HVWire
   components:
-  - parent: 855
-    pos: -27.5,-11.5
+  - parent: 854
+    pos: -21.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3456
   type: HVWire
   components:
-  - parent: 855
-    pos: -21.5,-10.5
+  - parent: 854
+    pos: -28.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3457
   type: HVWire
   components:
-  - parent: 855
-    pos: -28.5,-11.5
+  - parent: 854
+    pos: -29.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3458
   type: HVWire
   components:
-  - parent: 855
-    pos: -29.5,-11.5
+  - parent: 854
+    pos: -30.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3459
   type: HVWire
   components:
-  - parent: 855
-    pos: -30.5,-11.5
+  - parent: 854
+    pos: -31.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3460
   type: HVWire
   components:
-  - parent: 855
-    pos: -31.5,-11.5
+  - parent: 854
+    pos: -32.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3461
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,-11.5
+  - parent: 854
+    pos: -33.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3462
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-11.5
+  - parent: 854
+    pos: -33.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3463
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-10.5
+  - parent: 854
+    pos: -33.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3464
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-9.5
+  - parent: 854
+    pos: -33.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3465
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-8.5
+  - parent: 854
+    pos: -33.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3466
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-7.5
+  - parent: 854
+    pos: -33.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3467
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-6.5
+  - parent: 854
+    pos: -33.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3468
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-5.5
+  - parent: 854
+    pos: -33.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3469
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-4.5
+  - parent: 854
+    pos: -33.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3470
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-3.5
+  - parent: 854
+    pos: -33.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3471
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-2.5
+  - parent: 854
+    pos: -33.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3472
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-1.5
+  - parent: 854
+    pos: -33.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3473
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,-0.5
+  - parent: 854
+    pos: -33.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3474
   type: HVWire
   components:
-  - parent: 855
-    pos: -33.5,0.5
+  - parent: 854
+    pos: -32.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3475
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,0.5
+  - parent: 854
+    pos: -32.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3476
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,1.5
+  - parent: 854
+    pos: -32.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3477
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,2.5
+  - parent: 854
+    pos: -32.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3478
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,3.5
+  - parent: 854
+    pos: -32.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3479
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,4.5
+  - parent: 854
+    pos: -32.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3480
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,5.5
+  - parent: 854
+    pos: -32.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3481
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,6.5
+  - parent: 854
+    pos: -32.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3482
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,7.5
+  - parent: 854
+    pos: -32.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3483
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,8.5
+  - parent: 854
+    pos: -32.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3484
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,9.5
+  - parent: 854
+    pos: -32.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3485
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,10.5
+  - parent: 854
+    pos: -32.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3486
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,11.5
+  - parent: 854
+    pos: -32.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3487
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,12.5
+  - parent: 854
+    pos: -32.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3488
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,13.5
+  - parent: 854
+    pos: -32.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3489
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3490
   type: HVWire
   components:
-  - parent: 855
-    pos: -32.5,14.5
+  - parent: 854
+    pos: -31.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3491
   type: HVWire
   components:
-  - parent: 855
-    pos: -31.5,14.5
+  - parent: 854
+    pos: -30.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3492
   type: HVWire
   components:
-  - parent: 855
-    pos: -30.5,14.5
+  - parent: 854
+    pos: -29.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3493
   type: HVWire
   components:
-  - parent: 855
-    pos: -29.5,14.5
+  - parent: 854
+    pos: -28.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3494
   type: HVWire
   components:
-  - parent: 855
-    pos: -28.5,14.5
+  - parent: 854
+    pos: -27.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3495
   type: HVWire
   components:
-  - parent: 855
-    pos: -27.5,14.5
+  - parent: 854
+    pos: -26.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3496
   type: HVWire
   components:
-  - parent: 855
-    pos: -26.5,14.5
+  - parent: 854
+    pos: -25.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3497
   type: HVWire
   components:
-  - parent: 855
-    pos: -25.5,14.5
+  - parent: 854
+    pos: -24.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3498
   type: HVWire
   components:
-  - parent: 855
-    pos: -24.5,14.5
+  - parent: 854
+    pos: -23.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3499
   type: HVWire
   components:
-  - parent: 855
-    pos: -23.5,14.5
+  - parent: 854
+    pos: -22.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3500
   type: HVWire
   components:
-  - parent: 855
-    pos: -22.5,14.5
+  - parent: 854
+    pos: -21.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3501
   type: HVWire
   components:
-  - parent: 855
-    pos: -21.5,14.5
+  - parent: 854
+    pos: -20.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3502
   type: HVWire
   components:
-  - parent: 855
-    pos: -20.5,14.5
+  - parent: 854
+    pos: -20.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3503
   type: HVWire
   components:
-  - parent: 855
-    pos: -20.5,13.5
+  - parent: 854
+    pos: -19.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3504
   type: HVWire
   components:
-  - parent: 855
-    pos: -19.5,13.5
+  - parent: 854
+    pos: -18.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3505
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -18.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3506
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,13.5
+  - parent: 854
+    pos: -17.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3507
   type: HVWire
   components:
-  - parent: 855
-    pos: -17.5,13.5
+  - parent: 854
+    pos: -17.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3508
   type: HVWire
   components:
-  - parent: 855
-    pos: -17.5,14.5
+  - parent: 854
+    pos: -17.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3509
   type: HVWire
   components:
-  - parent: 855
-    pos: -17.5,15.5
+  - parent: 854
+    pos: -18.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3510
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,16.5
+  - parent: 854
+    pos: -17.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3511
   type: HVWire
   components:
-  - parent: 855
-    pos: -17.5,16.5
+  - parent: 854
+    pos: -16.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3512
   type: HVWire
   components:
-  - parent: 855
-    pos: -16.5,16.5
+  - parent: 854
+    pos: -15.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3513
   type: HVWire
   components:
-  - parent: 855
-    pos: -15.5,16.5
+  - parent: 854
+    pos: -18.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3514
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,17.5
+  - parent: 854
+    pos: -18.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3515
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,18.5
+  - parent: 854
+    pos: -18.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3516
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,19.5
+  - parent: 854
+    pos: -18.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3517
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,20.5
+  - parent: 854
+    pos: -18.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3518
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,21.5
+  - parent: 854
+    pos: -18.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3519
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,22.5
+  - parent: 854
+    pos: -18.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3520
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,23.5
+  - parent: 854
+    pos: -18.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3521
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,24.5
+  - parent: 854
+    pos: -18.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3522
   type: HVWire
   components:
-  - parent: 855
-    pos: -18.5,25.5
+  - parent: 854
+    pos: -17.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3523
   type: HVWire
   components:
-  - parent: 855
-    pos: -17.5,25.5
+  - parent: 854
+    pos: -16.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3524
   type: HVWire
   components:
-  - parent: 855
-    pos: -16.5,25.5
+  - parent: 854
+    pos: -15.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3525
   type: HVWire
   components:
-  - parent: 855
-    pos: -15.5,25.5
+  - parent: 854
+    pos: -14.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3526
   type: HVWire
   components:
-  - parent: 855
-    pos: -14.5,25.5
+  - parent: 854
+    pos: -13.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3527
   type: HVWire
   components:
-  - parent: 855
-    pos: -13.5,25.5
+  - parent: 854
+    pos: -12.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3528
   type: HVWire
   components:
-  - parent: 855
-    pos: -12.5,25.5
+  - parent: 854
+    pos: -11.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3529
   type: HVWire
   components:
-  - parent: 855
-    pos: -11.5,25.5
+  - parent: 854
+    pos: -10.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3530
   type: HVWire
   components:
-  - parent: 855
-    pos: -10.5,25.5
+  - parent: 854
+    pos: -9.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3531
   type: HVWire
   components:
-  - parent: 855
-    pos: -9.5,25.5
+  - parent: 854
+    pos: -8.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3532
   type: HVWire
   components:
-  - parent: 855
-    pos: -8.5,25.5
+  - parent: 854
+    pos: -7.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3533
   type: HVWire
   components:
-  - parent: 855
-    pos: -7.5,25.5
+  - parent: 854
+    pos: -7.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3534
   type: HVWire
   components:
-  - parent: 855
-    pos: -7.5,24.5
+  - parent: 854
+    pos: -6.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3535
   type: HVWire
   components:
-  - parent: 855
-    pos: -6.5,24.5
+  - parent: 854
+    pos: -5.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3536
   type: HVWire
   components:
-  - parent: 855
-    pos: -5.5,24.5
+  - parent: 854
+    pos: -4.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3537
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3538
   type: HVWire
   components:
-  - parent: 855
-    pos: -4.5,24.5
+  - parent: 854
+    pos: -4.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3539
   type: HVWire
   components:
-  - parent: 855
-    pos: -4.5,23.5
+  - parent: 854
+    pos: -4.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3540
   type: HVWire
   components:
-  - parent: 855
-    pos: -4.5,22.5
+  - parent: 854
+    pos: -4.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3541
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3542
   type: HVWire
   components:
-  - parent: 855
-    pos: -4.5,21.5
+  - parent: 854
+    pos: -3.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3543
   type: HVWire
   components:
-  - parent: 855
-    pos: -3.5,21.5
+  - parent: 854
+    pos: -2.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3544
   type: HVWire
   components:
-  - parent: 855
-    pos: -2.5,21.5
+  - parent: 854
+    pos: -1.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3545
   type: HVWire
   components:
-  - parent: 855
-    pos: -1.5,21.5
+  - parent: 854
+    pos: -0.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3546
   type: HVWire
   components:
-  - parent: 855
-    pos: -0.5,21.5
+  - parent: 854
+    pos: -0.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3547
   type: HVWire
   components:
-  - parent: 855
-    pos: -0.5,20.5
+  - parent: 854
+    pos: 0.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3548
   type: HVWire
   components:
-  - parent: 855
-    pos: 0.5,20.5
+  - parent: 854
+    pos: 1.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3549
   type: HVWire
   components:
-  - parent: 855
-    pos: 1.5,20.5
+  - parent: 854
+    pos: 2.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3550
   type: HVWire
   components:
-  - parent: 855
-    pos: 2.5,20.5
+  - parent: 854
+    pos: 3.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3551
   type: HVWire
   components:
-  - parent: 855
-    pos: 3.5,20.5
+  - parent: 854
+    pos: 4.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3552
   type: HVWire
   components:
-  - parent: 855
-    pos: 4.5,20.5
+  - parent: 854
+    pos: 5.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3553
   type: HVWire
   components:
-  - parent: 855
-    pos: 5.5,20.5
+  - parent: 854
+    pos: 6.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3554
   type: HVWire
   components:
-  - parent: 855
-    pos: 6.5,20.5
+  - parent: 854
+    pos: 7.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3555
   type: HVWire
   components:
-  - parent: 855
-    pos: 7.5,20.5
+  - parent: 854
+    pos: 8.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3556
   type: HVWire
   components:
-  - parent: 855
-    pos: 8.5,20.5
+  - parent: 854
+    pos: 9.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3557
   type: HVWire
   components:
-  - parent: 855
-    pos: 9.5,20.5
+  - parent: 854
+    pos: 10.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3558
   type: HVWire
   components:
-  - parent: 855
-    pos: 10.5,20.5
+  - parent: 854
+    pos: 11.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3559
   type: HVWire
   components:
-  - parent: 855
-    pos: 11.5,20.5
+  - parent: 854
+    pos: 12.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3560
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,20.5
+  - parent: 854
+    pos: 12.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3561
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,21.5
+  - parent: 854
+    pos: 12.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3562
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,22.5
+  - parent: 854
+    pos: 12.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3563
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,23.5
+  - parent: 854
+    pos: 12.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3564
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,24.5
+  - parent: 854
+    pos: 11.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3565
   type: HVWire
   components:
-  - parent: 855
-    pos: 11.5,24.5
+  - parent: 854
+    pos: 12.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3566
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,20.5
+  - parent: 854
+    pos: 12.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3567
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,19.5
+  - parent: 854
+    pos: 12.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3568
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,18.5
+  - parent: 854
+    pos: 12.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3569
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,17.5
+  - parent: 854
+    pos: 12.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3570
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,16.5
+  - parent: 854
+    pos: 12.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3571
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,15.5
+  - parent: 854
+    pos: 12.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3572
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,14.5
+  - parent: 854
+    pos: 11.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3573
   type: HVWire
   components:
-  - parent: 855
-    pos: 11.5,14.5
+  - parent: 854
+    pos: 10.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3574
   type: HVWire
   components:
-  - parent: 855
-    pos: 10.5,14.5
+  - parent: 854
+    pos: 10.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3575
   type: HVWire
   components:
-  - parent: 855
-    pos: 10.5,13.5
+  - parent: 854
+    pos: 10.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3576
   type: HVWire
   components:
-  - parent: 855
-    pos: 10.5,12.5
+  - parent: 854
+    pos: 10.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3577
   type: HVWire
   components:
-  - parent: 855
-    pos: 10.5,11.5
+  - parent: 854
+    pos: 11.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3578
   type: HVWire
   components:
-  - parent: 855
-    pos: 11.5,11.5
+  - parent: 854
+    pos: 12.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3579
   type: HVWire
   components:
-  - parent: 855
-    pos: 12.5,11.5
+  - parent: 854
+    pos: 13.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3580
   type: HVWire
   components:
-  - parent: 855
-    pos: 13.5,11.5
+  - parent: 854
+    pos: 14.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3581
   type: HVWire
   components:
-  - parent: 855
-    pos: 14.5,11.5
+  - parent: 854
+    pos: 15.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3582
   type: HVWire
   components:
-  - parent: 855
-    pos: 15.5,11.5
+  - parent: 854
+    pos: 16.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3583
   type: HVWire
   components:
-  - parent: 855
-    pos: 16.5,11.5
+  - parent: 854
+    pos: 17.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3584
   type: HVWire
   components:
-  - parent: 855
-    pos: 17.5,11.5
+  - parent: 854
+    pos: 18.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3585
   type: HVWire
   components:
-  - parent: 855
-    pos: 18.5,11.5
+  - parent: 854
+    pos: 19.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3586
   type: HVWire
   components:
-  - parent: 855
-    pos: 19.5,11.5
+  - parent: 854
+    pos: 20.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3587
   type: HVWire
   components:
-  - parent: 855
-    pos: 20.5,11.5
+  - parent: 854
+    pos: 21.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3588
   type: HVWire
   components:
-  - parent: 855
-    pos: 21.5,11.5
+  - parent: 854
+    pos: 22.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3589
   type: HVWire
   components:
-  - parent: 855
-    pos: 22.5,11.5
+  - parent: 854
+    pos: 23.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3590
   type: HVWire
   components:
-  - parent: 855
-    pos: 23.5,11.5
+  - parent: 854
+    pos: 24.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3591
   type: HVWire
   components:
-  - parent: 855
-    pos: 24.5,11.5
+  - parent: 854
+    pos: 25.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3592
   type: HVWire
   components:
-  - parent: 855
-    pos: 25.5,11.5
+  - parent: 854
+    pos: 26.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3593
   type: HVWire
   components:
-  - parent: 855
-    pos: 26.5,11.5
+  - parent: 854
+    pos: 27.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3594
   type: HVWire
   components:
-  - parent: 855
-    pos: 27.5,11.5
+  - parent: 854
+    pos: 27.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3595
   type: HVWire
   components:
-  - parent: 855
-    pos: 27.5,12.5
+  - parent: 854
+    pos: 27.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3596
   type: HVWire
   components:
-  - parent: 855
-    pos: 27.5,13.5
+  - parent: 854
+    pos: 28.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3597
   type: HVWire
   components:
-  - parent: 855
-    pos: 28.5,11.5
+  - parent: 854
+    pos: 29.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3598
   type: HVWire
   components:
-  - parent: 855
-    pos: 29.5,11.5
+  - parent: 854
+    pos: 30.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3599
   type: HVWire
   components:
-  - parent: 855
-    pos: 30.5,11.5
+  - parent: 854
+    pos: 31.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3600
   type: HVWire
   components:
-  - parent: 855
-    pos: 31.5,11.5
+  - parent: 854
+    pos: 32.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3601
   type: HVWire
   components:
-  - parent: 855
-    pos: 32.5,11.5
+  - parent: 854
+    pos: 33.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3602
   type: HVWire
   components:
-  - parent: 855
-    pos: 33.5,11.5
+  - parent: 854
+    pos: 34.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3603
   type: HVWire
   components:
-  - parent: 855
-    pos: 34.5,11.5
+  - parent: 854
+    pos: 34.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3604
   type: HVWire
   components:
-  - parent: 855
-    pos: 34.5,10.5
+  - parent: 854
+    pos: 34.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3605
   type: HVWire
   components:
-  - parent: 855
-    pos: 34.5,9.5
+  - parent: 854
+    pos: 34.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3606
   type: HVWire
   components:
-  - parent: 855
-    pos: 34.5,8.5
+  - parent: 854
+    pos: 34.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3607
   type: HVWire
   components:
-  - parent: 855
-    pos: 34.5,7.5
+  - parent: 854
+    pos: 34.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3608
   type: HVWire
   components:
-  - parent: 855
-    pos: 34.5,6.5
+  - parent: 854
+    pos: 34.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3609
   type: HVWire
   components:
-  - parent: 855
-    pos: 34.5,5.5
+  - parent: 854
+    pos: 35.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3610
   type: HVWire
   components:
-  - parent: 855
-    pos: 35.5,5.5
+  - parent: 854
+    pos: 36.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3611
   type: HVWire
   components:
-  - parent: 855
-    pos: 36.5,5.5
+  - parent: 854
+    pos: 37.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3612
   type: HVWire
   components:
-  - parent: 855
-    pos: 37.5,5.5
+  - parent: 854
+    pos: 38.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3613
   type: HVWire
   components:
-  - parent: 855
-    pos: 38.5,5.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3614
-  type: HVWire
-  components:
-  - parent: 855
+  - parent: 854
     pos: 39.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3615
+- uid: 3614
   type: SalternSubstation
   components:
-  - parent: 855
+  - parent: 854
     pos: 42.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
+  - startingCharge: 3345920
+    type: Battery
+  - drawRate: 8000
+    type: PowerConsumer
+  - supplyRate: 6000
+    type: PowerSupplier
+- uid: 3615
+  type: SalternSubstation
+  components:
+  - parent: 854
+    pos: 27.5,13.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 3345920
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
@@ -40538,11 +40573,11 @@ entities:
 - uid: 3616
   type: SalternSubstation
   components:
-  - parent: 855
-    pos: 27.5,13.5
+  - parent: 854
+    pos: 11.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
+  - startingCharge: 3345920
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
@@ -40551,11 +40586,11 @@ entities:
 - uid: 3617
   type: SalternSubstation
   components:
-  - parent: 855
-    pos: 11.5,24.5
+  - parent: 854
+    pos: 21.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
+  - startingCharge: 3345920
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
@@ -40564,11 +40599,11 @@ entities:
 - uid: 3618
   type: SalternSubstation
   components:
-  - parent: 855
-    pos: 21.5,-9.5
+  - parent: 854
+    pos: -15.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
+  - startingCharge: 3345920
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
@@ -40577,44 +40612,44 @@ entities:
 - uid: 3619
   type: SalternSubstation
   components:
-  - parent: 855
-    pos: -15.5,16.5
+  - parent: 854
+    pos: -0.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
+  - startingCharge: 3345920
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
   - supplyRate: 6000
     type: PowerSupplier
 - uid: 3620
-  type: SalternSubstation
+  type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
+- uid: 3621
+  type: SalternSubstation
+  components:
+  - parent: 854
+    pos: 0.5,-6.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 3345920
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
   - supplyRate: 6000
     type: PowerSupplier
-- uid: 3621
-  type: HVWire
-  components:
-  - parent: 855
-    pos: -0.5,-22.5
-    rot: -1.5707963267948966 rad
-    type: Transform
 - uid: 3622
   type: SalternSubstation
   components:
-  - parent: 855
-    pos: 0.5,-6.5
+  - parent: 854
+    pos: -21.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
+  - startingCharge: 3345920
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
@@ -40623,1818 +40658,1805 @@ entities:
 - uid: 3623
   type: SalternSubstation
   components:
-  - parent: 855
-    pos: -21.5,-10.5
+  - parent: 854
+    pos: -32.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
+  - startingCharge: 3345920
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
   - supplyRate: 6000
     type: PowerSupplier
 - uid: 3624
-  type: SalternSubstation
+  type: MVWire
   components:
-  - parent: 855
-    pos: -32.5,7.5
+  - parent: 854
+    pos: 27.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565117
-    type: Battery
-  - drawRate: 8000
-    type: PowerConsumer
-  - supplyRate: 6000
-    type: PowerSupplier
 - uid: 3625
   type: MVWire
   components:
-  - parent: 855
-    pos: 27.5,13.5
+  - parent: 854
+    pos: 28.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3626
   type: MVWire
   components:
-  - parent: 855
-    pos: 28.5,13.5
+  - parent: 854
+    pos: 28.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3627
   type: MVWire
   components:
-  - parent: 855
-    pos: 28.5,14.5
+  - parent: 854
+    pos: 26.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3628
   type: MVWire
   components:
-  - parent: 855
-    pos: 26.5,13.5
+  - parent: 854
+    pos: 25.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3629
   type: MVWire
   components:
-  - parent: 855
-    pos: 25.5,13.5
+  - parent: 854
+    pos: 24.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3630
   type: MVWire
   components:
-  - parent: 855
-    pos: 24.5,13.5
+  - parent: 854
+    pos: 24.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3631
   type: MVWire
   components:
-  - parent: 855
-    pos: 24.5,14.5
+  - parent: 854
+    pos: 24.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3632
   type: MVWire
   components:
-  - parent: 855
-    pos: 24.5,12.5
+  - parent: 854
+    pos: 23.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3633
   type: MVWire
   components:
-  - parent: 855
-    pos: 23.5,12.5
+  - parent: 854
+    pos: 22.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3634
   type: MVWire
   components:
-  - parent: 855
-    pos: 22.5,12.5
+  - parent: 854
+    pos: 21.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3635
   type: MVWire
   components:
-  - parent: 855
-    pos: 21.5,12.5
+  - parent: 854
+    pos: 20.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3636
   type: MVWire
   components:
-  - parent: 855
-    pos: 20.5,12.5
+  - parent: 854
+    pos: 19.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3637
   type: MVWire
   components:
-  - parent: 855
-    pos: 19.5,12.5
+  - parent: 854
+    pos: 18.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3638
   type: MVWire
   components:
-  - parent: 855
-    pos: 18.5,12.5
+  - parent: 854
+    pos: 17.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3639
   type: MVWire
   components:
-  - parent: 855
-    pos: 17.5,12.5
+  - parent: 854
+    pos: 16.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3640
   type: MVWire
   components:
-  - parent: 855
-    pos: 16.5,12.5
+  - parent: 854
+    pos: 15.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3641
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,12.5
+  - parent: 854
+    pos: 14.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3642
   type: MVWire
   components:
-  - parent: 855
-    pos: 14.5,12.5
+  - parent: 854
+    pos: 13.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3643
   type: MVWire
   components:
-  - parent: 855
-    pos: 13.5,12.5
+  - parent: 854
+    pos: 12.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3644
   type: MVWire
   components:
-  - parent: 855
-    pos: 12.5,12.5
+  - parent: 854
+    pos: 12.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3645
   type: MVWire
   components:
-  - parent: 855
-    pos: 12.5,13.5
+  - parent: 854
+    pos: 11.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3646
   type: MVWire
   components:
-  - parent: 855
-    pos: 11.5,24.5
+  - parent: 854
+    pos: 9.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3647
   type: MVWire
   components:
-  - parent: 855
-    pos: 9.5,24.5
+  - parent: 854
+    pos: 10.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3648
   type: MVWire
   components:
-  - parent: 855
-    pos: 10.5,24.5
+  - parent: 854
+    pos: 9.5,23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3649
   type: MVWire
   components:
-  - parent: 855
-    pos: 9.5,23.5
+  - parent: 854
+    pos: 9.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3650
   type: MVWire
   components:
-  - parent: 855
-    pos: 9.5,22.5
+  - parent: 854
+    pos: 9.5,24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3651
   type: MVWire
   components:
-  - parent: 855
-    pos: 9.5,24.5
+  - parent: 854
+    pos: 9.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3652
   type: MVWire
   components:
-  - parent: 855
-    pos: 9.5,25.5
+  - parent: 854
+    pos: 9.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3653
   type: MVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3654
   type: MVWire
   components:
-  - parent: 855
-    pos: 9.5,26.5
+  - parent: 854
+    pos: 9.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3655
   type: MVWire
   components:
-  - parent: 855
-    pos: 9.5,27.5
+  - parent: 854
+    pos: 8.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3656
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,25.5
+  - parent: 854
+    pos: 7.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3657
   type: MVWire
   components:
-  - parent: 855
-    pos: 7.5,25.5
+  - parent: 854
+    pos: 6.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3658
   type: MVWire
   components:
-  - parent: 855
-    pos: 6.5,25.5
+  - parent: 854
+    pos: 5.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3659
   type: MVWire
   components:
-  - parent: 855
-    pos: 5.5,25.5
+  - parent: 854
+    pos: 4.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3660
   type: MVWire
   components:
-  - parent: 855
-    pos: 4.5,25.5
+  - parent: 854
+    pos: 3.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3661
   type: MVWire
   components:
-  - parent: 855
-    pos: 3.5,25.5
+  - parent: 854
+    pos: 2.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3662
   type: MVWire
   components:
-  - parent: 855
-    pos: 2.5,25.5
+  - parent: 854
+    pos: 1.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3663
   type: MVWire
   components:
-  - parent: 855
-    pos: 1.5,25.5
+  - parent: 854
+    pos: 0.5,25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3664
   type: MVWire
   components:
-  - parent: 855
-    pos: 0.5,25.5
+  - parent: 854
+    pos: 0.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3665
   type: MVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3666
   type: MVWire
   components:
-  - parent: 855
-    pos: 0.5,26.5
+  - parent: 854
+    pos: -0.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3667
   type: MVWire
   components:
-  - parent: 855
-    pos: -0.5,26.5
+  - parent: 854
+    pos: -1.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3668
   type: MVWire
   components:
-  - parent: 855
-    pos: -1.5,26.5
+  - parent: 854
+    pos: -2.5,26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3669
   type: MVWire
   components:
-  - parent: 855
-    pos: -2.5,26.5
+  - parent: 854
+    pos: -2.5,27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3670
   type: MVWire
   components:
-  - parent: 855
-    pos: -2.5,27.5
+  - parent: 854
+    pos: 42.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3671
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-0.5
+  - parent: 854
+    pos: 43.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3672
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,-0.5
+  - parent: 854
+    pos: 43.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3673
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,0.5
+  - parent: 854
+    pos: 43.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3674
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,1.5
+  - parent: 854
+    pos: 44.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3675
   type: MVWire
   components:
-  - parent: 855
-    pos: 44.5,1.5
+  - parent: 854
+    pos: 45.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3676
   type: MVWire
   components:
-  - parent: 855
-    pos: 45.5,1.5
+  - parent: 854
+    pos: 46.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3677
   type: MVWire
   components:
-  - parent: 855
-    pos: 46.5,1.5
+  - parent: 854
+    pos: 47.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3678
   type: MVWire
   components:
-  - parent: 855
-    pos: 47.5,1.5
+  - parent: 854
+    pos: 48.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3679
   type: MVWire
   components:
-  - parent: 855
-    pos: 48.5,1.5
+  - parent: 854
+    pos: 48.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3680
   type: MVWire
   components:
-  - parent: 855
-    pos: 48.5,0.5
+  - parent: 854
+    pos: 48.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3681
   type: MVWire
   components:
-  - parent: 855
-    pos: 48.5,-0.5
+  - parent: 854
+    pos: 48.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3682
   type: MVWire
   components:
-  - parent: 855
-    pos: 48.5,-1.5
+  - parent: 854
+    pos: 48.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3683
   type: MVWire
   components:
-  - parent: 855
-    pos: 48.5,-2.5
+  - parent: 854
+    pos: 47.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3684
   type: MVWire
   components:
-  - parent: 855
-    pos: 47.5,-2.5
+  - parent: 854
+    pos: 47.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3685
   type: MVWire
   components:
-  - parent: 855
-    pos: 47.5,-1.5
+  - parent: 854
+    pos: 41.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3686
   type: MVWire
   components:
-  - parent: 855
-    pos: 41.5,-0.5
+  - parent: 854
+    pos: 40.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3687
   type: MVWire
   components:
-  - parent: 855
-    pos: 40.5,-0.5
+  - parent: 854
+    pos: 39.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3688
   type: MVWire
   components:
-  - parent: 855
-    pos: 39.5,-0.5
+  - parent: 854
+    pos: 38.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3689
   type: MVWire
   components:
-  - parent: 855
-    pos: 38.5,-0.5
+  - parent: 854
+    pos: 37.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3690
   type: MVWire
   components:
-  - parent: 855
-    pos: 37.5,-0.5
+  - parent: 854
+    pos: 36.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3691
   type: MVWire
   components:
-  - parent: 855
-    pos: 36.5,-0.5
+  - parent: 854
+    pos: 35.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3692
   type: MVWire
   components:
-  - parent: 855
-    pos: 35.5,-0.5
+  - parent: 854
+    pos: 34.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3693
   type: MVWire
   components:
-  - parent: 855
-    pos: 34.5,-0.5
+  - parent: 854
+    pos: 33.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3694
   type: MVWire
   components:
-  - parent: 855
-    pos: 33.5,-0.5
+  - parent: 854
+    pos: 32.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3695
   type: MVWire
   components:
-  - parent: 855
-    pos: 32.5,-0.5
+  - parent: 854
+    pos: 32.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3696
   type: MVWire
   components:
-  - parent: 855
-    pos: 32.5,0.5
+  - parent: 854
+    pos: 31.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3697
   type: MVWire
   components:
-  - parent: 855
-    pos: 31.5,0.5
+  - parent: 854
+    pos: 31.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3698
   type: MVWire
   components:
-  - parent: 855
-    pos: 31.5,1.5
+  - parent: 854
+    pos: 43.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3699
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,2.5
+  - parent: 854
+    pos: 43.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3700
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,3.5
+  - parent: 854
+    pos: 43.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3701
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,4.5
+  - parent: 854
+    pos: 43.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3702
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,5.5
+  - parent: 854
+    pos: 43.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3703
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,6.5
+  - parent: 854
+    pos: 43.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3704
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,7.5
+  - parent: 854
+    pos: 43.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3705
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,8.5
+  - parent: 854
+    pos: 43.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3706
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,9.5
+  - parent: 854
+    pos: 43.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3707
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,10.5
+  - parent: 854
+    pos: 21.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3708
   type: MVWire
   components:
-  - parent: 855
-    pos: 21.5,-9.5
+  - parent: 854
+    pos: 21.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3709
   type: MVWire
   components:
-  - parent: 855
-    pos: 21.5,-8.5
+  - parent: 854
+    pos: 21.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3710
   type: MVWire
   components:
-  - parent: 855
-    pos: 21.5,-7.5
+  - parent: 854
+    pos: 21.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3711
   type: MVWire
   components:
-  - parent: 855
-    pos: 21.5,-6.5
+  - parent: 854
+    pos: 21.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3712
   type: MVWire
   components:
-  - parent: 855
-    pos: 21.5,-5.5
+  - parent: 854
+    pos: 21.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3713
   type: MVWire
   components:
-  - parent: 855
-    pos: 21.5,-4.5
+  - parent: 854
+    pos: 22.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3714
   type: MVWire
   components:
-  - parent: 855
-    pos: 22.5,-4.5
+  - parent: 854
+    pos: 22.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3715
   type: MVWire
   components:
-  - parent: 855
-    pos: 22.5,-3.5
+  - parent: 854
+    pos: 20.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3716
   type: MVWire
   components:
-  - parent: 855
-    pos: 20.5,-9.5
+  - parent: 854
+    pos: 19.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3717
   type: MVWire
   components:
-  - parent: 855
-    pos: 19.5,-9.5
+  - parent: 854
+    pos: 21.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3718
   type: MVWire
   components:
-  - parent: 855
-    pos: 21.5,-9.5
+  - parent: 854
+    pos: 18.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3719
   type: MVWire
   components:
-  - parent: 855
-    pos: 18.5,-9.5
+  - parent: 854
+    pos: 17.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3720
   type: MVWire
   components:
-  - parent: 855
-    pos: 17.5,-9.5
+  - parent: 854
+    pos: 16.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3721
   type: MVWire
   components:
-  - parent: 855
-    pos: 16.5,-9.5
+  - parent: 854
+    pos: 15.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3722
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-9.5
+  - parent: 854
+    pos: 14.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3723
   type: MVWire
   components:
-  - parent: 855
-    pos: 14.5,-9.5
+  - parent: 854
+    pos: 13.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3724
   type: MVWire
   components:
-  - parent: 855
-    pos: 13.5,-9.5
+  - parent: 854
+    pos: 12.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3725
   type: MVWire
   components:
-  - parent: 855
-    pos: 12.5,-9.5
+  - parent: 854
+    pos: 11.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3726
   type: MVWire
   components:
-  - parent: 855
-    pos: 11.5,-9.5
+  - parent: 854
+    pos: 10.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3727
   type: MVWire
   components:
-  - parent: 855
-    pos: 10.5,-9.5
+  - parent: 854
+    pos: 9.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3728
   type: MVWire
   components:
-  - parent: 855
-    pos: 9.5,-9.5
+  - parent: 854
+    pos: 8.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3729
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,-9.5
+  - parent: 854
+    pos: 8.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3730
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,-10.5
+  - parent: 854
+    pos: 8.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3731
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,-11.5
+  - parent: 854
+    pos: 8.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3732
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,-12.5
+  - parent: 854
+    pos: 8.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3733
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,-13.5
+  - parent: 854
+    pos: 8.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3734
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,-14.5
+  - parent: 854
+    pos: 8.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3735
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,-15.5
+  - parent: 854
+    pos: 8.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3736
   type: MVWire
   components:
-  - parent: 855
-    pos: 8.5,-16.5
+  - parent: 854
+    pos: 7.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3737
   type: MVWire
   components:
-  - parent: 855
-    pos: 7.5,-16.5
+  - parent: 854
+    pos: 7.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3738
   type: MVWire
   components:
-  - parent: 855
-    pos: 7.5,-17.5
+  - parent: 854
+    pos: 15.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3739
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-8.5
+  - parent: 854
+    pos: 15.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3740
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-7.5
+  - parent: 854
+    pos: 15.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3741
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-6.5
+  - parent: 854
+    pos: 15.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3742
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-5.5
+  - parent: 854
+    pos: 15.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3743
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-4.5
+  - parent: 854
+    pos: 15.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3744
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-3.5
+  - parent: 854
+    pos: 15.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3745
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-2.5
+  - parent: 854
+    pos: 15.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3746
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-1.5
+  - parent: 854
+    pos: 15.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3747
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,-0.5
+  - parent: 854
+    pos: 15.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3748
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,0.5
+  - parent: 854
+    pos: 15.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3749
   type: MVWire
   components:
-  - parent: 855
-    pos: 15.5,1.5
+  - parent: 854
+    pos: 16.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3750
   type: MVWire
   components:
-  - parent: 855
-    pos: 16.5,1.5
+  - parent: 854
+    pos: 16.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3751
   type: MVWire
   components:
-  - parent: 855
-    pos: 16.5,2.5
+  - parent: 854
+    pos: -0.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3752
   type: MVWire
   components:
-  - parent: 855
-    pos: -0.5,-22.5
+  - parent: 854
+    pos: -0.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3753
   type: MVWire
   components:
-  - parent: 855
-    pos: -0.5,-21.5
+  - parent: 854
+    pos: -0.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3754
   type: MVWire
   components:
-  - parent: 855
-    pos: -0.5,-20.5
+  - parent: 854
+    pos: -16.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3755
   type: MVWire
   components:
-  - parent: 855
-    pos: -16.5,15.5
+  - parent: 854
+    pos: -1.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3756
   type: MVWire
   components:
-  - parent: 855
-    pos: -1.5,-19.5
+  - parent: 854
+    pos: -1.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3757
   type: MVWire
   components:
-  - parent: 855
-    pos: -1.5,-18.5
+  - parent: 854
+    pos: -1.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3758
   type: MVWire
   components:
-  - parent: 855
-    pos: -1.5,-20.5
+  - parent: 854
+    pos: -2.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3759
   type: MVWire
   components:
-  - parent: 855
-    pos: -2.5,-20.5
+  - parent: 854
+    pos: -3.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3760
   type: MVWire
   components:
-  - parent: 855
-    pos: -3.5,-20.5
+  - parent: 854
+    pos: -4.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3761
   type: MVWire
   components:
-  - parent: 855
-    pos: -4.5,-20.5
+  - parent: 854
+    pos: -5.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3762
   type: MVWire
   components:
-  - parent: 855
-    pos: -5.5,-20.5
+  - parent: 854
+    pos: -6.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3763
   type: MVWire
   components:
-  - parent: 855
-    pos: -6.5,-20.5
+  - parent: 854
+    pos: -7.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3764
   type: MVWire
   components:
-  - parent: 855
-    pos: -7.5,-20.5
+  - parent: 854
+    pos: -8.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3765
   type: MVWire
   components:
-  - parent: 855
-    pos: -8.5,-20.5
+  - parent: 854
+    pos: -9.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3766
   type: MVWire
   components:
-  - parent: 855
-    pos: -9.5,-20.5
+  - parent: 854
+    pos: -9.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3767
   type: MVWire
   components:
-  - parent: 855
-    pos: -9.5,-21.5
+  - parent: 854
+    pos: -10.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3768
   type: MVWire
   components:
-  - parent: 855
-    pos: -10.5,-20.5
+  - parent: 854
+    pos: -11.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3769
   type: MVWire
   components:
-  - parent: 855
-    pos: -11.5,-20.5
+  - parent: 854
+    pos: -12.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3770
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,-20.5
+  - parent: 854
+    pos: -13.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3771
   type: MVWire
   components:
-  - parent: 855
-    pos: -13.5,-20.5
+  - parent: 854
+    pos: -13.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3772
   type: MVWire
   components:
-  - parent: 855
-    pos: -13.5,-19.5
+  - parent: 854
+    pos: -13.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3773
   type: MVWire
   components:
-  - parent: 855
-    pos: -13.5,-18.5
+  - parent: 854
+    pos: -13.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3774
   type: MVWire
   components:
-  - parent: 855
-    pos: -13.5,-17.5
+  - parent: 854
+    pos: -14.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3775
   type: MVWire
   components:
-  - parent: 855
-    pos: -14.5,-17.5
+  - parent: 854
+    pos: -14.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3776
   type: MVWire
   components:
-  - parent: 855
-    pos: -14.5,-16.5
+  - parent: 854
+    pos: 0.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3777
   type: MVWire
   components:
-  - parent: 855
-    pos: 0.5,-6.5
+  - parent: 854
+    pos: 0.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3778
   type: MVWire
   components:
-  - parent: 855
-    pos: 0.5,-7.5
+  - parent: 854
+    pos: 0.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3779
   type: MVWire
   components:
-  - parent: 855
-    pos: 0.5,-8.5
+  - parent: 854
+    pos: -0.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3780
   type: MVWire
   components:
-  - parent: 855
-    pos: -0.5,-8.5
+  - parent: 854
+    pos: -1.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3781
   type: MVWire
   components:
-  - parent: 855
-    pos: -1.5,-8.5
+  - parent: 854
+    pos: -1.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3782
   type: MVWire
   components:
-  - parent: 855
-    pos: -1.5,-9.5
+  - parent: 854
+    pos: -2.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3783
   type: MVWire
   components:
-  - parent: 855
-    pos: -2.5,-9.5
+  - parent: 854
+    pos: -3.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3784
   type: MVWire
   components:
-  - parent: 855
-    pos: -3.5,-9.5
+  - parent: 854
+    pos: -4.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3785
   type: MVWire
   components:
-  - parent: 855
-    pos: -4.5,-9.5
+  - parent: 854
+    pos: -5.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3786
   type: MVWire
   components:
-  - parent: 855
-    pos: -5.5,-9.5
+  - parent: 854
+    pos: -5.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3787
   type: MVWire
   components:
-  - parent: 855
-    pos: -5.5,-8.5
+  - parent: 854
+    pos: -6.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3788
   type: MVWire
   components:
-  - parent: 855
-    pos: -6.5,-9.5
+  - parent: 854
+    pos: -7.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3789
   type: MVWire
   components:
-  - parent: 855
-    pos: -7.5,-9.5
+  - parent: 854
+    pos: -8.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3790
   type: MVWire
   components:
-  - parent: 855
-    pos: -8.5,-9.5
+  - parent: 854
+    pos: -9.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3791
   type: MVWire
   components:
-  - parent: 855
-    pos: -9.5,-9.5
+  - parent: 854
+    pos: -9.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3792
   type: MVWire
   components:
-  - parent: 855
-    pos: -9.5,-8.5
+  - parent: 854
+    pos: -9.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3793
   type: MVWire
   components:
-  - parent: 855
-    pos: -9.5,-7.5
+  - parent: 854
+    pos: -9.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3794
   type: MVWire
   components:
-  - parent: 855
-    pos: -9.5,-6.5
+  - parent: 854
+    pos: -10.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3795
   type: MVWire
   components:
-  - parent: 855
-    pos: -10.5,-6.5
+  - parent: 854
+    pos: -11.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3796
   type: MVWire
   components:
-  - parent: 855
-    pos: -11.5,-6.5
+  - parent: 854
+    pos: -12.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3797
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,-6.5
+  - parent: 854
+    pos: -12.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3798
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,-5.5
+  - parent: 854
+    pos: -12.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3799
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,-4.5
+  - parent: 854
+    pos: -12.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3800
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,-3.5
+  - parent: 854
+    pos: -12.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3801
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,-2.5
+  - parent: 854
+    pos: -12.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3802
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,-1.5
+  - parent: 854
+    pos: -12.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3803
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,-0.5
+  - parent: 854
+    pos: -12.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3804
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,0.5
+  - parent: 854
+    pos: -12.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3805
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,1.5
+  - parent: 854
+    pos: -11.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3806
   type: MVWire
   components:
-  - parent: 855
-    pos: -11.5,1.5
+  - parent: 854
+    pos: -11.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3807
   type: MVWire
   components:
-  - parent: 855
-    pos: -11.5,2.5
+  - parent: 854
+    pos: -21.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3808
   type: MVWire
   components:
-  - parent: 855
-    pos: -21.5,-10.5
+  - parent: 854
+    pos: -21.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3809
   type: MVWire
   components:
-  - parent: 855
-    pos: -21.5,-9.5
+  - parent: 854
+    pos: -21.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3810
   type: MVWire
   components:
-  - parent: 855
-    pos: -21.5,-8.5
+  - parent: 854
+    pos: -20.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3811
   type: MVWire
   components:
-  - parent: 855
-    pos: -20.5,-8.5
+  - parent: 854
+    pos: -19.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3812
   type: MVWire
   components:
-  - parent: 855
-    pos: -19.5,-8.5
+  - parent: 854
+    pos: -18.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3813
   type: MVWire
   components:
-  - parent: 855
-    pos: -18.5,-8.5
+  - parent: 854
+    pos: -17.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3814
   type: MVWire
   components:
-  - parent: 855
-    pos: -17.5,-8.5
+  - parent: 854
+    pos: -17.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3815
   type: MVWire
   components:
-  - parent: 855
-    pos: -17.5,-9.5
+  - parent: 854
+    pos: -16.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3816
   type: MVWire
   components:
-  - parent: 855
-    pos: -16.5,-9.5
+  - parent: 854
+    pos: -15.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3817
   type: MVWire
   components:
-  - parent: 855
-    pos: -15.5,-9.5
+  - parent: 854
+    pos: -14.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3818
   type: MVWire
   components:
-  - parent: 855
-    pos: -14.5,-9.5
+  - parent: 854
+    pos: -14.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3819
   type: MVWire
   components:
-  - parent: 855
-    pos: -14.5,-8.5
+  - parent: 854
+    pos: -22.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3820
   type: MVWire
   components:
-  - parent: 855
-    pos: -22.5,-8.5
+  - parent: 854
+    pos: -21.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3821
   type: MVWire
   components:
-  - parent: 855
-    pos: -21.5,-11.5
+  - parent: 854
+    pos: -21.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3822
   type: MVWire
   components:
-  - parent: 855
-    pos: -21.5,-12.5
+  - parent: 854
+    pos: -20.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3823
   type: MVWire
   components:
-  - parent: 855
-    pos: -20.5,-12.5
+  - parent: 854
+    pos: -23.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3824
   type: MVWire
   components:
-  - parent: 855
-    pos: -23.5,-8.5
+  - parent: 854
+    pos: -24.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3825
   type: MVWire
   components:
-  - parent: 855
-    pos: -24.5,-8.5
+  - parent: 854
+    pos: -25.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3826
   type: MVWire
   components:
-  - parent: 855
-    pos: -25.5,-8.5
+  - parent: 854
+    pos: -26.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3827
   type: MVWire
   components:
-  - parent: 855
-    pos: -26.5,-8.5
+  - parent: 854
+    pos: -27.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3828
   type: MVWire
   components:
-  - parent: 855
-    pos: -27.5,-8.5
+  - parent: 854
+    pos: -28.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3829
   type: MVWire
   components:
-  - parent: 855
-    pos: -28.5,-8.5
+  - parent: 854
+    pos: -29.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3830
   type: MVWire
   components:
-  - parent: 855
-    pos: -29.5,-8.5
+  - parent: 854
+    pos: -29.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3831
   type: MVWire
   components:
-  - parent: 855
-    pos: -29.5,-7.5
+  - parent: 854
+    pos: -29.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3832
   type: MVWire
   components:
-  - parent: 855
-    pos: -29.5,-6.5
+  - parent: 854
+    pos: -29.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3833
   type: MVWire
   components:
-  - parent: 855
-    pos: -29.5,-5.5
+  - parent: 854
+    pos: -29.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3834
   type: MVWire
   components:
-  - parent: 855
-    pos: -29.5,-4.5
+  - parent: 854
+    pos: -30.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3835
   type: MVWire
   components:
-  - parent: 855
-    pos: -30.5,-4.5
+  - parent: 854
+    pos: -30.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3836
   type: MVWire
   components:
-  - parent: 855
-    pos: -30.5,-3.5
+  - parent: 854
+    pos: -32.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3837
   type: MVWire
   components:
-  - parent: 855
-    pos: -32.5,7.5
+  - parent: 854
+    pos: -32.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3838
   type: MVWire
   components:
-  - parent: 855
-    pos: -32.5,8.5
+  - parent: 854
+    pos: -32.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3839
   type: MVWire
   components:
-  - parent: 855
-    pos: -32.5,9.5
+  - parent: 854
+    pos: -33.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3840
   type: MVWire
   components:
-  - parent: 855
-    pos: -33.5,9.5
+  - parent: 854
+    pos: -34.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3841
   type: MVWire
   components:
-  - parent: 855
-    pos: -34.5,9.5
+  - parent: 854
+    pos: -35.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3842
   type: MVWire
   components:
-  - parent: 855
-    pos: -35.5,9.5
+  - parent: 854
+    pos: -36.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3843
   type: MVWire
   components:
-  - parent: 855
-    pos: -36.5,9.5
+  - parent: 854
+    pos: -37.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3844
   type: MVWire
   components:
-  - parent: 855
-    pos: -37.5,9.5
+  - parent: 854
+    pos: -38.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3845
   type: MVWire
   components:
-  - parent: 855
-    pos: -38.5,9.5
+  - parent: 854
+    pos: -38.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3846
   type: MVWire
   components:
-  - parent: 855
-    pos: -38.5,10.5
+  - parent: 854
+    pos: -39.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3847
   type: MVWire
   components:
-  - parent: 855
-    pos: -39.5,10.5
+  - parent: 854
+    pos: -39.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3848
   type: MVWire
   components:
-  - parent: 855
-    pos: -39.5,11.5
+  - parent: 854
+    pos: -28.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3849
   type: MVWire
   components:
-  - parent: 855
-    pos: -28.5,12.5
+  - parent: 854
+    pos: -31.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3850
   type: MVWire
   components:
-  - parent: 855
-    pos: -31.5,9.5
+  - parent: 854
+    pos: -31.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3851
   type: MVWire
   components:
-  - parent: 855
-    pos: -31.5,10.5
+  - parent: 854
+    pos: -31.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3852
   type: MVWire
   components:
-  - parent: 855
-    pos: -31.5,11.5
+  - parent: 854
+    pos: -31.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3853
   type: MVWire
   components:
-  - parent: 855
-    pos: -31.5,12.5
+  - parent: 854
+    pos: -31.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3854
   type: MVWire
   components:
-  - parent: 855
-    pos: -31.5,13.5
+  - parent: 854
+    pos: -30.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3855
   type: MVWire
   components:
-  - parent: 855
-    pos: -30.5,13.5
+  - parent: 854
+    pos: -29.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3856
   type: MVWire
   components:
-  - parent: 855
-    pos: -29.5,13.5
+  - parent: 854
+    pos: -28.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3857
   type: MVWire
   components:
-  - parent: 855
-    pos: -28.5,13.5
+  - parent: 854
+    pos: -15.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3858
   type: MVWire
   components:
-  - parent: 855
-    pos: -15.5,16.5
+  - parent: 854
+    pos: -14.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3859
   type: MVWire
   components:
-  - parent: 855
-    pos: -14.5,16.5
+  - parent: 854
+    pos: -13.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3860
   type: MVWire
   components:
-  - parent: 855
-    pos: -13.5,16.5
+  - parent: 854
+    pos: -13.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3861
   type: MVWire
   components:
-  - parent: 855
-    pos: -13.5,15.5
+  - parent: 854
+    pos: -13.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3862
   type: MVWire
   components:
-  - parent: 855
-    pos: -13.5,14.5
+  - parent: 854
+    pos: -13.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3863
   type: MVWire
   components:
-  - parent: 855
-    pos: -13.5,13.5
+  - parent: 854
+    pos: -12.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3864
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,13.5
+  - parent: 854
+    pos: -12.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3865
   type: MVWire
   components:
-  - parent: 855
-    pos: -12.5,12.5
+  - parent: 854
+    pos: -11.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3866
   type: MVWire
   components:
-  - parent: 855
-    pos: -11.5,13.5
+  - parent: 854
+    pos: -10.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3867
   type: MVWire
   components:
-  - parent: 855
-    pos: -10.5,13.5
+  - parent: 854
+    pos: -9.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3868
   type: MVWire
   components:
-  - parent: 855
-    pos: -9.5,13.5
+  - parent: 854
+    pos: -8.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3869
   type: MVWire
   components:
-  - parent: 855
-    pos: -8.5,13.5
+  - parent: 854
+    pos: -7.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3870
   type: MVWire
   components:
-  - parent: 855
-    pos: -7.5,13.5
+  - parent: 854
+    pos: -6.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3871
   type: MVWire
   components:
-  - parent: 855
-    pos: -6.5,13.5
+  - parent: 854
+    pos: -5.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3872
   type: MVWire
   components:
-  - parent: 855
-    pos: -5.5,13.5
+  - parent: 854
+    pos: -4.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3873
   type: MVWire
   components:
-  - parent: 855
-    pos: -4.5,13.5
+  - parent: 854
+    pos: -3.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3874
   type: MVWire
   components:
-  - parent: 855
-    pos: -3.5,13.5
+  - parent: 854
+    pos: -3.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3875
   type: MVWire
   components:
-  - parent: 855
-    pos: -3.5,14.5
+  - parent: 854
+    pos: -3.5,15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3876
   type: MVWire
   components:
-  - parent: 855
-    pos: -3.5,15.5
+  - parent: 854
+    pos: -15.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3877
   type: MVWire
   components:
-  - parent: 855
-    pos: -15.5,16.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3878
-  type: MVWire
-  components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,16.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3879
+- uid: 3878
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3880
+- uid: 3879
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.528679,-9.003884
     rot: 1.5707963267948966 rad
     type: Transform
@@ -42444,89 +42466,100 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 3881
+- uid: 3880
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-7.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 3882
+- uid: 3881
   type: AirlockMaintMedLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-10.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 3883
+- uid: 3882
   type: AirlockMaintSecLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: -16.5,16.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 3884
+- uid: 3883
   type: AirlockMaintCommandLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,22.5
     rot: 1.5707963267948966 rad
     type: Transform
+- uid: 3884
+  type: EmergencyLight
+  components:
+  - parent: 854
+    pos: 44.486908,10
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 30000
+    type: Battery
 - uid: 3885
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 44.486908,10
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 47.22923,-3
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3886
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 47.22923,-3
+  - parent: 854
+    pos: 29.299644,-7.5
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3887
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 29.299644,-7.5
+  - parent: 854
+    pos: 31.467993,-4.5
+    rot: 1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3888
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 31.467993,-4.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 30.278831,9.5
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3889
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 30.278831,9.5
+  - parent: 854
+    pos: 18.260162,9.5
     type: Transform
+  - powerLoad: 1
+    type: PowerReceiver
   - startingCharge: 30000
     type: Battery
 - uid: 3890
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 18.260162,9.5
+  - parent: 854
+    pos: 26.46292,-1
+    rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3891
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 26.46292,-1
+  - parent: 854
+    pos: 17.399544,2
     rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
@@ -42534,33 +42567,33 @@ entities:
 - uid: 3892
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 17.399544,2
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 7.2721233,-15.5
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3893
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 7.2721233,-15.5
+  - parent: 854
+    pos: 7.3033733,-20.5
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3894
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 7.3033733,-20.5
+  - parent: 854
+    pos: -10.487591,2
+    rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3895
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -10.487591,2
+  - parent: 854
+    pos: -2.7508366,15
     rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
@@ -42568,34 +42601,34 @@ entities:
 - uid: 3896
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -2.7508366,15
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 5.701264,16.5
+    rot: 3.141592653589793 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3897
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 5.701264,16.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 6.2924953,10.5
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3898
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 6.2924953,10.5
+  - parent: 854
+    pos: 12.41432,9.5
+    rot: 1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3899
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 12.41432,9.5
+  - parent: 854
+    pos: 16.47682,3.5
     rot: 1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
@@ -42603,76 +42636,76 @@ entities:
 - uid: 3900
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 16.47682,3.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -24.514448,12
+    rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3901
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -24.514448,12
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: -39.802197,11.207858
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3902
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -39.802197,11.207858
+  - parent: 854
+    pos: -22.347473,-1.5
+    rot: 3.141592653589793 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3903
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -22.347473,-1.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -20.745232,-0.5
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3904
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -20.745232,-0.5
-    type: Transform
-  - startingCharge: 30000
-    type: Battery
-- uid: 3905
-  type: EmergencyLight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -13.885857,-9
     rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
-- uid: 3906
+- uid: 3905
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 3906
+  type: EmergencyLight
+  components:
+  - parent: 854
+    pos: 10.68897,19.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - startingCharge: 30000
+    type: Battery
 - uid: 3907
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 10.68897,19.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 8.923345,28.5
+    rot: 1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3908
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 8.923345,28.5
+  - parent: 854
+    pos: -2.4985301,28.5
     rot: 1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
@@ -42680,78 +42713,82 @@ entities:
 - uid: 3909
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -2.4985301,28.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -2.7641551,26.5
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3910
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -2.7641551,26.5
+  - parent: 854
+    pos: 9.704595,26.5
+    rot: 3.141592653589793 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3911
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 9.704595,26.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - startingCharge: 30000
-    type: Battery
-- uid: 3912
-  type: EmergencyLight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -12.509865,6
     rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
-- uid: 3913
+- uid: 3912
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3914
+- uid: 3913
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3915
+- uid: 3914
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: 41.5,7.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 3915
+  type: SalternGenerator
+  components:
+  - parent: 854
+    pos: 40.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3916
   type: SalternGenerator
   components:
-  - parent: 855
-    pos: 40.5,7.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3917
-  type: SalternGenerator
-  components:
-  - parent: 855
+  - parent: 854
     pos: 42.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3918
+- uid: 3917
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.924418,16.541348
+    type: Transform
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
+- uid: 3918
+  type: PoweredSmallLight
+  components:
+  - parent: 854
+    pos: -1.4929452,19.970068
+    rot: -1.5707963267948966 rad
     type: Transform
   - powerLoad: 0
     type: PowerReceiver
@@ -42762,8 +42799,8 @@ entities:
 - uid: 3919
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -1.4929452,19.970068
+  - parent: 854
+    pos: -15.494916,16.030584
     rot: -1.5707963267948966 rad
     type: Transform
   - powerLoad: 0
@@ -42775,7 +42812,7 @@ entities:
 - uid: 3920
   type: PoweredSmallLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -15.494916,16.030584
     rot: -1.5707963267948966 rad
     type: Transform
@@ -42788,20 +42825,7 @@ entities:
 - uid: 3921
   type: PoweredSmallLight
   components:
-  - parent: 855
-    pos: -15.494916,16.030584
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 3922
-  type: PoweredSmallLight
-  components:
-  - parent: 855
+  - parent: 854
     pos: -15.494916,15.968084
     rot: -1.5707963267948966 rad
     type: Transform
@@ -42811,20 +42835,31 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 3923
+- uid: 3922
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -12.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 11999.087
+  - startingCharge: 11998.174
+    type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 3923
+  type: EmergencyLight
+  components:
+  - parent: 854
+    pos: -13.5,-17
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - startingCharge: 30000
     type: Battery
 - uid: 3924
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -13.5,-17
+  - parent: 854
+    pos: -10.5,-17
     rot: -1.5707963267948966 rad
     type: Transform
   - startingCharge: 30000
@@ -42832,127 +42867,118 @@ entities:
 - uid: 3925
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: -10.5,-17
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 5.7693076,-15.5
+    rot: 3.141592653589793 rad
     type: Transform
   - startingCharge: 30000
     type: Battery
 - uid: 3926
   type: EmergencyLight
   components:
-  - parent: 855
-    pos: 5.7693076,-15.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - startingCharge: 30000
-    type: Battery
-- uid: 3927
-  type: EmergencyLight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 2.2274737,8.5
     type: Transform
   - startingCharge: 30000
     type: Battery
-- uid: 3928
+- uid: 3927
   type: ClothingBackpackDuffelSurgeryFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.283348,-4.2176166
     type: Transform
   - containers:
       storagebase:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 3929
+- uid: 3928
   type: MetalStack
   components:
-  - parent: 855
+  - parent: 854
     pos: 47.585052,4.443361
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 3929
+  type: Table
+  components:
+  - parent: 854
+    pos: 46.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3930
   type: Table
   components:
-  - parent: 855
-    pos: 46.5,4.5
+  - parent: 854
+    pos: 48.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3931
   type: Table
   components:
-  - parent: 855
-    pos: 48.5,4.5
+  - parent: 854
+    pos: 47.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3932
   type: Table
   components:
-  - parent: 855
-    pos: 47.5,4.5
+  - parent: 854
+    pos: 49.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3933
   type: Table
   components:
-  - parent: 855
-    pos: 49.5,4.5
+  - parent: 854
+    pos: 50.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3934
-  type: Table
+  type: HVWireStack
   components:
-  - parent: 855
+  - parent: 854
     pos: 50.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3935
-  type: HVWireStack
-  components:
-  - parent: 855
-    pos: 50.5,4.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3936
   type: MVWireStack
   components:
-  - parent: 855
+  - parent: 854
     pos: 50.288177,4.693361
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3937
+- uid: 3936
   type: ApcExtensionCableStack
   components:
-  - parent: 855
+  - parent: 854
     pos: 50.053802,4.474611
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 3937
+  type: GlassStack
+  components:
+  - parent: 854
+    pos: 49.131927,4.677736
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3938
   type: GlassStack
   components:
-  - parent: 855
-    pos: 49.131927,4.677736
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3939
-  type: GlassStack
-  components:
-  - parent: 855
+  - parent: 854
     pos: 48.788177,4.505861
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3940
+- uid: 3939
   type: MetalStack
   components:
-  - parent: 855
+  - parent: 854
     pos: 48.038177,4.677736
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3941
+- uid: 3940
   type: CrateGeneric
   components:
-  - parent: 855
+  - parent: 854
     pos: 45.585052,4.6
     rot: 1.5707963267948966 rad
     type: Transform
@@ -42962,31 +42988,31 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
+- uid: 3941
+  type: Crowbar
+  components:
+  - parent: 854
+    pos: -29.463713,8.897233
+    rot: 1.5707963267948966 rad
+    type: Transform
 - uid: 3942
   type: Crowbar
   components:
-  - parent: 855
-    pos: -29.463713,8.897233
+  - parent: 854
+    pos: -15.314676,-12.357978
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 3943
   type: Crowbar
   components:
-  - parent: 855
-    pos: -15.314676,-12.357978
-    rot: 1.5707963267948966 rad
-    type: Transform
-- uid: 3944
-  type: Crowbar
-  components:
-  - parent: 855
+  - parent: 854
     pos: -15.502176,-11.748603
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 3945
+- uid: 3944
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -22.00058,-5.6251965
     rot: 3.141592653589793 rad
     type: Transform
@@ -42996,61 +43022,70 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 3945
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: 3.5,0.5
+    type: Transform
 - uid: 3946
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,0.5
+  - parent: 974
     type: Transform
 - uid: 3947
-  type: ApcExtensionCable
-  components:
-  - parent: 975
-    type: Transform
-- uid: 3948
   type: FirelockGlass
   components:
-  - parent: 976
+  - parent: 975
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3949
+- uid: 3948
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 8.5,20.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 3950
+- uid: 3949
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -36.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3951
+- uid: 3950
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -35.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3952
+- uid: 3951
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 3.5,1.5
     type: Transform
-- uid: 3953
+- uid: 3952
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 5.5,0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
+- uid: 3953
+  type: Firelock
+  components:
+  - parent: 854
+    pos: -4.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43058,17 +43093,17 @@ entities:
 - uid: 3954
   type: Firelock
   components:
-  - parent: 855
-    pos: -4.5,-27.5
+  - parent: 854
+    pos: -4.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
 - uid: 3955
-  type: Firelock
+  type: FirelockGlass
   components:
-  - parent: 855
-    pos: -4.5,-26.5
+  - parent: 854
+    pos: -26.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43076,8 +43111,8 @@ entities:
 - uid: 3956
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -26.5,3.5
+  - parent: 854
+    pos: -21.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43085,38 +43120,38 @@ entities:
 - uid: 3957
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -21.5,3.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 3958
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
+- uid: 3958
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: 2.5,0.5
+    type: Transform
 - uid: 3959
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 2.5,0.5
-    type: Transform
-- uid: 3960
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,0.5
     type: Transform
+- uid: 3960
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: 2.5,-12.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
 - uid: 3961
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 2.5,-12.5
+  - parent: 854
+    pos: -26.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43124,8 +43159,8 @@ entities:
 - uid: 3962
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -26.5,4.5
+  - parent: 854
+    pos: -26.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43133,95 +43168,86 @@ entities:
 - uid: 3963
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -26.5,5.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 3964
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
+- uid: 3964
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -31.5,5.5
+    type: Transform
 - uid: 3965
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -31.5,5.5
-    type: Transform
-- uid: 3966
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 7.5,20.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 3967
+- uid: 3966
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3968
+- uid: 3967
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3969
+- uid: 3968
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 3970
+- uid: 3969
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3971
+- uid: 3970
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3972
+- uid: 3971
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3973
+- uid: 3972
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-8.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 3974
+- uid: 3973
   type: DisposalPipe
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -43229,126 +43255,135 @@ entities:
       DisposalTransit:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 3975
+- uid: 3974
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-3.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
+- uid: 3975
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: 2.5,6.5
+    rot: 3.141592653589793 rad
+    type: Transform
 - uid: 3976
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 2.5,6.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -26.5,7.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3977
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -26.5,7.5
+  - parent: 854
+    pos: -26.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 3978
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -26.5,6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 3979
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 3980
+- uid: 3979
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3981
+- uid: 3980
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3982
+- uid: 3981
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 3983
+- uid: 3982
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: -25.5,7.5
     rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 3983
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: 3.5,6.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 3984
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 3.5,6.5
-    rot: 3.141592653589793 rad
-    type: Transform
-- uid: 3985
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 4.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 3986
+- uid: 3985
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3987
+- uid: 3986
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3988
+- uid: 3987
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-9.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 3989
+- uid: 3988
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: 22.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3990
+- uid: 3989
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-9.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
+- uid: 3990
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: -2.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43356,47 +43391,47 @@ entities:
 - uid: 3991
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -2.5,2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 3992
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3993
+- uid: 3992
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-8.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 3994
+- uid: 3993
   type: CommsComputerCircuitboard
   components:
-  - parent: 982
+  - parent: 981
     type: Transform
-- uid: 3995
+- uid: 3994
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -37.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3996
+- uid: 3995
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-9.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
+- uid: 3996
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: -24.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43404,26 +43439,26 @@ entities:
 - uid: 3997
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -24.5,7.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 3998
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: -23.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 3999
+- uid: 3998
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
+- uid: 3999
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: -1.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43431,8 +43466,8 @@ entities:
 - uid: 4000
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -1.5,2.5
+  - parent: 854
+    pos: -0.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43440,8 +43475,8 @@ entities:
 - uid: 4001
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -0.5,2.5
+  - parent: 854
+    pos: -23.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43449,8 +43484,8 @@ entities:
 - uid: 4002
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -23.5,1.5
+  - parent: 854
+    pos: -33.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43458,8 +43493,8 @@ entities:
 - uid: 4003
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -33.5,3.5
+  - parent: 854
+    pos: -33.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43467,96 +43502,96 @@ entities:
 - uid: 4004
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -33.5,4.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 4005
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: -33.5,5.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4006
+- uid: 4005
   type: Spoon
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.275527,-0.41787672
     type: Transform
-- uid: 4007
+- uid: 4006
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-7.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4008
+- uid: 4007
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4009
+- uid: 4008
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 36.5,4.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4010
+- uid: 4009
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4011
+- uid: 4010
   type: ResearchComputerCircuitboard
   components:
-  - parent: 1060
+  - parent: 1059
     type: Transform
-- uid: 4012
+- uid: 4011
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4013
+- uid: 4012
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 16.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 4013
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: -15.5,0.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
 - uid: 4014
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -15.5,0.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 5.5,-1.5
+    rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
 - uid: 4015
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 5.5,-1.5
+  - parent: 854
+    pos: 5.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43564,8 +43599,8 @@ entities:
 - uid: 4016
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 5.5,-0.5
+  - parent: 854
+    pos: 5.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43573,8 +43608,8 @@ entities:
 - uid: 4017
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 5.5,-2.5
+  - parent: 854
+    pos: -4.5,4.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43582,26 +43617,26 @@ entities:
 - uid: 4018
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -4.5,4.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 4019
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,3.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4020
+- uid: 4019
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: 37.5,-5.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
+- uid: 4020
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: 0.5,-14.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43609,56 +43644,56 @@ entities:
 - uid: 4021
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 0.5,-14.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 4022
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,0.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4023
+- uid: 4022
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 23.5,-18.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4024
+- uid: 4023
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -33.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4025
+- uid: 4024
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -24.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4026
+- uid: 4025
   type: SupplyRequestComputerCircuitboard
   components:
-  - parent: 961
+  - parent: 960
     type: Transform
+- uid: 4026
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: 3.5,15.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
 - uid: 4027
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 3.5,15.5
+  - parent: 854
+    pos: 4.5,15.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43666,26 +43701,26 @@ entities:
 - uid: 4028
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 4.5,15.5
+  - parent: 854
+    pos: 2.5,15.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
 - uid: 4029
-  type: FirelockGlass
+  type: Firelock
   components:
-  - parent: 855
-    pos: 2.5,15.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 25.5,-1.5
+    rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
 - uid: 4030
   type: Firelock
   components:
-  - parent: 855
-    pos: 25.5,-1.5
+  - parent: 854
+    pos: 25.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
@@ -43693,44 +43728,44 @@ entities:
 - uid: 4031
   type: Firelock
   components:
-  - parent: 855
-    pos: 25.5,-2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 4032
-  type: Firelock
-  components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4033
+- uid: 4032
   type: ComfyChair
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-29.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4034
+- uid: 4033
   type: CommsComputerCircuitboard
   components:
-  - parent: 994
+  - parent: 993
     type: Transform
-- uid: 4035
+- uid: 4034
   type: Fork
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.6817768,-0.5116267
     type: Transform
+- uid: 4035
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: -10.5,1.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
 - uid: 4036
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -10.5,1.5
+  - parent: 854
+    pos: -10.5,0.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43738,8 +43773,8 @@ entities:
 - uid: 4037
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -10.5,0.5
+  - parent: 854
+    pos: 15.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43747,8 +43782,8 @@ entities:
 - uid: 4038
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 15.5,8.5
+  - parent: 854
+    pos: 36.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43756,8 +43791,8 @@ entities:
 - uid: 4039
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 36.5,3.5
+  - parent: 854
+    pos: -10.5,11.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43765,8 +43800,8 @@ entities:
 - uid: 4040
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -10.5,11.5
+  - parent: 854
+    pos: -10.5,10.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43774,26 +43809,26 @@ entities:
 - uid: 4041
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: -10.5,10.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 4042
-  type: FirelockGlass
-  components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-0.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4043
+- uid: 4042
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: 38.5,-5.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
+- uid: 4043
+  type: FirelockGlass
+  components:
+  - parent: 854
+    pos: 0.5,-15.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43801,35 +43836,35 @@ entities:
 - uid: 4044
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 0.5,-15.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 4.5,-12.5
+    rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
 - uid: 4045
   type: FirelockGlass
   components:
-  - parent: 855
-    pos: 4.5,-12.5
+  - parent: 854
+    pos: 3.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
 - uid: 4046
-  type: FirelockGlass
+  type: Firelock
   components:
-  - parent: 855
-    pos: 3.5,-12.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 11.5,14.5
+    rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
 - uid: 4047
   type: Firelock
   components:
-  - parent: 855
-    pos: 11.5,14.5
+  - parent: 854
+    pos: -17.5,17.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
@@ -43837,579 +43872,585 @@ entities:
 - uid: 4048
   type: Firelock
   components:
-  - parent: 855
-    pos: -17.5,17.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 4049
-  type: Firelock
-  components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
+- uid: 4049
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -18.5,13.5
+    rot: 3.141592653589793 rad
+    type: Transform
 - uid: 4050
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -18.5,13.5
+  - parent: 854
+    pos: -17.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 4051
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -17.5,13.5
-    rot: 3.141592653589793 rad
-    type: Transform
-- uid: 4052
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: -17.5,14.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4053
+- uid: 4052
   type: HVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4054
+- uid: 4053
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,3.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4055
+- uid: 4054
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4056
+- uid: 4055
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,5.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4057
+- uid: 4056
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4058
+- uid: 4057
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: 11.5,4.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4059
+- uid: 4058
   type: PlushieCarp
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.134902,-3.2616267
     type: Transform
-- uid: 4060
+- uid: 4059
   type: PianoInstrument
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4061
+- uid: 4060
   type: FoodMint
   components:
-  - parent: 855
+  - parent: 854
     pos: -2.5880268,-3.3710017
     type: Transform
-- uid: 4062
+- uid: 4061
   type: solid_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4063
+- uid: 4062
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4064
+- uid: 4063
   type: FirelockGlass
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4065
+- uid: 4064
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4066
+- uid: 4065
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: 21.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4067
+- uid: 4066
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-7.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4068
+- uid: 4067
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-6.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4069
+- uid: 4068
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,24.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4070
+- uid: 4069
   type: Firelock
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,25.5
     rot: 3.141592653589793 rad
     type: Transform
   - airBlocked: False
     type: Airtight
-- uid: 4071
+- uid: 4070
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: -26.5,4.5
     rot: 3.141592653589793 rad
     type: Transform
+- uid: 4071
+  type: Firelock
+  components:
+  - parent: 854
+    pos: -18.5,17.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - airBlocked: False
+    type: Airtight
 - uid: 4072
   type: Firelock
   components:
-  - parent: 855
-    pos: -18.5,17.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 27.5,-11.5
+    rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
 - uid: 4073
   type: Firelock
   components:
-  - parent: 855
-    pos: 27.5,-11.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - airBlocked: False
-    type: Airtight
-- uid: 4074
-  type: Firelock
-  components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
   - airBlocked: False
     type: Airtight
+- uid: 4074
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: -19.5,13.5
+    rot: 3.141592653589793 rad
+    type: Transform
 - uid: 4075
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: -19.5,13.5
+  - parent: 854
+    pos: 0.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 4076
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 0.5,6.5
+  - parent: 854
+    pos: -0.5,6.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 4077
-  type: ApcExtensionCable
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -0.5,6.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: -3.5,-7.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4078
   type: solid_wall
   components:
-  - parent: 855
-    pos: -3.5,-7.5
+  - parent: 854
+    pos: -4.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4079
   type: solid_wall
   components:
-  - parent: 855
-    pos: -4.5,-7.5
+  - parent: 854
+    pos: -5.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4080
   type: solid_wall
   components:
-  - parent: 855
-    pos: -5.5,-7.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4081
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4082
+- uid: 4081
   type: MVWire
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,-7.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 4083
+- uid: 4082
   type: EmergencyLight
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.4964724,-8
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4084
+- uid: 4083
   type: AirlockMaint
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-6.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4084
+  type: Table
+  components:
+  - parent: 854
+    pos: -3.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4085
   type: Table
   components:
-  - parent: 855
-    pos: -3.5,-6.5
+  - parent: 854
+    pos: -4.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4086
-  type: Table
+  type: StoolBar
   components:
-  - parent: 855
-    pos: -4.5,-6.5
+  - parent: 854
+    pos: -6.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4087
   type: StoolBar
   components:
-  - parent: 855
-    pos: -6.5,-2.5
+  - parent: 854
+    pos: -5.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4088
   type: StoolBar
   components:
-  - parent: 855
-    pos: -5.5,-2.5
+  - parent: 854
+    pos: -4.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4089
   type: StoolBar
   components:
-  - parent: 855
-    pos: -4.5,-2.5
+  - parent: 854
+    pos: -3.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4090
   type: StoolBar
   components:
-  - parent: 855
-    pos: -3.5,-2.5
+  - parent: 854
+    pos: -2.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4091
-  type: StoolBar
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -2.5,-2.5
+  - parent: 854
+    pos: -26.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4092
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,-0.5
+  - parent: 854
+    pos: -27.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4093
   type: solid_wall
   components:
-  - parent: 855
-    pos: -27.5,-0.5
+  - parent: 854
+    pos: -28.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4094
   type: solid_wall
   components:
-  - parent: 855
-    pos: -28.5,-0.5
+  - parent: 854
+    pos: -29.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4095
   type: solid_wall
   components:
-  - parent: 855
-    pos: -29.5,-0.5
+  - parent: 854
+    pos: -30.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4096
   type: solid_wall
   components:
-  - parent: 855
-    pos: -30.5,-0.5
+  - parent: 854
+    pos: -26.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4097
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,-3.5
+  - parent: 854
+    pos: -27.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4098
   type: solid_wall
   components:
-  - parent: 855
-    pos: -27.5,-3.5
+  - parent: 854
+    pos: -28.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4099
   type: solid_wall
   components:
-  - parent: 855
-    pos: -28.5,-3.5
+  - parent: 854
+    pos: -31.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4100
   type: solid_wall
   components:
-  - parent: 855
-    pos: -31.5,-6.5
+  - parent: 854
+    pos: -26.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4101
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,-6.5
+  - parent: 854
+    pos: -27.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4102
   type: solid_wall
   components:
-  - parent: 855
-    pos: -27.5,-6.5
+  - parent: 854
+    pos: -28.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4103
   type: solid_wall
   components:
-  - parent: 855
-    pos: -28.5,-6.5
+  - parent: 854
+    pos: -29.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4104
   type: solid_wall
   components:
-  - parent: 855
-    pos: -29.5,-6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4105
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4106
+- uid: 4105
   type: AirlockMaint
   components:
-  - parent: 855
+  - parent: 854
     pos: -31.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4107
+- uid: 4106
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: -32.5,-7.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4107
+  type: solid_wall
+  components:
+  - parent: 854
+    pos: -26.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4108
   type: solid_wall
   components:
-  - parent: 855
-    pos: -26.5,-1.5
+  - parent: 854
+    pos: -26.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4109
-  type: solid_wall
+  type: Airlock
   components:
-  - parent: 855
-    pos: -26.5,-4.5
+  - name: Dorms 1
+    type: MetaData
+  - parent: 854
+    pos: -26.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4110
   type: Airlock
   components:
-  - name: Dorms 1
+  - name: Dorms 2
     type: MetaData
-  - parent: 855
-    pos: -26.5,0.5
+  - parent: 854
+    pos: -26.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4111
   type: Airlock
   components:
-  - name: Dorms 2
-    type: MetaData
-  - parent: 855
-    pos: -26.5,-2.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4112
-  type: Airlock
-  components:
   - name: Dorms 3
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: -26.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4113
+- uid: 4112
   type: SalternApc
   components:
-  - parent: 855
+  - parent: 854
     pos: -30.517641,-3.5
     rot: 3.141592653589793 rad
     type: Transform
-  - startingCharge: 11999.17
+  - startingCharge: 11998.34
     type: Battery
+  - drawRate: 2000
+    type: PowerConsumer
+- uid: 4113
+  type: Bed
+  components:
+  - parent: 854
+    pos: -27.5,-1.5
+    rot: 1.5707963267948966 rad
+    type: Transform
 - uid: 4114
   type: Bed
   components:
-  - parent: 855
-    pos: -27.5,-1.5
+  - parent: 854
+    pos: -27.5,1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4115
   type: Bed
   components:
-  - parent: 855
-    pos: -27.5,1.5
+  - parent: 854
+    pos: -27.5,-4.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4116
-  type: Bed
+  type: BedsheetNT
   components:
-  - parent: 855
-    pos: -27.5,-4.5
+  - parent: 854
+    pos: -27.5,1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4117
   type: BedsheetNT
   components:
-  - parent: 855
-    pos: -27.5,1.5
+  - parent: 854
+    pos: -27.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4118
   type: BedsheetNT
   components:
-  - parent: 855
-    pos: -27.5,-1.5
+  - parent: 854
+    pos: -27.5,-4.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4119
-  type: BedsheetNT
+  type: TableWood
   components:
-  - parent: 855
-    pos: -27.5,-4.5
+  - parent: 854
+    pos: -30.5,-4.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4120
   type: TableWood
   components:
-  - parent: 855
-    pos: -30.5,-4.5
+  - parent: 854
+    pos: -30.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4121
   type: TableWood
   components:
-  - parent: 855
-    pos: -30.5,-1.5
+  - parent: 854
+    pos: -30.5,1.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4122
-  type: TableWood
+  type: ChairWood
   components:
-  - parent: 855
-    pos: -30.5,1.5
+  - parent: 854
+    pos: -30.5,-5.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4123
   type: ChairWood
   components:
-  - parent: 855
-    pos: -30.5,-5.5
-    rot: 1.5707963267948966 rad
-    type: Transform
-- uid: 4124
-  type: ChairWood
-  components:
-  - parent: 855
+  - parent: 854
     pos: -30.5,-2.5
     rot: 1.5707963267948966 rad
     type: Transform
+- uid: 4124
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: -26,-0.5
+    type: Transform
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 4125
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -26,-0.5
+  - parent: 854
+    pos: 46.5,5
+    rot: -1.5707963267948966 rad
     type: Transform
   - powerLoad: 0
     type: PowerReceiver
@@ -44420,20 +44461,7 @@ entities:
 - uid: 4126
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 46.5,5
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 4127
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 38.5,10
     rot: -1.5707963267948966 rad
     type: Transform
@@ -44443,94 +44471,94 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 4127
+  type: CarpetGreen
+  components:
+  - parent: 854
+    pos: -29.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 4128
   type: CarpetGreen
   components:
-  - parent: 855
-    pos: -29.5,1.5
+  - parent: 854
+    pos: -29.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4129
   type: CarpetGreen
   components:
-  - parent: 855
-    pos: -29.5,0.5
+  - parent: 854
+    pos: -28.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4130
   type: CarpetGreen
   components:
-  - parent: 855
-    pos: -28.5,1.5
+  - parent: 854
+    pos: -28.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4131
-  type: CarpetGreen
+  type: CarpetGay
   components:
-  - parent: 855
-    pos: -28.5,0.5
+  - parent: 854
+    pos: -29.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4132
   type: CarpetGay
   components:
-  - parent: 855
-    pos: -29.5,-4.5
+  - parent: 854
+    pos: -29.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4133
   type: CarpetGay
   components:
-  - parent: 855
-    pos: -29.5,-5.5
+  - parent: 854
+    pos: -28.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4134
   type: CarpetGay
   components:
-  - parent: 855
-    pos: -28.5,-4.5
+  - parent: 854
+    pos: -28.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4135
-  type: CarpetGay
+  type: CarpetBlue
   components:
-  - parent: 855
-    pos: -28.5,-5.5
+  - parent: 854
+    pos: -29.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4136
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: -29.5,-1.5
+  - parent: 854
+    pos: -29.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4137
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: -29.5,-2.5
+  - parent: 854
+    pos: -28.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4138
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: -28.5,-1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4139
-  type: CarpetBlue
-  components:
-  - parent: 855
+  - parent: 854
     pos: -28.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4140
+- uid: 4139
   type: BoxDonkpocket
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-29.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -44538,45 +44566,45 @@ entities:
       storagebase:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4141
+- uid: 4140
   type: TableR
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,8.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4141
+  type: Bed
+  components:
+  - parent: 854
+    pos: -2.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4142
   type: Bed
   components:
-  - parent: 855
-    pos: -2.5,7.5
+  - parent: 854
+    pos: 0.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4143
-  type: Bed
+  type: BedsheetOrange
   components:
-  - parent: 855
-    pos: 0.5,7.5
+  - parent: 854
+    pos: -2.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4144
   type: BedsheetOrange
   components:
-  - parent: 855
-    pos: -2.5,7.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4145
-  type: BedsheetOrange
-  components:
-  - parent: 855
+  - parent: 854
     pos: 0.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4146
+- uid: 4145
   type: LockerGeneric
   components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -44586,10 +44614,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4147
+- uid: 4146
   type: LockerGeneric
   components:
-  - parent: 855
+  - parent: 854
     pos: -0.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -44599,11 +44627,23 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
+- uid: 4147
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: -31,-1.5
+    type: Transform
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 4148
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -31,-1.5
+  - parent: 854
+    pos: -31,1.5
     type: Transform
   - powerLoad: 0
     type: PowerReceiver
@@ -44614,8 +44654,8 @@ entities:
 - uid: 4149
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -31,1.5
+  - parent: 854
+    pos: -31,-4.5
     type: Transform
   - powerLoad: 0
     type: PowerReceiver
@@ -44626,19 +44666,7 @@ entities:
 - uid: 4150
   type: Poweredlight
   components:
-  - parent: 855
-    pos: -31,-4.5
-    type: Transform
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 4151
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,25
     rot: -1.5707963267948966 rad
     type: Transform
@@ -44646,17 +44674,17 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4152
+- uid: 4151
   type: Rack
   components:
-  - parent: 855
+  - parent: 854
     pos: 31.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4153
+- uid: 4152
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -8,-4.5
     type: Transform
   - powerLoad: 0
@@ -44665,81 +44693,93 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 4153
+  type: hydroponicsTray
+  components:
+  - parent: 854
+    pos: -18.5,1.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 4154
   type: hydroponicsTray
   components:
-  - parent: 855
-    pos: -18.5,1.5
+  - parent: 854
+    pos: -19.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4155
   type: hydroponicsTray
   components:
-  - parent: 855
-    pos: -19.5,1.5
+  - parent: 854
+    pos: -20.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4156
   type: hydroponicsTray
   components:
-  - parent: 855
-    pos: -20.5,1.5
+  - parent: 854
+    pos: -20.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4157
   type: hydroponicsTray
   components:
-  - parent: 855
-    pos: -20.5,0.5
+  - parent: 854
+    pos: -20.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4158
   type: hydroponicsTray
   components:
-  - parent: 855
-    pos: -20.5,-0.5
+  - parent: 854
+    pos: -19.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4159
   type: hydroponicsTray
   components:
-  - parent: 855
-    pos: -19.5,-0.5
+  - parent: 854
+    pos: -18.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4160
-  type: hydroponicsTray
+  type: solid_wall
   components:
-  - parent: 855
-    pos: -18.5,-0.5
+  - parent: 854
+    pos: 16.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4161
   type: solid_wall
   components:
-  - parent: 855
-    pos: 16.5,-13.5
+  - parent: 854
+    pos: 12.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4162
   type: solid_wall
   components:
-  - parent: 855
-    pos: 12.5,-12.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4163
-  type: solid_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
+- uid: 4163
+  type: Morgue
+  components:
+  - parent: 854
+    pos: 12.5,-13.5
+    type: Transform
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+      morgue_tray:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 4164
   type: Morgue
   components:
-  - parent: 855
-    pos: 12.5,-13.5
+  - parent: 854
+    pos: 12.5,-14.5
     type: Transform
   - containers:
       EntityStorageComponent:
@@ -44750,8 +44790,8 @@ entities:
 - uid: 4165
   type: Morgue
   components:
-  - parent: 855
-    pos: 12.5,-14.5
+  - parent: 854
+    pos: 12.5,-15.5
     type: Transform
   - containers:
       EntityStorageComponent:
@@ -44762,8 +44802,8 @@ entities:
 - uid: 4166
   type: Morgue
   components:
-  - parent: 855
-    pos: 12.5,-15.5
+  - parent: 854
+    pos: 12.5,-16.5
     type: Transform
   - containers:
       EntityStorageComponent:
@@ -44774,19 +44814,7 @@ entities:
 - uid: 4167
   type: Morgue
   components:
-  - parent: 855
-    pos: 12.5,-16.5
-    type: Transform
-  - containers:
-      EntityStorageComponent:
-        type: Robust.Server.GameObjects.Components.Container.Container
-      morgue_tray:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 4168
-  type: Morgue
-  components:
-  - parent: 855
+  - parent: 854
     pos: 12.5,-17.5
     type: Transform
   - containers:
@@ -44795,30 +44823,30 @@ entities:
       morgue_tray:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4169
+- uid: 4168
   type: SignMorgue
   components:
-  - parent: 855
+  - parent: 854
     pos: 17.313038,-12.573634
+    type: Transform
+- uid: 4169
+  type: TableMetal
+  components:
+  - parent: 854
+    pos: 14.5,-13.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4170
   type: TableMetal
   components:
-  - parent: 855
-    pos: 14.5,-13.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4171
-  type: TableMetal
-  components:
-  - parent: 855
+  - parent: 854
     pos: 15.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4172
+- uid: 4171
   type: CrayonBoxFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -19.173923,-9.122305
     rot: 3.141592653589793 rad
     type: Transform
@@ -44826,10 +44854,10 @@ entities:
       storagebase:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4173
+- uid: 4172
   type: MagazinePistolSmgTopMounted
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.129097,21.659065
     rot: 3.141592653589793 rad
     type: Transform
@@ -44837,10 +44865,10 @@ entities:
       RangedMagazine-magazine:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4174
+- uid: 4173
   type: MagazinePistolSmgTopMounted
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.347847,21.83094
     rot: 3.141592653589793 rad
     type: Transform
@@ -44848,58 +44876,58 @@ entities:
       RangedMagazine-magazine:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4175
+- uid: 4174
   type: AirlockMedicalLocked
   components:
   - name: Morgue
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 16.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4176
+- uid: 4175
   type: computerBodyScanner
   components:
-  - parent: 855
+  - parent: 854
     pos: 10.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
   - containers:
       board:
         entities:
-        - 4177
+        - 4176
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4177
+- uid: 4176
   type: BodyScannerComputerCircuitboard
   components:
-  - parent: 4176
+  - parent: 4175
     type: Transform
-- uid: 4178
+- uid: 4177
   type: Rack
   components:
-  - parent: 855
+  - parent: 854
     pos: 29.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4179
+- uid: 4178
   type: BarSign
   components:
-  - parent: 855
+  - parent: 854
     pos: -5.5,2.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4180
+- uid: 4179
   type: SignBar
   components:
-  - parent: 855
+  - parent: 854
     pos: 0.7031777,2.4187772
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4181
+- uid: 4180
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,2
     rot: -1.5707963267948966 rad
     type: Transform
@@ -44909,10 +44937,10 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4182
+- uid: 4181
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 1.5,1
     rot: -1.5707963267948966 rad
     type: Transform
@@ -44922,35 +44950,24 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4183
+- uid: 4182
   type: MopBucket
   components:
-  - parent: 855
+  - parent: 854
     pos: -21.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4184
-  type: ComputerSupplyOrdering
+- uid: 4183
+  type: AMEJar
   components:
-  - parent: 855
-    pos: 23.5,13.5
+  - parent: 854
+    pos: 38.585155,11.629917
     rot: -1.5707963267948966 rad
     type: Transform
-  - containers:
-      board:
-        entities:
-        - 4185
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
-- uid: 4185
-  type: SupplyComputerCircuitboard
-  components:
-  - parent: 4184
-    type: Transform
-- uid: 4186
+- uid: 4184
   type: KitchenReagentGrinder
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -44960,136 +44977,136 @@ entities:
       ReagentGrinder-entityContainerContainer:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4187
+- uid: 4185
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4188
+- uid: 4186
   type: ApcExtensionCable
   components:
-  - parent: 855
+  - parent: 854
     pos: 25.5,-10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4187
+  type: Carpet
+  components:
+  - parent: 854
+    pos: -8.5,0.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4188
+  type: Carpet
+  components:
+  - parent: 854
+    pos: -8.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4189
   type: Carpet
   components:
-  - parent: 855
-    pos: -8.5,0.5
+  - parent: 854
+    pos: -7.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4190
   type: Carpet
   components:
-  - parent: 855
-    pos: -8.5,-0.5
+  - parent: 854
+    pos: -7.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4191
   type: Carpet
   components:
-  - parent: 855
-    pos: -7.5,0.5
+  - parent: 854
+    pos: -6.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4192
   type: Carpet
   components:
-  - parent: 855
-    pos: -7.5,-0.5
+  - parent: 854
+    pos: -6.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4193
   type: Carpet
   components:
-  - parent: 855
-    pos: -6.5,0.5
+  - parent: 854
+    pos: -5.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4194
   type: Carpet
   components:
-  - parent: 855
-    pos: -6.5,-0.5
+  - parent: 854
+    pos: -5.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4195
   type: Carpet
   components:
-  - parent: 855
-    pos: -5.5,0.5
+  - parent: 854
+    pos: -4.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4196
   type: Carpet
   components:
-  - parent: 855
-    pos: -5.5,-0.5
+  - parent: 854
+    pos: -4.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4197
   type: Carpet
   components:
-  - parent: 855
-    pos: -4.5,0.5
+  - parent: 854
+    pos: -3.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4198
   type: Carpet
   components:
-  - parent: 855
-    pos: -4.5,-0.5
+  - parent: 854
+    pos: -3.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4199
   type: Carpet
   components:
-  - parent: 855
-    pos: -3.5,0.5
+  - parent: 854
+    pos: -2.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4200
   type: Carpet
   components:
-  - parent: 855
-    pos: -3.5,-0.5
+  - parent: 854
+    pos: -2.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4201
   type: Carpet
   components:
-  - parent: 855
-    pos: -2.5,0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4202
-  type: Carpet
-  components:
-  - parent: 855
-    pos: -2.5,-0.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4203
-  type: Carpet
-  components:
-  - parent: 855
+  - parent: 854
     pos: -1.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4204
+- uid: 4202
   type: KitchenSpike
   components:
-  - parent: 855
+  - parent: 854
     pos: -9.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4205
+- uid: 4203
   type: LockerFreezer
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -45099,10 +45116,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4206
+- uid: 4204
   type: LockerFreezer
   components:
-  - parent: 855
+  - parent: 854
     pos: -13.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
@@ -45112,10 +45129,10 @@ entities:
       EntityStorageComponent:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4207
+- uid: 4205
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -11.5,-5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -45125,143 +45142,143 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4208
+- uid: 4206
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 4209
+- uid: 4207
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-1.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 4210
+- uid: 4208
   type: Carpet
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,-1.5
+    rot: 1.5707963267948966 rad
+    type: Transform
+- uid: 4209
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -9.5,23.5
+    rot: 1.5707963267948966 rad
+    type: Transform
+- uid: 4210
+  type: reinforced_wall
+  components:
+  - parent: 854
+    pos: -8.5,23.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4211
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: -9.5,23.5
-    rot: 1.5707963267948966 rad
-    type: Transform
-- uid: 4212
-  type: reinforced_wall
-  components:
-  - parent: 855
-    pos: -8.5,23.5
-    rot: 1.5707963267948966 rad
-    type: Transform
-- uid: 4213
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,23.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 4214
+- uid: 4212
   type: SpawnPointHeadOfSecurity
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,22.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4213
+  type: CarpetBlack
+  components:
+  - parent: 854
+    pos: -6.5,22.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4214
+  type: CarpetBlack
+  components:
+  - parent: 854
+    pos: -6.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4215
   type: CarpetBlack
   components:
-  - parent: 855
-    pos: -6.5,22.5
+  - parent: 854
+    pos: -6.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4216
   type: CarpetBlack
   components:
-  - parent: 855
-    pos: -6.5,21.5
+  - parent: 854
+    pos: -7.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4217
   type: CarpetBlack
   components:
-  - parent: 855
-    pos: -6.5,20.5
+  - parent: 854
+    pos: -7.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4218
   type: CarpetBlack
   components:
-  - parent: 855
-    pos: -7.5,22.5
+  - parent: 854
+    pos: -7.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4219
   type: CarpetBlack
   components:
-  - parent: 855
-    pos: -7.5,21.5
+  - parent: 854
+    pos: -8.5,22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4220
   type: CarpetBlack
   components:
-  - parent: 855
-    pos: -7.5,20.5
+  - parent: 854
+    pos: -8.5,21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4221
   type: CarpetBlack
   components:
-  - parent: 855
-    pos: -8.5,22.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4222
-  type: CarpetBlack
-  components:
-  - parent: 855
-    pos: -8.5,21.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4223
-  type: CarpetBlack
-  components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4224
+- uid: 4222
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,20.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 4225
+- uid: 4223
   type: Chair
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,20.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 4226
+- uid: 4224
   type: TableWood
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,21.5
     rot: 1.5707963267948966 rad
     type: Transform
-- uid: 4227
+- uid: 4225
   type: WeaponCapacitorRecharger
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,21.5
     rot: 1.5707963267948966 rad
     type: Transform
@@ -45271,107 +45288,131 @@ entities:
       WeaponCapacitorCharger-powerCellContainer:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 4226
+  type: Table
+  components:
+  - parent: 854
+    pos: -4.5,14.5
+    rot: 1.5707963267948966 rad
+    type: Transform
+- uid: 4227
+  type: Table
+  components:
+  - parent: 854
+    pos: -4.5,13.5
+    rot: 1.5707963267948966 rad
+    type: Transform
 - uid: 4228
   type: Table
   components:
-  - parent: 855
-    pos: -4.5,14.5
+  - parent: 854
+    pos: -5.5,13.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4229
   type: Table
   components:
-  - parent: 855
-    pos: -4.5,13.5
+  - parent: 854
+    pos: -6.5,13.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4230
   type: Table
   components:
-  - parent: 855
-    pos: -5.5,13.5
+  - parent: 854
+    pos: -7.5,13.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4231
   type: Table
   components:
-  - parent: 855
-    pos: -6.5,13.5
+  - parent: 854
+    pos: -7.5,14.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4232
-  type: Table
+  type: Chair
   components:
-  - parent: 855
-    pos: -7.5,13.5
+  - parent: 854
+    pos: -4.5,12.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4233
-  type: Table
+  type: Chair
   components:
-  - parent: 855
-    pos: -7.5,14.5
+  - parent: 854
+    pos: -5.5,12.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4234
   type: Chair
   components:
-  - parent: 855
-    pos: -4.5,12.5
+  - parent: 854
+    pos: -6.5,12.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4235
   type: Chair
   components:
-  - parent: 855
-    pos: -5.5,12.5
+  - parent: 854
+    pos: -7.5,12.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4236
   type: Chair
   components:
-  - parent: 855
-    pos: -6.5,12.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -8.5,13.5
     type: Transform
 - uid: 4237
   type: Chair
   components:
-  - parent: 855
-    pos: -7.5,12.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: -8.5,14.5
     type: Transform
 - uid: 4238
   type: Chair
   components:
-  - parent: 855
-    pos: -8.5,13.5
+  - parent: 854
+    pos: -3.5,14.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 4239
   type: Chair
   components:
-  - parent: 855
-    pos: -8.5,14.5
-    type: Transform
-- uid: 4240
-  type: Chair
-  components:
-  - parent: 855
-    pos: -3.5,14.5
-    rot: 3.141592653589793 rad
-    type: Transform
-- uid: 4241
-  type: Chair
-  components:
-  - parent: 855
+  - parent: 854
     pos: -3.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4242
+- uid: 4240
   type: BoxHandcuff
   components:
-  - parent: 855
+  - parent: 854
     pos: -4.5,14.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - containers:
+      storagebase:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
+- uid: 4241
+  type: WeaponCapacitorRecharger
+  components:
+  - parent: 854
+    pos: -7.5,14.5
+    rot: 3.141592653589793 rad
+    type: Transform
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      WeaponCapacitorCharger-powerCellContainer:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
+- uid: 4242
+  type: BoxDonkpocket
+  components:
+  - parent: 854
+    pos: -5.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
   - containers:
@@ -45379,75 +45420,51 @@ entities:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
 - uid: 4243
-  type: WeaponCapacitorRecharger
+  type: RadioHandheld
   components:
-  - parent: 855
-    pos: -7.5,14.5
+  - parent: 854
+    pos: -7.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      WeaponCapacitorCharger-powerCellContainer:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
 - uid: 4244
-  type: BoxDonkpocket
+  type: RadioHandheld
   components:
-  - parent: 855
-    pos: -5.5,13.5
+  - parent: 854
+    pos: -4.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
-  - containers:
-      storagebase:
-        type: Robust.Server.GameObjects.Components.Container.Container
-    type: ContainerContainer
 - uid: 4245
   type: RadioHandheld
   components:
-  - parent: 855
-    pos: -7.5,13.5
+  - parent: 854
+    pos: 1.5,28.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 4246
   type: RadioHandheld
   components:
-  - parent: 855
-    pos: -4.5,13.5
-    rot: 3.141592653589793 rad
-    type: Transform
-- uid: 4247
-  type: RadioHandheld
-  components:
-  - parent: 855
-    pos: 1.5,28.5
-    rot: 3.141592653589793 rad
-    type: Transform
-- uid: 4248
-  type: RadioHandheld
-  components:
-  - parent: 855
+  - parent: 854
     pos: 26.5,8.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4249
+- uid: 4247
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-28.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4250
+- uid: 4248
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-29.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4251
+- uid: 4249
   type: KitchenMicrowave
   components:
-  - parent: 855
+  - parent: 854
     pos: -7.5,-28.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -45455,17 +45472,17 @@ entities:
       microwave_entity_container:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4252
+- uid: 4250
   type: ClothingHeadHelmetScaf
   components:
-  - parent: 855
+  - parent: 854
     pos: 13.5,24.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4253
+- uid: 4251
   type: ClothingBeltSecurityFilled
   components:
-  - parent: 855
+  - parent: 854
     pos: -6.5,13.5
     rot: 3.141592653589793 rad
     type: Transform
@@ -45473,38 +45490,38 @@ entities:
       storagebase:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4254
+- uid: 4252
   type: Shelf
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,7.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4255
+- uid: 4253
   type: SprayBottleSpaceCleaner
   components:
-  - parent: 855
+  - parent: 854
     pos: -20.5,7.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4256
+- uid: 4254
   type: RCDAmmo
   components:
-  - parent: 855
+  - parent: 854
     pos: 32.5,-2.5
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4257
+- uid: 4255
   type: RCDAmmo
   components:
-  - parent: 855
+  - parent: 854
     pos: 32.812416,-2.3740568
     rot: 3.141592653589793 rad
     type: Transform
-- uid: 4258
+- uid: 4256
   type: SmgWt550
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.457222,21.596565
     rot: 3.141592653589793 rad
     type: Transform
@@ -45515,22 +45532,22 @@ entities:
         type: Content.Server.GameObjects.ContainerSlot
       MagazineBarrel-magazine:
         entities:
-        - 4259
+        - 4257
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4259
+- uid: 4257
   type: MagazinePistolSmgTopMounted
   components:
-  - parent: 4258
+  - parent: 4256
     type: Transform
   - containers:
       RangedMagazine-magazine:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
-- uid: 4260
+- uid: 4258
   type: BodyBag_Container
   components:
-  - parent: 855
+  - parent: 854
     pos: 14.594889,-13.278449
     rot: 3.141592653589793 rad
     type: Transform
@@ -45540,10 +45557,10 @@ entities:
       body_bag_label:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4261
+- uid: 4259
   type: BodyBag_Container
   components:
-  - parent: 855
+  - parent: 854
     pos: 15.594889,-13.262824
     rot: 3.141592653589793 rad
     type: Transform
@@ -45553,10 +45570,10 @@ entities:
       body_bag_label:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4262
+- uid: 4260
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: -8.5,23
     rot: -1.5707963267948966 rad
     type: Transform
@@ -45566,88 +45583,88 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4263
+- uid: 4261
   type: TableMetal
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,18.5
     type: Transform
-- uid: 4264
+- uid: 4262
   type: TableMetal
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.5,19.5
     type: Transform
-- uid: 4265
+- uid: 4263
   type: BoxFlashbang
   components:
-  - parent: 855
+  - parent: 854
     pos: -14.43611,19.60069
     type: Transform
   - containers:
       storagebase:
         type: Robust.Server.GameObjects.Components.Container.Container
     type: ContainerContainer
+- uid: 4264
+  type: CarpetBlue
+  components:
+  - parent: 854
+    pos: 8.5,20.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4265
+  type: CarpetBlue
+  components:
+  - parent: 854
+    pos: 8.5,19.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 4266
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: 8.5,20.5
+  - parent: 854
+    pos: 8.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4267
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: 8.5,19.5
+  - parent: 854
+    pos: 8.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4268
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: 8.5,18.5
+  - parent: 854
+    pos: 9.5,20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4269
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: 8.5,17.5
+  - parent: 854
+    pos: 9.5,19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4270
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: 9.5,20.5
+  - parent: 854
+    pos: 9.5,18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4271
   type: CarpetBlue
   components:
-  - parent: 855
-    pos: 9.5,19.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4272
-  type: CarpetBlue
-  components:
-  - parent: 855
-    pos: 9.5,18.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4273
-  type: CarpetBlue
-  components:
-  - parent: 855
+  - parent: 854
     pos: 9.5,17.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4274
+- uid: 4272
   type: LampGold
   components:
-  - parent: 855
+  - parent: 854
     pos: 9.434699,18.224125
     rot: -1.5707963267948966 rad
     type: Transform
@@ -45655,350 +45672,350 @@ entities:
       cellslot_cell_container:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
-- uid: 4275
+- uid: 4273
   type: Table
   components:
-  - parent: 855
+  - parent: 854
     pos: -10.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4276
+- uid: 4274
   type: ProtolatheMachineCircuitboard
   components:
-  - parent: 1045
+  - parent: 1044
+    type: Transform
+- uid: 4275
+  type: MatterBinStockPart
+  components:
+  - parent: 1044
+    type: Transform
+- uid: 4276
+  type: MatterBinStockPart
+  components:
+  - parent: 1044
     type: Transform
 - uid: 4277
-  type: MatterBinStockPart
+  type: MicroManipulatorStockPart
   components:
-  - parent: 1045
+  - parent: 1044
     type: Transform
 - uid: 4278
-  type: MatterBinStockPart
+  type: MicroManipulatorStockPart
   components:
-  - parent: 1045
+  - parent: 1044
     type: Transform
 - uid: 4279
-  type: MicroManipulatorStockPart
+  type: Beaker
   components:
-  - parent: 1045
+  - parent: 1044
     type: Transform
 - uid: 4280
-  type: MicroManipulatorStockPart
+  type: Beaker
   components:
-  - parent: 1045
+  - parent: 1044
     type: Transform
 - uid: 4281
-  type: Beaker
+  type: TraitorDMRedemptionMachineSpawner
   components:
-  - parent: 1045
+  - parent: 854
+    pos: -18.5,25.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4282
-  type: Beaker
+  type: TraitorDMRedemptionMachineSpawner
   components:
-  - parent: 1045
+  - parent: 854
+    pos: 10.5,13.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4283
   type: TraitorDMRedemptionMachineSpawner
   components:
-  - parent: 855
-    pos: -18.5,25.5
+  - parent: 854
+    pos: -9.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4284
   type: TraitorDMRedemptionMachineSpawner
   components:
-  - parent: 855
-    pos: 10.5,13.5
+  - parent: 854
+    pos: 27.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4285
-  type: TraitorDMRedemptionMachineSpawner
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: -9.5,-25.5
+  - parent: 854
+    pos: 52.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4286
-  type: TraitorDMRedemptionMachineSpawner
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: 27.5,-1.5
+  - parent: 854
+    pos: 52.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4287
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 52.5,-1.5
+  - parent: 854
+    pos: 52.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4288
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 52.5,-2.5
+  - parent: 854
+    pos: 52.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4289
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 52.5,-3.5
+  - parent: 854
+    pos: 52.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4290
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 52.5,-4.5
+  - parent: 854
+    pos: 52.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4291
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 52.5,-5.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4292
-  type: reinforced_wall
-  components:
-  - parent: 855
-    pos: 52.5,-6.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4293
-  type: reinforced_wall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 52.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4294
+- uid: 4292
   type: SinguloGenerator
   components:
-  - parent: 855
+  - parent: 854
     pos: 49.5,-24.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4293
+  type: LowWall
+  components:
+  - parent: 854
+    pos: 46.5,14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4294
+  type: LowWall
+  components:
+  - parent: 854
+    pos: 47.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4295
   type: LowWall
   components:
-  - parent: 855
-    pos: 46.5,14.5
+  - parent: 854
+    pos: 48.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4296
   type: LowWall
   components:
-  - parent: 855
-    pos: 47.5,14.5
+  - parent: 854
+    pos: 49.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4297
   type: LowWall
   components:
-  - parent: 855
-    pos: 48.5,14.5
+  - parent: 854
+    pos: 50.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4298
   type: LowWall
   components:
-  - parent: 855
-    pos: 49.5,14.5
+  - parent: 854
+    pos: 51.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4299
   type: LowWall
   components:
-  - parent: 855
-    pos: 50.5,14.5
+  - parent: 854
+    pos: 51.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4300
   type: LowWall
   components:
-  - parent: 855
-    pos: 51.5,14.5
+  - parent: 854
+    pos: 51.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4301
   type: LowWall
   components:
-  - parent: 855
-    pos: 51.5,13.5
+  - parent: 854
+    pos: 51.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4302
   type: LowWall
   components:
-  - parent: 855
-    pos: 51.5,12.5
+  - parent: 854
+    pos: 51.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4303
   type: LowWall
   components:
-  - parent: 855
-    pos: 51.5,11.5
+  - parent: 854
+    pos: 51.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4304
   type: LowWall
   components:
-  - parent: 855
-    pos: 51.5,10.5
+  - parent: 854
+    pos: 51.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4305
   type: LowWall
   components:
-  - parent: 855
-    pos: 51.5,9.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4306
-  type: LowWall
-  components:
-  - parent: 855
-    pos: 51.5,8.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4307
-  type: LowWall
-  components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4308
+- uid: 4306
   type: reinforced_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,6.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4309
+- uid: 4307
   type: reinforced_wall
   components:
-  - parent: 855
+  - parent: 854
     pos: 45.5,14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4308
+  type: ReinforcedWindow
+  components:
+  - parent: 854
+    pos: 46.5,14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4309
+  type: ReinforcedWindow
+  components:
+  - parent: 854
+    pos: 47.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4310
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 46.5,14.5
+  - parent: 854
+    pos: 48.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4311
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 47.5,14.5
+  - parent: 854
+    pos: 49.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4312
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 48.5,14.5
+  - parent: 854
+    pos: 50.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4313
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 49.5,14.5
+  - parent: 854
+    pos: 51.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4314
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 50.5,14.5
+  - parent: 854
+    pos: 51.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4315
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 51.5,14.5
+  - parent: 854
+    pos: 51.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4316
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 51.5,13.5
+  - parent: 854
+    pos: 51.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4317
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 51.5,12.5
+  - parent: 854
+    pos: 51.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4318
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 51.5,11.5
+  - parent: 854
+    pos: 51.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4319
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 51.5,10.5
+  - parent: 854
+    pos: 51.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4320
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 51.5,9.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4321
-  type: ReinforcedWindow
-  components:
-  - parent: 855
-    pos: 51.5,8.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4322
-  type: ReinforcedWindow
-  components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4323
+- uid: 4321
   type: AirlockEngineeringLocked
   components:
   - name: Antimatter Engine
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 45.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4324
+- uid: 4322
   type: AirlockEngineeringLocked
   components:
   - name: Antimatter Engine
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 45.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4325
+- uid: 4323
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 45,12.5
     type: Transform
   - powerLoad: 0
@@ -46007,122 +46024,122 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 4324
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: 45.5,8.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4325
+  type: ApcExtensionCable
+  components:
+  - parent: 854
+    pos: 46.5,8.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 4326
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 45.5,8.5
+  - parent: 854
+    pos: 46.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4327
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 46.5,8.5
+  - parent: 854
+    pos: 47.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4328
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 46.5,12.5
+  - parent: 854
+    pos: 47.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4329
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,9.5
+  - parent: 854
+    pos: 47.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4330
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,10.5
+  - parent: 854
+    pos: 47.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4331
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,11.5
+  - parent: 854
+    pos: 47.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4332
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,12.5
+  - parent: 854
+    pos: 47.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4333
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,8.5
+  - parent: 854
+    pos: 49.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4334
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,7.5
+  - parent: 854
+    pos: 49.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4335
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,12.5
+  - parent: 854
+    pos: 49.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4336
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,11.5
+  - parent: 854
+    pos: 49.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4337
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,10.5
+  - parent: 854
+    pos: 49.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4338
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,9.5
+  - parent: 854
+    pos: 49.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4339
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,8.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4340
-  type: ApcExtensionCable
-  components:
-  - parent: 855
-    pos: 49.5,7.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4341
-  type: ApcExtensionCable
-  components:
-  - parent: 855
+  - parent: 854
     pos: 48.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4342
+- uid: 4340
   type: Poweredlight
   components:
-  - parent: 855
+  - parent: 854
     pos: 46,6.5
     type: Transform
   - powerLoad: 0
@@ -46131,1031 +46148,1057 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 4341
+  type: HVWire
+  components:
+  - parent: 854
+    pos: 42.5,7.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4342
+  type: HVWire
+  components:
+  - parent: 854
+    pos: 43.5,7.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 4343
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,7.5
+  - parent: 854
+    pos: 44.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4344
   type: HVWire
   components:
-  - parent: 855
-    pos: 43.5,7.5
+  - parent: 854
+    pos: 45.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4345
   type: HVWire
   components:
-  - parent: 855
-    pos: 44.5,7.5
+  - parent: 854
+    pos: 46.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4346
   type: HVWire
   components:
-  - parent: 855
-    pos: 45.5,7.5
+  - parent: 854
+    pos: 47.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4347
   type: HVWire
   components:
-  - parent: 855
-    pos: 46.5,7.5
+  - parent: 854
+    pos: 48.5,7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4348
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,7.5
+  - parent: 854
+    pos: 48.5,8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4349
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,7.5
+  - parent: 854
+    pos: 48.5,9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4350
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,8.5
+  - parent: 854
+    pos: 48.5,10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4351
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,9.5
+  - parent: 854
+    pos: 48.5,11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4352
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,10.5
+  - parent: 854
+    pos: 48.5,12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4353
-  type: HVWire
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: 48.5,11.5
+  - parent: 854
+    pos: 46.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4354
-  type: HVWire
+  type: reinforced_wall
   components:
-  - parent: 855
-    pos: 48.5,12.5
+  - parent: 854
+    pos: 45.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4355
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-8.5
+  - parent: 854
+    pos: 44.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4356
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 45.5,-8.5
+  - parent: 854
+    pos: 43.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4357
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 44.5,-8.5
+  - parent: 854
+    pos: 43.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4358
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,-8.5
+  - parent: 854
+    pos: 43.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4359
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,-9.5
+  - parent: 854
+    pos: 43.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4360
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,-10.5
+  - parent: 854
+    pos: 43.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4361
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,-11.5
+  - parent: 854
+    pos: 43.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4362
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,-12.5
+  - parent: 854
+    pos: 43.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4363
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,-13.5
+  - parent: 854
+    pos: 55.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4364
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 43.5,-14.5
+  - parent: 854
+    pos: 55.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4365
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 55.5,-14.5
+  - parent: 854
+    pos: 55.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4366
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 55.5,-13.5
+  - parent: 854
+    pos: 55.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4367
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 55.5,-12.5
+  - parent: 854
+    pos: 55.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4368
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 55.5,-11.5
+  - parent: 854
+    pos: 55.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4369
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 55.5,-10.5
+  - parent: 854
+    pos: 55.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4370
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 55.5,-9.5
+  - parent: 854
+    pos: 54.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4371
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 55.5,-8.5
+  - parent: 854
+    pos: 53.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4372
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 54.5,-8.5
+  - parent: 854
+    pos: 52.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4373
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 53.5,-8.5
+  - parent: 854
+    pos: 46.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4374
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 52.5,-8.5
+  - parent: 854
+    pos: 46.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4375
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-10.5
+  - parent: 854
+    pos: 46.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4376
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-11.5
+  - parent: 854
+    pos: 52.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4377
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 46.5,-12.5
+  - parent: 854
+    pos: 52.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4378
   type: reinforced_wall
   components:
-  - parent: 855
-    pos: 52.5,-12.5
+  - parent: 854
+    pos: 52.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4379
-  type: reinforced_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 52.5,-11.5
+  - parent: 854
+    pos: 46.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4380
-  type: reinforced_wall
+  type: LowWall
   components:
-  - parent: 855
-    pos: 52.5,-10.5
+  - parent: 854
+    pos: 46.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4381
   type: LowWall
   components:
-  - parent: 855
-    pos: 46.5,-13.5
+  - parent: 854
+    pos: 45.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4382
   type: LowWall
   components:
-  - parent: 855
-    pos: 46.5,-14.5
+  - parent: 854
+    pos: 47.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4383
   type: LowWall
   components:
-  - parent: 855
-    pos: 45.5,-14.5
+  - parent: 854
+    pos: 48.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4384
   type: LowWall
   components:
-  - parent: 855
-    pos: 47.5,-14.5
+  - parent: 854
+    pos: 49.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4385
   type: LowWall
   components:
-  - parent: 855
-    pos: 48.5,-14.5
+  - parent: 854
+    pos: 50.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4386
   type: LowWall
   components:
-  - parent: 855
-    pos: 49.5,-14.5
+  - parent: 854
+    pos: 51.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4387
   type: LowWall
   components:
-  - parent: 855
-    pos: 50.5,-14.5
+  - parent: 854
+    pos: 52.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4388
   type: LowWall
   components:
-  - parent: 855
-    pos: 51.5,-14.5
+  - parent: 854
+    pos: 52.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4389
   type: LowWall
   components:
-  - parent: 855
-    pos: 52.5,-14.5
+  - parent: 854
+    pos: 53.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4390
-  type: LowWall
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 52.5,-13.5
+  - parent: 854
+    pos: 46.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4391
-  type: LowWall
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 53.5,-14.5
+  - parent: 854
+    pos: 46.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4392
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 46.5,-13.5
+  - parent: 854
+    pos: 45.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4393
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 46.5,-14.5
+  - parent: 854
+    pos: 47.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4394
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 45.5,-14.5
+  - parent: 854
+    pos: 48.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4395
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 47.5,-14.5
+  - parent: 854
+    pos: 52.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4396
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 48.5,-14.5
+  - parent: 854
+    pos: 53.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4397
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 52.5,-13.5
+  - parent: 854
+    pos: 52.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4398
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 53.5,-14.5
+  - parent: 854
+    pos: 51.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4399
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 52.5,-14.5
+  - parent: 854
+    pos: 50.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4400
   type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 51.5,-14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4401
-  type: ReinforcedWindow
-  components:
-  - parent: 855
-    pos: 50.5,-14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4402
-  type: ReinforcedWindow
-  components:
-  - parent: 855
+  - parent: 854
     pos: 49.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4403
+- uid: 4401
   type: AirlockExternalLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 44.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4404
+- uid: 4402
   type: AirlockExternalLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 54.5,-14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4403
+  type: Emitter
+  components:
+  - parent: 854
+    pos: 45.5,-17.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4404
+  type: Emitter
+  components:
+  - parent: 854
+    pos: 49.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4405
   type: Emitter
   components:
-  - parent: 855
-    pos: 45.5,-17.5
+  - parent: 854
+    pos: 53.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4406
   type: Emitter
   components:
-  - parent: 855
-    pos: 49.5,-17.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 56.5,-20.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 4407
   type: Emitter
   components:
-  - parent: 855
-    pos: 53.5,-17.5
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 56.5,-24.5
+    rot: 3.141592653589793 rad
     type: Transform
 - uid: 4408
   type: Emitter
   components:
-  - parent: 855
-    pos: 56.5,-20.5
+  - parent: 854
+    pos: 56.5,-28.5
     rot: 3.141592653589793 rad
     type: Transform
 - uid: 4409
   type: Emitter
   components:
-  - parent: 855
-    pos: 56.5,-24.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 53.5,-31.5
+    rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4410
   type: Emitter
   components:
-  - parent: 855
-    pos: 56.5,-28.5
-    rot: 3.141592653589793 rad
+  - parent: 854
+    pos: 49.5,-31.5
+    rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4411
   type: Emitter
   components:
-  - parent: 855
-    pos: 53.5,-31.5
+  - parent: 854
+    pos: 45.5,-31.5
     rot: 1.5707963267948966 rad
     type: Transform
 - uid: 4412
   type: Emitter
   components:
-  - parent: 855
-    pos: 49.5,-31.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 42.5,-28.5
     type: Transform
 - uid: 4413
   type: Emitter
   components:
-  - parent: 855
-    pos: 45.5,-31.5
-    rot: 1.5707963267948966 rad
+  - parent: 854
+    pos: 42.5,-24.5
     type: Transform
 - uid: 4414
   type: Emitter
   components:
-  - parent: 855
-    pos: 42.5,-28.5
+  - parent: 854
+    pos: 42.5,-20.5
     type: Transform
 - uid: 4415
-  type: Emitter
+  type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 42.5,-24.5
+  - parent: 854
+    pos: 44.5,-12.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4416
-  type: Emitter
+  type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 42.5,-20.5
+  - parent: 854
+    pos: 44.5,-11.5
+    rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4417
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,-12.5
+  - parent: 854
+    pos: 44.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4418
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,-11.5
+  - parent: 854
+    pos: 44.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4419
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,-10.5
+  - parent: 854
+    pos: 45.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4420
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 44.5,-9.5
+  - parent: 854
+    pos: 46.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4421
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 45.5,-9.5
+  - parent: 854
+    pos: 54.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4422
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 46.5,-9.5
+  - parent: 854
+    pos: 54.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4423
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 54.5,-12.5
+  - parent: 854
+    pos: 54.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4424
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 54.5,-11.5
+  - parent: 854
+    pos: 54.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4425
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 54.5,-10.5
+  - parent: 854
+    pos: 53.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4426
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 54.5,-9.5
+  - parent: 854
+    pos: 52.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4427
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 53.5,-9.5
+  - parent: 854
+    pos: 51.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4428
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 52.5,-9.5
+  - parent: 854
+    pos: 47.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4429
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 51.5,-9.5
+  - parent: 854
+    pos: 48.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4430
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,-9.5
+  - parent: 854
+    pos: 49.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4431
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 48.5,-9.5
+  - parent: 854
+    pos: 50.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4432
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,-9.5
+  - parent: 854
+    pos: 49.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4433
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 50.5,-9.5
+  - parent: 854
+    pos: 49.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4434
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,-8.5
+  - parent: 854
+    pos: 49.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4435
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,-7.5
+  - parent: 854
+    pos: 48.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4436
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,-6.5
+  - parent: 854
+    pos: 47.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4437
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 48.5,-6.5
+  - parent: 854
+    pos: 47.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4438
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,-6.5
+  - parent: 854
+    pos: 47.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4439
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,-5.5
+  - parent: 854
+    pos: 49.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4440
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 47.5,-4.5
+  - parent: 854
+    pos: 49.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4441
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,-10.5
+  - parent: 854
+    pos: 49.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4442
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,-11.5
+  - parent: 854
+    pos: 48.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4443
   type: ApcExtensionCable
   components:
-  - parent: 855
-    pos: 49.5,-12.5
+  - parent: 854
+    pos: 50.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4444
-  type: ApcExtensionCable
+  type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-11.5
+  - parent: 854
+    pos: 45.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4445
-  type: ApcExtensionCable
+  type: HVWire
   components:
-  - parent: 855
-    pos: 50.5,-11.5
+  - parent: 854
+    pos: 45.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4446
   type: HVWire
   components:
-  - parent: 855
-    pos: 45.5,-11.5
+  - parent: 854
+    pos: 45.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4447
   type: HVWire
   components:
-  - parent: 855
-    pos: 45.5,-10.5
+  - parent: 854
+    pos: 46.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4448
   type: HVWire
   components:
-  - parent: 855
-    pos: 45.5,-12.5
+  - parent: 854
+    pos: 47.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4449
   type: HVWire
   components:
-  - parent: 855
-    pos: 46.5,-11.5
+  - parent: 854
+    pos: 48.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4450
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-11.5
+  - parent: 854
+    pos: 48.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4451
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-11.5
+  - parent: 854
+    pos: 49.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4452
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-10.5
+  - parent: 854
+    pos: 50.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4453
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-10.5
+  - parent: 854
+    pos: 49.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4454
   type: HVWire
   components:
-  - parent: 855
-    pos: 50.5,-10.5
+  - parent: 854
+    pos: 51.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4455
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-12.5
+  - parent: 854
+    pos: 52.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4456
   type: HVWire
   components:
-  - parent: 855
-    pos: 51.5,-11.5
+  - parent: 854
+    pos: 53.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4457
   type: HVWire
   components:
-  - parent: 855
-    pos: 52.5,-11.5
+  - parent: 854
+    pos: 53.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4458
   type: HVWire
   components:
-  - parent: 855
-    pos: 53.5,-11.5
+  - parent: 854
+    pos: 53.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4459
   type: HVWire
   components:
-  - parent: 855
-    pos: 53.5,-10.5
+  - parent: 854
+    pos: 49.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4460
   type: HVWire
   components:
-  - parent: 855
-    pos: 53.5,-12.5
+  - parent: 854
+    pos: 49.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4461
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-9.5
+  - parent: 854
+    pos: 49.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4462
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-8.5
+  - parent: 854
+    pos: 49.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4463
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-7.5
+  - parent: 854
+    pos: 48.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4464
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-6.5
+  - parent: 854
+    pos: 47.5,-6.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4465
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-6.5
+  - parent: 854
+    pos: 47.5,-5.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4466
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-6.5
+  - parent: 854
+    pos: 47.5,-4.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4467
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-5.5
+  - parent: 854
+    pos: 47.5,-3.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4468
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-4.5
+  - parent: 854
+    pos: 47.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4469
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-3.5
+  - parent: 854
+    pos: 48.5,-2.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4470
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-2.5
+  - parent: 854
+    pos: 48.5,-1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4471
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-2.5
+  - parent: 854
+    pos: 48.5,-0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4472
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-1.5
+  - parent: 854
+    pos: 48.5,0.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4473
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-0.5
+  - parent: 854
+    pos: 48.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4474
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,0.5
+  - parent: 854
+    pos: 47.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4475
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,1.5
+  - parent: 854
+    pos: 46.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4476
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,1.5
+  - parent: 854
+    pos: 45.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4477
   type: HVWire
   components:
-  - parent: 855
-    pos: 46.5,1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4478
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 45.5,1.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4479
-  type: HVWire
-  components:
-  - parent: 855
+  - parent: 854
     pos: 44.5,1.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4480
+- uid: 4478
   type: AirlockExternalLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 46.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4481
+- uid: 4479
   type: AirlockExternalLocked
   components:
-  - parent: 855
+  - parent: 854
     pos: 52.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4482
+- uid: 4480
   type: AirlockEngineeringLocked
   components:
   - name: Singularity Engine
     type: MetaData
-  - parent: 855
+  - parent: 854
     pos: 49.5,-7.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4483
+- uid: 4481
   type: SalternSmes
   components:
-  - parent: 855
+  - parent: 854
     pos: 45.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4484
+- uid: 4482
   type: SalternSmes
   components:
-  - parent: 855
+  - parent: 854
     pos: 53.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4485
+- uid: 4483
   type: SalternSubstation
   components:
-  - parent: 855
+  - parent: 854
     pos: 45.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565081
+  - startingCharge: 3345884
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
   - supplyRate: 6000
     type: PowerSupplier
-- uid: 4486
+- uid: 4484
   type: SalternSubstation
   components:
-  - parent: 855
+  - parent: 854
     pos: 53.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
-  - startingCharge: 3565081
+  - startingCharge: 3345884
     type: Battery
   - drawRate: 8000
     type: PowerConsumer
   - supplyRate: 6000
     type: PowerSupplier
+- uid: 4485
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 44.5,-9
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
+- uid: 4486
+  type: Poweredlight
+  components:
+  - parent: 854
+    pos: 54.5,-9
+    rot: -1.5707963267948966 rad
+    type: Transform
+  - powerLoad: 0
+    type: PowerReceiver
+  - containers:
+      light_bulb:
+        type: Content.Server.GameObjects.ContainerSlot
+    type: ContainerContainer
 - uid: 4487
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 44.5,-9
-    rot: -1.5707963267948966 rad
+  - parent: 854
+    pos: 52,-11.5
+    rot: 3.141592653589793 rad
     type: Transform
   - powerLoad: 0
     type: PowerReceiver
@@ -47166,33 +47209,7 @@ entities:
 - uid: 4488
   type: Poweredlight
   components:
-  - parent: 855
-    pos: 54.5,-9
-    rot: -1.5707963267948966 rad
-    type: Transform
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 4489
-  type: Poweredlight
-  components:
-  - parent: 855
-    pos: 52,-11.5
-    rot: 3.141592653589793 rad
-    type: Transform
-  - powerLoad: 0
-    type: PowerReceiver
-  - containers:
-      light_bulb:
-        type: Content.Server.GameObjects.ContainerSlot
-    type: ContainerContainer
-- uid: 4490
-  type: Poweredlight
-  components:
-  - parent: 855
+  - parent: 854
     pos: 47,-11.5
     type: Transform
   - powerLoad: 0
@@ -47201,1690 +47218,1632 @@ entities:
       light_bulb:
         type: Content.Server.GameObjects.ContainerSlot
     type: ContainerContainer
+- uid: 4489
+  type: MVWire
+  components:
+  - parent: 854
+    pos: 45.5,-10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4490
+  type: MVWire
+  components:
+  - parent: 854
+    pos: 45.5,-11.5
+    rot: -1.5707963267948966 rad
+    type: Transform
 - uid: 4491
   type: MVWire
   components:
-  - parent: 855
-    pos: 45.5,-10.5
+  - parent: 854
+    pos: 53.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4492
   type: MVWire
   components:
-  - parent: 855
-    pos: 45.5,-11.5
+  - parent: 854
+    pos: 53.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4493
   type: MVWire
   components:
-  - parent: 855
-    pos: 53.5,-10.5
+  - parent: 854
+    pos: 52.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4494
   type: MVWire
   components:
-  - parent: 855
-    pos: 53.5,-11.5
+  - parent: 854
+    pos: 51.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4495
   type: MVWire
   components:
-  - parent: 855
-    pos: 52.5,-11.5
+  - parent: 854
+    pos: 51.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4496
   type: MVWire
   components:
-  - parent: 855
-    pos: 51.5,-11.5
+  - parent: 854
+    pos: 46.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4497
   type: MVWire
   components:
-  - parent: 855
-    pos: 51.5,-12.5
+  - parent: 854
+    pos: 47.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4498
   type: MVWire
   components:
-  - parent: 855
-    pos: 46.5,-11.5
+  - parent: 854
+    pos: 47.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4499
   type: MVWire
   components:
-  - parent: 855
-    pos: 47.5,-11.5
+  - parent: 854
+    pos: 47.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4500
   type: MVWire
   components:
-  - parent: 855
-    pos: 47.5,-12.5
+  - parent: 854
+    pos: 49.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4501
   type: MVWire
   components:
-  - parent: 855
-    pos: 47.5,-13.5
+  - parent: 854
+    pos: 48.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4502
   type: MVWire
   components:
-  - parent: 855
-    pos: 49.5,-13.5
+  - parent: 854
+    pos: 50.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4503
   type: MVWire
   components:
-  - parent: 855
-    pos: 48.5,-13.5
+  - parent: 854
+    pos: 51.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4504
   type: MVWire
   components:
-  - parent: 855
-    pos: 50.5,-13.5
+  - parent: 854
+    pos: 49.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4505
   type: MVWire
   components:
-  - parent: 855
-    pos: 51.5,-13.5
+  - parent: 854
+    pos: 49.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4506
   type: MVWire
   components:
-  - parent: 855
-    pos: 49.5,-14.5
+  - parent: 854
+    pos: 49.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4507
   type: MVWire
   components:
-  - parent: 855
-    pos: 49.5,-15.5
+  - parent: 854
+    pos: 49.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4508
   type: MVWire
   components:
-  - parent: 855
-    pos: 49.5,-16.5
+  - parent: 854
+    pos: 48.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4509
   type: MVWire
   components:
-  - parent: 855
-    pos: 49.5,-17.5
+  - parent: 854
+    pos: 47.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4510
   type: MVWire
   components:
-  - parent: 855
-    pos: 48.5,-17.5
+  - parent: 854
+    pos: 46.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4511
   type: MVWire
   components:
-  - parent: 855
-    pos: 47.5,-17.5
+  - parent: 854
+    pos: 45.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4512
   type: MVWire
   components:
-  - parent: 855
-    pos: 46.5,-17.5
+  - parent: 854
+    pos: 50.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4513
   type: MVWire
   components:
-  - parent: 855
-    pos: 45.5,-17.5
+  - parent: 854
+    pos: 51.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4514
   type: MVWire
   components:
-  - parent: 855
-    pos: 50.5,-17.5
+  - parent: 854
+    pos: 52.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4515
   type: MVWire
   components:
-  - parent: 855
-    pos: 51.5,-17.5
+  - parent: 854
+    pos: 53.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4516
   type: MVWire
   components:
-  - parent: 855
-    pos: 52.5,-17.5
+  - parent: 854
+    pos: 54.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4517
   type: MVWire
   components:
-  - parent: 855
-    pos: 53.5,-17.5
+  - parent: 854
+    pos: 55.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4518
   type: MVWire
   components:
-  - parent: 855
-    pos: 54.5,-17.5
+  - parent: 854
+    pos: 56.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4519
   type: MVWire
   components:
-  - parent: 855
-    pos: 55.5,-17.5
+  - parent: 854
+    pos: 56.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4520
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-17.5
+  - parent: 854
+    pos: 56.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4521
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-18.5
+  - parent: 854
+    pos: 56.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4522
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-19.5
+  - parent: 854
+    pos: 56.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4523
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-20.5
+  - parent: 854
+    pos: 56.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4524
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-21.5
+  - parent: 854
+    pos: 56.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4525
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-22.5
+  - parent: 854
+    pos: 56.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4526
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-23.5
+  - parent: 854
+    pos: 56.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4527
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-24.5
+  - parent: 854
+    pos: 56.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4528
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-25.5
+  - parent: 854
+    pos: 56.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4529
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-26.5
+  - parent: 854
+    pos: 56.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4530
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-27.5
+  - parent: 854
+    pos: 56.5,-29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4531
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-28.5
+  - parent: 854
+    pos: 56.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4532
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-29.5
+  - parent: 854
+    pos: 56.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4533
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-30.5
+  - parent: 854
+    pos: 55.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4534
   type: MVWire
   components:
-  - parent: 855
-    pos: 56.5,-31.5
+  - parent: 854
+    pos: 54.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4535
   type: MVWire
   components:
-  - parent: 855
-    pos: 55.5,-31.5
+  - parent: 854
+    pos: 53.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4536
   type: MVWire
   components:
-  - parent: 855
-    pos: 54.5,-31.5
+  - parent: 854
+    pos: 52.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4537
   type: MVWire
   components:
-  - parent: 855
-    pos: 53.5,-31.5
+  - parent: 854
+    pos: 51.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4538
   type: MVWire
   components:
-  - parent: 855
-    pos: 52.5,-31.5
+  - parent: 854
+    pos: 50.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4539
   type: MVWire
   components:
-  - parent: 855
-    pos: 51.5,-31.5
+  - parent: 854
+    pos: 49.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4540
   type: MVWire
   components:
-  - parent: 855
-    pos: 50.5,-31.5
+  - parent: 854
+    pos: 48.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4541
   type: MVWire
   components:
-  - parent: 855
-    pos: 49.5,-31.5
+  - parent: 854
+    pos: 47.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4542
   type: MVWire
   components:
-  - parent: 855
-    pos: 48.5,-31.5
+  - parent: 854
+    pos: 46.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4543
   type: MVWire
   components:
-  - parent: 855
-    pos: 47.5,-31.5
+  - parent: 854
+    pos: 45.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4544
   type: MVWire
   components:
-  - parent: 855
-    pos: 46.5,-31.5
+  - parent: 854
+    pos: 44.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4545
   type: MVWire
   components:
-  - parent: 855
-    pos: 45.5,-31.5
+  - parent: 854
+    pos: 43.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4546
   type: MVWire
   components:
-  - parent: 855
-    pos: 44.5,-31.5
+  - parent: 854
+    pos: 42.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4547
   type: MVWire
   components:
-  - parent: 855
-    pos: 43.5,-31.5
+  - parent: 854
+    pos: 42.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4548
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-31.5
+  - parent: 854
+    pos: 42.5,-29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4549
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-30.5
+  - parent: 854
+    pos: 42.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4550
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-29.5
+  - parent: 854
+    pos: 42.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4551
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-28.5
+  - parent: 854
+    pos: 42.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4552
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-27.5
+  - parent: 854
+    pos: 42.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4553
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-26.5
+  - parent: 854
+    pos: 42.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4554
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-25.5
+  - parent: 854
+    pos: 42.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4555
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-22.5
+  - parent: 854
+    pos: 42.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4556
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-23.5
+  - parent: 854
+    pos: 42.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4557
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-24.5
+  - parent: 854
+    pos: 42.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4558
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-21.5
+  - parent: 854
+    pos: 42.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4559
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-20.5
+  - parent: 854
+    pos: 42.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4560
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-19.5
+  - parent: 854
+    pos: 42.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4561
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-18.5
+  - parent: 854
+    pos: 43.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4562
   type: MVWire
   components:
-  - parent: 855
-    pos: 42.5,-17.5
+  - parent: 854
+    pos: 44.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4563
-  type: MVWire
+  type: ContainmentFieldGenerator
   components:
-  - parent: 855
-    pos: 43.5,-17.5
+  - parent: 854
+    pos: 45.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4564
-  type: MVWire
+  type: ContainmentFieldGenerator
   components:
-  - parent: 855
-    pos: 44.5,-17.5
+  - parent: 854
+    pos: 49.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4565
   type: ContainmentFieldGenerator
   components:
-  - parent: 855
-    pos: 45.5,-20.5
+  - parent: 854
+    pos: 53.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4566
   type: ContainmentFieldGenerator
   components:
-  - parent: 855
-    pos: 49.5,-20.5
+  - parent: 854
+    pos: 53.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4567
   type: ContainmentFieldGenerator
   components:
-  - parent: 855
-    pos: 53.5,-20.5
+  - parent: 854
+    pos: 53.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4568
   type: ContainmentFieldGenerator
   components:
-  - parent: 855
-    pos: 53.5,-24.5
+  - parent: 854
+    pos: 49.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4569
   type: ContainmentFieldGenerator
   components:
-  - parent: 855
-    pos: 53.5,-28.5
+  - parent: 854
+    pos: 45.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4570
   type: ContainmentFieldGenerator
   components:
-  - parent: 855
-    pos: 49.5,-28.5
+  - parent: 854
+    pos: 45.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4571
-  type: ContainmentFieldGenerator
+  type: Catwalk
   components:
-  - parent: 855
-    pos: 45.5,-28.5
+  - parent: 854
+    pos: 53.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4572
-  type: ContainmentFieldGenerator
+  type: Catwalk
   components:
-  - parent: 855
-    pos: 45.5,-24.5
+  - parent: 854
+    pos: 54.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4573
   type: Catwalk
   components:
-  - parent: 855
-    pos: 53.5,-9.5
+  - parent: 854
+    pos: 54.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4574
   type: Catwalk
   components:
-  - parent: 855
-    pos: 54.5,-9.5
+  - parent: 854
+    pos: 54.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4575
   type: Catwalk
   components:
-  - parent: 855
-    pos: 54.5,-10.5
+  - parent: 854
+    pos: 54.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4576
   type: Catwalk
   components:
-  - parent: 855
-    pos: 54.5,-11.5
+  - parent: 854
+    pos: 54.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4577
   type: Catwalk
   components:
-  - parent: 855
-    pos: 54.5,-12.5
+  - parent: 854
+    pos: 53.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4578
   type: Catwalk
   components:
-  - parent: 855
-    pos: 54.5,-13.5
+  - parent: 854
+    pos: 53.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4579
   type: Catwalk
   components:
-  - parent: 855
-    pos: 53.5,-13.5
+  - parent: 854
+    pos: 45.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4580
   type: Catwalk
   components:
-  - parent: 855
-    pos: 53.5,-11.5
+  - parent: 854
+    pos: 44.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4581
   type: Catwalk
   components:
-  - parent: 855
-    pos: 45.5,-9.5
+  - parent: 854
+    pos: 44.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4582
   type: Catwalk
   components:
-  - parent: 855
-    pos: 44.5,-9.5
+  - parent: 854
+    pos: 44.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4583
   type: Catwalk
   components:
-  - parent: 855
-    pos: 44.5,-10.5
+  - parent: 854
+    pos: 45.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4584
   type: Catwalk
   components:
-  - parent: 855
-    pos: 44.5,-11.5
+  - parent: 854
+    pos: 44.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4585
   type: Catwalk
   components:
-  - parent: 855
-    pos: 45.5,-11.5
+  - parent: 854
+    pos: 44.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4586
   type: Catwalk
   components:
-  - parent: 855
-    pos: 44.5,-12.5
+  - parent: 854
+    pos: 45.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4587
   type: Catwalk
   components:
-  - parent: 855
-    pos: 44.5,-13.5
+  - parent: 854
+    pos: 47.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4588
   type: Catwalk
   components:
-  - parent: 855
-    pos: 45.5,-13.5
+  - parent: 854
+    pos: 49.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4589
   type: Catwalk
   components:
-  - parent: 855
-    pos: 47.5,-8.5
+  - parent: 854
+    pos: 48.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4590
   type: Catwalk
   components:
-  - parent: 855
-    pos: 49.5,-8.5
+  - parent: 854
+    pos: 50.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4591
   type: Catwalk
   components:
-  - parent: 855
-    pos: 48.5,-8.5
+  - parent: 854
+    pos: 51.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4592
-  type: Catwalk
+  type: HVWire
   components:
-  - parent: 855
-    pos: 50.5,-8.5
+  - parent: 854
+    pos: 49.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4593
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-9.5
+  - parent: 854
+    pos: 51.5,-8.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4594
-  type: HVWire
+  type: Catwalk
   components:
-  - parent: 855
-    pos: 49.5,-11.5
+  - parent: 854
+    pos: 51.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4595
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-8.5
+  - parent: 854
+    pos: 51.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4596
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-11.5
+  - parent: 854
+    pos: 51.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4597
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-12.5
+  - parent: 854
+    pos: 50.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4598
   type: Catwalk
   components:
-  - parent: 855
-    pos: 51.5,-13.5
+  - parent: 854
+    pos: 49.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4599
   type: Catwalk
   components:
-  - parent: 855
-    pos: 50.5,-13.5
+  - parent: 854
+    pos: 48.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4600
   type: Catwalk
   components:
-  - parent: 855
-    pos: 49.5,-13.5
+  - parent: 854
+    pos: 47.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4601
   type: Catwalk
   components:
-  - parent: 855
-    pos: 48.5,-13.5
+  - parent: 854
+    pos: 47.5,-12.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4602
   type: Catwalk
   components:
-  - parent: 855
-    pos: 47.5,-13.5
+  - parent: 854
+    pos: 47.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4603
-  type: Catwalk
+  type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-12.5
+  - parent: 854
+    pos: 50.5,-11.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4604
   type: Catwalk
   components:
-  - parent: 855
-    pos: 47.5,-11.5
+  - parent: 854
+    pos: 47.5,-9.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4605
-  type: HVWire
+  type: RadiationCollector
   components:
-  - parent: 855
-    pos: 50.5,-11.5
+  - parent: 854
+    pos: 42.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4606
-  type: Catwalk
+  type: RadiationCollector
   components:
-  - parent: 855
-    pos: 47.5,-9.5
+  - parent: 854
+    pos: 42.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4607
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 42.5,-23.5
+  - parent: 854
+    pos: 42.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4608
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 42.5,-22.5
+  - parent: 854
+    pos: 42.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4609
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 42.5,-21.5
+  - parent: 854
+    pos: 42.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4610
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 42.5,-27.5
+  - parent: 854
+    pos: 42.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4611
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 42.5,-26.5
+  - parent: 854
+    pos: 46.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4612
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 42.5,-25.5
+  - parent: 854
+    pos: 47.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4613
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 46.5,-31.5
+  - parent: 854
+    pos: 48.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4614
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 47.5,-31.5
+  - parent: 854
+    pos: 50.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4615
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 48.5,-31.5
+  - parent: 854
+    pos: 51.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4616
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 50.5,-31.5
+  - parent: 854
+    pos: 52.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4617
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 51.5,-31.5
+  - parent: 854
+    pos: 56.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4618
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 52.5,-31.5
+  - parent: 854
+    pos: 56.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4619
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 56.5,-27.5
+  - parent: 854
+    pos: 56.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4620
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 56.5,-26.5
+  - parent: 854
+    pos: 56.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4621
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 56.5,-25.5
+  - parent: 854
+    pos: 56.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4622
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 56.5,-23.5
+  - parent: 854
+    pos: 56.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4623
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 56.5,-22.5
+  - parent: 854
+    pos: 46.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4624
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 56.5,-21.5
+  - parent: 854
+    pos: 47.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4625
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 46.5,-17.5
+  - parent: 854
+    pos: 48.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4626
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 47.5,-17.5
+  - parent: 854
+    pos: 50.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4627
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 48.5,-17.5
+  - parent: 854
+    pos: 51.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4628
   type: RadiationCollector
   components:
-  - parent: 855
-    pos: 50.5,-17.5
+  - parent: 854
+    pos: 52.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4629
-  type: RadiationCollector
+  type: HVWire
   components:
-  - parent: 855
-    pos: 51.5,-17.5
+  - parent: 854
+    pos: 46.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4630
-  type: RadiationCollector
+  type: HVWire
   components:
-  - parent: 855
-    pos: 52.5,-17.5
+  - parent: 854
+    pos: 47.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4631
   type: HVWire
   components:
-  - parent: 855
-    pos: 46.5,-17.5
+  - parent: 854
+    pos: 48.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4632
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-17.5
+  - parent: 854
+    pos: 49.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4633
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-17.5
+  - parent: 854
+    pos: 50.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4634
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-17.5
+  - parent: 854
+    pos: 51.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4635
   type: HVWire
   components:
-  - parent: 855
-    pos: 50.5,-17.5
+  - parent: 854
+    pos: 52.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4636
   type: HVWire
   components:
-  - parent: 855
-    pos: 51.5,-17.5
+  - parent: 854
+    pos: 53.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4637
   type: HVWire
   components:
-  - parent: 855
-    pos: 52.5,-17.5
+  - parent: 854
+    pos: 45.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4638
   type: HVWire
   components:
-  - parent: 855
-    pos: 53.5,-17.5
+  - parent: 854
+    pos: 44.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4639
   type: HVWire
   components:
-  - parent: 855
-    pos: 45.5,-17.5
+  - parent: 854
+    pos: 43.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4640
   type: HVWire
   components:
-  - parent: 855
-    pos: 44.5,-17.5
+  - parent: 854
+    pos: 42.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4641
   type: HVWire
   components:
-  - parent: 855
-    pos: 43.5,-17.5
+  - parent: 854
+    pos: 54.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4642
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-17.5
+  - parent: 854
+    pos: 55.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4643
   type: HVWire
   components:
-  - parent: 855
-    pos: 54.5,-17.5
+  - parent: 854
+    pos: 56.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4644
   type: HVWire
   components:
-  - parent: 855
-    pos: 55.5,-17.5
+  - parent: 854
+    pos: 57.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4645
   type: HVWire
   components:
-  - parent: 855
-    pos: 56.5,-17.5
+  - parent: 854
+    pos: 58.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4646
   type: HVWire
   components:
-  - parent: 855
-    pos: 57.5,-17.5
+  - parent: 854
+    pos: 58.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4647
   type: HVWire
   components:
-  - parent: 855
-    pos: 58.5,-17.5
+  - parent: 854
+    pos: 58.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4648
   type: HVWire
   components:
-  - parent: 855
-    pos: 58.5,-18.5
+  - parent: 854
+    pos: 58.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4649
   type: HVWire
   components:
-  - parent: 855
-    pos: 58.5,-19.5
+  - parent: 854
+    pos: 58.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4650
   type: HVWire
   components:
-  - parent: 855
-    pos: 58.5,-20.5
+  - parent: 854
+    pos: 58.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4651
   type: HVWire
   components:
-  - parent: 855
-    pos: 58.5,-21.5
+  - parent: 854
+    pos: 57.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4652
   type: HVWire
   components:
-  - parent: 855
-    pos: 58.5,-22.5
+  - parent: 854
+    pos: 58.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4653
   type: HVWire
   components:
-  - parent: 855
-    pos: 57.5,-24.5
+  - parent: 854
+    pos: 58.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4654
   type: HVWire
   components:
-  - parent: 855
-    pos: 58.5,-24.5
+  - parent: 854
+    pos: 41.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4655
   type: HVWire
   components:
-  - parent: 855
-    pos: 58.5,-23.5
+  - parent: 854
+    pos: 40.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4656
   type: HVWire
   components:
-  - parent: 855
-    pos: 41.5,-24.5
+  - parent: 854
+    pos: 40.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4657
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-24.5
+  - parent: 854
+    pos: 40.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4658
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-23.5
+  - parent: 854
+    pos: 40.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4659
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-22.5
+  - parent: 854
+    pos: 40.5,-20.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4660
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-21.5
+  - parent: 854
+    pos: 40.5,-19.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4661
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-20.5
+  - parent: 854
+    pos: 40.5,-18.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4662
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-19.5
+  - parent: 854
+    pos: 40.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4663
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-18.5
+  - parent: 854
+    pos: 41.5,-17.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4664
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-17.5
+  - parent: 854
+    pos: 42.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4665
   type: HVWire
   components:
-  - parent: 855
-    pos: 41.5,-17.5
+  - parent: 854
+    pos: 42.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4666
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-24.5
+  - parent: 854
+    pos: 42.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4667
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-23.5
+  - parent: 854
+    pos: 42.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4668
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-22.5
+  - parent: 854
+    pos: 42.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4669
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-21.5
+  - parent: 854
+    pos: 42.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4670
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-25.5
+  - parent: 854
+    pos: 42.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4671
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-26.5
+  - parent: 854
+    pos: 56.5,-24.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4672
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-27.5
+  - parent: 854
+    pos: 56.5,-23.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4673
   type: HVWire
   components:
-  - parent: 855
-    pos: 56.5,-24.5
+  - parent: 854
+    pos: 56.5,-22.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4674
   type: HVWire
   components:
-  - parent: 855
-    pos: 56.5,-23.5
+  - parent: 854
+    pos: 56.5,-21.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4675
   type: HVWire
   components:
-  - parent: 855
-    pos: 56.5,-22.5
+  - parent: 854
+    pos: 56.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4676
   type: HVWire
   components:
-  - parent: 855
-    pos: 56.5,-21.5
+  - parent: 854
+    pos: 56.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4677
   type: HVWire
   components:
-  - parent: 855
-    pos: 56.5,-25.5
+  - parent: 854
+    pos: 56.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4678
   type: HVWire
   components:
-  - parent: 855
-    pos: 56.5,-26.5
+  - parent: 854
+    pos: 49.5,-16.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4679
   type: HVWire
   components:
-  - parent: 855
-    pos: 56.5,-27.5
+  - parent: 854
+    pos: 49.5,-15.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4680
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-16.5
+  - parent: 854
+    pos: 49.5,-14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4681
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-15.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4682
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 49.5,-14.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4683
-  type: HVWire
-  components:
-  - parent: 855
+  - parent: 854
     pos: 49.5,-13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4684
+- uid: 4682
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 47.5,-10.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4685
+- uid: 4683
   type: Catwalk
   components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,-10.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4684
+  type: HVWire
+  components:
+  - parent: 854
+    pos: 49.5,-31.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4685
+  type: HVWire
+  components:
+  - parent: 854
+    pos: 48.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4686
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-31.5
+  - parent: 854
+    pos: 47.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4687
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-31.5
+  - parent: 854
+    pos: 46.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4688
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-31.5
+  - parent: 854
+    pos: 50.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4689
   type: HVWire
   components:
-  - parent: 855
-    pos: 46.5,-31.5
+  - parent: 854
+    pos: 51.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4690
   type: HVWire
   components:
-  - parent: 855
-    pos: 50.5,-31.5
+  - parent: 854
+    pos: 52.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4691
   type: HVWire
   components:
-  - parent: 855
-    pos: 51.5,-31.5
+  - parent: 854
+    pos: 49.5,-32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4692
   type: HVWire
   components:
-  - parent: 855
-    pos: 52.5,-31.5
+  - parent: 854
+    pos: 49.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4693
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-32.5
+  - parent: 854
+    pos: 48.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4694
   type: HVWire
   components:
-  - parent: 855
-    pos: 49.5,-33.5
+  - parent: 854
+    pos: 47.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4695
   type: HVWire
   components:
-  - parent: 855
-    pos: 48.5,-33.5
+  - parent: 854
+    pos: 46.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4696
   type: HVWire
   components:
-  - parent: 855
-    pos: 47.5,-33.5
+  - parent: 854
+    pos: 45.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4697
   type: HVWire
   components:
-  - parent: 855
-    pos: 46.5,-33.5
+  - parent: 854
+    pos: 44.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4698
   type: HVWire
   components:
-  - parent: 855
-    pos: 45.5,-33.5
+  - parent: 854
+    pos: 43.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4699
   type: HVWire
   components:
-  - parent: 855
-    pos: 44.5,-33.5
+  - parent: 854
+    pos: 42.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4700
   type: HVWire
   components:
-  - parent: 855
-    pos: 43.5,-33.5
+  - parent: 854
+    pos: 41.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4701
   type: HVWire
   components:
-  - parent: 855
-    pos: 42.5,-33.5
+  - parent: 854
+    pos: 40.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4702
   type: HVWire
   components:
-  - parent: 855
-    pos: 41.5,-33.5
+  - parent: 854
+    pos: 40.5,-32.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4703
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-33.5
+  - parent: 854
+    pos: 40.5,-31.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4704
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-32.5
+  - parent: 854
+    pos: 40.5,-30.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4705
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-31.5
+  - parent: 854
+    pos: 40.5,-29.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4706
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-30.5
+  - parent: 854
+    pos: 40.5,-28.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4707
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-29.5
+  - parent: 854
+    pos: 40.5,-27.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4708
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-28.5
+  - parent: 854
+    pos: 40.5,-26.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4709
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-27.5
+  - parent: 854
+    pos: 40.5,-25.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4710
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-26.5
+  - parent: 854
+    pos: 50.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4711
   type: HVWire
   components:
-  - parent: 855
-    pos: 40.5,-25.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4712
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 50.5,-33.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4713
-  type: HVWire
-  components:
-  - parent: 855
+  - parent: 854
     pos: 51.5,-33.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4714
-  type: HVWire
+- uid: 4712
+  type: LowWall
   components:
-  - parent: 855
-    pos: 52.5,-33.5
+  - parent: 854
+    pos: 20.5,14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4713
+  type: LowWall
+  components:
+  - parent: 854
+    pos: 22.5,14.5
+    rot: -1.5707963267948966 rad
+    type: Transform
+- uid: 4714
+  type: ReinforcedWindow
+  components:
+  - parent: 854
+    pos: 20.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4715
-  type: HVWire
+  type: ReinforcedWindow
   components:
-  - parent: 855
-    pos: 53.5,-33.5
+  - parent: 854
+    pos: 22.5,14.5
     rot: -1.5707963267948966 rad
     type: Transform
 - uid: 4716
-  type: HVWire
+  type: CrateMaterialsMetal
   components:
-  - parent: 855
-    pos: 54.5,-33.5
+  - parent: 854
+    pos: 21.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
 - uid: 4717
-  type: HVWire
+  type: CrateServiceReplacementLights
   components:
-  - parent: 855
-    pos: 55.5,-33.5
+  - parent: 854
+    pos: 20.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
 - uid: 4718
-  type: HVWire
+  type: CrateEmergencyFire
   components:
-  - parent: 855
-    pos: 56.5,-33.5
+  - parent: 854
+    pos: 22.5,13.5
     rot: -1.5707963267948966 rad
     type: Transform
-- uid: 4719
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 57.5,-33.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4720
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-33.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4721
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-32.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4722
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-31.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4723
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-30.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4724
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-29.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4725
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-28.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4726
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-27.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4727
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-26.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4728
-  type: HVWire
-  components:
-  - parent: 855
-    pos: 58.5,-25.5
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4729
-  type: Emitter
-  components:
-  - parent: 855
-    pos: 43.5,11.5
-    type: Transform
-- uid: 4730
-  type: AMEJar
-  components:
-  - parent: 855
-    pos: 38.25703,11.473667
-    rot: -1.5707963267948966 rad
-    type: Transform
-- uid: 4731
-  type: AMEJar
-  components:
-  - parent: 855
-    pos: 38.585155,11.629917
-    rot: -1.5707963267948966 rad
-    type: Transform
+  - IsPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent:
+        type: Robust.Server.GameObjects.Components.Container.Container
+    type: ContainerContainer
 ...


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49448379/103130611-5c725400-4695-11eb-94a5-167aba1512a7.png)

Also removes the impotent cargo dock and provides some simple crates filled with various useful stuff.