### PR TITLE
Updates maint airlock meta.json timing.

### DIFF
--- a/Resources/Textures/Constructible/Structures/Doors/airlock_maint.rsi/meta.json
+++ b/Resources/Textures/Constructible/Structures/Doors/airlock_maint.rsi/meta.json
@@ -5,7 +5,7 @@
     "y": 32
   },
   "license": "CC-BY-SA-3.0",
-  "copyright": "Taken from https://github.com/discordia-space/CEV-Eris/blob/2b969adc2dfd3e9621bf3597c5cbffeb3ac8c9f0/icons/obj/doors/Dooreng.dmi",
+  "copyright": "Taken from https://github.com/discordia-space/CEV-Eris/blob/d86e175508b8553ca8396f39f2af7ecec4595375/icons/obj/doors/Doormaint.dmi - modified by rexonaje#5787 on discord",
   "states": [
     {
       "name": "bolted",

--- a/Resources/Textures/Constructible/Structures/Doors/airlock_maint.rsi/meta.json
+++ b/Resources/Textures/Constructible/Structures/Doors/airlock_maint.rsi/meta.json
@@ -5,7 +5,7 @@
     "y": 32
   },
   "license": "CC-BY-SA-3.0",
-  "copyright": "Taken from https://github.com/discordia-space/CEV-Eris/blob/d86e175508b8553ca8396f39f2af7ecec4595375/icons/obj/doors/Doormaint.dmi - modified by rexonaje#5787 on discord",
+  "copyright": "Taken from https://github.com/discordia-space/CEV-Eris/blob/2b969adc2dfd3e9621bf3597c5cbffeb3ac8c9f0/icons/obj/doors/Dooreng.dmi",
   "states": [
     {
       "name": "bolted",
@@ -62,12 +62,12 @@
       "directions": 1,
       "delays": [
         [
-          0.5,
-          0.1,
-          0.1,
-          0.1,
-          0.1,
-          0.3
+          0.25,
+          0.07,
+          0.07,
+          0.07,
+          0.07,
+          0.15
         ]
       ]
     },
@@ -96,14 +96,14 @@
       "directions": 1,
       "delays": [
         [
-          0.2,
-          0.2,
           0.1,
           0.1,
-          0.1,
-          0.1,
-          0.1,
-          0.3
+          0.07,
+          0.07,
+          0.07,
+          0.07,
+          0.07,
+          0.2
         ]
       ]
     },
@@ -112,12 +112,12 @@
       "directions": 1,
       "delays": [
         [
-          0.2,
-          0.2,
           0.1,
           0.1,
-          0.1,
-          0.5
+          0.07,
+          0.07,
+          0.07,
+          0.25
         ]
       ]
     },
@@ -126,13 +126,13 @@
       "directions": 1,
       "delays": [
         [
-          0.2,
           0.1,
           0.1,
-          0.1,
-          0.1,
-          0.1,
-          0.5
+          0.07,
+          0.07,
+          0.07,
+          0.07,
+          0.27
         ]
       ]
     },
@@ -150,13 +150,13 @@
       "directions": 1,
       "delays": [
         [
-          0.4,
-          0.1,
-          0.1,
-          0.1,
-          0.1,
-          0.1,
-          0.3
+          0.2,
+          0.07,
+          0.07,
+          0.07,
+          0.07,
+          0.07,
+          0.2
         ]
       ]
     },


### PR DESCRIPTION
When pushed this was using the old airlock timings which made them super slow. This just updates them to be on par with the rest.