### PR TITLE
ApcNet code improvements

### DIFF
--- a/Content.Server/GameObjects/Components/NodeContainer/NodeGroups/ApcNetNodeGroup.cs
+++ b/Content.Server/GameObjects/Components/NodeContainer/NodeGroups/ApcNetNodeGroup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -42,7 +43,8 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
         private int TotalReceivers => _providers.SelectMany(provider => provider.LinkedReceivers).Count();
 
         [ViewVariables]
-        private int TotalPowerReceiverLoad { get; set; } = 0;
+        private int TotalPowerReceiverLoad { get => _totalPowerReceiverLoad; set => SetTotalPowerReceiverLoad(value); }
+        private int _totalPowerReceiverLoad = 0;
 
         public static readonly IApcNet NullNet = new NullApcNet();
 
@@ -146,6 +148,13 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
             }
         }
 
+        private void SetTotalPowerReceiverLoad(int totalPowerReceiverLoad)
+        {
+            Debug.Assert(totalPowerReceiverLoad >= 0);
+            _totalPowerReceiverLoad = totalPowerReceiverLoad;
+
+        }
+
         #endregion
 
         private class NullApcNet : IApcNet
@@ -154,6 +163,7 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
             ///     It is important that this returns false, so <see cref="PowerProviderComponent"/>s with a <see cref="NullApcNet"/> have no power.
             /// </summary>
             public bool Powered => false;
+
             public void AddApc(ApcComponent apc) { }
             public void AddPowerProvider(PowerProviderComponent provider) { }
             public void RemoveApc(ApcComponent apc) { }

--- a/Content.Server/GameObjects/Components/NodeContainer/NodeGroups/ApcNetNodeGroup.cs
+++ b/Content.Server/GameObjects/Components/NodeContainer/NodeGroups/ApcNetNodeGroup.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Content.Server.GameObjects.Components.Power;
@@ -9,6 +9,8 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
 {
     public interface IApcNet
     {
+        bool Powered { get; }
+
         void AddApc(ApcComponent apc);
 
         void RemoveApc(ApcComponent apc);
@@ -17,7 +19,7 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
 
         void RemovePowerProvider(PowerProviderComponent provider);
 
-        void UpdatePowerProviderReceivers(PowerProviderComponent provider);
+        void UpdatePowerProviderReceivers(PowerProviderComponent provider, int oldLoad, int newLoad);
 
         void Update(float frameTime);
     }
@@ -29,11 +31,18 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
         private readonly Dictionary<ApcComponent, BatteryComponent> _apcBatteries = new();
 
         [ViewVariables]
-        private readonly Dictionary<PowerProviderComponent, List<PowerReceiverComponent>> _providerReceivers = new();
+        private readonly List<PowerProviderComponent> _providers = new();
+
+        [ViewVariables]
+        public bool Powered { get => _powered; private set => SetPowered(value); }
+        private bool _powered = false;
 
         //Debug property
         [ViewVariables]
-        private int TotalReceivers => _providerReceivers.SelectMany(kvp => kvp.Value).Count();
+        private int TotalReceivers => _providers.SelectMany(provider => provider.LinkedReceivers).Count();
+
+        [ViewVariables]
+        private int TotalPowerReceiverLoad { get; set; } = 0;
 
         public static readonly IApcNet NullNet = new NullApcNet();
 
@@ -57,80 +66,99 @@ namespace Content.Server.GameObjects.Components.NodeContainer.NodeGroups
         public void RemoveApc(ApcComponent apc)
         {
             _apcBatteries.Remove(apc);
-            if (!_apcBatteries.Any())
-            {
-                foreach (var receiver in _providerReceivers.SelectMany(kvp => kvp.Value))
-                {
-                    receiver.HasApcPower = false;
-                }
-            }
         }
 
         public void AddPowerProvider(PowerProviderComponent provider)
         {
-            _providerReceivers.Add(provider, provider.LinkedReceivers.ToList());
+            _providers.Add(provider);
+
+            foreach (var receiver in provider.LinkedReceivers)
+            {
+                TotalPowerReceiverLoad += receiver.Load;
+            }
         }
 
         public void RemovePowerProvider(PowerProviderComponent provider)
         {
-            _providerReceivers.Remove(provider);
+            _providers.Remove(provider);
+
+            foreach (var receiver in provider.LinkedReceivers)
+            {
+                TotalPowerReceiverLoad -= receiver.Load;
+            }
         }
 
-        public void UpdatePowerProviderReceivers(PowerProviderComponent provider)
+        public void UpdatePowerProviderReceivers(PowerProviderComponent provider, int oldLoad, int newLoad)
         {
-            Debug.Assert(_providerReceivers.ContainsKey(provider));
-            _providerReceivers[provider] = provider.LinkedReceivers.ToList();
-        }
+            Debug.Assert(_providers.Contains(provider));
+            TotalPowerReceiverLoad -= oldLoad;
+            TotalPowerReceiverLoad += newLoad;
+        } 
 
         public void Update(float frameTime)
         {
-            var totalCharge = 0.0;
-            var totalMaxCharge = 0;
-            foreach (var (apc, battery) in _apcBatteries)
+            var remainingPowerNeeded = TotalPowerReceiverLoad * frameTime;
+
+            foreach (var apcBatteryPair in _apcBatteries)
             {
+                var apc = apcBatteryPair.Key;
+
                 if (!apc.MainBreakerEnabled)
                     continue;
 
-                totalCharge += battery.CurrentCharge;
-                totalMaxCharge += battery.MaxCharge;
+                var battery = apcBatteryPair.Value;
+
+                if (battery.CurrentCharge < remainingPowerNeeded)
+                {
+                    remainingPowerNeeded -= battery.CurrentCharge;
+                    battery.CurrentCharge = 0;
+                }
+                else
+                {
+                    battery.UseCharge(remainingPowerNeeded);
+                    remainingPowerNeeded = 0;
+                }
+
+                if (remainingPowerNeeded == 0)
+                    break;
             }
 
-            foreach (var (_, receivers) in _providerReceivers)
-            {
-                foreach (var receiver in receivers)
-                {
-                    if (!receiver.NeedsPower || receiver.PowerDisabled)
-                        continue;
+            Powered = remainingPowerNeeded == 0;
+        }
 
-                    receiver.HasApcPower = TryUsePower(receiver.Load * frameTime);
-                }
+        private void SetPowered(bool powered)
+        {
+            if (powered != Powered)
+            {
+                _powered = powered;
+                PoweredChanged();
             }
         }
 
-        private bool TryUsePower(float neededCharge)
+        private void PoweredChanged()
         {
-            foreach (var (apc, battery) in _apcBatteries)
+            foreach (var provider in _providers)
             {
-                if (!apc.MainBreakerEnabled)
-                    continue;
-
-                if (battery.TryUseCharge(neededCharge)) //simplification - all power needed must come from one battery
+                foreach (var receiver in provider.LinkedReceivers)
                 {
-                    return true;
+                    receiver.ApcPowerChanged();
                 }
             }
-            return false;
         }
 
         #endregion
 
         private class NullApcNet : IApcNet
         {
+            /// <summary>
+            ///     It is important that this returns false, so <see cref="PowerProviderComponent"/>s with a <see cref="NullApcNet"/> have no power.
+            /// </summary>
+            public bool Powered => false;
             public void AddApc(ApcComponent apc) { }
             public void AddPowerProvider(PowerProviderComponent provider) { }
             public void RemoveApc(ApcComponent apc) { }
             public void RemovePowerProvider(PowerProviderComponent provider) { }
-            public void UpdatePowerProviderReceivers(PowerProviderComponent provider) { }
+            public void UpdatePowerProviderReceivers(PowerProviderComponent provider, int oldLoad, int newLoad) { }
             public void Update(float frameTime) { }
         }
     }

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerProviderComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerProviderComponent.cs
@@ -18,6 +18,8 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
 
         void RemoveReceiver(PowerReceiverComponent receiver);
 
+        void UpdateReceiverLoad(int oldLoad, int newLoad);
+
         public IEntity ProviderOwner { get; }
 
         public bool HasApcPower { get; }
@@ -65,6 +67,11 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
             var oldLoad = GetTotalLoad();
             _linkedReceivers.Remove(receiver);
             var newLoad = oldLoad - receiver.Load;
+            Net.UpdatePowerProviderReceivers(this, oldLoad, newLoad);
+        }
+
+        public void UpdateReceiverLoad(int oldLoad, int newLoad)
+        {
             Net.UpdatePowerProviderReceivers(this, oldLoad, newLoad);
         }
 
@@ -145,13 +152,15 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
 
         private class NullPowerProvider : IPowerProvider
         {
-            public void AddReceiver(PowerReceiverComponent receiver) { }
-            public void RemoveReceiver(PowerReceiverComponent receiver) { }
-            public IEntity ProviderOwner => default;
             /// <summary>
             ///     It is important that this returns false, so <see cref="PowerReceiverComponent"/>s with a <see cref="NullPowerProvider"/> have no power.
             /// </summary>
             public bool HasApcPower => false;
+
+            public void AddReceiver(PowerReceiverComponent receiver) { }
+            public void RemoveReceiver(PowerReceiverComponent receiver) { }
+            public void UpdateReceiverLoad(int oldLoad, int newLoad) { }
+            public IEntity ProviderOwner => default;
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
@@ -182,6 +182,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
 
         private void SetLoad(int newLoad)
         {
+            Provider.UpdateReceiverLoad(Load, newLoad);
             _load = newLoad;
         }
 

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using Content.Server.GameObjects.Components.NodeContainer.NodeGroups;
 using Content.Shared.GameObjects.Components.Power;
@@ -33,9 +33,11 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
         [ViewVariables]
         public bool Powered => (HasApcPower || !NeedsPower) && !PowerDisabled;
 
+        /// <summary>
+        ///     If this is being powered by an Apc.
+        /// </summary>
         [ViewVariables]
-        public bool HasApcPower { get => _hasApcPower; set => SetHasApcPower(value); }
-        private bool _hasApcPower;
+        public bool HasApcPower { get; private set; }
 
         /// <summary>
         ///     The max distance from a <see cref="PowerProviderComponent"/> that this can receive power from.
@@ -102,7 +104,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
             }
         }
 
-        public override void OnRemove()
+        public override void OnRemove() 
         {
             if (_physicsComponent != null)
             {
@@ -118,6 +120,14 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
             {
                 Provider = provider;
             }
+        }
+
+        public void ApcPowerChanged()
+        {
+            var oldPowered = Powered;
+            HasApcPower = Provider.HasApcPower;
+            if (Powered != oldPowered)
+                OnNewPowerState();
         }
 
         private bool TryFindAvailableProvider(out IPowerProvider foundProvider)
@@ -151,7 +161,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
             _provider.RemoveReceiver(this);
             _provider = PowerProviderComponent.NullProvider;
             NeedsProvider = true;
-            HasApcPower = false;
+            ApcPowerChanged();
         }
 
         private void SetProvider(IPowerProvider newProvider)
@@ -160,16 +170,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
             _provider = newProvider;
             newProvider.AddReceiver(this);
             NeedsProvider = false;
-        }
-
-        private void SetHasApcPower(bool newHasApcPower)
-        {
-            var oldPowered = Powered;
-            _hasApcPower = newHasApcPower;
-            if (oldPowered != Powered)
-            {
-                OnNewPowerState();
-            }
+            ApcPowerChanged();
         }
 
         private void SetPowerReceptionRange(int newPowerReceptionRange)
@@ -227,10 +228,10 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents
                 ClearProvider();
             }
         }
+
         ///<summary>
         ///Adds some markup to the examine text of whatever object is using this component to tell you if it's powered or not, even if it doesn't have an icon state to do this for you.
         ///</summary>
-
         public void Examine(FormattedMessage message, bool inDetailsRange)
         {
             message.AddMarkup(Loc.GetString("It appears to be {0}.", Powered ? "[color=darkgreen]powered[/color]" : "[color=darkred]un-powered[/color]"));


### PR DESCRIPTION
Previously, ApcNets wrote to each connected PowerReceiverComponent.HasApcPower every frame. Instead, this only occurs when the ApcNet no longer has enough power, or regains power.