### PR TITLE
You can now examine Node Containers to see their "connectors"

### DIFF
--- a/Content.Server/GameObjects/Components/NodeContainer/NodeContainerComponent.cs
+++ b/Content.Server/GameObjects/Components/NodeContainer/NodeContainerComponent.cs
@@ -1,7 +1,11 @@
 ﻿using System.Collections.Generic;
+using Content.Server.GameObjects.Components.NodeContainer.NodeGroups;
 using Content.Server.GameObjects.Components.NodeContainer.Nodes;
+using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.NodeContainer
@@ -10,18 +14,20 @@ namespace Content.Server.GameObjects.Components.NodeContainer
     ///     Creates and maintains a set of <see cref="Node"/>s.
     /// </summary>
     [RegisterComponent]
-    public class NodeContainerComponent : Component
+    public class NodeContainerComponent : Component, IExamine
     {
         public override string Name => "NodeContainer";
 
         [ViewVariables]
         public IReadOnlyList<Node> Nodes => _nodes;
         private List<Node> _nodes = new();
+        private bool _examinable;
 
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);
             serializer.DataField(ref _nodes, "nodes", new List<Node>());
+            serializer.DataField(ref _examinable, "examinable", false);
         }
 
         public override void Initialize()
@@ -49,6 +55,35 @@ namespace Content.Server.GameObjects.Components.NodeContainer
                 node.OnContainerRemove();
             }
             base.OnRemove();
+        }
+
+        public void Examine(FormattedMessage message, bool inDetailsRange)
+        {
+            if (!_examinable || !inDetailsRange) return;
+
+            for (var i = 0; i < Nodes.Count; i++)
+            {
+                var node = Nodes[i];
+                if (node == null) continue;
+                switch (node.NodeGroupID)
+                {
+                    case NodeGroupID.HVPower:
+                        message.AddMarkup(
+                            Loc.GetString("It has a connector for [color=orange]HV cables[/color]."));
+                        break;
+                    case NodeGroupID.MVPower:
+                        message.AddMarkup(
+                            Loc.GetString("It has a connector for [color=yellow]MV cables[/color]."));
+                        break;
+                    case NodeGroupID.Apc:
+                        message.AddMarkup(
+                            Loc.GetString("It has a connector for [color=green]LV cables[/color]."));
+                        break;
+                }
+
+                if(i != Nodes.Count - 1)
+                    message.AddMarkup("\n");
+            }
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverComponent.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using Content.Server.GameObjects.Components.NodeContainer;
 using Content.Server.GameObjects.Components.NodeContainer.NodeGroups;
 using Content.Shared.GameObjects.Components.Power;
 using Content.Shared.GameObjects.EntitySystems;

--- a/Resources/Prototypes/Entities/Constructible/Power/particleAccelerator.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/particleAccelerator.yml
@@ -225,6 +225,7 @@
     - type: PowerConsumer
       voltage: High
     - type: NodeContainer
+      examinable: true
       nodes:
         - !type:AdjacentNode
           nodeGroupID: HVPower

--- a/Resources/Prototypes/Entities/Constructible/Power/power_base.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/power_base.yml
@@ -30,6 +30,7 @@
     sprite: Constructible/Power/power.rsi
     state: generator
   - type: NodeContainer
+    examinable: true
     nodes:
     - !type:AdjacentNode
       nodeGroupID: HVPower
@@ -80,6 +81,7 @@
     maxCharge: 1000
     startingCharge: 1000
   - type: NodeContainer
+    examinable: true
     nodes:
     - !type:AdjacentNode
       nodeGroupID: HVPower
@@ -131,6 +133,7 @@
     maxCharge: 1000
     startingCharge: 1000
   - type: NodeContainer
+    examinable: true
     nodes:
     - !type:AdjacentNode
       nodeGroupID: HVPower
@@ -177,6 +180,7 @@
     maxCharge: 10000
     startingCharge: 10000
   - type: NodeContainer
+    examinable: true
     nodes:
     - !type:AdjacentNode
       nodeGroupID: MVPower
@@ -226,6 +230,7 @@
     sprite: Constructible/Power/solar_panel.rsi
     state: normal
   - type: NodeContainer
+    examinable: true
     nodes:
     - !type:AdjacentNode
       nodeGroupID: HVPower

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/AME/ame_controller.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/AME/ame_controller.yml
@@ -43,6 +43,7 @@
     visuals:
     - type: AMEControllerVisualizer
   - type: NodeContainer
+    examinable: true
     nodes:
     - !type:AdjacentNode
       nodeGroupID: AMEngine

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/emitter.yml
@@ -38,6 +38,7 @@
   - type: PowerConsumer
     voltage: Medium
   - type: NodeContainer
+    examinable: true
     nodes:
     - !type:AdjacentNode
       nodeGroupID: MVPower

--- a/Resources/Prototypes/Entities/singularity.yml
+++ b/Resources/Prototypes/Entities/singularity.yml
@@ -51,6 +51,7 @@
     visuals:
       - type: RadiationCollectorVisualizer
   - type: NodeContainer
+    examinable: true
     nodes:
     - !type:AdjacentNode
       nodeGroupID: HVPower


### PR DESCRIPTION
Added an "opt-in" field to NodeContainerComponent so it shows "connector" info on examine.
For now it only supports power cables.

![image](https://user-images.githubusercontent.com/6766154/103439204-24da4d80-4c3b-11eb-80b3-569f9b9492aa.png)
![image](https://user-images.githubusercontent.com/6766154/103439206-273ca780-4c3b-11eb-9723-220491f0d734.png)
Colored after the cables themselves.