### PR TITLE
Destructible spawning fix redux

### DIFF
--- a/Content.IntegrationTests/Tests/Destructible/DestructibleTests.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleTests.cs
@@ -20,9 +20,15 @@ namespace Content.IntegrationTests.Tests.Destructible
     [TestOf(typeof(Threshold))]
     public class DestructibleTests : ContentIntegrationTest
     {
+        private static readonly string SpawnedEntityId = "DestructibleTestsSpawnedEntity";
         private static readonly string DestructibleEntityId = "DestructibleTestsDestructibleEntity";
+        private static readonly string DestructibleDestructionEntityId = "DestructibleTestsDestructibleDestructionEntity";
 
         private static readonly string Prototypes = $@"
+- type: entity
+  id: {SpawnedEntityId}
+  name: {SpawnedEntityId}
+
 - type: entity
   id: {DestructibleEntityId}
   name: {DestructibleEntityId}
@@ -41,7 +47,27 @@ namespace Content.IntegrationTests.Tests.Destructible
           sound: /Audio/Effects/woodhit.ogg
         - !type:SpawnEntitiesBehavior
           spawn:
-            WoodPlank:
+            {SpawnedEntityId}:
+              min: 1
+              max: 1
+  - type: TestThresholdListener
+
+- type: entity
+  id: {DestructibleDestructionEntityId}
+  name: {DestructibleDestructionEntityId}
+  components:
+  - type: Damageable
+  - type: Destructible
+    thresholds:
+      50:
+        behaviors:
+        - !type:DoActsBehavior # This must come first to test a potential crash
+          acts: [""Destruction""]
+        - !type:PlaySoundBehavior
+          sound: /Audio/Effects/woodhit.ogg
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            {SpawnedEntityId}:
               min: 1
               max: 1
   - type: TestThresholdListener
@@ -155,7 +181,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                 Assert.That(soundThreshold.Sound, Is.EqualTo("/Audio/Effects/woodhit.ogg"));
                 Assert.That(spawnThreshold.Spawn, Is.Not.Null);
                 Assert.That(spawnThreshold.Spawn.Count, Is.EqualTo(1));
-                Assert.That(spawnThreshold.Spawn.Single().Key, Is.EqualTo("WoodPlank"));
+                Assert.That(spawnThreshold.Spawn.Single().Key, Is.EqualTo(SpawnedEntityId));
                 Assert.That(spawnThreshold.Spawn.Single().Value.Min, Is.EqualTo(1));
                 Assert.That(spawnThreshold.Spawn.Single().Value.Max, Is.EqualTo(1));
                 Assert.That(threshold.Triggered, Is.True);
@@ -211,7 +237,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                 Assert.That(soundThreshold.Sound, Is.EqualTo("/Audio/Effects/woodhit.ogg"));
                 Assert.That(spawnThreshold.Spawn, Is.Not.Null);
                 Assert.That(spawnThreshold.Spawn.Count, Is.EqualTo(1));
-                Assert.That(spawnThreshold.Spawn.Single().Key, Is.EqualTo("WoodPlank"));
+                Assert.That(spawnThreshold.Spawn.Single().Key, Is.EqualTo(SpawnedEntityId));
                 Assert.That(spawnThreshold.Spawn.Single().Value.Min, Is.EqualTo(1));
                 Assert.That(spawnThreshold.Spawn.Single().Value.Max, Is.EqualTo(1));
                 Assert.That(threshold.Triggered, Is.True);
@@ -263,7 +289,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                 Assert.That(soundThreshold.Sound, Is.EqualTo("/Audio/Effects/woodhit.ogg"));
                 Assert.That(spawnThreshold.Spawn, Is.Not.Null);
                 Assert.That(spawnThreshold.Spawn.Count, Is.EqualTo(1));
-                Assert.That(spawnThreshold.Spawn.Single().Key, Is.EqualTo("WoodPlank"));
+                Assert.That(spawnThreshold.Spawn.Single().Key, Is.EqualTo(SpawnedEntityId));
                 Assert.That(spawnThreshold.Spawn.Single().Value.Min, Is.EqualTo(1));
                 Assert.That(spawnThreshold.Spawn.Single().Value.Max, Is.EqualTo(1));
                 Assert.That(threshold.Triggered, Is.True);
@@ -303,6 +329,85 @@ namespace Content.IntegrationTests.Tests.Destructible
 
                 // They shouldn't have been triggered by changing TriggersOnce
                 Assert.That(sThresholdListenerComponent.ThresholdsReached, Is.Empty);
+            });
+        }
+
+        [Test]
+        public async Task DestructibleDestructionTest()
+        {
+            var server = StartServerDummyTicker(new ServerContentIntegrationOption
+            {
+                ExtraPrototypes = Prototypes,
+                ContentBeforeIoC = () =>
+                {
+                    IoCManager.Resolve<IComponentFactory>().Register<TestThresholdListenerComponent>();
+                }
+            });
+
+            await server.WaitIdleAsync();
+
+            var sEntityManager = server.ResolveDependency<IEntityManager>();
+            var sMapManager = server.ResolveDependency<IMapManager>();
+
+            IEntity sDestructibleEntity = null;
+            IDamageableComponent sDamageableComponent = null;
+            DestructibleComponent sDestructibleComponent = null;
+            TestThresholdListenerComponent sThresholdListenerComponent = null;
+
+            await server.WaitPost(() =>
+            {
+                var mapId = new MapId(1);
+                var coordinates = new MapCoordinates(0, 0, mapId);
+                sMapManager.CreateMap(mapId);
+
+                sDestructibleEntity = sEntityManager.SpawnEntity(DestructibleDestructionEntityId, coordinates);
+                sDamageableComponent = sDestructibleEntity.GetComponent<IDamageableComponent>();
+                sDestructibleComponent = sDestructibleEntity.GetComponent<DestructibleComponent>();
+                sThresholdListenerComponent = sDestructibleEntity.GetComponent<TestThresholdListenerComponent>();
+            });
+
+            await server.WaitAssertion(() =>
+            {
+                var coordinates = sDestructibleEntity.Transform.Coordinates;
+
+                Assert.DoesNotThrow(() =>
+                {
+                    Assert.True(sDamageableComponent.ChangeDamage(DamageClass.Brute, 50, true));
+                });
+
+                Assert.That(sThresholdListenerComponent.ThresholdsReached.Count, Is.EqualTo(1));
+
+                var threshold = sThresholdListenerComponent.ThresholdsReached[0].Threshold;
+
+                Assert.True(threshold.Triggered);
+                Assert.That(threshold.Behaviors.Count, Is.EqualTo(3));
+
+                var spawnEntitiesBehavior = (SpawnEntitiesBehavior) threshold.Behaviors.Single(b => b is SpawnEntitiesBehavior);
+
+                Assert.That(spawnEntitiesBehavior.Spawn.Count, Is.EqualTo(1));
+                Assert.That(spawnEntitiesBehavior.Spawn.Keys.Single(), Is.EqualTo(SpawnedEntityId));
+                Assert.That(spawnEntitiesBehavior.Spawn.Values.Single(), Is.EqualTo(new MinMax {Min = 1, Max = 1}));
+
+                var entitiesInRange = sEntityManager.GetEntitiesInRange(coordinates, 2);
+                var found = false;
+
+                foreach (var entity in entitiesInRange)
+                {
+                    if (entity.Prototype == null)
+                    {
+                        continue;
+                    }
+
+                    if (entity.Prototype.Name != SpawnedEntityId)
+                    {
+                        continue;
+                    }
+
+                    found = true;
+                    break;
+                }
+
+                Assert.True(found);
             });
         }
     }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleTests.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleTests.cs
@@ -41,8 +41,6 @@ namespace Content.IntegrationTests.Tests.Destructible
       50:
         triggersOnce: false
         behaviors:
-        - !type:DoActsBehavior
-          acts: [""Breakage""]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/woodhit.ogg
         - !type:SpawnEntitiesBehavior
@@ -50,6 +48,8 @@ namespace Content.IntegrationTests.Tests.Destructible
             {SpawnedEntityId}:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [""Breakage""]
   - type: TestThresholdListener
 
 - type: entity
@@ -61,10 +61,6 @@ namespace Content.IntegrationTests.Tests.Destructible
     thresholds:
       50:
         behaviors:
-        - !type:DoActsBehavior # This must come first to test a potential crash
-          acts: [""Destruction""]
-        - !type:DoActsBehavior
-          acts: [""Destruction""]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/woodhit.ogg
         - !type:SpawnEntitiesBehavior
@@ -72,6 +68,8 @@ namespace Content.IntegrationTests.Tests.Destructible
             {SpawnedEntityId}:
               min: 1
               max: 1
+        - !type:DoActsBehavior # This must come last as it destroys the entity.
+          acts: [""Destruction""]
   - type: TestThresholdListener
 ";
 
@@ -175,9 +173,9 @@ namespace Content.IntegrationTests.Tests.Destructible
                 // Check that it matches the YAML prototype
                 Assert.That(threshold.Behaviors, Has.Count.EqualTo(3));
 
-                var actsThreshold = (DoActsBehavior) threshold.Behaviors[0];
-                var soundThreshold = (PlaySoundBehavior) threshold.Behaviors[1];
-                var spawnThreshold = (SpawnEntitiesBehavior) threshold.Behaviors[2];
+                var soundThreshold = (PlaySoundBehavior) threshold.Behaviors[0];
+                var spawnThreshold = (SpawnEntitiesBehavior) threshold.Behaviors[1];
+                var actsThreshold = (DoActsBehavior) threshold.Behaviors[2];
 
                 Assert.That(actsThreshold.Acts, Is.EqualTo(ThresholdActs.Breakage));
                 Assert.That(soundThreshold.Sound, Is.EqualTo("/Audio/Effects/woodhit.ogg"));
@@ -230,9 +228,9 @@ namespace Content.IntegrationTests.Tests.Destructible
                 // Check that it matches the YAML prototype
                 Assert.That(threshold.Behaviors, Has.Count.EqualTo(3));
 
-                actsThreshold = (DoActsBehavior) threshold.Behaviors[0];
-                soundThreshold = (PlaySoundBehavior) threshold.Behaviors[1];
-                spawnThreshold = (SpawnEntitiesBehavior) threshold.Behaviors[2];
+                soundThreshold = (PlaySoundBehavior) threshold.Behaviors[0];
+                spawnThreshold = (SpawnEntitiesBehavior) threshold.Behaviors[1];
+                actsThreshold = (DoActsBehavior) threshold.Behaviors[2];
 
                 // Check that it matches the YAML prototype
                 Assert.That(actsThreshold.Acts, Is.EqualTo(ThresholdActs.Breakage));
@@ -282,9 +280,9 @@ namespace Content.IntegrationTests.Tests.Destructible
 
                 Assert.That(threshold.Behaviors, Has.Count.EqualTo(3));
 
-                actsThreshold = (DoActsBehavior) threshold.Behaviors[0];
-                soundThreshold = (PlaySoundBehavior) threshold.Behaviors[1];
-                spawnThreshold = (SpawnEntitiesBehavior) threshold.Behaviors[2];
+                soundThreshold = (PlaySoundBehavior) threshold.Behaviors[0];
+                spawnThreshold = (SpawnEntitiesBehavior) threshold.Behaviors[1];
+                actsThreshold = (DoActsBehavior) threshold.Behaviors[2];
 
                 // Check that it matches the YAML prototype
                 Assert.That(actsThreshold.Acts, Is.EqualTo(ThresholdActs.Breakage));
@@ -381,8 +379,8 @@ namespace Content.IntegrationTests.Tests.Destructible
 
                 var threshold = sThresholdListenerComponent.ThresholdsReached[0].Threshold;
 
-                Assert.True(threshold.Triggered);
-                Assert.That(threshold.Behaviors.Count, Is.EqualTo(4));
+                Assert.That(threshold.Triggered, Is.True);
+                Assert.That(threshold.Behaviors.Count, Is.EqualTo(3));
 
                 var spawnEntitiesBehavior = (SpawnEntitiesBehavior) threshold.Behaviors.Single(b => b is SpawnEntitiesBehavior);
 
@@ -409,7 +407,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                     break;
                 }
 
-                Assert.True(found);
+                Assert.That(found, Is.True);
             });
         }
     }

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleTests.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleTests.cs
@@ -63,6 +63,8 @@ namespace Content.IntegrationTests.Tests.Destructible
         behaviors:
         - !type:DoActsBehavior # This must come first to test a potential crash
           acts: [""Destruction""]
+        - !type:DoActsBehavior
+          acts: [""Destruction""]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/woodhit.ogg
         - !type:SpawnEntitiesBehavior
@@ -380,7 +382,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                 var threshold = sThresholdListenerComponent.ThresholdsReached[0].Threshold;
 
                 Assert.True(threshold.Triggered);
-                Assert.That(threshold.Behaviors.Count, Is.EqualTo(3));
+                Assert.That(threshold.Behaviors.Count, Is.EqualTo(4));
 
                 var spawnEntitiesBehavior = (SpawnEntitiesBehavior) threshold.Behaviors.Single(b => b is SpawnEntitiesBehavior);
 

--- a/Content.Server/GameObjects/Components/Destructible/Thresholds/Behavior/DoActsBehavior.cs
+++ b/Content.Server/GameObjects/Components/Destructible/Thresholds/Behavior/DoActsBehavior.cs
@@ -9,6 +9,8 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds.Behavior
     {
         private int _acts;
 
+        public bool DeletesEntity => HasAct(ThresholdActs.Destruction);
+
         /// <summary>
         ///     What acts should be triggered upon activation.
         ///     See <see cref="ActSystem"/>.

--- a/Content.Server/GameObjects/Components/Destructible/Thresholds/Behavior/DoActsBehavior.cs
+++ b/Content.Server/GameObjects/Components/Destructible/Thresholds/Behavior/DoActsBehavior.cs
@@ -9,8 +9,6 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds.Behavior
     {
         private int _acts;
 
-        public bool DeletesEntity => HasAct(ThresholdActs.Destruction);
-
         /// <summary>
         ///     What acts should be triggered upon activation.
         ///     See <see cref="ActSystem"/>.

--- a/Content.Server/GameObjects/Components/Destructible/Thresholds/Behavior/IThresholdBehavior.cs
+++ b/Content.Server/GameObjects/Components/Destructible/Thresholds/Behavior/IThresholdBehavior.cs
@@ -6,6 +6,20 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds.Behavior
 {
     public interface IThresholdBehavior : IExposeData
     {
+        /// <summary>
+        ///     Whether or not this behavior will delete the entity.
+        ///     Used to order it during execution.
+        /// </summary>
+        bool DeletesEntity => false;
+
+        /// <summary>
+        ///     Triggers this behavior.
+        /// </summary>
+        /// <param name="owner">The entity that owns this behavior.</param>
+        /// <param name="system">
+        ///     An instance of <see cref="DestructibleSystem"/> to pull dependencies
+        ///     and other systems from.
+        /// </param>
         void Trigger(IEntity owner, DestructibleSystem system);
     }
 }

--- a/Content.Server/GameObjects/Components/Destructible/Thresholds/Behavior/IThresholdBehavior.cs
+++ b/Content.Server/GameObjects/Components/Destructible/Thresholds/Behavior/IThresholdBehavior.cs
@@ -7,12 +7,6 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds.Behavior
     public interface IThresholdBehavior : IExposeData
     {
         /// <summary>
-        ///     Whether or not this behavior will delete the entity.
-        ///     Used to order it during execution.
-        /// </summary>
-        bool DeletesEntity => false;
-
-        /// <summary>
         ///     Triggers this behavior.
         /// </summary>
         /// <param name="owner">The entity that owns this behavior.</param>

--- a/Content.Server/GameObjects/Components/Destructible/Thresholds/Threshold.cs
+++ b/Content.Server/GameObjects/Components/Destructible/Thresholds/Threshold.cs
@@ -48,6 +48,8 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds
         {
             Triggered = true;
 
+            Behaviors.Sort((a, b) => a.DeletesEntity ? 1 : 0);
+
             foreach (var behavior in Behaviors)
             {
                 behavior.Trigger(owner, system);

--- a/Content.Server/GameObjects/Components/Destructible/Thresholds/Threshold.cs
+++ b/Content.Server/GameObjects/Components/Destructible/Thresholds/Threshold.cs
@@ -48,7 +48,7 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds
         {
             Triggered = true;
 
-            Behaviors.Sort((a, b) => a.DeletesEntity ? 1 : 0);
+            Behaviors.Sort((a, b) => a.DeletesEntity.CompareTo(b.DeletesEntity));
 
             foreach (var behavior in Behaviors)
             {

--- a/Content.Server/GameObjects/Components/Destructible/Thresholds/Threshold.cs
+++ b/Content.Server/GameObjects/Components/Destructible/Thresholds/Threshold.cs
@@ -11,10 +11,12 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds
 {
     public class Threshold : IExposeData
     {
+        private List<IThresholdBehavior> _behaviors = new();
+
         /// <summary>
         ///     Whether or not this threshold has already been triggered.
         /// </summary>
-        [ViewVariables] public bool Triggered;
+        [ViewVariables] public bool Triggered { get; private set; }
 
         /// <summary>
         ///     Whether or not this threshold only triggers once.
@@ -22,18 +24,18 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds
         ///     and then damaged to reach this threshold once again.
         ///     It will not repeatedly trigger as damage rises beyond that.
         /// </summary>
-        [ViewVariables] public bool TriggersOnce;
+        [ViewVariables] public bool TriggersOnce { get; set; }
 
         /// <summary>
         ///     Behaviors to activate once this threshold is triggered.
         /// </summary>
-        [ViewVariables] public List<IThresholdBehavior> Behaviors = new();
+        [ViewVariables] public IReadOnlyList<IThresholdBehavior> Behaviors => _behaviors;
 
         public void ExposeData(ObjectSerializer serializer)
         {
-            serializer.DataField(ref Triggered, "triggered", false);
-            serializer.DataField(ref TriggersOnce, "triggersOnce", false);
-            serializer.DataField(ref Behaviors, "behaviors", new List<IThresholdBehavior>());
+            serializer.DataField(this, x => x.Triggered, "triggered", false);
+            serializer.DataField(this, x => x.TriggersOnce, "triggersOnce", false);
+            serializer.DataField(ref _behaviors, "behaviors", new List<IThresholdBehavior>());
         }
 
         /// <summary>
@@ -48,10 +50,12 @@ namespace Content.Server.GameObjects.Components.Destructible.Thresholds
         {
             Triggered = true;
 
-            Behaviors.Sort((a, b) => a.DeletesEntity.CompareTo(b.DeletesEntity));
-
             foreach (var behavior in Behaviors)
             {
+                // The owner has been deleted. We stop execution of behaviors here.
+                if (owner.Deleted)
+                    return;
+
                 behavior.Trigger(owner, system);
             }
         }

--- a/Resources/Prototypes/Entities/Constructible/Furniture/bookshelf.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/bookshelf.yml
@@ -25,8 +25,6 @@
     thresholds:
       30:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/woodhit.ogg
         - !type:SpawnEntitiesBehavior
@@ -34,6 +32,9 @@
             WoodPlank:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+
   - type: Occluder
     sizeX: 32
     sizeY: 32

--- a/Resources/Prototypes/Entities/Constructible/Furniture/storage.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/storage.yml
@@ -33,8 +33,6 @@
     thresholds:
       30:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/metalbreak.ogg
         - !type:SpawnEntitiesBehavior
@@ -42,6 +40,8 @@
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   id: Shelf
@@ -78,8 +78,6 @@
     thresholds:
       30:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/metalbreak.ogg
         - !type:SpawnEntitiesBehavior
@@ -87,3 +85,5 @@
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Constructible/Furniture/tables.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/tables.yml
@@ -41,8 +41,6 @@
     thresholds:
       15:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/metalbreak.ogg
         - !type:SpawnEntitiesBehavior
@@ -50,6 +48,8 @@
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   id: TableFrame
@@ -67,8 +67,6 @@
     thresholds:
       1:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/metalbreak.ogg
         - !type:SpawnEntitiesBehavior
@@ -76,6 +74,8 @@
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Construction
     graph: Tables
     node: TableFrame
@@ -96,8 +96,6 @@
     thresholds:
       1:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/metalbreak.ogg
         - !type:SpawnEntitiesBehavior
@@ -105,6 +103,8 @@
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   id: TableMetal
@@ -122,8 +122,6 @@
     thresholds:
       15:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/metalbreak.ogg
         - !type:SpawnEntitiesBehavior
@@ -131,6 +129,8 @@
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Construction
     graph: Tables
     node: MetalTable
@@ -151,8 +151,6 @@
     thresholds:
       75:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/metalbreak.ogg
         - !type:SpawnEntitiesBehavior
@@ -160,6 +158,8 @@
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Construction
     graph: Tables
     node: ReinforcedTable
@@ -180,8 +180,6 @@
     thresholds:
       5:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/glass_break2.ogg
         - !type:SpawnEntitiesBehavior
@@ -189,6 +187,8 @@
             ShardGlass:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Construction
     graph: Tables
     node: GlassTable
@@ -209,8 +209,6 @@
     thresholds:
       20:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/glass_break2.ogg
         - !type:SpawnEntitiesBehavior
@@ -218,6 +216,8 @@
             ShardGlass:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Construction
     graph: Tables
     node: RGlassTable
@@ -238,8 +238,6 @@
     thresholds:
       15:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/woodhit.ogg
         - !type:SpawnEntitiesBehavior
@@ -247,6 +245,8 @@
             WoodPlank:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Construction
     graph: Tables
     node: WoodTable
@@ -267,8 +267,6 @@
     thresholds:
       15:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/woodhit.ogg
         - !type:SpawnEntitiesBehavior
@@ -276,6 +274,8 @@
             WoodPlank:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Construction
     graph: Tables
     node: PokerTable
@@ -296,10 +296,10 @@
     thresholds:
       50:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/picaxe2.ogg
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   id: TableDebug

--- a/Resources/Prototypes/Entities/Constructible/Power/wires.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/wires.yml
@@ -55,13 +55,13 @@
     thresholds:
       100:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             HVWireStack1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   parent: WireBase
@@ -92,13 +92,13 @@
     thresholds:
       100:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             MVWireStack1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   parent: WireBase
@@ -131,10 +131,10 @@
     thresholds:
       100:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             ApcExtensionCableStack1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Constructible/Specific/chem_master.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/chem_master.yml
@@ -37,13 +37,13 @@
     thresholds:
       50:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             chem_master_broken:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: UserInterface
     interfaces:
     - key: enum.ChemMasterUiKey.Key
@@ -86,13 +86,13 @@
     thresholds:
       25:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: UserInterface
     interfaces:
     - key: enum.ChemMasterUiKey.Key

--- a/Resources/Prototypes/Entities/Constructible/Walls/girder.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/girder.yml
@@ -31,13 +31,13 @@
     thresholds:
       50:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: SnapGrid
     offset: Edge
   placement:

--- a/Resources/Prototypes/Entities/Constructible/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/walls.yml
@@ -50,13 +50,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: brick
@@ -76,13 +76,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: clock
@@ -102,13 +102,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: clown
@@ -129,13 +129,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: cult
@@ -155,13 +155,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: debug
@@ -181,13 +181,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: diamond
@@ -208,13 +208,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: gold
@@ -234,13 +234,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: ice
@@ -260,13 +260,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: metal
@@ -286,13 +286,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: plasma
@@ -312,13 +312,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: plastic
@@ -371,13 +371,13 @@
     thresholds:
       1000:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: riveted
@@ -397,13 +397,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: sandstone
@@ -423,13 +423,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: silver
@@ -477,13 +477,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: uranium
@@ -503,13 +503,13 @@
     thresholds:
       300:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:SpawnEntitiesBehavior
           spawn:
             Girder:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: IconSmooth
     key: walls
     base: wood

--- a/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
@@ -32,8 +32,6 @@
     thresholds:
       15:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundCollectionBehavior
           soundCollection: WindowBreak
         - !type:SpawnEntitiesBehavior
@@ -41,6 +39,8 @@
             ShardGlass:
               min: 1
               max: 2
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: SnapGrid
     offset: Center
   - type: Airtight
@@ -70,8 +70,6 @@
     thresholds:
       75:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundCollectionBehavior
           soundCollection: WindowBreak
         - !type:SpawnEntitiesBehavior
@@ -79,6 +77,8 @@
             ShardGlassReinforced:
               min: 1
               max: 2
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Window
     base: rwindow
     maxDamage: 75
@@ -102,8 +102,6 @@
     thresholds:
       100:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundCollectionBehavior
           soundCollection: WindowBreak
         - !type:SpawnEntitiesBehavior
@@ -111,6 +109,8 @@
             ShardGlassPhoron:
               min: 1
               max: 2
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
     resistances: metallicResistances
   - type: Window
     base: pwindow

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
@@ -29,8 +29,6 @@
     thresholds:
       5:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundCollectionBehavior
           soundCollection: WindowBreak
         - !type:SpawnEntitiesBehavior
@@ -38,6 +36,8 @@
             ShardGlass:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: DamageOnLand
     amount: 5
   - type: DamageOtherOnHit

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -133,8 +133,6 @@
     thresholds:
       10:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/glass_break1.ogg
         - !type:SpawnEntitiesBehavior
@@ -142,6 +140,8 @@
             FloodlightBroken:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Appearance
     visuals:
       - type: FlashLightVisualizer
@@ -162,8 +162,6 @@
     thresholds:
       20:
         behaviors:
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
         - !type:PlaySoundBehavior
           sound: /Audio/Effects/metalbreak.ogg
         - !type:SpawnEntitiesBehavior
@@ -171,6 +169,8 @@
             SteelSheet1:
               min: 1
               max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: Physics
     shapes:
     - !type:PhysShapeAabb


### PR DESCRIPTION
Supersedes #2829, fixes #2827
Basically does the same, but instead of ordering by whether a behavior deletes the entity or not, we execute behaviors linearly (same order as defined in YAML) and stop executing behaviors if the entity has been deleted. This is the same thing construction does!