### PR TITLE
Adds DSay command

### DIFF
--- a/Content.Server/Administration/Commands/DSay.cs
+++ b/Content.Server/Administration/Commands/DSay.cs
@@ -1,0 +1,40 @@
+using Content.Server.Interfaces.Chat;
+using Content.Shared.Administration;
+using Robust.Server.Interfaces.Console;
+using Robust.Server.Interfaces.Player;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+
+namespace Content.Server.Administration.Commands
+{
+    [AdminCommand(AdminFlags.Admin)]
+    class DSay : IClientCommand
+    {
+        public string Command => "dsay";
+
+        public string Description => Loc.GetString("Sends a message to deadchat as an admin");
+
+        public string Help => Loc.GetString($"Usage: {Command} <message>");
+
+        public void Execute(IConsoleShell shell, IPlayerSession player, string[] args)
+        {
+            if (player == null)
+            {
+                shell.SendText((IPlayerSession) null, "Only players can use this command");
+                return;
+            }
+
+            if (args.Length < 1)
+                return;
+
+            var message = string.Join(" ", args).Trim();
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            var chat = IoCManager.Resolve<IChatManager>();
+
+            chat.SendAdminDeadChat(player, message);
+            
+        }
+    }
+}

--- a/Content.Server/Chat/ChatManager.cs
+++ b/Content.Server/Chat/ChatManager.cs
@@ -212,9 +212,7 @@ namespace Content.Server.Chat
                 return;
             }
 
-            var clients = _playerManager
-                .GetPlayersBy(x => x.AttachedEntity != null && x.AttachedEntity.HasComponent<GhostComponent>())
-                .Select(p => p.ConnectedClient);
+            var clients = GetDeadChatClients();
 
             var msg = _netManager.CreateNetMessage<MsgChatMessage>();
             msg.Channel = ChatChannel.Dead;
@@ -233,16 +231,20 @@ namespace Content.Server.Chat
                 return;
             }
 
-            var clients = _playerManager
-                .GetPlayersBy(x => x.AttachedEntity != null && x.AttachedEntity.HasComponent<GhostComponent>())
-                .Select(p => p.ConnectedClient);
+            var clients = GetDeadChatClients();
 
             var msg = _netManager.CreateNetMessage<MsgChatMessage>();
             msg.Channel = ChatChannel.Dead;
             msg.Message = message;
             msg.MessageWrap = $"{Loc.GetString("ADMIN")}:(${player.ConnectedClient.UserName}): {{0}}";
-            msg.SenderEntity = player.AttachedEntityUid.GetValueOrDefault();
             _netManager.ServerSendToMany(msg, clients.ToList());
+        }
+
+        private IEnumerable<INetChannel> GetDeadChatClients()
+        {
+            return _playerManager
+                .GetPlayersBy(x => x.AttachedEntity != null && x.AttachedEntity.HasComponent<GhostComponent>())
+                .Select(p => p.ConnectedClient);
         }
 
         public void SendAdminChat(IPlayerSession player, string message)

--- a/Content.Server/Interfaces/Chat/IChatManager.cs
+++ b/Content.Server/Interfaces/Chat/IChatManager.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Server.Interfaces.Player;
+using Robust.Server.Interfaces.Player;
 using Robust.Shared.Interfaces.GameObjects;
 
 namespace Content.Server.Interfaces.Chat
@@ -27,6 +27,7 @@ namespace Content.Server.Interfaces.Chat
         void SendOOC(IPlayerSession player, string message);
         void SendAdminChat(IPlayerSession player, string message);
         void SendDeadChat(IPlayerSession player, string message);
+        void SendAdminDeadChat(IPlayerSession player, string message);
 
         void SendHookOOC(string sender, string message);
 


### PR DESCRIPTION
Adds the `dsay` command to admins, which allows to send message to deadchat at any point. 
Currently admins can't see deadchat when alive and not aghosted, however the message it sent regardless.

The message will be displayed as:
`ADMIN(UserName): <message>`