### PR TITLE
Remove collision from comfy chairs

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Furniture/seats.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/seats.yml
@@ -119,7 +119,7 @@
     shapes:
       - !type:PhysShapeAabb
         bounds: "-0.45, -0.3, 0.35, 0.3"
-        layer: [ MobMask ]
+        layer: [ Passable ]
 
 - type: entity
   name: wooden chair


### PR DESCRIPTION
No idea why these ones in particular had collision but it made the HOS' locker unreachable without having a nice sit-down