### PR TITLE
Puts metal rods in their place.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/metal_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/metal_rod.yml
@@ -10,9 +10,8 @@
     - type: Item
       size: 24
       icon:
-        sprite: /Textures/Constructible/Structures/Walls/materials.rsi
+        sprite: Objects/Materials/materials.rsi
         state: rods
-      prefix: inhand
     - type: Construction
       graph: metalRod
       node: MetalRod


### PR DESCRIPTION
Sprite path was fucked up and they're objects not constructibles.