### PR TITLE
Repeating action improvements

### DIFF
--- a/Content.Client/GameObjects/Components/Mobs/Actions/ActionAssignments.cs
+++ b/Content.Client/GameObjects/Components/Mobs/Actions/ActionAssignments.cs
@@ -69,8 +69,6 @@ namespace Content.Client.GameObjects.Components.Mobs.Actions
                 }
             }
 
-
-
             foreach (var (item, itemStates) in itemActionStates)
             {
                 foreach (var itemActionState in itemStates)

--- a/Content.Client/GameObjects/Components/Mobs/ClientActionsComponent.cs
+++ b/Content.Client/GameObjects/Components/Mobs/ClientActionsComponent.cs
@@ -217,6 +217,15 @@ namespace Content.Client.GameObjects.Components.Mobs
                     }
                     return true;
                 }
+                // we're targeting entities, but the user didn't point at one
+                case BehaviorType.TargetEntity when args.EntityUid == EntityUid.Invalid:
+
+                    // If we don't repeat, stop targeting.
+                    if (!attempt.Action.Repeat)
+                        goto default;
+
+                    // Otherwise, continue as normal.
+                    return true;
                 default:
                     _ui.StopTargeting();
                     return false;

--- a/Content.Client/UserInterface/ActionsUI.cs
+++ b/Content.Client/UserInterface/ActionsUI.cs
@@ -327,13 +327,6 @@ namespace Content.Client.UserInterface
                 // action is currently granted
                 actionSlot.EnableAction();
                 actionSlot.Cooldown = actionState.Cooldown;
-
-                // if we are targeting with an action now on cooldown, stop targeting
-                if (SelectingTargetFor?.Action != null && SelectingTargetFor.Action == action &&
-                    actionState.IsOnCooldown(_gameTiming))
-                {
-                    StopTargeting();
-                }
             }
 
             // check if we need to toggle it
@@ -400,14 +393,6 @@ namespace Content.Client.UserInterface
             {
                 // action is currently granted
                 actionSlot.EnableAction();
-
-                // if we are targeting with an action now on cooldown, stop targeting
-                if (SelectingTargetFor?.Action != null && SelectingTargetFor.Action == action &&
-                    SelectingTargetFor.Item == itemEntity &&
-                    actionState.IsOnCooldown(_gameTiming))
-                {
-                    StopTargeting();
-                }
             }
             actionSlot.Cooldown = actionState.Cooldown;
 

--- a/Content.Client/UserInterface/Controls/ActionSlot.cs
+++ b/Content.Client/UserInterface/Controls/ActionSlot.cs
@@ -340,7 +340,8 @@ namespace Content.Client.UserInterface.Controls
         /// </summary>
         public void Depress(bool depress)
         {
-            if (!CanUseAction) return;
+            // Allow people to toggle repeatable actions on cooldown.
+            if (!CanUseAction && (!Action?.Repeat ?? true)) return;
 
             if (_depressed && !depress)
             {


### PR DESCRIPTION
This works best along #2950 

- Repeating entity targeting actions don't become deselected once they enter a cooldown now.
- You can now toggle repeating actions while they're on cooldown.
- Not clicking on an entity while using a repeating entity-targeting action no longer deselects it.

(CC @chairbender)