### PR TITLE
Makes lightbulbs destructible

### DIFF
--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/LightBulbComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/LightBulbComponent.cs
@@ -124,7 +124,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
             if (State == LightBulbState.Broken)
                 return;
 
-            var soundCollection = _prototypeManager.Index<SoundCollectionPrototype>("glassbreak");
+            var soundCollection = _prototypeManager.Index<SoundCollectionPrototype>("GlassBreak");
             var file = _random.Pick(soundCollection.PickFiles);
 
             EntitySystem.Get<AudioSystem>().PlayFromEntity(file, Owner);

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/LightBulbComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/LightBulbComponent.cs
@@ -1,7 +1,7 @@
 using System;
 using Content.Shared.Audio;
-using Content.Shared.Interfaces.GameObjects.Components;
 using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
@@ -33,7 +33,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
     ///     Component that represents a light bulb. Can be broken, or burned, which turns them mostly useless.
     /// </summary>
     [RegisterComponent]
-    public class LightBulbComponent : Component, ILand, IDestroyAct
+    public class LightBulbComponent : Component, ILand, IBreakAct
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
@@ -122,8 +122,6 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
 
         public void Land(LandEventArgs eventArgs)
         {
-            if (State == LightBulbState.Broken)
-                return;
 
             var soundCollection = _prototypeManager.Index<SoundCollectionPrototype>("GlassBreak");
             var file = _random.Pick(soundCollection.PickFiles);
@@ -133,7 +131,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
             State = LightBulbState.Broken;
         }
 
-        void IDestroyAct.OnDestroy(DestructionEventArgs eventArgs)
+        public void OnBreak(BreakageEventArgs eventArgs)
         {
             State = LightBulbState.Broken;
         }

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/LightBulbComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/LightBulbComponent.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Content.Shared.Audio;
 using Content.Shared.Interfaces.GameObjects.Components;
+using Content.Shared.GameObjects.EntitySystems;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
@@ -32,7 +33,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
     ///     Component that represents a light bulb. Can be broken, or burned, which turns them mostly useless.
     /// </summary>
     [RegisterComponent]
-    public class LightBulbComponent : Component, ILand
+    public class LightBulbComponent : Component, ILand, IDestroyAct
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
@@ -129,6 +130,11 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
 
             EntitySystem.Get<AudioSystem>().PlayFromEntity(file, Owner);
 
+            State = LightBulbState.Broken;
+        }
+
+        void IDestroyAct.OnDestroy(DestructionEventArgs eventArgs)
+        {
             State = LightBulbState.Broken;
         }
     }

--- a/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
@@ -33,7 +33,7 @@
       15:
         behaviors:
         - !type:PlaySoundCollectionBehavior
-          soundCollection: WindowBreak
+          soundCollection: GlassBreak
         - !type:SpawnEntitiesBehavior
           spawn:
             ShardGlass:
@@ -71,7 +71,7 @@
       75:
         behaviors:
         - !type:PlaySoundCollectionBehavior
-          soundCollection: WindowBreak
+          soundCollection: GlassBreak
         - !type:SpawnEntitiesBehavior
           spawn:
             ShardGlassReinforced:
@@ -103,7 +103,7 @@
       100:
         behaviors:
         - !type:PlaySoundCollectionBehavior
-          soundCollection: WindowBreak
+          soundCollection: GlassBreak
         - !type:SpawnEntitiesBehavior
           spawn:
             ShardGlassPhoron:
@@ -120,7 +120,7 @@
     node: phoronWindow
 
 - type: soundCollection
-  id: WindowBreak
+  id: GlassBreak
   files:
   - /Audio/Effects/glass_break1.ogg
   - /Audio/Effects/glass_break2.ogg

--- a/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
@@ -118,10 +118,3 @@
   - type: Construction
     graph: window
     node: phoronWindow
-
-- type: soundCollection
-  id: GlassBreak
-  files:
-  - /Audio/Effects/glass_break1.ogg
-  - /Audio/Effects/glass_break2.ogg
-  - /Audio/Effects/glass_break3.ogg

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
@@ -29,7 +29,7 @@
       5:
         behaviors:
         - !type:PlaySoundCollectionBehavior
-          soundCollection: WindowBreak
+          soundCollection: GlassBreak
         - !type:SpawnEntitiesBehavior
           spawn:
             ShardGlass:

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   parent: BaseItem
   id: BaseLightbulb
   abstract: true
@@ -11,6 +11,12 @@
     amount: 5
   - type: Destructible
     thresholds:
+      5:
+        behaviors:
+        - !type:PlaySoundCollectionBehavior
+          soundCollection: GlassBreak
+        - !type:DoActsBehavior
+          acts: [ "Breakage" ]
       10:
         behaviors:
         - !type:PlaySoundCollectionBehavior

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -1,6 +1,5 @@
 ﻿- type: entity
   parent: BaseItem
-  name: baselightbulb
   id: BaseLightbulb
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -1,4 +1,26 @@
 ﻿- type: entity
+  parent: BaseItem
+  name: baselightbulb
+  id: BaseLightbulb
+  abstract: true
+  components:
+  - type: LightBulb
+  - type: Damageable
+  - type: Destructible
+    thresholds:
+      10:
+        behaviors:
+        - !type:PlaySoundCollectionBehavior
+          soundCollection: GlassBreak
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            ShardGlass:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+
+- type: entity
   parent: BaseLightbulb
   name: light bulb
   id: LightBulb
@@ -9,14 +31,6 @@
   - type: Sprite
     sprite: Objects/Power/light_bulb.rsi
     state: normal
-
-- type: entity
-  parent: BaseItem
-  name: baselightbulb
-  id: BaseLightbulb
-  abstract: true
-  components:
-  - type: LightBulb
 
 - type: entity
   parent: BaseLightbulb

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -1,10 +1,14 @@
-﻿- type: entity
+- type: entity
   parent: BaseItem
   id: BaseLightbulb
   abstract: true
   components:
   - type: LightBulb
   - type: Damageable
+  - type: DamageOnLand
+    amount: 5
+  - type: DamageOtherOnHit
+    amount: 5
   - type: Destructible
     thresholds:
       10:

--- a/Resources/Prototypes/SoundCollections/glassbreak.yml
+++ b/Resources/Prototypes/SoundCollections/glassbreak.yml
@@ -1,6 +1,6 @@
 - type: soundCollection
-  id: glassbreak
+  id: GlassBreak
   files:
-  - /Audio/Effects/glassbreak1.ogg
-  - /Audio/Effects/glassbreak2.ogg
-  - /Audio/Effects/glassbreak3.ogg
+  - /Audio/Effects/glass_break1.ogg
+  - /Audio/Effects/glass_break2.ogg
+  - /Audio/Effects/glass_break3.ogg


### PR DESCRIPTION
Title, makes light bulb and light tube entities destructible

Also moved the base lightbulb entity to the top of the file

Also renamed the WindowBreak soundCollection to GlassBreak to be more descriptive. I was unsure where to put the soundCollection, as it currently resides in the windows.yml file.

https://user-images.githubusercontent.com/4741640/104078131-cf251880-51d9-11eb-92a5-9d515e0f0900.mp4
