### PR TITLE
Adds KeywordLabeler bot configuration for user PR labeling

### DIFF
--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -1,0 +1,47 @@
+# Determines if we search the title (optional). Defaults to true.
+matchTitle: false
+
+# Determines if we search the body (optional). Defaults to true.
+matchBody: true
+
+# Determines if label matching is case sensitive (optional). Defaults to true.
+caseSensitive: false
+
+# Explicit keyword mappings to labels. Form of match:label. Required.
+labelMappings:
+    "[ATMOS]": "Feature: Atmospherics"
+    "[AUDIO]": "Feature: Audio"
+    "[CONSTRUCTION]": "Feature: Construction"
+    "[ENTITIES]": "Feature: Entities"
+    "[ENTITY]": "Feature: Entities"
+    "[ENTITY AI]": "Feature: Entity AI"
+    "[EVENTS]": "Feature: Events"
+    "[EVENT]": "Feature: Events"
+    "[INTERACTION]": "Feature: Interaction"
+    "[MEDICAL]": "Feature: Medical"
+    "[PHYSICS]": "Feature: Physics"
+    "[POWER]": "Feature: Power"
+    "[SPRITES]": "Feature: Sprites"
+    "[SPRITE]": "Feature: Sprites"
+    "[UI]": "Feature: UI"
+
+    "[BUG]": "Type: Bug"
+    "[CLEANUP]": "Type: Cleanup"
+    "[CLEAN]": "Type: Cleanup"
+    "[CLEANLINESS]": "Type: Cleanup"
+    "[DISCUSSION]": "Type: Discussion"
+    "[DISCUSS]": "Type: Discussion"
+    "[FEATURE]": "Type: Feature"
+    "[FEAT]": "Type: Feature"
+    "[IMPROVEMENT]": "Type: Improvement"
+    "[IMPROVE]": "Type: Improvement"
+    "[PERFORMANCE]": "Type: Performance"
+    "[PERF]": "Type: Performance"
+    "[REFACTOR]": "Type: Refactor"
+
+    "[HELP WANTED]": "Status: Help Wanted"
+    "[DO NOT MERGE]": "Status: DO NOT MERGE"
+    "[DNM]": "Status: DO NOT MERGE"
+
+    "[RESOURCES]": "Resources (No code)"
+    "[NOCODE]": "Resources (No code)"


### PR DESCRIPTION
This bot enables any PR/issue submitter to label their PR/issue, without needing triage-level access.
A note: *This bot does not let users remove labels that have been applied (they can't remove a do not merge that was placed).*

### How 2 Use
Let's say I'm adding a rainbow bike horn. This would probably a situation where I'm just editing resources, no code at all.
So, I'd say the `Resources (No code)` applies. The two bindings I've setup are `[RESOURCES]` and `[NOCODE]` for that label.

I'm more of a fan of the first. So, to label my PR, I'd just put `[RESOURCES]` in the description. As soon as I submit the PR, the bot would label it after a second or two. You can also add additional labels by editing the description, as the bot is triggered on every edit.

### Implementation
I'm unfamiliar with this project's methodology of labelling, so I didn't set up all the labels to be able to be assigned. These are the ones I set up bindings and some easy aliases for:

* All `Feature:` labels
* All `Type:` labels
* `Status: Help Wanted` and `Status: DO NOT MERGE`
* `Resources (No code)`

I was unsure whether to add the various `Priority:` and `Project:` labels, as again, I'm unfamiliar with this project's flow. Can add though, of course.

### Before Merging

This PR would **need** to be accompanied with an installation of https://github.com/marketplace/keywordlabeler by a Org/Repo owner.

### Security / Privacy

All source code for the bot is available here (it's really short): https://github.com/ZeWaka/KeywordLabeler

For posterity, these are the permissions required by the bot (to update the labels):
![msedge_2021-01-08_15-08-11](https://user-images.githubusercontent.com/4741640/104071272-130e2280-51c6-11eb-8ad8-4941d996452e.png)
