### PR TITLE
Fix traitor identification overlay

### DIFF
--- a/Content.Client/GameObjects/Components/Suspicion/TraitorOverlay.cs
+++ b/Content.Client/GameObjects/Components/Suspicion/TraitorOverlay.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.GameObjects.EntitySystems;
 using Robust.Client.Graphics;
 using Robust.Client.Graphics.Drawing;
 using Robust.Client.Graphics.Overlays;
@@ -64,18 +64,18 @@ namespace Content.Client.GameObjects.Components.Suspicion
                 // Otherwise the entity can not exist yet
                 if (!_entityManager.TryGetEntity(uid, out var ally))
                 {
-                    return;
+                    continue;
                 }
 
                 if (!ally.TryGetComponent(out IPhysicsComponent physics))
                 {
-                    return;
+                    continue;
                 }
 
                 if (!ExamineSystemShared.InRangeUnOccluded(ent.Transform.MapPosition, ally.Transform.MapPosition, 15,
                     entity => entity == ent || entity == ally))
                 {
-                    return;
+                    continue;
                 }
 
                 // all entities have a TransformComponent

--- a/Content.Server/GameObjects/EntitySystems/SuspicionRoleSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/SuspicionRoleSystem.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Content.Server.GameObjects.Components.Suspicion;
+using Content.Shared.GameTicking;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects.Systems;
 
 namespace Content.Server.GameObjects.EntitySystems
 {
     [UsedImplicitly]
-    public class SuspicionRoleSystem : EntitySystem
+    public class SuspicionRoleSystem : EntitySystem, IResettingEntitySystem
     {
         private readonly HashSet<SuspicionRoleComponent> _traitors = new();
 
@@ -46,6 +47,11 @@ namespace Content.Server.GameObjects.EntitySystems
         {
             _traitors.Clear();
             base.Shutdown();
+        }
+
+        public void Reset()
+        {
+            _traitors.Clear();
         }
     }
 }


### PR DESCRIPTION
Changed returns to continues.
Fixed traitor list not being cleared in SuspicionRoleSystem on round restart.