### PR TITLE
Fix tutorial button being weird

### DIFF
--- a/Content.Client/UserInterface/GameHud.cs
+++ b/Content.Client/UserInterface/GameHud.cs
@@ -322,6 +322,7 @@ namespace Content.Client.UserInterface
 
         private void ButtonTutorialOnOnToggled()
         {
+            _buttonTutorial.StyleClasses.Remove(TopButton.StyleClassRedTopButton);
             if (_tutorialWindow.IsOpen)
             {
                 if (!_tutorialWindow.IsAtFront())


### PR DESCRIPTION
One line change that makes the tutorial button not red when it is clicked once.
This issue was brought up in #2966 