### PR TITLE
Singularity Engine: Containment field emitters emit soft light

### DIFF
--- a/Content.Server/GameObjects/Components/Singularity/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Server/GameObjects/Components/Singularity/ContainmentFieldGeneratorComponent.cs
@@ -7,6 +7,7 @@ using Content.Server.Utility;
 using Content.Shared.Physics;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Components;
+using Robust.Shared.GameObjects.ComponentDependencies;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Physics;
 using Robust.Shared.IoC;
@@ -64,25 +65,14 @@ namespace Content.Server.GameObjects.Components.Singularity
             }
         }
 
-        private PhysicsComponent? _collidableComponent;
-        private PointLightComponent? _pointLightComponent;
+        [ComponentDependency] private readonly PhysicsComponent? _collidableComponent = default;
+        [ComponentDependency] private readonly PointLightComponent? _pointLightComponent = default;
 
         private Tuple<Direction, ContainmentFieldConnection>? _connection1;
         private Tuple<Direction, ContainmentFieldConnection>? _connection2;
 
         public bool CanRepell(IEntity toRepell) => _connection1?.Item2?.CanRepell(toRepell) == true ||
                                                    _connection2?.Item2?.CanRepell(toRepell) == true;
-
-        public override void Initialize()
-        {
-            base.Initialize();
-            if (!Owner.TryGetComponent(out _collidableComponent))
-            {
-                Logger.Error("ContainmentFieldGeneratorComponent created with no CollidableComponent");
-                return;
-            }
-            _pointLightComponent = Owner.GetComponentOrNull<PointLightComponent>();
-        }
 
         public override void HandleMessage(ComponentMessage message, IComponent? component)
         {
@@ -208,11 +198,8 @@ namespace Content.Server.GameObjects.Components.Singularity
         {
             if (_pointLightComponent != null)
             {
-                bool res = (_connection1 != null) || (_connection2 != null);
-                // hmm, this will dirty things even if the value doesn't change.
-                // thus, is checking this a bad thing?
-                if (_pointLightComponent.Enabled != res)
-                    _pointLightComponent.Enabled = res;
+                bool hasAnyConnection = (_connection1 != null) || (_connection2 != null);
+                _pointLightComponent.Enabled = hasAnyConnection;
             }
         }
 

--- a/Resources/Prototypes/Entities/singularity.yml
+++ b/Resources/Prototypes/Entities/singularity.yml
@@ -85,6 +85,12 @@
   - type: ContainmentFieldGenerator
   - type: Anchorable
   - type: Pullable
+  - type: PointLight
+    enabled: false
+    color: "#4080FF"
+    radius: 32
+    energy: 2.0
+    softness: 32.0
 
 - type: entity
   name: Containment Field


### PR DESCRIPTION
## About the PR

This causes the containment field emitters to emit light.
Note that this is a grand total of 8 point lights in a 9x9 area, not accounting for the required safety space around the Singularity, so really this is returning the singularity area to the expected amount of point lights.
However, they do throw light a fair distance - it might be necessary to cheat the light curves if this becomes a performance (or just plain PVS) problem.

**Screenshots**

NOTE: For demonstration purposes, the lights in Saltern have been removed and a wall has been added to demonstrate the shadows. This is *not* a change in the PR.

Soft shadows OFF:
![2021-1-14_14 27 57](https://user-images.githubusercontent.com/22304167/104604369-30833680-5675-11eb-80de-4a90f2d5ef17.png)
Soft shadows ON:
![2021-1-14_14 28 05](https://user-images.githubusercontent.com/22304167/104604397-3842db00-5675-11eb-8164-43f698c5a71c.png)
