### PR TITLE
Removes SmallImpassable from melee swing collision mask

### DIFF
--- a/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
@@ -6,6 +6,7 @@ using Content.Shared.Damage;
 using Content.Shared.GameObjects.Components.Damage;
 using Content.Shared.GameObjects.Components.Items;
 using Content.Shared.Interfaces.GameObjects.Components;
+using Content.Shared.Physics;
 using Robust.Server.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameObjects.Systems;
@@ -203,7 +204,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
             for (var i = 0; i < increments; i++)
             {
                 var castAngle = new Angle(baseAngle + increment * i);
-                var res = _physicsManager.IntersectRay(mapId, new CollisionRay(position, castAngle.ToVec(), 23), Range, ignore).FirstOrDefault();
+                var res = _physicsManager.IntersectRay(mapId, new CollisionRay(position, castAngle.ToVec(), (int) CollisionGroup.SwingAttack), Range, ignore).FirstOrDefault();
                 if (res.HitEntity != null)
                 {
                     resSet.Add(res.HitEntity);

--- a/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
@@ -204,7 +204,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
             for (var i = 0; i < increments; i++)
             {
                 var castAngle = new Angle(baseAngle + increment * i);
-                var res = _physicsManager.IntersectRay(mapId, new CollisionRay(position, castAngle.ToVec(), (int) CollisionGroup.SwingAttack), Range, ignore).FirstOrDefault();
+                var res = _physicsManager.IntersectRay(mapId, new CollisionRay(position, castAngle.ToVec(), (int) (CollisionGroup.Impassable|CollisionGroup.MobImpassable)), Range, ignore).FirstOrDefault();
                 if (res.HitEntity != null)
                 {
                     resSet.Add(res.HitEntity);

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -28,6 +28,7 @@ namespace Content.Shared.Physics
 
         MobMask = Impassable | MobImpassable | VaultImpassable | SmallImpassable,
         ThrownItem = MobImpassable | Impassable,
+        SwingAttack = Opaque | Impassable | MobImpassable,
         // 32 possible groups
         AllMask = -1,
     }

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -28,7 +28,6 @@ namespace Content.Shared.Physics
 
         MobMask = Impassable | MobImpassable | VaultImpassable | SmallImpassable,
         ThrownItem = MobImpassable | Impassable,
-        SwingAttack = Opaque | Impassable | MobImpassable,
         // 32 possible groups
         AllMask = -1,
     }


### PR DESCRIPTION
## About the PR 
The collision mask for melee swings used to be "23", corresponding to Opaque | Impassable | MobImpassable | SmallImpassable -- that is, melee swings (attacks using spacebar) used to collide with objects on any of those collision layers. This, however, resulted in some behavior that I found unusual and irritating.

For example, a bare low wall has the layers VaultImpassable and SmallImpassable. It cannot be walked through, but can be vaulted over. Meanwhile, a table only has the layer VaultImpassable. It cannot be walked through, but can be vaulted over. Because low walls have the layer SmallImpassable, they can be hit by melee swing attacks, while tables cannot. This is odd and inconsistent, since, to the player, most of the time, there really isn't a difference between the way the two objects inhibit the player's motion. 

Additionally, swinging at a window would often hit the low wall below the window instead of the window itself. This further compounded the annoying inconsistency.

This PR changes the collision mask for melee swing attacks to Impassable | MobImpassable, stopping the swing from colliding with objects on the collision layer SmallImpassable (and Opaque), thus fixing both of the issues mentioned above.
