### PR TITLE
Basic AHelp panel (incomplete)

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/BwoinkSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/BwoinkSystem.cs
@@ -1,0 +1,70 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Content.Client.UserInterface;
+using Content.Shared.GameObjects.EntitySystemMessages;
+using Content.Shared.GameObjects.EntitySystems;
+using JetBrains.Annotations;
+using Robust.Client.Player;
+using Robust.Shared.Localization;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components;
+using Robust.Shared.GameObjects.Systems;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Network;
+using Robust.Shared.Players;
+using Robust.Shared.IoC;
+
+namespace Content.Client.GameObjects.EntitySystems
+{
+    [UsedImplicitly]
+    public class BwoinkSystem : SharedBwoinkSystem
+    {
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
+        private readonly Dictionary<NetUserId, BwoinkWindow> _activeWindowMap = new();
+
+        protected override void OnBwoinkTextMessage(BwoinkSystemMessages.BwoinkTextMessage message, EntitySessionEventArgs eventArgs)
+        {
+            base.OnBwoinkTextMessage(message, eventArgs);
+            LogBwoink(message);
+            // TODO: Well, for one, a sound
+            var window = EnsureWindow(message.ChannelId);
+            window.ReceiveLine(message.Text);
+        }
+
+        public BwoinkWindow EnsureWindow(NetUserId channelId)
+        {
+            if (_activeWindowMap.TryGetValue(channelId, out var existingWindow))
+            {
+                existingWindow.Open();
+                return existingWindow;
+            }
+            string title;
+            if (_playerManager.SessionsDict.TryGetValue(channelId, out var otherSession))
+            {
+                title = otherSession.Name;
+            }
+            else
+            {
+                title = channelId.ToString();
+            }
+            var window = new BwoinkWindow(channelId, Loc.GetString("AHelp: {0}", title));
+            _activeWindowMap[channelId] = window;
+            window.Open();
+            return window;
+        }
+
+        public void EnsureWindowForLocalPlayer()
+        {
+            var localPlayer = _playerManager.LocalPlayer;
+            if (localPlayer != null)
+                EnsureWindow(localPlayer.UserId);
+        }
+
+        public void Send(NetUserId channelId, string text)
+        {
+            RaiseNetworkEvent(new BwoinkSystemMessages.BwoinkTextMessage(channelId, text));
+        }
+    }
+}
+

--- a/Content.Client/UserInterface/BwoinkWindow.cs
+++ b/Content.Client/UserInterface/BwoinkWindow.cs
@@ -1,0 +1,78 @@
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Content.Client.UserInterface.Stylesheets;
+using Content.Client.GameObjects.EntitySystems;
+using Content.Shared;
+using Robust.Client.Credits;
+using Robust.Client.Interfaces.ResourceManagement;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Interfaces.Configuration;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+using Robust.Shared.Network;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
+using YamlDotNet.RepresentationModel;
+
+namespace Content.Client.UserInterface
+{
+    /// <summary>
+    /// This window connects to a BwoinkSystem channel. BwoinkSystem manages the rest.
+    /// </summary>
+    public sealed class BwoinkWindow : SS14Window
+    {
+        [Dependency] private readonly IEntitySystemManager _systemManager = default!;
+
+        private readonly NetUserId _channelId;
+        private OutputPanel _text;
+        private HistoryLineEdit _lineEdit;
+
+        public BwoinkWindow(NetUserId channelId, string title)
+        {
+            IoCManager.InjectDependencies(this);
+
+            Title = title;
+            _channelId = channelId;
+
+            var rootContainer = new VBoxContainer();
+
+            _text = new OutputPanel()
+            {
+                SizeFlagsVertical = SizeFlags.FillExpand
+            };
+            rootContainer.AddChild(_text);
+
+            _lineEdit = new HistoryLineEdit();
+            _lineEdit.OnTextEntered += Input_OnTextEntered;
+            rootContainer.AddChild(_lineEdit);
+
+            Contents.AddChild(rootContainer);
+
+            CustomMinimumSize = (650, 450);
+        }
+
+        private void Input_OnTextEntered(LineEdit.LineEditEventArgs args)
+        {
+            if (!string.IsNullOrWhiteSpace(args.Text))
+            {
+                var bwoink = _systemManager.GetEntitySystem<BwoinkSystem>();
+                bwoink.Send(_channelId, args.Text);
+            }
+
+            _lineEdit.Clear();
+        }
+
+        public void ReceiveLine(string text)
+        {
+            var formatted = new FormattedMessage(1);
+            formatted.AddText(text);
+            _text.AddMessage(formatted);
+        }
+    }
+}

--- a/Content.Client/UserInterface/EscapeMenu.cs
+++ b/Content.Client/UserInterface/EscapeMenu.cs
@@ -1,18 +1,23 @@
-﻿using Robust.Client.Console;
+﻿using Content.Client.GameObjects.EntitySystems;
+using Robust.Client.Console;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Interfaces.GameObjects;
 
 namespace Content.Client.UserInterface
 {
     internal sealed class EscapeMenu : SS14Window
     {
+        [Dependency] private readonly IEntitySystemManager _systemManager = default!;
+
         private readonly IClientConsole _console;
 
         private BaseButton DisconnectButton;
         private BaseButton QuitButton;
         private BaseButton OptionsButton;
+        private BaseButton AHelpButton;
         private OptionsMenu optionsMenu;
 
         public EscapeMenu(IClientConsole console)
@@ -39,6 +44,10 @@ namespace Content.Client.UserInterface
             OptionsButton.OnPressed += OnOptionsButtonClicked;
             vBox.AddChild(OptionsButton);
 
+            AHelpButton = new Button {Text = Loc.GetString("AHelp")};
+            AHelpButton.OnPressed += OnAHelpButtonClicked;
+            vBox.AddChild(AHelpButton);
+
             DisconnectButton = new Button {Text = Loc.GetString("Disconnect")};
             DisconnectButton.OnPressed += OnDisconnectButtonClicked;
             vBox.AddChild(DisconnectButton);
@@ -63,6 +72,11 @@ namespace Content.Client.UserInterface
         private void OnOptionsButtonClicked(BaseButton.ButtonEventArgs args)
         {
             optionsMenu.OpenCentered();
+        }
+
+        private void OnAHelpButtonClicked(BaseButton.ButtonEventArgs args)
+        {
+            _systemManager.GetEntitySystem<BwoinkSystem>().EnsureWindowForLocalPlayer();
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Server/GameObjects/EntitySystems/BwoinkSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/BwoinkSystem.cs
@@ -1,0 +1,57 @@
+﻿#nullable enable
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Content.Server.Administration;
+using Content.Shared.GameObjects.EntitySystemMessages;
+using Content.Shared.GameObjects.EntitySystems;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components;
+using Robust.Shared.GameObjects.Systems;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Players;
+using Robust.Shared.Network;
+using Robust.Server.Interfaces.Player;
+using Robust.Shared.IoC;
+
+namespace Content.Server.GameObjects.EntitySystems
+{
+    [UsedImplicitly]
+    public class BwoinkSystem : SharedBwoinkSystem
+    {
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
+        [Dependency] private readonly IAdminManager _adminManager = default!;
+
+        protected override void OnBwoinkTextMessage(BwoinkSystemMessages.BwoinkTextMessage message, EntitySessionEventArgs eventArgs)
+        {
+            base.OnBwoinkTextMessage(message, eventArgs);
+            var senderSession = (IPlayerSession) eventArgs.SenderSession;
+
+            // TODO: Sanitize text?
+            // Confirm that this person is actually allowed to send a message here.
+            if ((eventArgs.SenderSession.UserId != message.ChannelId) && (_adminManager.GetAdminData(senderSession) == null))
+            {
+                // Unauthorized bwoink (log?)
+                return;
+            }
+
+            var msg = new BwoinkSystemMessages.BwoinkTextMessage(message.ChannelId, $"{eventArgs.SenderSession.Name}: {message.Text}");
+
+            LogBwoink(msg);
+
+            var targets = _adminManager.ActiveAdmins.Select(p => p.ConnectedClient);
+
+            // Admins
+            foreach (var channel in targets)
+                RaiseNetworkEvent(msg, channel);
+
+            // And involved player
+            if (_playerManager.TryGetSessionById(message.ChannelId, out var session))
+                if (!targets.Contains(session.ConnectedClient))
+                    RaiseNetworkEvent(msg, session.ConnectedClient);
+        }
+    }
+}
+

--- a/Content.Shared/GameObjects/EntitySystemMessages/BwoinkSystemMessages.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/BwoinkSystemMessages.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System;
+using Content.Shared.GameObjects.Verbs;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Network;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.GameObjects.EntitySystemMessages
+{
+    public static class BwoinkSystemMessages
+    {
+        [Serializable, NetSerializable]
+        public class BwoinkTextMessage : EntitySystemMessage
+        {
+            public NetUserId ChannelId { get; }
+            public string Text { get; }
+
+            public BwoinkTextMessage(NetUserId channelId, string text)
+            {
+                ChannelId = channelId;
+                Text = text;
+            }
+        }
+    }
+}

--- a/Content.Shared/GameObjects/EntitySystems/SharedBwoinkSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedBwoinkSystem.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.GameObjects.EntitySystemMessages;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components;
+using Robust.Shared.GameObjects.Systems;
+using Robust.Shared.Interfaces.GameObjects;
+using Robust.Shared.Log;
+
+namespace Content.Shared.GameObjects.EntitySystems
+{
+    [UsedImplicitly]
+    public abstract class SharedBwoinkSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeNetworkEvent<BwoinkSystemMessages.BwoinkTextMessage>(OnBwoinkTextMessage);
+        }
+
+        protected virtual void OnBwoinkTextMessage(BwoinkSystemMessages.BwoinkTextMessage message, EntitySessionEventArgs eventArgs)
+        {
+            // Specific side code in target.
+        }
+
+        protected void LogBwoink(BwoinkSystemMessages.BwoinkTextMessage message)
+        {
+            Logger.InfoS("c.s.go.es.bwoink", $"@{message.ChannelId}: {message.Text}");
+        }
+    }
+}


### PR DESCRIPTION
many-admin/one-player Text chat between admins and users.

The primary issue with this right now more than anything else is that the entitysystemmessages for received text magically disappear into a black hole.
They get to RaiseNetworkEvent and then I have no idea what happens, but they don't end up at the client.

Anyway, note that the logic right now of this is that any received ahelp automatically opens the dialog for that ahelp channel.
That logic... definitely needs improvement, but I'm hoping to get it working first.
