### PR TITLE
update UpdateVisuals to use Destructible thresholds

### DIFF
--- a/Content.Server/GameObjects/Components/WindowComponent.cs
+++ b/Content.Server/GameObjects/Components/WindowComponent.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using Content.Server.Utility;
 using Content.Shared.Audio;
@@ -6,6 +6,7 @@ using Content.Shared.GameObjects.Components;
 using Content.Shared.GameObjects.Components.Damage;
 using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces.GameObjects.Components;
+using Content.Server.GameObjects.Components.Destructible;
 using Content.Shared.Utility;
 using Robust.Server.GameObjects;
 using Robust.Server.GameObjects.EntitySystems;
@@ -50,7 +51,12 @@ namespace Content.Server.GameObjects.Components
         {
             if (Owner.TryGetComponent(out AppearanceComponent? appearance))
             {
-                appearance.SetData(WindowVisuals.Damage, (float) currentDamage / _maxDamage);
+                if (Owner.TryGetComponent(out DestructibleComponent? destructible))
+                {
+                    var damageThreshold = destructible.LowestToHighestThresholds.FirstOrNull()?.Key;
+                    if (damageThreshold == null) return;
+                    appearance.SetData(WindowVisuals.Damage, (float) currentDamage / damageThreshold);
+                }
             }
         }
 

--- a/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
@@ -46,7 +46,6 @@
   - type: Airtight
   - type: Window
     base: window
-    maxDamage: 15
   - type: Construction
     graph: window
     node: window
@@ -81,7 +80,6 @@
           acts: [ "Destruction" ]
   - type: Window
     base: rwindow
-    maxDamage: 75
   - type: Construction
     graph: window
     node: reinforcedWindow
@@ -114,7 +112,6 @@
     resistances: metallicResistances
   - type: Window
     base: pwindow
-    maxDamage: 100
   - type: Construction
     graph: window
     node: phoronWindow


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Addresses #2959.

It changes it so that window's visual cracking rely on the Destructible component's first destruction threshold
