### PR TITLE
Walls, catwalks, table frames can no longer be constructed rotated.

### DIFF
--- a/Content.Server/Construction/Completions/SnapToGrid.cs
+++ b/Content.Server/Construction/Completions/SnapToGrid.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Robust.Shared.GameObjects.Components.Transform;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Serialization;
+using Robust.Shared.Maths;
 
 namespace Content.Server.Construction.Completions
 {
@@ -13,12 +14,12 @@ namespace Content.Server.Construction.Completions
     public class SnapToGrid : IGraphAction
     {
         public SnapGridOffset Offset { get; private set; } = SnapGridOffset.Center;
-        public bool ZeroRotation { get; private set; } = false;
+        public bool SouthRotation { get; private set; } = false;
 
         public void ExposeData(ObjectSerializer serializer)
         {
             serializer.DataField(this, x => x.Offset, "offset", SnapGridOffset.Center);
-            serializer.DataField(this, x => x.ZeroRotation, "zeroRotation", false);
+            serializer.DataField(this, x => x.SouthRotation, "southRotation", false);
         }
 
         public async Task PerformAction(IEntity entity, IEntity? user)
@@ -26,9 +27,9 @@ namespace Content.Server.Construction.Completions
             if (entity.Deleted) return;
 
             entity.SnapToGrid(Offset);
-            if (ZeroRotation)
+            if (SouthRotation)
             {
-                entity.Transform.LocalRotation = 0;
+                entity.Transform.LocalRotation = Angle.South;
             }
         }
     }

--- a/Content.Server/Construction/Completions/SnapToGrid.cs
+++ b/Content.Server/Construction/Completions/SnapToGrid.cs
@@ -13,10 +13,12 @@ namespace Content.Server.Construction.Completions
     public class SnapToGrid : IGraphAction
     {
         public SnapGridOffset Offset { get; private set; } = SnapGridOffset.Center;
+        public bool ZeroRotation { get; private set; } = false;
 
         public void ExposeData(ObjectSerializer serializer)
         {
             serializer.DataField(this, x => x.Offset, "offset", SnapGridOffset.Center);
+            serializer.DataField(this, x => x.ZeroRotation, "zeroRotation", false);
         }
 
         public async Task PerformAction(IEntity entity, IEntity? user)
@@ -24,6 +26,10 @@ namespace Content.Server.Construction.Completions
             if (entity.Deleted) return;
 
             entity.SnapToGrid(Offset);
+            if (ZeroRotation)
+            {
+                entity.Transform.LocalRotation = 0;
+            }
         }
     }
 }

--- a/Resources/Prototypes/Recipes/Construction/Graphs/catwalk.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/catwalk.yml
@@ -7,7 +7,7 @@
         - to: Catwalk
           completed:
             - !type:SnapToGrid
-              zeroRotation: true
+              southRotation: true
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/catwalk.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/catwalk.yml
@@ -6,7 +6,8 @@
       edges:
         - to: Catwalk
           completed:
-          - !type:SnapToGrid { }
+            - !type:SnapToGrid
+              zeroRotation: true
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/girder.yml
@@ -7,7 +7,7 @@
         - to: girder
           completed:
             - !type:SnapToGrid
-              zeroRotation: true
+              southRotation: true
           steps:
             - material: Metal
               amount: 2
@@ -37,7 +37,7 @@
         - to: wall
           completed:
             - !type:SnapToGrid
-              zeroRotation: true
+              southRotation: true
           conditions:
             - !type:EntityAnchored {}
           steps:
@@ -47,7 +47,7 @@
         - to: reinforcedGirder
           completed:
             - !type:SnapToGrid
-              zeroRotation: true
+              southRotation: true
           conditions:
             - !type:EntityAnchored {}
           steps:
@@ -76,7 +76,7 @@
         - to: reinforcedWall
           completed:
             - !type:SnapToGrid
-              zeroRotation: true
+              southRotation: true
           conditions:
             - !type:EntityAnchored { }
           steps:
@@ -87,7 +87,7 @@
         - to: girder
           completed:
             - !type:SnapToGrid
-              zeroRotation: true
+              southRotation: true
           conditions:
             - !type:EntityAnchored { }
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/girder.yml
@@ -6,7 +6,8 @@
       edges:
         - to: girder
           completed:
-            - !type:SnapToGrid { }
+            - !type:SnapToGrid
+              zeroRotation: true
           steps:
             - material: Metal
               amount: 2
@@ -35,7 +36,8 @@
 
         - to: wall
           completed:
-            - !type:SnapToGrid {}
+            - !type:SnapToGrid
+              zeroRotation: true
           conditions:
             - !type:EntityAnchored {}
           steps:
@@ -44,7 +46,8 @@
 
         - to: reinforcedGirder
           completed:
-            - !type:SnapToGrid { }
+            - !type:SnapToGrid
+              zeroRotation: true
           conditions:
             - !type:EntityAnchored {}
           steps:
@@ -72,7 +75,8 @@
       edges:
         - to: reinforcedWall
           completed:
-            - !type:SnapToGrid { }
+            - !type:SnapToGrid
+              zeroRotation: true
           conditions:
             - !type:EntityAnchored { }
           steps:
@@ -82,7 +86,8 @@
 
         - to: girder
           completed:
-            - !type:SnapToGrid { }
+            - !type:SnapToGrid
+              zeroRotation: true
           conditions:
             - !type:EntityAnchored { }
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/tables.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/tables.yml
@@ -7,7 +7,7 @@
         - to: TableFrame
           completed:
             - !type:SnapToGrid
-              snapRotation: true
+              southRotation: true
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/tables.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/tables.yml
@@ -6,7 +6,8 @@
       edges:
         - to: TableFrame
           completed:
-            - !type:SnapToGrid { }
+            - !type:SnapToGrid
+              snapRotation: true
           steps:
             - material: MetalRod
               amount: 2


### PR DESCRIPTION
This fixes the bug where if you pull a girder, the resulting wall is rotated.