### PR TITLE
Move TagComponent from server to shared

### DIFF
--- a/Content.Client/IgnoredComponents.cs
+++ b/Content.Client/IgnoredComponents.cs
@@ -228,7 +228,6 @@ namespace Content.Client
             "MachineFrame",
             "MachineBoard",
             "ChemicalAmmo",
-            "Tag",
             "BiologicalSurgeryData",
             "CargoTelepad",
             "TraitorDeathMatchRedemption",

--- a/Content.IntegrationTests/Tests/Tag/TagTest.cs
+++ b/Content.IntegrationTests/Tests/Tag/TagTest.cs
@@ -69,9 +69,8 @@ namespace Content.IntegrationTests.Tests.Tag
             {
                 // Has one tag, the starting tag
                 Assert.That(sTagComponent.Tags.Count, Is.EqualTo(1));
-
-                var startingTagPrototype = sPrototypeManager.Index<TagPrototype>(StartingTag);
-                Assert.That(sTagComponent.Tags, Contains.Item(startingTagPrototype));
+                sPrototypeManager.Index<TagPrototype>(StartingTag);
+                Assert.That(sTagComponent.Tags, Contains.Item(StartingTag));
 
                 // Single
                 Assert.True(sTagDummy.HasTag(StartingTag));

--- a/Content.IntegrationTests/Tests/Tag/TagTest.cs
+++ b/Content.IntegrationTests/Tests/Tag/TagTest.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Content.Server.GameObjects.Components.Tag;
+using Content.Shared.GameObjects.Components.Tag;
 using Content.Shared.Prototypes.Tag;
 using NUnit.Framework;
 using Robust.Shared.Interfaces.GameObjects;

--- a/Content.Shared/GameObjects/Components/Tag/TagComponentExtensions.cs
+++ b/Content.Shared/GameObjects/Components/Tag/TagComponentExtensions.cs
@@ -5,7 +5,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.GameObjects.Components.Tag
+namespace Content.Shared.GameObjects.Components.Tag
 {
     public static class TagComponentExtensions
     {

--- a/Content.Shared/GameObjects/Components/Tag/TagComponentState.cs
+++ b/Content.Shared/GameObjects/Components/Tag/TagComponentState.cs
@@ -1,0 +1,14 @@
+﻿using Robust.Shared.GameObjects;
+
+namespace Content.Shared.GameObjects.Components.Tag
+{
+    public class TagComponentState : ComponentState
+    {
+        public TagComponentState(string[] tags) : base(ContentNetIDs.TAG)
+        {
+            Tags = tags;
+        }
+
+        public string[] Tags { get; }
+    }
+}

--- a/Content.Shared/GameObjects/Components/Tag/TagComponentState.cs
+++ b/Content.Shared/GameObjects/Components/Tag/TagComponentState.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameObjects;
+#nullable enable
+using Robust.Shared.GameObjects;
 
 namespace Content.Shared.GameObjects.Components.Tag
 {

--- a/Content.Shared/GameObjects/ContentNetIDs.cs
+++ b/Content.Shared/GameObjects/ContentNetIDs.cs
@@ -90,6 +90,7 @@
         public const uint ACTIONS = 1083;
         public const uint DAMAGEABLE = 1084;
         public const uint MAGBOOTS = 1085;
+        public const uint TAG = 1086;
 
         // Net IDs for integration tests.
         public const uint PREDICTION_TEST = 10001;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It does not make any distinction between different tags at the moment, the server syncs them all with the client whenever any change.
Also changes tags to be stored as strings instead of prototypes on the component, and adds a private method to throw if a tag doesn't exist.
The component state stores tags in an array as that is the cheapest way to pass a collection to the client if I remember correctly.