### PR TITLE
Remove IgnorePause

### DIFF
--- a/Content.Client/GameObjects/Components/Movement/PlayerInputMoverComponent.cs
+++ b/Content.Client/GameObjects/Components/Movement/PlayerInputMoverComponent.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Map;
 namespace Content.Client.GameObjects.Components.Movement
 {
     [RegisterComponent]
-    [ComponentReference(typeof(IMoverComponent))]
+    [ComponentReference(typeof(IMoverComponent)), ComponentReference(typeof(SharedPlayerInputMoverComponent))]
     public class PlayerInputMoverComponent : SharedPlayerInputMoverComponent
     {
         public override EntityCoordinates LastPosition { get; set; }

--- a/Content.Client/GameObjects/EntitySystems/MobMoverSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/MobMoverSystem.cs
@@ -10,7 +10,7 @@ using Robust.Shared.IoC;
 namespace Content.Client.GameObjects.EntitySystems
 {
     [UsedImplicitly]
-    public class MoverSystem : SharedMoverSystem
+    public class MobMoverSystem : SharedMobMoverSystem
     {
         [Dependency] private readonly IPlayerManager _playerManager = default!;
 
@@ -25,7 +25,10 @@ namespace Content.Client.GameObjects.EntitySystems
         {
             var playerEnt = _playerManager.LocalPlayer?.ControlledEntity;
 
-            if (playerEnt == null || !playerEnt.TryGetComponent(out IMoverComponent? mover) || !playerEnt.TryGetComponent(out IPhysicsComponent? physics))
+            if (playerEnt == null ||
+                !playerEnt.TryGetComponent(out SharedPlayerInputMoverComponent? mover) ||
+                (playerEnt.Paused && !mover.IgnorePaused) ||
+                !playerEnt.TryGetComponent(out IPhysicsComponent? physics))
             {
                 return;
             }

--- a/Content.Server/GameObjects/Components/Movement/PlayerInputMoverComponent.cs
+++ b/Content.Server/GameObjects/Components/Movement/PlayerInputMoverComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Server.GameObjects.Components.Movement
     ///     Moves the entity based on input from a KeyBindingInputComponent.
     /// </summary>
     [RegisterComponent]
-    [ComponentReference(typeof(IMoverComponent))]
+    [ComponentReference(typeof(IMoverComponent)), ComponentReference(typeof(SharedPlayerInputMoverComponent))]
     public class PlayerInputMoverComponent : SharedPlayerInputMoverComponent
     {
         public override EntityCoordinates LastPosition { get; set; }

--- a/Content.Shared/GameObjects/Components/Movement/SharedPlayerInputMoverComponent.cs
+++ b/Content.Shared/GameObjects/Components/Movement/SharedPlayerInputMoverComponent.cs
@@ -43,6 +43,12 @@ namespace Content.Shared.GameObjects.Components.Movement
         public sealed override string Name => "PlayerInputMover";
         public sealed override uint? NetID => ContentNetIDs.PLAYER_INPUT_MOVER;
 
+        // Look it saves an extra component alright.
+        /// <summary>
+        ///     Can this mob mover still work even when paused.
+        /// </summary>
+        public bool IgnorePaused { get; set; }
+
         private GameTick _lastInputTick;
         private ushort _lastInputSubTick;
         private Vector2 _curTickWalkMovement;
@@ -141,16 +147,22 @@ namespace Content.Shared.GameObjects.Components.Movement
         [ViewVariables]
         public bool DiagonalMovementEnabled => _configurationManager.GetCVar<bool>(CCVars.GameDiagonalMovement);
 
-        /// <inheritdoc />
-        public override void OnAdd()
+        public override void ExposeData(ObjectSerializer serializer)
         {
+            serializer.DataField(this, x => x.IgnorePaused, "ignorePaused", false);
+        }
+
+        /// <inheritdoc />
+        public override void Initialize()
+        {
+            base.Initialize();
+            // can't use OnAdd because not all of the components are attached yet so you can get race conditions.
+
             // This component requires that the entity has a IPhysicsComponent.
             if (!Owner.HasComponent<IPhysicsComponent>())
                 Logger.Error(
                     $"[ECS] {Owner.Prototype?.Name} - {nameof(SharedPlayerInputMoverComponent)} requires" +
                     $" {nameof(IPhysicsComponent)}. ");
-
-            base.OnAdd();
         }
 
 

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -4,3 +4,6 @@
   id: AdminObserver
   name: admin observer
   abstract: true
+  components:
+  - type: PlayerInputMover
+    ignorePaused: true

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -25,7 +25,6 @@
     context: "ghost"
   - type: Examiner
     DoRangeCheck: false
-  - type: IgnorePause
   - type: Ghost
   - type: Sprite
     netsync: false


### PR DESCRIPTION
It was only used for aghost movement but we can probably just add a bool to playerinput to get around it.

Requires https://github.com/space-wizards/RobustToolbox/pull/1534

Fixes https://github.com/space-wizards/space-station-14/issues/3081