### PR TITLE
Add warning when using the mapping command in debug mode

### DIFF
--- a/Content.Client/Commands/DebugCommands.cs
+++ b/Content.Client/Commands/DebugCommands.cs
@@ -1,3 +1,5 @@
+// ReSharper disable once RedundantUsingDirective
+// Used to warn the player in big red letters in debug mode
 using System;
 using Content.Client.GameObjects.Components;
 using Content.Client.GameObjects.EntitySystems;
@@ -8,6 +10,7 @@ using Robust.Shared.Console;
 using Robust.Shared.GameObjects.Systems;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Maths;
 
 namespace Content.Client.Commands
 {
@@ -92,6 +95,10 @@ namespace Content.Client.Commands
                 shell.WriteLine(Help);
                 return;
             }
+
+#if DEBUG
+            shell.WriteLine("WARNING: The client is using a debug build. You are risking losing your changes.", Color.Red);
+#endif
 
             shell.ConsoleHost.RegisteredCommands["togglelight"].Execute(shell, string.Empty, Array.Empty<string>());
             shell.ConsoleHost.RegisteredCommands["showsubfloorforever"].Execute(shell, string.Empty, Array.Empty<string>());

--- a/Content.Server/Commands/GameTicking/MappingCommand.cs
+++ b/Content.Server/Commands/GameTicking/MappingCommand.cs
@@ -1,3 +1,5 @@
+// ReSharper disable once RedundantUsingDirective
+// Used to warn the player in big red letters in debug mode
 using System.Linq;
 using Content.Server.Administration;
 using Content.Shared.Administration;
@@ -6,6 +8,7 @@ using Robust.Server.Interfaces.Timing;
 using Robust.Shared.Console;
 using Robust.Shared.Interfaces.Map;
 using Robust.Shared.IoC;
+using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Commands.GameTicking
@@ -25,6 +28,10 @@ namespace Content.Server.Commands.GameTicking
                 shell.WriteLine("Only players can use this command");
                 return;
             }
+
+#if DEBUG
+            shell.WriteLine("WARNING: The server is using a debug build. You are risking losing your changes.", Color.Red);
+#endif
 
             var mapManager = IoCManager.Resolve<IMapManager>();
             int mapId;


### PR DESCRIPTION
## About the PR
Prints a warning in the console when you run the mapping command if the client or server are running a debug build of the game.
Because mapping and crashing isn't fun.

**Screenshots**
Debug:
![image](https://user-images.githubusercontent.com/10968691/107083648-40b2af80-67f6-11eb-812a-59487a154064.png)

Release:
![image](https://user-images.githubusercontent.com/10968691/107083789-6f308a80-67f6-11eb-9b81-c68d5cb37565.png)
