### PR TITLE
Increase lobbyduration default

### DIFF
--- a/Content.Shared/CCVars.cs
+++ b/Content.Shared/CCVars.cs
@@ -29,7 +29,7 @@ namespace Content.Shared
             GameLobbyEnabled = CVarDef.Create("game.lobbyenabled", false, CVar.ARCHIVE);
 
         public static readonly CVarDef<int>
-            GameLobbyDuration = CVarDef.Create("game.lobbyduration", 20, CVar.ARCHIVE);
+            GameLobbyDuration = CVarDef.Create("game.lobbyduration", 60, CVar.ARCHIVE);
 
         public static readonly CVarDef<string>
             GameLobbyDefaultPreset = CVarDef.Create("game.defaultpreset", "Suspicion", CVar.ARCHIVE);


### PR DESCRIPTION
I think 60's okay for SSS but when we get actual rounds I'd make it 90.