### PR TITLE
Fix missing ignored components on the client

### DIFF
--- a/Content.Client/IgnoredComponents.cs
+++ b/Content.Client/IgnoredComponents.cs
@@ -1,3 +1,4 @@
+// ReSharper disable ArrangeTrailingCommaInMultilineLists
 namespace Content.Client
 {
     public static class IgnoredComponents
@@ -242,7 +243,10 @@ namespace Content.Client
             "SecretStash",
             "Toilet",
             "ClusterFlash",
-            "GasGenerator"
+            "GasGenerator",
+            "SolutionTransfer",
+            "Shovel",
+            "ReagentTank",
         };
     }
 }

--- a/Content.Server/IgnoredComponents.cs
+++ b/Content.Server/IgnoredComponents.cs
@@ -1,9 +1,8 @@
+// ReSharper disable ArrangeTrailingCommaInMultilineLists
 namespace Content.Server
 {
-
     public static class IgnoredComponents
     {
-
         public static string[] List => new [] {
             "ConstructionGhost",
             "IconSmooth",
@@ -18,9 +17,7 @@ namespace Content.Server
             "Clickable",
             "RadiatingLight",
             "Icon",
-            "ClientEntitySpawner"
+            "ClientEntitySpawner",
         };
-
     }
-
 }


### PR DESCRIPTION
## About the PR
GasGenerator, SolutionTransfer, Shovel and ReagentTank.
Also disables the trailing comma warning in both IgnoredComponents files, saving everyone one second of their lives per conflict.