### PR TITLE
Cleanup integration tests prototype usage, naming and unused variables

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/AtmosHelpersTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AtmosHelpersTest.cs
@@ -91,6 +91,7 @@ namespace Content.IntegrationTests.Tests.Atmos
             await server.WaitIdleAsync();
         }
 
+        // ReSharper disable once InconsistentNaming
         [Test]
         public async Task GetTileAtmosphereVector2iNotNullTest()
         {
@@ -109,6 +110,7 @@ namespace Content.IntegrationTests.Tests.Atmos
             await server.WaitIdleAsync();
         }
 
+        // ReSharper disable once InconsistentNaming
         [Test]
         public async Task GetTileAirVector2iNotNullTest()
         {
@@ -127,6 +129,7 @@ namespace Content.IntegrationTests.Tests.Atmos
             await server.WaitIdleAsync();
         }
 
+        // ReSharper disable once InconsistentNaming
         [Test]
         public async Task TryGetTileAtmosphereVector2iNotNullTest()
         {
@@ -146,6 +149,7 @@ namespace Content.IntegrationTests.Tests.Atmos
             await server.WaitIdleAsync();
         }
 
+        // ReSharper disable once InconsistentNaming
         [Test]
         public async Task TryGetTileAirVector2iNotNullTest()
         {

--- a/Content.IntegrationTests/Tests/Body/LegTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LegTest.cs
@@ -17,7 +17,7 @@ namespace Content.IntegrationTests.Tests.Body
     [TestOf(typeof(BodyComponent))]
     public class LegTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: HumanBodyAndAppearanceDummy
   id: HumanBodyAndAppearanceDummy
@@ -32,7 +32,7 @@ namespace Content.IntegrationTests.Tests.Body
         [Test]
         public async Task RemoveLegsFallTest()
         {
-            var options = new ServerContentIntegrationOption{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerContentIntegrationOption{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             AppearanceComponent appearance = null;

--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -164,7 +164,7 @@ namespace Content.IntegrationTests.Tests.Body
             {
                 var center = new Vector2(0.5f, -1.5f);
                 var coordinates = new EntityCoordinates(grid.GridEntityId, center);
-                human = entityManager.SpawnEntity("HumanMob_Content", coordinates);
+                human = entityManager.SpawnEntity("HumanBodyAndBloodstreamDummy", coordinates);
 
                 Assert.True(human.TryGetComponent(out IBody body));
                 Assert.True(body.HasMechanismBehavior<LungBehavior>());

--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -8,7 +8,6 @@ using Content.Server.GameObjects.Components.Body.Circulatory;
 using Content.Server.GameObjects.Components.Metabolism;
 using Content.Shared.Atmos;
 using Content.Shared.GameObjects.Components.Body;
-using Content.Shared.GameObjects.Components.Body.Mechanism;
 using NUnit.Framework;
 using Robust.Server.Interfaces.Maps;
 using Robust.Shared.Interfaces.GameObjects;
@@ -23,7 +22,7 @@ namespace Content.IntegrationTests.Tests.Body
     [TestOf(typeof(LungBehavior))]
     public class LungTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: HumanBodyAndBloodstreamDummy
   id: HumanBodyAndBloodstreamDummy
@@ -52,7 +51,7 @@ namespace Content.IntegrationTests.Tests.Body
         [Test]
         public async Task AirConsistencyTest()
         {
-            var options = new ServerContentIntegrationOption{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerContentIntegrationOption{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             server.Assert(() =>

--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -138,7 +138,9 @@ namespace Content.IntegrationTests.Tests.Body
         [Test]
         public async Task NoSuffocationTest()
         {
-            var server = StartServerDummyTicker();
+            var options = new ServerContentIntegrationOption{ExtraPrototypes = Prototypes};
+            var server = StartServerDummyTicker(options);
+
             await server.WaitIdleAsync();
 
             var mapLoader = server.ResolveDependency<IMapLoader>();

--- a/Content.IntegrationTests/Tests/Body/MechanismBehaviorEventsTest.cs
+++ b/Content.IntegrationTests/Tests/Body/MechanismBehaviorEventsTest.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Content.Server.GameObjects.Components.Body.Behavior;
 using Content.Shared.GameObjects.Components.Body;
-using Content.Shared.GameObjects.Components.Body.Behavior;
 using Content.Shared.GameObjects.Components.Body.Mechanism;
 using Content.Shared.GameObjects.Components.Body.Part;
 using NUnit.Framework;
@@ -103,7 +102,7 @@ namespace Content.IntegrationTests.Tests.Body
             }
         }
 
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: HumanBodyDummy
   id: HumanBodyDummy
@@ -117,7 +116,7 @@ namespace Content.IntegrationTests.Tests.Body
         [Test]
         public async Task EventsTest()
         {
-            var options = new ServerContentIntegrationOption {ExtraPrototypes = PROTOTYPES};
+            var options = new ServerContentIntegrationOption {ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             await server.WaitAssertion(() =>

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -22,7 +22,7 @@ namespace Content.IntegrationTests.Tests.Buckle
     [TestOf(typeof(StrapComponent))]
     public class BuckleTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: BuckleDummy
   id: BuckleDummy
@@ -43,7 +43,7 @@ namespace Content.IntegrationTests.Tests.Buckle
         [Test]
         public async Task BuckleUnbuckleCooldownRangeTest()
         {
-            var options = new ServerIntegrationOptions {ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions {ExtraPrototypes = Prototypes};
             var server = StartServer(options);
 
             IEntity human = null;
@@ -194,7 +194,7 @@ namespace Content.IntegrationTests.Tests.Buckle
         [Test]
         public async Task BuckledDyingDropItemsTest()
         {
-            var options = new ServerIntegrationOptions {ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions {ExtraPrototypes = Prototypes};
             var server = StartServer(options);
 
             IEntity human = null;
@@ -280,7 +280,7 @@ namespace Content.IntegrationTests.Tests.Buckle
         [Test]
         public async Task ForceUnbuckleBuckleTest()
         {
-            var options = new ServerIntegrationOptions {ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions {ExtraPrototypes = Prototypes};
             var server = StartServer(options);
 
             IEntity human = null;

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -22,10 +22,14 @@ namespace Content.IntegrationTests.Tests.Buckle
     [TestOf(typeof(StrapComponent))]
     public class BuckleTest : ContentIntegrationTest
     {
-        private const string Prototypes = @"
+        private const string BuckleDummyId = "BuckleDummy";
+        private const string StrapDummyId = "StrapDummy";
+        private const string ItemDummyId = "ItemDummy";
+
+        private static readonly string Prototypes = $@"
 - type: entity
-  name: BuckleDummy
-  id: BuckleDummy
+  name: {BuckleDummyId}
+  id: {BuckleDummyId}
   components:
   - type: Buckle
   - type: Hands
@@ -35,10 +39,16 @@ namespace Content.IntegrationTests.Tests.Buckle
     centerSlot: torso
 
 - type: entity
-  name: StrapDummy
-  id: StrapDummy
+  name: {StrapDummyId}
+  id: {StrapDummyId}
   components:
   - type: Strap
+
+- type: entity
+  name: {ItemDummyId}
+  id: {ItemDummyId}
+  components:
+  - type: Item
 ";
         [Test]
         public async Task BuckleUnbuckleCooldownRangeTest()
@@ -60,8 +70,8 @@ namespace Content.IntegrationTests.Tests.Buckle
                 var grid = mapManager.GetGrid(gridId);
                 var coordinates = grid.GridEntityId.ToCoordinates();
 
-                human = entityManager.SpawnEntity("BuckleDummy", coordinates);
-                chair = entityManager.SpawnEntity("StrapDummy", coordinates);
+                human = entityManager.SpawnEntity(BuckleDummyId, coordinates);
+                chair = entityManager.SpawnEntity(StrapDummyId, coordinates);
 
                 // Default state, unbuckled
                 Assert.True(human.TryGetComponent(out buckle));
@@ -213,8 +223,8 @@ namespace Content.IntegrationTests.Tests.Buckle
                 var grid = mapManager.GetGrid(gridId);
                 var coordinates = grid.GridEntityId.ToCoordinates();
 
-                human = entityManager.SpawnEntity("BuckleDummy", coordinates);
-                IEntity chair = entityManager.SpawnEntity("StrapDummy", coordinates);
+                human = entityManager.SpawnEntity(BuckleDummyId, coordinates);
+                IEntity chair = entityManager.SpawnEntity(StrapDummyId, coordinates);
 
                 // Component sanity check
                 Assert.True(human.TryGetComponent(out buckle));
@@ -230,7 +240,7 @@ namespace Content.IntegrationTests.Tests.Buckle
                 // Put an item into every hand
                 for (var i = 0; i < hands.Count; i++)
                 {
-                    var akms = entityManager.SpawnEntity("RifleAk", coordinates);
+                    var akms = entityManager.SpawnEntity(ItemDummyId, coordinates);
 
                     // Equip items
                     Assert.True(akms.TryGetComponent(out ItemComponent item));
@@ -296,8 +306,8 @@ namespace Content.IntegrationTests.Tests.Buckle
                 var grid = mapManager.GetGrid(gridId);
                 var coordinates = grid.GridEntityId.ToCoordinates();
 
-                human = entityManager.SpawnEntity("BuckleDummy", coordinates);
-                chair = entityManager.SpawnEntity("StrapDummy", coordinates);
+                human = entityManager.SpawnEntity(BuckleDummyId, coordinates);
+                chair = entityManager.SpawnEntity(StrapDummyId, coordinates);
 
                 // Component sanity check
                 Assert.True(human.TryGetComponent(out buckle));

--- a/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
@@ -11,9 +11,9 @@ namespace Content.IntegrationTests.Tests.Damageable
 {
     [TestFixture]
     [TestOf(typeof(DamageableComponent))]
-    public class DamageTest : ContentIntegrationTest
+    public class DamageableTest : ContentIntegrationTest
     {
-        private static readonly string DamageableEntityId = "DamageableEntityId";
+        private const string DamageableEntityId = "DamageableEntityId";
 
         private static readonly string Prototypes = $@"
 - type: entity
@@ -36,7 +36,7 @@ namespace Content.IntegrationTests.Tests.Damageable
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sMapManager = server.ResolveDependency<IMapManager>();
 
-            IEntity sDamageableEntity = null;
+            IEntity sDamageableEntity;
             IDamageableComponent sDamageableComponent = null;
 
             await server.WaitPost(() =>
@@ -89,7 +89,7 @@ namespace Content.IntegrationTests.Tests.Damageable
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var sMapManager = server.ResolveDependency<IMapManager>();
 
-            IEntity sDamageableEntity = null;
+            IEntity sDamageableEntity;
             IDamageableComponent sDamageableComponent = null;
 
             await server.WaitPost(() =>

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -50,7 +50,7 @@ namespace Content.IntegrationTests.Tests.Disposal
             UnitContains(unit, result, entities);
         }
 
-        private void Flush(DisposalUnitComponent unit, bool result, DisposalEntryComponent? entry = null, params IEntity[] entities)
+        private void Flush(DisposalUnitComponent unit, bool result, params IEntity[] entities)
         {
             Assert.That(unit.ContainedEntities, Is.SupersetOf(entities));
             Assert.That(entities.Length, Is.EqualTo(unit.ContainedEntities.Count));
@@ -101,7 +101,6 @@ namespace Content.IntegrationTests.Tests.Disposal
             IEntity human;
             IEntity wrench;
             DisposalUnitComponent unit;
-            DisposalEntryComponent entry;
 
             server.Assert(async () =>
             {
@@ -119,7 +118,7 @@ namespace Content.IntegrationTests.Tests.Disposal
 
                 // Test for components existing
                 Assert.True(disposalUnit.TryGetComponent(out unit!));
-                Assert.True(disposalTrunk.TryGetComponent(out entry!));
+                Assert.True(disposalTrunk.HasComponent<DisposalEntryComponent>());
 
                 // Can't insert, unanchored and unpowered
                 var disposalUnitAnchorable = disposalUnit.GetComponent<AnchorableComponent>();
@@ -146,13 +145,13 @@ namespace Content.IntegrationTests.Tests.Disposal
                 disposalTrunk.Transform.WorldPosition += (1, 0);
 
                 // Fail to flush with a mob and an item
-                Flush(unit, false, null, human, wrench);
+                Flush(unit, false, human, wrench);
 
                 // Move the disposal trunk back
                 disposalTrunk.Transform.WorldPosition -= (1, 0);
 
                 // Fail to flush with a mob and an item, no power
-                Flush(unit, false, entry, human, wrench);
+                Flush(unit, false, human, wrench);
 
                 // Remove power need
                 Assert.True(disposalUnit.TryGetComponent(out PowerReceiverComponent? power));
@@ -160,10 +159,10 @@ namespace Content.IntegrationTests.Tests.Disposal
                 Assert.True(unit.Powered);
 
                 // Flush with a mob and an item
-                Flush(unit, true, entry, human, wrench);
+                Flush(unit, true, human, wrench);
 
                 // Re-pressurizing
-                Flush(unit, false, entry);
+                Flush(unit, false);
             });
 
             await server.WaitIdleAsync();

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -59,7 +59,7 @@ namespace Content.IntegrationTests.Tests.Disposal
             Assert.That(result || entities.Length == 0, Is.EqualTo(unit.ContainedEntities.Count == 0));
         }
 
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: HumanDummy
   id: HumanDummy
@@ -95,7 +95,7 @@ namespace Content.IntegrationTests.Tests.Disposal
         [Test]
         public async Task Test()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             IEntity human;

--- a/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
+++ b/Content.IntegrationTests/Tests/DoAfter/DoAfterServerTest.cs
@@ -16,7 +16,7 @@ namespace Content.IntegrationTests.Tests.DoAfter
     [TestOf(typeof(DoAfterComponent))]
     public class DoAfterServerTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: Dummy
   id: Dummy
@@ -28,7 +28,7 @@ namespace Content.IntegrationTests.Tests.DoAfter
         public async Task TestFinished()
         {
             Task<DoAfterStatus> task = null;
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             // That it finishes successfully
@@ -52,7 +52,7 @@ namespace Content.IntegrationTests.Tests.DoAfter
         public async Task TestCancelled()
         {
             Task<DoAfterStatus> task = null;
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             server.Post(() =>

--- a/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
@@ -16,6 +16,12 @@ namespace Content.IntegrationTests.Tests.Doors
     {
         private const string Prototypes = @"
 - type: entity
+  name: PhysicsDummy
+  id: PhysicsDummy
+  components:
+  - type: Physics
+
+- type: entity
   name: AirlockDummy
   id: AirlockDummy
   components:
@@ -39,7 +45,7 @@ namespace Content.IntegrationTests.Tests.Doors
             {
                 mapManager.CreateNewMapEntity(MapId.Nullspace);
 
-                airlock = entityManager.SpawnEntity("Airlock", MapCoordinates.Nullspace);
+                airlock = entityManager.SpawnEntity("AirlockDummy", MapCoordinates.Nullspace);
 
                 Assert.True(airlock.TryGetComponent(out airlockComponent));
                 Assert.That(airlockComponent.State, Is.EqualTo(DoorState.Closed));
@@ -93,7 +99,7 @@ namespace Content.IntegrationTests.Tests.Doors
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
 
-            IEntity human = null;
+            IEntity physicsDummy = null;
             IEntity airlock = null;
             TestController controller = null;
             AirlockComponent airlockComponent = null;
@@ -106,11 +112,11 @@ namespace Content.IntegrationTests.Tests.Doors
                 mapManager.CreateNewMapEntity(mapId);
 
                 var humanCoordinates = new MapCoordinates((humanStartingX, 0), mapId);
-                human = entityManager.SpawnEntity("HumanMob_Content", humanCoordinates);
+                physicsDummy = entityManager.SpawnEntity("PhysicsDummy", humanCoordinates);
 
-                airlock = entityManager.SpawnEntity("Airlock", new MapCoordinates((0, 0), mapId));
+                airlock = entityManager.SpawnEntity("AirlockDummy", new MapCoordinates((0, 0), mapId));
 
-                Assert.True(human.TryGetComponent(out IPhysicsComponent physics));
+                Assert.True(physicsDummy.TryGetComponent(out IPhysicsComponent physics));
 
                 controller = physics.EnsureController<TestController>();
 
@@ -136,10 +142,10 @@ namespace Content.IntegrationTests.Tests.Doors
             }
 
             // Sanity check
-            Assert.That(human.Transform.MapPosition.X, Is.GreaterThan(humanStartingX));
+            Assert.That(physicsDummy.Transform.MapPosition.X, Is.GreaterThan(humanStartingX));
 
             // Blocked by the airlock
-            Assert.That(human.Transform.MapPosition.X, Is.Negative.Or.Zero);
+            Assert.That(physicsDummy.Transform.MapPosition.X, Is.Negative.Or.Zero);
         }
 
         private class TestController : VirtualController { }

--- a/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
@@ -14,7 +14,7 @@ namespace Content.IntegrationTests.Tests.Doors
     [TestOf(typeof(AirlockComponent))]
     public class AirlockTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: AirlockDummy
   id: AirlockDummy
@@ -24,7 +24,7 @@ namespace Content.IntegrationTests.Tests.Doors
         [Test]
         public async Task OpenCloseDestroyTest()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             await server.WaitIdleAsync();
@@ -85,7 +85,7 @@ namespace Content.IntegrationTests.Tests.Doors
         [Test]
         public async Task AirlockBlockTest()
         {
-            var options = new ServerIntegrationOptions {ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions {ExtraPrototypes = Prototypes};
             var server = StartServer(options);
 
             await server.WaitIdleAsync();

--- a/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
@@ -20,17 +20,29 @@ namespace Content.IntegrationTests.Tests.Doors
   id: PhysicsDummy
   components:
   - type: Physics
+    anchored: false
+    shapes:
+    - !type:PhysShapeAabb
+      bounds: ""-0.49,-0.49,0.49,0.49""
+      layer:
+      - Impassable
 
 - type: entity
   name: AirlockDummy
   id: AirlockDummy
   components:
   - type: Airlock
+  - type: Physics
+    shapes:
+    - !type:PhysShapeAabb
+      bounds: ""-0.49,-0.49,0.49,0.49""
+      mask:
+      - Impassable
 ";
         [Test]
         public async Task OpenCloseDestroyTest()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
+            var options = new ServerIntegrationOptions {ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             await server.WaitIdleAsync();
@@ -104,14 +116,14 @@ namespace Content.IntegrationTests.Tests.Doors
             TestController controller = null;
             AirlockComponent airlockComponent = null;
 
-            var humanStartingX = -1;
+            var physicsDummyStartingX = -1;
 
             server.Assert(() =>
             {
                 var mapId = new MapId(1);
                 mapManager.CreateNewMapEntity(mapId);
 
-                var humanCoordinates = new MapCoordinates((humanStartingX, 0), mapId);
+                var humanCoordinates = new MapCoordinates((physicsDummyStartingX, 0), mapId);
                 physicsDummy = entityManager.SpawnEntity("PhysicsDummy", humanCoordinates);
 
                 airlock = entityManager.SpawnEntity("AirlockDummy", new MapCoordinates((0, 0), mapId));
@@ -142,7 +154,7 @@ namespace Content.IntegrationTests.Tests.Doors
             }
 
             // Sanity check
-            Assert.That(physicsDummy.Transform.MapPosition.X, Is.GreaterThan(humanStartingX));
+            Assert.That(physicsDummy.Transform.MapPosition.X, Is.GreaterThan(physicsDummyStartingX));
 
             // Blocked by the airlock
             Assert.That(physicsDummy.Transform.MapPosition.X, Is.Negative.Or.Zero);

--- a/Content.IntegrationTests/Tests/DummyIconTest.cs
+++ b/Content.IntegrationTests/Tests/DummyIconTest.cs
@@ -27,7 +27,7 @@ namespace Content.IntegrationTests.Tests
                 {
                     if (!proto.Components.ContainsKey("Sprite")) continue;
 
-                    SpriteComponent.GetPrototypeTextures(proto, resourceCache).ToList();
+                    var _ = SpriteComponent.GetPrototypeTextures(proto, resourceCache).ToList();
                 }
             });
         }

--- a/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
@@ -118,11 +118,10 @@ namespace Content.IntegrationTests.Tests.Fluids
             var sEntityManager = server.ResolveDependency<IEntityManager>();
 
             MapId sMapId = default;
-            IMapGrid sGrid = null;
+            IMapGrid sGrid;
             GridId sGridId = default;
             IEntity sGridEntity = null;
             EntityCoordinates sCoordinates = default;
-            TimerComponent sTimerComponent = null;
 
             // Spawn a paused map with one tile to spawn puddles on
             await server.WaitPost(() =>
@@ -170,7 +169,7 @@ namespace Content.IntegrationTests.Tests.Fluids
                 Assert.Positive(sPuddle.EvaporateTime);
 
                 // Should have a timer component added to it for evaporation
-                Assert.True(sPuddle.Owner.TryGetComponent(out sTimerComponent));
+                Assert.True(sPuddle.Owner.TryGetComponent(out TimerComponent _));
 
                 sEvaporateTime = sPuddle.EvaporateTime;
                 sPuddleStartingVolume = sPuddle.CurrentVolume;
@@ -184,7 +183,7 @@ namespace Content.IntegrationTests.Tests.Fluids
             await server.WaitAssertion(() =>
             {
                 Assert.True(sPuddle.Owner.Paused);
-                Assert.True(sPuddle.Owner.TryGetComponent(out sTimerComponent));
+                Assert.True(sPuddle.Owner.TryGetComponent(out TimerComponent _));
 
                 // Check that the puddle still exists
                 Assert.False(sPuddle.Owner.Deleted);

--- a/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
@@ -47,11 +47,8 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
             IEntity otherHuman;
             IEntity cuffs;
             IEntity secondCuffs;
-            HandcuffComponent handcuff;
-            HandcuffComponent secondHandcuff;
             CuffableComponent cuffed;
             IHandsComponent hands;
-            IBody body;
 
             server.Assert(() =>
             {
@@ -71,9 +68,9 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
                 // Test for components existing
                 Assert.True(human.TryGetComponent(out cuffed!), $"Human has no {nameof(CuffableComponent)}");
                 Assert.True(human.TryGetComponent(out hands!), $"Human has no {nameof(HandsComponent)}");
-                Assert.True(human.TryGetComponent(out body!), $"Human has no {nameof(IBody)}");
-                Assert.True(cuffs.TryGetComponent(out handcuff!), $"Handcuff has no {nameof(HandcuffComponent)}");
-                Assert.True(secondCuffs.TryGetComponent(out secondHandcuff!), $"Second handcuffs has no {nameof(HandcuffComponent)}");
+                Assert.True(human.TryGetComponent(out IBody _), $"Human has no {nameof(IBody)}");
+                Assert.True(cuffs.TryGetComponent(out HandcuffComponent _), $"Handcuff has no {nameof(HandcuffComponent)}");
+                Assert.True(secondCuffs.TryGetComponent(out HandcuffComponent _), $"Second handcuffs has no {nameof(HandcuffComponent)}");
 
                 // Test to ensure cuffed players register the handcuffs
                 cuffed.TryAddNewCuffs(human, cuffs);

--- a/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/ActionBlocking/HandCuffTest.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Content.Client.GameObjects.Components.Items;
 using Content.Server.GameObjects.Components.ActionBlocking;
-using Content.Server.GameObjects.Components.Body;
 using Content.Server.Interfaces.GameObjects.Components.Items;
 using Content.Shared.GameObjects.Components.Body;
 using NUnit.Framework;
@@ -20,7 +19,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
     [TestOf(typeof(HandcuffComponent))]
     public class HandCuffTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: HumanDummy
   id: HumanDummy
@@ -41,7 +40,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.ActionBlocking
         [Test]
         public async Task Test()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             IEntity human;

--- a/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/ActionsComponentTests.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/ActionsComponentTests.cs
@@ -8,14 +8,14 @@ using Content.Server.GameObjects.Components.Items.Storage;
 using Content.Server.GameObjects.Components.Mobs;
 using Content.Shared.Actions;
 using Content.Shared.GameObjects.Components.Mobs;
+using Content.Shared.Utility;
 using NUnit.Framework;
 using Robust.Client.Interfaces.UserInterface;
 using Robust.Client.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
-using Robust.Shared.Map;
-using Content.Shared.Utility;
 using Robust.Shared.Interfaces.Timing;
+using Robust.Shared.Map;
 using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
@@ -27,7 +27,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
     [TestOf(typeof(ItemActionsComponent))]
     public class ActionsComponentTests : ContentIntegrationTest
     {
-        const string PROTOTYPES = @"
+        const string Prototypes = @"
 - type: entity
   name: flashlight
   parent: BaseItem
@@ -220,8 +220,8 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
         [Test]
         public async Task GrantsAndRevokesItemActions()
         {
-            var serverOptions = new ServerIntegrationOptions { ExtraPrototypes = PROTOTYPES };
-            var clientOptions = new ClientIntegrationOptions { ExtraPrototypes = PROTOTYPES };
+            var serverOptions = new ServerIntegrationOptions { ExtraPrototypes = Prototypes };
+            var clientOptions = new ClientIntegrationOptions { ExtraPrototypes = Prototypes };
             var (client, server) = await StartConnectedServerClientPair(serverOptions: serverOptions, clientOptions: clientOptions);
 
             await server.WaitIdleAsync();

--- a/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/ActionsComponentTests.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/ActionsComponentTests.cs
@@ -72,7 +72,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
             {
                 var player = serverPlayerManager.GetAllPlayers().Single();
                 var playerEnt = player.AttachedEntity;
-                var actionsComponent = playerEnt.GetComponent<ServerActionsComponent>();
+                var actionsComponent = playerEnt!.GetComponent<ServerActionsComponent>();
 
                 // player should begin with their innate actions granted
                 innateActions.AddRange(actionsComponent.InnateActions);
@@ -94,12 +94,12 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
             var clientPlayerMgr = client.ResolveDependency<IPlayerManager>();
             var clientUIMgr = client.ResolveDependency<IUserInterfaceManager>();
             var expectedOrder = new List<ActionType>();
+
             await client.WaitAssertion(() =>
             {
-
                 var local = clientPlayerMgr.LocalPlayer;
-                var controlled = local.ControlledEntity;
-                var actionsComponent = controlled.GetComponent<ClientActionsComponent>();
+                var controlled = local!.ControlledEntity;
+                var actionsComponent = controlled!.GetComponent<ClientActionsComponent>();
 
                 // we should have our innate actions and debug1.
                 foreach (var innateAction in innateActions)
@@ -155,7 +155,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
             {
                 var player = serverPlayerManager.GetAllPlayers().Single();
                 var playerEnt = player.AttachedEntity;
-                var actionsComponent = playerEnt.GetComponent<ServerActionsComponent>();
+                var actionsComponent = playerEnt!.GetComponent<ServerActionsComponent>();
                 actionsComponent.Revoke(ActionType.DebugInstant);
             });
 
@@ -164,10 +164,9 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
 
             await client.WaitAssertion(() =>
             {
-
                 var local = clientPlayerMgr.LocalPlayer;
-                var controlled = local.ControlledEntity;
-                var actionsComponent = controlled.GetComponent<ClientActionsComponent>();
+                var controlled = local!.ControlledEntity;
+                var actionsComponent = controlled!.GetComponent<ClientActionsComponent>();
 
                 // we should have our innate actions, but debug1 should be revoked
                 foreach (var innateAction in innateActions)
@@ -212,7 +211,6 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
                         Assert.That(slot.Item, Is.Null);
                         Assert.That(slot.Action, Is.Null);
                         Assert.That(slot.ActionEnabled, Is.False);
-                        continue;
                     }
                 }
             });
@@ -242,7 +240,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
             await server.WaitAssertion(() =>
             {
                 serverPlayerEnt = serverPlayerManager.GetAllPlayers().Single().AttachedEntity;
-                serverActionsComponent = serverPlayerEnt.GetComponent<ServerActionsComponent>();
+                serverActionsComponent = serverPlayerEnt!.GetComponent<ServerActionsComponent>();
 
                 // spawn and give them an item that has actions
                 serverFlashlight = serverEntManager.SpawnEntity("TestFlashlight",
@@ -281,13 +279,13 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
             await client.WaitAssertion(() =>
             {
                 var local = clientPlayerMgr.LocalPlayer;
-                var controlled = local.ControlledEntity;
-                clientActionsComponent = controlled.GetComponent<ClientActionsComponent>();
+                var controlled = local!.ControlledEntity;
+                clientActionsComponent = controlled!.GetComponent<ClientActionsComponent>();
 
                 var lightEntry = clientActionsComponent.ItemActionStates()
                     .Where(entry => entry.Value.ContainsKey(ItemActionType.ToggleLight))
                     .FirstOrNull();
-                clientFlashlight = lightEntry.Value.Key;
+                clientFlashlight = lightEntry!.Value.Key;
                 Assert.That(lightEntry, Is.Not.Null);
                 Assert.That(lightEntry.Value.Value.TryGetValue(ItemActionType.ToggleLight, out var lightState));
                 Assert.That(lightState.Equals(new ActionState(true)));

--- a/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/ActionsComponentTests.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/Mobs/ActionsComponentTests.cs
@@ -175,7 +175,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
                     Assert.That(actionsComponent.TryGetActionState(innateAction, out var innateState));
                     Assert.That(innateState.Enabled);
                 }
-                Assert.That(actionsComponent.TryGetActionState(ActionType.DebugInstant, out var state), Is.False);
+                Assert.That(actionsComponent.TryGetActionState(ActionType.DebugInstant, out _), Is.False);
 
                 // all actions should be in the same order as before, but the slot with DebugInstant should appear
                 // disabled.
@@ -195,6 +195,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
                         Assert.That(slot.Action, Is.Not.Null);
                         var asAction = slot.Action as ActionPrototype;
                         Assert.That(asAction, Is.Not.Null);
+                        Assert.That(expected, Is.EqualTo(asAction.ActionType));
 
                         if (asAction.ActionType == ActionType.DebugInstant)
                         {
@@ -276,7 +277,6 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Mobs
             // check that client has the actions, and toggle the light on via the action slot it was auto-assigned to
             var clientPlayerMgr = client.ResolveDependency<IPlayerManager>();
             var clientUIMgr = client.ResolveDependency<IUserInterfaceManager>();
-            var clientEntMgr = client.ResolveDependency<IEntityManager>();
             EntityUid clientFlashlight = default;
             await client.WaitAssertion(() =>
             {

--- a/Content.IntegrationTests/Tests/GameObjects/Components/Movement/ClimbUnitTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/Movement/ClimbUnitTest.cs
@@ -17,7 +17,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Movement
     [TestOf(typeof(ClimbingComponent))]
     public class ClimbUnitTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: HumanDummy
   id: HumanDummy
@@ -35,7 +35,7 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Movement
         [Test]
         public async Task Test()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             IEntity human;

--- a/Content.IntegrationTests/Tests/GameObjects/Components/Movement/ClimbUnitTest.cs
+++ b/Content.IntegrationTests/Tests/GameObjects/Components/Movement/ClimbUnitTest.cs
@@ -40,7 +40,6 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Movement
 
             IEntity human;
             IEntity table;
-            ClimbableComponent climbable;
             ClimbingComponent climbing;
 
             server.Assert(() =>
@@ -56,20 +55,20 @@ namespace Content.IntegrationTests.Tests.GameObjects.Components.Movement
 
                 // Test for climb components existing
                 // Players and tables should have these in their prototypes.
-                Assert.That(human.TryGetComponent(out climbing!), "Human has no climbing", Is.True);
-                Assert.That(table.TryGetComponent(out climbable!), "Table has no climbable", Is.True);
+                Assert.That(human.TryGetComponent(out climbing!), "Human has no climbing");
+                Assert.That(table.TryGetComponent(out ClimbableComponent _), "Table has no climbable");
 
                 // Now let's make the player enter a climbing transitioning state.
                 climbing.IsClimbing = true;
                 climbing.TryMoveTo(human.Transform.WorldPosition, table.Transform.WorldPosition);
                 var body = human.GetComponent<IPhysicsComponent>();
 
-                Assert.That(body.HasController<ClimbController>(), "Player has no ClimbController", Is.True);
+                Assert.That(body.HasController<ClimbController>(), "Player has no ClimbController");
 
                 // Force the player out of climb state. It should immediately remove the ClimbController.
                 climbing.IsClimbing = false;
 
-                Assert.That(!body.HasController<ClimbController>(), "Player wrongly has a ClimbController", Is.True);
+                Assert.That(!body.HasController<ClimbController>(), "Player wrongly has a ClimbController");
 
             });
 

--- a/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
+++ b/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
@@ -19,7 +19,7 @@ namespace Content.IntegrationTests.Tests.Gravity
     [TestOf(typeof(GravityGeneratorComponent))]
     public class WeightlessStatusTests : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: HumanDummy
   id: HumanDummy
@@ -29,7 +29,7 @@ namespace Content.IntegrationTests.Tests.Gravity
         [Test]
         public async Task WeightlessStatusTest()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServer(options);
 
             await server.WaitIdleAsync();

--- a/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
+++ b/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
@@ -6,7 +6,6 @@ using Content.Shared.GameObjects.Components.Mobs;
 using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Utility;
 using NUnit.Framework;
-using Robust.Server.Interfaces.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Interfaces.GameObjects;
 using Robust.Shared.Interfaces.Map;
@@ -36,8 +35,6 @@ namespace Content.IntegrationTests.Tests.Gravity
 
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
-            var pauseManager = server.ResolveDependency<IPauseManager>();
-            var tileDefinitionManager = server.ResolveDependency<ITileDefinitionManager>();
 
             IEntity human = null;
             SharedAlertsComponent alerts = null;

--- a/Content.IntegrationTests/Tests/GravityGridTest.cs
+++ b/Content.IntegrationTests/Tests/GravityGridTest.cs
@@ -17,7 +17,7 @@ namespace Content.IntegrationTests.Tests
     [TestOf(typeof(GravityGeneratorComponent))]
     public class GravityGridTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: GravityGeneratorDummy
   id: GravityGeneratorDummy
@@ -28,7 +28,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             IEntity generator = null;

--- a/Content.IntegrationTests/Tests/GridTileLookupTest.cs
+++ b/Content.IntegrationTests/Tests/GridTileLookupTest.cs
@@ -13,7 +13,7 @@ namespace Content.IntegrationTests.Tests
     [TestFixture]
     public class GridTileLookupTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: Dummy
   id: Dummy
@@ -22,7 +22,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
             await server.WaitIdleAsync();
 

--- a/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
@@ -16,7 +16,7 @@ namespace Content.IntegrationTests.Tests
     [TestOf(typeof(HumanInventoryControllerComponent))]
     public class HumanInventoryUniformSlotsTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: HumanDummy
   id: HumanDummy
@@ -59,7 +59,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task Test()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             IEntity human = null;

--- a/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
+++ b/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
@@ -83,7 +83,7 @@ namespace Content.IntegrationTests.Tests
                 Assert.That(inventory.TryGetSlotItem(Slots.IDCARD, out ItemComponent _), Is.False);
 
                 // Let's try skipping the interaction check and see if it equips it!
-                Assert.That(inventory.SpawnItemInSlot(Slots.IDCARD, "InventoryIDCardDummy", false));
+                Assert.That(inventory.SpawnItemInSlot(Slots.IDCARD, "InventoryIDCardDummy"));
                 Assert.That(inventory.TryGetSlotItem(Slots.IDCARD, out ItemComponent id));
                 Assert.That(id.Owner.Prototype != null && id.Owner.Prototype.ID == "InventoryIDCardDummy");
             });

--- a/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
+++ b/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
@@ -16,7 +16,7 @@ namespace Content.IntegrationTests.Tests
     [TestOf(typeof(InventoryHelpers))]
     public class InventoryHelpersTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: InventoryStunnableDummy
   id: InventoryStunnableDummy
@@ -45,7 +45,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task SpawnItemInSlotTest()
         {
-            var options = new ServerIntegrationOptions {ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions {ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             IEntity human = null;

--- a/Content.IntegrationTests/Tests/PowerTest.cs
+++ b/Content.IntegrationTests/Tests/PowerTest.cs
@@ -15,7 +15,7 @@ namespace Content.IntegrationTests.Tests
     [TestFixture]
     public class PowerTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: GeneratorDummy
   id: GeneratorDummy
@@ -118,7 +118,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task PowerNetTest()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             PowerSupplierComponent supplier = null;
@@ -169,7 +169,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task ApcChargingTest()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             BatteryComponent apcBattery = null;
@@ -217,7 +217,7 @@ namespace Content.IntegrationTests.Tests
         [Test]
         public async Task ApcNetTest()
         {
-            var options = new ServerIntegrationOptions{ExtraPrototypes = PROTOTYPES};
+            var options = new ServerIntegrationOptions{ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             PowerReceiverComponent receiver = null;

--- a/Content.IntegrationTests/Tests/Pulling/PullTest.cs
+++ b/Content.IntegrationTests/Tests/Pulling/PullTest.cs
@@ -16,7 +16,7 @@ namespace Content.IntegrationTests.Tests.Pulling
     [TestOf(typeof(PullController))]
     public class PullTest : ContentIntegrationTest
     {
-        private const string PROTOTYPES = @"
+        private const string Prototypes = @"
 - type: entity
   name: PullTestPullerDummy
   id: PullTestPullerDummy
@@ -35,7 +35,7 @@ namespace Content.IntegrationTests.Tests.Pulling
         [Test]
         public async Task AnchoredNoPullTest()
         {
-            var options = new ServerContentIntegrationOption {ExtraPrototypes = PROTOTYPES};
+            var options = new ServerContentIntegrationOption {ExtraPrototypes = Prototypes};
             var server = StartServerDummyTicker(options);
 
             await server.WaitIdleAsync();

--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -30,7 +30,7 @@ namespace Content.IntegrationTests.Tests
                 mapLoader.SaveBlueprint(new GridId(1), "save load save 1.yml");
                 var mapId = mapManager.CreateMap();
                 var grid = mapLoader.LoadBlueprint(mapId, "save load save 1.yml");
-                mapLoader.SaveBlueprint(grid.Index, "save load save 2.yml");
+                mapLoader.SaveBlueprint(grid!.Index, "save load save 2.yml");
             });
 
             await server.WaitIdleAsync();


### PR DESCRIPTION
## About the PR
Some tests were still using entities from content, now they all define their own entity dummies to use. Also fixes the naming for the Prototypes field in tests and removes unused variables.