### PR TITLE
Remove IDamageableComponent.HealthChangedEvent

### DIFF
--- a/Content.Server/GameObjects/Components/DoAfterComponent.cs
+++ b/Content.Server/GameObjects/Components/DoAfterComponent.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using Content.Server.GameObjects.EntitySystems.DoAfter;
 using Content.Shared.GameObjects.Components;
+using Content.Shared.GameObjects.Components.Damage;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Interfaces.GameObjects;
 
 namespace Content.Server.GameObjects.Components
 {
@@ -19,7 +21,7 @@ namespace Content.Server.GameObjects.Components
         public override ComponentState GetComponentState()
         {
             var toAdd = new List<ClientDoAfter>();
-            
+
             foreach (var doAfter in DoAfters)
             {
                 // THE ALMIGHTY PYRAMID
@@ -33,11 +35,40 @@ namespace Content.Server.GameObjects.Components
                     doAfter.EventArgs.BreakOnTargetMove,
                     doAfter.EventArgs.MovementThreshold,
                     doAfter.EventArgs.Target?.Uid ?? EntityUid.Invalid);
-                
+
                 toAdd.Add(clientDoAfter);
             }
 
             return new DoAfterComponentState(toAdd);
+        }
+
+        public override void HandleMessage(ComponentMessage message, IComponent? component)
+        {
+            base.HandleMessage(message, component);
+
+            switch (message)
+            {
+                case DamageChangedMessage msg:
+                    if (DoAfters.Count == 0)
+                    {
+                        return;
+                    }
+
+                    if (!msg.TookDamage)
+                    {
+                        return;
+                    }
+
+                    foreach (var doAfter in _doAfters.Keys)
+                    {
+                        if (doAfter.EventArgs.BreakOnDamage)
+                        {
+                            doAfter.TookDamage = true;
+                        }
+                    }
+
+                    break;
+            }
         }
 
         public void Add(DoAfter doAfter)

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfter.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Content.Server.GameObjects.Components.GUI;
 using Content.Server.GameObjects.Components.Items.Storage;
 using Content.Server.GameObjects.Components.Mobs;
-using Content.Shared.GameObjects.Components.Damage;
 using Robust.Shared.Interfaces.Timing;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -15,7 +14,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
     {
         public Task<DoAfterStatus> AsTask { get; }
 
-        private TaskCompletionSource<DoAfterStatus> Tcs { get;}
+        private TaskCompletionSource<DoAfterStatus> Tcs { get; }
 
         public DoAfterEventArgs EventArgs;
 
@@ -27,7 +26,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
 
         public EntityCoordinates TargetGrid { get; }
 
-        private bool _tookDamage;
+        public bool TookDamage { get; set; }
 
         public DoAfterStatus Status => AsTask.IsCompletedSuccessfully ? AsTask.Result : DoAfterStatus.Running;
 
@@ -61,11 +60,6 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
 
             Tcs = new TaskCompletionSource<DoAfterStatus>();
             AsTask = Tcs.Task;
-        }
-
-        public void HandleDamage(DamageChangedEventArgs args)
-        {
-            _tookDamage = true;
         }
 
         public void Run(float frameTime)
@@ -130,7 +124,7 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
                 return true;
             }
 
-            if (EventArgs.BreakOnDamage && _tookDamage)
+            if (EventArgs.BreakOnDamage && TookDamage)
             {
                 return true;
             }

--- a/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoAfter/DoAfterSystem.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Content.Server.GameObjects.Components;
-using Content.Shared.GameObjects.Components.Damage;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects.Systems;
 
@@ -68,20 +67,8 @@ namespace Content.Server.GameObjects.EntitySystems.DoAfter
             // Caller's gonna be responsible for this I guess
             var doAfterComponent = eventArgs.User.GetComponent<DoAfterComponent>();
             doAfterComponent.Add(doAfter);
-            IDamageableComponent? damageableComponent = null;
-
-            // TODO: If the component's deleted this may not get unsubscribed?
-            if (eventArgs.BreakOnDamage && eventArgs.User.TryGetComponent(out damageableComponent))
-            {
-                damageableComponent.HealthChangedEvent += doAfter.HandleDamage;
-            }
 
             await doAfter.AsTask;
-
-            if (damageableComponent != null)
-            {
-                damageableComponent.HealthChangedEvent -= doAfter.HandleDamage;
-            }
 
             return doAfter.Status;
         }

--- a/Content.Shared/GameObjects/Components/Damage/DamageChangedMessage.cs
+++ b/Content.Shared/GameObjects/Components/Damage/DamageChangedMessage.cs
@@ -31,5 +31,21 @@ namespace Content.Shared.GameObjects.Components.Damage
         ///     List containing data on each <see cref="DamageType"/> that was changed.
         /// </summary>
         public IReadOnlyList<DamageChangeData> Data { get; }
+
+        public bool TookDamage
+        {
+            get
+            {
+                foreach (var datum in Data)
+                {
+                    if (datum.Delta > 0)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
     }
 }

--- a/Content.Shared/GameObjects/Components/Damage/DamageableComponent.cs
+++ b/Content.Shared/GameObjects/Components/Damage/DamageableComponent.cs
@@ -39,8 +39,6 @@ namespace Content.Shared.GameObjects.Components.Damage
         private readonly HashSet<DamageClass> _supportedClasses = new();
         private DamageFlag _flags;
 
-        public event Action<DamageChangedEventArgs>? HealthChangedEvent;
-
         // TODO DAMAGE Use as default values, specify overrides in a separate property through yaml for better (de)serialization
         [ViewVariables] public string DamageContainerId { get; set; } = default!;
 
@@ -460,7 +458,6 @@ namespace Content.Shared.GameObjects.Components.Damage
         protected virtual void OnHealthChanged(DamageChangedEventArgs e)
         {
             Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, e);
-            HealthChangedEvent?.Invoke(e);
 
             var message = new DamageChangedMessage(this, e.Data);
             SendMessage(message);

--- a/Content.Shared/GameObjects/Components/Damage/IDamageableComponent.cs
+++ b/Content.Shared/GameObjects/Components/Damage/IDamageableComponent.cs
@@ -10,14 +10,6 @@ namespace Content.Shared.GameObjects.Components.Damage
     public interface IDamageableComponent : IComponent, IExAct
     {
         /// <summary>
-        ///     Called when the entity's <see cref="IDamageableComponent"/> values change.
-        ///     Of note is that a "deal 0 damage" call will still trigger this event
-        ///     (including both damage negated by resistance or simply inputting 0 as
-        ///     the amount of damage to deal).
-        /// </summary>
-        event Action<DamageChangedEventArgs> HealthChangedEvent;
-
-        /// <summary>
         ///     Sum of all damages taken.
         /// </summary>
         int TotalDamage { get; }


### PR DESCRIPTION
## About the PR
Makes DoAfters use DamageChangedMessage instead of the event, as it was the last thing left using it.
Could cache the doafters that actually need to care about damage but I'm not sure how important that is @metalgearsloth 