### PR TITLE
Toggling all chat options will correctly toggle Dead chat button

### DIFF
--- a/Content.Client/Chat/ChatManager.cs
+++ b/Content.Client/Chat/ChatManager.cs
@@ -355,6 +355,7 @@ namespace Content.Client.Chat
                     chatBox.OOCButton.Pressed ^= true;
                     if (chatBox.AdminButton != null)
                         chatBox.AdminButton.Pressed ^= true;
+                    chatBox.DeadButton.Pressed ^= true;
                     _allState = !_allState;
                     break;
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Just a small fix that was missed when it was implemented. The All button for chat will properly toggle the dead chat button's state.