### PR TITLE
Removed unnecessary stunbatons and added security restrictions to secure crates

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/Starter Gear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/Starter Gear/backpack.yml
@@ -24,7 +24,6 @@
   - type: StorageFill
     contents:
       - name: BoxSurvival
-      - name: Stunbaton
       - name: Flash
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/Starter Gear/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/Starter Gear/duffelbag.yml
@@ -24,7 +24,6 @@
   - type: StorageFill
     contents:
       - name: BoxSurvival
-      - name: Stunbaton
       - name: Flash
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/Starter Gear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/Starter Gear/satchel.yml
@@ -24,7 +24,6 @@
   - type: StorageFill
     contents:
       - name: BoxSurvival
-      - name: Stunbaton
       - name: Flash
 
 - type: entity

--- a/Resources/Prototypes/Entities/Constructible/Storage/Crates/crate_types.yml
+++ b/Resources/Prototypes/Entities/Constructible/Storage/Crates/crate_types.yml
@@ -260,6 +260,7 @@
   parent: CrateGeneric
   components:
   - type: AccessReader
+    access: [["Security"]]
   - type: SecureEntityStorage
   - type: Sprite
     sprite: Constructible/Storage/Crates/sec_gear.rsi
@@ -288,6 +289,7 @@
   parent: CrateGeneric
   components:
   - type: AccessReader
+    access: [["Engineering"]]
   - type: SecureEntityStorage
   - type: Sprite
     sprite: Constructible/Storage/Crates/engicrate_secure.rsi
@@ -316,6 +318,7 @@
   parent: CrateGeneric
   components:
   - type: AccessReader
+    access: [["Medical"]]
   - type: SecureEntityStorage
   - type: Sprite
     sprite: Constructible/Storage/Crates/medicalcrate_secure.rsi
@@ -372,6 +375,7 @@
   parent: CrateGeneric
   components:
   - type: AccessReader
+    access: [["Science"]]
   - type: SecureEntityStorage
   - type: Sprite
     sprite: Constructible/Storage/Crates/scicrate_secure.rsi
@@ -400,6 +404,7 @@
   parent: CrateGeneric
   components:
   - type: AccessReader
+    access: [["Engineering"]]
   - type: SecureEntityStorage
   - type: Sprite
     sprite: Constructible/Storage/Crates/plasma.rsi
@@ -456,6 +461,7 @@
   parent: CrateGeneric
   components:
   - type: AccessReader
+    access: [["Service"]]
   - type: SecureEntityStorage
   - type: Sprite
     sprite: Constructible/Storage/Crates/hydro_secure.rsi
@@ -484,6 +490,7 @@
   parent: CrateGeneric
   components:
   - type: AccessReader
+    access: [["Security"]]
   - type: SecureEntityStorage
   - type: Sprite
     sprite: Constructible/Storage/Crates/weapon.rsi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pull request removes stunbatons from security backpacks/duffelbags/satchels and adds security restrictions to secure crates so that assistans can't get guns just by breaking the glass to the cargo teleporter.
