### PR TITLE
Add being able to breathe healing asphyxiation damage

### DIFF
--- a/Content.Server/GameObjects/Components/Metabolism/MetabolismComponent.cs
+++ b/Content.Server/GameObjects/Components/Metabolism/MetabolismComponent.cs
@@ -42,6 +42,8 @@ namespace Content.Server.GameObjects.Components.Metabolism
 
         [ViewVariables(VVAccess.ReadWrite)] private int _suffocationDamage;
 
+        [ViewVariables(VVAccess.ReadWrite)] private int _suffocationDamageRecovery;
+
         [ViewVariables] public Dictionary<Gas, float> NeedsGases { get; set; } = new();
 
         [ViewVariables] public Dictionary<Gas, float> ProducesGases { get; set; } = new();
@@ -107,6 +109,7 @@ namespace Content.Server.GameObjects.Components.Metabolism
             serializer.DataField(this, b => b.ThermalRegulationTemperatureThreshold,
                 "thermalRegulationTemperatureThreshold", 0);
             serializer.DataField(ref _suffocationDamage, "suffocationDamage", 1);
+            serializer.DataField(ref _suffocationDamageRecovery, "suffocationDamageRecovery", 1);
         }
 
         private Dictionary<Gas, float> NeedsAndDeficit(float frameTime)
@@ -405,6 +408,11 @@ namespace Content.Server.GameObjects.Components.Metabolism
         private void StopSuffocation()
         {
             Suffocating = false;
+
+            if (Owner.TryGetComponent(out IDamageableComponent? damageable))
+            {
+                damageable.ChangeDamage(DamageClass.Airloss, -_suffocationDamageRecovery, false);
+            }
 
             if (Owner.TryGetComponent(out ServerAlertsComponent? alertsComponent))
             {

--- a/Content.Server/GameObjects/Components/Metabolism/MetabolismComponent.cs
+++ b/Content.Server/GameObjects/Components/Metabolism/MetabolismComponent.cs
@@ -402,7 +402,7 @@ namespace Content.Server.GameObjects.Components.Metabolism
                 return;
             }
 
-            damageable.ChangeDamage(DamageClass.Airloss, _suffocationDamage, false);
+            damageable.ChangeDamage(DamageType.Asphyxiation, _suffocationDamage, false);
         }
 
         private void StopSuffocation()
@@ -411,7 +411,7 @@ namespace Content.Server.GameObjects.Components.Metabolism
 
             if (Owner.TryGetComponent(out IDamageableComponent? damageable))
             {
-                damageable.ChangeDamage(DamageClass.Airloss, -_suffocationDamageRecovery, false);
+                damageable.ChangeDamage(DamageType.Asphyxiation, -_suffocationDamageRecovery, false);
             }
 
             if (Owner.TryGetComponent(out ServerAlertsComponent? alertsComponent))


### PR DESCRIPTION
## About the PR
Before being able to breathe didn't heal asphyxiation. Now it does, at the same rate.
Also fixes it dealing Airloss before, which also dealt Bloodloss.