### PR TITLE
objects with wires now open wire ui when a multitool/wirecutter is used on an open panel

### DIFF
--- a/Content.Server/GameObjects/Components/Doors/AirlockComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/AirlockComponent.cs
@@ -397,7 +397,7 @@ namespace Content.Server.GameObjects.Components.Doors
                 }
             }
 
-            if (args.Action == Mend)
+            else if (args.Action == Mend)
             {
                 switch (args.Identifier)
                 {
@@ -420,7 +420,7 @@ namespace Content.Server.GameObjects.Components.Doors
                 }
             }
 
-            if (args.Action == Cut)
+            else if (args.Action == Cut)
             {
                 switch (args.Identifier)
                 {


### PR DESCRIPTION
if an object has a wirecomponent, and the wirecomponent has been screwed open, then this PR makes it such that clicking on the object with a multitool or wirecutter in hand will open the wire ui. this is more convenient than having to use an open hand, or E, on the object to open the wire ui.

closes #3187 