### PR TITLE
Add stunbaton charging, fix other recharger related bugs

### DIFF
--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/BaseCharger.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/BaseCharger.cs
@@ -229,7 +229,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
         /// </summary>
         protected abstract bool IsEntityCompatible(IEntity entity);
 
-        protected abstract BatteryComponent GetBatteryFrom(IEntity entity);
+        protected abstract BatteryComponent? GetBatteryFrom(IEntity entity);
 
         private void UpdateStatus()
         {

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/WeaponCapacitorChargerComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/WeaponCapacitorChargerComponent.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using Content.Server.GameObjects.Components.Weapon.Ranged.Barrels;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.GameObjects;
@@ -17,12 +17,29 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
 
         protected override bool IsEntityCompatible(IEntity entity)
         {
-            return entity.HasComponent<ServerBatteryBarrelComponent>();
+            return entity.TryGetComponent(out ServerBatteryBarrelComponent? battery) && battery.PowerCell != null ||
+                   entity.TryGetComponent(out PowerCellSlotComponent? slot) && slot.HasCell;
         }
 
-        protected override BatteryComponent GetBatteryFrom(IEntity entity)
+        protected override BatteryComponent? GetBatteryFrom(IEntity entity)
         {
-            return entity.GetComponent<ServerBatteryBarrelComponent>().PowerCell;
+            if (entity.TryGetComponent(out PowerCellSlotComponent? slot))
+            {
+                if (slot.Cell != null)
+                {
+                    return slot.Cell;
+                }
+            }
+
+            if (entity.TryGetComponent(out ServerBatteryBarrelComponent? battery))
+            {
+                if (battery.PowerCell != null)
+                {
+                    return battery.PowerCell;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Barrels/ServerBatteryBarrelComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Barrels/ServerBatteryBarrelComponent.cs
@@ -130,6 +130,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Barrels
             _appearanceComponent?.SetData(MagazineBarrelVisuals.MagLoaded, _powerCellContainer.ContainedEntity != null);
             _appearanceComponent?.SetData(AmmoVisuals.AmmoCount, ShotsLeft);
             _appearanceComponent?.SetData(AmmoVisuals.AmmoMax, Capacity);
+            Dirty();
         }
 
         public override IEntity PeekAmmo()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows rechargers to recharge items that have PowerCellSlotComponent, like batons

Also fixes a bug where the ammo UI wasn't updated when pulling guns out of rechargers, and makes it so you can't put guns/stunbatons/etc without a cell into the recharger

Fixes #3128 
