### PR TITLE
Makes matches flammable in hand

### DIFF
--- a/Content.Server/GameObjects/Components/Interactable/MatchstickComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/MatchstickComponent.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System.Threading.Tasks;
+using Content.Server.Atmos;
 using Content.Shared.Audio;
 using Content.Shared.GameObjects.Components;
 using Content.Shared.Interfaces.GameObjects.Components;
@@ -82,6 +83,8 @@ namespace Content.Server.GameObjects.Components.Interactable
             // Change state
             CurrentState = SharedBurningStates.Lit;
             Owner.SpawnTimer(_duration * 1000, () => CurrentState = SharedBurningStates.Burnt);
+            Owner.Transform.Coordinates
+                .GetTileAtmosphere()?.HotspotExpose(700f, 50f, true);//causes match to light atmosphere when held.
         }
 
         async Task<bool> IInteractUsing.InteractUsing(InteractUsingEventArgs eventArgs)


### PR DESCRIPTION
Makes matches start atmos based fires when lit in hand. (Does not cause fire when dropped - Out of my depth for now).

Closes #3153 to some extent however after discussing in discord it was decided that the temperature system needs a good looking over (which is also out of my depth).

Let me know your thoughts or if you want to add the ability for matches to start fires on tiles (although IMO not massively necessary right now) since realistically matches can't be thrown and they have a 10 second life). Will be necessary for lighters however which can be thrown.

Tested on localhost and works.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
