### PR TITLE
PauseManager moved to Shared

### DIFF
--- a/Content.Client/Chat/SpeechBubble.cs
+++ b/Content.Client/Chat/SpeechBubble.cs
@@ -5,7 +5,6 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
-using Robust.Shared.Timers;
 using Robust.Shared.Timing;
 
 namespace Content.Client.Chat

--- a/Content.Client/Command/CommunicationsConsoleMenu.cs
+++ b/Content.Client/Command/CommunicationsConsoleMenu.cs
@@ -6,7 +6,7 @@ using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Client.Command
 {

--- a/Content.Client/GameObjects/EntitySystems/AI/ClientPathfindingDebugSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/AI/ClientPathfindingDebugSystem.cs
@@ -10,7 +10,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Timers;
 
 namespace Content.Client.GameObjects.EntitySystems.AI
 {

--- a/Content.Client/GameObjects/EntitySystems/AI/ClientPathfindingDebugSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/AI/ClientPathfindingDebugSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.AI;
@@ -10,6 +10,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Client.GameObjects.EntitySystems.AI
 {

--- a/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/VerbSystem.cs
@@ -30,7 +30,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Client.GameObjects.EntitySystems
 {

--- a/Content.Client/Instruments/InstrumentMenu.xaml.cs
+++ b/Content.Client/Instruments/InstrumentMenu.xaml.cs
@@ -17,7 +17,6 @@ using Robust.Shared.Input;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
-using Robust.Shared.Timers;
 using Robust.Shared.Timing;
 using Range = Robust.Client.UserInterface.Controls.Range;
 

--- a/Content.IntegrationTests/ContentIntegrationTest.cs
+++ b/Content.IntegrationTests/ContentIntegrationTest.cs
@@ -7,11 +7,11 @@ using Content.Server.Interfaces.GameTicking;
 using Content.Shared;
 using NUnit.Framework;
 using Robust.Server.Maps;
-using Robust.Server.Timing;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
+using Robust.Shared.Timing;
 using Robust.UnitTesting;
 
 namespace Content.IntegrationTests

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -1,14 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Content.Shared.Utility;
 using NUnit.Framework;
-using Robust.Server.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.IntegrationTests.Tests
 {

--- a/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
@@ -1,10 +1,9 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Content.Server.GameObjects.Components.Fluids;
 using Content.Shared.Chemistry;
 using Content.Shared.Utility;
 using NUnit.Framework;
-using Robust.Server.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;

--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -1,11 +1,11 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Robust.Server.Maps;
-using Robust.Server.Timing;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Map;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests

--- a/Content.Server/Commands/GameTicking/MappingCommand.cs
+++ b/Content.Server/Commands/GameTicking/MappingCommand.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using Content.Server.Administration;
 using Content.Shared.Administration;
 using Robust.Server.Player;
-using Robust.Server.Timing;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Commands.GameTicking

--- a/Content.Server/Commands/MakeSentientCommand.cs
+++ b/Content.Server/Commands/MakeSentientCommand.cs
@@ -8,7 +8,7 @@ using Content.Shared.GameObjects.Components.Mobs.Speech;
 using Robust.Shared.Console;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.Commands
 {

--- a/Content.Server/GameObjects/Components/Disposal/DisposalMailingUnitComponent.cs
+++ b/Content.Server/GameObjects/Components/Disposal/DisposalMailingUnitComponent.cs
@@ -29,7 +29,7 @@ using Robust.Shared.Log;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.ViewVariables;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameObjects.Components.Disposal
 {

--- a/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
@@ -27,7 +27,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameObjects.Components.Doors
 {

--- a/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
@@ -10,7 +10,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
-using Robust.Shared.Timers;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 

--- a/Content.Server/GameObjects/Components/PA/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/GameObjects/Components/PA/ParticleAcceleratorControlBoxComponent.cs
@@ -20,7 +20,7 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using static Content.Shared.GameObjects.Components.SharedWiresComponent;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameObjects.Components.PA
 {

--- a/Content.Server/GameObjects/Components/PA/ParticleProjectileComponent.cs
+++ b/Content.Server/GameObjects/Components/PA/ParticleProjectileComponent.cs
@@ -6,7 +6,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
-using Robust.Shared.Timers;
+using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.Components.PA
 {

--- a/Content.Server/GameObjects/Components/Singularity/ContainmentFieldConnection.cs
+++ b/Content.Server/GameObjects/Components/Singularity/ContainmentFieldConnection.cs
@@ -6,7 +6,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Maths;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameObjects.Components.Singularity
 {

--- a/Content.Server/GameObjects/Components/Singularity/EmitterComponent.cs
+++ b/Content.Server/GameObjects/Components/Singularity/EmitterComponent.cs
@@ -19,7 +19,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 #nullable enable
 

--- a/Content.Server/GameObjects/Components/Singularity/SingularityComponent.cs
+++ b/Content.Server/GameObjects/Components/Singularity/SingularityComponent.cs
@@ -15,7 +15,7 @@ using Robust.Shared.Maths;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Random;
-using Robust.Shared.Timers;
+using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.Components.Singularity
 {

--- a/Content.Server/GameObjects/EntitySystems/AI/Steering/AiSteeringSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Steering/AiSteeringSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,11 +9,11 @@ using Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Pathfinders;
 using Content.Server.GameObjects.EntitySystems.JobQueues;
 using Content.Shared.GameObjects.EntitySystems.ActionBlocker;
 using Content.Shared.Utility;
-using Robust.Server.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 

--- a/Content.Server/GameObjects/EntitySystems/ApcNetSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ApcNetSystem.cs
@@ -1,11 +1,10 @@
 #nullable enable
 using Content.Server.GameObjects.Components.NodeContainer.NodeGroups;
 using JetBrains.Annotations;
-using Robust.Server.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Map;
 using System.Collections.Generic;
+using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.EntitySystems
 {

--- a/Content.Server/GameObjects/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AtmosphereSystem.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,13 +11,13 @@ using Content.Shared.GameObjects.EntitySystems.Atmos;
 using Content.Shared.Maps;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Server.Timing;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.EntitySystems
 {

--- a/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ConstructionSystem.cs
@@ -23,8 +23,7 @@ using Robust.Shared.Maths;
 using Robust.Shared.Players;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Timers;
-
+using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.EntitySystems
 {

--- a/Content.Server/GameObjects/EntitySystems/RoundEndSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/RoundEndSystem.cs
@@ -8,7 +8,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Timing;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameObjects.EntitySystems
 {

--- a/Content.Server/GameObjects/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/TriggerSystem.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Timers;
+using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.EntitySystems
 {

--- a/Content.Server/GameTicking/GameRules/RuleDeathMatch.cs
+++ b/Content.Server/GameTicking/GameRules/RuleDeathMatch.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameTicking.GameRules
 {

--- a/Content.Server/GameTicking/GameRules/RuleInactivityTimeRestart.cs
+++ b/Content.Server/GameTicking/GameRules/RuleInactivityTimeRestart.cs
@@ -6,7 +6,7 @@ using Content.Server.Interfaces.GameTicking;
 using Robust.Server.Player;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameTicking.GameRules
 {

--- a/Content.Server/GameTicking/GameRules/RuleMaxTimeRestart.cs
+++ b/Content.Server/GameTicking/GameRules/RuleMaxTimeRestart.cs
@@ -4,7 +4,7 @@ using Content.Server.Interfaces.Chat;
 using Content.Server.Interfaces.GameTicking;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameTicking.GameRules
 {

--- a/Content.Server/GameTicking/GameRules/RuleSuspicion.cs
+++ b/Content.Server/GameTicking/GameRules/RuleSuspicion.cs
@@ -17,7 +17,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Timing;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameTicking.GameRules
 {

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -49,7 +49,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 using static Content.Shared.GameObjects.Components.Inventory.EquipmentSlotDefines;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameTicking
 {

--- a/Content.Server/GameTicking/GameTickerBase.cs
+++ b/Content.Server/GameTicking/GameTickerBase.cs
@@ -3,7 +3,7 @@ using Content.Shared.GameTicking;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.IoC;
-using Robust.Shared.Timers;
+using Robust.Shared.Timing;
 
 #nullable enable
 

--- a/Content.Server/StationEvents/PowerGridCheck.cs
+++ b/Content.Server/StationEvents/PowerGridCheck.cs
@@ -8,7 +8,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Random;
-using Timer = Robust.Shared.Timers.Timer;
+using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.StationEvents
 {

--- a/Content.Server/StationEvents/RadiationStorm.cs
+++ b/Content.Server/StationEvents/RadiationStorm.cs
@@ -1,14 +1,14 @@
-﻿#nullable enable
+#nullable enable
 using JetBrains.Annotations;
 using Content.Server.GameObjects.Components.StationEvents;
 using Content.Server.Interfaces.GameTicking;
 using Content.Shared.Utility;
-using Robust.Server.Timing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server.StationEvents
 {


### PR DESCRIPTION
Namespace and API changes for engine.

*    IPauseManager moved from Server to Shared.
*   Timers moved from Shared.Timers to Shared.Timing.

Requires https://github.com/space-wizards/RobustToolbox/pull/1553.