### PR TITLE
Made firelocks damageable & destructible

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Doors/firelock.yml
+++ b/Resources/Prototypes/Entities/Constructible/Doors/firelock.yml
@@ -5,6 +5,16 @@
   components:
     - type: Clickable
     - type: InteractionOutline
+    - type: Damageable
+      resistances: metallicResistances
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 500
+        behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
     - type: Sprite
       netsync: false
       drawdepth: Mobs # They're on the same layer as mobs, perspective.

--- a/Resources/Prototypes/Entities/Constructible/Doors/firelock_frame.yml
+++ b/Resources/Prototypes/Entities/Constructible/Doors/firelock_frame.yml
@@ -11,6 +11,16 @@
       node: frame1
     - type: Clickable
     - type: InteractionOutline
+    - type: Damageable
+      resistances: metallicResistances
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 500
+        behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
     - type: Physics
       shapes:
         - !type:PhysShapeAabb


### PR DESCRIPTION
Gave firelock and firelock frame damageable (metallicResistances) and destructible types so that they break when damaged enough or when bombs go off.

Just looked silly when some massive destruction happened and the firelock remained.

tested on localhost and closes #3302
