### PR TITLE
Added remaining vendor inventories

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/magivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/magivend.yml
@@ -4,3 +4,14 @@
   description: A mystical vending machine containing magical garments and magic supplies.
   animationDuration: 1.5
   spriteName: magivend
+  startingInventory:
+    ClothingHeadHatWizard: 3
+    ClothingOuterWizard: 3
+    ClothingHeadHatWizardFake: 3
+    ClothingHeadHatRedwizard: 3
+    ClothingOuterWizardRed: 3
+    ClothingHeadHatVioletwizard: 3
+    ClothingOuterWizardViolet: 3
+    ClothingShoesWizard: 9
+    #only missing staff
+    #and if wizarditis reagent when hacked if we want this.

--- a/Resources/Prototypes/Catalog/VendingMachines/magivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/magivend.yml
@@ -13,5 +13,6 @@
     ClothingHeadHatVioletwizard: 3
     ClothingOuterWizardViolet: 3
     ClothingShoesWizard: 9
+    #TO DO:
     #only missing staff
     #and if wizarditis reagent when hacked if we want this.

--- a/Resources/Prototypes/Catalog/VendingMachines/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/nutri.yml
@@ -3,3 +3,14 @@
   name: NutriMax
   description: A vending machine containing nutritional substances for plants and botanical tools.
   spriteName: nutri
+  startingInventory:
+    Spade: 3
+    PlantBGoneSpray: 20
+    WeedSpray: 20
+    PestSpray: 20
+    #syringe
+    #cultivator
+    #secateurs
+    #plant analyzer
+    #plant bag
+

--- a/Resources/Prototypes/Catalog/VendingMachines/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/nutri.yml
@@ -8,7 +8,8 @@
     PlantBGoneSpray: 20
     WeedSpray: 20
     PestSpray: 20
-    #syringe
+    Syringe: 5
+    #TO DO:
     #cultivator
     #secateurs
     #plant analyzer

--- a/Resources/Prototypes/Catalog/VendingMachines/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/robotics.yml
@@ -4,6 +4,7 @@
   description: All the fine parts you need in one vending machine!
   spriteName: robotics
   startingInventory:
+    #TO DO: add missing prototypes
     ClothingOuterCoatLab: 4
     #roboticist under
     CableStack: 4
@@ -13,7 +14,7 @@
     #signaller
     #health anaylzer
     Scalpel: 2
-    #circular saw
+    BoneSaw
     #bonesetter
     #anaesthetic
     #medical mask

--- a/Resources/Prototypes/Catalog/VendingMachines/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/robotics.yml
@@ -3,3 +3,20 @@
   name: Robotech Deluxe
   description: All the fine parts you need in one vending machine!
   spriteName: robotics
+  startingInventory:
+    ClothingOuterCoatLab: 4
+    #roboticist under
+    CableStack: 4
+    Flash: 4
+    PowerCellLargeHigh: 12
+    #proximity sensor
+    #signaller
+    #health anaylzer
+    Scalpel: 2
+    #circular saw
+    #bonesetter
+    #anaesthetic
+    #medical mask
+    Screwdriver: 5
+    Crowbar: 5
+    

--- a/Resources/Prototypes/Catalog/VendingMachines/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/robotics.yml
@@ -14,7 +14,7 @@
     #signaller
     #health anaylzer
     Scalpel: 2
-    BoneSaw
+    BoneSaw: 1
     #bonesetter
     #anaesthetic
     #medical mask

--- a/Resources/Prototypes/Catalog/VendingMachines/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/sec.yml
@@ -4,3 +4,14 @@
   description: "A vending machine containing Security equipment. A label reads \"SECURITY PERSONNEL ONLY\"."
   animationDuration: 1.4
   spriteName: sec
+  startingInventory:
+    Handcuffs: 8
+        GrenadeFlashBang: 4
+        Flash: 5
+        FoodDonut: 12
+        FoodContainerDonutBox: 2
+        FlashlightLantern: 4 #seclite
+        ClothingEyesGlassesSunglasses: 2
+        ClothingBeltSecurityWebbing: 5
+        #box evidence
+        

--- a/Resources/Prototypes/Catalog/VendingMachines/sovietsoda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/sovietsoda.yml
@@ -3,3 +3,5 @@
   name: BODA
   description: An old vending machine containing sweet water.
   spriteName: sovietsoda
+  startingInventory:
+    DrinkColaCan: 10 #typically hacked product. Default product is "soda"

--- a/Resources/Prototypes/Catalog/VendingMachines/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/theater.yml
@@ -3,3 +3,12 @@
   name: AutoDrobe
   description: A vending machine containing costumes.
   spriteName: theater
+  startingInventory:
+    ClothingOuterCardborg: 2
+    ClothingOuterPonchoClassic: 2
+    ClothingOuterRobesJudge: 2
+    ClothingOuterPoncho: 2
+    ClothingOuterSanta: 2
+    ClothingOuterXenos: 2
+    ClothingOuterSkub: 2
+    ClothingHeadHatXeno: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/wallmed.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/wallmed.yml
@@ -3,3 +3,6 @@
   name: NanoMed
   description: Wall-mounted medical equipment dispenser.
   spriteName: wallmed
+  startingInventory:
+    Brutepack: 5
+    Ointment: 5


### PR DESCRIPTION
Made remaining vendors usable.
nutri and robotics have some job specific items missing that aren't in yet (nutri is two tools, robotics is surgical related).

medical will need updated when medical is in.

Theater I put some costumes in that we already have in. Nowhere near as exhaustive as /TG/ but some of the other items are already covered in the shoe and hat vendor for example.

Untouched are Ptech (Cart) for PDA cartridges, sales as this is generic and doesn't need inventory? Vendomat and Vox.
I also noticed TG had wardrobes with all job specific clothing items in so could be worth considering as well as a games vendor.


For the most part will roundout and close #436 minus the exceptions above which are as and when.