### PR TITLE
Separate ghost warp message into two

### DIFF
--- a/Content.Client/GameObjects/Components/Observer/GhostComponent.cs
+++ b/Content.Client/GameObjects/Components/Observer/GhostComponent.cs
@@ -99,7 +99,7 @@ namespace Content.Client.GameObjects.Components.Observer
 
         public void SendReturnToBodyMessage() => SendNetworkMessage(new ReturnToBodyComponentMessage());
 
-        public void SendGhostWarpRequestMessage(string warpName) => SendNetworkMessage(new GhostWarpToNameRequestMessage(warpName));
+        public void SendGhostWarpRequestMessage(string warpName) => SendNetworkMessage(new GhostWarpToLocationRequestMessage(warpName));
 
         public void SendGhostWarpRequestMessage(EntityUid target) => SendNetworkMessage(new GhostWarpToTargetRequestMessage(target));
 

--- a/Content.Client/GameObjects/Components/Observer/GhostComponent.cs
+++ b/Content.Client/GameObjects/Components/Observer/GhostComponent.cs
@@ -20,6 +20,7 @@ namespace Content.Client.GameObjects.Components.Observer
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IComponentManager _componentManager = default!;
         [Dependency] private readonly IChatManager _chatManager = default!;
+
         public List<string> WarpNames = new();
         public Dictionary<EntityUid,string> PlayerNames = new();
 
@@ -41,7 +42,6 @@ namespace Content.Client.GameObjects.Components.Observer
                 SetGhostVisibility(false);
             }
         }
-
 
         private void SetGhostVisibility(bool visibility)
         {
@@ -99,7 +99,9 @@ namespace Content.Client.GameObjects.Components.Observer
 
         public void SendReturnToBodyMessage() => SendNetworkMessage(new ReturnToBodyComponentMessage());
 
-        public void SendGhostWarpRequestMessage(EntityUid target = default, string warpName = default!) => SendNetworkMessage(new GhostWarpRequestMessage(target, warpName));
+        public void SendGhostWarpRequestMessage(string warpName) => SendNetworkMessage(new GhostWarpToNameRequestMessage(warpName));
+
+        public void SendGhostWarpRequestMessage(EntityUid target) => SendNetworkMessage(new GhostWarpToTargetRequestMessage(target));
 
         public void GhostRequestWarpPoint() => SendNetworkMessage(new GhostRequestWarpPointData());
 

--- a/Content.Client/UserInterface/GhostGui.cs
+++ b/Content.Client/UserInterface/GhostGui.cs
@@ -17,7 +17,7 @@ namespace Content.Client.UserInterface
         private readonly Button _ghostRoles = new() {Text = Loc.GetString("Ghost Roles")};
         private readonly GhostComponent _owner;
 
-        public GhostTargetWindow? TargetWindow { get; private set; }
+        public GhostTargetWindow? TargetWindow { get; }
 
         public GhostGui(GhostComponent owner)
         {
@@ -114,7 +114,7 @@ namespace Content.Client.UserInterface
                     ClipText = true,
                 };
 
-                currentButtonRef.OnPressed += (args) =>
+                currentButtonRef.OnPressed += (_) =>
                 {
                     _owner.SendGhostWarpRequestMessage(key);
                 };
@@ -138,9 +138,9 @@ namespace Content.Client.UserInterface
                     ClipText = true,
                 };
 
-                currentButtonRef.OnPressed += (args) =>
+                currentButtonRef.OnPressed += (_) =>
                 {
-                    _owner.SendGhostWarpRequestMessage(default,name);
+                    _owner.SendGhostWarpRequestMessage(name);
                 };
 
                 _buttonContainer.AddChild(currentButtonRef);

--- a/Content.Client/UserInterface/GhostGui.cs
+++ b/Content.Client/UserInterface/GhostGui.cs
@@ -29,8 +29,8 @@ namespace Content.Client.UserInterface
 
             MouseFilter = MouseFilterMode.Ignore;
 
-            _ghostWarp.OnPressed += args => TargetWindow.Populate();
-            _returnToBody.OnPressed += args => owner.SendReturnToBodyMessage();
+            _ghostWarp.OnPressed += _ => TargetWindow.Populate();
+            _returnToBody.OnPressed += _ => owner.SendReturnToBodyMessage();
             _ghostRoles.OnPressed += _ => IoCManager.Resolve<IClientConsoleHost>().RemoteExecuteCommand(null, "ghostroles");
 
             AddChild(new HBoxContainer

--- a/Content.Server/GameObjects/Components/Observer/GhostComponent.cs
+++ b/Content.Server/GameObjects/Components/Observer/GhostComponent.cs
@@ -94,43 +94,48 @@ namespace Content.Server.GameObjects.Components.Observer
                         Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new GhostReturnMessage(mind.Mind));
                     }
                     break;
-                case GhostWarpRequestMessage warp:
+                case GhostWarpToNameRequestMessage warp:
                 {
                     if (session?.AttachedEntity != Owner)
                     {
                         break;
                     }
 
-                    if (warp.PlayerTarget != default)
+                    foreach (var warpPoint in FindWaypoints())
                     {
-                        if (!Owner.EntityManager.TryGetEntity(warp.PlayerTarget, out var entity))
+                        if (warp.WarpName == warpPoint.Location)
                         {
+                            Owner.Transform.Coordinates = warpPoint.Owner.Transform.Coordinates;
                             break;
-                        }
-
-                        if (!entity.TryGetComponent(out IActorComponent? actor))
-                        {
-                            break;
-                        }
-
-                        if (!_playerManager.TryGetSessionByChannel(actor.playerSession.ConnectedClient, out var player) ||
-                            player.AttachedEntity != entity)
-                        {
-                            break;
-                        }
-
-                        Owner.Transform.Coordinates = entity.Transform.Coordinates;
-                    }
-                    else
-                    {
-                        foreach (var warpPoint in FindWaypoints())
-                        {
-                            if (warp.WarpName == warpPoint.Location)
-                            {
-                                Owner.Transform.Coordinates = warpPoint.Owner.Transform.Coordinates;
-                            }
                         }
                     }
+
+                    break;
+                }
+                case GhostWarpToTargetRequestMessage target:
+                {
+                    if (session?.AttachedEntity != Owner)
+                    {
+                        break;
+                    }
+
+                    if (!Owner.EntityManager.TryGetEntity(target.Target, out var entity))
+                    {
+                        break;
+                    }
+
+                    if (!entity.TryGetComponent(out IActorComponent? actor))
+                    {
+                        break;
+                    }
+
+                    if (!_playerManager.TryGetSessionByChannel(actor.playerSession.ConnectedClient, out var player) ||
+                        player.AttachedEntity != entity)
+                    {
+                        break;
+                    }
+
+                    Owner.Transform.Coordinates = entity.Transform.Coordinates;
                     break;
                 }
                 case GhostRequestPlayerNameData _:

--- a/Content.Server/GameObjects/Components/Observer/GhostComponent.cs
+++ b/Content.Server/GameObjects/Components/Observer/GhostComponent.cs
@@ -12,6 +12,7 @@ using Robust.Server.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Players;
 using Robust.Shared.Timing;
@@ -94,7 +95,7 @@ namespace Content.Server.GameObjects.Components.Observer
                         Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new GhostReturnMessage(mind.Mind));
                     }
                     break;
-                case GhostWarpToNameRequestMessage warp:
+                case GhostWarpToLocationRequestMessage warp:
                 {
                     if (session?.AttachedEntity != Owner)
                     {
@@ -103,12 +104,14 @@ namespace Content.Server.GameObjects.Components.Observer
 
                     foreach (var warpPoint in FindWaypoints())
                     {
-                        if (warp.WarpName == warpPoint.Location)
+                        if (warp.Name == warpPoint.Location)
                         {
                             Owner.Transform.Coordinates = warpPoint.Owner.Transform.Coordinates;
                             break;
                         }
                     }
+
+                    Logger.Warning($"User {session.Name} tried to warp to an invalid warp: {warp.Name}");
 
                     break;
                 }
@@ -119,13 +122,14 @@ namespace Content.Server.GameObjects.Components.Observer
                         break;
                     }
 
-                    if (!Owner.EntityManager.TryGetEntity(target.Target, out var entity))
+                    if (!Owner.TryGetComponent(out IActorComponent? actor))
                     {
                         break;
                     }
 
-                    if (!entity.TryGetComponent(out IActorComponent? actor))
+                    if (!Owner.EntityManager.TryGetEntity(target.Target, out var entity))
                     {
+                        Logger.Warning($"User {session.Name} tried to warp to an invalid entity id: {target.Target}");
                         break;
                     }
 

--- a/Content.Shared/GameObjects/Components/Observer/GhostWarpToLocationRequestMessage.cs
+++ b/Content.Shared/GameObjects/Components/Observer/GhostWarpToLocationRequestMessage.cs
@@ -7,12 +7,12 @@ namespace Content.Shared.GameObjects.Components.Observer
     [Serializable, NetSerializable]
     public class GhostWarpToLocationRequestMessage : ComponentMessage
     {
+        public string Name { get; }
+
         public GhostWarpToLocationRequestMessage(string name)
         {
             Name = name;
             Directed = true;
         }
-
-        public string Name { get; }
     }
 }

--- a/Content.Shared/GameObjects/Components/Observer/GhostWarpToLocationRequestMessage.cs
+++ b/Content.Shared/GameObjects/Components/Observer/GhostWarpToLocationRequestMessage.cs
@@ -5,14 +5,14 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.GameObjects.Components.Observer
 {
     [Serializable, NetSerializable]
-    public class GhostWarpToNameRequestMessage : ComponentMessage
+    public class GhostWarpToLocationRequestMessage : ComponentMessage
     {
-        public GhostWarpToNameRequestMessage(string warpTarget = default)
+        public GhostWarpToLocationRequestMessage(string name)
         {
-            WarpName = warpTarget;
+            Name = name;
             Directed = true;
         }
 
-        public string WarpName { get; }
+        public string Name { get; }
     }
 }

--- a/Content.Shared/GameObjects/Components/Observer/GhostWarpToNameRequestMessage.cs
+++ b/Content.Shared/GameObjects/Components/Observer/GhostWarpToNameRequestMessage.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.GameObjects.Components.Observer
+{
+    [Serializable, NetSerializable]
+    public class GhostWarpToNameRequestMessage : ComponentMessage
+    {
+        public GhostWarpToNameRequestMessage(string warpTarget = default)
+        {
+            WarpName = warpTarget;
+            Directed = true;
+        }
+
+        public string WarpName { get; }
+    }
+}

--- a/Content.Shared/GameObjects/Components/Observer/GhostWarpToTargetRequestMessage.cs
+++ b/Content.Shared/GameObjects/Components/Observer/GhostWarpToTargetRequestMessage.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.GameObjects.Components.Observer
+{
+    [Serializable, NetSerializable]
+    public class GhostWarpToTargetRequestMessage : ComponentMessage
+    {
+        public GhostWarpToTargetRequestMessage(EntityUid target)
+        {
+            Target = target;
+            Directed = true;
+        }
+
+        public EntityUid Target { get; }
+    }
+}

--- a/Content.Shared/GameObjects/Components/Observer/GhostWarpToTargetRequestMessage.cs
+++ b/Content.Shared/GameObjects/Components/Observer/GhostWarpToTargetRequestMessage.cs
@@ -7,12 +7,12 @@ namespace Content.Shared.GameObjects.Components.Observer
     [Serializable, NetSerializable]
     public class GhostWarpToTargetRequestMessage : ComponentMessage
     {
+        public EntityUid Target { get; }
+
         public GhostWarpToTargetRequestMessage(EntityUid target)
         {
             Target = target;
             Directed = true;
         }
-
-        public EntityUid Target { get; }
     }
 }

--- a/Content.Shared/GameObjects/Components/Observer/SharedGhostComponent.cs
+++ b/Content.Shared/GameObjects/Components/Observer/SharedGhostComponent.cs
@@ -41,19 +41,6 @@ namespace Content.Shared.GameObjects.Components.Observer
     }
 
     [Serializable, NetSerializable]
-    public class GhostWarpRequestMessage : ComponentMessage
-    {
-        public EntityUid PlayerTarget;
-        public string WarpName;
-        public GhostWarpRequestMessage(EntityUid playerTarget = default, string warpTarget = default)
-        {
-            WarpName = warpTarget;
-            PlayerTarget = playerTarget;
-            Directed = true;
-        }
-    }
-
-    [Serializable, NetSerializable]
     public class GhostRequestWarpPointData : ComponentMessage
     {
         public GhostRequestWarpPointData()


### PR DESCRIPTION
## About the PR
Previously it was setting one of the two properties to differentiate between warps to warp locations and entities, now it uses 2 separate messages instead.