### PR TITLE
Fix the admin panel not showing the account name

### DIFF
--- a/Content.Client/UserInterface/AdminMenu/Tabs/PlayerTab.xaml.cs
+++ b/Content.Client/UserInterface/AdminMenu/Tabs/PlayerTab.xaml.cs
@@ -85,7 +85,7 @@ namespace Content.Client.UserInterface.AdminMenu.Tabs
                     {
                         new Label
                         {
-                            Text = player,
+                            Text = name,
                             SizeFlagsStretchRatio = 2f,
                             SizeFlagsHorizontal = SizeFlags.FillExpand,
                             ClipText = true


### PR DESCRIPTION
**Screenshots**
![dotnet_hVqXmvJiH8](https://user-images.githubusercontent.com/10968691/108522234-e7a24b80-72cc-11eb-842c-2f792ce8cc39.png)
