### PR TITLE
Fix dead people standing up after being stunned

### DIFF
--- a/Content.Server/GameObjects/Components/Buckle/BuckleComponent.cs
+++ b/Content.Server/GameObjects/Components/Buckle/BuckleComponent.cs
@@ -334,7 +334,8 @@ namespace Content.Server.GameObjects.Components.Buckle
 
             Appearance?.SetData(BuckleVisuals.Buckled, false);
 
-            if (_stunnable != null && _stunnable.KnockedDown)
+            if (_stunnable != null && _stunnable.KnockedDown
+                || (_mobState?.IsIncapacitated() ?? false))
             {
                 EntitySystem.Get<StandingStateSystem>().Down(Owner);
             }

--- a/Content.Server/GameObjects/Components/Instruments/InstrumentComponent.cs
+++ b/Content.Server/GameObjects/Components/Instruments/InstrumentComponent.cs
@@ -353,13 +353,16 @@ namespace Content.Server.GameObjects.Components.Instruments
 
                 UserInterface?.CloseAll();
 
-                if(Handheld)
-                    EntitySystem.Get<StandingStateSystem>().DropAllItemsInHands(mob, false);
-
-                if (mob != null && mob.TryGetComponent(out StunnableComponent? stun))
+                if (mob != null)
                 {
-                    stun.Stun(1);
-                    Clean();
+                    if (Handheld)
+                        EntitySystem.Get<StandingStateSystem>().DropAllItemsInHands(mob, false);
+
+                    if (mob.TryGetComponent(out StunnableComponent? stun))
+                    {
+                        stun.Stun(1);
+                        Clean();
+                    }
                 }
 
                 InstrumentPlayer = null;

--- a/Content.Server/GameObjects/Components/Mobs/StunnableComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/StunnableComponent.cs
@@ -1,9 +1,11 @@
-﻿using Content.Server.GameObjects.EntitySystems;
+﻿#nullable enable
+using Content.Server.GameObjects.EntitySystems;
 using Content.Server.Interfaces.GameObjects;
 using Content.Server.Utility;
 using Content.Shared.Alert;
 using Content.Shared.Audio;
 using Content.Shared.GameObjects.Components.Mobs;
+using Content.Shared.GameObjects.Components.Mobs.State;
 using Content.Shared.GameObjects.Components.Movement;
 using Content.Shared.Interfaces;
 using Robust.Server.GameObjects;
@@ -39,7 +41,8 @@ namespace Content.Server.GameObjects.Components.Mobs
             StunnedTimer = 0f;
             SlowdownTimer = 0f;
 
-            if (KnockedDown)
+            if (KnockedDown &&
+                Owner.TryGetComponent(out IMobStateComponent? mobState) && !mobState.IsIncapacitated())
             {
                 EntitySystem.Get<StandingStateSystem>().Standing(Owner);
             }
@@ -82,7 +85,7 @@ namespace Content.Server.GameObjects.Components.Mobs
                 {
                     SlowdownTimer = 0f;
 
-                    if (Owner.TryGetComponent(out MovementSpeedModifierComponent movement))
+                    if (Owner.TryGetComponent(out MovementSpeedModifierComponent? movement))
                     {
                         movement.RefreshMovementSpeedModifiers();
                     }
@@ -92,7 +95,7 @@ namespace Content.Server.GameObjects.Components.Mobs
             }
 
             if (!StunStart.HasValue || !StunEnd.HasValue ||
-                !Owner.TryGetComponent(out ServerAlertsComponent status))
+                !Owner.TryGetComponent(out ServerAlertsComponent? status))
             {
                 return;
             }

--- a/Content.Server/GameObjects/Components/Mobs/StunnableComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/StunnableComponent.cs
@@ -68,7 +68,8 @@ namespace Content.Server.GameObjects.Components.Mobs
             {
                 KnockdownTimer -= delta;
 
-                if (KnockdownTimer <= 0f)
+                if (KnockdownTimer <= 0f
+                    && Owner.TryGetComponent(out IMobStateComponent? mobState) && !mobState.IsIncapacitated())
                 {
                     EntitySystem.Get<StandingStateSystem>().Standing(Owner);
 

--- a/Content.Server/GameObjects/EntitySystems/StandingStateSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/StandingStateSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Interfaces.GameObjects.Components.Items;
 using Content.Shared.Audio;
+using Content.Shared.GameObjects.Components.Mobs.State;
 using Content.Shared.GameObjects.Components.Rotation;
 using Content.Shared.GameObjects.EntitySystems;
 using JetBrains.Annotations;
@@ -38,6 +39,12 @@ namespace Content.Server.GameObjects.EntitySystems
         protected override bool OnStand(IEntity entity)
         {
             if (!entity.TryGetComponent(out AppearanceComponent appearance)) return false;
+
+            if (entity.TryGetComponent(out IMobStateComponent mobState)
+                && mobState.IsIncapacitated())
+            {
+                return false; // the dead cannot be allowed to walk
+            }
 
             appearance.TryGetData<RotationState>(RotationVisuals.RotationState, out var oldState);
             var newState = RotationState.Vertical;

--- a/Content.Server/GameObjects/EntitySystems/StandingStateSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/StandingStateSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.Interfaces.GameObjects.Components.Items;
+﻿#nullable enable
+using Content.Server.Interfaces.GameObjects.Components.Items;
 using Content.Shared.Audio;
 using Content.Shared.GameObjects.Components.Mobs.State;
 using Content.Shared.GameObjects.Components.Rotation;
@@ -14,7 +15,7 @@ namespace Content.Server.GameObjects.EntitySystems
     {
         protected override bool OnDown(IEntity entity, bool playSound = true, bool dropItems = true, bool force = false)
         {
-            if (!entity.TryGetComponent(out AppearanceComponent appearance))
+            if (!entity.TryGetComponent(out AppearanceComponent? appearance))
             {
                 return false;
             }
@@ -38,13 +39,7 @@ namespace Content.Server.GameObjects.EntitySystems
 
         protected override bool OnStand(IEntity entity)
         {
-            if (!entity.TryGetComponent(out AppearanceComponent appearance)) return false;
-
-            if (entity.TryGetComponent(out IMobStateComponent mobState)
-                && mobState.IsIncapacitated())
-            {
-                return false; // the dead cannot be allowed to walk
-            }
+            if (!entity.TryGetComponent(out AppearanceComponent? appearance)) return false;
 
             appearance.TryGetData<RotationState>(RotationVisuals.RotationState, out var oldState);
             var newState = RotationState.Vertical;
@@ -60,7 +55,7 @@ namespace Content.Server.GameObjects.EntitySystems
         {
             base.DropAllItemsInHands(entity, doMobChecks);
 
-            if (!entity.TryGetComponent(out IHandsComponent hands)) return;
+            if (!entity.TryGetComponent(out IHandsComponent? hands)) return;
 
             foreach (var heldItem in hands.GetAllHeldItems())
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Fixes dead people standing up after their stuns run out (fixes #3325)
- Fixes dead people standing up after being unbuckled from a chair
- Adds nullability to various files we touched like a fairy sprinkling magic dust

Not sure if there's a better way to handle than checking every time we try and call StandingStateSystem.Standing(), maybe have a TryStand() that actually does checks