### PR TITLE
fix for sandbox menu not keeping button toggle state between instances

### DIFF
--- a/Content.Client/Sandbox/SandboxManager.cs
+++ b/Content.Client/Sandbox/SandboxManager.cs
@@ -1,13 +1,17 @@
 ﻿using System;
+using Content.Client.GameObjects.EntitySystems;
 using Content.Client.UserInterface;
 using Content.Shared.Input;
 using Content.Shared.Sandbox;
 using Robust.Client.Console;
+using Robust.Client.Debugging;
+using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Placement;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
@@ -60,25 +64,25 @@ namespace Content.Client.Sandbox
             GiveAghostButton = new Button { Text = Loc.GetString("Ghost") };
             vBox.AddChild(GiveAghostButton);
 
-            ToggleLightButton = new Button { Text = Loc.GetString("Toggle Lights"), ToggleMode = true };
+            ToggleLightButton = new Button { Text = Loc.GetString("Toggle Lights"), ToggleMode = true, Pressed = !IoCManager.Resolve<ILightManager>().Enabled };
             vBox.AddChild(ToggleLightButton);
 
-            ToggleFovButton = new Button { Text = Loc.GetString("Toggle FOV"), ToggleMode = true };
+            ToggleFovButton = new Button { Text = Loc.GetString("Toggle FOV"), ToggleMode = true, Pressed = !IoCManager.Resolve<IEyeManager>().CurrentEye.DrawFov };
             vBox.AddChild(ToggleFovButton);
 
-            ToggleShadowsButton = new Button { Text = Loc.GetString("Toggle Shadows"), ToggleMode = true };
+            ToggleShadowsButton = new Button { Text = Loc.GetString("Toggle Shadows"), ToggleMode = true, Pressed = !IoCManager.Resolve<ILightManager>().DrawShadows };
             vBox.AddChild(ToggleShadowsButton);
 
-            ToggleSubfloorButton = new Button { Text = Loc.GetString("Toggle Subfloor"), ToggleMode = true };
+            ToggleSubfloorButton = new Button { Text = Loc.GetString("Toggle Subfloor"), ToggleMode = true, Pressed = EntitySystem.Get<SubFloorHideSystem>().EnableAll };
             vBox.AddChild(ToggleSubfloorButton);
 
             SuicideButton = new Button { Text = Loc.GetString("Suicide") };
             vBox.AddChild(SuicideButton);
 
-            ShowMarkersButton = new Button { Text = Loc.GetString("Show Spawns"), ToggleMode = true };
+            ShowMarkersButton = new Button { Text = Loc.GetString("Show Spawns"), ToggleMode = true, Pressed = EntitySystem.Get<MarkerSystem>().MarkersVisible };
             vBox.AddChild(ShowMarkersButton);
 
-            ShowBbButton = new Button { Text = Loc.GetString("Show BB"), ToggleMode = true };
+            ShowBbButton = new Button { Text = Loc.GetString("Show BB"), ToggleMode = true, Pressed = IoCManager.Resolve<IDebugDrawing>().DebugColliders };
             vBox.AddChild(ShowBbButton);
 
             MachineLinkingButton = new Button { Text = Loc.GetString("Link machines"), ToggleMode = true };


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## Maintain Togglestate for Sandbox Menu <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes issue #3282 
