### PR TITLE
SpriteFix Compatibility

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -29,6 +29,7 @@
   - type: Ghost
   - type: Sprite
     netsync: false
+    noRot: true
     drawdepth: Ghosts
     sprite: Mobs/Ghosts/ghost_human.rsi
     state: animated

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -34,6 +34,7 @@
     state: full
   - type: Sprite
     netsync: false
+    noRot: true
     drawdepth: Mobs
     layers:
     - map: [ "enum.HumanoidVisualLayers.Chest" ]

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -42,6 +42,12 @@ binds:
 - function: Walk
   type: State
   key: Shift
+- function: CameraRotateLeft
+  type: State
+  key: NumpadNum7
+- function: CameraRotateRight
+  type: State
+  key: NumpadNum9
 - function: ShowEscapeMenu
   type: State
   key: Escape


### PR DESCRIPTION
Added noRot flag to player and ghost sprite prototypes so that they stay upright.
Added keybinds to rotate the camera.

Related to https://github.com/space-wizards/RobustToolbox/pull/1551.