### PR TITLE
Show the prototype id when failing dummy icon test

### DIFF
--- a/Content.IntegrationTests/Tests/DummyIconTest.cs
+++ b/Content.IntegrationTests/Tests/DummyIconTest.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -26,7 +27,11 @@ namespace Content.IntegrationTests.Tests
                 {
                     if (!proto.Components.ContainsKey("Sprite")) continue;
 
-                    var _ = SpriteComponent.GetPrototypeTextures(proto, resourceCache).ToList();
+                    Assert.DoesNotThrow(() =>
+                    {
+                        var _ = SpriteComponent.GetPrototypeTextures(proto, resourceCache).ToList();
+                    }, "Prototype {0} threw an exception when getting its textures.",
+                        proto.ID);
                 }
             });
         }

--- a/Content.IntegrationTests/Tests/DummyIconTest.cs
+++ b/Content.IntegrationTests/Tests/DummyIconTest.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;


### PR DESCRIPTION
## About the PR
Previously it was anyone's guess as to which prototype was actually failing the test.