### PR TITLE
fixed apcnet causing crash

### DIFF
--- a/Content.Server/GameObjects/EntitySystems/ApcNetSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ApcNetSystem.cs
@@ -38,7 +38,9 @@ namespace Content.Server.GameObjects.EntitySystems
 
         public void Reset()
         {
-            _apcNets = new HashSet<IApcNet>();
+            // NodeGroupSystem does not remake ApcNets affected during restarting until a frame later,
+            // when their grid is invalid. So, we are clearing them on round restart.
+            _apcNets.Clear();
         }
     }
 }

--- a/Content.Server/GameObjects/EntitySystems/ApcNetSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ApcNetSystem.cs
@@ -4,12 +4,13 @@ using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using System.Collections.Generic;
+using Content.Shared.GameTicking;
 using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.EntitySystems
 {
     [UsedImplicitly]
-    internal sealed class ApcNetSystem : EntitySystem
+    internal sealed class ApcNetSystem : EntitySystem, IResettingEntitySystem
     {
         [Dependency] private readonly IPauseManager _pauseManager = default!;
 
@@ -33,6 +34,11 @@ namespace Content.Server.GameObjects.EntitySystems
         public void RemoveApcNet(ApcNetNodeGroup apcNet)
         {
             _apcNets.Remove(apcNet);
+        }
+
+        public void Reset()
+        {
+            _apcNets = new HashSet<IApcNet>();
         }
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## Fix for Round Restart causing a Crash on Content.Server <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Noticed this while I was messing around in the admin menu. Calling round restart (or round end for that matter) from the admin menu caused Content.Server to receive a fatal error. After a bit of debugging, it appears to be because the ApcNetSystem is not properly reset on round restart, and continues to query about mapdata that no longer exists. I've implemented a fix for this, by resetting the list of apcs in the system upon round restart.

Here's the initial stack trace I used to track down the error:
```[FATL] unhandled: System.Collections.Generic.KeyNotFoundException: The given key '1' was not present in the dictionary.
   at System.Collections.Generic.Dictionary2.get_Item(TKey key)
   at Robust.Shared.Map.MapManager.GetGrid(GridId gridID) in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Shared\Map\MapManager.cs:line 470

   at Robust.Shared.Timing.PauseManager.IsGridPaused(GridId gridId) in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Shared\Timing\PauseManager.cs:line 94

   at Content.Server.GameObjects.EntitySystems.ApcNetSystem.Update(Single frameTime) in C:\My Stuff\Game Making\SS14\space-station-14\Content.Server\GameObjects\EntitySystems\ApcNetSystem.cs:line 23

   at Robust.Shared.GameObjects.EntitySystemManager.Update(Single frameTime) in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntitySystemManager.cs:line 258

   at Robust.Shared.GameObjects.EntityManager.Update(Single frameTime, Histogram histogram) in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.cs:line 88

   at Robust.Server.GameObjects.ServerEntityManager.Update(Single frameTime, Histogram histogram) in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Server\GameObjects\ServerEntityManager.cs:line 957

   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 564

   at Robust.Server.BaseServer.<MainLoop>b__44_1(Object sender, FrameEventArgs args) in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 408

   at Robust.Shared.Timing.GameLoop.Run() in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Shared\Timing\GameLoop.cs:line 192

   at Robust.Server.BaseServer.MainLoop() in C:\My Stuff\Game Making\SS14\space-station-14\RobustToolbox\Robust.Server\BaseServer.cs:line 414```

I'm unaware of any issues with this specific problem, so I can't link any in this PR.
