### PR TITLE
Don't show warnings when Serializer isn't from YAML

### DIFF
--- a/Content.Server/GameObjects/Components/Items/Storage/StorageCounterComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/Storage/StorageCounterComponent.cs
@@ -38,7 +38,8 @@ namespace Content.Server.GameObjects.Components.Items.Storage
             base.ExposeData(serializer);
 
             serializer.DataField(ref _countTag, "countTag", null);
-            if (_countTag == null)
+            // We only print this message if YAML config doesn't have the countTag
+            if (serializer is YamlObjectSerializer && _countTag == null)
             {
                 Logger.Warning("StorageCounterComponent without a `countTag` is useless");
             }


### PR DESCRIPTION
There was an issue that when DefaultSerializer was accessing the entity, it
wasn't setting `countTag` so the component would report a pointless warning. 

Closes #3287 

