### PR TITLE
Fixes mobs rotating

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -23,6 +23,8 @@
     soundHit: /Audio/Effects/hit_kick.ogg
   - type: InteractionOutline
   - type: Sprite
+    netsync: false
+    noRot: true
     drawdepth: Mobs
   - type: Clickable
   - type: Physics


### PR DESCRIPTION
This doesn't actually fix it in monkeys as displayed below, but i'm going to push a PR that ties all animals to the base simplemob better and it'll fix it there.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![2021-02-21_18-12-16](https://user-images.githubusercontent.com/49448379/108649333-03684600-74b5-11eb-8cd1-366cab438c29.gif)
