### PR TITLE
Fix bug with animated sprites not being initially animated

### DIFF
--- a/Content.Client/GameObjects/Components/HUD/Inventory/ClientInventoryComponent.cs
+++ b/Content.Client/GameObjects/Components/HUD/Inventory/ClientInventoryComponent.cs
@@ -186,6 +186,7 @@ namespace Content.Client.GameObjects.Components.HUD.Inventory
                     var (rsi, state) = data.Value;
                     _sprite.LayerSetVisible(slot, true);
                     _sprite.LayerSetState(slot, state, rsi);
+                    _sprite.LayerSetAutoAnimated(slot, true);
 
                     if (slot == Slots.INNERCLOTHING)
                     {


### PR DESCRIPTION
Sets auto animated of client inventory to true, enables cosmos bedsheets to be
animated when first equipping.

Fixes #1144


**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/1146204/108778821-420a0900-7566-11eb-970f-755f1e771786.mp4

