### PR TITLE
Refactor stacks to use prototypes

### DIFF
--- a/Content.Client/Construction/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/ConstructionMenuPresenter.cs
@@ -251,8 +251,8 @@ namespace Content.Client.Construction
                             stepList.AddItem(
                                 !firstNode
                                     ? Loc.GetString(
-                                        "{0}. Add {1}x {2}.", stepNumber++, materialStep.Amount, materialStep.MaterialPrototype.ID)
-                                    : Loc.GetString("      {0}x {1}", materialStep.Amount, materialStep.MaterialPrototype.ID), icon);
+                                        "{0}. Add {1}x {2}.", stepNumber++, materialStep.Amount, materialStep.MaterialPrototype.Name)
+                                    : Loc.GetString("      {0}x {1}", materialStep.Amount, materialStep.MaterialPrototype.Name), icon);
 
                             break;
 
@@ -283,7 +283,7 @@ namespace Content.Client.Construction
                                     switch (subStep)
                                     {
                                         case MaterialConstructionGraphStep materialStep:
-                                            if (!(prototype.Type == ConstructionType.Item)) stepList.AddItem(Loc.GetString("    {0}.{1}.{2}. Add {3}x {4}.", stepNumber, parallelNumber, subStepNumber++, materialStep.Amount, materialStep.MaterialPrototype.ID), icon);
+                                            if (prototype.Type != ConstructionType.Item) stepList.AddItem(Loc.GetString("    {0}.{1}.{2}. Add {3}x {4}.", stepNumber, parallelNumber, subStepNumber++, materialStep.Amount, materialStep.MaterialPrototype.Name), icon);
                                             break;
 
                                         case ToolConstructionGraphStep toolStep:

--- a/Content.Client/Construction/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/ConstructionMenuPresenter.cs
@@ -18,6 +18,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Construction
 {
@@ -71,7 +72,7 @@ namespace Content.Client.Construction
                     _constructionView.Close();
             }
         }
-        
+
         /// <summary>
         /// Constructs a new instance of <see cref="ConstructionMenuPresenter" />.
         /// </summary>
@@ -250,8 +251,8 @@ namespace Content.Client.Construction
                             stepList.AddItem(
                                 !firstNode
                                     ? Loc.GetString(
-                                        "{0}. Add {1}x {2}.", stepNumber++, materialStep.Amount, materialStep.Material)
-                                    : Loc.GetString("      {0}x {1}", materialStep.Amount, materialStep.Material), icon);
+                                        "{0}. Add {1}x {2}.", stepNumber++, materialStep.Amount, materialStep.MaterialPrototype.ID)
+                                    : Loc.GetString("      {0}x {1}", materialStep.Amount, materialStep.MaterialPrototype.ID), icon);
 
                             break;
 
@@ -282,7 +283,7 @@ namespace Content.Client.Construction
                                     switch (subStep)
                                     {
                                         case MaterialConstructionGraphStep materialStep:
-                                            if (!(prototype.Type == ConstructionType.Item)) stepList.AddItem(Loc.GetString("    {0}.{1}.{2}. Add {3}x {4}.", stepNumber, parallelNumber, subStepNumber++, materialStep.Amount, materialStep.Material), icon);
+                                            if (!(prototype.Type == ConstructionType.Item)) stepList.AddItem(Loc.GetString("    {0}.{1}.{2}. Add {3}x {4}.", stepNumber, parallelNumber, subStepNumber++, materialStep.Amount, materialStep.MaterialPrototype.ID), icon);
                                             break;
 
                                         case ToolConstructionGraphStep toolStep:
@@ -315,28 +316,7 @@ namespace Content.Client.Construction
             switch (step)
             {
                 case MaterialConstructionGraphStep materialStep:
-                    switch (materialStep.Material)
-                    {
-                        case StackType.Metal:
-                            return resourceCache.GetTexture("/Textures/Objects/Materials/sheets.rsi/metal.png");
-
-                        case StackType.Glass:
-                            return resourceCache.GetTexture("/Textures/Objects/Materials/sheets.rsi/glass.png");
-
-                        case StackType.Plasteel:
-                            return resourceCache.GetTexture("/Textures/Objects/Materials/sheets.rsi/plasteel.png");
-
-                        case StackType.Plasma:
-                            return resourceCache.GetTexture("/Textures/Objects/Materials/sheets.rsi/phoron.png");
-
-                        case StackType.Cable:
-                            return resourceCache.GetTexture("/Textures/Objects/Tools/cables.rsi/coil-30.png");
-
-                        case StackType.MetalRod:
-                            return resourceCache.GetTexture("/Textures/Objects/Materials/materials.rsi/rods.png");
-                    }
-
-                    break;
+                    return materialStep.MaterialPrototype.Icon?.Frame0();
 
                 case ToolConstructionGraphStep toolStep:
                     switch (toolStep.Tool)
@@ -430,7 +410,7 @@ namespace Content.Client.Construction
 
             _constructionView.BuildButtonPressed = true;
         }
-        
+
         private void OnSystemLoaded(object? sender, SystemChangedArgs args)
         {
             if (args.System is ConstructionSystem system) SystemBindingChanged(system);

--- a/Content.Server/Construction/StackHelpers.cs
+++ b/Content.Server/Construction/StackHelpers.cs
@@ -2,6 +2,7 @@
 using System;
 using Content.Server.GameObjects.Components.Stack;
 using Content.Shared.GameObjects.Components;
+using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -13,46 +14,15 @@ namespace Content.Server.Construction
         /// <summary>
         ///     Spawns a stack of a specified type given an amount.
         /// </summary>
-        public static IEntity SpawnStack(StackType stack, int amount, EntityCoordinates coordinates, IEntityManager? entityManager = null)
+        public static IEntity SpawnStack(StackPrototype stack, int amount, EntityCoordinates coordinates, IEntityManager? entityManager = null)
         {
             entityManager ??= IoCManager.Resolve<IEntityManager>();
 
-            string prototype;
-
-            switch (stack)
-            {
-                case StackType.Metal:
-                    prototype = "SteelSheet1";
-                    break;
-
-                case StackType.Glass:
-                    prototype = "GlassSheet1";
-                    break;
-
-                case StackType.MetalRod:
-                    prototype = "MetalRodStack1";
-                    break;
-
-                case StackType.Plasma:
-                    prototype = "PlasmaStack1";
-                    break;
-
-                case StackType.Plasteel:
-                    prototype = "PlasteelSheet1";
-                    break;
-
-                case StackType.Cable:
-                    prototype = "ApcExtensionCableStack1";
-                    break;
-
-                // TODO: Add more.
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(stack),"Stack type doesn't have a prototype specified yet!");
-            }
+            // TODO: Add more.
+            string prototype = stack.Spawn ?? throw new ArgumentOutOfRangeException(nameof(stack),
+                "Stack type doesn't have a prototype specified yet!");
 
             var ent = entityManager.SpawnEntity(prototype, coordinates);
-
             var stackComponent = ent.GetComponent<StackComponent>();
 
             stackComponent.Count = Math.Min(amount, stackComponent.MaxCount);

--- a/Content.Server/GameObjects/Components/Construction/MachineBoardComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/MachineBoardComponent.cs
@@ -75,9 +75,9 @@ namespace Content.Server.GameObjects.Components.Construction
                 message.AddMarkup(Loc.GetString("[color=yellow]{0}x[/color] [color=green]{1}[/color]\n", amount, Loc.GetString(part.ToString())));
             }
 
-            foreach (var (material, amount) in MaterialIdRequirements)
+            foreach (var (material, amount) in MaterialRequirements)
             {
-                message.AddMarkup(Loc.GetString("[color=yellow]{0}x[/color] [color=green]{1}[/color]\n", amount, Loc.GetString(material)));
+                message.AddMarkup(Loc.GetString("[color=yellow]{0}x[/color] [color=green]{1}[/color]\n", amount, Loc.GetString(material.Name)));
             }
 
             foreach (var (_, info) in ComponentRequirements)

--- a/Content.Server/GameObjects/Components/Construction/MachineBoardComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/MachineBoardComponent.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using Content.Server.Construction;
-using Content.Shared.GameObjects.Components;
 using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
@@ -14,13 +16,15 @@ namespace Content.Server.GameObjects.Components.Construction
     [RegisterComponent]
     public class MachineBoardComponent : Component, IExamine
     {
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
         public override string Name => "MachineBoard";
 
         [ViewVariables]
         private Dictionary<MachinePart, int> _requirements;
 
         [ViewVariables]
-        private Dictionary<StackType, int> _materialRequirements;
+        private Dictionary<string, int> _materialIdRequirements;
 
         [ViewVariables]
         private Dictionary<string, ComponentPartInfo> _componentRequirements;
@@ -28,7 +32,20 @@ namespace Content.Server.GameObjects.Components.Construction
         [ViewVariables(VVAccess.ReadWrite)]
         public string Prototype { get; private set; }
         public IReadOnlyDictionary<MachinePart, int> Requirements => _requirements;
-        public IReadOnlyDictionary<StackType, int> MaterialRequirements => _materialRequirements;
+        public IReadOnlyDictionary<string, int> MaterialIdRequirements => _materialIdRequirements;
+
+        public IEnumerable<KeyValuePair<StackPrototype, int>> MaterialRequirements
+        {
+            get
+            {
+                foreach (var (materialId, amount) in MaterialIdRequirements)
+                {
+                    var material = _prototypeManager.Index<StackPrototype>(materialId);
+                    yield return new KeyValuePair<StackPrototype, int>(material, amount);
+                }
+            }
+        }
+
         public IReadOnlyDictionary<string, ComponentPartInfo> ComponentRequirements => _componentRequirements;
 
         public override void ExposeData(ObjectSerializer serializer)
@@ -36,8 +53,18 @@ namespace Content.Server.GameObjects.Components.Construction
             base.ExposeData(serializer);
             serializer.DataField(this, x => x.Prototype, "prototype", null);
             serializer.DataField(ref _requirements, "requirements", new Dictionary<MachinePart, int>());
-            serializer.DataField(ref _materialRequirements, "materialRequirements", new Dictionary<StackType, int>());
+            serializer.DataField(ref _materialIdRequirements, "materialRequirements", new Dictionary<string, int>());
             serializer.DataField(ref _componentRequirements, "componentRequirements", new Dictionary<string, ComponentPartInfo>());
+        }
+
+        protected override void Startup()
+        {
+            base.Startup();
+
+            foreach (var material in _materialIdRequirements.Keys)
+            {
+                _prototypeManager.Index<StackPrototype>(material);
+            }
         }
 
         public void Examine(FormattedMessage message, bool inDetailsRange)
@@ -48,9 +75,9 @@ namespace Content.Server.GameObjects.Components.Construction
                 message.AddMarkup(Loc.GetString("[color=yellow]{0}x[/color] [color=green]{1}[/color]\n", amount, Loc.GetString(part.ToString())));
             }
 
-            foreach (var (material, amount) in MaterialRequirements)
+            foreach (var (material, amount) in MaterialIdRequirements)
             {
-                message.AddMarkup(Loc.GetString("[color=yellow]{0}x[/color] [color=green]{1}[/color]\n", amount, Loc.GetString(material.ToString())));
+                message.AddMarkup(Loc.GetString("[color=yellow]{0}x[/color] [color=green]{1}[/color]\n", amount, Loc.GetString(material)));
             }
 
             foreach (var (_, info) in ComponentRequirements)

--- a/Content.Server/GameObjects/Components/Construction/MachineBoardComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/MachineBoardComponent.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using Content.Server.Construction;
 using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Stacks;
+using Microsoft.Extensions.Logging;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Log;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
@@ -63,7 +65,10 @@ namespace Content.Server.GameObjects.Components.Construction
 
             foreach (var material in _materialIdRequirements.Keys)
             {
-                _prototypeManager.Index<StackPrototype>(material);
+                if (!_prototypeManager.HasIndex<StackPrototype>(material))
+                {
+                    Logger.Error($"No {nameof(StackPrototype)} found with id {material}");
+                }
             }
         }
 

--- a/Content.Server/GameObjects/Components/Stack/StackComponent.cs
+++ b/Content.Server/GameObjects/Components/Stack/StackComponent.cs
@@ -14,7 +14,6 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Stack
 {
-
     // TODO: Naming and presentation and such could use some improvement.
     [RegisterComponent]
     [ComponentReference(typeof(SharedStackComponent))]
@@ -85,7 +84,7 @@ namespace Content.Server.GameObjects.Components.Stack
             if (!eventArgs.Using.TryGetComponent<StackComponent>(out var stack))
                 return false;
 
-            if (!stack.StackType.Equals(StackType))
+            if (!stack.StackTypeId.Equals(StackTypeId))
             {
                 return false;
             }

--- a/Content.Shared/Construction/MaterialConstructionGraphStep.cs
+++ b/Content.Shared/Construction/MaterialConstructionGraphStep.cs
@@ -1,8 +1,13 @@
 ﻿#nullable enable
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.GameObjects.Components;
+using Content.Shared.Materials;
+using Content.Shared.Stacks;
+using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -12,30 +17,34 @@ namespace Content.Shared.Construction
     {
         // TODO: Make this use the material system.
         // TODO TODO: Make the material system not shit.
-        public StackType Material { get; private set; }
+        private string MaterialPrototypeId { get; [UsedImplicitly] set; } = default!;
+
+        public StackPrototype MaterialPrototype =>
+            IoCManager.Resolve<IPrototypeManager>().Index<StackPrototype>(MaterialPrototypeId);
+
         public int Amount { get; private set; }
 
         public override void ExposeData(ObjectSerializer serializer)
         {
             base.ExposeData(serializer);
 
-            serializer.DataField(this, x => x.Material, "material", StackType.Metal);
+            serializer.DataField(this, x => x.MaterialPrototypeId, "material", "Steel");
             serializer.DataField(this, x => x.Amount, "amount", 1);
         }
 
         public override void DoExamine(FormattedMessage message, bool inDetailsRange)
         {
-            message.AddMarkup(Loc.GetString("Next, add [color=yellow]{0}x[/color] [color=cyan]{1}[/color].", Amount, Material));
+            message.AddMarkup(Loc.GetString("Next, add [color=yellow]{0}x[/color] [color=cyan]{1}[/color].", Amount, MaterialPrototypeId));
         }
 
         public override bool EntityValid(IEntity entity)
         {
-            return entity.TryGetComponent(out SharedStackComponent? stack) && stack.StackType.Equals(Material);
+            return entity.TryGetComponent(out SharedStackComponent? stack) && stack.StackTypeId.Equals(MaterialPrototypeId);
         }
 
         public bool EntityValid(IEntity entity, [NotNullWhen(true)] out SharedStackComponent? stack)
         {
-            if(entity.TryGetComponent(out SharedStackComponent? otherStack) && otherStack.StackType.Equals(Material))
+            if (entity.TryGetComponent(out SharedStackComponent? otherStack) && otherStack.StackTypeId.Equals(MaterialPrototypeId))
                 stack = otherStack;
             else
                 stack = null;

--- a/Content.Shared/Construction/MaterialConstructionGraphStep.cs
+++ b/Content.Shared/Construction/MaterialConstructionGraphStep.cs
@@ -34,7 +34,7 @@ namespace Content.Shared.Construction
 
         public override void DoExamine(FormattedMessage message, bool inDetailsRange)
         {
-            message.AddMarkup(Loc.GetString("Next, add [color=yellow]{0}x[/color] [color=cyan]{1}[/color].", Amount, MaterialPrototypeId));
+            message.AddMarkup(Loc.GetString("Next, add [color=yellow]{0}x[/color] [color=cyan]{1}[/color].", Amount, MaterialPrototype.Name));
         }
 
         public override bool EntityValid(IEntity entity)

--- a/Content.Shared/GameObjects/Components/SharedStackComponent.cs
+++ b/Content.Shared/GameObjects/Components/SharedStackComponent.cs
@@ -2,6 +2,7 @@ using System;
 using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Players;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -50,7 +51,7 @@ namespace Content.Shared.GameObjects.Components
 
         [ViewVariables] public int AvailableSpace => MaxCount - Count;
 
-        [ViewVariables] public string StackTypeId { get; private set; }
+        [ViewVariables] public string StackTypeId { get; private set; } = string.Empty;
 
         public StackPrototype StackType => _prototypeManager.Index<StackPrototype>(StackTypeId);
 
@@ -70,9 +71,9 @@ namespace Content.Shared.GameObjects.Components
                 return;
             }
 
-            serializer.DataFieldCached(ref stackType, "stackType", null);
+            serializer.DataFieldCached(ref stackType, "stackType", string.Empty);
 
-            if (stackType != null)
+            if (!string.IsNullOrEmpty(stackType))
             {
                 serializer.SetCacheData(SerializationCache, stackType);
                 StackTypeId = stackType;
@@ -83,7 +84,10 @@ namespace Content.Shared.GameObjects.Components
         {
             base.Startup();
 
-            _prototypeManager.Index<StackPrototype>(StackTypeId);
+            if (!_prototypeManager.HasIndex<StackPrototype>(StackTypeId))
+            {
+                Logger.Error($"No {nameof(StackPrototype)} found with id {StackTypeId}");
+            }
         }
 
         public override ComponentState GetComponentState(ICommonSession player)

--- a/Content.Shared/GameObjects/Components/SharedStackComponent.cs
+++ b/Content.Shared/GameObjects/Components/SharedStackComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.GameObjects.Components
 {
     public abstract class SharedStackComponent : Component
     {
-        [Dependency] private readonly IPrototypeManager _prototypeManager;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
         private const string SerializationCache = "stack";
 

--- a/Content.Shared/GameObjects/Components/SharedStackComponent.cs
+++ b/Content.Shared/GameObjects/Components/SharedStackComponent.cs
@@ -52,7 +52,7 @@ namespace Content.Shared.GameObjects.Components
 
         [ViewVariables] public string StackTypeId { get; private set; }
 
-        public StackPrototype StackType => IoCManager.Resolve<IPrototypeManager>().Index<StackPrototype>(StackTypeId);
+        public StackPrototype StackType => _prototypeManager.Index<StackPrototype>(StackTypeId);
 
         public override void ExposeData(ObjectSerializer serializer)
         {
@@ -70,12 +70,13 @@ namespace Content.Shared.GameObjects.Components
                 return;
             }
 
-            stackType = serializer.TryReadDataFieldCached("stackType", out string raw)
-                ? raw
-                : Owner.Prototype.ID;
+            serializer.DataFieldCached(ref stackType, "stackType", null);
 
-            serializer.SetCacheData(SerializationCache, stackType);
-            StackTypeId = stackType;
+            if (stackType != null)
+            {
+                serializer.SetCacheData(SerializationCache, stackType);
+                StackTypeId = stackType;
+            }
         }
 
         protected override void Startup()

--- a/Content.Shared/Stacks/StackPrototype.cs
+++ b/Content.Shared/Stacks/StackPrototype.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+using YamlDotNet.RepresentationModel;
+
+namespace Content.Shared.Stacks
+{
+    [Prototype("stack")]
+    public class StackPrototype : IPrototype
+    {
+        public string ID { get; private set; } = default!;
+
+        public SpriteSpecifier? Icon { get; private set; }
+
+        /// <summary>
+        ///     The entity id that will be spawned by default from this stack.
+        /// </summary>
+        public string? Spawn { get; private set; }
+
+        public void LoadFrom(YamlMappingNode mapping)
+        {
+            var reader = YamlObjectSerializer.NewReader(mapping);
+
+            reader.DataField(this, x => x.ID, "id", string.Empty);
+            reader.DataField(this, x => x.Icon, "icon", null);
+            reader.DataField(this, x => x.Spawn, "spawn", null);
+        }
+    }
+}

--- a/Content.Shared/Stacks/StackPrototype.cs
+++ b/Content.Shared/Stacks/StackPrototype.cs
@@ -9,7 +9,9 @@ namespace Content.Shared.Stacks
     [Prototype("stack")]
     public class StackPrototype : IPrototype
     {
-        public string ID { get; private set; } = default!;
+        public string ID { get; private set; } = string.Empty;
+
+        public string Name { get; private set; } = string.Empty;
 
         public SpriteSpecifier? Icon { get; private set; }
 
@@ -23,6 +25,7 @@ namespace Content.Shared.Stacks
             var reader = YamlObjectSerializer.NewReader(mapping);
 
             reader.DataField(this, x => x.ID, "id", string.Empty);
+            reader.DataField(this, x => x.Name, "name", string.Empty);
             reader.DataField(this, x => x.Icon, "icon", null);
             reader.DataField(this, x => x.Spawn, "spawn", null);
         }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/rolling_paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/rolling_paper.yml
@@ -22,7 +22,7 @@
   parent: BaseItem
   components:
     - type: Stack
-      stacktype: enum.StackType.PaperRolling
+      stackType: PaperRolling
       max: 5
       count: 1
     - type: Sprite
@@ -39,7 +39,7 @@
   parent: BaseItem
   components:
     - type: Stack
-      stacktype: enum.StackType.CigaretteFilter
+      stackType: CigaretteFilter
       max: 5
       count: 1
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/material_stacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/material_stacks.yml
@@ -162,6 +162,7 @@
       sprite: Objects/Materials/materials.rsi
       state: goldbar_10
     - type: Stack
+      stackType: GoldStack1
       count: 1
 
 - type: entity
@@ -199,6 +200,7 @@
   suffix: 1
   components:
   - type: Stack
+    stackType: PlasmaStack1
     count: 1
 
 - type: entity
@@ -227,6 +229,7 @@
   suffix: 1
   components:
   - type: Stack
+    stackType: WoodPlank1
     count: 1
 
 - type: entity
@@ -255,4 +258,5 @@
   suffix: 1
   components:
   - type: Stack
+    stackType: PlasticSheet1
     count: 1

--- a/Resources/Prototypes/Entities/Objects/Misc/material_stacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/material_stacks.yml
@@ -19,7 +19,7 @@
         - key: enum.MaterialKeys.Stack
           mat: steel
     - type: Stack
-      stacktype: enum.StackType.Metal
+      stackType: Steel
     - type: Sprite
       sprite: Objects/Materials/sheets.rsi
       state: metal
@@ -37,7 +37,7 @@
   suffix: 1
   components:
     - type: Stack
-      stacktype: enum.StackType.Metal
+      stackType: Steel
       count: 1
 
 - type: entity
@@ -51,7 +51,7 @@
         - key: enum.MaterialKeys.Stack
           mat: glass
     - type: Stack
-      stacktype: enum.StackType.Glass
+      stackType: Glass
     - type: Sprite
       sprite: Objects/Materials/sheets.rsi
       state: glass
@@ -66,7 +66,7 @@
   suffix: 1
   components:
     - type: Stack
-      stacktype: enum.StackType.Glass
+      stackType: Glass
       count: 1
 
 - type: entity
@@ -80,7 +80,7 @@
         - key: enum.MaterialKeys.Stack
           mat: rglass
     - type: Stack
-      stacktype: enum.StackType.ReinforcedGlass
+      stackType: ReinforcedGlass
     - type: Sprite
       sprite: Objects/Materials/sheets.rsi
       state: rglass
@@ -95,7 +95,7 @@
   suffix: 1
   components:
     - type: Stack
-      StackType: enum.StackType.ReinforcedGlass
+      stackType: ReinforcedGlass
       count: 1
 
 
@@ -110,7 +110,7 @@
         - key: enum.MaterialKeys.Stack
           mat: plasteel
     - type: Stack
-      stacktype: enum.StackType.Plasteel
+      stackType: Plasteel
     - type: Sprite
       sprite: Objects/Materials/sheets.rsi
       state: plasteel
@@ -125,7 +125,7 @@
   suffix: 1
   components:
     - type: Stack
-      stacktype: enum.StackType.Plasteel
+      stackType: Plasteel
       count: 1
 
 - type: entity
@@ -139,7 +139,7 @@
         - key: enum.MaterialKeys.Stack
           mat: gold
     - type: Stack
-      stacktype: enum.StackType.Gold
+      stackType: Gold
     - type: Sprite
       sprite: Objects/Materials/materials.rsi
       state: goldbar_30
@@ -184,7 +184,7 @@
     - key: enum.MaterialKeys.Stack
       mat: plasma
   - type: Stack
-    stacktype: enum.StackType.Plasma
+    stackType: Plasma
   - type: Sprite
     sprite: Objects/Materials/sheets.rsi
     state: plasma
@@ -212,7 +212,7 @@
     - key: enum.MaterialKeys.Stack
       mat: wood
   - type: Stack
-    stacktype: enum.StackType.Wood
+    stackType: Wood
   - type: Sprite
     sprite: Objects/Materials/materials.rsi
     state: wood
@@ -240,7 +240,7 @@
     - key: enum.MaterialKeys.Stack
       mat: plastic
   - type: Stack
-    stacktype: enum.StackType.Plastic
+    stackType: Plastic
   - type: Sprite
     sprite: Objects/Materials/sheets.rsi
     state: plastic

--- a/Resources/Prototypes/Entities/Objects/Misc/metal_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/metal_rod.yml
@@ -16,7 +16,7 @@
       graph: metalRod
       node: MetalRod
     - type: Stack
-      stacktype: enum.StackType.MetalRod
+      stackType: MetalRod
       count: 50
       max: 50
     - type: FloorTile
@@ -30,6 +30,6 @@
   suffix: 1
   components:
     - type: Stack
-      stacktype: enum.StackType.MetalRod
+      stackType: MetalRod
       count: 1
       max: 50

--- a/Resources/Prototypes/Entities/Objects/Power/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/cable_coils.yml
@@ -10,7 +10,7 @@
   suffix: Full
   components:
     - type: Stack
-      stacktype: enum.StackType.Cable
+      stackType: Cable
     - type: Sprite
       sprite: Objects/Tools/cables.rsi
       netsync: false
@@ -27,7 +27,7 @@
   suffix: Full
   components:
     - type: Stack
-      stacktype: enum.StackType.HVCable
+      stackType: HVCable
     - type: Sprite
       state: coilhv-30
     - type: Item
@@ -50,7 +50,7 @@
   suffix: 1
   components:
     - type: Sprite
-      state: coilhv-10      
+      state: coilhv-10
     - type: Item
       size: 3
     - type: Stack
@@ -98,7 +98,7 @@
   suffix: Full
   components:
     - type: Stack
-      stacktype: enum.StackType.MVCable
+      stackType: MVCable
     - type: Sprite
       state: coilmv-30
     - type: Item

--- a/Resources/Prototypes/Entities/Objects/Power/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/cable_coils.yml
@@ -54,6 +54,7 @@
     - type: Item
       size: 3
     - type: Stack
+      stackType: HVWireStack1
       count: 1
 
 - type: entity
@@ -89,6 +90,7 @@
     - type: Item
       size: 3
     - type: Stack
+      stackType: ApcExtensionCableStack1
       count: 1
 
 - type: entity
@@ -125,4 +127,5 @@
     - type: Item
       size: 3
     - type: Stack
+      stackType: MVWireStack1
       count: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/produce.yml
@@ -276,7 +276,7 @@
   description: "Dried cannabis leaves, ready to be ground."
   components:
     - type: Stack
-      stacktype: enum.StackType.LeavesCannabisDried
+      stackType: LeavesCannabisDried
       max: 5
       count: 1
     - type: SolutionContainer
@@ -295,7 +295,7 @@
   description: "Ground cannabis, ready to take you on a trip."
   components:
     - type: Stack
-      stacktype: enum.StackType.GroundCannabis
+      stackType: GroundCannabis
       max: 5
       count: 1
     - type: SolutionContainer
@@ -329,7 +329,7 @@
   description: "Dried tobacco leaves, ready to be ground."
   components:
     - type: Stack
-      stacktype: enum.StackType.LeavesTobaccoDried
+      stackType: LeavesTobaccoDried
       max: 5
       count: 1
     - type: SolutionContainer
@@ -348,7 +348,7 @@
   description: "Ground tobacco, perfect for hand-rolled cigarettes."
   components:
     - type: Stack
-      stacktype: enum.StackType.GroundTobacco
+      stackType: GroundTobacco
       max: 5
       count: 1
     - type: SolutionContainer

--- a/Resources/Prototypes/Entities/Objects/Specific/medical.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/medical.yml
@@ -50,7 +50,7 @@
   - type: Stack
     max: 5
     count: 5
-    stacktype: enum.StackType.Ointment
+    stackType: Ointment
 
 - type: entity
   name: bruise pack
@@ -67,7 +67,7 @@
     - type: Stack
       max: 5
       count: 5
-      stacktype: enum.StackType.Brutepack
+      stackType: Brutepack
 
 - type: entity
   name: roll of gauze
@@ -84,4 +84,4 @@
   - type: Stack
     max: 5
     count: 5
-    stacktype: enum.StackType.Gauze
+    stackType: Gauze

--- a/Resources/Prototypes/Entities/Objects/Specific/medical.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/medical.yml
@@ -31,7 +31,6 @@
   parent: BaseItem
   abstract: true
   components:
-  - type: Stack
   - type: Item
   - type: Healing
 
@@ -48,9 +47,9 @@
     heal:
       Heat: 10
   - type: Stack
+    stackType: Ointment
     max: 5
     count: 5
-    stackType: Ointment
 
 - type: entity
   name: bruise pack
@@ -65,9 +64,9 @@
       heal:
         Blunt: 10
     - type: Stack
+      stackType: Brutepack
       max: 5
       count: 5
-      stackType: Brutepack
 
 - type: entity
   name: roll of gauze
@@ -82,6 +81,6 @@
 #    heal:
 #      Blunt: 10
   - type: Stack
+    stackType: Gauze
     max: 5
     count: 5
-    stackType: Gauze

--- a/Resources/Prototypes/Entities/Objects/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/tiles.yml
@@ -12,7 +12,7 @@
       - plating
       - floor_steel
   - type: Stack
-    stacktype: FloorTileSteel
+    stackType: FloorTileSteel
     count: 1
     max: 8
 
@@ -41,7 +41,7 @@
       - plating
       - floor_wood
   - type: Stack
-    stacktype: FloorTileWood
+    stackType: FloorTileWood
     count: 1
     max: 8
 
@@ -61,7 +61,7 @@
       - plating
       - floor_white
   - type: Stack
-    stacktype: FloorTileWhite
+    stackType: FloorTileWhite
     count: 1
     max: 8
 
@@ -81,7 +81,7 @@
       - plating
       - floor_dark
   - type: Stack
-    stacktype: FloorTileDark
+    stackType: FloorTileDark
     count: 1
     max: 8
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/APC.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/APC.yml
@@ -6,7 +6,7 @@
       edges:
         - to: apc
           steps:
-            - material: Metal
+            - material: Steel
               amount: 3
 
     - node: apc

--- a/Resources/Prototypes/Recipes/Construction/Graphs/computer.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/computer.yml
@@ -9,7 +9,7 @@
             - !type:SetAnchor
               value: false
           steps:
-            - material: Metal
+            - material: Steel
               amount: 5
 
     - node: frameUnsecured

--- a/Resources/Prototypes/Recipes/Construction/Graphs/conveyor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/conveyor.yml
@@ -46,7 +46,7 @@
         completed:
           - !type:SnapToGrid {}
         steps:
-          - material: Metal
+          - material: Steel
             amount: 2
             doAfter: 1
   - node: lever

--- a/Resources/Prototypes/Recipes/Construction/Graphs/firelock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/firelock.yml
@@ -8,7 +8,7 @@
           completed:
             - !type:SnapToGrid { }
           steps:
-            - material: Metal
+            - material: Steel
               amount: 3
               doAfter: 1
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/girder.yml
@@ -9,7 +9,7 @@
             - !type:SnapToGrid
               southRotation: true
           steps:
-            - material: Metal
+            - material: Steel
               amount: 2
               doAfter: 1
 
@@ -41,7 +41,7 @@
           conditions:
             - !type:EntityAnchored {}
           steps:
-            - material: Metal
+            - material: Steel
               amount: 2
 
         - to: reinforcedGirder

--- a/Resources/Prototypes/Recipes/Construction/Graphs/lighting.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/lighting.yml
@@ -6,12 +6,12 @@
       edges:
         - to: bulbLight
           steps:
-            - material: Metal
+            - material: Steel
               amount: 1
-              doAfter: 2.0      
+              doAfter: 2.0
         - to: tubeLight
           steps:
-            - material: Metal
+            - material: Steel
               amount: 2
               doAfter: 2.0
     - node: tubeLight
@@ -28,7 +28,7 @@
             - !type:SpawnPrototype
               prototype: SteelSheet1
               amount: 2
-            - !type:DeleteEntity {}         
+            - !type:DeleteEntity {}
     - node: bulbLight
       entity: PoweredSmallLightEmpty
       edges:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/low_wall.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/low_wall.yml
@@ -15,7 +15,7 @@
       edges:
         - to: lowWall
           steps:
-            - material: Metal
+            - material: Steel
               amount: 3
               doAfter: 5
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machine.yml
@@ -13,7 +13,7 @@
             - !type:SetAnchor
               value: false
           steps:
-            - material: Metal
+            - material: Steel
               amount: 5
               doAfter: 2.5
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/metal_rod.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/metal_rod.yml
@@ -9,7 +9,7 @@
             - !type:SetStackCount
               amount: 2
           steps:
-            - material: Metal
+            - material: Steel
               amount: 1
 
     - node: MetalRod

--- a/Resources/Prototypes/Recipes/Construction/Graphs/spear.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/spear.yml
@@ -6,7 +6,7 @@
       edges:
         - to: spear
           steps:
-            - material: Metal
+            - material: Steel
               amount: 2
               doAfter: 2
             - material: Glass

--- a/Resources/Prototypes/Recipes/Construction/Graphs/tables.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/tables.yml
@@ -31,7 +31,7 @@
 
         - to: MetalTable
           steps:
-            - material: Metal
+            - material: Steel
               amount: 1
               doAfter: 1
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/toilet.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/toilet.yml
@@ -8,7 +8,7 @@
           completed:
             - !type:SnapToGrid { }
           steps:
-            - material: Metal
+            - material: Steel
               amount: 5
               doAfter: 1
     - node: toilet
@@ -18,12 +18,12 @@
             - !type:SpawnPrototype
               prototype: SteelSheet1
               amount: 5
-            - !type:EmptyAllContainers {}              
+            - !type:EmptyAllContainers {}
             - !type:DeleteEntity {}
           conditions:
             - !type:EntityAnchored
               anchored: false
-            - !type:ToiletLidClosed {}  
+            - !type:ToiletLidClosed {}
           steps:
             - tool: Welding
               doAfter: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/window.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/window.yml
@@ -6,7 +6,7 @@
       edges:
         - to: plasmaWindow
           steps:
-            - material: Metal
+            - material: Steel
               amount: 2
               doAfter: 2
             - material: Glass

--- a/Resources/Prototypes/Stacks/floor_tile_stacks.yml
+++ b/Resources/Prototypes/Stacks/floor_tile_stacks.yml
@@ -1,14 +1,19 @@
 ﻿- type: stack
   id: FloorTileSteel
+  name: steel tile
 
 - type: stack
   id: FloorTileCarpet
+  name: carpet tile
 
 - type: stack
   id: FloorTileWhite
+  name: white tile
 
 - type: stack
   id: FloorTileDark
+  name: dark tile
 
 - type: stack
   id: FloorTileWood
+  name: wood tile

--- a/Resources/Prototypes/Stacks/floor_tile_stacks.yml
+++ b/Resources/Prototypes/Stacks/floor_tile_stacks.yml
@@ -1,0 +1,14 @@
+﻿- type: stack
+  id: FloorTileSteel
+
+- type: stack
+  id: FloorTileCarpet
+
+- type: stack
+  id: FloorTileWhite
+
+- type: stack
+  id: FloorTileDark
+
+- type: stack
+  id: FloorTileWood

--- a/Resources/Prototypes/Stacks/material_stacks.yml
+++ b/Resources/Prototypes/Stacks/material_stacks.yml
@@ -43,3 +43,19 @@
   name: metal rod
   icon: "/Textures/Objects/Materials/materials.rsi/rods.png"
   spawn: MetalRodStack1
+
+- type: stack
+  id: GoldStack1
+  name: gold
+
+- type: stack
+  id: PlasmaStack1
+  name: plasma
+
+- type: stack
+  id: WoodPlank1
+  name: wood
+
+- type: stack
+  id: PlasticSheet1
+  name: plastic

--- a/Resources/Prototypes/Stacks/material_stacks.yml
+++ b/Resources/Prototypes/Stacks/material_stacks.yml
@@ -1,0 +1,36 @@
+﻿- type: stack
+  id: Steel
+  icon: "/Textures/Objects/Materials/sheets.rsi/metal.png"
+  spawn: SteelSheet1
+
+- type: stack
+  id: Glass
+  icon: "/Textures/Objects/Materials/sheets.rsi/glass.png"
+  spawn: GlassSheet1
+
+- type: stack
+  id: ReinforcedGlass
+
+- type: stack
+  id: Plasteel
+  icon: "/Textures/Objects/Materials/sheets.rsi/plasteel.png"
+  spawn: PlasteelSheet1
+
+- type: stack
+  id: Wood
+
+- type: stack
+  id: Plastic
+
+- type: stack
+  id: Gold
+
+- type: stack
+  id: Plasma
+  icon: "/Textures/Objects/Materials/sheets.rsi/phoron.png"
+  spawn: PlasmaStack1
+
+- type: stack
+  id: MetalRod
+  icon: "/Textures/Objects/Materials/materials.rsi/rods.png"
+  spawn: MetalRodStack1

--- a/Resources/Prototypes/Stacks/material_stacks.yml
+++ b/Resources/Prototypes/Stacks/material_stacks.yml
@@ -1,36 +1,45 @@
 ﻿- type: stack
   id: Steel
+  name: steel
   icon: "/Textures/Objects/Materials/sheets.rsi/metal.png"
   spawn: SteelSheet1
 
 - type: stack
   id: Glass
+  name: glass
   icon: "/Textures/Objects/Materials/sheets.rsi/glass.png"
   spawn: GlassSheet1
 
 - type: stack
   id: ReinforcedGlass
+  name: reinforced glass
 
 - type: stack
   id: Plasteel
+  name: plasteel
   icon: "/Textures/Objects/Materials/sheets.rsi/plasteel.png"
   spawn: PlasteelSheet1
 
 - type: stack
   id: Wood
+  name: wood
 
 - type: stack
   id: Plastic
+  name: plastic
 
 - type: stack
   id: Gold
+  name: gold
 
 - type: stack
   id: Plasma
+  name: plasma
   icon: "/Textures/Objects/Materials/sheets.rsi/phoron.png"
   spawn: PlasmaStack1
 
 - type: stack
   id: MetalRod
+  name: metal rod
   icon: "/Textures/Objects/Materials/materials.rsi/rods.png"
   spawn: MetalRodStack1

--- a/Resources/Prototypes/Stacks/medical_stacks.yml
+++ b/Resources/Prototypes/Stacks/medical_stacks.yml
@@ -1,0 +1,8 @@
+﻿- type: stack
+  id: Ointment
+
+- type: stack
+  id: Gauze
+
+- type: stack
+  id: Brutepack

--- a/Resources/Prototypes/Stacks/medical_stacks.yml
+++ b/Resources/Prototypes/Stacks/medical_stacks.yml
@@ -1,8 +1,11 @@
 ﻿- type: stack
   id: Ointment
+  name: ointment
 
 - type: stack
   id: Gauze
+  name: gauze
 
 - type: stack
   id: Brutepack
+  name: brutepack

--- a/Resources/Prototypes/Stacks/power_stacks.yml
+++ b/Resources/Prototypes/Stacks/power_stacks.yml
@@ -1,10 +1,13 @@
 ﻿- type: stack
   id: Cable
+  name: cable
   icon: "/Textures/Objects/Tools/cables.rsi/coil-30.png"
   spawn: ApcExtensionCableStack1
 
 - type: stack
   id: MVCable
+  name: mv cable
 
 - type: stack
   id: HVCable
+  name: hv cable

--- a/Resources/Prototypes/Stacks/power_stacks.yml
+++ b/Resources/Prototypes/Stacks/power_stacks.yml
@@ -11,3 +11,15 @@
 - type: stack
   id: HVCable
   name: hv cable
+
+- type: stack
+  id: HVWireStack1
+  name: hv wire
+
+- type: stack
+  id: MVWireStack1
+  name: mv wire
+
+- type: stack
+  id: ApcExtensionCableStack1
+  name: apc extension cable

--- a/Resources/Prototypes/Stacks/power_stacks.yml
+++ b/Resources/Prototypes/Stacks/power_stacks.yml
@@ -1,0 +1,10 @@
+﻿- type: stack
+  id: Cable
+  icon: "/Textures/Objects/Tools/cables.rsi/coil-30.png"
+  spawn: ApcExtensionCableStack1
+
+- type: stack
+  id: MVCable
+
+- type: stack
+  id: HVCable

--- a/Resources/Prototypes/Stacks/tobacco_stacks.yml
+++ b/Resources/Prototypes/Stacks/tobacco_stacks.yml
@@ -1,17 +1,23 @@
 ﻿- type: stack
   id: PaperRolling
+  name: paper rolling
 
 - type: stack
   id: CigaretteFilter
+  name: cigarette filter
 
 - type: stack
   id: GroundTobacco
+  name: ground tobacco
 
 - type: stack
   id: GroundCannabis
+  name: ground cannabis
 
 - type: stack
   id: LeavesTobaccoDried
+  name: dried tobacco leaves
 
 - type: stack
   id: LeavesCannabisDried
+  name: dried cannabis leaves

--- a/Resources/Prototypes/Stacks/tobacco_stacks.yml
+++ b/Resources/Prototypes/Stacks/tobacco_stacks.yml
@@ -1,0 +1,17 @@
+﻿- type: stack
+  id: PaperRolling
+
+- type: stack
+  id: CigaretteFilter
+
+- type: stack
+  id: GroundTobacco
+
+- type: stack
+  id: GroundCannabis
+
+- type: stack
+  id: LeavesTobaccoDried
+
+- type: stack
+  id: LeavesCannabisDried


### PR DESCRIPTION
## About the PR
Previously stacks used an object to identity their StackType (which was always an enum), now it uses a string id of a stack prototype which is validated on startup and resolved when used.
Also changes the Metal stack to Steel as requested by Zumorica.
Pasta prototype not included.