### PR TITLE
Cap gun and foam crossbow fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Toy/boxes.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Toy/boxes.yml
@@ -13,13 +13,24 @@
 # Boxes
 - type: entity
   id: BoxDonkSoftBox
-  name: "foamdart box"
+  name: "foam dart box"
   parent: BoxDonkSoftBase
   components:
   - type: AmmoBox
     capacity: 40
     fillPrototype: BulletDonkSoft
-
   - type: Sprite
     sprite: Objects/Fun/toys.rsi
     state: foambox
+    
+- type: entity
+  id: BoxCartridgeCap
+  name: "cap gun cartridge box"
+  parent: BoxDonkSoftBase
+  components:
+  - type: AmmoBox
+    capacity: 20
+    fillPrototype: CartridgeCap
+  - type: Sprite
+    sprite: Objects\Storage\boxes.rsi
+    state: box

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Toy/cartridges.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Toy/cartridges.yml
@@ -9,7 +9,7 @@
   - type: Sprite
     netsync: false
     directional: true
-    sprite: Objects/Consumable/Trash/ash.rsi
+    sprite: Objects\Weapons\Guns\Ammunition\Casings\ammo_casing.rsi
     layers:
     - state: base
       map: ["enum.AmmoVisualLayers.Base"]
@@ -17,7 +17,7 @@
 
 - type: entity
   id: CartridgeCap
-  name: cartridge (cap)
+  name: cap gun cartridge
   parent: CartridgeCapBase
   components:
   - type: Ammo

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Toy/speedloaders.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Toy/speedloaders.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CapAmmoBase
-  name: "cap loader"
+  name: "cap gun loader"
   parent: BaseItem
   abstract: true
   components:
@@ -23,7 +23,7 @@
 
 - type: entity
   id: CapLoader
-  name: "capgun loader"
+  name: "cap gun loader"
   parent: CapAmmoBase
   components:
   - type: SpeedLoader

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -229,3 +229,5 @@
     state: capbullet
   - type: Projectile
     deleteOnCollide: true
+    damages:
+      Piercing: 0


### PR DESCRIPTION
- Assigned sprite for cap gun cartridge. 
- Added cap gun cartridge box. 
- Fixed naming of cap gun speed loader and foam dart box so it shows easier in entity spawner. 
- Fixed cap gun so it deals 0 damage now instead of copying parent pistol projectile of 20 piercing damage.

Closes #3254 

Will look to add these to crates / vendors next.