### PR TITLE
Changes SMG crate to wt550 from c20r

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -3,7 +3,7 @@
   id: cargo.armorysmg
   description: "Contains three high-powered, semiautomatic rifles with six mags. Requires Armory access to open."
   icon:
-    sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
+    sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
     state: icon
   product: CrateArmorySMG
   cost: 8000

--- a/Resources/Prototypes/Catalog/Fills/Storage/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Storage/Crates/armory.yml
@@ -6,7 +6,7 @@
   components:
   - type: StorageFill
     contents:
-      - name: SmgC20r
+      - name: SmgWt550
         amount: 3
       - name: MagazinePistolSmg
         amount: 6


### PR DESCRIPTION
C20r is a syndicate weapon. WT550 is sec SMG.

Closes #3361 

Tested, working no errors. Sprites show as should etc etc

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->