### PR TITLE
fixes weird occlusion of constructed walls

### DIFF
--- a/Content.Server/Construction/Completions/SnapToGrid.cs
+++ b/Content.Server/Construction/Completions/SnapToGrid.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System.Threading.Tasks;
 using Content.Server.Utility;
 using Content.Shared.Construction;
@@ -28,7 +28,7 @@ namespace Content.Server.Construction.Completions
             entity.SnapToGrid(Offset);
             if (SouthRotation)
             {
-                entity.Transform.LocalRotation = Angle.South;
+                entity.Transform.LocalRotation = Angle.Zero;
             }
         }
     }


### PR DESCRIPTION
it looked like this, they were being auto-rotated to... west, i think, instead of south
![image](https://user-images.githubusercontent.com/53132901/109073382-22302d80-76ab-11eb-9672-3cb32592ceb9.png)
this fixes that

:cl:
- fix: Constructed walls don't have broken lighting anymore