### PR TITLE
Fix changelog button text going out of window

### DIFF
--- a/Content.Client/UserInterface/EscapeMenu.xaml
+++ b/Content.Client/UserInterface/EscapeMenu.xaml
@@ -4,7 +4,7 @@
             Title="{Loc 'ui-escape-title'}"
             Resizable="False">
 
-    <VBoxContainer SeparationOverride="4" CustomMinimumSize="0 160">
+    <VBoxContainer SeparationOverride="4" CustomMinimumSize="150 160">
         <changelog:ChangelogButton />
         <voting:VoteCallMenuButton />
         <Button Name="OptionsButton" Text="{Loc 'ui-escape-options'}" />


### PR DESCRIPTION
When the changelog had an update its text in the escape button went out of the button limits. 
![stats7](https://user-images.githubusercontent.com/60196617/109394287-a1687000-78fc-11eb-949a-0c8f230a9029.png)
Set a min size to account for that

:cl: AJCM
- fix: Fixes the changelog escape menu button text going out of the limits of the button when there is an update.

