### PR TITLE
Fix verb error texture

### DIFF
--- a/Content.Shared/GameObjects/EntitySystemMessages/VerbSystemMessages.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/VerbSystemMessages.cs
@@ -38,7 +38,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
                 public readonly string Text;
                 public readonly string Key;
                 public readonly string Category;
-                public readonly SpriteSpecifier Icon;
+                public readonly SpriteSpecifier? Icon;
                 public readonly SpriteSpecifier? CategoryIcon;
                 public readonly bool Available;
 

--- a/Content.Shared/GameObjects/Verbs/VerbData.cs
+++ b/Content.Shared/GameObjects/Verbs/VerbData.cs
@@ -22,7 +22,7 @@ namespace Content.Shared.GameObjects.Verbs
         /// <summary>
         ///     Sprite of the icon that the user sees on the verb button.
         /// </summary>
-        public SpriteSpecifier Icon { get; set; } = SpriteSpecifier.Invalid;
+        public SpriteSpecifier? Icon { get; set; }
 
         /// <summary>
         ///     Name of the category this button is under.
@@ -32,7 +32,7 @@ namespace Content.Shared.GameObjects.Verbs
         /// <summary>
         ///     Sprite of the icon that the user sees on the verb button.
         /// </summary>
-        public SpriteSpecifier? CategoryIcon { get; set; } = SpriteSpecifier.Invalid;
+        public SpriteSpecifier? CategoryIcon { get; set; }
 
         /// <summary>
         ///     Whether this verb is visible, disabled (greyed out) or hidden.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
My nullable PR (#3238) broke the verbs, as they now displayed errors. This fixes it.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
-->

- fix: Fix error texture in verbs

