### PR TITLE
Fix visualizer issues

### DIFF
--- a/Content.Client/GameObjects/Components/StackVisualizer.cs
+++ b/Content.Client/GameObjects/Components/StackVisualizer.cs
@@ -152,8 +152,8 @@ namespace Content.Client.GameObjects.Components
         private void ProcessCompositeSprites(AppearanceComponent component, ISpriteComponent spriteComponent)
         {
             // If hidden, don't render any sprites
-            if (!component.TryGetData<bool>(StackVisuals.Hide, out var hide)
-                || hide)
+            if (component.TryGetData<bool>(StackVisuals.Hide, out var hide)
+                && hide)
             {
                 foreach (var transparentSprite in _spriteLayers)
                 {

--- a/Content.Client/GameObjects/Components/Storage/BagOpenCloseVisualizer.cs
+++ b/Content.Client/GameObjects/Components/Storage/BagOpenCloseVisualizer.cs
@@ -63,6 +63,7 @@ namespace Content.Client.GameObjects.Components.Storage
                             spriteComponent.LayerSetVisible(OpenIcon, false);
                             break;
                     }
+                    component.SetData(StackVisuals.Hide, bagState == SharedBagState.Close);
                 }
             }
         }

--- a/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
+++ b/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
@@ -39,7 +39,7 @@ namespace Content.Client.GameObjects.Components.Storage
             base.Initialize();
 
             // Hide stackVisualizer on start
-            _bagState = SharedBagState.Close;
+            ChangeStorageVisualization(SharedBagState.Close);
         }
 
         public override void OnAdd()
@@ -149,7 +149,6 @@ namespace Content.Client.GameObjects.Components.Storage
             if (Owner.TryGetComponent<AppearanceComponent>(out var appearanceComponent))
             {
                 appearanceComponent.SetData(SharedBagOpenVisuals.BagState, state);
-                appearanceComponent.SetData(StackVisuals.Hide, state == SharedBagState.Close);
             }
         }
 


### PR DESCRIPTION
It changes the AppearanceComponent flow. It affects  `StackVisualizer` and `BagOpenCloseVisualizer`.

Before `ClientStorageComponent` being opened or closed would show/hide the `StackVisualizer`. Now the `BagOpenCloseVisualizer` decides whether to show `StackVisualizer`. It introduces a dependency between these two components.

**Changelog**

:cl: Ygg01
- fix: Stack visualizer no longer affected by open/close state by default.

