### PR TITLE
Improves sprite click detection

### DIFF
--- a/Content.Client/GameObjects/Components/ClickableComponent.cs
+++ b/Content.Client/GameObjects/Components/ClickableComponent.cs
@@ -5,7 +5,6 @@ using Robust.Client.Graphics;
 using Robust.Client.Utility;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
@@ -126,19 +125,10 @@ namespace Content.Client.GameObjects.Components
                         }
 
                         var (mX, mY) = localOffset + rsi.Size / 2;
-
-                        switch (layer.DirOffset)
-                        {
-                            case SpriteComponent.DirectionOffset.None:
-                            case SpriteComponent.DirectionOffset.Flip:
-                                break;
-                            case SpriteComponent.DirectionOffset.Clockwise:
-                            case SpriteComponent.DirectionOffset.CounterClockwise:
-                                (mX, mY) = (mY, mX);
-                                break;
-                            default:
-                                throw new ArgumentOutOfRangeException();
-                        }
+                        (mX, mY) = layer.DirOffset == SpriteComponent.DirectionOffset.Clockwise ||
+                                   layer.DirOffset == SpriteComponent.DirectionOffset.CounterClockwise
+                            ? (mY, mX)
+                            : (mX, mY);
 
                         if (_clickMapManager.IsOccluding(rsi, layer.RsiState, dir,
                             layer.AnimationFrame, ((int) mX, (int) mY)))


### PR DESCRIPTION
## About the PR 
Improves sprite detection as code was treating layers with different direction offsets the same way.
Fixes vaulting not working sometimes.

**Changelog**
:cl:
- fix : Fix sprite click detection of layers with different direction offsets. (Tables, walls, etc)
- fix : Fix vaulting not working if not clicking on a specific layer.

___

<details>
  <summary> Before </summary>

https://user-images.githubusercontent.com/12466334/109719831-d7ad2600-7b6e-11eb-84bf-87faa2a2e21d.mp4
</details>

<details>
  <summary> After </summary>

https://user-images.githubusercontent.com/12466334/109719827-d7148f80-7b6e-11eb-8acd-def96c743a86.mp4
</details>

---

<details>
  <summary> Before </summary>

https://user-images.githubusercontent.com/12466334/109720847-37580100-7b70-11eb-9dfe-55b604ae08e3.mp4
</details>

<details>
  <summary> After </summary>

https://user-images.githubusercontent.com/12466334/109720868-3de67880-7b70-11eb-97f6-f6780505883b.mp4
</details>
