### PR TITLE
Ejected casings now look cool as fuck

### DIFF
--- a/Content.Server/GameObjects/Components/Weapon/Ranged/Barrels/ServerRangedBarrelComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Ranged/Barrels/ServerRangedBarrelComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +11,7 @@ using Content.Shared.GameObjects.Components.Weapons.Ranged;
 using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Content.Shared.Physics;
+using Content.Shared.Utility;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
@@ -278,12 +279,12 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Barrels
 
             if (ejectDirections == null)
             {
-                ejectDirections = new[] {Direction.East, Direction.North, Direction.South, Direction.West};
+                ejectDirections = new[] {Direction.East, Direction.North, Direction.NorthWest, Direction.South, Direction.SouthEast, Direction.West};
             }
 
-            const float ejectOffset = 0.2f;
+            const float ejectOffset = 1.8f;
             var ammo = entity.GetComponent<AmmoComponent>();
-            var offsetPos = (robustRandom.NextFloat() * ejectOffset, robustRandom.NextFloat() * ejectOffset);
+            var offsetPos = ((robustRandom.NextFloat() - 0.5f) * ejectOffset, (robustRandom.NextFloat() - 0.5f) * ejectOffset);
             entity.Transform.Coordinates = entity.Transform.Coordinates.Offset(offsetPos);
             entity.Transform.LocalRotation = robustRandom.Pick(ejectDirections).ToAngle();
 
@@ -311,7 +312,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Ranged.Barrels
         {
             var robustRandom = IoCManager.Resolve<IRobustRandom>();
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            var ejectDirections = new[] {Direction.East, Direction.North, Direction.South, Direction.West};
+            var ejectDirections = new[] {Direction.East, Direction.North, Direction.NorthWest, Direction.South, Direction.SouthEast, Direction.West};
             var soundPlayCount = 0;
             var playSound = true;
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Thanks to @mirrorcult for being a chad and fixing this.

Closes #2325.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
Before
![2021-03-04_22-53-31](https://user-images.githubusercontent.com/49448379/110080126-f6373b00-7d81-11eb-9545-ae340a28e4f7.gif)
After
![2021-03-04_23-04-33](https://user-images.githubusercontent.com/49448379/110080131-f800fe80-7d81-11eb-9f6e-aeb56c55e4fc.gif)

**Changelog**
<!--
![2021-03-04_23-04-33](https://user-images.githubusercontent.com/49448379/110080131-f800fe80-7d81-11eb-9f6e-aeb56c55e4fc.gif)

Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
-->

:cl:
- tweak: Ejected casings now have much more variation and look cooler


