### PR TITLE
Set OccludesLight to false for hands and inventory

### DIFF
--- a/Content.Server/GameObjects/Components/GUI/HandsComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/HandsComponent.cs
@@ -458,6 +458,7 @@ namespace Content.Server.GameObjects.Components.GUI
             }
 
             var container = ContainerHelpers.CreateContainer<ContainerSlot>(Owner, $"hand {_nextHand++}");
+            container.OccludesLight = false;
             var hand = new Hand(this, name, container);
 
             _hands.Add(hand);

--- a/Content.Server/GameObjects/Components/GUI/InventoryComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/InventoryComponent.cs
@@ -426,7 +426,9 @@ namespace Content.Server.GameObjects.Components.GUI
 
             Dirty();
 
-            _slotContainers[slot] = ContainerHelpers.CreateContainer<ContainerSlot>(Owner, GetSlotString(slot));
+            var container = ContainerHelpers.CreateContainer<ContainerSlot>(Owner, GetSlotString(slot));
+            container.OccludesLight = false;
+            _slotContainers[slot] = container;
 
             OnItemChanged?.Invoke();
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes flashlights in inventory and hands.

Hand and inventory ContainerSlots had OccludeLight set to true, so it would block light when holding a flashlight or putting it in pockets.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
-->

:cl:
- fix: Hands and inventory (pockets) no longer block the light from flashlights

