### PR TITLE
Reformat the construction menu to become less stretchy

### DIFF
--- a/Content.Client/Construction/ConstructionMenu.xaml
+++ b/Content.Client/Construction/ConstructionMenu.xaml
@@ -1,23 +1,26 @@
 <SS14Window xmlns="https://spacestation14.io">
     <HBoxContainer HorizontalExpand="True">
-        <VBoxContainer HorizontalExpand="True" SizeFlagsStretchRatio="0.45">
-            <HBoxContainer HorizontalExpand="True" VerticalExpand="True" SizeFlagsStretchRatio="0.1">
-                <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True" SizeFlagsStretchRatio="0.6"/>
-                <OptionButton Name="Category" HorizontalExpand="True" SizeFlagsStretchRatio="0.4"/>
+        <VBoxContainer HorizontalExpand="True" SizeFlagsStretchRatio="0.4">
+            <HBoxContainer HorizontalExpand="True">
+                <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True"/>
+                <OptionButton Name="Category" MinSize="130 0"/>
             </HBoxContainer>
-            <ItemList Name="RecipesList" SelectMode="Single" VerticalExpand="True" SizeFlagsStretchRatio="0.9"/>
+            <ItemList Name="RecipesList" SelectMode="Single" VerticalExpand="True"/>
         </VBoxContainer>
-        <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.05"/>
-        <VBoxContainer HorizontalExpand="True" SizeFlagsStretchRatio="0.45">
-            <HBoxContainer Align="Center" VerticalExpand="True" SizeFlagsStretchRatio="0.25">
-                <TextureRect Name="TargetTexture" HorizontalExpand="True" SizeFlagsStretchRatio="0.15" Stretch="KeepCentered"/>
-                <VBoxContainer HorizontalExpand="True" SizeFlagsStretchRatio="0.85">
-                    <RichTextLabel Name="TargetName" VerticalExpand="True" SizeFlagsStretchRatio="0.1"/>
-                    <RichTextLabel Name="TargetDesc" VerticalExpand="True" SizeFlagsStretchRatio="0.9"/>
-                </VBoxContainer>
-            </HBoxContainer>
-            <ItemList Name="StepList" VerticalExpand="True" SizeFlagsStretchRatio="0.1"/>
-            <VBoxContainer VerticalExpand="True" SizeFlagsStretchRatio="0.1">
+        <Control MinSize="10 0"/>
+        <VBoxContainer HorizontalExpand="True" SizeFlagsStretchRatio="0.6">
+            <Control>
+                <HBoxContainer Align="Center">
+                    <TextureRect Name="TargetTexture" HorizontalAlignment="Right" Stretch="Keep"/>
+                    <Control MinSize="10 0"/>
+                    <VBoxContainer>
+                        <RichTextLabel Name="TargetName"/>
+                        <RichTextLabel Name="TargetDesc"/>
+                    </VBoxContainer>
+                </HBoxContainer>
+            </Control>
+            <ItemList Name="StepList" VerticalExpand="True"/>
+            <VBoxContainer>
                 <Button Name="BuildButton" Disabled="True" ToggleMode="True" VerticalExpand="True" SizeFlagsStretchRatio="0.5"/>
                 <HBoxContainer VerticalExpand="True" SizeFlagsStretchRatio="0.5">
                     <Button Name="EraseButton" ToggleMode="True" HorizontalExpand="True" SizeFlagsStretchRatio="0.7"/>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes a lot of the SizeFlagsStretchRatio so that the recipes have more space and the buttons don't take up a third of the window.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

Current
![image](https://user-images.githubusercontent.com/10494922/110214641-63b69a80-7e5a-11eb-951f-a060962d19d2.png)
![image](https://user-images.githubusercontent.com/10494922/110214650-7204b680-7e5a-11eb-966e-af0f1f48fa6d.png)

Updated
![image](https://user-images.githubusercontent.com/10494922/110214654-7630d400-7e5a-11eb-9138-0da11a38e5ff.png)
![image](https://user-images.githubusercontent.com/10494922/110214657-77fa9780-7e5a-11eb-9c5b-95d561916f1d.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
-->

:cl:
- tweak: Reworked the construction UI so that the recipe is easier to see