### PR TITLE
Update WelderRefinable usages to new glass id

### DIFF
--- a/Content.Server/GameObjects/Components/Construction/WelderRefinableComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/WelderRefinableComponent.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Content.Server.GameObjects.Components.Interactable;
@@ -22,7 +22,7 @@ namespace Content.Server.GameObjects.Components.Construction
     {
         [ViewVariables]
         [DataField("refineResult")]
-        private HashSet<string>? _refineResult = new() { "GlassStack" };
+        private HashSet<string>? _refineResult = new() { };
         [ViewVariables]
         [DataField("refineTime")]
         private float _refineTime = 2f;

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -34,7 +34,7 @@
       color: "#bbeeff"
     - type: WelderRefinable
       refineResult:
-      - GlassStack
+      - SheetGlass
 
 - type: entity
   id: ShardGlassReinforced
@@ -48,7 +48,7 @@
       color: "#96cdef"
     - type: WelderRefinable
       refineResult:
-      - GlassStack
+      - SheetGlass
       - SheetSteel
     - type: DamageOtherOnHit
       amount: 10
@@ -65,7 +65,7 @@
       color: "#f3b489"
     - type: WelderRefinable
       refineResult:
-      - GlassStack
-      - PlasmaStack
+      - SheetGlass
+      - SheetPlasma
     - type: DamageOtherOnHit
       amount: 15


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Updates WelderRefinable results to use SheetGlass instead of the old id GlassStack.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
-->

:cl:
- fix: Glass shards can be turned into glass sheets with a welder again

