### PR TITLE
Fix metal rods trying to create a new grid on MapId.Nullspace

### DIFF
--- a/Content.Server/GameObjects/Components/Items/FloorTileItemComponent.cs
+++ b/Content.Server/GameObjects/Components/Items/FloorTileItemComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.GameObjects.Components.Stack;
+using Content.Server.GameObjects.Components.Stack;
 using Content.Shared.Audio;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Content.Shared.Maps;
@@ -62,6 +62,8 @@ namespace Content.Server.GameObjects.Components.Items
 
             var location = eventArgs.ClickLocation.AlignWithClosestGridTile();
             var locationMap = location.ToMap(Owner.EntityManager);
+            if (locationMap.MapId == MapId.Nullspace)
+                return true;
             mapManager.TryGetGrid(location.GetGridId(Owner.EntityManager), out var mapGrid);
             foreach (var currentTile in _outputTiles)
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When holding metal rods and clicking an item in the offhand, FloorTileItemComponent tries to create a new grid in MapId.Nullspace. This fixes that by adding a check.

