### PR TITLE
unshades crit overlay

### DIFF
--- a/Resources/Textures/Shaders/gradient_circle_mask.swsl
+++ b/Resources/Textures/Shaders/gradient_circle_mask.swsl
@@ -1,3 +1,5 @@
+light_mode unshaded;
+
 const highp float percentagedistanceshow = 0.05;
 const highp float gradientfalloffwidth = 3.0;
 


### PR DESCRIPTION
it used to be affected by lighting so it looked like ass
this fixes that

:cl:
- fix: Crit overlay is now unaffected by lights.