### PR TITLE
Remove unshaded from window cracks

### DIFF
--- a/Content.Client/GameObjects/Components/WindowComponent.cs
+++ b/Content.Client/GameObjects/Components/WindowComponent.cs
@@ -37,28 +37,24 @@ namespace Content.Client.GameObjects.Components
             _sprite.LayerMapSet(CornerLayers.SE, _sprite.AddLayerState(state0));
             _sprite.LayerSetDirOffset(CornerLayers.SE, SpriteComponent.DirectionOffset.None);
             _sprite.LayerMapSet(WindowDamageLayers.DamageSE, _sprite.AddLayerState("0_1", cracksRSIPath));
-            _sprite.LayerSetShader(WindowDamageLayers.DamageSE, "unshaded");
             _sprite.LayerSetVisible(WindowDamageLayers.DamageSE, false);
 
             _sprite.LayerMapSet(CornerLayers.NE, _sprite.AddLayerState(state0));
             _sprite.LayerSetDirOffset(CornerLayers.NE, SpriteComponent.DirectionOffset.CounterClockwise);
             _sprite.LayerMapSet(WindowDamageLayers.DamageNE, _sprite.AddLayerState("0_1", cracksRSIPath));
             _sprite.LayerSetDirOffset(WindowDamageLayers.DamageNE, SpriteComponent.DirectionOffset.CounterClockwise);
-            _sprite.LayerSetShader(WindowDamageLayers.DamageNE, "unshaded");
             _sprite.LayerSetVisible(WindowDamageLayers.DamageNE, false);
 
             _sprite.LayerMapSet(CornerLayers.NW, _sprite.AddLayerState(state0));
             _sprite.LayerSetDirOffset(CornerLayers.NW, SpriteComponent.DirectionOffset.Flip);
             _sprite.LayerMapSet(WindowDamageLayers.DamageNW, _sprite.AddLayerState("0_1", cracksRSIPath));
             _sprite.LayerSetDirOffset(WindowDamageLayers.DamageNW, SpriteComponent.DirectionOffset.Flip);
-            _sprite.LayerSetShader(WindowDamageLayers.DamageNW, "unshaded");
             _sprite.LayerSetVisible(WindowDamageLayers.DamageNW, false);
 
             _sprite.LayerMapSet(CornerLayers.SW, _sprite.AddLayerState(state0));
             _sprite.LayerSetDirOffset(CornerLayers.SW, SpriteComponent.DirectionOffset.Clockwise);
             _sprite.LayerMapSet(WindowDamageLayers.DamageSW, _sprite.AddLayerState("0_1", cracksRSIPath));
             _sprite.LayerSetDirOffset(WindowDamageLayers.DamageSW, SpriteComponent.DirectionOffset.Clockwise);
-            _sprite.LayerSetShader(WindowDamageLayers.DamageSW, "unshaded");
             _sprite.LayerSetVisible(WindowDamageLayers.DamageSW, false);
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I'm not sure why, but window cracks layer was unshaded. It was causing weird effect that you can see very bright white cracks in complete darkness.

**Screenshots**
Was:
![Снимок2](https://user-images.githubusercontent.com/6161335/110234222-4d800b80-7f3a-11eb-8c2c-fb3198db657a.PNG)
Now:
![Снимок1](https://user-images.githubusercontent.com/6161335/110234248-65578f80-7f3a-11eb-9996-5d910ae934a5.PNG)
![Снимок](https://user-images.githubusercontent.com/6161335/110234253-6b4d7080-7f3a-11eb-903b-793f1430eb35.PNG)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
-->
