### PR TITLE
EntitySystemMessage Removal & InteractionSystem directed events

### DIFF
--- a/Content.Client/GameObjects/Components/Doors/ClientDoorComponent.cs
+++ b/Content.Client/GameObjects/Components/Doors/ClientDoorComponent.cs
@@ -88,7 +88,7 @@ namespace Content.Client.GameObjects.Components.Doors
         }
     }
 
-    public sealed class DoorStateMessage : EntitySystemMessage
+    public sealed class DoorStateMessage : EntityEventArgs
     {
         public ClientDoorComponent Component { get; }
         public SharedDoorComponent.DoorState State { get; }

--- a/Content.Client/GameObjects/Components/SubFloorHideComponent.cs
+++ b/Content.Client/GameObjects/Components/SubFloorHideComponent.cs
@@ -52,7 +52,7 @@ namespace Content.Client.GameObjects.Components
         }
     }
 
-    internal sealed class SubFloorHideDirtyEvent : EntitySystemMessage
+    internal sealed class SubFloorHideDirtyEvent : EntityEventArgs
     {
         public IEntity Sender { get; }
 

--- a/Content.Client/GameObjects/EntitySystems/IconSmoothSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/IconSmoothSystem.cs
@@ -129,7 +129,7 @@ namespace Content.Client.GameObjects.EntitySystems
     /// <summary>
     ///     Event raised by a <see cref="IconSmoothComponent"/> when it needs to be recalculated.
     /// </summary>
-    public sealed class IconSmoothDirtyEvent : EntitySystemMessage
+    public sealed class IconSmoothDirtyEvent : EntityEventArgs
     {
         public IconSmoothDirtyEvent(IEntity sender, (GridId grid, Vector2i pos)? lastPosition, SnapGridOffset offset, IconSmoothingMode mode)
         {

--- a/Content.Client/GameObjects/EntitySystems/WindowSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/WindowSystem.cs
@@ -46,7 +46,7 @@ namespace Content.Client.GameObjects.EntitySystems
     /// <summary>
     ///     Event raised by a <see cref="WindowComponent"/> when it needs to be recalculated.
     /// </summary>
-    public sealed class WindowSmoothDirtyEvent : EntitySystemMessage
+    public sealed class WindowSmoothDirtyEvent : EntityEventArgs
     {
         public IEntity Sender { get; }
 

--- a/Content.Client/State/OutlineToggleMessage.cs
+++ b/Content.Client/State/OutlineToggleMessage.cs
@@ -2,7 +2,7 @@
 
 namespace Content.Client.State
 {
-    public sealed class OutlineToggleMessage : EntitySystemMessage
+    public sealed class OutlineToggleMessage : EntityEventArgs
     {
         public bool Enabled { get; }
 

--- a/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/SimplePredictReconcileTest.cs
@@ -460,7 +460,7 @@ namespace Content.IntegrationTests.Tests.Networking
             }
         }
 
-        private sealed class SetFooMessage : EntitySystemMessage
+        private sealed class SetFooMessage : EntityEventArgs
         {
             public SetFooMessage(EntityUid uid, bool newFoo)
             {

--- a/Content.Server/GameObjects/Components/Access/AccessReaderChangeMessage.cs
+++ b/Content.Server/GameObjects/Components/Access/AccessReaderChangeMessage.cs
@@ -2,7 +2,7 @@ using Robust.Shared.GameObjects;
 
 namespace Content.Server.GameObjects.Components.Access
 {
-    public sealed class AccessReaderChangeMessage : EntitySystemMessage
+    public sealed class AccessReaderChangeMessage : EntityEventArgs
     {
         public IEntity Sender { get; }
 

--- a/Content.Server/GameObjects/Components/Buckle/BuckleComponent.cs
+++ b/Content.Server/GameObjects/Components/Buckle/BuckleComponent.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.GameObjects.Components.GUI;
@@ -33,7 +33,7 @@ namespace Content.Server.GameObjects.Components.Buckle
     /// </summary>
     [RegisterComponent]
     [ComponentReference(typeof(SharedBuckleComponent))]
-    public class BuckleComponent : SharedBuckleComponent, IInteractHand
+    public class BuckleComponent : SharedBuckleComponent
     {
         [Dependency] private readonly IGameTiming _gameTiming = default!;
 
@@ -410,12 +410,7 @@ namespace Content.Server.GameObjects.Components.Buckle
 
             return new BuckleComponentState(Buckled, drawDepth, LastEntityBuckledTo, DontCollide);
         }
-
-        bool IInteractHand.InteractHand(InteractHandEventArgs eventArgs)
-        {
-            return TryUnbuckle(eventArgs.User);
-        }
-
+        
         public void Update()
         {
             if (!DontCollide || Physics == null)

--- a/Content.Server/GameObjects/Components/GUI/HandsComponent.cs
+++ b/Content.Server/GameObjects/Components/GUI/HandsComponent.cs
@@ -839,7 +839,7 @@ namespace Content.Server.GameObjects.Components.GUI
         }
     }
 
-    public class HandCountChangedEvent : EntitySystemMessage
+    public class HandCountChangedEvent : EntityEventArgs
     {
         public HandCountChangedEvent(IEntity sender)
         {

--- a/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Interactable/HandheldLightComponent.cs
@@ -275,7 +275,7 @@ namespace Content.Server.GameObjects.Components.Interactable
         }
     }
 
-    internal sealed class ActivateHandheldLightMessage : EntitySystemMessage
+    internal sealed class ActivateHandheldLightMessage : EntityEventArgs
     {
         public HandheldLightComponent Component { get; }
 
@@ -285,7 +285,7 @@ namespace Content.Server.GameObjects.Components.Interactable
         }
     }
 
-    internal sealed class DeactivateHandheldLightMessage : EntitySystemMessage
+    internal sealed class DeactivateHandheldLightMessage : EntityEventArgs
     {
         public HandheldLightComponent Component { get; }
 

--- a/Content.Server/GameObjects/Components/Observer/GhostComponent.cs
+++ b/Content.Server/GameObjects/Components/Observer/GhostComponent.cs
@@ -180,7 +180,7 @@ namespace Content.Server.GameObjects.Components.Observer
             message.AddMarkup(Loc.GetString("Died [color=yellow]{0}[/color].", deathTimeInfo));
         }
 
-        public class GhostReturnMessage : EntitySystemMessage
+        public class GhostReturnMessage : EntityEventArgs
         {
             public GhostReturnMessage(Mind sender)
             {

--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/EmergencyLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/EmergencyLightComponent.cs
@@ -167,7 +167,7 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
         };
     }
 
-    public sealed class EmergencyLightMessage : EntitySystemMessage
+    public sealed class EmergencyLightMessage : EntityEventArgs
     {
         public EmergencyLightComponent Component { get; }
 

--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingChunk.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingChunk.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding
 {
-    public class PathfindingChunkUpdateMessage : EntitySystemMessage
+    public class PathfindingChunkUpdateMessage : EntityEventArgs
     {
         public PathfindingChunk Chunk { get; }
 

--- a/Content.Server/GameObjects/EntitySystems/AI/SleepAiMessage.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/SleepAiMessage.cs
@@ -7,7 +7,7 @@ namespace Content.Server.GameObjects.EntitySystems.AI
     ///     Indicates whether an AI should be updated by the AiSystem or not.
     ///     Useful to sleep AI when they die or otherwise should be inactive.
     /// </summary>
-    internal sealed class SleepAiMessage : EntitySystemMessage
+    internal sealed class SleepAiMessage : EntityEventArgs
     {
         /// <summary>
         ///     Sleep or awake.

--- a/Content.Server/GameObjects/EntitySystems/BuckleSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/BuckleSystem.cs
@@ -1,7 +1,8 @@
-﻿#nullable enable
+#nullable enable
 using Content.Server.GameObjects.Components.Buckle;
 using Content.Server.GameObjects.Components.Strap;
 using Content.Server.GameObjects.EntitySystems.Click;
+using Content.Shared.Interfaces.GameObjects.Components;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
@@ -22,11 +23,18 @@ namespace Content.Server.GameObjects.EntitySystems
             SubscribeLocalEvent<MoveEvent>(MoveEvent);
             SubscribeLocalEvent<EntInsertedIntoContainerMessage>(ContainerModified);
             SubscribeLocalEvent<EntRemovedFromContainerMessage>(ContainerModified);
+
+            SubscribeLocalEvent<BuckleComponent, AttackHandMessage>(HandleAttackHand);
+        }
+
+        private void HandleAttackHand(EntityUid uid, BuckleComponent component, AttackHandMessage args)
+        {
+            args.Handled = component.TryUnbuckle(args.User);
         }
 
         public override void Update(float frameTime)
         {
-            foreach (var comp in ComponentManager.EntityQuery<BuckleComponent>(false))
+            foreach (var comp in ComponentManager.EntityQuery<BuckleComponent>())
             {
                 comp.Update();
             }
@@ -37,6 +45,7 @@ namespace Content.Server.GameObjects.EntitySystems
             base.Shutdown();
 
             UnsubscribeLocalEvent<MoveEvent>();
+            UnsubscribeLocalEvent<BuckleComponent, AttackHandMessage>(HandleAttackHand);
         }
 
         private void MoveEvent(MoveEvent ev)

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -73,6 +73,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
             if (!interactionArgs.InRangeUnobstructed(ignoreInsideBlocker: true, popup: true)) return;
 
             // trigger dragdrops on the dropped entity
+            RaiseLocalEvent(dropped.Uid, interactionArgs);
             foreach (var dragDrop in dropped.GetAllComponents<IDraggable>())
             {
                 if (dragDrop.CanDrop(interactionArgs) &&
@@ -83,6 +84,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
             }
 
             // trigger dragdropons on the targeted entity
+            RaiseLocalEvent(target.Uid, interactionArgs, false);
             foreach (var dragDropOn in target.GetAllComponents<IDragDropOn>())
             {
                 if (dragDropOn.CanDragDropOn(interactionArgs) &&
@@ -408,7 +410,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         private async void InteractAfter(IEntity user, IEntity weapon, EntityCoordinates clickLocation, bool canReach)
         {
             var message = new AfterInteractMessage(user, weapon, null, clickLocation, canReach);
-            RaiseLocalEvent(message);
+            RaiseLocalEvent(weapon.Uid, message);
             if (message.Handled)
             {
                 return;
@@ -425,11 +427,9 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public async Task Interaction(IEntity user, IEntity weapon, IEntity attacked, EntityCoordinates clickLocation)
         {
             var attackMsg = new InteractUsingMessage(user, weapon, attacked, clickLocation);
-            RaiseLocalEvent(attackMsg);
+            RaiseLocalEvent(attacked.Uid, attackMsg);
             if (attackMsg.Handled)
-            {
                 return;
-            }
 
             var attackBys = attacked.GetAllComponents<IInteractUsing>().OrderByDescending(x => x.Priority);
             var attackByEventArgs = new InteractUsingEventArgs
@@ -451,7 +451,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
             }
 
             var afterAtkMsg = new AfterInteractMessage(user, weapon, attacked, clickLocation, true);
-            RaiseLocalEvent(afterAtkMsg);
+            RaiseLocalEvent(weapon.Uid, afterAtkMsg, false);
             if (afterAtkMsg.Handled)
             {
                 return;
@@ -470,18 +470,16 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void Interaction(IEntity user, IEntity attacked)
         {
             var message = new AttackHandMessage(user, attacked);
-            RaiseLocalEvent(message);
+            RaiseLocalEvent(attacked.Uid, message);
             if (message.Handled)
-            {
                 return;
-            }
 
-            var attackHands = attacked.GetAllComponents<IInteractHand>().ToList();
             var attackHandEventArgs = new InteractHandEventArgs { User = user, Target = attacked };
 
             // all attackHands should only fire when in range / unobstructed
             if (attackHandEventArgs.InRangeUnobstructed(ignoreInsideBlocker: true, popup: true))
             {
+                var attackHands = attacked.GetAllComponents<IInteractHand>().ToList();
                 foreach (var attackHand in attackHands)
                 {
                     if (attackHand.InteractHand(attackHandEventArgs))
@@ -525,7 +523,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
             }
 
             var useMsg = new UseInHandMessage(user, used);
-            RaiseLocalEvent(useMsg);
+            RaiseLocalEvent(used.Uid, useMsg);
             if (useMsg.Handled)
             {
                 return;
@@ -563,7 +561,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void ThrownInteraction(IEntity user, IEntity thrown)
         {
             var throwMsg = new ThrownMessage(user, thrown);
-            RaiseLocalEvent(throwMsg);
+            RaiseLocalEvent(thrown.Uid, throwMsg);
             if (throwMsg.Handled)
             {
                 return;
@@ -586,7 +584,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void EquippedInteraction(IEntity user, IEntity equipped, EquipmentSlotDefines.Slots slot)
         {
             var equipMsg = new EquippedMessage(user, equipped, slot);
-            RaiseLocalEvent(equipMsg);
+            RaiseLocalEvent(equipped.Uid, equipMsg);
             if (equipMsg.Handled)
             {
                 return;
@@ -608,7 +606,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void UnequippedInteraction(IEntity user, IEntity equipped, EquipmentSlotDefines.Slots slot)
         {
             var unequipMsg = new UnequippedMessage(user, equipped, slot);
-            RaiseLocalEvent(unequipMsg);
+            RaiseLocalEvent(equipped.Uid, unequipMsg);
             if (unequipMsg.Handled)
             {
                 return;
@@ -630,7 +628,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void EquippedHandInteraction(IEntity user, IEntity item, SharedHand hand)
         {
             var equippedHandMessage = new EquippedHandMessage(user, item, hand);
-            RaiseLocalEvent(equippedHandMessage);
+            RaiseLocalEvent(item.Uid, equippedHandMessage);
             if (equippedHandMessage.Handled)
             {
                 return;
@@ -651,7 +649,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void UnequippedHandInteraction(IEntity user, IEntity item, SharedHand hand)
         {
             var unequippedHandMessage = new UnequippedHandMessage(user, item, hand);
-            RaiseLocalEvent(unequippedHandMessage);
+            RaiseLocalEvent(item.Uid, unequippedHandMessage);
             if (unequippedHandMessage.Handled)
             {
                 return;
@@ -684,7 +682,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void DroppedInteraction(IEntity user, IEntity item, bool intentional)
         {
             var dropMsg = new DroppedMessage(user, item, intentional);
-            RaiseLocalEvent(dropMsg);
+            RaiseLocalEvent(item.Uid, dropMsg);
             if (dropMsg.Handled)
             {
                 return;
@@ -706,7 +704,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void HandSelectedInteraction(IEntity user, IEntity item)
         {
             var handSelectedMsg = new HandSelectedMessage(user, item);
-            RaiseLocalEvent(handSelectedMsg);
+            RaiseLocalEvent(item.Uid, handSelectedMsg);
             if (handSelectedMsg.Handled)
             {
                 return;
@@ -728,7 +726,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public void HandDeselectedInteraction(IEntity user, IEntity item)
         {
             var handDeselectedMsg = new HandDeselectedMessage(user, item);
-            RaiseLocalEvent(handDeselectedMsg);
+            RaiseLocalEvent(item.Uid, handDeselectedMsg);
             if (handDeselectedMsg.Handled)
             {
                 return;
@@ -750,7 +748,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
         public async void RangedInteraction(IEntity user, IEntity weapon, IEntity attacked, EntityCoordinates clickLocation)
         {
             var rangedMsg = new RangedInteractMessage(user, weapon, attacked, clickLocation);
-            RaiseLocalEvent(rangedMsg);
+            RaiseLocalEvent(attacked.Uid, rangedMsg);
             if (rangedMsg.Handled)
                 return;
 
@@ -771,7 +769,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
             }
 
             var afterAtkMsg = new AfterInteractMessage(user, weapon, attacked, clickLocation, false);
-            RaiseLocalEvent(afterAtkMsg);
+            RaiseLocalEvent(weapon.Uid, afterAtkMsg);
             if (afterAtkMsg.Handled)
                 return;
 
@@ -820,6 +818,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
 
                 if (item != null)
                 {
+                    RaiseLocalEvent(item.Uid, eventArgs, false);
                     foreach (var attackComponent in item.GetAllComponents<IAttack>())
                     {
                         if (wideAttack ? attackComponent.WideAttack(eventArgs) : attackComponent.ClickAttack(eventArgs))
@@ -840,6 +839,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
                 }
             }
 
+            RaiseLocalEvent(player.Uid, eventArgs);
             foreach (var attackComponent in player.GetAllComponents<IAttack>())
             {
                 if (wideAttack)

--- a/Content.Shared/AI/SharedAiDebug.cs
+++ b/Content.Shared/AI/SharedAiDebug.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.AI
     {
         #region Mob Debug
         [Serializable, NetSerializable]
-        public class UtilityAiDebugMessage : EntitySystemMessage
+        public class UtilityAiDebugMessage : EntityEventArgs
         {
             public EntityUid EntityUid { get; }
             public double PlanningTime { get; }
@@ -40,10 +40,10 @@ namespace Content.Shared.AI
         /// Client asks the server for the pathfinding graph details
         /// </summary>
         [Serializable, NetSerializable]
-        public class RequestPathfindingGraphMessage : EntitySystemMessage {}
+        public class RequestPathfindingGraphMessage : EntityEventArgs {}
 
         [Serializable, NetSerializable]
-        public class PathfindingGraphMessage : EntitySystemMessage
+        public class PathfindingGraphMessage : EntityEventArgs
         {
             public Dictionary<int, List<Vector2>> Graph { get; }
 
@@ -97,7 +97,7 @@ namespace Content.Shared.AI
         }
 
         [Serializable, NetSerializable]
-        public class AStarRouteMessage : EntitySystemMessage
+        public class AStarRouteMessage : EntityEventArgs
         {
             public readonly EntityUid EntityUid;
             public readonly IEnumerable<Vector2> Route;
@@ -121,7 +121,7 @@ namespace Content.Shared.AI
         }
 
         [Serializable, NetSerializable]
-        public class JpsRouteMessage : EntitySystemMessage
+        public class JpsRouteMessage : EntityEventArgs
         {
             public readonly EntityUid EntityUid;
             public readonly IEnumerable<Vector2> Route;
@@ -143,7 +143,7 @@ namespace Content.Shared.AI
         #endregion
         #region Reachable Debug
         [Serializable, NetSerializable]
-        public sealed class ReachableChunkRegionsDebugMessage : EntitySystemMessage
+        public sealed class ReachableChunkRegionsDebugMessage : EntityEventArgs
         {
             public GridId GridId { get; }
             public Dictionary<int, Dictionary<int, List<Vector2>>> Regions { get; }
@@ -156,7 +156,7 @@ namespace Content.Shared.AI
         }
 
         [Serializable, NetSerializable]
-        public sealed class ReachableCacheDebugMessage : EntitySystemMessage
+        public sealed class ReachableCacheDebugMessage : EntityEventArgs
         {
             public GridId GridId { get; }
             public Dictionary<int, List<Vector2>> Regions { get; }
@@ -174,13 +174,13 @@ namespace Content.Shared.AI
         ///     Send if someone is subscribing to reachable regions for NPCs.
         /// </summary>
         [Serializable, NetSerializable]
-        public sealed class SubscribeReachableMessage : EntitySystemMessage {}
+        public sealed class SubscribeReachableMessage : EntityEventArgs {}
 
         /// <summary>
         ///     Send if someone is unsubscribing to reachable regions for NPCs.
         /// </summary>
         [Serializable, NetSerializable]
-        public sealed class UnsubscribeReachableMessage : EntitySystemMessage {}
+        public sealed class UnsubscribeReachableMessage : EntityEventArgs {}
         #endregion
     }
 }

--- a/Content.Shared/GameObjects/EntitySystemMessages/CombatModeSystemMessages.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/CombatModeSystemMessages.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
     public static class CombatModeSystemMessages
     {
         [Serializable, NetSerializable]
-        public sealed class SetTargetZoneMessage : EntitySystemMessage
+        public sealed class SetTargetZoneMessage : EntityEventArgs
         {
             public SetTargetZoneMessage(TargetingZone targetZone)
             {
@@ -20,7 +20,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
         }
 
         [Serializable, NetSerializable]
-        public sealed class SetCombatModeActiveMessage : EntitySystemMessage
+        public sealed class SetCombatModeActiveMessage : EntityEventArgs
         {
             public SetCombatModeActiveMessage(bool active)
             {

--- a/Content.Shared/GameObjects/EntitySystemMessages/DragDropMessage.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/DragDropMessage.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
     /// Requests a drag / drop interaction to be performed
     /// </summary>
     [Serializable, NetSerializable]
-    public class DragDropMessage : EntitySystemMessage
+    public class DragDropMessage : EntityEventArgs
     {
         public EntityCoordinates DropLocation { get; }
         public EntityUid Dropped { get; }

--- a/Content.Shared/GameObjects/EntitySystemMessages/ExamineSystemMessages.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/ExamineSystemMessages.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
     public static class ExamineSystemMessages
     {
         [Serializable, NetSerializable]
-        public class RequestExamineInfoMessage : EntitySystemMessage
+        public class RequestExamineInfoMessage : EntityEventArgs
         {
             public readonly EntityUid EntityUid;
 
@@ -20,7 +20,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
         }
 
         [Serializable, NetSerializable]
-        public class ExamineInfoResponseMessage : EntitySystemMessage
+        public class ExamineInfoResponseMessage : EntityEventArgs
         {
             public readonly EntityUid EntityUid;
             public readonly FormattedMessage Message;

--- a/Content.Shared/GameObjects/EntitySystemMessages/Gravity/GravityChangedMessage.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/Gravity/GravityChangedMessage.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Map;
 
 namespace Content.Shared.GameObjects.EntitySystemMessages.Gravity
 {
-    public class GravityChangedMessage : EntitySystemMessage
+    public class GravityChangedMessage : EntityEventArgs
     {
         public GravityChangedMessage(IMapGrid grid)
         {

--- a/Content.Shared/GameObjects/EntitySystemMessages/MeleeWeaponSystemMessages.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/MeleeWeaponSystemMessages.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
     public static class MeleeWeaponSystemMessages
     {
         [Serializable, NetSerializable]
-        public sealed class PlayMeleeWeaponAnimationMessage : EntitySystemMessage
+        public sealed class PlayMeleeWeaponAnimationMessage : EntityEventArgs
         {
             public PlayMeleeWeaponAnimationMessage(string arcPrototype, Angle angle, EntityUid attacker, EntityUid source, List<EntityUid> hits, bool textureEffect = false, bool arcFollowAttacker = true)
             {
@@ -33,7 +33,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
         }
 
         [Serializable, NetSerializable]
-        public sealed class PlayLungeAnimationMessage : EntitySystemMessage
+        public sealed class PlayLungeAnimationMessage : EntityEventArgs
         {
             public Angle Angle { get; }
             public EntityUid Source { get; }

--- a/Content.Shared/GameObjects/EntitySystemMessages/PlayerContainerVisibilityMessage.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/PlayerContainerVisibilityMessage.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.GameObjects.EntitySystemMessages
 {
     [Serializable, NetSerializable]
-    public class PlayerContainerVisibilityMessage : EntitySystemMessage
+    public class PlayerContainerVisibilityMessage : EntityEventArgs
     {
         public readonly bool CanSeeThrough;
 

--- a/Content.Shared/GameObjects/EntitySystemMessages/SuspicionMessages.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/SuspicionMessages.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
     public static class SuspicionMessages
     {
         [Serializable, NetSerializable]
-        public sealed class SetSuspicionEndTimerMessage : EntitySystemMessage
+        public sealed class SetSuspicionEndTimerMessage : EntityEventArgs
         {
             public TimeSpan? EndTime;
         }

--- a/Content.Shared/GameObjects/EntitySystemMessages/VerbSystemMessages.cs
+++ b/Content.Shared/GameObjects/EntitySystemMessages/VerbSystemMessages.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
     public static class VerbSystemMessages
     {
         [Serializable, NetSerializable]
-        public class RequestVerbsMessage : EntitySystemMessage
+        public class RequestVerbsMessage : EntityEventArgs
         {
             public readonly EntityUid EntityUid;
 
@@ -21,7 +21,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
         }
 
         [Serializable, NetSerializable]
-        public class VerbsResponseMessage : EntitySystemMessage
+        public class VerbsResponseMessage : EntityEventArgs
         {
             public readonly NetVerbData[] Verbs;
             public readonly EntityUid Entity;
@@ -55,7 +55,7 @@ namespace Content.Shared.GameObjects.EntitySystemMessages
         }
 
         [Serializable, NetSerializable]
-        public class UseVerbMessage : EntitySystemMessage
+        public class UseVerbMessage : EntityEventArgs
         {
             public readonly EntityUid EntityUid;
             public readonly string VerbKey;

--- a/Content.Shared/GameObjects/EntitySystems/Atmos/SharedAtmosDebugOverlaySystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/Atmos/SharedAtmosDebugOverlaySystem.cs
@@ -38,7 +38,7 @@ namespace Content.Shared.GameObjects.EntitySystems.Atmos
         ///     No point re-sending every tile if only a subset might have been updated.
         /// </summary>
         [Serializable, NetSerializable]
-        public sealed class AtmosDebugOverlayMessage : EntitySystemMessage
+        public sealed class AtmosDebugOverlayMessage : EntityEventArgs
         {
             public GridId GridId { get; }
 
@@ -55,7 +55,7 @@ namespace Content.Shared.GameObjects.EntitySystems.Atmos
         }
 
         [Serializable, NetSerializable]
-        public sealed class AtmosDebugOverlayDisableMessage : EntitySystemMessage
+        public sealed class AtmosDebugOverlayDisableMessage : EntityEventArgs
         {
         }
     }

--- a/Content.Shared/GameObjects/EntitySystems/Atmos/SharedGasTileOverlaySystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/Atmos/SharedGasTileOverlaySystem.cs
@@ -100,7 +100,7 @@ namespace Content.Shared.GameObjects.EntitySystems.Atmos
         ///     No point re-sending every tile if only a subset might have been updated.
         /// </summary>
         [Serializable, NetSerializable]
-        public sealed class GasOverlayMessage : EntitySystemMessage
+        public sealed class GasOverlayMessage : EntityEventArgs
         {
             public GridId GridId { get; }
 

--- a/Content.Shared/GameObjects/EntitySystems/SharedConstructionSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedConstructionSystem.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.GameObjects.EntitySystems
         ///     a structure-construction.
         /// </summary>
         [Serializable, NetSerializable]
-        public class TryStartStructureConstructionMessage : EntitySystemMessage
+        public class TryStartStructureConstructionMessage : EntityEventArgs
         {
             /// <summary>
             ///     Position to start building.
@@ -47,7 +47,7 @@ namespace Content.Shared.GameObjects.EntitySystems
         ///     an item-construction.
         /// </summary>
         [Serializable, NetSerializable]
-        public class TryStartItemConstructionMessage : EntitySystemMessage
+        public class TryStartItemConstructionMessage : EntityEventArgs
         {
             /// <summary>
             ///     The construction prototype to start building.
@@ -64,7 +64,7 @@ namespace Content.Shared.GameObjects.EntitySystems
         /// Send server -> client to tell the client that a ghost has started to be constructed.
         /// </summary>
         [Serializable, NetSerializable]
-        public class AckStructureConstructionMessage : EntitySystemMessage
+        public class AckStructureConstructionMessage : EntityEventArgs
         {
             public readonly int GhostId;
 

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IActivate.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IActivate.cs
@@ -31,13 +31,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when an entity is activated in the world.
     /// </summary>
     [PublicAPI]
-    public class ActivateInWorldMessage : EntitySystemMessage
+    public class ActivateInWorldMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that activated the world entity.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IAfterInteract.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IAfterInteract.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -50,13 +50,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when clicking on another object and no attack event was handled.
     /// </summary>
     [PublicAPI]
-    public class AfterInteractMessage : EntitySystemMessage
+    public class AfterInteractMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that triggered the attack.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IAttack.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IAttack.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
@@ -18,7 +18,7 @@ namespace Content.Shared.Interfaces.GameObjects.Components
         bool ClickAttack(AttackEventArgs eventArgs);
     }
 
-    public class AttackEventArgs : EventArgs
+    public class AttackEventArgs : EntityEventArgs
     {
         public AttackEventArgs(IEntity user, EntityCoordinates clickLocation, bool wideAttack, EntityUid target = default)
         {

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IDraggable.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IDraggable.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
@@ -58,7 +58,7 @@ namespace Content.Shared.Interfaces.GameObjects.Components
         }
     }
 
-    public class StartDragDropEventArgs : EventArgs
+    public class StartDragDropEventArgs : EntityEventArgs
     {
         /// <summary>
         ///     Creates a new instance of <see cref="StartDragDropEventArgs"/>.

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IDropped.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IDropped.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
@@ -32,13 +32,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when an entity is dropped
     /// </summary>
     [PublicAPI]
-    public class DroppedMessage : EntitySystemMessage
+    public class DroppedMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that dropped the item.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IEquipped.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IEquipped.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using Content.Shared.GameObjects.Components.Inventory;
 using JetBrains.Annotations;
@@ -45,13 +45,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when equipping the entity in an inventory slot.
     /// </summary>
     [PublicAPI]
-    public class EquippedMessage : EntitySystemMessage
+    public class EquippedMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that equipped the item.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IEquippedHand.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IEquippedHand.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using Content.Shared.GameObjects.Components.Items;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
@@ -32,13 +32,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when putting the entity into a hand slot
     /// </summary>
     [PublicAPI]
-    public class EquippedHandMessage : EntitySystemMessage
+    public class EquippedHandMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that equipped the item.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IHandDeselected.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IHandDeselected.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
@@ -29,13 +29,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when an entity item in a hand is deselected.
     /// </summary>
     [PublicAPI]
-    public class HandDeselectedMessage : EntitySystemMessage
+    public class HandDeselectedMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that owns the deselected hand.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IHandSelected.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IHandSelected.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
@@ -29,13 +29,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when an entity item in a hand is selected.
     /// </summary>
     [PublicAPI]
-    public class HandSelectedMessage : EntitySystemMessage
+    public class HandSelectedMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that owns the selected hand.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IInteractHand.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IInteractHand.cs
@@ -29,13 +29,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///      Raised when being clicked on or "attacked" by a user with an empty hand.
     /// </summary>
     [PublicAPI]
-    public class AttackHandMessage : EntitySystemMessage
+    public class AttackHandMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that triggered the attack.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IInteractUsing.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IInteractUsing.cs
@@ -39,13 +39,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when being clicked on or "attacked" by a user with an object in their hand
     /// </summary>
     [PublicAPI]
-    public class InteractUsingMessage : EntitySystemMessage
+    public class InteractUsingMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that triggered the attack.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/ILand.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/ILand.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
@@ -32,13 +32,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when an entity that was thrown lands.
     /// </summary>
     [PublicAPI]
-    public class LandMessage : EntitySystemMessage
+    public class LandMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that threw the item.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IRangedInteract.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IRangedInteract.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
@@ -32,13 +32,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when being clicked by objects outside the range of direct use.
     /// </summary>
     [PublicAPI]
-    public class RangedInteractMessage : EntitySystemMessage
+    public class RangedInteractMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that triggered the attack.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IThrowCollide.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IThrowCollide.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
@@ -38,13 +38,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
         }
     }
 
-    public class ThrowCollideMessage : EntitySystemMessage
+    public class ThrowCollideMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     The entity that threw <see cref="Thrown"/>.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IThrown.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IThrown.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
@@ -29,13 +29,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when throwing the entity in your hands.
     /// </summary>
     [PublicAPI]
-    public class ThrownMessage : EntitySystemMessage
+    public class ThrownMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that threw the item.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IUnequipped.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IUnequipped.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using Content.Shared.GameObjects.Components.Inventory;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
@@ -34,13 +34,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when removing the entity from an inventory slot.
     /// </summary>
     [PublicAPI]
-    public class UnequippedMessage : EntitySystemMessage
+    public class UnequippedMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that equipped the item.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IUnequippedHand.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IUnequippedHand.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using Content.Shared.GameObjects.Components.Items;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
@@ -31,13 +31,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when removing the entity from an inventory slot.
     /// </summary>
     [PublicAPI]
-    public class UnequippedHandMessage : EntitySystemMessage
+    public class UnequippedHandMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity that equipped the item.
         /// </summary>

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IUse.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IUse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
@@ -28,13 +28,8 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     ///     Raised when using the entity in your hands.
     /// </summary>
     [PublicAPI]
-    public class UseInHandMessage : EntitySystemMessage
+    public class UseInHandMessage : HandledEntityEventArgs
     {
-        /// <summary>
-        ///     If this message has already been "handled" by a previous system.
-        /// </summary>
-        public bool Handled { get; set; }
-
         /// <summary>
         ///     Entity holding the item in their hand.
         /// </summary>


### PR DESCRIPTION
Removed obsolete EntitySystemMessage, now everything uses the base EntityEventArgs or the derived HandledEntityEventArgs.
Setup InteractionSystem to use new directed events.

Requires https://github.com/space-wizards/RobustToolbox/pull/1601.