### PR TITLE
Disable atmosphericswatervapor in cargo console

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Power/cargo_console.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/cargo_console.yml
@@ -52,7 +52,7 @@
       - atmosphericsoxygen
       - atmosphericsnitrogen
       - atmosphericscarbondioxide
-      - atmosphericswatervapor
+#      - atmosphericswatervapor
 #      - atmosphericsplasma
 #      - atmosphericstritium
   - type: UserInterface


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes the water vapor canister from the cargo console market.

The water vapor canister is causing problems because when fully emptied, it can cover a fourth of the station in water vapor, which causes slipping by making every floor tile wet and also suffocation.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.
-->

:cl:
- remove: Water vapor canister from cargo console

