### PR TITLE
Disable texture preloading in integration tests

### DIFF
--- a/Content.IntegrationTests/ContentIntegrationTest.cs
+++ b/Content.IntegrationTests/ContentIntegrationTest.cs
@@ -7,6 +7,7 @@ using Content.Server.Interfaces.GameTicking;
 using Content.Shared;
 using NUnit.Framework;
 using Robust.Server.Maps;
+using Robust.Shared;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
@@ -51,6 +52,9 @@ namespace Content.IntegrationTests
             // Connecting to Discord is a massive waste of time.
             // Basically just makes the CI logs a mess.
             options.CVarOverrides["discord.enabled"] = "false";
+
+            // Avoid preloading textures in tests.
+            options.CVarOverrides.TryAdd(CVars.TexturePreloadingEnabled.Name, "false");
 
             return base.StartClient(options);
         }


### PR DESCRIPTION
## About the PR
Requires https://github.com/space-wizards/RobustToolbox/pull/1623

Tests began taking double the time to execute in https://github.com/space-wizards/space-station-14/commit/6edc416afc2db1a29ca666b0030f5bf69f54896c (up to 10 minutes).
This PR disables texture preloading in tests to see how much that brings it back down.

The answer is 30 seconds, apparently.
