### PR TITLE
Disable collisions on a lot of stuff

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Furniture/carpets.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/carpets.yml
@@ -16,6 +16,7 @@
     key: full
     base: carpet_
   - type: Physics
+    canCollide: false
     fixtures:
       - shape:
           !type:PhysShapeAabb

--- a/Resources/Prototypes/Entities/Constructible/Ground/catwalk.yml
+++ b/Resources/Prototypes/Entities/Constructible/Ground/catwalk.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: Catwalk
   name: catwalk
   description: A catwalk for easier EVA maneuvering and cable placement.
@@ -8,6 +8,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
+    canCollide: false
     fixtures:
       - shape:
           !type:PhysShapeAabb

--- a/Resources/Prototypes/Entities/Constructible/Walls/lighting.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/lighting.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: WallLight
   name: unpowered light
   description: "An unpowered light."
@@ -9,6 +9,7 @@
     graph: lightFixture
     node: tubeLight
   - type: Physics
+    canCollide: false
     fixtures:
     - shape:
         !type:PhysShapeAabb

--- a/Resources/Prototypes/Entities/Constructible/Walls/signs.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/signs.yml
@@ -6,6 +6,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
+    canCollide: false
     fixtures:
     - shape:
         !type:PhysShapeAabb {}


### PR DESCRIPTION
:cl:
- tweak: Remove collisions for wall lights, carpets, catwalks

Reduces broadphase a bunch more. I didn't remove physics entirely because they'll probably need it toggled on/off at some stage. Additionally because melee swings use raycasts these won't show up in swings but I doubt it's a problem as click-attacking still works (worst case wall lights need collision again).