### PR TITLE
Increase climbdelay

### DIFF
--- a/Content.Server/GameObjects/Components/Movement/ClimbableComponent.cs
+++ b/Content.Server/GameObjects/Components/Movement/ClimbableComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Content.Server.GameObjects.EntitySystems.DoAfter;
 using Content.Server.Utility;
 using Content.Shared.GameObjects.Components.Body;
@@ -29,7 +29,7 @@ namespace Content.Server.GameObjects.Components.Movement
         /// </summary>
         [ViewVariables]
         [DataField("delay")]
-        private float _climbDelay = 0.8f;
+        private float _climbDelay = 3.0f;
 
         public override void Initialize()
         {


### PR DESCRIPTION
:cl:
- tweak: Increase default climbdelay from 0.8s to 3.0s

Should help getting rushed at the bar if you're bartending IMO (or if there's actually a chemist).