### PR TITLE
Fix body dragging

### DIFF
--- a/Content.Client/GameObjects/Components/Mobs/State/DeadMobState.cs
+++ b/Content.Client/GameObjects/Components/Mobs/State/DeadMobState.cs
@@ -1,8 +1,9 @@
-﻿using Content.Client.GameObjects.EntitySystems;
+using Content.Client.GameObjects.EntitySystems;
 using Content.Shared.GameObjects.Components.Mobs;
 using Content.Shared.GameObjects.Components.Mobs.State;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Physics;
 
 namespace Content.Client.GameObjects.Components.Mobs.State
 {
@@ -18,11 +19,6 @@ namespace Content.Client.GameObjects.Components.Mobs.State
             }
 
             EntitySystem.Get<StandingStateSystem>().Down(entity);
-
-            if (entity.TryGetComponent(out PhysicsComponent? physics))
-            {
-                physics.CanCollide = false;
-            }
         }
 
         public override void ExitState(IEntity entity)
@@ -30,11 +26,6 @@ namespace Content.Client.GameObjects.Components.Mobs.State
             base.ExitState(entity);
 
             EntitySystem.Get<StandingStateSystem>().Standing(entity);
-
-            if (entity.TryGetComponent(out PhysicsComponent? physics))
-            {
-                physics.CanCollide = true;
-            }
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Mobs/State/CriticalMobState.cs
+++ b/Content.Server/GameObjects/Components/Mobs/State/CriticalMobState.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.GameObjects.EntitySystems;
+using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.GameObjects.Components.Mobs;
 using Content.Shared.GameObjects.Components.Mobs.State;
 using Robust.Server.GameObjects;

--- a/Content.Shared/GameObjects/Components/Mobs/State/SharedCriticalMobState.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/State/SharedCriticalMobState.cs
@@ -36,7 +36,11 @@ namespace Content.Shared.GameObjects.Components.Mobs.State
             base.ExitState(entity);
 
             EntitySystem.Get<SharedStandingStateSystem>().Standing(entity);
-            entity.RemoveComponent<CollisionWakeComponent>();
+            if (entity.HasComponent<CollisionWakeComponent>())
+            {
+                entity.RemoveComponent<CollisionWakeComponent>();
+            }
+
             if (entity.TryGetComponent(out IPhysBody? body))
             {
                 body.BodyType = BodyType.KinematicController;

--- a/Content.Shared/GameObjects/Components/Mobs/State/SharedCriticalMobState.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/State/SharedCriticalMobState.cs
@@ -1,7 +1,8 @@
-﻿#nullable enable
+#nullable enable
 using Content.Shared.Alert;
 using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Physics;
 
 namespace Content.Shared.GameObjects.Components.Mobs.State
 {
@@ -20,6 +21,14 @@ namespace Content.Shared.GameObjects.Components.Mobs.State
             {
                 status.ShowAlert(AlertType.HumanCrit); // TODO: combine humancrit-0 and humancrit-1 into a gif and display it
             }
+
+            // TODO: Predicted sharedstunnablecomp here instead of CriticalMobState
+
+            entity.EnsureComponent<CollisionWakeComponent>();
+            if (entity.TryGetComponent(out IPhysBody? body))
+            {
+                body.BodyType = BodyType.Dynamic;
+            }
         }
 
         public override void ExitState(IEntity entity)
@@ -27,6 +36,11 @@ namespace Content.Shared.GameObjects.Components.Mobs.State
             base.ExitState(entity);
 
             EntitySystem.Get<SharedStandingStateSystem>().Standing(entity);
+            entity.RemoveComponent<CollisionWakeComponent>();
+            if (entity.TryGetComponent(out IPhysBody? body))
+            {
+                body.BodyType = BodyType.KinematicController;
+            }
         }
 
         public override bool CanInteract()

--- a/Content.Shared/GameObjects/Components/Mobs/State/SharedDeadMobState.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/State/SharedDeadMobState.cs
@@ -21,7 +21,11 @@ namespace Content.Shared.GameObjects.Components.Mobs.State
         public override void ExitState(IEntity entity)
         {
             base.ExitState(entity);
-            entity.RemoveComponent<CollisionWakeComponent>();
+            if (entity.HasComponent<CollisionWakeComponent>())
+            {
+                entity.RemoveComponent<CollisionWakeComponent>();
+            }
+            
             if (entity.TryGetComponent(out IPhysBody? physics))
             {
                 physics.BodyType = BodyType.KinematicController;

--- a/Content.Shared/GameObjects/Components/Mobs/State/SharedDeadMobState.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/State/SharedDeadMobState.cs
@@ -1,9 +1,32 @@
-﻿#nullable enable
+#nullable enable
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics;
+
 namespace Content.Shared.GameObjects.Components.Mobs.State
 {
     public abstract class SharedDeadMobState : BaseMobState
     {
         protected override DamageState DamageState => DamageState.Dead;
+
+        public override void EnterState(IEntity entity)
+        {
+            base.EnterState(entity);
+            entity.EnsureComponent<CollisionWakeComponent>();
+            if (entity.TryGetComponent(out IPhysBody? physics))
+            {
+                physics.BodyType = BodyType.Dynamic;
+            }
+        }
+
+        public override void ExitState(IEntity entity)
+        {
+            base.ExitState(entity);
+            entity.RemoveComponent<CollisionWakeComponent>();
+            if (entity.TryGetComponent(out IPhysBody? physics))
+            {
+                physics.BodyType = BodyType.KinematicController;
+            }
+        }
 
         public override bool CanInteract()
         {


### PR DESCRIPTION
Also uses CollisionWakeComponent so they won't have collision when not moving (may also need to tamper with their mask but I think this is good enough for now) so you can spam out bodies and broadphase won't be affected.

Fixes https://github.com/space-wizards/space-station-14/issues/974
I thought there was another issue for floor entity collision but I couldn't find that.
Requires https://github.com/space-wizards/RobustToolbox/pull/1626

:cl:
- fix: Fixes body dragging and collision
