### PR TITLE
Fix minsizes for all windows that needed it

### DIFF
--- a/Content.Client/Arcade/BlockGameMenu.cs
+++ b/Content.Client/Arcade/BlockGameMenu.cs
@@ -59,6 +59,8 @@ namespace Content.Client.Arcade
             Title = Loc.GetString("Nanotrasen Block Game");
             _owner = owner;
 
+            MinSize = SetSize = (410, 490);
+
             var resourceCache = IoCManager.Resolve<IResourceCache>();
             var backgroundTexture = resourceCache.GetTexture("/Textures/Interface/Nano/button.svg.96dpi.png");
 

--- a/Content.Client/Arcade/SpaceVillainArcadeMenu.cs
+++ b/Content.Client/Arcade/SpaceVillainArcadeMenu.cs
@@ -20,7 +20,7 @@ namespace Content.Client.Arcade
         private readonly Button[] _gameButtons = new Button[3]; //used to disable/enable all game buttons
         public SpaceVillainArcadeMenu(SpaceVillainArcadeBoundUserInterface owner)
         {
-            MinSize = SetSize = (400, 200);
+            MinSize = SetSize = (300, 225);
             Title = Loc.GetString("Space Villain");
             Owner = owner;
 
@@ -68,9 +68,7 @@ namespace Content.Client.Arcade
                 {Text = Loc.GetString("New Game")};
             grid.AddChild(newGame);
 
-            centerContainer = new CenterContainer();
-            centerContainer.AddChild(grid);
-            Contents.AddChild(centerContainer);
+            Contents.AddChild(grid);
         }
 
         private void UpdateMetadata(SharedSpaceVillainArcadeComponent.SpaceVillainArcadeMetaDataUpdateMessage message)

--- a/Content.Client/GameObjects/Components/Access/IdCardConsoleWindow.cs
+++ b/Content.Client/GameObjects/Components/Access/IdCardConsoleWindow.cs
@@ -36,7 +36,7 @@ namespace Content.Client.GameObjects.Components.Access
 
         public IdCardConsoleWindow(IdCardConsoleBoundUserInterface owner, IPrototypeManager prototypeManager)
         {
-            MinSize = SetSize = (650, 270);
+            MinSize = SetSize = (650, 290);
             _owner = owner;
             var vBox = new VBoxContainer();
 

--- a/Content.Client/GameObjects/Components/Atmos/GasCanisterWindow.cs
+++ b/Content.Client/GameObjects/Components/Atmos/GasCanisterWindow.cs
@@ -33,7 +33,7 @@ namespace Content.Client.GameObjects.Components.Atmos
 
         public GasCanisterWindow()
         {
-            SetSize = MinSize = (300, 200);
+            SetSize = MinSize = (450, 200);
             HBoxContainer releasePressureButtons;
 
             Contents.AddChild(new VBoxContainer

--- a/Content.Client/GameObjects/Components/Chemistry/ChemMaster/ChemMasterWindow.cs
+++ b/Content.Client/GameObjects/Components/Chemistry/ChemMaster/ChemMasterWindow.cs
@@ -54,7 +54,7 @@ namespace Content.Client.GameObjects.Components.Chemistry.ChemMaster
         /// </summary>
         public ChemMasterWindow()
         {
-            MinSize = SetSize = (400, 200);
+            MinSize = SetSize = (400, 525);
             IoCManager.InjectDependencies(this);
 
             Contents.AddChild(new VBoxContainer

--- a/Content.Client/GameObjects/Components/Chemistry/ReagentDispenser/ReagentDispenserWindow.cs
+++ b/Content.Client/GameObjects/Components/Chemistry/ReagentDispenser/ReagentDispenserWindow.cs
@@ -67,7 +67,7 @@ namespace Content.Client.GameObjects.Components.Chemistry.ReagentDispenser
         /// </summary>
         public ReagentDispenserWindow()
         {
-            SetSize = MinSize = (500, 600);
+            SetSize = MinSize = (590, 400);
             IoCManager.InjectDependencies(this);
 
             var dispenseAmountGroup = new ButtonGroup();

--- a/Content.Client/GameObjects/Components/Disposal/DisposalMailingUnitWindow.cs
+++ b/Content.Client/GameObjects/Components/Disposal/DisposalMailingUnitWindow.cs
@@ -28,7 +28,7 @@ namespace Content.Client.GameObjects.Components.Disposal
 
         public DisposalMailingUnitWindow()
         {
-            MinSize = SetSize = (460, 220);
+            MinSize = SetSize = (460, 230);
             TargetList = new List<string>();
             Contents.AddChild(new HBoxContainer
             {

--- a/Content.Client/GameObjects/Components/Disposal/DisposalRouterWindow.cs
+++ b/Content.Client/GameObjects/Components/Disposal/DisposalRouterWindow.cs
@@ -18,7 +18,7 @@ namespace Content.Client.GameObjects.Components.Disposal
 
         public DisposalRouterWindow()
         {
-            MinSize = SetSize = (400, 80);
+            MinSize = SetSize = (500, 110);
             Title = Loc.GetString("Disposal Router");
 
             Contents.AddChild(new VBoxContainer

--- a/Content.Client/GameObjects/Components/Disposal/DisposalTaggerWindow.cs
+++ b/Content.Client/GameObjects/Components/Disposal/DisposalTaggerWindow.cs
@@ -18,7 +18,7 @@ namespace Content.Client.GameObjects.Components.Disposal
 
         public DisposalTaggerWindow()
         {
-            MinSize = SetSize = (400, 80);
+            MinSize = SetSize = (500, 110);
             Title = Loc.GetString("Disposal Tagger");
 
             Contents.AddChild(new VBoxContainer

--- a/Content.Client/GameObjects/Components/Disposal/DisposalUnitWindow.cs
+++ b/Content.Client/GameObjects/Components/Disposal/DisposalUnitWindow.cs
@@ -23,7 +23,7 @@ namespace Content.Client.GameObjects.Components.Disposal
 
         public DisposalUnitWindow()
         {
-            MinSize = SetSize = (300, 200);
+            MinSize = SetSize = (300, 225);
 
             Contents.AddChild(new VBoxContainer
             {

--- a/Content.Client/GameObjects/Components/MedicalScanner/MedicalScannerWindow.cs
+++ b/Content.Client/GameObjects/Components/MedicalScanner/MedicalScannerWindow.cs
@@ -16,7 +16,7 @@ namespace Content.Client.GameObjects.Components.MedicalScanner
         private readonly Label _diagnostics;
         public MedicalScannerWindow()
         {
-            MinSize = SetSize = (250, 100);
+            SetSize = (250, 100);
 
             Contents.AddChild(new VBoxContainer
             {
@@ -44,6 +44,7 @@ namespace Content.Client.GameObjects.Components.MedicalScanner
             {
                 _diagnostics.Text = Loc.GetString("No patient data.");
                 ScanButton.Disabled = true;
+                SetSize = (250, 100);
             }
             else
             {
@@ -68,6 +69,8 @@ namespace Content.Client.GameObjects.Components.MedicalScanner
 
                 _diagnostics.Text = text.ToString();
                 ScanButton.Disabled = state.IsScanned;
+
+                SetSize = (250, 575);
             }
         }
     }

--- a/Content.Client/GameObjects/Components/MedicalScanner/MedicalScannerWindow.cs
+++ b/Content.Client/GameObjects/Components/MedicalScanner/MedicalScannerWindow.cs
@@ -16,7 +16,7 @@ namespace Content.Client.GameObjects.Components.MedicalScanner
         private readonly Label _diagnostics;
         public MedicalScannerWindow()
         {
-            MinSize = SetSize = (485, 90);
+            MinSize = SetSize = (250, 100);
 
             Contents.AddChild(new VBoxContainer
             {

--- a/Content.Client/GameObjects/Components/Power/AME/AMEWindow.cs
+++ b/Content.Client/GameObjects/Components/Power/AME/AMEWindow.cs
@@ -28,6 +28,9 @@ namespace Content.Client.GameObjects.Components.Power.AME
             IoCManager.InjectDependencies(this);
 
             Title = "Antimatter Control Unit";
+
+            MinSize = SetSize = (250, 250);
+
             Contents.AddChild(new VBoxContainer
             {
                 Children =

--- a/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
+++ b/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
@@ -188,7 +188,7 @@ namespace Content.Client.GameObjects.Components.Storage
             public StorageWindow(ClientStorageComponent storageEntity)
             {
                 StorageEntity = storageEntity;
-                MinSize = SetSize = (180, 320);
+                MinSize = SetSize = (200, 320);
                 Title = "Storage Item";
                 RectClipContent = true;
 

--- a/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
+++ b/Content.Client/GameObjects/Components/Storage/ClientStorageComponent.cs
@@ -188,7 +188,7 @@ namespace Content.Client.GameObjects.Components.Storage
             public StorageWindow(ClientStorageComponent storageEntity)
             {
                 StorageEntity = storageEntity;
-                MinSize = SetSize = (200, 320);
+                SetSize = (200, 320);
                 Title = "Storage Item";
                 RectClipContent = true;
 

--- a/Content.Client/UserInterface/ParticleAccelerator/ParticleAcceleratorControlMenu.cs
+++ b/Content.Client/UserInterface/ParticleAccelerator/ParticleAcceleratorControlMenu.cs
@@ -52,7 +52,7 @@ namespace Content.Client.UserInterface.ParticleAccelerator
 
         public ParticleAcceleratorControlMenu(ParticleAcceleratorBoundUserInterface owner)
         {
-            MinSize = SetSize = (400, 320);
+            SetSize = (400, 320);
             _greyScaleShader = IoCManager.Resolve<IPrototypeManager>().Index<ShaderPrototype>("Greyscale").Instance();
 
             Owner = owner;

--- a/Content.Client/UserInterface/ParticleAccelerator/ParticleAcceleratorControlMenu.cs
+++ b/Content.Client/UserInterface/ParticleAccelerator/ParticleAcceleratorControlMenu.cs
@@ -52,7 +52,7 @@ namespace Content.Client.UserInterface.ParticleAccelerator
 
         public ParticleAcceleratorControlMenu(ParticleAcceleratorBoundUserInterface owner)
         {
-            SetSize = (400, 300);
+            MinSize = SetSize = (400, 320);
             _greyScaleShader = IoCManager.Resolve<IPrototypeManager>().Index<ShaderPrototype>("Greyscale").Instance();
 
             Owner = owner;

--- a/Content.Client/VendingMachines/VendingMachineMenu.cs
+++ b/Content.Client/VendingMachines/VendingMachineMenu.cs
@@ -23,7 +23,7 @@ namespace Content.Client.VendingMachines
 
         public VendingMachineMenu(VendingMachineBoundUserInterface owner)
         {
-            SetSize = MinSize = (300, 450);
+            SetSize = (300, 450);
             IoCManager.InjectDependencies(this);
 
             Owner = owner;
@@ -60,7 +60,7 @@ namespace Content.Client.VendingMachines
                 _items.AddItem($"{itemName} ({entry.Amount} left)", icon);
             }
 
-            MinSize = SetSize = ((longestEntry.Length + 8) * 12, _items.Count * 40 + 50);
+            SetSize = ((longestEntry.Length + 8) * 12, _items.Count * 40 + 50);
         }
 
         public void ItemSelected(ItemList.ItemListSelectedEventArgs args)

--- a/Content.Client/VendingMachines/VendingMachineMenu.cs
+++ b/Content.Client/VendingMachines/VendingMachineMenu.cs
@@ -42,17 +42,25 @@ namespace Content.Client.VendingMachines
         {
             _items.Clear();
             _cachedInventory = inventory;
+            var longestEntry = "";
             foreach (VendingMachineInventoryEntry entry in inventory)
             {
                 var itemName = _prototypeManager.Index<EntityPrototype>(entry.ID).Name;
+                if (itemName.Length > longestEntry.Length)
+                {
+                    longestEntry = itemName;
+                }
 
                 Texture? icon = null;
                 if(_prototypeManager.TryIndex(entry.ID, out EntityPrototype? prototype))
                 {
                     icon = SpriteComponent.GetPrototypeIcon(prototype, _resourceCache).Default;
                 }
+
                 _items.AddItem($"{itemName} ({entry.Amount} left)", icon);
             }
+
+            MinSize = SetSize = ((longestEntry.Length + 8) * 12, _items.Count * 40 + 50);
         }
 
         public void ItemSelected(ItemList.ItemListSelectedEventArgs args)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #3376 

Just tweaks minsizes for most windows in the game so that they open correctly scaled

Vendors modified to have custom minsize depending on their contents (there's almost certainly a better way to do this)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/19853115/111024974-ae766c00-839e-11eb-8a7b-d21e749d34a1.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixes default window sizes for vendors, chemistry machines, etc.

