### PR TITLE
Increase time to clone people

### DIFF
--- a/Content.Client/GameObjects/Components/CloningPod/CloningPodWindow.cs
+++ b/Content.Client/GameObjects/Components/CloningPod/CloningPodWindow.cs
@@ -59,7 +59,7 @@ namespace Content.Client.GameObjects.Components.CloningPod
                     {
                         MinSize = (200, 20),
                         MinValue = 0,
-                        MaxValue = 10,
+                        MaxValue = 120, // todo make this actually derive from cloning time
                         Page = 0,
                         Value = 0.5f,
                         Children =

--- a/Content.Server/GameObjects/Components/Medical/CloningPodComponent.cs
+++ b/Content.Server/GameObjects/Components/Medical/CloningPodComponent.cs
@@ -46,7 +46,7 @@ namespace Content.Server.GameObjects.Components.Medical
         private CloningPodStatus _status;
         private float _cloningProgress = 0;
         [DataField("cloningTime")]
-        private float _cloningTime = 10f;
+        private float _cloningTime = 120f;
 
         public override void Initialize()
         {

--- a/Resources/Prototypes/Entities/Constructible/Specific/Medical/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Medical/cloning_machine.yml
@@ -30,7 +30,6 @@
   - type: SnapGrid
     offset: Center
   - type: CloningPod
-    cloningTime: 10.0
   - type: Damageable
     resistances: metallicResistances
   - type: Destructible


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Was 10 seconds, which let you mass clone people freely and potentially lag the server. Now takes 2 minutes

Fixes #3389

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Increased cloning time from 10 seconds to 2 minutes

