### PR TITLE
Fix edge.completed not getting run if node.action deletes

### DIFF
--- a/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
+++ b/Content.Server/GameObjects/Components/Construction/ConstructionComponent.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -357,6 +357,12 @@ namespace Content.Server.GameObjects.Components.Construction
             Edge = null;
             Node = GraphPrototype.Nodes[edge.Target];
 
+            foreach (var completed in edge.Completed)
+            {
+                await completed.PerformAction(Owner, user);
+                if (Owner.Deleted) return true;
+            }
+
             // Perform node actions!
             foreach (var action in Node.Actions)
             {
@@ -368,12 +374,6 @@ namespace Content.Server.GameObjects.Components.Construction
 
             if (Target == Node)
                 ClearTarget();
-
-            foreach (var completed in edge.Completed)
-            {
-                await completed.PerformAction(Owner, user);
-                if (Owner.Deleted) return true;
-            }
 
             await HandleEntityChange(Node, user);
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes `edge.completed` actions to run before the next `node.actions`. This is so that when the `node.actions` contains a `!type:DeleteEntity`, it still runs `edge.completed`.

It allows for the example below to work. The current implementation returns before spawning the steel sheet.
```yaml
- node: start
  actions:
    - !type:DeleteEntity {}
  edges:
    - to: one
    steps:
      - material: Steel

- node: one
  edges:
  - to: start
    completed:
      - !type:SpawnPrototype
        prototype: SheetSteel1
    steps:
      - tool: Screwing
```