### PR TITLE
Fixed visualizer init for wall light

### DIFF
--- a/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/PoweredLightComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ApcNetComponents/PowerReceiverUsers/PoweredLightComponent.cs
@@ -268,8 +268,10 @@ namespace Content.Server.GameObjects.Components.Power.ApcNetComponents.PowerRece
 
                 var entity = Owner.EntityManager.SpawnEntity(prototype, Owner.Transform.Coordinates);
                 _lightBulbContainer.Insert(entity);
-                UpdateLight();
             }
+
+            // need this to update visualizers
+            UpdateLight();
         }
 
         public void TriggerSignal(bool signal)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #3666
Light visualizer wasn't initialized right for unpowered light, Not it will be with `MapInit` hook.

Thanks @TimrodDX for a report

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fix nonexistent bulbs in built wall light

