### PR TITLE
Allow ownerless ids to show in pda

### DIFF
--- a/Content.Client/GameObjects/Components/PDA/PDABoundUserInterface.cs
+++ b/Content.Client/GameObjects/Components/PDA/PDABoundUserInterface.cs
@@ -106,19 +106,32 @@ namespace Content.Client.GameObjects.Components.PDA
                             msg.PDAOwnerInfo.ActualOwnerName));
                     }
 
-                    if (msg.PDAOwnerInfo.JobTitle == null || msg.PDAOwnerInfo.IdOwner == null)
-                    {
-                        _menu.IDInfoLabel.SetMarkup(Loc.GetString("ID:"));
-                    }
-                    else
+                    if (msg.PDAOwnerInfo.JobTitle != null && msg.PDAOwnerInfo.IdOwner != null)
                     {
                         _menu.IDInfoLabel.SetMarkup(Loc.GetString(
                             "ID: [color=white]{0}[/color], [color=yellow]{1}[/color]",
                             msg.PDAOwnerInfo.IdOwner,
+                            msg.PDAOwnerInfo.JobTitle?? ""));
+                        
+                    }
+                    else if(msg.PDAOwnerInfo.IdOwner != null)
+                    {
+                        _menu.IDInfoLabel.SetMarkup(Loc.GetString(
+                            "ID: [color=white]{0}[/color]",
+                            msg.PDAOwnerInfo.IdOwner));
+                    }
+                    else if(msg.PDAOwnerInfo.JobTitle != null)
+                    {
+                        _menu.IDInfoLabel.SetMarkup(Loc.GetString(
+                            "ID: [color=yellow]{0}[/color]",
                             msg.PDAOwnerInfo.JobTitle));
                     }
+                    else
+                    {
+                        _menu.IDInfoLabel.SetMarkup(Loc.GetString("ID:"));
+                    }
 
-                    _menu.EjectIDButton.Visible = msg.PDAOwnerInfo.IdOwner != null;
+                    _menu.EjectIDButton.Visible = msg.PDAOwnerInfo.IdOwner != null || msg.PDAOwnerInfo.JobTitle != null;
                     _menu.EjectPenButton.Visible = msg.HasPen;
 
                     if (msg.Account != null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #3690 by allowing ID's without an owner to still show their rank in the ID field, and allows the Eject ID button to appear.
**Screenshots**
What the Captain's spare looks like in a PDA:
![image](https://user-images.githubusercontent.com/16856738/111408457-f0ebc180-869a-11eb-98ed-fe1a55c0fea4.png)

<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Ownerless ID's now show in PDA (Captain's Spare)

