### PR TITLE
Fix chairs not unbuckling entities when deconstructed or destroyed

### DIFF
--- a/Content.Server/Construction/Completions/DestroyEntity.cs
+++ b/Content.Server/Construction/Completions/DestroyEntity.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using Content.Server.GameObjects.EntitySystems;
+using Content.Shared.Construction;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization.Manager.Attributes;
+using System.Threading.Tasks;
+
+namespace Content.Server.Construction.Completions
+{
+    [UsedImplicitly]
+    [DataDefinition]
+    public class DestroyEntity : IGraphAction
+    {
+        public async Task PerformAction(IEntity entity, IEntity? user)
+        {
+            if (entity.Deleted) return;
+
+            var destructibleSystem = EntitySystem.Get<DestructibleSystem>();
+            destructibleSystem.ActSystem.HandleDestruction(entity);
+        }
+    }
+}

--- a/Content.Server/GameObjects/Components/Strap/StrapComponent.cs
+++ b/Content.Server/GameObjects/Components/Strap/StrapComponent.cs
@@ -1,9 +1,10 @@
-﻿#nullable enable
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Content.Server.GameObjects.Components.Buckle;
 using Content.Shared.Alert;
 using Content.Shared.GameObjects.Components.Strap;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.GameObjects.EntitySystems.ActionBlocker;
 using Content.Shared.GameObjects.Verbs;
 using Content.Shared.Interfaces.GameObjects.Components;
@@ -20,7 +21,7 @@ namespace Content.Server.GameObjects.Components.Strap
 {
     [RegisterComponent]
     [ComponentReference(typeof(SharedStrapComponent))]
-    public class StrapComponent : SharedStrapComponent, IInteractHand, ISerializationHooks
+    public class StrapComponent : SharedStrapComponent, IInteractHand, ISerializationHooks, IDestroyAct
     {
         [ComponentDependency] public readonly SpriteComponent? SpriteComponent = null;
 
@@ -134,6 +135,16 @@ namespace Content.Server.GameObjects.Components.Strap
         {
             base.OnRemove();
 
+            RemoveAll();
+        }
+
+        void IDestroyAct.OnDestroy(DestructionEventArgs eventArgs)
+        {
+            RemoveAll();
+        }
+
+        private void RemoveAll()
+        {
             foreach (var entity in _buckledEntities.ToArray())
             {
                 if (entity.TryGetComponent<BuckleComponent>(out var buckle))

--- a/Resources/Prototypes/Recipes/Construction/Graphs/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/seats.yml
@@ -4,7 +4,7 @@
   graph:
     - node: start
       actions:
-        - !type:DeleteEntity {}
+        - !type:DestroyEntity {}
       edges:
         - to: chair
           steps:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Chairs deleted any entities that were buckled to them when deconstructed or destroyed. This PR fixes that by adding an OnDestroy to StrapComponent and changing deconstruction to call OnDestroy.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed chairs so that when destroyed they don't delete whatever is sitting in them

