### PR TITLE
Magazine name renamed to be more specific

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/LRifle/magazines.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/LRifle/magazines.yml
@@ -27,7 +27,7 @@
 # Magazines
 - type: entity
   id: MagazineLRifleBox
-  name: "magazine box (.30 rifle)"
+  name: "L6 SAW Magazine box (.30 rifle)"
   parent: MagazineLRifleBase
   components:
   - type: RangedMagazine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/LRifle/magazines.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/LRifle/magazines.yml
@@ -27,7 +27,7 @@
 # Magazines
 - type: entity
   id: MagazineLRifleBox
-  name: "L6 SAW Magazine box (.30 rifle)"
+  name: "L6 SAW magazine box (.30 rifle)"
   parent: MagazineLRifleBase
   components:
   - type: RangedMagazine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magnum/magazines.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magnum/magazines.yml
@@ -1,7 +1,7 @@
 # Empty mags
 - type: entity
   id: MagazineMagnumBase
-  name: "Lamia Magazine (.40 magnum)"
+  name: "Lamia magazine (.40 magnum)"
   parent: BaseItem
   abstract: true
   components:
@@ -26,7 +26,7 @@
 
 - type: entity
   id: MagazineMagnumSmgBase
-  name: "Drozd Magazine (.40 magnum)"
+  name: "Drozd magazine (.40 magnum)"
   parent: BaseItem
   abstract: true
   components:
@@ -52,7 +52,7 @@
 # Magazines
 - type: entity
   id: MagazineMagnum
-  name: "Lamia Magazine (.40 magnum)"
+  name: "Lamia magazine (.40 magnum)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -63,7 +63,7 @@
 
 - type: entity
   id: MagazineMagnumFlash
-  name: "Lamia Magazine (.40 magnum flash)"
+  name: "Lamia magazine (.40 magnum flash)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -74,7 +74,7 @@
 
 - type: entity
   id: MagazineMagnumHV
-  name: "Lamia Magazine (.40 magnum high-velocity)"
+  name: "Lamia magazine (.40 magnum high-velocity)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -85,7 +85,7 @@
 
 - type: entity
   id: MagazineMagnumPractice
-  name: "Lamia Magazine (.40 magnum practice)"
+  name: "Lamia magazine (.40 magnum practice)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -96,7 +96,7 @@
 
 - type: entity
   id: MagazineMagnumRubber
-  name: "Lamia Magazine (.40 magnum rubber)"
+  name: "Lamia magazine (.40 magnum rubber)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -107,7 +107,7 @@
 
 - type: entity
   id: MagazineMagnumSmg
-  name: "Drozd Magazine (.40 magnum)"
+  name: "Drozd magazine (.40 magnum)"
   parent: MagazineMagnumSmgBase
   components:
   - type: RangedMagazine
@@ -118,7 +118,7 @@
 
 - type: entity
   id: MagazineMagnumSmgHV
-  name: "Drozd Magazine (.40 magnum High-Velocity)"
+  name: "Drozd magazine (.40 magnum High-Velocity)"
   parent: MagazineMagnumSmgBase
   components:
   - type: RangedMagazine
@@ -129,7 +129,7 @@
 
 - type: entity
   id: MagazineMagnumSmgPractice
-  name: "Drozd Magazine (.40 magnum practice)"
+  name: "Drozd magazine (.40 magnum practice)"
   parent: MagazineMagnumSmgBase
   components:
   - type: RangedMagazine
@@ -140,7 +140,7 @@
 
 - type: entity
   id: MagazineMagnumSmgRubber
-  name: "Drozd Magazine (.40 magnum rubber)"
+  name: "Drozd magazine (.40 magnum rubber)"
   parent: MagazineMagnumSmgBase
   components:
   - type: RangedMagazine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magnum/magazines.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magnum/magazines.yml
@@ -1,7 +1,7 @@
 # Empty mags
 - type: entity
   id: MagazineMagnumBase
-  name: "magazine (.40 magnum)"
+  name: "Lamia Magazine (.40 magnum)"
   parent: BaseItem
   abstract: true
   components:
@@ -26,7 +26,7 @@
 
 - type: entity
   id: MagazineMagnumSmgBase
-  name: "SMG Magazine (.40 magnum)"
+  name: "Drozd Magazine (.40 magnum)"
   parent: BaseItem
   abstract: true
   components:
@@ -52,7 +52,7 @@
 # Magazines
 - type: entity
   id: MagazineMagnum
-  name: "magazine (.40 magnum)"
+  name: "Lamia Magazine (.40 magnum)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -63,7 +63,7 @@
 
 - type: entity
   id: MagazineMagnumFlash
-  name: "magazine (.40 magnum flash)"
+  name: "Lamia Magazine (.40 magnum flash)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -74,7 +74,7 @@
 
 - type: entity
   id: MagazineMagnumHV
-  name: "magazine (.40 magnum high-velocity)"
+  name: "Lamia Magazine (.40 magnum high-velocity)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -85,7 +85,7 @@
 
 - type: entity
   id: MagazineMagnumPractice
-  name: "magazine (.40 magnum practice)"
+  name: "Lamia Magazine (.40 magnum practice)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -96,7 +96,7 @@
 
 - type: entity
   id: MagazineMagnumRubber
-  name: "magazine (.40 magnum rubber)"
+  name: "Lamia Magazine (.40 magnum rubber)"
   parent: MagazineMagnumBase
   components:
   - type: RangedMagazine
@@ -107,7 +107,7 @@
 
 - type: entity
   id: MagazineMagnumSmg
-  name: "SMG Magazine (.40 magnum)"
+  name: "Drozd Magazine (.40 magnum)"
   parent: MagazineMagnumSmgBase
   components:
   - type: RangedMagazine
@@ -118,7 +118,7 @@
 
 - type: entity
   id: MagazineMagnumSmgHV
-  name: "SMG Magazine (.40 magnum High-Velocity)"
+  name: "Drozd Magazine (.40 magnum High-Velocity)"
   parent: MagazineMagnumSmgBase
   components:
   - type: RangedMagazine
@@ -129,7 +129,7 @@
 
 - type: entity
   id: MagazineMagnumSmgPractice
-  name: "SMG Magazine (.40 magnum practice)"
+  name: "Drozd Magazine (.40 magnum practice)"
   parent: MagazineMagnumSmgBase
   components:
   - type: RangedMagazine
@@ -140,7 +140,7 @@
 
 - type: entity
   id: MagazineMagnumSmgRubber
-  name: "SMG Magazine (.40 magnum rubber)"
+  name: "Drozd Magazine (.40 magnum rubber)"
   parent: MagazineMagnumSmgBase
   components:
   - type: RangedMagazine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Pistol/magazines.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Pistol/magazines.yml
@@ -1,6 +1,7 @@
+# Empty mags
 - type: entity
   id: MagazinePistolBase
-  name: magazine (.35 auto)
+  name: Pistol Magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -25,7 +26,7 @@
 
 - type: entity
   id: MagazinePistolHCBase
-  name: high-capacity magazine (.35 auto)
+  name: Machine Pistol Magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -50,7 +51,7 @@
 
 - type: entity
   id: MagazinePistolSmgBase  # Yeah it's weird but it's pistol caliber
-  name: SMG magazine (.35 auto)
+  name: SMG Magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -76,7 +77,7 @@
 # Magazines
 - type: entity
   id: MagazinePistolSmgTopMounted
-  name: SMG magazine (.35 auto top-mounted)
+  name: WT550 Magazine (.35 auto top-mounted)
   parent: MagazinePistolSmgBase
   components:
   - type: RangedMagazine
@@ -126,7 +127,7 @@
 
 - type: entity
   id: MagazinePistol
-  name: magazine (.35 auto)
+  name: Pistol Magazine (.35 auto)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -137,7 +138,7 @@
 
 - type: entity
   id: MagazinePistolFlash
-  name: magazine (.35 auto flash)
+  name: Pistol Magazine (.35 auto flash)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -148,7 +149,7 @@
 
 - type: entity
   id: MagazinePistolHV
-  name: magazine (.35 auto high-velocity)
+  name: Pistol Magazine (.35 auto high-velocity)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -159,7 +160,7 @@
 
 - type: entity
   id: MagazinePistolPractice
-  name: magazine (.35 auto practice)
+  name: Pistol Magazine (.35 auto practice)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -170,7 +171,7 @@
 
 - type: entity
   id: MagazinePistolRubber
-  name: magazine (.35 auto rubber)
+  name: Pistol Magazine (.35 auto rubber)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -181,7 +182,7 @@
 
 - type: entity
   id: MagazineHCPistol
-  name: high-capacity magazine (.35 auto)
+  name: Machine Pistol Magazine (.35 auto)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -192,7 +193,7 @@
 
 - type: entity
   id: MagazineHCPistolHV
-  name: high-capacity magazine (.35 auto high-velocity)
+  name: Machine Pistol Magazine (.35 auto high-velocity)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -203,7 +204,7 @@
 
 - type: entity
   id: MagazineHCPistolPractice
-  name: high-capacity magazine (.35 auto practice)
+  name: Machine Pistol Magazine (.35 auto practice)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -214,7 +215,7 @@
 
 - type: entity
   id: MagazineHCPistolRubber
-  name: high-capacity magazine (.35 auto rubber)
+  name: Machine Pistol Magazine (.35 auto rubber)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Pistol/magazines.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Pistol/magazines.yml
@@ -1,7 +1,7 @@
 # Empty mags
 - type: entity
   id: MagazinePistolBase
-  name: Pistol Magazine (.35 auto)
+  name: Pistol magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -26,7 +26,7 @@
 
 - type: entity
   id: MagazinePistolHCBase
-  name: Machine Pistol Magazine (.35 auto)
+  name: Machine Pistol magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -51,7 +51,7 @@
 
 - type: entity
   id: MagazinePistolSmgBase  # Yeah it's weird but it's pistol caliber
-  name: SMG Magazine (.35 auto)
+  name: SMG magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -77,7 +77,7 @@
 # Magazines
 - type: entity
   id: MagazinePistolSmgTopMounted
-  name: WT550 Magazine (.35 auto top-mounted)
+  name: WT550 magazine (.35 auto top-mounted)
   parent: MagazinePistolSmgBase
   components:
   - type: RangedMagazine
@@ -102,7 +102,7 @@
 
 - type: entity
   id: MagazinePistolCalicoTopMounted
-  name: Calico Magazine (.35 auto top-mounted)
+  name: Calico magazine (.35 auto top-mounted)
   parent: MagazinePistolSmgBase
   components:
   - type: RangedMagazine
@@ -127,7 +127,7 @@
 
 - type: entity
   id: MagazinePistol
-  name: Pistol Magazine (.35 auto)
+  name: Pistol magazine (.35 auto)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -138,7 +138,7 @@
 
 - type: entity
   id: MagazinePistolFlash
-  name: Pistol Magazine (.35 auto flash)
+  name: Pistol magazine (.35 auto flash)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -149,7 +149,7 @@
 
 - type: entity
   id: MagazinePistolHV
-  name: Pistol Magazine (.35 auto high-velocity)
+  name: Pistol magazine (.35 auto high-velocity)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -160,7 +160,7 @@
 
 - type: entity
   id: MagazinePistolPractice
-  name: Pistol Magazine (.35 auto practice)
+  name: Pistol magazine (.35 auto practice)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -171,7 +171,7 @@
 
 - type: entity
   id: MagazinePistolRubber
-  name: Pistol Magazine (.35 auto rubber)
+  name: Pistol magazine (.35 auto rubber)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -182,7 +182,7 @@
 
 - type: entity
   id: MagazineHCPistol
-  name: Machine Pistol Magazine (.35 auto)
+  name: Machine Pistol magazine (.35 auto)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -193,7 +193,7 @@
 
 - type: entity
   id: MagazineHCPistolHV
-  name: Machine Pistol Magazine (.35 auto high-velocity)
+  name: Machine Pistol magazine (.35 auto high-velocity)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -204,7 +204,7 @@
 
 - type: entity
   id: MagazineHCPistolPractice
-  name: Machine Pistol Magazine (.35 auto practice)
+  name: Machine Pistol magazine (.35 auto practice)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -215,7 +215,7 @@
 
 - type: entity
   id: MagazineHCPistolRubber
-  name: Machine Pistol Magazine (.35 auto rubber)
+  name: Machine Pistol magazine (.35 auto rubber)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -226,7 +226,7 @@
 
 - type: entity
   id: MagazinePistolSmg
-  name: SMG Magazine (.35 auto)
+  name: SMG magazine (.35 auto)
   parent: MagazinePistolSmgBase
   components:
   - type: RangedMagazine
@@ -237,7 +237,7 @@
 
 - type: entity
   id: MagazinePistolSmgFlash
-  name: SMG Magazine (.35 auto flash)
+  name: SMG magazine (.35 auto flash)
   parent: MagazinePistolSmgBase
   components:
   - type: RangedMagazine
@@ -248,7 +248,7 @@
 
 - type: entity
   id: MagazinePistolSmgHV
-  name: SMG Magazine (.35 auto high-velocity)
+  name: SMG magazine (.35 auto high-velocity)
   parent: MagazinePistolSmgBase
   components:
   - type: RangedMagazine
@@ -259,7 +259,7 @@
 
 - type: entity
   id: MagazinePistolSmgPractice
-  name: SMG Magazine (.35 auto practice)
+  name: SMG magazine (.35 auto practice)
   parent: MagazinePistolSmgBase
   components:
   - type: RangedMagazine
@@ -270,7 +270,7 @@
 
 - type: entity
   id: MagazinePistolSmgRubber
-  name: SMG Magazine (.35 auto rubber)
+  name: SMG magazine (.35 auto rubber)
   parent: MagazinePistolSmgBase
   components:
   - type: RangedMagazine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Pistol/magazines.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Pistol/magazines.yml
@@ -1,7 +1,7 @@
 # Empty mags
 - type: entity
   id: MagazinePistolBase
-  name: Pistol magazine (.35 auto)
+  name: pistol magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -26,7 +26,7 @@
 
 - type: entity
   id: MagazinePistolHCBase
-  name: Machine Pistol magazine (.35 auto)
+  name: machine pistol magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -127,7 +127,7 @@
 
 - type: entity
   id: MagazinePistol
-  name: Pistol magazine (.35 auto)
+  name: pistol magazine (.35 auto)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -138,7 +138,7 @@
 
 - type: entity
   id: MagazinePistolFlash
-  name: Pistol magazine (.35 auto flash)
+  name: pistol magazine (.35 auto flash)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -149,7 +149,7 @@
 
 - type: entity
   id: MagazinePistolHV
-  name: Pistol magazine (.35 auto high-velocity)
+  name: pistol magazine (.35 auto high-velocity)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -160,7 +160,7 @@
 
 - type: entity
   id: MagazinePistolPractice
-  name: Pistol magazine (.35 auto practice)
+  name: pistol magazine (.35 auto practice)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -171,7 +171,7 @@
 
 - type: entity
   id: MagazinePistolRubber
-  name: Pistol magazine (.35 auto rubber)
+  name: pistol magazine (.35 auto rubber)
   parent: MagazinePistolBase
   components:
   - type: RangedMagazine
@@ -182,7 +182,7 @@
 
 - type: entity
   id: MagazineHCPistol
-  name: Machine Pistol magazine (.35 auto)
+  name: machine pistol magazine (.35 auto)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -193,7 +193,7 @@
 
 - type: entity
   id: MagazineHCPistolHV
-  name: Machine Pistol magazine (.35 auto high-velocity)
+  name: machine pistol magazine (.35 auto high-velocity)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -204,7 +204,7 @@
 
 - type: entity
   id: MagazineHCPistolPractice
-  name: Machine Pistol magazine (.35 auto practice)
+  name: machine pistol magazine (.35 auto practice)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine
@@ -215,7 +215,7 @@
 
 - type: entity
   id: MagazineHCPistolRubber
-  name: Machine Pistol magazine (.35 auto rubber)
+  name: machine pistol magazine (.35 auto rubber)
   parent: MagazinePistolHCBase
   components:
   - type: RangedMagazine


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Made magazine names more specific
eg. SMG magazine (.35 auto top-mounted) was renamed to WT550 magazine in order to make it more clear that the magazine is exclusive to WT550.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
<img src=https://i.imgur.com/IrOlZmf.png>

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- magazine box (.30 rifle) renamed to L6 SAW magazine box (.30 rifle)
- magazine (.40 magnum) renamed to Lamia magazine (.40 magnum)
- SMG Magazine (.40 magnum) renamed to Drozd magazine (.40 magnum)
- magazine (.35 auto) renamed to Pistol magazine (.35 auto)
- high-capacity magazine (.35 auto) renamed to Machine Pistol magazine (.35 auto)
- SMG magazine (.35 auto top-mounted) renamed to WT550 magazine (.35 auto top-mounted)

EDIT: Worth noting that most of these changes are from Timrod's suggestions in #3679.