### PR TITLE
Revert "Moved VisibilityFlags to EyeComponent"

### DIFF
--- a/Content.Server/GameObjects/Components/Observer/GhostComponent.cs
+++ b/Content.Server/GameObjects/Components/Observer/GhostComponent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Server.GameObjects.Components.Markers;
@@ -40,39 +40,31 @@ namespace Content.Server.GameObjects.Components.Observer
             }
         }
 
-        /// <inheritdoc />
-        protected override void Startup()
+        public override void Initialize()
         {
-            base.Startup();
+            base.Initialize();
 
-            // Allow this entity to be seen by other ghosts.
             Owner.EnsureComponent<VisibilityComponent>().Layer = (int) VisibilityFlags.Ghost;
-
-            // Allows this entity to see other ghosts.
-            Owner.EnsureComponent<EyeComponent>().VisibilityMask |= (uint) VisibilityFlags.Ghost;
-
             _timeOfDeath = _gameTimer.RealTime;
         }
 
-        /// <inheritdoc />
-        protected override void Shutdown()
-        {
-            //Perf: If the entity is deleting itself, no reason to change these back.
-            if(Owner.LifeStage < EntityLifeStage.Terminating)
-            {
-                // Entity can't be seen by ghosts anymore.
-                if (Owner.TryGetComponent<VisibilityComponent>(out var visComp))
-                    visComp.Layer &= ~(int) VisibilityFlags.Ghost;
-
-                // Entity can't see ghosts anymore.
-                if (Owner.TryGetComponent<EyeComponent>(out var eyeComp))
-                    eyeComp.VisibilityMask &= ~(uint) VisibilityFlags.Ghost;
-            }
-
-            base.Shutdown();
-        }
-
         public override ComponentState GetComponentState(ICommonSession player) => new GhostComponentState(CanReturnToBody);
+
+        public override void HandleMessage(ComponentMessage message, IComponent? component)
+        {
+            base.HandleMessage(message, component);
+
+            switch (message)
+            {
+                case PlayerAttachedMsg msg:
+                    msg.NewPlayer.VisibilityMask |= (int) VisibilityFlags.Ghost;
+                    Dirty();
+                    break;
+                case PlayerDetachedMsg msg:
+                    msg.OldPlayer.VisibilityMask &= ~(int) VisibilityFlags.Ghost;
+                    break;
+            }
+        }
 
         public override void HandleNetworkMessage(ComponentMessage message, INetChannel netChannel, ICommonSession? session = null!)
         {

--- a/Content.Server/GameObjects/EntitySystems/PointingSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/PointingSystem.cs
@@ -131,12 +131,13 @@ namespace Content.Server.GameObjects.EntitySystems
             // Get players that are in range and whose visibility layer matches the arrow's.
             var viewers = _playerManager.GetPlayersBy((playerSession) =>
             {
+                if ((playerSession.VisibilityMask & layer) == 0)
+                    return false;
+
                 var ent = playerSession.ContentData()?.Mind?.CurrentEntity;
 
-                if (ent is null || (!ent.TryGetComponent<EyeComponent>(out var eyeComp) || (eyeComp.VisibilityMask & layer) != 0))
-                    return false;
-                
-                return ent.Transform.MapPosition.InRange(player.Transform.MapPosition, PointingRange);
+                return ent != null
+                       && ent.Transform.MapPosition.InRange(player.Transform.MapPosition, PointingRange);
             });
 
             string selfMessage;

--- a/Content.Server/GameObjects/VisibilityFlags.cs
+++ b/Content.Server/GameObjects/VisibilityFlags.cs
@@ -3,10 +3,9 @@ using System;
 namespace Content.Server.GameObjects
 {
     [Flags]
-    public enum VisibilityFlags : uint
+    public enum VisibilityFlags
     {
-        None   = 0,
-        Normal = 1 << 0,
-        Ghost  = 1 << 1,
+        Normal = 1,
+        Ghost = 2,
     }
 }


### PR DESCRIPTION
This breaks firing weapons which is pretty critical so gonna revert this since PJB merged this then went to bed.