### PR TITLE
Content grid-trees

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/AtmosDebugOverlaySystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/AtmosDebugOverlaySystem.cs
@@ -72,7 +72,7 @@ namespace Content.Client.GameObjects.EntitySystems
             _tileData.Clear();
         }
 
-        private void OnGridRemoved(GridId gridId)
+        private void OnGridRemoved(MapId mapId, GridId gridId)
         {
             if (_tileData.ContainsKey(gridId))
             {

--- a/Content.Client/GameObjects/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/GasTileOverlaySystem.cs
@@ -131,7 +131,7 @@ namespace Content.Client.GameObjects.EntitySystems
                 overlayManager.RemoveOverlay<GasTileOverlay>();
         }
 
-        private void OnGridRemoved(GridId gridId)
+        private void OnGridRemoved(MapId mapId, GridId gridId)
         {
             if (_tileData.ContainsKey(gridId))
             {

--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/Accessible/AiReachableSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/Accessible/AiReachableSystem.cs
@@ -90,7 +90,7 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding.Accessible
             _mapManager.OnGridRemoved += GridRemoved;
         }
 
-        private void GridRemoved(GridId gridId)
+        private void GridRemoved(MapId mapId, GridId gridId)
         {
             _regions.Remove(gridId);
         }

--- a/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/AI/Pathfinding/PathfindingSystem.cs
@@ -229,7 +229,7 @@ namespace Content.Server.GameObjects.EntitySystems.AI.Pathfinding
             node.UpdateTile(tile);
         }
 
-        private void HandleGridRemoval(GridId gridId)
+        private void HandleGridRemoval(MapId mapId, GridId gridId)
         {
             if (_graph.ContainsKey(gridId))
             {

--- a/Content.Server/GameObjects/EntitySystems/Atmos/GasTileOverlaySystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Atmos/GasTileOverlaySystem.cs
@@ -107,7 +107,7 @@ namespace Content.Server.GameObjects.EntitySystems.Atmos
             return chunk;
         }
 
-        private void OnGridRemoved(GridId gridId)
+        private void OnGridRemoved(MapId mapId, GridId gridId)
         {
             if (_overlay.ContainsKey(gridId))
             {


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/1666 ; this is due to the gridchangedeventhandler change.