### PR TITLE
Uplink uses correct clarissa magazine ID

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -83,7 +83,7 @@
 - type: uplinkListing
   id: UplinkPistol9mmMagazine
   category: Ammo
-  itemId: magazine_9mm
+  itemId: MagazinePistol
   price: 2
 
 # For the Mandella

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Pistol/magazines.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Pistol/magazines.yml
@@ -9,7 +9,6 @@
     caliber: Pistol
     magazineType: Pistol
     capacity: 10
-
   - type: Sprite
     netsync: false
     layers:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Uplink now has correct mags for clarissa

