### PR TITLE
Makes RnD less useless

### DIFF
--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -10,7 +10,7 @@
   icon:
     sprite: Constructible/Power/server.rsi
     state: server-on
-  requiredPoints: 250
+  requiredPoints: 2500
 
 # Biological Technology Tree
 
@@ -21,9 +21,12 @@
   icon:
     sprite: Constructible/Misc/potted_plants.rsi
     state: applebush
-  requiredPoints: 1000
+  requiredPoints: 10000
   requiredTechnologies:
     - BasicResearch
+  unlockedRecipes:
+    - Scythe
+    - Hatchet
 
 - type: technology
   name: "advanced botany"
@@ -32,9 +35,11 @@
   icon:
     sprite: Objects/Specific/Hydroponics/potato.rsi
     state: seed
-  requiredPoints: 1500
+  requiredPoints: 15000
   requiredTechnologies:
     - BiologicalTechnology
+  unlockedRecipes:
+    - Shovel
 
 - type: technology
   name: "advanced surgery"
@@ -43,9 +48,16 @@
   icon:
     sprite: Objects/Specific/Medical/Surgery/saw.rsi
     state: saw
-  requiredPoints: 1500
+  requiredPoints: 15000
   requiredTechnologies:
     - BiologicalTechnology
+  unlockedRecipes:
+    - Scalpel
+    - Retractor
+    - Cautery
+    - Drill
+    - BoneSaw
+    - Hemostat
 
 # Chemistry Technology Tree
 
@@ -56,9 +68,14 @@
   icon:
     sprite: Objects/Specific/Chemistry/beaker_large.rsi
     state: beakerlarge
-  requiredPoints: 1000
+  requiredPoints: 10000
   requiredTechnologies:
     - BasicResearch
+  unlockedRecipes:
+    - Beaker
+    - LargeBeaker
+    - Dropper
+    - Syringe
 
 # Security Technology Tree
 
@@ -69,66 +86,70 @@
   icon:
     sprite: Objects/Weapons/Melee/stunbaton.rsi
     state: stunbaton_off
-  requiredPoints: 1000
+  requiredPoints: 10000
   requiredTechnologies:
     - BasicResearch
+  unlockedRecipes:
+    - Flash
+    - Handcuffs
+    - Stunbaton
 
-- type: technology
-  name: "ballistic technology"
-  id: BallisticTechnology
-  description: Just a fancy term for guns.
-  icon:
-    sprite: Objects/Weapons/Guns/Pistols/clarissa.rsi
-    state: icon
-  requiredPoints: 1500
-  requiredTechnologies:
-    - SecurityTechnology
-
-- type: technology
-  name: "direct energy technology"
-  id: DirectEnergyTechnology
-  description: Basically laser guns.
-  icon:
-    sprite: Objects/Weapons/Guns/Battery/taser.rsi
-    state: icon
-  requiredPoints: 1500
-  requiredTechnologies:
-    - SecurityTechnology
-
-- type: technology
-  name: "explosives technology"
-  id: ExplosivesTechnology
-  description: Let's just start with grenades for now.
-  icon:
-    sprite: Objects/Weapons/Grenades/flashbang.rsi
-    state: icon
-  requiredPoints: 1500
-  requiredTechnologies:
-    - SecurityTechnology
-
-- type: technology
-  name: "armor technology"
-  id: ArmorTechnology
-  description: Basic protective gear for security personnel.
-  icon:
-    sprite: Clothing/OuterClothing/Vests/kevlar.rsi
-    state: icon
-  requiredPoints: 1500
-  requiredTechnologies:
-    - SecurityTechnology
+# - type: technology
+#   name: "ballistic technology"
+#   id: BallisticTechnology
+#   description: Just a fancy term for guns.
+#   icon:
+#     sprite: Objects/Weapons/Guns/Pistols/clarissa.rsi
+#     state: icon
+#   requiredPoints: 15000
+#   requiredTechnologies:
+#     - SecurityTechnology
+#
+# - type: technology
+#   name: "direct energy technology"
+#   id: DirectEnergyTechnology
+#   description: Basically laser guns.
+#   icon:
+#     sprite: Objects/Weapons/Guns/Battery/taser.rsi
+#     state: icon
+#   requiredPoints: 15000
+#   requiredTechnologies:
+#     - SecurityTechnology
+#
+# - type: technology
+#   name: "explosives technology"
+#   id: ExplosivesTechnology
+#   description: Let's just start with grenades for now.
+#   icon:
+#     sprite: Objects/Weapons/Grenades/flashbang.rsi
+#     state: icon
+#   requiredPoints: 15000
+#   requiredTechnologies:
+#     - SecurityTechnology
+#
+# - type: technology
+#   name: "armor technology"
+#   id: ArmorTechnology
+#   description: Basic protective gear for security personnel.
+#   icon:
+#     sprite: Clothing/OuterClothing/Vests/kevlar.rsi
+#     state: icon
+#   requiredPoints: 15000
+#   requiredTechnologies:
+#     - SecurityTechnology
 
 # Data Theory Technology Tree
 
-- type: technology
-  name: "data theory"
-  id: DataTheory
-  description: Just like regular data, but in space!
-  icon:
-    sprite: Constructible/Power/computers.rsi
-    state: computer-datatheory
-  requiredPoints: 1000
-  requiredTechnologies:
-    - BasicResearch
+# - type: technology
+#   name: "data theory"
+#   id: DataTheory
+#   description: Just like regular data, but in space!
+#   icon:
+#     sprite: Constructible/Power/computers.rsi
+#     state: computer-datatheory
+#   requiredPoints: 10000
+#   requiredTechnologies:
+#     - BasicResearch
 
 # Industrial Engineering Technology Tree
 
@@ -139,18 +160,20 @@
   icon:
     sprite: Constructible/Power/protolathe.rsi
     state: icon
-  requiredPoints: 1000
+  requiredPoints: 10000
   requiredTechnologies:
     - BasicResearch
   unlockedRecipes:
     - ConveyorAssembly
+    - RCD
+    - RCDAmmo
 
 - type: technology
   name: material sheet printing
   id: Sheets
   description: Print those sheets!
   icon: Objects/Materials/Sheets/researchicon.png
-  requiredPoints: 250
+  requiredPoints: 2500
   requiredTechnologies:
     - IndustrialEngineering
   unlockedRecipes:
@@ -166,19 +189,23 @@
   icon:
     sprite: Constructible/Power/apc.rsi
     state: apcewires
-  requiredPoints: 1000
+  requiredPoints: 10000
   requiredTechnologies:
     - BasicResearch
+  unlockedRecipes:
+    - CableStack
+    - LightTube
+    - LightBulb
 
 # Bluespace Theory Technology Tree
 
-- type: technology
-  name: "basic bluespace theory"
-  id: BluespaceTheory
-  description: An experimental course on the mysterious technology known as bluespace.
-  icon:
-    sprite: Objects/Misc/skub.rsi
-    state: icon
-  requiredPoints: 1000
-  requiredTechnologies:
-    - BasicResearch
+# - type: technology
+#   name: "basic bluespace theory"
+#   id: BluespaceTheory
+#   description: An experimental course on the mysterious technology known as bluespace.
+#   icon:
+#     sprite: Objects/Misc/skub.rsi
+#     state: icon
+#   requiredPoints: 999999
+#   requiredTechnologies:
+#     - BasicResearch

--- a/Resources/Prototypes/Entities/Constructible/Power/lathe.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/lathe.yml
@@ -76,20 +76,13 @@
     recipes:
       - Brutepack
       - Ointment
-      - LightTube
-      - LightBulb
-      - SheetSteel
-      - GlassStack
       - Wirecutter
       - Screwdriver
       - Welder
       - Wrench
-      - CableStack
       - Crowbar
       - Multitool
       - MiniHoe
-      - Scythe
-      - Hatchet
       - Shovel
       - Spade
   - type: Appearance
@@ -139,20 +132,31 @@
   - type: TechnologyDatabase
   - type: ProtolatheDatabase
     protolatherecipes:
-      - Brutepack
-      - Ointment
       - LightTube
       - LightBulb
       - SheetSteel
       - GlassStack
-      - Wirecutter
-      - Screwdriver
-      - Welder
-      - Wrench
       - CableStack
-      - Crowbar
-      - Multitool
       - ConveyorAssembly
+      - RCD
+      - RCDAmmo
+      - Scythe
+      - Hatchet
+      - Shovel
+      - Scalpel
+      - Retractor
+      - Cautery
+      - Drill
+      - BoneSaw
+      - Hemostat
+      - Beaker
+      - LargeBeaker
+      - Dropper
+      - Syringe
+      - Flash
+      - Handcuffs
+      - Stunbaton
+
   - type: UserInterface
     interfaces:
     - key: enum.LatheUiKey.Key

--- a/Resources/Prototypes/Entities/Constructible/Specific/Research/research.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Research/research.yml
@@ -51,7 +51,7 @@
         - Opaque
         - MobImpassable
   - type: ResearchPointSource
-    pointspersecond: 1000
+    pointspersecond: 100
     active: true
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -20,7 +20,9 @@
 
 - type: latheRecipe
   id: Dropper
-  icon: Objects/Specific/Chemistry/dropper.rsi
+  icon:
+    sprite: Objects/Specific/Chemistry/dropper.rsi
+    state: dropper
   result: Dropper
   completetime: 500
   materials:
@@ -28,16 +30,10 @@
 
 - type: latheRecipe
   id: Syringe
-  icon: Objects/Specific/Chemistry/syringe.rsi
+  icon:
+    sprite: Objects/Specific/Chemistry/syringe.rsi
+    state: syringe_base0
   result: Syringe
   completetime: 500
   materials:
     glass: 50
-
-- type: latheRecipe
-  id: bottle
-  icon: Objects/Specific/Chemistry/bottle.rsi
-  result: bottle
-  completetime: 500
-  materials:
-    glass: 60

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -1,6 +1,8 @@
 - type: latheRecipe
   id: Handcuffs
-  icon: Objects/Misc/handcuffs.rsi
+  icon:
+    sprite: Objects/Misc/handcuffs.rsi
+    state: handcuff
   result: Handcuffs
   completetime: 500
   materials:
@@ -8,7 +10,9 @@
 
 - type: latheRecipe
   id: Stunbaton
-  icon: Objects/Weapons/Melee/stunbaton.rsi
+  icon:
+    sprite: Objects/Weapons/Melee/stunbaton.rsi
+    state: stunbaton_off
   result: Stunbaton
   completetime: 500
   materials:
@@ -17,7 +21,9 @@
 
 - type: latheRecipe
   id: Flash
-  icon: Objects/Weapons/Melee/flash.rsi
+  icon:
+    sprite: Objects/Weapons/Melee/flash.rsi
+    state: flash
   result: Flash
   completetime: 500
   materials:

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -96,7 +96,7 @@
   id: RCD
   icon:
     sprite: Objects/Tools/rcd.rsi
-    state: rcd
+    state: icon
   result: RCD
   completetime: 1000
   materials:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR just ties a bunch of the protolathe recipes to the technologies we have.

It also: 
- Comments out technologies that don't do anything.
- Removes some recipe from the autolathe that could go in the protolathe.
- Adds a zero to the end of every existing technology point requirement.
- Nerfs point gen to 100

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Swept
- add: The technology recipes actually unlock recipes for the protolathe!
- tweak: Some things can no longer be built in the autolathe
- tweak: Nerfs point gen to 100 (REMEMBER TO PRESS SYNC TO GET YOUR POINTS ON CONSOLE)

