### PR TITLE
Disable pulling collision

### DIFF
--- a/Content.Shared/GameObjects/Components/Pulling/SharedPullableComponent.cs
+++ b/Content.Shared/GameObjects/Components/Pulling/SharedPullableComponent.cs
@@ -152,7 +152,7 @@ namespace Content.Shared.GameObjects.Components.Pulling
                     _physics.WakeBody();
                     _pullJoint = pullerPhysics.CreateDistanceJoint(_physics);
                     // _physics.BodyType = BodyType.Kinematic; // TODO: Need to consider their original bodytype
-                    _pullJoint.CollideConnected = true;
+                    _pullJoint.CollideConnected = false;
                     _pullJoint.Length = length * 0.75f;
                     _pullJoint.MaxLength = length;
                 }


### PR DESCRIPTION
Realistically I need to revert and modify the old pulling system but this is a stopgap for now. At least it's helped me with debugging joints.

:cl:
- tweak: Pulling collision disabled again
