### PR TITLE
Change anchorable snap default to true

### DIFF
--- a/Content.Server/GameObjects/Components/AnchorableComponent.cs
+++ b/Content.Server/GameObjects/Components/AnchorableComponent.cs
@@ -31,7 +31,7 @@ namespace Content.Server.GameObjects.Components
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("snap")]
-        public bool Snap { get; private set; }
+        public bool Snap { get; private set; } = true;
 
         public override void Initialize()
         {

--- a/Resources/Prototypes/Entities/Constructible/Doors/airlock_base.yml
+++ b/Resources/Prototypes/Entities/Constructible/Doors/airlock_base.yml
@@ -102,7 +102,6 @@
       - MobImpassable
       - VaultImpassable
   - type: Anchorable
-    snap: true
   - type: Pullable
   - type: SnapGrid
     offset: Center

--- a/Resources/Prototypes/Entities/Constructible/Furniture/seats.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/seats.yml
@@ -42,7 +42,6 @@
   parent: SeatBase
   components:
   - type: Anchorable
-    snap: true
   - type: Rotatable
   - type: Sprite
     state: chair
@@ -68,7 +67,6 @@
   description: Apply butt.
   components:
   - type: Anchorable
-    snap: true
   - type: Sprite
     state: stool_base
     color: "#8e9799"
@@ -92,7 +90,6 @@
   parent: SeatBase
   components:
   - type: Anchorable
-    snap: true
   - type: Sprite
     state: bar_stool
   - type: Physics
@@ -149,7 +146,6 @@
   description: It looks comfy.
   components:
   - type: Anchorable
-    snap: true
   - type: Sprite
     state: comfychair_preview
   - type: Physics

--- a/Resources/Prototypes/Entities/Constructible/Furniture/storage.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/storage.yml
@@ -24,7 +24,6 @@
       - VaultImpassable
   - type: Pullable
   - type: Anchorable
-    snap: true
   - type: Damageable
     resistances: metallicResistances
   - type: Destructible

--- a/Resources/Prototypes/Entities/Constructible/Ground/kitchen.yml
+++ b/Resources/Prototypes/Entities/Constructible/Ground/kitchen.yml
@@ -21,5 +21,4 @@
         acts: ["Destruction"]
   - type: KitchenSpike
   - type: Anchorable
-    snap: true
   - type: Pullable

--- a/Resources/Prototypes/Entities/Constructible/Power/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/vending_machines.yml
@@ -43,7 +43,6 @@
     BoardName: "Vending Machine"
     LayoutId: Vending
   - type: Anchorable
-    snap: true
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/AME/controller.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/AME/controller.yml
@@ -43,7 +43,6 @@
   - type: SnapGrid
     offset: Center
   - type: Anchorable
-    snap: true
   - type: Pullable
   - type: AMEController
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/PA/base.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/PA/base.yml
@@ -6,7 +6,6 @@
   components:
     - type: InteractionOutline
     - type: Anchorable
-      snap: true
     - type: Physics
       bodyType: Static
       fixtures:

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/collector.yml
@@ -40,5 +40,4 @@
       nodeGroupID: HVPower
   - type: RadiationCollector
   - type: Anchorable
-    snap: true
   - type: Pullable

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/containment.yml
@@ -33,7 +33,6 @@
     state: icon
   - type: ContainmentFieldGenerator
   - type: Anchorable
-    snap: true
   - type: Pullable
   - type: PointLight
     enabled: false

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/emitter.yml
@@ -59,7 +59,6 @@
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
   - type: Anchorable
-    snap: true
   - type: Pullable
   - type: Rotatable
   - type: Appearance

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/generator.yml
@@ -25,5 +25,4 @@
   - type: SnapGrid
     offset: Center
   - type: Anchorable
-    snap: true
   - type: Pullable

--- a/Resources/Prototypes/Entities/Constructible/Specific/Medical/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Medical/medical_scanner.yml
@@ -29,7 +29,6 @@
   - type: SnapGrid
     offset: Center
   - type: Anchorable
-    snap: true
   - type: Pullable
   - type: MedicalScanner
   - type: Damageable

--- a/Resources/Prototypes/Entities/Constructible/Specific/chem_master.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/chem_master.yml
@@ -19,7 +19,6 @@
   - type: PowerReceiver
   - type: InteractionOutline
   - type: Anchorable
-    snap: true
   - type: Physics
     bodyType: Static
     fixtures:

--- a/Resources/Prototypes/Entities/Constructible/Specific/disposal.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/disposal.yml
@@ -145,7 +145,6 @@
       - Opaque
       - MobImpassable
   - type: Anchorable
-    snap: true
   - type: Damageable
     resistances: metallicResistances
   - type: Destructible

--- a/Resources/Prototypes/Entities/Constructible/Specific/hydroponics.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/hydroponics.yml
@@ -66,7 +66,6 @@
       mask:
       - Impassable
   - type: Anchorable
-    snap: true
   - type: Pullable
   - type: Sprite
     sprite: Constructible/Hydroponics/containers.rsi

--- a/Resources/Prototypes/Entities/Constructible/Watercloset/toilet.yml
+++ b/Resources/Prototypes/Entities/Constructible/Watercloset/toilet.yml
@@ -6,7 +6,6 @@
   description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.
   components:
   - type: Anchorable
-    snap: true
   - type: Sprite
     sprite: Constructible/Watercloset/toilet.rsi
     state: closed_toilet_seat_up

--- a/Resources/Prototypes/Entities/Constructible/base.yml
+++ b/Resources/Prototypes/Entities/Constructible/base.yml
@@ -42,5 +42,4 @@
       mask:
       - VaultImpassable
   - type: Anchorable
-    snap: true
   - type: Pullable


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes AnchorableComponent.SnapGrid default to true so that YAML definitions don't need to keep adding `snap: true`, since most of them want it to snap to grid.
