### PR TITLE
Gas canisters HP buffed and now spawn broken version

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Piping/gascanisters.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/gascanisters.yml
@@ -368,12 +368,12 @@
       sprite: Constructible/Atmos/canister.rsi
       state: grey-1
     - type: Physics
-      mass: 25
       bodyType: Dynamic
       fixtures:
         - shape:
             !type:PhysShapeAabb
               bounds: "-0.3,-0.4,0.3,0.4"
+          mass: 25
           mask:
             - MobImpassable
           layer:

--- a/Resources/Prototypes/Entities/Constructible/Piping/gascanisters.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/gascanisters.yml
@@ -8,6 +8,7 @@
     offset: Center
   - type: Sprite
   - type: Damageable
+    resistances: metallicResistances
   - type: Physics
     bodyType: Dynamic
     fixtures:
@@ -57,6 +58,21 @@
     interfaces:
       - key: enum.GasCanisterUiKey.Key
         type: GasCanisterBoundUserInterface
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound: /Audio/Effects/metalbreak.ogg
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          GasCanisterBrokenBase:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: GasCanister
@@ -77,6 +93,21 @@
           - 0 # Tritium
           - 0 # Water vapor
         temperature: 293.15
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound: /Audio/Effects/metalbreak.ogg
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            StorageCanisterBroken:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 # Filled canisters, contain 1871.71051 moles each
 
@@ -95,6 +126,21 @@
         - 393.0592071 # oxygen 21%
         - 1478.6513029 # nitrogen 79%
       temperature: 293.15
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound: /Audio/Effects/metalbreak.ogg
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          AirCanisterBroken:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: GasCanister
@@ -110,6 +156,21 @@
       moles:
         - 1871.71051 # oxygen
       temperature: 293.15
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound: /Audio/Effects/metalbreak.ogg
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          OxygenCanisterBroken:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: GasCanister
@@ -126,6 +187,21 @@
           - 0 # oxygen
           - 1871.71051 # nitrogen
         temperature: 293.15
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound: /Audio/Effects/metalbreak.ogg
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            NitrogenCanisterBroken:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   parent: GasCanister
@@ -143,6 +219,21 @@
           - 0 # nitrogen
           - 1871.71051 # CO2
         temperature: 293.15
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound: /Audio/Effects/metalbreak.ogg
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            CarbonDioxideCanisterBroken:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   parent: GasCanister
@@ -161,6 +252,21 @@
           - 0 # carbon dioxide
           - 1871.71051 # plasma
         temperature: 293.15
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound: /Audio/Effects/metalbreak.ogg
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            PlasmaCanisterBroken:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   parent: GasCanister
@@ -180,6 +286,21 @@
           - 0 # Plasma
           - 1871.71051 # Tritium
         temperature: 293.15
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound: /Audio/Effects/metalbreak.ogg
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            TritiumCanisterBroken:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   parent: GasCanister
@@ -200,3 +321,135 @@
           - 0 # Tritium
           - 1871.71051 # Water vapor
         temperature: 293.15
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound: /Audio/Effects/metalbreak.ogg
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            WaterVaporCanisterBroken:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+
+# Broke Entities
+
+- type: entity
+  parent: BaseConstructible
+  id: GasCanisterBrokenBase
+  name: broken gas canister
+  description: A broken gas canister. Not useless yet, as it can be salvaged for high quality materials.
+  abstract: true
+  components:
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound: /Audio/Effects/metalbreak.ogg
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            SheetPlasteel1:
+              min: 1
+              max: 2
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+    - type: Damageable
+      resistances: metallicResistances
+    - type: InteractionOutline
+    - type: Sprite
+      sprite: Constructible/Atmos/canister.rsi
+      state: grey-1
+    - type: Physics
+      mass: 25
+      bodyType: Dynamic
+      fixtures:
+        - shape:
+            !type:PhysShapeAabb
+              bounds: "-0.3,-0.4,0.3,0.4"
+          mask:
+            - MobImpassable
+          layer:
+            - Opaque
+            - MobImpassable
+            - SmallImpassable
+            - VaultImpassable
+
+- type: entity
+  parent: GasCanisterBrokenBase
+  id: StorageCanisterBroken
+  name: broken storage canister
+  abstract: true
+  components:
+    - type: Sprite
+      state: yellow-1
+
+- type: entity
+  parent: GasCanisterBrokenBase
+  id: AirCanisterBroken
+  name: broken air canister
+  abstract: true
+  components:
+  - type: Sprite
+    state: grey-1
+
+- type: entity
+  parent: GasCanisterBrokenBase
+  id: OxygenCanisterBroken
+  name: broken oxygen canister
+  abstract: true
+  components:
+  - type: Sprite
+    state: blue-1
+
+- type: entity
+  parent: GasCanisterBrokenBase
+  id: NitrogenCanisterBroken
+  name: broken nitrogen canister
+  abstract: true
+  components:
+    - type: Sprite
+      state: red-1
+
+- type: entity
+  parent: GasCanisterBrokenBase
+  id: CarbonDioxideCanisterBroken
+  name: broken carbon dioxide canister
+  abstract: true
+  components:
+    - type: Sprite
+      state: black-1
+
+- type: entity
+  parent: GasCanisterBrokenBase
+  id: PlasmaCanisterBroken
+  name: broken plasma canister
+  abstract: true
+  components:
+    - type: Sprite
+      state: orange-1
+
+- type: entity
+  parent: GasCanisterBrokenBase
+  id: TritiumCanisterBroken
+  name: broken tritium canister
+  abstract: true
+  components:
+    - type: Sprite
+      state: green-1
+
+- type: entity
+  parent: GasCanisterBrokenBase
+  id: WaterVaporCanisterBroken
+  name: broken water vapor canister
+  abstract: true
+  components:
+    - type: Sprite
+      state: water_vapor-1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Buffed the HP of the gas canisters a little and they now spawn their busted counterpart when destroyed. This can then be broken more into some plasteel.

I know these don't leak gas after being destroyed but that's out of my skillset and until that's added this is fine.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![112746379-ea642080-8f9d-11eb-9b86-245149a52c56](https://user-images.githubusercontent.com/49448379/113386065-eb6bc800-9378-11eb-820f-6af28e681848.gif)
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Swept
- add: Destroyed state for canisters
- tweak: Buffed canister HP from 100 to 300

