### PR TITLE
Sets rack/shelf drawDepth to be under objects

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Furniture/storage.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/storage.yml
@@ -11,6 +11,7 @@
   - type: Sprite
     sprite: Constructible/Misc/furniture.rsi
     state: rack
+    drawdepth: FloorObjects
   - type: Physics
     bodyType: Static
     fixtures:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This just makes it so items can't be under it.

