### PR TITLE
Buffed hardsuit light to last longer and recharge

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base.yml
@@ -58,4 +58,4 @@
     # so hardsuit helmet just have small battery inside
   - type: HandheldLight
   - type: PowerCellSlot
-    startingCellType: PowerCellSmallHigh
+    startingCellType: PowerCellHardsuitHelmet

--- a/Resources/Prototypes/Entities/Clothing/Head/base.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base.yml
@@ -59,3 +59,5 @@
   - type: HandheldLight
   - type: PowerCellSlot
     startingCellType: PowerCellHardsuitHelmet
+    canRemoveCell: false
+    showVerb: false

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -157,6 +157,27 @@
           prefix: s_ar
 
 - type: entity
+  name: hardsuit helmet power cell
+  description: A small cell that recharges itself intended for hardsuit helmets.
+  id: PowerCellHardsuitHelmet
+  parent: PowerCellSmallBase
+  components:
+    - type: Sprite
+      sprite: Objects/Power/PowerCells/power_cell_small_autorecharge.rsi
+      layers:
+        - state: s_ar
+    - type: PowerCell
+      maxCharge: 600 #lights drain 3/s but recharge of 2 makes this 1/s. Therefore 600 is 10 minutes of light.
+      startingCharge: 600
+      autoRecharge: true
+      autoRechargeRate: 2 #recharge of 2 makes total drain 1w / s so max charge is 1:1 with time. Time to fully charge should be 5 minutes. Having recharge gives light an extended flicker period which gives you some warning to return to light area.
+    - type: Appearance
+      visuals:
+        - type: PowerCellVisualizer
+          prefix: s_ar
+
+
+- type: entity
   name: medium standard power cell
   description: A rechargeable standardized power cell, size M. This is the cheapest kind you can find.
   id: PowerCellMediumStandard


### PR DESCRIPTION
As per title, made a power cell for the hardsuit that lasts 10 minutes and recharges over 5 minutes when off.

Because of the recharge rate the light also flickers for much longer when in it's lowest power level so gives the user lots of time to get back to a lit area and gives off some pants *hitting vibes in some situations.

closes #3138 and is the solution defined there. 

Tested locally in real time and thus found #3815 during testing. Not game breaking but expect some related bug reports at some point on discord when people notice it. Also noticed a crash when trying to turn the light on repeatedly when it was in flicker state but have not recreated yet. Not related to this PR but the recharge makes it possible.



**technical details**
Because flashlights drain at 3w per second and the recharge rate is set to 2w per second it technically recharges constantly but net power is -1 when on so it still drains. This makes the max charge a 1:1 ratio with the light power on time so 600 charge is 600 seconds or 10 minutes.

**Changelog**
- fix: Buffed hardsuit light to last 10 minutes and recharge over 5 minutes when off.
- fix: Made hardsuit helmet power cell non removable.

