### PR TITLE
Nodes in entities are now named.

### DIFF
--- a/Content.IntegrationTests/Tests/Construction/ConstructionActionValid.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionActionValid.cs
@@ -59,7 +59,7 @@ namespace Content.IntegrationTests.Tests.Construction
 
             foreach (var graph in protoMan.EnumeratePrototypes<ConstructionGraphPrototype>())
             {
-                foreach (var (_, node) in graph.Nodes)
+                foreach (var node in graph.Nodes.Values)
                 {
                     foreach (var action in node.Actions)
                     {
@@ -99,7 +99,7 @@ namespace Content.IntegrationTests.Tests.Construction
 
             foreach (var graph in protoMan.EnumeratePrototypes<ConstructionGraphPrototype>())
             {
-                foreach (var (_, node) in graph.Nodes)
+                foreach (var node in graph.Nodes.Values)
                 {
                     if (string.IsNullOrEmpty(node.Entity) || protoMan.TryIndex(node.Entity, out EntityPrototype _)) continue;
 
@@ -125,7 +125,7 @@ namespace Content.IntegrationTests.Tests.Construction
 
             foreach (var graph in protoMan.EnumeratePrototypes<ConstructionGraphPrototype>())
             {
-                foreach (var (_, node) in graph.Nodes)
+                foreach (var node in graph.Nodes.Values)
                 {
                     foreach (var edge in node.Edges)
                     {

--- a/Content.IntegrationTests/Tests/PowerTest.cs
+++ b/Content.IntegrationTests/Tests/PowerTest.cs
@@ -23,8 +23,9 @@ namespace Content.IntegrationTests.Tests
   components:
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      output:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerSupplier
     supplyRate: 3000
   - type: Anchorable
@@ -39,8 +40,9 @@ namespace Content.IntegrationTests.Tests
     offset: Center
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      input:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerConsumer
     drawRate: 50
 
@@ -53,10 +55,12 @@ namespace Content.IntegrationTests.Tests
     startingCharge: 1000
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
-    - !type:AdjacentNode
-      nodeGroupID: MVPower
+      input:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
+      output:
+        !type:AdjacentNode
+        nodeGroupID: MVPower
   - type: PowerConsumer
   - type: BatteryStorage
     activeDrawRate: 1500
@@ -84,10 +88,12 @@ namespace Content.IntegrationTests.Tests
     voltage: Medium
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: MVPower
-    - !type:AdjacentNode
-      nodeGroupID: Apc
+      input:
+        !type:AdjacentNode
+        nodeGroupID: MVPower
+      output:
+        !type:AdjacentNode
+        nodeGroupID: Apc
   - type: SnapGrid
     offset: Center
   - type: UserInterface
@@ -103,10 +109,12 @@ namespace Content.IntegrationTests.Tests
   components:
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: Apc
-    - !type:AdjacentNode
-      nodeGroupID: WireNet
+      apc:
+        !type:AdjacentNode
+        nodeGroupID: Apc
+      wire:
+        !type:AdjacentNode
+        nodeGroupID: WireNet
   - type: PowerProvider
     voltage: Apc
   - type: Wire

--- a/Content.Server/DeviceNetwork/NetworkConnections/WiredNetworkConnection.cs
+++ b/Content.Server/DeviceNetwork/NetworkConnections/WiredNetworkConnection.cs
@@ -70,7 +70,7 @@ namespace Content.Server.GameObjects.EntitySystems.DeviceNetwork
             {
                 var nodes = nodeContainer.Nodes;
 
-                foreach (var node in nodes)
+                foreach (var node in nodes.Values)
                 {
                     if (node.NodeGroupID == NodeGroupID.WireNet)
                     {

--- a/Content.Server/GameObjects/Components/NodeContainer/NodeContainerComponent.cs
+++ b/Content.Server/GameObjects/Components/NodeContainer/NodeContainerComponent.cs
@@ -5,8 +5,6 @@ using Content.Server.GameObjects.Components.NodeContainer.Nodes;
 using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
@@ -22,16 +20,18 @@ namespace Content.Server.GameObjects.Components.NodeContainer
         public override string Name => "NodeContainer";
 
         [ViewVariables]
-        public IReadOnlyList<Node> Nodes => _nodes;
+        public IReadOnlyDictionary<string, Node> Nodes => _nodes;
+
         [DataField("nodes")]
-        private List<Node> _nodes = new();
+        private readonly Dictionary<string, Node> _nodes = new();
+
         [DataField("examinable")]
-        private bool _examinable;
+        private bool _examinable = false;
 
         public override void Initialize()
         {
             base.Initialize();
-            foreach (var node in _nodes)
+            foreach (var node in _nodes.Values)
             {
                 node.Initialize(Owner);
             }
@@ -40,20 +40,9 @@ namespace Content.Server.GameObjects.Components.NodeContainer
         protected override void Startup()
         {
             base.Startup();
-            foreach (var node in _nodes)
+            foreach (var node in _nodes.Values)
             {
                 node.OnContainerStartup();
-            }
-        }
-
-        public override void HandleMessage(ComponentMessage message, IComponent? component)
-        {
-            base.HandleMessage(message, component);
-            switch (message)
-            {
-                case AnchoredChangedMessage:
-                    AnchorUpdate();
-                    break;
             }
         }
 
@@ -61,15 +50,15 @@ namespace Content.Server.GameObjects.Components.NodeContainer
         {
             base.Shutdown();
 
-            foreach (var node in _nodes)
+            foreach (var node in _nodes.Values)
             {
                 node.OnContainerShutdown();
             }
         }
 
-        private void AnchorUpdate()
+        public void AnchorUpdate()
         {
-            foreach (var node in Nodes)
+            foreach (var node in Nodes.Values)
             {
                 node.AnchorUpdate();
             }
@@ -79,28 +68,24 @@ namespace Content.Server.GameObjects.Components.NodeContainer
         {
             if (!_examinable || !inDetailsRange) return;
 
-            for (var i = 0; i < Nodes.Count; i++)
+            foreach (var node in Nodes.Values)
             {
-                var node = Nodes[i];
                 if (node == null) continue;
                 switch (node.NodeGroupID)
                 {
                     case NodeGroupID.HVPower:
                         message.AddMarkup(
-                            Loc.GetString("It has a connector for [color=orange]HV cables[/color]."));
+                            Loc.GetString("It has a connector for [color=orange]HV cables[/color].\n"));
                         break;
                     case NodeGroupID.MVPower:
                         message.AddMarkup(
-                            Loc.GetString("It has a connector for [color=yellow]MV cables[/color]."));
+                            Loc.GetString("It has a connector for [color=yellow]MV cables[/color].\n"));
                         break;
                     case NodeGroupID.Apc:
                         message.AddMarkup(
-                            Loc.GetString("It has a connector for [color=green]APC cables[/color]."));
+                            Loc.GetString("It has a connector for [color=green]APC cables[/color].\n"));
                         break;
                 }
-
-                if(i != Nodes.Count - 1)
-                    message.AddMarkup("\n");
             }
         }
     }

--- a/Content.Server/GameObjects/Components/NodeContainer/Nodes/AdjacentNode.cs
+++ b/Content.Server/GameObjects/Components/NodeContainer/Nodes/AdjacentNode.cs
@@ -13,26 +13,22 @@ namespace Content.Server.GameObjects.Components.NodeContainer.Nodes
     {
         protected override IEnumerable<Node> GetReachableNodes()
         {
-            if (!Owner.TryGetComponent(out SnapGridComponent? grid))
+            if (!Owner.TryGetComponent(out SnapGridComponent? snap))
                 yield break;
 
-            var cells = grid.GetCardinalNeighborCells();
-
-            foreach (var cell in cells)
+            foreach (var cell in snap.GetCardinalNeighborCells())
+            foreach (var entity in cell.GetLocal())
             {
-                foreach (var entity in cell.GetLocal())
+                if (!entity.TryGetComponent<NodeContainerComponent>(out var container)) continue;
+
+                foreach (var node in container.Nodes.Values)
                 {
-                    if (entity.TryGetComponent<NodeContainerComponent>(out var container))
+                    if (node != null && node != this)
                     {
-                        foreach (var node in container.Nodes)
-                        {
-                            if (node != null && node != this)
-                            {
-                                yield return node;
-                            }
-                        }
+                        yield return node;
                     }
                 }
+
             }
         }
     }

--- a/Content.Server/GameObjects/Components/NodeContainer/Nodes/PipeNode.cs
+++ b/Content.Server/GameObjects/Components/NodeContainer/Nodes/PipeNode.cs
@@ -179,7 +179,7 @@ namespace Content.Server.GameObjects.Components.NodeContainer.Nodes
                 if (!entity.TryGetComponent<NodeContainerComponent>(out var container))
                     continue;
 
-                foreach (var node in container.Nodes)
+                foreach (var node in container.Nodes.Values)
                 {
                     if (node is PipeNode pipe)
                         yield return pipe;
@@ -243,7 +243,7 @@ namespace Content.Server.GameObjects.Components.NodeContainer.Nodes
             var netConnectedDirections = PipeDirection.None;
             if (Owner.TryGetComponent<NodeContainerComponent>(out var container))
             {
-                foreach (var node in container.Nodes)
+                foreach (var node in container.Nodes.Values)
                 {
                     if (node is PipeNode pipe)
                     {

--- a/Content.Server/GameObjects/Components/Power/AME/AMEControllerComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/AME/AMEControllerComponent.cs
@@ -286,7 +286,7 @@ namespace Content.Server.GameObjects.Components.Power.AME
         {
             Owner.TryGetComponent(out NodeContainerComponent? nodeContainer);
 
-            var engineNodeGroup = nodeContainer?.Nodes
+            var engineNodeGroup = nodeContainer?.Nodes.Values
             .Select(node => node.NodeGroup)
             .OfType<AMENodeGroup>()
             .FirstOrDefault();

--- a/Content.Server/GameObjects/Components/Power/BaseNetConnectorComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/BaseNetConnectorComponent.cs
@@ -69,7 +69,7 @@ namespace Content.Server.GameObjects.Components.Power
         {
             if (Owner.TryGetComponent<NodeContainerComponent>(out var container))
             {
-                var compatibleNet = container.Nodes
+                var compatibleNet = container.Nodes.Values
                     .Where(node => node.NodeGroupID == (NodeGroupID) Voltage)
                     .Select(node => node.NodeGroup)
                     .OfType<TNetType>()

--- a/Content.Server/GameObjects/EntitySystems/NodeContainerSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/NodeContainerSystem.cs
@@ -13,30 +13,34 @@ namespace Content.Server.GameObjects.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<RotateEvent>(RotateEvent);
+            SubscribeLocalEvent<NodeContainerComponent, PhysicsBodyTypeChangedEvent>(OnBodyTypeChanged);
+            SubscribeLocalEvent<NodeContainerComponent, RotateEvent>(OnRotateEvent);
         }
 
         public override void Shutdown()
         {
             base.Shutdown();
 
-            UnsubscribeLocalEvent<RotateEvent>();
+
+            UnsubscribeLocalEvent<NodeContainerComponent, PhysicsBodyTypeChangedEvent>(OnBodyTypeChanged);
+            UnsubscribeLocalEvent<NodeContainerComponent, RotateEvent>(OnRotateEvent);
         }
 
-        private void RotateEvent(RotateEvent ev)
+        private void OnBodyTypeChanged(EntityUid uid, NodeContainerComponent component, PhysicsBodyTypeChangedEvent args)
         {
-            if (!ev.Sender.TryGetComponent(out NodeContainerComponent? container))
-            {
-                return;
-            }
+            component.AnchorUpdate();
+        }
 
+        private void OnRotateEvent(EntityUid uid, NodeContainerComponent container, RotateEvent ev)
+        {
             if (ev.NewRotation == ev.OldRotation)
             {
                 return;
             }
 
-            foreach (var rotatableNode in container.Nodes.OfType<IRotatableNode>())
+            foreach (var node in container.Nodes.Values)
             {
+                if (node is not IRotatableNode rotatableNode) continue;
                 rotatableNode.RotateEvent(ev);
             }
         }

--- a/Resources/Prototypes/Entities/Constructible/Piping/gascanisterports.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/gascanisterports.yml
@@ -39,6 +39,7 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: South
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: South

--- a/Resources/Prototypes/Entities/Constructible/Piping/gasfilters.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/gasfilters.yml
@@ -40,15 +40,18 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: West
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: South
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: East
+      inlet:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: West
+      filter:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: South
+      outlet:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: East
   - type: GasFilter
     inletDirection: West
     filterOutletDirection: South

--- a/Resources/Prototypes/Entities/Constructible/Piping/gasgenerator.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/gasgenerator.yml
@@ -41,7 +41,8 @@
     - state: gasGenerator
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: Fourway
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: Fourway
 

--- a/Resources/Prototypes/Entities/Constructible/Piping/heaters.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/heaters.yml
@@ -27,8 +27,9 @@
     - state: heaterPipe
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: East
+      inlet:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: East
   - type: PipeHeater
   - type: PipeNetDevice

--- a/Resources/Prototypes/Entities/Constructible/Piping/pipes.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/pipes.yml
@@ -29,7 +29,7 @@
   - type: Icon
     sprite: Constructible/Atmos/pipe.rsi
 
-#Note: The PipeDirection of the PipeNode should be the east-facing version, because the entity starts at an angle of 0 (east)
+#Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (east)
 
 - type: entity
   parent: PipeBase
@@ -38,9 +38,10 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: South
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: South
   - type: Icon
     state: pipeHalf
 
@@ -51,12 +52,13 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: Longitudinal
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: Longitudinal
   - type: Icon
     state: pipeStraight
-    
+
 - type: entity
   parent: PipeBase
   id: PipeBend
@@ -64,12 +66,13 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: SWBend
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: SWBend
   - type: Icon
     state: pipeBend
-    
+
 - type: entity
   parent: PipeBase
   id: PipeTJunction
@@ -77,12 +80,13 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: TSouth
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: TSouth
   - type: Icon
     state: pipeTJunction
-    
+
 - type: entity
   parent: PipeBase
   id: PipeFourway
@@ -90,8 +94,9 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: Fourway
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: Fourway
   - type: Icon
     state: pipeFourway

--- a/Resources/Prototypes/Entities/Constructible/Piping/pumps.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/pumps.yml
@@ -39,12 +39,14 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: North
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: South
+      inlet:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: North
+      outlet:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: South
   - type: PressurePump
     initialInletDirection: North
     initialOutletDirection: South

--- a/Resources/Prototypes/Entities/Constructible/Piping/scrubbers.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/scrubbers.yml
@@ -40,8 +40,9 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: South
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: South
   - type: PressureSiphon
     scrubberOutletDirection: South

--- a/Resources/Prototypes/Entities/Constructible/Piping/vents.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/vents.yml
@@ -40,8 +40,9 @@
   components:
   - type: NodeContainer
     nodes:
-    - !type:PipeNode
-      nodeGroupID: Pipe
-      pipeDirection: South
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: South
   - type: PressureVent
     ventInletDirection: South

--- a/Resources/Prototypes/Entities/Constructible/Power/debug_power.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/debug_power.yml
@@ -24,8 +24,9 @@
     state: wiredmachine
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      input:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerConsumer
     drawRate: 50
   - type: Damageable
@@ -62,8 +63,9 @@
   - type: Battery
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      input:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerConsumer
   - type: BatteryStorage
   - type: Anchorable
@@ -90,8 +92,9 @@
   - type: Battery
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      input:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerSupplier
   - type: BatteryDischarger
   - type: Anchorable

--- a/Resources/Prototypes/Entities/Constructible/Power/power_base.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/power_base.yml
@@ -33,8 +33,9 @@
   - type: NodeContainer
     examinable: true
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      output:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerSupplier
     supplyRate: 3000
   - type: Anchorable
@@ -88,8 +89,9 @@
   - type: NodeContainer
     examinable: true
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      power:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerConsumer
   - type: BatteryStorage
     activeDrawRate: 1500
@@ -144,10 +146,12 @@
   - type: NodeContainer
     examinable: true
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
-    - !type:AdjacentNode
-      nodeGroupID: MVPower
+      input:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
+      output:
+        !type:AdjacentNode
+        nodeGroupID: MVPower
   - type: PowerConsumer
   - type: BatteryStorage
     activeDrawRate: 1500
@@ -196,10 +200,12 @@
   - type: NodeContainer
     examinable: true
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: MVPower
-    - !type:AdjacentNode
-      nodeGroupID: Apc
+      input:
+        !type:AdjacentNode
+        nodeGroupID: MVPower
+      output:
+        !type:AdjacentNode
+        nodeGroupID: Apc
   - type: PowerConsumer
     voltage: Medium
   - type: BatteryStorage
@@ -249,8 +255,9 @@
   - type: NodeContainer
     examinable: true
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      output:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerSupplier
   - type: SolarPanel
     supply: 1500

--- a/Resources/Prototypes/Entities/Constructible/Power/wires.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/wires.yml
@@ -48,10 +48,12 @@
     key: hv_cables
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
-    - !type:AdjacentNode
-      nodeGroupID: WireNet
+      power:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
+      wire:
+        !type:AdjacentNode
+        nodeGroupID: WireNet
   - type: Wire
     wireDroppedOnCutPrototype: HVWireStack1
     wireType: HighVoltage
@@ -88,10 +90,12 @@
     key: mv_cables
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: MVPower
-    - !type:AdjacentNode
-      nodeGroupID: WireNet
+      power:
+        !type:AdjacentNode
+        nodeGroupID: MVPower
+      wire:
+        !type:AdjacentNode
+        nodeGroupID: WireNet
   - type: Wire
     wireDroppedOnCutPrototype: MVWireStack1
     wireType: MediumVoltage
@@ -128,10 +132,12 @@
     key: lv_cables
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: Apc
-    - !type:AdjacentNode
-      nodeGroupID: WireNet
+      power:
+        !type:AdjacentNode
+        nodeGroupID: Apc
+      wire:
+        !type:AdjacentNode
+        nodeGroupID: WireNet
   - type: PowerProvider
     voltage: Apc
   - type: Wire

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/AME/controller.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/AME/controller.yml
@@ -55,10 +55,12 @@
   - type: NodeContainer
     examinable: true
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: AMEngine
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      ame:
+        !type:AdjacentNode
+        nodeGroupID: AMEngine
+      input:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: PowerReceiver
   - type: PowerSupplier
     supplyRate: 0

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/AME/shielding.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/AME/shielding.yml
@@ -45,8 +45,9 @@
   - type: AMEShield
   - type: NodeContainer
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: AMEngine
+      ame:
+        !type:AdjacentNode
+        nodeGroupID: AMEngine
   - type: PointLight
     enabled: false
     radius: 5

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/PA/power_box.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/PA/power_box.yml
@@ -23,7 +23,8 @@
     - type: NodeContainer
       examinable: true
       nodes:
-        - !type:AdjacentNode
+        input:
+          !type:AdjacentNode
           nodeGroupID: HVPower
     - type: Construction
       graph: particleAcceleratorPowerBox

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/collector.yml
@@ -36,8 +36,9 @@
   - type: NodeContainer
     examinable: true
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: HVPower
+      input:
+        !type:AdjacentNode
+        nodeGroupID: HVPower
   - type: RadiationCollector
   - type: Anchorable
   - type: Pullable

--- a/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Engines/Singularity/emitter.yml
@@ -39,8 +39,9 @@
   - type: NodeContainer
     examinable: true
     nodes:
-    - !type:AdjacentNode
-      nodeGroupID: MVPower
+      input:
+        !type:AdjacentNode
+        nodeGroupID: MVPower
   - type: Damageable
     resistances: metallicResistances
   - type: Destructible


### PR DESCRIPTION
Nodes in a NodeContainer are now stored in a dictionary, where the key is the name of the node.
Since a IReadOnlyDictionary is exposed, I didn't add any methods to get nodes from the component.
Note: Now that this is a thing, many current usages of NodeContainer could be updated to use this so a bunch of LINQ usages could be removed. Currently, this PR doesn't change any old code, only updates it to work with this new change.