### PR TITLE
Anchorable component now raises cancellable event on (un)anchor.

### DIFF
--- a/Content.Server/GameObjects/Components/AnchorableComponent.cs
+++ b/Content.Server/GameObjects/Components/AnchorableComponent.cs
@@ -83,6 +83,13 @@ namespace Content.Server.GameObjects.Components
             if (_physicsComponent == null)
                 return false;
 
+            var attempt = new AnchorAttemptMessage();
+
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, attempt);
+
+            if (attempt.Cancelled)
+                return false;
+
             _physicsComponent.BodyType = BodyType.Static;
 
             // Snap rotation to cardinal (multiple of 90)
@@ -120,6 +127,13 @@ namespace Content.Server.GameObjects.Components
             if (_physicsComponent == null)
                 return false;
 
+            var attempt = new UnanchorAttemptMessage();
+
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, attempt);
+
+            if (attempt.Cancelled)
+                return false;
+
             _physicsComponent.BodyType = BodyType.Dynamic;
 
             return true;
@@ -147,4 +161,7 @@ namespace Content.Server.GameObjects.Components
             return await TryToggleAnchor(eventArgs.User, eventArgs.Using);
         }
     }
+
+    public class AnchorAttemptMessage : CancellableEntityEventArgs { }
+    public class UnanchorAttemptMessage : CancellableEntityEventArgs { }
 }

--- a/Content.Server/GameObjects/Components/AnchorableComponent.cs
+++ b/Content.Server/GameObjects/Components/AnchorableComponent.cs
@@ -85,7 +85,7 @@ namespace Content.Server.GameObjects.Components
 
             var attempt = new AnchorAttemptMessage();
 
-            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, attempt);
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, attempt, false);
 
             if (attempt.Cancelled)
                 return false;
@@ -106,6 +106,8 @@ namespace Content.Server.GameObjects.Components
 
             if (Snap)
                 Owner.SnapToGrid(SnapGridOffset.Center, Owner.EntityManager);
+
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new AnchoredMessage(), false);
 
             return true;
         }
@@ -129,12 +131,14 @@ namespace Content.Server.GameObjects.Components
 
             var attempt = new UnanchorAttemptMessage();
 
-            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, attempt);
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, attempt, false);
 
             if (attempt.Cancelled)
                 return false;
 
             _physicsComponent.BodyType = BodyType.Dynamic;
+
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new UnanchoredMessage(), false);
 
             return true;
         }
@@ -164,4 +168,7 @@ namespace Content.Server.GameObjects.Components
 
     public class AnchorAttemptMessage : CancellableEntityEventArgs { }
     public class UnanchorAttemptMessage : CancellableEntityEventArgs { }
+
+    public class AnchoredMessage : EntityEventArgs {}
+    public class UnanchoredMessage : EntityEventArgs {}
 }

--- a/SpaceStation14.sln.DotSettings
+++ b/SpaceStation14.sln.DotSettings
@@ -165,6 +165,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tickrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Trasen/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unanchor/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unanchored/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uncancel/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uncancels/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uncuff/@EntryIndexedValue">True</s:Boolean>

--- a/SpaceStation14.sln.DotSettings
+++ b/SpaceStation14.sln.DotSettings
@@ -165,6 +165,8 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tickrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Trasen/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unanchor/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uncancel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uncancels/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uncuff/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=underplating/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unequip/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Anchorable now raises an (un)anchor attempt directed (but not broadcast) event that can be cancelled by anything that subscribes to it.
This is required for pipenets.

Requires https://github.com/space-wizards/RobustToolbox/pull/1688