### PR TITLE
Content integration tests set ContentStart to true.

### DIFF
--- a/Content.IntegrationTests/ContentIntegrationTest.cs
+++ b/Content.IntegrationTests/ContentIntegrationTest.cs
@@ -28,6 +28,8 @@ namespace Content.IntegrationTests
                 FailureLogLevel = LogLevel.Warning
             };
 
+            options.ContentStart = true;
+
             options.ContentAssemblies = new[]
             {
                 typeof(Shared.EntryPoint).Assembly,
@@ -68,6 +70,8 @@ namespace Content.IntegrationTests
             {
                 FailureLogLevel = LogLevel.Warning
             };
+
+            options.ContentStart = true;
 
             options.ContentAssemblies = new[]
             {


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/1711.
This makes it so tests set ContentStart to true, and therefore gamepack mounting shenanigans work.
Hey, it's better than hardcoding it to check if `Content.Shared.dll` exists in the running folder...