### PR TITLE
Pulling change entity rotation

### DIFF
--- a/Content.Client/GameObjects/Components/Rotatable/RotatableComponent.cs
+++ b/Content.Client/GameObjects/Components/Rotatable/RotatableComponent.cs
@@ -1,0 +1,12 @@
+#nullable enable
+using Content.Shared.GameObjects.Components.Rotatable;
+using Robust.Shared.GameObjects;
+
+namespace Content.Client.GameObjects.Components.Rotatable
+{
+    [RegisterComponent]
+    [ComponentReference(typeof(SharedRotatableComponent))]
+    public class RotatableComponent : SharedRotatableComponent
+    {
+    }
+}

--- a/Content.Client/IgnoredComponents.cs
+++ b/Content.Client/IgnoredComponents.cs
@@ -56,7 +56,6 @@ namespace Content.Client
             "Drink",
             "Food",
             "FoodContainer",
-            "Rotatable",
             "MagicMirror",
             "FloorTile",
             "ShuttleController",

--- a/Content.Server/GameObjects/Components/Rotatable/RotatableComponent.cs
+++ b/Content.Server/GameObjects/Components/Rotatable/RotatableComponent.cs
@@ -1,27 +1,19 @@
-﻿using Content.Shared.GameObjects.EntitySystems.ActionBlocker;
+#nullable enable
+using Content.Shared.GameObjects.Components.Rotatable;
+using Content.Shared.GameObjects.EntitySystems.ActionBlocker;
 using Content.Shared.GameObjects.Verbs;
 using Content.Shared.Interfaces;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Rotatable
 {
     [RegisterComponent]
-    public class RotatableComponent : Component
+    [ComponentReference(typeof(SharedRotatableComponent))]
+    public class RotatableComponent : SharedRotatableComponent
     {
-        public override string Name => "Rotatable";
-
-        /// <summary>
-        ///     If true, this entity can be rotated even while anchored.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("rotateWhileAnchored")]
-        public bool RotateWhileAnchored { get; private set; }
-
         private void TryRotate(IEntity user, Angle angle)
         {
             if (!RotateWhileAnchored && Owner.TryGetComponent(out IPhysBody? physics))

--- a/Content.Shared/GameObjects/Components/Rotatable/SharedRotatableComponent.cs
+++ b/Content.Shared/GameObjects/Components/Rotatable/SharedRotatableComponent.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Shared.GameObjects.Components.Rotatable
+{
+    public abstract class SharedRotatableComponent : Component
+    {
+        public override string Name => "Rotatable";
+
+        /// <summary>
+        ///     If true, this entity can be rotated even while anchored.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("rotateWhileAnchored")]
+        public bool RotateWhileAnchored { get; protected set; }
+
+        /// <summary>
+        ///     If true, will rotate entity in players direction when pulled
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("rotateWhilePulling")]
+        public bool RotateWhilePulling { get; protected set; } = true;
+    }
+}

--- a/Content.Shared/GameObjects/EntitySystems/SharedPullingSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedPullingSystem.cs
@@ -236,7 +236,7 @@ namespace Content.Shared.GameObjects.EntitySystems
 
                 var diff = newAngle - oldAngle;
                 if (Math.Abs(diff.Degrees) > ThresholdRotAngle)
-                    pulled.Transform.LocalRotation = newAngle;
+                    pulled.Transform.WorldRotation = newAngle;
             }
         }
     }

--- a/Content.Shared/GameObjects/EntitySystems/SharedPullingSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedPullingSystem.cs
@@ -221,6 +221,7 @@ namespace Content.Shared.GameObjects.EntitySystems
 
         private void UpdatePulledRotation(IEntity puller, IEntity pulled)
         {
+            // TODO: update once ComponentReference works with directed event bus.
             if (!pulled.TryGetComponent(out SharedRotatableComponent? rotatable))
                 return;
 
@@ -230,7 +231,7 @@ namespace Content.Shared.GameObjects.EntitySystems
             var dir = puller.Transform.WorldPosition - pulled.Transform.WorldPosition;
             if (dir.LengthSquared > ThresholdRotDistance * ThresholdRotDistance)
             {
-                var oldAngle = pulled.Transform.LocalRotation;
+                var oldAngle = pulled.Transform.WorldRotation;
                 var newAngle = Angle.FromWorldVec(dir);
 
                 var diff = newAngle - oldAngle;

--- a/Content.Shared/GameObjects/EntitySystems/SharedPullingSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedPullingSystem.cs
@@ -1,7 +1,9 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.GameObjects.Components.Pulling;
+using Content.Shared.GameObjects.Components.Rotatable;
 using Content.Shared.GameObjects.EntitySystemMessages.Pulling;
 using Content.Shared.GameTicking;
 using Content.Shared.Input;
@@ -11,6 +13,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
+using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Dynamics.Joints;
 using Robust.Shared.Players;
@@ -28,6 +31,20 @@ namespace Content.Shared.GameObjects.EntitySystems
 
         private readonly HashSet<SharedPullableComponent> _moving = new();
         private readonly HashSet<SharedPullableComponent> _stoppedMoving = new();
+
+        /// <summary>
+        ///     If distance between puller and pulled entity lower that this threshold,
+        ///     pulled entity will not change its rotation.
+        ///     Helps with small distance jittering
+        /// </summary>
+        private const float ThresholdRotDistance = 1;
+
+        /// <summary>
+        ///     If difference between puller and pulled angle  lower that this threshold,
+        ///     pulled entity will not change its rotation.
+        ///     Helps with diagonal movement jittering
+        /// </summary>
+        private const float ThresholdRotAngle = 30;
 
         public IReadOnlySet<SharedPullableComponent> Moving => _moving;
 
@@ -89,6 +106,7 @@ namespace Content.Shared.GameObjects.EntitySystems
 
         private void PullerMoved(MoveEvent ev)
         {
+            var puller = ev.Sender;
             if (!TryGetPulled(ev.Sender, out var pulled))
             {
                 return;
@@ -98,6 +116,8 @@ namespace Content.Shared.GameObjects.EntitySystems
             {
                 return;
             }
+
+            UpdatePulledRotation(puller, pulled);
 
             physics.WakeBody();
 
@@ -197,6 +217,26 @@ namespace Content.Shared.GameObjects.EntitySystems
         public bool IsPulling(IEntity puller)
         {
             return _pullers.ContainsKey(puller);
+        }
+
+        private void UpdatePulledRotation(IEntity puller, IEntity pulled)
+        {
+            if (!pulled.TryGetComponent(out SharedRotatableComponent? rotatable))
+                return;
+
+            if (!rotatable.RotateWhilePulling)
+                return;
+
+            var dir = puller.Transform.WorldPosition - pulled.Transform.WorldPosition;
+            if (dir.LengthSquared > ThresholdRotDistance * ThresholdRotDistance)
+            {
+                var oldAngle = pulled.Transform.LocalRotation;
+                var newAngle = Angle.FromWorldVec(dir);
+
+                var diff = newAngle - oldAngle;
+                if (Math.Abs(diff.Degrees) > ThresholdRotAngle)
+                    pulled.Transform.LocalRotation = newAngle;
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Now when you pull some object with Rotatable component, it will change object rotation. Doesn't work on mobs.
Moved RotatableComponent to Shared namespace.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/6161335/115990706-4d60cb80-a5cd-11eb-8a4f-9bd27916b212.mp4


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Chairs and other object will change their direction when you pull them.

