### PR TITLE
Use MainViewport when input is not provided a viewport

### DIFF
--- a/Content.Client/State/GameScreen.cs
+++ b/Content.Client/State/GameScreen.cs
@@ -165,5 +165,13 @@ namespace Content.Client.State
 
             Viewport.Viewport.Eye = _eyeManager.CurrentEye;
         }
+
+        protected override void OnKeyBindStateChanged(ViewportBoundKeyEventArgs args)
+        {
+            if (args.Viewport == null)
+                base.OnKeyBindStateChanged(new ViewportBoundKeyEventArgs(args.KeyEventArgs, Viewport.Viewport));
+            else
+                base.OnKeyBindStateChanged(args);
+        }
     }
 }

--- a/Content.Client/State/GameScreenBase.cs
+++ b/Content.Client/State/GameScreenBase.cs
@@ -214,7 +214,7 @@ namespace Content.Client.State
         ///     Converts a state change event from outside the simulation to inside the simulation.
         /// </summary>
         /// <param name="args">Event data values for a bound key state change.</param>
-        private void OnKeyBindStateChanged(ViewportBoundKeyEventArgs args)
+        protected virtual void OnKeyBindStateChanged(ViewportBoundKeyEventArgs args)
         {
             // If there is no InputSystem, then there is nothing to forward to, and nothing to do here.
             if(!EntitySystemManager.TryGetEntitySystem(out InputSystem inputSys))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes input EntityCoordinates when hovering over a UI element, so that it can get the entity under the cursor like it did before the viewport change.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/10494922/116236673-35e02a80-a714-11eb-9a6f-b132fb422fd5.mp4

https://user-images.githubusercontent.com/10494922/116236716-40022900-a714-11eb-9fba-cebde4c7a4ac.mp4