### PR TITLE
Pull controller manages velocity better than it did before.

### DIFF
--- a/Content.Server/Physics/Controllers/PullController.cs
+++ b/Content.Server/Physics/Controllers/PullController.cs
@@ -5,13 +5,34 @@ using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Controllers;
+using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Physics.Controllers
 {
     public class PullController : VirtualController
     {
-        private const int ImpulseModifier = 20;
+        // Parameterization for pulling:
+        // Speeds. Note that the speed is mass-independent (multiplied by mass).
+        // Instead, tuning to mass is done via the mass values below.
+        // Note that setting the speed too high results in overshoots (stabilized by drag, but bad)
+        private const float AccelModifierHigh = 7.5f;
+        private const float AccelModifierLow = 60.0f;
+        // High/low-mass marks. Curve is constant-lerp-constant, i.e. if you can even pull an item,
+        // you'll always get at least AccelModifierLow and no more than AccelModifierHigh.
+        private const float AccelModifierHighMass = 70.0f; // locker
+        private const float AccelModifierLowMass = 1.0f; // to taste
+        // Used to control settling (turns off pulling).
+        // Note that once an object gets within MaximumSettleDistance, impulses change to trying to shut down velocity.
+        private const float MaximumSettleVelocity = 0.1f;
+        private const float MaximumSettleDistance = 0.1f;
+        // Settle shutdown control.
+        // Mustn't be too massive, as that causes severe mispredicts *and can prevent it ever resolving*.
+        // Exists to bleed off "I pulled my crowbar" overshoots.
+        // Distance in which settle shutdown applies
+        private const float SettleShutdownDistance = 1.0f;
+        // Velocity change of -LinearVelocity * frameTime * this
+        private const float SettleShutdownMultiplier = 5.0f;
 
         private SharedPullingSystem _pullableSystem = default!;
 
@@ -60,7 +81,7 @@ namespace Content.Server.Physics.Controllers
                 var movingPosition = pullable.MovingTo.Value.Position;
                 var ownerPosition = pullable.Owner.Transform.MapPosition.Position;
 
-                if (movingPosition.EqualsApprox(ownerPosition, 0.01))
+                if (movingPosition.EqualsApprox(ownerPosition, MaximumSettleDistance) && (physics.LinearVelocity.Length < MaximumSettleVelocity))
                 {
                     pullable.MovingTo = null;
                     continue;
@@ -68,10 +89,17 @@ namespace Content.Server.Physics.Controllers
 
                 var diff = movingPosition - ownerPosition;
                 var diffLength = diff.Length;
-                var multiplier = diffLength < 1 ? ImpulseModifier * diffLength : ImpulseModifier;
-                var impulse = diff.Normalized * multiplier;
-
-                physics.ApplyLinearImpulse(impulse);
+                var impulseModifierLerp = Math.Min(1.0f, Math.Max(0.0f, (physics.Mass - AccelModifierLowMass) / (AccelModifierHighMass - AccelModifierLowMass)));
+                var impulseModifier = MathHelper.Lerp(AccelModifierLow, AccelModifierHigh, impulseModifierLerp);
+                var multiplier = diffLength < 1 ? impulseModifier * diffLength : impulseModifier;
+                // Note the implication that the real rules of physics don't apply to pulling control.
+                var accel = diff.Normalized * multiplier;
+                // Now for the part where velocity gets shutdown...
+                if (movingPosition.EqualsApprox(ownerPosition, SettleShutdownDistance))
+                {
+                    accel -= physics.LinearVelocity * SettleShutdownMultiplier;
+                }
+                physics.ApplyLinearImpulse(accel * physics.Mass * frameTime);
             }
         }
     }


### PR DESCRIPTION
## About the PR

Fixes pull-to-location overshooting all the time by mostly pretending mass doesn't exist, manually tuning speed, and introducing extra drag when approaching the target.

Tested with lockers and crowbars.

**Changelog**

:cl:
- fix: Pull-to-location velocity control is more stable. (Won't send items flying all the time.)

