### PR TITLE
Bring singularity back from the brink of "particles don't even hit"

### DIFF
--- a/Content.Server/GameObjects/Components/Singularity/ServerSingularityComponent.cs
+++ b/Content.Server/GameObjects/Components/Singularity/ServerSingularityComponent.cs
@@ -113,7 +113,6 @@ namespace Content.Server.GameObjects.Components.Singularity
             SoundSystem.Play(Filter.Pvs(Owner), "/Audio/Effects/singularity_form.ogg", Owner);
             Timer.Spawn(5200,() => _playingSound = SoundSystem.Play(Filter.Pvs(Owner), "/Audio/Effects/singularity.ogg", Owner, audioParams));
 
-            _collidableComponent!.Hard = false;
             Level = 1;
         }
 

--- a/Content.Server/GameObjects/Components/Singularity/SingularityGenerator.cs
+++ b/Content.Server/GameObjects/Components/Singularity/SingularityGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Singularity
 {
@@ -8,7 +9,7 @@ namespace Content.Server.GameObjects.Components.Singularity
     {
         public override string Name => "SingularityGenerator";
 
-        private int _power;
+        [ViewVariables] private int _power;
 
         public int Power
         {

--- a/Resources/Prototypes/Entities/Constructible/Power/Engines/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/Engines/PA/particles.yml
@@ -20,8 +20,9 @@
           !type:PhysShapeAabb
             bounds: "-0.48,-0.48,0.48,0.48"
         hard: false
-        layer:
+        layer: [None]
+        mask:
           # Has to hit mobs, singularity, and singularity generator
           - MobMask
-        mask: [None]
+          - Opaque
     - type: ParticleProjectile

--- a/Resources/Prototypes/Entities/Constructible/Power/Engines/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/Engines/PA/particles.yml
@@ -20,7 +20,8 @@
           !type:PhysShapeAabb
             bounds: "-0.48,-0.48,0.48,0.48"
         hard: false
-        layer: [None]
-        mask:
-        - MobMask
+        layer:
+          # Has to hit mobs, singularity, and singularity generator
+          - MobMask
+        mask: [None]
     - type: ParticleProjectile

--- a/Resources/Prototypes/Entities/Constructible/Power/Engines/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/Engines/Singularity/generator.yml
@@ -18,6 +18,7 @@
         !type:PhysShapeAabb
           bounds: "-0.5, -0.5, 0.5, 0.5"
       mass: 25
+      # Keep an eye on ParticlesProjectile when adjusting these
       layer:
       - Opaque
       mask:

--- a/Resources/Prototypes/Entities/Constructible/Power/Engines/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/Engines/Singularity/singularity.yml
@@ -11,6 +11,7 @@
         !type:PhysShapeCircle
           radius: 0.5
       mass: 5
+      # Keep an eye on ParticlesProjectile when adjusting these
       layer:
       - Impassable
       mask:


### PR DESCRIPTION
## About the PR

Particles actually hit the singulo & singulo generator.

Also, ServerSingularityComponent doesn't force-disable hard collisions (which made the singularity completely uncontainable)

Note that the singularity still escapes eventually because of the containment field not working.

**Screenshots**

![image](https://user-images.githubusercontent.com/22304167/118399899-4589c980-b657-11eb-8902-861eed0bb514.png)

**Changelog**

:cl:
- fix: Particle Accelerator particles actually affect singularity & singularity generator again
- fix: Singularity doesn't instantly escape all containment