### PR TITLE
Fix clicking a locker while inside of said locker

### DIFF
--- a/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
@@ -1,4 +1,3 @@
-using Content.IntegrationTests;
 using Content.Server.GameObjects.Components.GUI;
 using Content.Server.GameObjects.Components.Items.Storage;
 using Content.Server.GameObjects.EntitySystems.Click;
@@ -10,7 +9,6 @@ using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Reflection;
-using System;
 using System.Threading.Tasks;
 
 namespace Content.IntegrationTests.Tests.Interaction.Click
@@ -63,9 +61,6 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
             IEntity other = null;
             IEntity containerEntity = null;
             IContainer container = null;
-            IComponent component = null;
-            EntityCoordinates entityCoordinates = default;
-            MapCoordinates mapCoordinates = default;
 
             server.Assert(() =>
             {
@@ -77,9 +72,6 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
                 other = entityManager.SpawnEntity(null, coordinates);
                 containerEntity = entityManager.SpawnEntity(null, coordinates);
                 container = ContainerHelpers.EnsureContainer<Container>(containerEntity, "InteractionTestContainer");
-                component = containerEntity.Transform;
-                entityCoordinates = containerEntity.Transform.Coordinates;
-                mapCoordinates = containerEntity.Transform.MapPosition;
             });
 
             await server.WaitIdleAsync();

--- a/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
@@ -1,0 +1,141 @@
+using Content.IntegrationTests;
+using Content.Server.GameObjects.Components.GUI;
+using Content.Server.GameObjects.Components.Items.Storage;
+using Content.Server.GameObjects.EntitySystems.Click;
+using Content.Shared.Interfaces.GameObjects.Components;
+using NUnit.Framework;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Reflection;
+using System;
+using System.Threading.Tasks;
+
+namespace Content.IntegrationTests.Tests.Interaction.Click
+{
+    [TestFixture]
+    [TestOf(typeof(InteractionSystem))]
+    public class InteractionSystemTests : ContentIntegrationTest
+    {
+        [Reflect(false)]
+        private class TestAttackEntitySystem : EntitySystem
+        {
+            public EntityEventHandler<AttackEventArgs> AttackEvent;
+            public EntityEventHandler<InteractUsingMessage> InteractUsingEvent;
+            public EntityEventHandler<AttackHandMessage> InteractHandEvent;
+
+            public override void Initialize()
+            {
+                base.Initialize();
+                SubscribeLocalEvent<AttackEventArgs>((e) => AttackEvent?.Invoke(e));
+                SubscribeLocalEvent<InteractUsingMessage>((e) => InteractUsingEvent?.Invoke(e));
+                SubscribeLocalEvent<AttackHandMessage>((e) => InteractHandEvent?.Invoke(e));
+            }
+
+            public override void Shutdown()
+            {
+                base.Shutdown();
+                UnsubscribeLocalEvent<AttackEventArgs>();
+                UnsubscribeLocalEvent<InteractUsingMessage>();
+                UnsubscribeLocalEvent<AttackHandMessage>();
+            }
+        }
+
+        [Test]
+        public async Task InsideContainerInteractionBlockTest()
+        {
+            var server = StartServerDummyTicker(new ServerContentIntegrationOption
+            {
+                ContentBeforeIoC = () =>
+                {
+                    IoCManager.Resolve<IEntitySystemManager>().LoadExtraSystemType<TestAttackEntitySystem>();
+                }
+            });
+
+            await server.WaitIdleAsync();
+
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var mapManager = server.ResolveDependency<IMapManager>();
+
+            IEntity origin = null;
+            IEntity other = null;
+            IEntity containerEntity = null;
+            IContainer container = null;
+            IComponent component = null;
+            EntityCoordinates entityCoordinates = default;
+            MapCoordinates mapCoordinates = default;
+
+            server.Assert(() =>
+            {
+                var mapId = mapManager.CreateMap();
+                var coordinates = new MapCoordinates(Vector2.Zero, mapId);
+
+                origin = entityManager.SpawnEntity(null, coordinates);
+                origin.EnsureComponent<HandsComponent>();
+                other = entityManager.SpawnEntity(null, coordinates);
+                containerEntity = entityManager.SpawnEntity(null, coordinates);
+                container = ContainerHelpers.EnsureContainer<Container>(containerEntity, "InteractionTestContainer");
+                component = containerEntity.Transform;
+                entityCoordinates = containerEntity.Transform.Coordinates;
+                mapCoordinates = containerEntity.Transform.MapPosition;
+            });
+
+            await server.WaitIdleAsync();
+
+            var attack = false;
+            var interactUsing = false;
+            var interactHand = false;
+            server.Assert(() =>
+            {
+                Assert.That(container.Insert(origin));
+                Assert.That(origin.Transform.Parent!.Owner, Is.EqualTo(containerEntity));
+
+                var entitySystemManager = IoCManager.Resolve<IEntitySystemManager>();
+                Assert.That(entitySystemManager.TryGetEntitySystem<InteractionSystem>(out var interactionSystem));
+
+                Assert.That(entitySystemManager.TryGetEntitySystem<TestAttackEntitySystem>(out var testAttackEntitySystem));
+                testAttackEntitySystem.AttackEvent = (ev) =>
+                {
+                    Assert.That(ev.Target, Is.EqualTo(containerEntity.Uid));
+                    attack = true;
+                };
+                testAttackEntitySystem.InteractUsingEvent = (ev) =>
+                {
+                    Assert.That(ev.Attacked, Is.EqualTo(containerEntity));
+                    interactUsing = true;
+                };
+                testAttackEntitySystem.InteractHandEvent = (ev) =>
+                {
+                    Assert.That(ev.Attacked, Is.EqualTo(containerEntity));
+                    interactHand = true;
+                };
+
+                interactionSystem.DoAttack(origin, other.Transform.Coordinates, false, other.Uid);
+                interactionSystem.UserInteraction(origin, other.Transform.Coordinates, other.Uid);
+                Assert.That(attack, Is.False);
+                Assert.That(interactUsing, Is.False);
+                Assert.That(interactHand, Is.False);
+
+                interactionSystem.DoAttack(origin, containerEntity.Transform.Coordinates, false, containerEntity.Uid);
+                interactionSystem.UserInteraction(origin, containerEntity.Transform.Coordinates, containerEntity.Uid);
+                Assert.That(attack);
+                Assert.That(interactUsing, Is.False);
+                Assert.That(interactHand);
+
+                var itemEntity = entityManager.SpawnEntity(null, origin.Transform.Coordinates);
+                var item = itemEntity.EnsureComponent<ItemComponent>();
+
+                Assert.That(origin.TryGetComponent<HandsComponent>(out var hands));
+                hands.PutInHand(item);
+
+                interactionSystem.UserInteraction(origin, other.Transform.Coordinates, other.Uid);
+                Assert.That(interactUsing, Is.False);
+
+                interactionSystem.UserInteraction(origin, containerEntity.Transform.Coordinates, containerEntity.Uid);
+                Assert.That(interactUsing);
+            });
+        }
+    }
+}

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -287,7 +287,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
             return pull.TogglePull(player);
         }
 
-        private async void UserInteraction(IEntity player, EntityCoordinates coordinates, EntityUid clickedUid)
+        public async void UserInteraction(IEntity player, EntityCoordinates coordinates, EntityUid clickedUid)
         {
             // Get entity clicked upon from UID if valid UID, if not assume no entity clicked upon and null
             if (!EntityManager.TryGetEntity(clickedUid, out var attacked))
@@ -782,7 +782,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
             }
         }
 
-        private void DoAttack(IEntity player, EntityCoordinates coordinates, bool wideAttack, EntityUid targetUid = default)
+        public void DoAttack(IEntity player, EntityCoordinates coordinates, bool wideAttack, EntityUid targetUid = default)
         {
             // Verify player is on the same map as the entity he clicked on
             if (coordinates.GetMapId(EntityManager) != player.Transform.MapID)

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -800,14 +800,11 @@ namespace Content.Server.GameObjects.EntitySystems.Click
                 return;
             }
 
-            if (!EntityManager.TryGetEntity(targetUid, out var target))
-            {
-                target = null;
-            }
 
             // In a container where the target entity is not the container's owner
             if (player.TryGetContainer(out var playerContainer) &&
-                target != playerContainer.Owner)
+                (!EntityManager.TryGetEntity(targetUid, out var target) ||
+                target != playerContainer.Owner))
             {
                 // Either the target entity is null, not contained or in a different container
                 if (target == null ||
@@ -837,7 +834,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
                 else
                 {
                     // We pick up items if our hand is empty, even if we're in combat mode.
-                    if(EntityManager.TryGetEntity(targetUid, out var targetEnt))
+                    if (EntityManager.TryGetEntity(targetUid, out var targetEnt))
                     {
                         if (targetEnt.HasComponent<ItemComponent>())
                         {


### PR DESCRIPTION
Fixes #1535 the right way.
Fixes #3031

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed clicking a locker when the player is inside of said locker.

