### PR TITLE
Fix anchoring? Maybe?

### DIFF
--- a/Content.Server/GameObjects/Components/AnchorableComponent.cs
+++ b/Content.Server/GameObjects/Components/AnchorableComponent.cs
@@ -89,8 +89,6 @@ namespace Content.Server.GameObjects.Components
             if (attempt.Cancelled)
                 return false;
 
-            _physicsComponent.BodyType = BodyType.Static;
-
             // Snap rotation to cardinal (multiple of 90)
             var rot = Owner.Transform.LocalRotation;
             Owner.Transform.LocalRotation = Math.Round(rot / (Math.PI / 2)) * (Math.PI / 2);
@@ -105,6 +103,8 @@ namespace Content.Server.GameObjects.Components
 
             if (Snap)
                 Owner.SnapToGrid(Owner.EntityManager);
+
+            _physicsComponent.BodyType = BodyType.Static;
 
             Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new AnchoredMessage(), false);
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #3917, fixes #3753
I have no idea what I did, but it seems to fix it.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

