### PR TITLE
Little component to make batteries examinable.

### DIFF
--- a/Content.Client/IgnoredComponents.cs
+++ b/Content.Client/IgnoredComponents.cs
@@ -88,6 +88,7 @@ namespace Content.Client
             "TilePrying",
             "RandomSpriteColor",
             "ConditionalSpawner",
+            "ExaminableBattery",
             "PottedPlantHide",
             "SecureEntityStorage",
             "PresetIdCard",

--- a/Content.Server/GameObjects/Components/Power/ExaminableBatteryComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/ExaminableBatteryComponent.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+using Robust.Shared.ViewVariables;
+using Robust.Shared.Localization;
+using Robust.Shared.Utility;
+using Content.Server.GameObjects.Components.Mobs;
+using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.Interfaces;
+using Content.Shared.Interfaces.GameObjects.Components;
+
+namespace Content.Server.GameObjects.Components.Power
+{
+    [RegisterComponent]
+    public class ExaminableBatteryComponent : Component, IExamine
+    {
+        public override string Name => "ExaminableBattery";
+
+        [ViewVariables]
+        [ComponentDependency] private BatteryComponent? _battery = default!;
+
+        void IExamine.Examine(FormattedMessage message, bool inDetailsRange)
+        {
+            if (_battery == null)
+                return;
+            if (inDetailsRange)
+            {
+                var effectiveMax = _battery.MaxCharge;
+                if (effectiveMax == 0)
+                    effectiveMax = 1;
+                var chargeFraction = _battery.CurrentCharge / effectiveMax;
+                var chargePercentRounded = (int) (chargeFraction * 100);
+                message.AddMarkup(
+                    Loc.GetString(
+                        "examinable-battery-component-examine-detail",
+                        ("percent", chargePercentRounded),
+                        ("markupPercentColor", "green")
+                    )
+                );
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/components/examinable-battery-component.ftl
+++ b/Resources/Locale/en-US/components/examinable-battery-component.ftl
@@ -1,0 +1,6 @@
+
+### UI
+
+# Shown when the battery is examined in details range
+examinable-battery-component-examine-detail = The battery is [color={$markupPercentColor}]{$percent}%[/color] full.
+

--- a/Resources/Prototypes/Entities/Constructible/Power/parts.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/parts.yml
@@ -39,6 +39,7 @@
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000
+  - type: ExaminableBattery
   - type: NodeContainer
     examinable: true
     nodes:
@@ -95,6 +96,7 @@
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000
+  - type: ExaminableBattery
   - type: NodeContainer
     examinable: true
     nodes:
@@ -148,6 +150,7 @@
   - type: Battery
     maxCharge: 10000
     startingCharge: 10000
+  - type: ExaminableBattery
   - type: NodeContainer
     examinable: true
     nodes:


### PR DESCRIPTION
## About the PR

Adds examination text of the form "The battery is XX% full." to battery-holding devices.

This can be easily applied to anything with a battery, and is applied to the major power infrastructure.

**Screenshots**

![image](https://user-images.githubusercontent.com/22304167/118005149-09e2bd00-b342-11eb-8533-7c368c0b49c2.png)

**Changelog**

:cl:
- add: Added a battery charge indicator on examination of substations, APCs, and SMESes.

