### PR TITLE
`drainallbatteries` - a command for testing low-power conditions

### DIFF
--- a/Content.Server/Commands/DrainAllBatteriesCommand.cs
+++ b/Content.Server/Commands/DrainAllBatteriesCommand.cs
@@ -1,0 +1,35 @@
+﻿#nullable enable
+using Content.Server.Administration;
+using Content.Server.GameObjects.Components.Power;
+using Content.Shared.Administration;
+using Content.Shared.GameObjects.Components;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+
+namespace Content.Server.Commands
+{
+    [AdminCommand(AdminFlags.Admin)]
+    public class DrainAllBatteriesCommand : IConsoleCommand
+    {
+        public string Command => "drainallbatteries";
+        public string Description => "Drains *all* batteries. Useful to make sure that an engine provides enough power to sustain the station.";
+        public string Help => $"{Command}";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length != 0)
+            {
+                shell.WriteLine($"Invalid amount of arguments: {args.Length}.\n{Help}");
+                return;
+            }
+
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            foreach (var ent in entityManager.GetEntities(new TypeEntityQuery(typeof(BatteryComponent))))
+            {
+                ent.GetComponent<BatteryComponent>().CurrentCharge = 0;
+            }
+            shell.WriteLine("Done!");
+        }
+    }
+}


### PR DESCRIPTION
## About the PR

Adds an admin command to drain anything with a `BatteryComponent`, called `drainallbatteries`.

**Changelog**

:cl:
- add: Added a command, drainallbatteries, so admins can drain all the batteries. Useful for local testing and/or training of Station Engineers on what to do in a power outage...
