### PR TITLE
Show nothing instead of error sprite when item has no inhands

### DIFF
--- a/Content.Client/GameObjects/Components/Items/HandsComponent.cs
+++ b/Content.Client/GameObjects/Components/Items/HandsComponent.cs
@@ -178,6 +178,9 @@ namespace Content.Client.GameObjects.Components.Items
                 var prefix = item.EquippedPrefix;
                 var state = prefix != null ? $"{prefix}-inhand-{handName}" : $"inhand-{handName}";
 
+                if (!rsi.TryGetState(state, out _))
+                    return;
+
                 var color = item.Color;
 
                 _sprite.LayerSetColor($"hand-{name}", color);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fix items with no inhands sprite showing the default error sprite instead of nothing

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed items with no inhands showing the error sprite.

