### PR TITLE
Various Paper adjustments

### DIFF
--- a/Content.Server/GameObjects/Components/Paper/PaperComponent.cs
+++ b/Content.Server/GameObjects/Components/Paper/PaperComponent.cs
@@ -7,6 +7,7 @@ using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
@@ -16,6 +17,7 @@ namespace Content.Server.GameObjects.Components.Paper
     public class PaperComponent : SharedPaperComponent, IExamine, IInteractUsing, IUse
     {
         private PaperAction _mode;
+        [DataField("content")]
         public string Content { get; private set; } = "";
 
         [ViewVariables] private BoundUserInterface? UserInterface => Owner.GetUIOrNull(PaperUiKey.Key);
@@ -42,7 +44,7 @@ namespace Content.Server.GameObjects.Components.Paper
             if (!inDetailsRange)
                 return;
 
-            message.AddMarkup(Content);
+            message.AddText(Content);
         }
 
         bool IUse.UseEntity(UseEntityEventArgs eventArgs)
@@ -66,7 +68,7 @@ namespace Content.Server.GameObjects.Components.Paper
 
             if (Owner.TryGetComponent(out SpriteComponent? sprite))
             {
-                sprite.LayerSetState(1, "paper_words");
+                sprite.LayerSetState(0, "paper_words");
             }
 
             Owner.Description = "";

--- a/Content.Server/GameObjects/Components/Paper/PaperComponent.cs
+++ b/Content.Server/GameObjects/Components/Paper/PaperComponent.cs
@@ -9,6 +9,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
+using Robust.Shared.Localization;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Paper
@@ -43,8 +44,14 @@ namespace Content.Server.GameObjects.Components.Paper
         {
             if (!inDetailsRange)
                 return;
+            if (Content == "")
+                return;
 
-            message.AddText(Content);
+            message.AddMarkup(
+                Loc.GetString(
+                    "paper-component-examine-detail-has-words"
+                )
+            );
         }
 
         bool IUse.UseEntity(UseEntityEventArgs eventArgs)

--- a/Resources/Locale/en-US/components/paper-component.ftl
+++ b/Resources/Locale/en-US/components/paper-component.ftl
@@ -1,0 +1,6 @@
+
+### UI
+
+# Shown when paper with words examined details
+paper-component-examine-detail-has-words = The paper has something written on it.
+

--- a/Resources/Prototypes/Catalog/Fills/Paper/manuals.yml
+++ b/Resources/Prototypes/Catalog/Fills/Paper/manuals.yml
@@ -1,0 +1,18 @@
+- type: entity
+  id: PaperWrittenAMEScribbles
+  suffix: "AME scribbles"
+  parent: PaperWritten
+  components:
+  - type: Paper
+    content: |
+      I don't know if you're trained already, so I hope this'll help.
+      AME controller needs LV power and an HV wire to output to. Check the area with a crowbar if you aren't sure.
+      There should be an empty room next to where you found this, that room's wired for the AME.
+      You can put an AME anywhere if you can get the wires to it, though.
+      3x3 grid of AME parts, multitool them to unpack. Be careful not to 'trap' anything.
+      AME controller adjacent horizontally or vertically (not diagonally) to any point.
+      With only 1 core (what a 3x3 grid will get you), don't turn it up above 2.
+      The golden rule is 2 injection for every 1 core. You can go lower to save fuel.
+      Higher will burn the engine out and eventually make it explode. Don't.
+      Don't forget to refuel it, it tends to stop at the worst possible time.
+

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -7,13 +7,21 @@
   - type: Sprite
     sprite: Objects/Misc/bureaucracy.rsi
     layers:
-    - state: paper_words
     - state: paper
   - type: Paper
   - type: UserInterface
     interfaces:
     - key: enum.PaperUiKey.Key
       type: PaperBoundUserInterface
+
+- type: entity
+  parent: Paper
+  id: PaperWritten
+  abstract: true
+  components:
+  - type: Sprite
+    layers:
+    - state: paper_words
 
 - type: entity
   name: pen


### PR DESCRIPTION
## About the PR

+ Paper text doesn't go into examine anymore (Swept asked. I previously only changed things so it doesn't get parsed as markup to make things consistent with the main paper UI.)
+ can now have prefilled text
+ cleaned up paper sprite layering a bit,
+ adds an AME manual as a test but doesn't put it anywhere

Note: Most of this stuff doesn't really matter enough to go into the changelog IMO - the AME manual would matter if it went into Saltern but right now it's just a spawnable thing.

**Screenshots**
![image](https://user-images.githubusercontent.com/22304167/118157507-8cd34880-b412-11eb-8289-9bbbe8dc14cc.png)

**Changelog**

:cl:
- fix: Paper can't be used to create exceptions by writing bad markup inside it and then examining it.
- remove: Examining paper no longer shows the contents.