### PR TITLE
Chat channel switching improvements

### DIFF
--- a/Content.Client/Chat/ChatBox.cs
+++ b/Content.Client/Chat/ChatBox.cs
@@ -7,6 +7,7 @@ using Content.Client.UserInterface;
 using Content.Client.UserInterface.Stylesheets;
 using Content.Client.Utility;
 using Content.Shared.Chat;
+using Content.Shared.Input;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.State;
@@ -503,6 +504,25 @@ namespace Content.Client.Chat
             UserInterfaceManager.KeyboardFocused?.ReleaseKeyboardFocus();
         }
 
+        public void CycleChatChannel(bool forward)
+        {
+            Input.IgnoreNext = true;
+            var channels = SelectableChannels;
+            var idx = channels.IndexOf(SelectedChannel);
+            if (forward)
+            {
+                idx++;
+                idx = MathHelper.Mod(idx, channels.Count());
+            }
+            else
+            {
+                idx--;
+                idx = MathHelper.Mod(idx, channels.Count());
+            }
+
+            SelectChannel(channels[idx]);
+        }
+
         private void InputKeyBindDown(GUIBoundKeyEventArgs args)
         {
             if (args.Function == EngineKeyFunctions.TextReleaseFocus)
@@ -512,9 +532,22 @@ namespace Content.Client.Chat
                 return;
             }
 
+            if (args.Function == ContentKeyFunctions.CycleChatChannelForward)
+            {
+                CycleChatChannel(true);
+                args.Handle();
+                return;
+            }
+
+            if (args.Function == ContentKeyFunctions.CycleChatChannelBackward)
+            {
+                CycleChatChannel(false);
+                args.Handle();
+                return;
+            }
+
             // if we temporarily selected another channel via a prefx, undo that when we backspace on an empty input
-            if (Input.Text.Length == 0 && _savedSelectedChannel.HasValue &&
-                args.Function == EngineKeyFunctions.TextBackspace)
+            if (args.Function == EngineKeyFunctions.TextBackspace && Input.Text.Length == 0 && _savedSelectedChannel.HasValue)
             {
                 SafelySelectChannel(_savedSelectedChannel.Value);
                 _savedSelectedChannel = null;

--- a/Content.Client/Chat/ChatBox.cs
+++ b/Content.Client/Chat/ChatBox.cs
@@ -509,16 +509,9 @@ namespace Content.Client.Chat
             Input.IgnoreNext = true;
             var channels = SelectableChannels;
             var idx = channels.IndexOf(SelectedChannel);
-            if (forward)
-            {
-                idx++;
-                idx = MathHelper.Mod(idx, channels.Count());
-            }
-            else
-            {
-                idx--;
-                idx = MathHelper.Mod(idx, channels.Count());
-            }
+            if (forward) idx++;
+            else idx--;
+            idx = MathHelper.Mod(idx, channels.Count);
 
             SelectChannel(channels[idx]);
         }

--- a/Content.Client/Chat/ChatBox.cs
+++ b/Content.Client/Chat/ChatBox.cs
@@ -509,8 +509,14 @@ namespace Content.Client.Chat
             Input.IgnoreNext = true;
             var channels = SelectableChannels;
             var idx = channels.IndexOf(SelectedChannel);
-            if (forward) idx++;
-            else idx--;
+            if (forward)
+            {
+                idx++;
+            }
+            else
+            {
+                idx--;
+            }
             idx = MathHelper.Mod(idx, channels.Count);
 
             SelectChannel(channels[idx]);

--- a/Content.Client/Chat/ChatManager.cs
+++ b/Content.Client/Chat/ChatManager.cs
@@ -242,7 +242,7 @@ namespace Content.Client.Chat
             }
 
             // let our chatbox know all the new settings
-            CurrentChatBox?.SetChannelPermissions(_selectableChannels, _filterableChannels, _channelFilters, _unreadMessages);
+            CurrentChatBox?.SetChannelPermissions(_selectableChannels, _filterableChannels, _channelFilters, _unreadMessages, true);
         }
 
         /// <summary>
@@ -311,7 +311,7 @@ namespace Content.Client.Chat
                 CurrentChatBox.FilterToggled += OnFilterButtonToggled;
                 CurrentChatBox.OnResized += ChatBoxOnResized;
 
-                CurrentChatBox.SetChannelPermissions(_selectableChannels, _filterableChannels, _channelFilters, _unreadMessages);
+                CurrentChatBox.SetChannelPermissions(_selectableChannels, _filterableChannels, _channelFilters, _unreadMessages, false);
             }
 
             RepopulateChat(_filteredHistory);

--- a/Content.Client/State/GameScreen.cs
+++ b/Content.Client/State/GameScreen.cs
@@ -139,7 +139,6 @@ namespace Content.Client.State
             chat.SelectChannel(channel);
             chat.Input.IgnoreNext = true;
             chat.Input.GrabKeyboardFocus();
-
         }
 
         public override void FrameUpdate(FrameEventArgs e)

--- a/Content.Client/State/GameScreen.cs
+++ b/Content.Client/State/GameScreen.cs
@@ -136,8 +136,10 @@ namespace Content.Client.State
                 return;
             }
 
-            chat.Input.IgnoreNext = true;
             chat.SelectChannel(channel);
+            chat.Input.IgnoreNext = true;
+            chat.Input.GrabKeyboardFocus();
+
         }
 
         public override void FrameUpdate(FrameEventArgs e)

--- a/Content.Client/State/GameScreen.cs
+++ b/Content.Client/State/GameScreen.cs
@@ -79,10 +79,10 @@ namespace Content.Client.State
                 InputCmdHandler.FromDelegate(_ => FocusChannel(_gameChat, ChatChannel.AdminChat)));
 
             _inputManager.SetInputCommand(ContentKeyFunctions.CycleChatChannelForward,
-                InputCmdHandler.FromDelegate(_ => CycleChatChannel(_gameChat, true)));
+                InputCmdHandler.FromDelegate(_ => _gameChat.CycleChatChannel(true)));
 
             _inputManager.SetInputCommand(ContentKeyFunctions.CycleChatChannelBackward,
-                InputCmdHandler.FromDelegate(_ => CycleChatChannel(_gameChat, false)));
+                InputCmdHandler.FromDelegate(_ => _gameChat.CycleChatChannel(false)));
 
             SetupPresenters();
 
@@ -138,25 +138,6 @@ namespace Content.Client.State
 
             chat.Input.IgnoreNext = true;
             chat.SelectChannel(channel);
-        }
-
-        internal static void CycleChatChannel(ChatBox chat, bool forward)
-        {
-            chat.Input.IgnoreNext = true;
-            var channels = chat.SelectableChannels;
-            var idx = channels.IndexOf(chat.SelectedChannel);
-            if (forward)
-            {
-                idx++;
-                idx = MathHelper.Mod(idx, channels.Count());
-            }
-            else
-            {
-                idx--;
-                idx = MathHelper.Mod(idx, channels.Count());
-            }
-
-            chat.SelectChannel(channels[idx]);
         }
 
         public override void FrameUpdate(FrameEventArgs e)

--- a/Content.Client/State/LobbyState.cs
+++ b/Content.Client/State/LobbyState.cs
@@ -83,10 +83,10 @@ namespace Content.Client.State
                 InputCmdHandler.FromDelegate(_ => GameScreen.FocusChannel(_lobby.Chat, ChatChannel.AdminChat)));
 
             _inputManager.SetInputCommand(ContentKeyFunctions.CycleChatChannelForward,
-                InputCmdHandler.FromDelegate(_ => GameScreen.CycleChatChannel(_lobby.Chat, true)));
+                InputCmdHandler.FromDelegate(_ => _lobby.Chat.CycleChatChannel(true)));
 
             _inputManager.SetInputCommand(ContentKeyFunctions.CycleChatChannelBackward,
-                InputCmdHandler.FromDelegate(_ => GameScreen.CycleChatChannel(_lobby.Chat, false)));
+                InputCmdHandler.FromDelegate(_ => _lobby.Chat.CycleChatChannel(false)));
 
             UpdateLobbyUi();
 

--- a/Content.Shared/Chat/ChatChannel.cs
+++ b/Content.Shared/Chat/ChatChannel.cs
@@ -65,6 +65,6 @@ namespace Content.Shared.Chat
         /// <summary>
         ///     Channels considered to be IC.
         /// </summary>
-        IC = Local | Radio | Damage | Radio | Visual | Emotes | Dead,
+        IC = Local | Radio | Dead | Emotes | Damage | Visual,
     }
 }

--- a/Content.Shared/Chat/ChatChannel.cs
+++ b/Content.Shared/Chat/ChatChannel.cs
@@ -61,5 +61,10 @@ namespace Content.Shared.Chat
         ///     Unspecified.
         /// </summary>
         Unspecified = 512,
+
+        /// <summary>
+        ///     Channels considered to be IC.
+        /// </summary>
+        IC = Local | Radio | Damage | Radio | Visual | Emotes | Dead,
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Default to IC channels when joining, switch to another IC channel if the current one disappears before trying OOC.
Allow chat channel cycling while the textbox is focused.


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- remove: Chat no longer defaults to OOC if IC channels are available.
- add: Can now cycle channels while typing.
- fix: Focus channel keybinds now actually focus the chatbox.

