### PR TITLE
DieCondition no longer inverted, spelling fix, objectives use consistent definitions of deadness

### DIFF
--- a/Content.Server/Objectives/Conditions/DieCondition.cs
+++ b/Content.Server/Objectives/Conditions/DieCondition.cs
@@ -20,18 +20,13 @@ namespace Content.Server.Objectives.Conditions
             return new DieCondition {_mind = mind};
         }
 
-        public string Title => Loc.GetString("Die a glorius death");
+        public string Title => Loc.GetString("Die a glorious death");
 
         public string Description => Loc.GetString("Die.");
 
         public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Mobs/Ghosts/ghost_human.rsi"), "icon");
 
-        public float Progress => _mind?
-            .OwnedEntity?
-            .GetComponentOrNull<IMobStateComponent>()?
-            .IsDead() ?? false
-            ? 0f
-            : 1f;
+        public float Progress => (_mind?.CharacterDeadIC ?? true) ? 1f : 0f;
 
         public float Difficulty => 1f;
 

--- a/Content.Server/Objectives/Conditions/KillPersonCondition.cs
+++ b/Content.Server/Objectives/Conditions/KillPersonCondition.cs
@@ -18,37 +18,7 @@ namespace Content.Server.Objectives.Conditions
 
         public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Objects/Weapons/Guns/Pistols/mk58_wood.rsi"), "icon");
 
-        public float Progress
-        {
-            get
-            {
-                // This is written explicitly so that the logic can be understood.
-                // The previous form was "cleaner" but also didn't work because any failure meant the person was "not dead".
-                // It may be an idea to move all this logic to Mind, as, say, "Mind.CharacterDead".
-                // But it's also weird and potentially situational.
-                // Specific considerations when updating this:
-                //  + Does being turned into a borg (if/when implemented) count as dead?
-                //  + Is being transformed into a donut 'dead'?
-                //  + *Ghost roles definitely shouldn't count as alive.*
-                //  + Is it necessary to have a reference to a specific 'mind iteration' to cycle when certain events happen?
-                //    (If being a borg or AI counts as dead, then this is highly likely, as it's still the same Mind for practical purposes.)
-
-                // This shouldn't be possible but assume dead just so the invalid goal doesn't do anything annoying.
-                if (Target == null)
-                    return 1f;
-                var targetOwnedEntity = Target.OwnedEntity;
-                // This can be null if they're deleted (spike / brain nom)
-                if (targetOwnedEntity == null)
-                    return 1f;
-                var targetMobState = targetOwnedEntity.GetComponentOrNull<IMobStateComponent>();
-                // This can be null if it's a brain (this happens very often)
-                // Brains are the result of gibbing so should definitely count as dead
-                if (targetMobState == null)
-                    return 1f;
-                // They might actually be alive.
-                return targetMobState.IsDead() ? 1f : 0f;
-            }
-        }
+        public float Progress => (Target?.CharacterDeadIC ?? true) ? 1f : 0f;
 
         public float Difficulty => 2f;
 

--- a/Content.Server/Objectives/Conditions/StayAliveCondition.cs
+++ b/Content.Server/Objectives/Conditions/StayAliveCondition.cs
@@ -26,12 +26,7 @@ namespace Content.Server.Objectives.Conditions
 
         public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Objects/Misc/skub.rsi"), "icon"); //didn't know what else would have been a good icon for staying alive
 
-        public float Progress => _mind?
-            .OwnedEntity?
-            .GetComponentOrNull<IMobStateComponent>()?
-            .IsDead() ?? false
-            ? 0f
-            : 1f;
+        public float Progress => (_mind?.CharacterDeadIC ?? false) ? 0f : 1f;
 
         public float Difficulty => 1f;
 


### PR DESCRIPTION
## About the PR

Really, this spreads the 'brains aren't alive' fixes to all the objectives.

This is one of those commits where testing is a pain because I still can't figure out how to add traitor role to self live.

Hopefully the code is clear enough.

**Changelog**

:cl:
- fix: Die a glorious death succeeds when you're dead instead of when you're alive.
- fix: Stay Alive / Die A Glorious Death don't treat brains as alive.
