### PR TITLE
#4014 ID card computer now has a power check

### DIFF
--- a/Content.Server/GameObjects/Components/Access/IdCardConsoleComponent.cs
+++ b/Content.Server/GameObjects/Components/Access/IdCardConsoleComponent.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using Robust.Shared.Prototypes;
 using Robust.Shared.ViewVariables;
+using Content.Server.GameObjects.Components.Power.ApcNetComponents;
 
 namespace Content.Server.GameObjects.Components.Access
 {
@@ -33,6 +34,7 @@ namespace Content.Server.GameObjects.Components.Access
         private ContainerSlot _targetIdContainer = default!;
 
         [ViewVariables] private BoundUserInterface? UserInterface => Owner.GetUIOrNull(IdCardConsoleUiKey.Key);
+        [ViewVariables] private bool Powered => !Owner.TryGetComponent(out PowerReceiverComponent? receiver) || receiver.Powered;
 
         private bool PrivilegedIDEmpty => _privilegedIdContainer.ContainedEntities.Count < 1;
         private bool TargetIDEmpty => _targetIdContainer.ContainedEntities.Count < 1;
@@ -218,6 +220,7 @@ namespace Content.Server.GameObjects.Components.Access
             {
                 return;
             }
+            if(!Powered) return;
 
             UserInterface?.Open(actor.PlayerSession);
         }


### PR DESCRIPTION
#4014 
I checked the consoles, R&D, Chem Dispenser, Cargo (!), Communications and so on (skipped through every 'IActivate'-Interface and checked whether it could be powered imho or not)
Exception the IdCardConsoleComponent every console had a power check.

🆑 
- 'ID card computer' will now stop working when there is no power.
