### PR TITLE
Fix incorrect shard protoype being spawned when computers are destroyed

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Power/computers.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/computers.yml
@@ -207,7 +207,7 @@
   parent: ComputerBase
   id: ComputerComms
   name: communications computer
-  description: This can be used for various important functions. Still under developement.
+  description: This can be used for various important functions. Still under development.
   components:
   - type: Appearance
     visuals:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/computer.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/computer.yml
@@ -144,7 +144,7 @@
             - !type:EntityAnchored {}
           completed:
             - !type:SpawnPrototype
-              prototype: ShardBase
+              prototype: ShardGlass
               amount: 2
           steps:
             - tool: Prying


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

used the abstract parent prototype instead of the glass one

fixes #4055 