### PR TITLE
Fix: #4037 Being able to dehandcuff yourself while dead

### DIFF
--- a/Content.Server/GameObjects/Components/ActionBlocking/CuffableComponent.cs
+++ b/Content.Server/GameObjects/Components/ActionBlocking/CuffableComponent.cs
@@ -7,6 +7,7 @@ using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.EntitySystems.DoAfter;
 using Content.Shared.Alert;
 using Content.Shared.GameObjects.Components.ActionBlocking;
+using Content.Shared.GameObjects.Components.Mobs.State;
 using Content.Shared.GameObjects.EntitySystems.ActionBlocker;
 using Content.Shared.GameObjects.Verbs;
 using Content.Shared.Interfaces;
@@ -180,6 +181,11 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
         public async void TryUncuff(IEntity user, IEntity? cuffsToRemove = null)
         {
             if (_uncuffing) return;
+            if (user.TryGetComponent<IMobStateComponent>(out var state))
+            {
+                if(state.IsDead() || state.IsIncapacitated())
+                    return;
+            }
 
             var isOwner = user == Owner;
 
@@ -237,7 +243,7 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
                 if (cuff.StartUncuffSound != null)
                     SoundSystem.Play(Filter.Pvs(Owner), cuff.StartUncuffSound, Owner);
             }
-            
+
             var uncuffTime = isOwner ? cuff.BreakoutTime : cuff.UncuffTime;
             var doAfterEventArgs = new DoAfterEventArgs(user, uncuffTime)
             {

--- a/Content.Server/GameObjects/Components/ActionBlocking/CuffableComponent.cs
+++ b/Content.Server/GameObjects/Components/ActionBlocking/CuffableComponent.cs
@@ -181,11 +181,6 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
         public async void TryUncuff(IEntity user, IEntity? cuffsToRemove = null)
         {
             if (_uncuffing) return;
-            if (user.TryGetComponent<IMobStateComponent>(out var state))
-            {
-                if(state.IsDead() || state.IsIncapacitated())
-                    return;
-            }
 
             var isOwner = user == Owner;
 
@@ -212,7 +207,7 @@ namespace Content.Server.GameObjects.Components.ActionBlocking
                 return;
             }
 
-            if (!isOwner && !ActionBlockerSystem.CanInteract(user))
+            if (!ActionBlockerSystem.CanInteract(user))
             {
                 user.PopupMessage(Loc.GetString("You can't do that!"));
                 return;

--- a/Content.Server/GameObjects/Components/ActionBlocking/CuffableComponent.cs
+++ b/Content.Server/GameObjects/Components/ActionBlocking/CuffableComponent.cs
@@ -7,7 +7,6 @@ using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.EntitySystems.DoAfter;
 using Content.Shared.Alert;
 using Content.Shared.GameObjects.Components.ActionBlocking;
-using Content.Shared.GameObjects.Components.Mobs.State;
 using Content.Shared.GameObjects.EntitySystems.ActionBlocker;
 using Content.Shared.GameObjects.Verbs;
 using Content.Shared.Interfaces;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #4037 
You now won't be able to get away if you're incapacitated or dead. 
I chose not to show a message, because, you know, dead people won't read.


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- You now won't be able to get out of handcuffs if you're dead or incapacitated

