### PR TITLE
Make IconSmoothComponent more failure-tolerant of the grid not being available

### DIFF
--- a/Content.Client/GameObjects/Components/ReinforcedWallComponent.cs
+++ b/Content.Client/GameObjects/Components/ReinforcedWallComponent.cs
@@ -2,6 +2,7 @@ using Content.Client.GameObjects.Components.IconSmoothing;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
+using Robust.Shared.Map;
 using static Robust.Client.GameObjects.SpriteComponent;
 
 namespace Content.Client.GameObjects.Components
@@ -35,11 +36,11 @@ namespace Content.Client.GameObjects.Components
             }
         }
 
-        internal override void CalculateNewSprite()
+        internal override void CalculateNewSprite(IMapGrid grid)
         {
-            base.CalculateNewSprite();
+            base.CalculateNewSprite(grid);
 
-            var (cornerNE, cornerNW, cornerSW, cornerSE) = CalculateCornerFill();
+            var (cornerNE, cornerNW, cornerSW, cornerSE) = CalculateCornerFill(grid);
 
             if (Sprite != null)
             {


### PR DESCRIPTION
## About the PR

This (hopefully) fixes power stuff disappearing by making IconSmoothComponent more failure-tolerant of grids not being available.

Theoretically this could be hiding the true issue.

Specific log entries that indicate this is occurring:
```
[ERRO] state: Server entity threw in Init: uid=26199, proto=EntityPrototype(SalternSubstation)
Robust.Shared.GameObjects.EntityCreationException: Exception inside InitializeAndStartEntity
 ---> System.Collections.Generic.KeyNotFoundException: The given key '0' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Robust.Shared.Map.MapManager.GetGrid(GridId gridID) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/Map/MapManager.cs:line 490
   at Content.Client.GameObjects.Components.IconSmoothing.IconSmoothComponent.Startup() in /home/runner/work/space-station-14/space-station-14/Content.Client/GameObjects/Components/IconSmoothing/IconSmoothComponent.cs:line 79
   at Robust.Shared.GameObjects.Component.set_Running(Boolean value) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/Component.cs:line 63
   at Robust.Shared.GameObjects.Entity.StartAllComponents() in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/Entity.cs:line 180
   at Robust.Shared.GameObjects.EntityManager.StartEntity(Entity entity) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 449
   at Robust.Shared.GameObjects.EntityManager.InitializeAndStartEntity(Entity entity) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 433
   --- End of inner exception stack trace ---
   at Robust.Shared.GameObjects.EntityManager.InitializeAndStartEntity(Entity entity) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 438
   at Robust.Shared.GameObjects.EntityManager.SpawnEntity(String protoName, EntityCoordinates coordinates) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 182
   at Content.Client.GameObjects.Components.ClientEntitySpawnerComponent.SpawnEntities() in /home/runner/work/space-station-14/space-station-14/Content.Client/GameObjects/Components/ClientEntitySpawnerComponent.cs:line 34
   at Robust.Shared.GameObjects.Entity.InitializeComponents() in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/Entity.cs:line 141
   at Robust.Shared.GameObjects.EntityManager.InitializeEntity(Entity entity) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 444
   at Robust.Client.GameObjects.ClientEntityManager.Robust.Client.GameObjects.IClientEntityManagerInternal.InitializeEntity(IEntity entity) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameObjects/ClientEntityManager.cs:line 46
   at Robust.Client.GameStates.ClientGameStateManager.ApplyEntityStates(EntityState[] curEntStates, IEnumerable`1 deletions, EntityState[] nextEntStates) in /home/runner/work/RobustToolbox/RobustToolbox/Robust.Client/GameStates/ClientGameStateManager.cs:line 481
```

**Changelog**

:cl:
- fix: Hopefully fix power equipment disappearing.
