### PR TITLE
Fix exception in IconSmoothSystem that occurs with power stuff

### DIFF
--- a/Content.Client/GameObjects/EntitySystems/IconSmoothSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/IconSmoothSystem.cs
@@ -66,10 +66,10 @@ namespace Content.Client.GameObjects.EntitySystems
             // This is simpler to implement. If you want to optimize it be my guest.
             var senderEnt = ev.Sender;
             if (senderEnt.IsValid() &&
+                _mapManager.TryGetGrid(senderEnt.Transform.GridID, out var grid1) &&
                 senderEnt.TryGetComponent(out IconSmoothComponent? iconSmooth)
                 && iconSmooth.Running)
             {
-                var grid1 = _mapManager.GetGrid(senderEnt.Transform.GridID);
                 var coords = senderEnt.Transform.Coordinates;
 
                 _dirtyEntities.Enqueue(senderEnt.Uid);


### PR DESCRIPTION
## About the PR

This finally ought to actually kill the missing powerstuff bug for real this time. Hopefully.

You may be wondering what happened with the last PR.
The answer is the last PR did avert the exceptions as planned. And then a bunch more came up because I forgot that there was code in the EntitySystem too.

To be clear, I've worked out that the underlying problem is that `ClientEntitySpawnerComponent` spawns the connector entities "too early" and therefore tries to spawn them in what is effectively nullspace.

I have no good ideas on how to solve this.

So for now I am continuing what I started in just adding more fault-tolerance.

If anyone has a more permanent plan, get that ready, close this PR, and revert my previous PR on the matter (#4063)

**Changelog**

:cl:
- fix: Attempt 2 at fixing substation/apc/generator disappearances

