### PR TITLE
More rotatability

### DIFF
--- a/Content.Client/GameObjects/Components/Buckle/BuckleComponent.cs
+++ b/Content.Client/GameObjects/Components/Buckle/BuckleComponent.cs
@@ -43,7 +43,7 @@ namespace Content.Client.GameObjects.Components.Buckle
                 return;
             }
 
-            if (!_buckled && _originalDrawDepth.HasValue)
+            if (_originalDrawDepth.HasValue && !buckle.DrawDepth.HasValue)
             {
                 ownerSprite.DrawDepth = _originalDrawDepth.Value;
                 _originalDrawDepth = null;

--- a/Content.Server/GameObjects/EntitySystems/BuckleSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/BuckleSystem.cs
@@ -33,23 +33,6 @@ namespace Content.Server.GameObjects.EntitySystems
             SubscribeLocalEvent<BuckleComponent, AttackHandEvent>(HandleAttackHand);
         }
 
-        public override void Shutdown()
-        {
-            base.Shutdown();
-
-            UnsubscribeLocalEvent<BuckleComponent, MoveEvent>();
-
-            UnsubscribeLocalEvent<StrapComponent, RotateEvent>();
-
-            UnsubscribeLocalEvent<BuckleComponent, EntInsertedIntoContainerMessage>();
-            UnsubscribeLocalEvent<StrapComponent, EntInsertedIntoContainerMessage>();
-
-            UnsubscribeLocalEvent<BuckleComponent, EntRemovedFromContainerMessage>();
-            UnsubscribeLocalEvent<StrapComponent, EntRemovedFromContainerMessage>();
-
-            UnsubscribeLocalEvent<BuckleComponent, AttackHandEvent>(HandleAttackHand);
-        }
-
         private void HandleAttackHand(EntityUid uid, BuckleComponent component, AttackHandEvent args)
         {
             args.Handled = component.TryUnbuckle(args.User);

--- a/Resources/Prototypes/Entities/Constructible/Furniture/seats.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/seats.yml
@@ -89,6 +89,8 @@
   id: StoolBar
   parent: SeatBase
   components:
+  - type: Rotatable
+    rotateWhileAnchored: true
   - type: Anchorable
   - type: Sprite
     state: bar_stool

--- a/Resources/Prototypes/Entities/Constructible/Power/Engines/PA/base.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/Engines/PA/base.yml
@@ -6,6 +6,7 @@
   components:
     - type: InteractionOutline
     - type: Anchorable
+    - type: Rotatable
     - type: Physics
       bodyType: Static
       fixtures:

--- a/Resources/Prototypes/Entities/Constructible/Power/Engines/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/Engines/Singularity/collector.yml
@@ -40,4 +40,5 @@
         nodeGroupID: HVPower
   - type: RadiationCollector
   - type: Anchorable
+  - type: Rotatable
   - type: Pullable


### PR DESCRIPTION
## About the PR

This PR makes barstools, PA components, and radiation collectors rotatable.

In addition, it allows you to implicitly rotate a rotate-while-anchored object when you turn to face it if you're buckled to it.

Finally, it fixes a bug with rotating such an object while someone is attached to it.

**Changelog**

:cl:
- add: You can rotate barstools, PA components, and radiation collectors.
- add: You can turn to face people on rotatable chairs.
- fix: Fixes draw depths and buckle offsets if a chair or such is rotated with someone on it.

