### PR TITLE
MindComponent loc, kitchenspike loc fixes, climbable loc fixes

### DIFF
--- a/Content.Server/GameObjects/Components/Kitchen/KitchenSpikeComponent.cs
+++ b/Content.Server/GameObjects/Components/Kitchen/KitchenSpikeComponent.cs
@@ -143,11 +143,11 @@ namespace Content.Server.GameObjects.Components.Kitchen
 
             _meatPrototype = butcherable.MeatPrototype;
             _meatParts = 5;
-            _meatSource1p = Loc.GetString("comp-kitchen-spike-remove-meat", ("victim", victim));
-            _meatSource0 = Loc.GetString("comp-kitchen-spike-remove-meat-last", ("victim", victim));
+            _meatSource1p = Loc.GetString("comp-kitchen-spike-remove-meat", ("victim", victim.Name));
+            _meatSource0 = Loc.GetString("comp-kitchen-spike-remove-meat-last", ("victim", victim.Name));
             // TODO: This could stand to be improved somehow, but it'd require Name to be much 'richer' in detail than it presently is.
             // But Name is RobustToolbox-level, so presumably it'd have to be done in some other way (interface???)
-            _meatName = Loc.GetString("comp-kitchen-spike-meat-name", ("victim", victim));
+            _meatName = Loc.GetString("comp-kitchen-spike-meat-name", ("victim", victim.Name));
 
             // TODO: Visualizer
             if (Owner.TryGetComponent<SpriteComponent>(out var sprite))

--- a/Content.Server/GameObjects/Components/Kitchen/KitchenSpikeComponent.cs
+++ b/Content.Server/GameObjects/Components/Kitchen/KitchenSpikeComponent.cs
@@ -85,7 +85,7 @@ namespace Content.Server.GameObjects.Components.Kitchen
 
             if (!victim.TryGetComponent(out butcherable))
             {
-                Owner.PopupMessage(user, Loc.GetString("comp-kitchen-spike-deny-butcher", ("victim", victim), ("this", Owner)));
+                Owner.PopupMessage(user, Loc.GetString("comp-kitchen-spike-deny-butcher", ("victim", victim.Name), ("this", Owner)));
                 return false;
             }
 
@@ -143,11 +143,11 @@ namespace Content.Server.GameObjects.Components.Kitchen
 
             _meatPrototype = butcherable.MeatPrototype;
             _meatParts = 5;
-            _meatSource1p = Loc.GetString("comp-kitchen-spike-remove-meat", ("victim", victim.Name));
-            _meatSource0 = Loc.GetString("comp-kitchen-spike-remove-meat-last", ("victim", victim.Name));
+            _meatSource1p = Loc.GetString("comp-kitchen-spike-remove-meat", ("victim", victim));
+            _meatSource0 = Loc.GetString("comp-kitchen-spike-remove-meat-last", ("victim", victim));
             // TODO: This could stand to be improved somehow, but it'd require Name to be much 'richer' in detail than it presently is.
             // But Name is RobustToolbox-level, so presumably it'd have to be done in some other way (interface???)
-            _meatName = Loc.GetString("comp-kitchen-spike-meat-name", ("victim", victim.Name));
+            _meatName = Loc.GetString("comp-kitchen-spike-meat-name", ("victim", victim));
 
             // TODO: Visualizer
             if (Owner.TryGetComponent<SpriteComponent>(out var sprite))

--- a/Content.Server/GameObjects/Components/Kitchen/KitchenSpikeComponent.cs
+++ b/Content.Server/GameObjects/Components/Kitchen/KitchenSpikeComponent.cs
@@ -85,7 +85,7 @@ namespace Content.Server.GameObjects.Components.Kitchen
 
             if (!victim.TryGetComponent(out butcherable))
             {
-                Owner.PopupMessage(user, Loc.GetString("comp-kitchen-spike-deny-butcher", ("victim", victim.Name), ("this", Owner)));
+                Owner.PopupMessage(user, Loc.GetString("comp-kitchen-spike-deny-butcher", ("victim", victim), ("this", Owner)));
                 return false;
             }
 

--- a/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
@@ -137,8 +137,8 @@ namespace Content.Server.GameObjects.Components.Mobs
             if (!HasMind)
             {
                 var aliveText =
-                    $"[color=red]{Loc.GetString("{0:They} {0:are} totally catatonic. The stresses of life in deep-space must have been too much for {0:them}. Any recovery is unlikely.", Owner)}[/color]";
-                var deadText = $"[color=purple]{Loc.GetString("{0:Their} soul has departed.", Owner)}[/color]";
+                    $"[color=purple]{Loc.GetString("comp-mind-examined-catatonic")}[/color]";
+                var deadText = $"[color=red]{Loc.GetString("comp-mind-examined-dead")}[/color]";
 
                 message.AddMarkup(dead ? deadText : aliveText);
             }
@@ -147,7 +147,7 @@ namespace Content.Server.GameObjects.Components.Mobs
                 if (dead) return;
 
                 var text =
-                    $"[color=yellow]{Loc.GetString("{0:They} {0:have} a blank, absent-minded stare and appears completely unresponsive to anything. {0:They} may snap out of it soon.", Owner)}[/color]";
+                    $"[color=yellow]{Loc.GetString("comp-mind-examined-ssd")}[/color]";
 
                 message.AddMarkup(text);
             }

--- a/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
+++ b/Content.Server/GameObjects/Components/Mobs/MindComponent.cs
@@ -137,8 +137,8 @@ namespace Content.Server.GameObjects.Components.Mobs
             if (!HasMind)
             {
                 var aliveText =
-                    $"[color=purple]{Loc.GetString("comp-mind-examined-catatonic")}[/color]";
-                var deadText = $"[color=red]{Loc.GetString("comp-mind-examined-dead")}[/color]";
+                    $"[color=purple]{Loc.GetString("comp-mind-examined-catatonic", ("ent", Owner))}[/color]";
+                var deadText = $"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", Owner))}[/color]";
 
                 message.AddMarkup(dead ? deadText : aliveText);
             }
@@ -147,7 +147,7 @@ namespace Content.Server.GameObjects.Components.Mobs
                 if (dead) return;
 
                 var text =
-                    $"[color=yellow]{Loc.GetString("comp-mind-examined-ssd")}[/color]";
+                    $"[color=yellow]{Loc.GetString("comp-mind-examined-ssd", ("ent", Owner))}[/color]";
 
                 message.AddMarkup(text);
             }

--- a/Content.Shared/GameObjects/Components/Mobs/SharedHumanoidAppearanceComponent.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/SharedHumanoidAppearanceComponent.cs
@@ -4,6 +4,7 @@ using Content.Shared.Preferences;
 using Content.Shared.Preferences.Appearance;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -65,6 +66,12 @@ namespace Content.Shared.GameObjects.Components.Mobs
             set
             {
                 _gender = value;
+
+                if (Owner.TryGetComponent(out GrammarComponent? g))
+                {
+                    g.Gender = value;
+                }
+
                 Dirty();
             }
         }

--- a/Resources/Locale/en-US/_lib.ftl
+++ b/Resources/Locale/en-US/_lib.ftl
@@ -14,4 +14,56 @@ zzzz-fmt-pressure = { TOSTRING($divided, "G3") } { $places ->
 zzzz-the = { PROPER($ent) ->
     *[false] the
      [true] {""}
-    } { $ent }
+    }
+
+# Used internally by the SUBJECT() function.
+zzzz-subject-pronoun = { GENDER($ent) ->
+    [male] he
+    [female] she
+    [epicene] they
+   *[neuter] it
+   }
+
+# Used internally by the OBJECT() function.
+zzzz-object-pronoun = { GENDER($ent) ->
+    [male] him
+    [female] her
+    [epicene] them
+   *[neuter] it
+   }
+
+# Used internally by the POSSPRONOUN() function.
+zzzz-possessive-pronoun = { GENDER($ent) ->
+    [male] his
+    [female] hers
+    [epicene] theirs
+   *[neuter] its
+   }
+
+# Used internally by the POSSADJ() function.
+zzzz-possessive-adjective = { GENDER($ent) ->
+    [male] his
+    [female] her
+    [epicene] their
+   *[neuter] its
+   }
+
+# Used internally by the REFLEXIVE() function.
+zzzz-reflexive-pronoun = { GENDER($ent) ->
+    [male] himself
+    [female] herself
+    [epicene] themselves
+   *[neuter] itself
+   }
+
+# Used internally by the CONJUGATE-BE() function.
+zzzz-conjugate-be = { GENDER($ent) ->
+    [epicene] are
+   *[other] is
+   }
+
+# Used internally by the CONJUGATE-HAVE() function.
+zzzz-conjugate-have = { GENDER($ent) ->
+    [epicene] have
+   *[other] has
+   }

--- a/Resources/Locale/en-US/_lib.ftl
+++ b/Resources/Locale/en-US/_lib.ftl
@@ -12,8 +12,8 @@ zzzz-fmt-pressure = { TOSTRING($divided, "G3") } { $places ->
 
 # Used internally by the THE() function.
 zzzz-the = { PROPER($ent) ->
-    *[false] the
-     [true] {""}
+    *[false] the { $ent }
+     [true] { $ent }
     }
 
 # Used internally by the SUBJECT() function.
@@ -32,7 +32,7 @@ zzzz-object-pronoun = { GENDER($ent) ->
    *[neuter] it
    }
 
-# Used internally by the POSSPRONOUN() function.
+# Used internally by the POSS-PRONOUN() function.
 zzzz-possessive-pronoun = { GENDER($ent) ->
     [male] his
     [female] hers
@@ -40,7 +40,7 @@ zzzz-possessive-pronoun = { GENDER($ent) ->
    *[neuter] its
    }
 
-# Used internally by the POSSADJ() function.
+# Used internally by the POSS-ADJ() function.
 zzzz-possessive-adjective = { GENDER($ent) ->
     [male] his
     [female] her

--- a/Resources/Locale/en-US/components/climbable-component.ftl
+++ b/Resources/Locale/en-US/components/climbable-component.ftl
@@ -10,13 +10,13 @@ comp-climbable-verb-climb = Vault
 comp-climbable-user-climbs = You jump onto { THE($climbable) }!
 
 # Shown to others when $user climbs on $climbable
-comp-climbable-user-climbs-other  = {$user} jumps onto { THE($climbable) }!
+comp-climbable-user-climbs-other  = { THE($user) } jumps onto { THE($climbable) }!
 
 # Shown to you when your character force someone to climb on $climbable
-comp-climbable-user-climbs-force = You force {$moved-user} onto { THE($climbable) }!
+comp-climbable-user-climbs-force = You force { THE($moved-user) } onto { THE($climbable) }!
 
 # Shown to others when someone force other $moved-user to climb on $climbable
-comp-climbable-user-climbs-force-other = {$user} forces {$moved-user} onto { THE($climbable) }!
+comp-climbable-user-climbs-force-other = { THE($user) } forces { THE($moved-user) } onto { THE($climbable) }!
 
 # Shown to you when your character is far away from climbable
 comp-climbable-cant-reach = You can't reach there!

--- a/Resources/Locale/en-US/components/climbable-component.ftl
+++ b/Resources/Locale/en-US/components/climbable-component.ftl
@@ -10,13 +10,13 @@ comp-climbable-verb-climb = Vault
 comp-climbable-user-climbs = You jump onto { THE($climbable) }!
 
 # Shown to others when $user climbs on $climbable
-comp-climbable-user-climbs-other  = { THE($user) } jumps onto { THE($climbable) }!
+comp-climbable-user-climbs-other  = { CAPITALIZE(THE($user)) } jumps onto { THE($climbable) }!
 
 # Shown to you when your character force someone to climb on $climbable
-comp-climbable-user-climbs-force = You force { THE($moved-user) } onto { THE($climbable) }!
+comp-climbable-user-climbs-force = You force { CAPITALIZE(THE($moved-user)) } onto { THE($climbable) }!
 
 # Shown to others when someone force other $moved-user to climb on $climbable
-comp-climbable-user-climbs-force-other = { THE($user) } forces { THE($moved-user) } onto { THE($climbable) }!
+comp-climbable-user-climbs-force-other = { CAPITALIZE(THE($user)) } forces { THE($moved-user) } onto { THE($climbable) }!
 
 # Shown to you when your character is far away from climbable
 comp-climbable-cant-reach = You can't reach there!

--- a/Resources/Locale/en-US/components/climbable-component.ftl
+++ b/Resources/Locale/en-US/components/climbable-component.ftl
@@ -7,16 +7,16 @@ comp-climbable-verb-climb = Vault
 ### Interaction Messages
 
 # Shown to you when your character climbs on $climbable
-comp-climbable-user-climbs = You jump onto {$climbable}!
+comp-climbable-user-climbs = You jump onto { THE($climbable) }!
 
 # Shown to others when $user climbs on $climbable
-comp-climbable-user-climbs-other  = {$user} jumps onto {$climbable}!
+comp-climbable-user-climbs-other  = {$user} jumps onto { THE($climbable) }!
 
 # Shown to you when your character force someone to climb on $climbable
-comp-climbable-user-climbs-force = You force {$moved-user} onto {$climbable}!
+comp-climbable-user-climbs-force = You force {$moved-user} onto { THE($climbable) }!
 
 # Shown to others when someone force other $moved-user to climb on $climbable
-comp-climbable-user-climbs-force-other = {$user} forces {$moved-user} onto {$climbable}!
+comp-climbable-user-climbs-force-other = {$user} forces {$moved-user} onto { THE($climbable) }!
 
 # Shown to you when your character is far away from climbable
 comp-climbable-cant-reach = You can't reach there!

--- a/Resources/Locale/en-US/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/components/kitchen-spike-component.ftl
@@ -13,4 +13,4 @@ comp-kitchen-spike-suicide-self = You throw yourself on a meat spike!
 comp-kitchen-spike-remove-meat = You remove some meat from { THE($victim) }.
 comp-kitchen-spike-remove-meat-last = You remove the last piece of meat from { THE($victim) }!
 
-comp-kitchen-spike-meat-name = { THE($victim) } meat
+comp-kitchen-spike-meat-name = { $victim } meat

--- a/Resources/Locale/en-US/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/components/kitchen-spike-component.ftl
@@ -1,13 +1,13 @@
-comp-kitchen-spike-deny-collect = { THE($this) } already has something on it, finish collecting its meat first!
-comp-kitchen-spike-deny-butcher = { THE($victim) } can't be butchered on { THE($this) }.
-comp-kitchen-spike-deny-not-dead = { THE($victim) } can't be butchered. { THE($victim) } is not dead!
+comp-kitchen-spike-deny-collect = { CAPITALIZE(THE(this)) } already has something on it, finish collecting its meat first!
+comp-kitchen-spike-deny-butcher = { CAPITALIZE(THE($victim)) } can't be butchered on { THE($this) }.
+comp-kitchen-spike-deny-not-dead = { CAPITALIZE(THE($victim)) } can't be butchered. { CAPITALIZE(SUBJECT($victim)) } { CONJUGATE-BE($victim) } is not dead!
 
 comp-kitchen-spike-begin-hook-victim = { THE($user) } begins dragging you onto { THE($this) }!
 comp-kitchen-spike-begin-hook-self = You begin dragging yourself onto { THE($this) }!
 
-comp-kitchen-spike-kill = { THE($user) } has forced { THE($victim) } onto the spike, killing them instantly!
+comp-kitchen-spike-kill = { CAPITALIZE(THE(user)) } has forced { THE($victim) } onto the spike, killing them instantly!
 
-comp-kitchen-spike-suicide-other = { THE($victim) } has thrown themselves on a meat spike!
+comp-kitchen-spike-suicide-other = { CAPITALIZE(THE($victim)) } has thrown themselves on a meat spike!
 comp-kitchen-spike-suicide-self = You throw yourself on a meat spike!
 
 comp-kitchen-spike-remove-meat = You remove some meat from { THE($victim) }.

--- a/Resources/Locale/en-US/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/components/kitchen-spike-component.ftl
@@ -1,16 +1,16 @@
 comp-kitchen-spike-deny-collect = { THE($this) } already has something on it, finish collecting its meat first!
-comp-kitchen-spike-deny-butcher = { THE($victim) } can't be butchered on { THE($this) }.
-comp-kitchen-spike-deny-not-dead = { THE($victim) } can't be butchered. { THE($victim) } is not dead!.
+comp-kitchen-spike-deny-butcher = { $victim } can't be butchered on { $this }.
+comp-kitchen-spike-deny-not-dead = { $victim } can't be butchered. { $victim } is not dead!
 
-comp-kitchen-spike-begin-hook-victim = { THE($user) } begins dragging you onto { THE($this) }!
+comp-kitchen-spike-begin-hook-victim = { $user } begins dragging you onto { THE($this) }!
 comp-kitchen-spike-begin-hook-self = You begin dragging yourself onto { THE($this) }!
 
-comp-kitchen-spike-kill = { THE($user) } has forced { THE($victim) } onto the spike, killing them instantly!
+comp-kitchen-spike-kill = { $user } has forced { $victim } onto the spike, killing them instantly!
 
-comp-kitchen-spike-suicide-other = { THE($victim) } has thrown themselves on a meat spike!
+comp-kitchen-spike-suicide-other = { $victim } has thrown themselves on a meat spike!
 comp-kitchen-spike-suicide-self = You throw yourself on a meat spike!
 
-comp-kitchen-spike-remove-meat = You remove some meat from { THE($victim) }.
-comp-kitchen-spike-remove-meat-last = You remove the last piece of meat from { THE($victim) }!
+comp-kitchen-spike-remove-meat = You remove some meat from { $victim }.
+comp-kitchen-spike-remove-meat-last = You remove the last piece of meat from { $victim }!
 
 comp-kitchen-spike-meat-name = { $victim } meat

--- a/Resources/Locale/en-US/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/components/kitchen-spike-component.ftl
@@ -1,16 +1,16 @@
 comp-kitchen-spike-deny-collect = { THE($this) } already has something on it, finish collecting its meat first!
-comp-kitchen-spike-deny-butcher = { $victim } can't be butchered on { $this }.
-comp-kitchen-spike-deny-not-dead = { $victim } can't be butchered. { $victim } is not dead!
+comp-kitchen-spike-deny-butcher = { THE($victim) } can't be butchered on { THE($this) }.
+comp-kitchen-spike-deny-not-dead = { THE($victim) } can't be butchered. { THE($victim) } is not dead!
 
-comp-kitchen-spike-begin-hook-victim = { $user } begins dragging you onto { THE($this) }!
+comp-kitchen-spike-begin-hook-victim = { THE($user) } begins dragging you onto { THE($this) }!
 comp-kitchen-spike-begin-hook-self = You begin dragging yourself onto { THE($this) }!
 
-comp-kitchen-spike-kill = { $user } has forced { $victim } onto the spike, killing them instantly!
+comp-kitchen-spike-kill = { THE($user) } has forced { THE($victim) } onto the spike, killing them instantly!
 
-comp-kitchen-spike-suicide-other = { $victim } has thrown themselves on a meat spike!
+comp-kitchen-spike-suicide-other = { THE($victim) } has thrown themselves on a meat spike!
 comp-kitchen-spike-suicide-self = You throw yourself on a meat spike!
 
-comp-kitchen-spike-remove-meat = You remove some meat from { $victim }.
-comp-kitchen-spike-remove-meat-last = You remove the last piece of meat from { $victim }!
+comp-kitchen-spike-remove-meat = You remove some meat from { THE($victim) }.
+comp-kitchen-spike-remove-meat-last = You remove the last piece of meat from { THE($victim) }!
 
-comp-kitchen-spike-meat-name = { $victim } meat
+comp-kitchen-spike-meat-name = { THE($victim) } meat

--- a/Resources/Locale/en-US/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/components/kitchen-spike-component.ftl
@@ -1,11 +1,11 @@
-comp-kitchen-spike-deny-collect = { CAPITALIZE(THE(this)) } already has something on it, finish collecting its meat first!
+comp-kitchen-spike-deny-collect = { CAPITALIZE(THE($this)) } already has something on it, finish collecting its meat first!
 comp-kitchen-spike-deny-butcher = { CAPITALIZE(THE($victim)) } can't be butchered on { THE($this) }.
 comp-kitchen-spike-deny-not-dead = { CAPITALIZE(THE($victim)) } can't be butchered. { CAPITALIZE(SUBJECT($victim)) } { CONJUGATE-BE($victim) } is not dead!
 
 comp-kitchen-spike-begin-hook-victim = { THE($user) } begins dragging you onto { THE($this) }!
 comp-kitchen-spike-begin-hook-self = You begin dragging yourself onto { THE($this) }!
 
-comp-kitchen-spike-kill = { CAPITALIZE(THE(user)) } has forced { THE($victim) } onto the spike, killing them instantly!
+comp-kitchen-spike-kill = { CAPITALIZE(THE($user)) } has forced { THE($victim) } onto the spike, killing them instantly!
 
 comp-kitchen-spike-suicide-other = { CAPITALIZE(THE($victim)) } has thrown themselves on a meat spike!
 comp-kitchen-spike-suicide-self = You throw yourself on a meat spike!

--- a/Resources/Locale/en-US/components/mind-component.ftl
+++ b/Resources/Locale/en-US/components/mind-component.ftl
@@ -1,0 +1,6 @@
+﻿# MindComponent localization
+
+## Messages displayed when a body is examined and in a certain state
+comp-mind-examined-catatonic = They are totally catatonic. The stresses of life in deep-space must have been too much for them. Any recovery is unlikely.
+comp-mind-examined-dead = Their soul has departed.
+comp-mind-examined-ssd = They have a blank, absent-minded stare and appears completely unresponsive to anything. They may snap out of it soon.

--- a/Resources/Locale/en-US/components/mind-component.ftl
+++ b/Resources/Locale/en-US/components/mind-component.ftl
@@ -1,6 +1,6 @@
 ﻿# MindComponent localization
 
 ## Messages displayed when a body is examined and in a certain state
-comp-mind-examined-catatonic = They are totally catatonic. The stresses of life in deep-space must have been too much for them. Any recovery is unlikely.
-comp-mind-examined-dead = Their soul has departed.
-comp-mind-examined-ssd = They have a blank, absent-minded stare and appears completely unresponsive to anything. They may snap out of it soon.
+comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. The stresses of life in deep-space must have been too much for { OBJECT($ent) }. Any recovery is unlikely.
+comp-mind-examined-dead = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed.
+comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } a blank, absent-minded stare and appears completely unresponsive to anything. { CAPITALIZE(SUBJECT($ent)) } may snap out of it soon.

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -232,6 +232,10 @@
     safe: false
   - type: Speech
   - type: Emoting
+  - type: Grammar
+    attributes:
+      proper: true
+
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

requires submod update

- Adds loc to MindComponent, this fixes really ugly dead/catatonic/ssd examine text
- Fixes random usages of THE() in kitchenspike loc and uses names for loc (fixes #3947)
- Adds THE() to climbable, no more "You jump on table!"

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Examining dead/catatonic people looks normal again
