### PR TITLE
Thrown items become not-thrown if you start pulling them.

### DIFF
--- a/Content.Shared/GameObjects/EntitySystems/ThrownItemSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/ThrownItemSystem.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.GameObjects.Components.Items;
+using Content.Shared.Physics.Pull;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Dynamics;
 
 namespace Content.Shared.GameObjects.EntitySystems
 {
@@ -18,22 +20,28 @@ namespace Content.Shared.GameObjects.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<PhysicsSleepMessage>(HandleSleep);
+            SubscribeLocalEvent<ThrownItemComponent, PhysicsSleepMessage>(HandleSleep);
+            SubscribeLocalEvent<PullStartedMessage>(HandlePullStarted);
         }
 
-        public override void Shutdown()
+        private void HandleSleep(EntityUid uid, ThrownItemComponent thrownItem, PhysicsSleepMessage message)
         {
-            base.Shutdown();
-            UnsubscribeLocalEvent<PhysicsSleepMessage>();
+            LandComponent(thrownItem);
         }
 
-        private void HandleSleep(PhysicsSleepMessage message)
+        private void HandlePullStarted(PullStartedMessage message)
         {
-            // TODO: Sub to ThrownitemComponent
-            if (message.Body.Deleted || !message.Body.Owner.TryGetComponent(out ThrownItemComponent? thrownItem)) return;
+            // TODO: this isn't directed so things have to be done the bad way
+            if (message.Pulled.Owner.TryGetComponent(out ThrownItemComponent? thrownItem))
+                LandComponent(thrownItem);
+        }
+
+        private void LandComponent(ThrownItemComponent thrownItem)
+        {
+            if (thrownItem.Owner.Deleted) return;
 
             var user = thrownItem.Thrower;
-            var landing = message.Body.Owner;
+            var landing = thrownItem.Owner;
             var coordinates = landing.Transform.Coordinates;
 
             // LandInteraction


### PR DESCRIPTION
## About the PR

Interesting bug of the day: Pulling a glass shard that is still "thrown" allows you to keep it awake, and therefore, as potent (deadly) as if it was actively thrown.

This PR fixes that bug by cancelling the thrown status when you start pulling the shard.

**Changelog**

:cl:
- fix: Dragging an object causes it to not count as thrown anymore.
