### PR TITLE
Increases spear damage, gives them throw damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -8,9 +8,12 @@
     sprite: Objects/Weapons/Melee/spear.rsi
     state: spear
   - type: MeleeWeapon
+    damage: 10
     range: 1.5
     arcwidth: 0
     arc: spear
+  - type: DamageOtherOnHit
+    amount: 15
   - type: Item
     size: 24
     sprite: Objects/Weapons/Melee/spear.rsi


### PR DESCRIPTION
## About the PR

Mostly gives spears a reason to exist - without this PR they seem to have the same damage as punching something.

Note that this might make them too powerful given their relative accessibility.
Damage numbers were taken from vgstation and seem to line up with the damage numbers of, say, shards, but that said those are also pretty powerful.

**Changelog**

:cl:
- add: Spears now apply damage when thrown, and have more damage

