### PR TITLE
You can now return to a brain. Also, clean up terrible console misuse.

### DIFF
--- a/Content.Server/Commands/Chat/SuicideCommand.cs
+++ b/Content.Server/Commands/Chat/SuicideCommand.cs
@@ -7,6 +7,7 @@ using Content.Server.GameObjects.Components.GUI;
 using Content.Server.GameObjects.Components.Items.Storage;
 using Content.Server.Interfaces.Chat;
 using Content.Server.Interfaces.GameObjects;
+using Content.Server.Interfaces.GameTicking;
 using Content.Server.Players;
 using Content.Server.Utility;
 using Content.Shared.Damage;
@@ -69,8 +70,10 @@ namespace Content.Server.Commands.Chat
                 return;
 
             var chat = IoCManager.Resolve<IChatManager>();
-            var owner = player.ContentData()?.Mind?.OwnedComponent?.Owner;
+            var mind = player.ContentData()?.Mind;
+            var owner = mind?.OwnedComponent?.Owner;
 
+            // This check also proves mind not-null for at the end when the mob is ghosted.
             if (owner == null)
             {
                 shell.WriteLine("You don't have a mind!");
@@ -121,9 +124,9 @@ namespace Content.Server.Commands.Chat
 
             dmgComponent.SetDamage(DamageType.Piercing, 200, owner);
 
-            // Prevent the player from returning to the body. Yes, this is an ugly hack.
-            var ghost = new Ghost(){CanReturn = false};
-            ghost.Execute(shell, argStr, Array.Empty<string>());
+            // Prevent the player from returning to the body.
+            // Note that mind cannot be null because otherwise owner would be null.
+            IoCManager.Resolve<IGameTicker>().OnGhostAttempt(mind!, false);
         }
     }
 }

--- a/Content.Server/Commands/Observer/Ghost.cs
+++ b/Content.Server/Commands/Observer/Ghost.cs
@@ -16,7 +16,6 @@ namespace Content.Server.Commands.Observer
         public string Description => "Give up on life and become a ghost.";
         public string Help => "ghost";
 
-        [Obsolete("Call IGameTicker.OnGhostAttempt(Mind, CanReturn) instead.")]
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var player = shell.Player as IPlayerSession;

--- a/Content.Server/Commands/Observer/Ghost.cs
+++ b/Content.Server/Commands/Observer/Ghost.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using Content.Server.Administration;
 using Content.Server.Interfaces.GameTicking;
 using Content.Server.Players;
@@ -14,8 +15,8 @@ namespace Content.Server.Commands.Observer
         public string Command => "ghost";
         public string Description => "Give up on life and become a ghost.";
         public string Help => "ghost";
-        public bool CanReturn { get; set; } = true;
 
+        [Obsolete("Call IGameTicker.OnGhostAttempt(Mind, CanReturn) instead.")]
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var player = shell.Player as IPlayerSession;
@@ -32,7 +33,7 @@ namespace Content.Server.Commands.Observer
                 return;
             }
 
-            if (!IoCManager.Resolve<IGameTicker>().OnGhostAttempt(mind, CanReturn))
+            if (!IoCManager.Resolve<IGameTicker>().OnGhostAttempt(mind, true))
             {
                 shell?.WriteLine("You can't ghost right now.");
                 return;

--- a/Content.Server/GameObjects/Components/Observer/GhostOnMoveComponent.cs
+++ b/Content.Server/GameObjects/Components/Observer/GhostOnMoveComponent.cs
@@ -1,7 +1,7 @@
 #nullable enable
 using System;
-using Content.Server.Commands.Observer;
 using Content.Server.GameObjects.Components.Mobs;
+using Content.Server.Interfaces.GameTicking;
 using Content.Shared.GameObjects.Components.Movement;
 using Robust.Server.Console;
 using Robust.Shared.Console;
@@ -17,6 +17,7 @@ namespace Content.Server.GameObjects.Components.Observer
     public class GhostOnMoveComponent : Component, IRelayMoveInput, IGhostOnMove
     {
         public override string Name => "GhostOnMove";
+        [Dependency] private readonly IGameTicker _gameTicker = default!;
 
         [DataField("canReturn")] public bool CanReturn { get; set; } = true;
 
@@ -26,8 +27,7 @@ namespace Content.Server.GameObjects.Components.Observer
             if (Owner.HasComponent<VisitingMindComponent>()) return;
             if (!Owner.TryGetComponent(out MindComponent? mind) || !mind.HasMind || mind.Mind!.IsVisitingEntity) return;
 
-            var host = IoCManager.Resolve<IServerConsoleHost>();
-            new Ghost().Execute(new ConsoleShell(host, session), string.Empty, Array.Empty<string>());
+            _gameTicker.OnGhostAttempt(mind.Mind!, CanReturn);
         }
     }
 }

--- a/Content.Server/Mobs/Mind.cs
+++ b/Content.Server/Mobs/Mind.cs
@@ -114,7 +114,13 @@ namespace Content.Server.Mobs
         ///     (Maybe you were looking for the action blocker system?)
         /// </summary>
         [ViewVariables]
-        public bool CharacterDeadIC
+        public bool CharacterDeadIC => CharacterDeadPhysically;
+        /// <summary>
+        ///     True if the OwnedEntity of this mind is physically dead.
+        ///     This specific definition, as opposed to CharacterDeadIC, is used to determine if ghosting should allow return.
+        /// </summary>
+        [ViewVariables]
+        public bool CharacterDeadPhysically
         {
             get
             {


### PR DESCRIPTION
## About the PR

When ghosting from a brain, you weren't able to return to it - the link was severed. This PR allows doing so.
In addition, there is some misuse of `new Ghost().Execute(new ConsoleShell(host, session), string.Empty, Array.Empty<string>());` that is cleaned up.

Mind gets an explicit property to measure "physical deadness" for ghosting purposes, which corrects the issue with ghosting from brains.
This is separate to IC deadness so that changes to IC deadness won't allow arbitrary ghost-and-return for an otherwise 'actually alive' character. (This doesn't have any effect right now but is future-proofing.)

But basically, this is primarily preparation to ensure brains properly carry minds in case anyone wants to do something with that.

**Changelog**

:cl:
- fix: You no longer technically 'go catatonic' when ghosting from a brain or other 'effectively inanimate' object.