### PR TITLE
Fix being able to fill beakers through walls

### DIFF
--- a/Content.Server/GameObjects/Components/Chemistry/SolutionTransferComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/SolutionTransferComponent.cs
@@ -4,6 +4,7 @@ using Content.Shared.Chemistry;
 using Content.Shared.GameObjects.Components.Chemistry;
 using Content.Shared.Interfaces;
 using Content.Shared.Interfaces.GameObjects.Components;
+using Content.Shared.Utility;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -47,7 +48,7 @@ namespace Content.Server.GameObjects.Components.Chemistry
 
         async Task<bool> IAfterInteract.AfterInteract(AfterInteractEventArgs eventArgs)
         {
-            if (!eventArgs.CanReach || eventArgs.Target == null)
+            if (!eventArgs.InRangeUnobstructed() || eventArgs.Target == null)
                 return false;
 
             if (!Owner.TryGetComponent(out ISolutionInteractionsComponent? ownerSolution))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #3928

eventArgs.CanReach seems like a misnomer since it was true even through walls and obstructions

<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

