### PR TITLE
Singularity Fixes, Part 3

### DIFF
--- a/Content.Client/Graphics/Overlays/SingularityOverlay.cs
+++ b/Content.Client/Graphics/Overlays/SingularityOverlay.cs
@@ -43,10 +43,8 @@ namespace Content.Client.Graphics.Overlays
             SingularityQuery(args.Viewport.Eye);
 
             var viewportWB = args.WorldBounds;
-            // This is a blatant cheat.
-            // The correct way of doing this would be if the singularity shader performed the matrix transforms.
-            // I don't need to explain why I'm not doing that.
-            var resolution = Math.Max(0.125f, Math.Min(args.Viewport.RenderScale.X, args.Viewport.RenderScale.Y));
+            // Has to be correctly handled because of the way intensity/falloff transform works so just do it.
+            _shader?.SetParameter("renderScale", args.Viewport.RenderScale);
             foreach (SingularityShaderInstance instance in _singularities.Values)
             {
                 // To be clear, this needs to use "inside-viewport" pixels.
@@ -56,8 +54,8 @@ namespace Content.Client.Graphics.Overlays
                 _shader?.SetParameter("positionInput", tempCoords);
                 if (ScreenTexture != null)
                     _shader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
-                _shader?.SetParameter("intensity", instance.Intensity / resolution);
-                _shader?.SetParameter("falloff", instance.Falloff / resolution);
+                _shader?.SetParameter("intensity", instance.Intensity);
+                _shader?.SetParameter("falloff", instance.Falloff);
 
                 var worldHandle = args.WorldHandle;
                 worldHandle.UseShader(_shader);

--- a/Content.Server/GameObjects/Components/Singularity/ServerSingularityComponent.cs
+++ b/Content.Server/GameObjects/Components/Singularity/ServerSingularityComponent.cs
@@ -61,12 +61,12 @@ namespace Content.Server.GameObjects.Components.Singularity
                 if (value < 0) value = 0;
                 if (value > 6) value = 6;
 
-                _level = value;
                 if ((_level > 1) && (value <= 1))
                 {
                     // Prevents it getting stuck (see SingularityController.MoveSingulo)
                     if (_collidableComponent != null) _collidableComponent.LinearVelocity = Vector2.Zero;
                 }
+                _level = value;
 
                 if(_radiationPulseComponent != null) _radiationPulseComponent.RadsPerSecond = 10 * value;
 

--- a/Resources/Prototypes/Entities/Constructible/Power/Engines/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/Engines/Singularity/generator.yml
@@ -15,8 +15,9 @@
     bodyType: Static
     fixtures:
     - shape:
-        !type:PhysShapeAabb
-          bounds: "-0.5, -0.5, 0.5, 0.5"
+        # Using a circle here makes it a lot easier to pull it all the way from Cargo
+        !type:PhysShapeCircle
+          radius: 0.45
       mass: 25
       # Keep an eye on ParticlesProjectile when adjusting these
       layer:

--- a/Resources/Prototypes/Entities/Constructible/Power/parts.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/parts.yml
@@ -12,7 +12,8 @@
     bodyType: Static
     fixtures:
     - shape:
-        !type:PhysShapeAabb {}
+        !type:PhysShapeAabb
+          bounds: "-0.45, -0.45, 0.45, 0.45"
       mass: 25
       mask:
       - Impassable
@@ -72,7 +73,8 @@
     bodyType: Static
     fixtures:
     - shape:
-        !type:PhysShapeAabb {}
+        !type:PhysShapeAabb
+          bounds: "-0.45, -0.45, 0.45, 0.45"
       mass: 25
       mask:
       - Impassable

--- a/Resources/Prototypes/Entities/Constructible/Power/parts.yml
+++ b/Resources/Prototypes/Entities/Constructible/Power/parts.yml
@@ -1,31 +1,12 @@
 - type: entity
   abstract: true
   id: BaseSmes
+  parent: BaseMachine
   name: SMES
   description: A high-capacity superconducting magnetic energy storage (SMES) unit.
   placement:
     mode: SnapgridCenter
   components:
-  - type: Clickable
-  - type: InteractionOutline
-  - type: Physics
-    bodyType: Static
-    fixtures:
-    - shape:
-        !type:PhysShapeAabb
-          bounds: "-0.45, -0.45, 0.45, 0.45"
-      mass: 25
-      mask:
-      - Impassable
-      - MobImpassable
-      - VaultImpassable
-      - SmallImpassable
-      layer:
-      - Opaque
-      - MobImpassable
-      - VaultImpassable
-      - SmallImpassable
-  - type: SnapGrid
   - type: Sprite
     netsync: false
     sprite: Constructible/Power/smes.rsi
@@ -53,8 +34,6 @@
   - type: PowerSupplier
   - type: BatteryDischarger
     activeSupplyRate: 1000
-  - type: Anchorable
-  - type: Pullable
   - type: ClientEntitySpawner
     prototypes:
     - HVDummyWire
@@ -62,31 +41,12 @@
 - type: entity
   abstract: true
   id: BaseSubstation
+  parent: BaseMachine
   name: substation
   description: Reduces the voltage of electricity put into it.
   placement:
     mode: SnapgridCenter
   components:
-  - type: Clickable
-  - type: InteractionOutline
-  - type: Physics
-    bodyType: Static
-    fixtures:
-    - shape:
-        !type:PhysShapeAabb
-          bounds: "-0.45, -0.45, 0.45, 0.45"
-      mass: 25
-      mask:
-      - Impassable
-      - MobImpassable
-      - VaultImpassable
-      - SmallImpassable
-      layer:
-      - Opaque
-      - MobImpassable
-      - VaultImpassable
-      - SmallImpassable
-  - type: SnapGrid
   - type: Sprite
     sprite: Constructible/Power/substation.rsi
     layers:
@@ -115,8 +75,6 @@
     voltage: Medium
   - type: BatteryDischarger
     activeSupplyRate: 1000
-  - type: Anchorable
-  - type: Pullable
   - type: ClientEntitySpawner
     prototypes:
     - HVDummyWire

--- a/Resources/Prototypes/Entities/Constructible/Specific/Medical/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Medical/cloning_machine.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: CloningPod
-  parent: BaseMachine
+  parent: BaseMachinePowered
   name: cloning pod
   description: A Cloning Pod. 50% reliable.
   components:

--- a/Resources/Prototypes/Entities/Constructible/Specific/Medical/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Constructible/Specific/Medical/medical_scanner.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: MedicalScanner
-  parent: BaseMachine
+  parent: BaseMachinePowered
   name: medical scanner
   description: A bulky medical scanner.
   components:

--- a/Resources/Prototypes/Entities/Constructible/base.yml
+++ b/Resources/Prototypes/Entities/Constructible/base.yml
@@ -10,7 +10,8 @@
     bodyType: Static
     fixtures:
     - shape:
-        !type:PhysShapeAabb {}
+        !type:PhysShapeAabb
+          bounds: "-0.45, -0.45, 0.45, 0.45"
       mass: 50
       layer:
       - SmallImpassable
@@ -34,7 +35,8 @@
     bodyType: Dynamic
     fixtures:
     - shape:
-        !type:PhysShapeAabb {}
+        !type:PhysShapeAabb
+          bounds: "-0.45, -0.45, 0.45, 0.45"
       mass: 50
       layer:
       - SmallImpassable

--- a/Resources/Prototypes/Entities/Constructible/base_machine.yml
+++ b/Resources/Prototypes/Entities/Constructible/base_machine.yml
@@ -5,13 +5,12 @@
   components:
   - type: InteractionOutline
   - type: Anchorable
-  - type: Pullable
-  - type: PowerReceiver
   - type: Physics
     bodyType: Static
     fixtures:
     - shape:
-        !type:PhysShapeAabb {}
+        !type:PhysShapeAabb
+          bounds: "-0.45, -0.45, 0.45, 0.45"
       mass: 25
       layer:
       - MobMask
@@ -28,3 +27,11 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+
+- type: entity
+  abstract: true
+  parent: BaseMachine
+  id: BaseMachinePowered
+  components:
+  - type: PowerReceiver
+

--- a/Resources/Textures/Shaders/singularity.swsl
+++ b/Resources/Textures/Shaders/singularity.swsl
@@ -2,13 +2,14 @@
 
 uniform sampler2D SCREEN_TEXTURE;
 uniform highp vec2 positionInput;
+uniform highp vec2 renderScale;
 uniform highp float falloff;
 uniform highp float intensity;
 
 
 
 void fragment() {
-	highp float distanceToCenter = length(FRAGCOORD.xy-positionInput);
+	highp float distanceToCenter = length((FRAGCOORD.xy - positionInput) / renderScale);
 
 	highp vec2 finalCoords = FRAGCOORD.xy - positionInput;
 	highp float deformation = (pow(intensity, 2.0)*500.0) / pow(distanceToCenter, pow(falloff, 0.5));


### PR DESCRIPTION
## About the PR

This may or may not fix shader intensity issues.
It should *properly* fix issues with the singularity deciding to wander off into a corner.

**Screenshots**

This is the state of the singularity at level 3 under this PR.
I've also worked out a way that should let me sanely adjust these settings - get the singulo to a particular level, then delete the singularity component (to keep it in the current state) and install a "toy singularity" client component to control the intensity and falloff values.

![Screenshot at 2021-05-28 17-41-47](https://user-images.githubusercontent.com/22304167/120016072-0f940000-bfdc-11eb-9660-1add4e13da3f.png)
![Screenshot at 2021-05-28 17-41-57](https://user-images.githubusercontent.com/22304167/120016077-102c9680-bfdc-11eb-93b2-9b098a3818d2.png)

**Changelog**

:cl:
- fix: Render scale (low viewport resolution) will no longer alter singularity intensity. This might reduce effect intensity, I am not sure.
- fix: Singularity should actually not wander off into a corner this time.
- fix: Singularity generators and substations should be easier to pull around through single-tile spaces.