### PR TITLE
Remove ICollideSpecial

### DIFF
--- a/Content.Client/GameObjects/Components/Projectiles/ProjectileComponent.cs
+++ b/Content.Client/GameObjects/Components/Projectiles/ProjectileComponent.cs
@@ -4,16 +4,14 @@ using Robust.Shared.GameObjects;
 namespace Content.Client.GameObjects.Components.Projectiles
 {
     [RegisterComponent]
+    [ComponentReference(typeof(SharedProjectileComponent))]
     public class ProjectileComponent : SharedProjectileComponent
     {
-        protected override EntityUid Shooter => _shooter;
-        private EntityUid _shooter;
-
         public override void HandleComponentState(ComponentState? curState, ComponentState? nextState)
         {
             if (curState is ProjectileComponentState compState)
             {
-                _shooter = compState.Shooter;
+                Shooter = compState.Shooter;
                 IgnoreShooter = compState.IgnoreShooter;
             }
         }

--- a/Content.Client/GameObjects/EntitySystems/BuckleSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/BuckleSystem.cs
@@ -1,0 +1,9 @@
+using Content.Shared.GameObjects.EntitySystems;
+
+namespace Content.Client.GameObjects.EntitySystems
+{
+    internal sealed class BuckleSystem : SharedBuckleSystem
+    {
+
+    }
+}

--- a/Content.Client/GameObjects/EntitySystems/DoorSystem.cs
+++ b/Content.Client/GameObjects/EntitySystems/DoorSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Content.Client.GameObjects.Components.Doors;
 using Content.Shared.GameObjects.Components.Doors;
+using Content.Shared.GameObjects.EntitySystems;
 using Robust.Shared.GameObjects;
 
 namespace Content.Client.GameObjects.EntitySystems
@@ -9,7 +10,7 @@ namespace Content.Client.GameObjects.EntitySystems
     /// <summary>
     /// Used by the client to "predict" when doors will change how collideable they are as part of their opening / closing.
     /// </summary>
-    public class ClientDoorSystem : EntitySystem
+    internal sealed class DoorSystem : SharedDoorSystem
     {
         /// <summary>
         /// List of doors that need to be periodically checked.

--- a/Content.Server/GameObjects/Components/Buckle/BuckleComponent.cs
+++ b/Content.Server/GameObjects/Components/Buckle/BuckleComponent.cs
@@ -413,12 +413,12 @@ namespace Content.Server.GameObjects.Components.Buckle
             return new BuckleComponentState(Buckled, drawDepth, LastEntityBuckledTo, DontCollide);
         }
 
-        public void Update()
+        public void Update(PhysicsComponent physics)
         {
-            if (!DontCollide || Physics == null)
+            if (!DontCollide)
                 return;
 
-            Physics.WakeBody();
+            physics.WakeBody();
 
             if (!IsOnStrapEntityThisFrame && DontCollide)
             {

--- a/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
+++ b/Content.Server/GameObjects/Components/Doors/ServerDoorComponent.cs
@@ -231,7 +231,7 @@ namespace Content.Server.GameObjects.Components.Doors
             // Disabled because it makes it suck hard to walk through double doors.
 
                 TryOpen(otherFixture.Body.Owner);
-            
+
         }
 
         #region Opening
@@ -266,14 +266,14 @@ namespace Content.Server.GameObjects.Components.Doors
                 return true;
             }
 
-            var doorSystem = EntitySystem.Get<ServerDoorSystem>();
+            var doorSystem = EntitySystem.Get<DoorSystem>();
             var isAirlockExternal = HasAccessType("External");
 
             return doorSystem.AccessType switch
             {
-                ServerDoorSystem.AccessTypes.AllowAll => true,
-                ServerDoorSystem.AccessTypes.AllowAllIdExternal => isAirlockExternal || access.IsAllowed(user),
-                ServerDoorSystem.AccessTypes.AllowAllNoExternal => !isAirlockExternal,
+                DoorSystem.AccessTypes.AllowAll => true,
+                DoorSystem.AccessTypes.AllowAllIdExternal => isAirlockExternal || access.IsAllowed(user),
+                DoorSystem.AccessTypes.AllowAllNoExternal => !isAirlockExternal,
                 _ => access.IsAllowed(user)
             };
         }

--- a/Content.Server/GameObjects/Components/Projectiles/ProjectileComponent.cs
+++ b/Content.Server/GameObjects/Components/Projectiles/ProjectileComponent.cs
@@ -15,11 +15,9 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Projectiles
 {
     [RegisterComponent]
+    [ComponentReference(typeof(SharedProjectileComponent))]
     public class ProjectileComponent : SharedProjectileComponent, IStartCollide
     {
-        protected override EntityUid Shooter => _shooter;
-
-        private EntityUid _shooter = EntityUid.Invalid;
 
         [DataField("damages")] private Dictionary<DamageType, int> _damages = new();
 
@@ -49,7 +47,7 @@ namespace Content.Server.GameObjects.Components.Projectiles
         /// <param name="shooter"></param>
         public void IgnoreEntity(IEntity shooter)
         {
-            _shooter = shooter.Uid;
+            Shooter = shooter.Uid;
             Dirty();
         }
 
@@ -77,7 +75,7 @@ namespace Content.Server.GameObjects.Components.Projectiles
 
             if (damage != null)
             {
-                Owner.EntityManager.TryGetEntity(_shooter, out var shooter);
+                Owner.EntityManager.TryGetEntity(Shooter, out var shooter);
 
                 foreach (var (damageType, amount) in _damages)
                 {
@@ -100,7 +98,7 @@ namespace Content.Server.GameObjects.Components.Projectiles
 
         public override ComponentState GetComponentState(ICommonSession player)
         {
-            return new ProjectileComponentState(NetID!.Value, _shooter, IgnoreShooter);
+            return new ProjectileComponentState(Shooter, IgnoreShooter);
         }
     }
 }

--- a/Content.Server/GameObjects/EntitySystems/BuckleSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/BuckleSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.GameObjects.Components.Buckle;
 using Content.Server.GameObjects.Components.Strap;
 using Content.Server.GameObjects.EntitySystems.Click;
+using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces.GameObjects.Components;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
@@ -11,7 +12,7 @@ using Robust.Shared.GameObjects;
 namespace Content.Server.GameObjects.EntitySystems
 {
     [UsedImplicitly]
-    internal sealed class BuckleSystem : EntitySystem
+    internal sealed class BuckleSystem : SharedBuckleSystem
     {
         public override void Initialize()
         {
@@ -40,9 +41,9 @@ namespace Content.Server.GameObjects.EntitySystems
 
         public override void Update(float frameTime)
         {
-            foreach (var comp in ComponentManager.EntityQuery<BuckleComponent>())
+            foreach (var (buckle, physics) in ComponentManager.EntityQuery<BuckleComponent, PhysicsComponent>())
             {
-                comp.Update();
+                buckle.Update(physics);
             }
         }
 

--- a/Content.Server/GameObjects/EntitySystems/DoorSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/DoorSystem.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Content.Shared.GameObjects.EntitySystems;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 
@@ -7,7 +8,7 @@ namespace Content.Server.GameObjects.EntitySystems
     /// <summary>
     /// Used on the server side to manage global access level overrides.
     /// </summary>
-    class ServerDoorSystem : EntitySystem
+    internal sealed class DoorSystem : SharedDoorSystem
     {
         /// <summary>
         ///     Determines the base access behavior of all doors on the station.

--- a/Content.Server/GameTicking/GameRules/RuleSuspicion.cs
+++ b/Content.Server/GameTicking/GameRules/RuleSuspicion.cs
@@ -53,7 +53,7 @@ namespace Content.Server.GameTicking.GameRules
             SoundSystem.Play(filter, "/Audio/Misc/tatoralert.ogg", AudioParams.Default);
             EntitySystem.Get<SuspicionEndTimerSystem>().EndTime = _endTime;
 
-            EntitySystem.Get<ServerDoorSystem>().AccessType = ServerDoorSystem.AccessTypes.AllowAllNoExternal;
+            EntitySystem.Get<DoorSystem>().AccessType = DoorSystem.AccessTypes.AllowAllNoExternal;
 
             Timer.SpawnRepeating(DeadCheckDelay, CheckWinConditions, _checkTimerCancel.Token);
         }
@@ -62,7 +62,7 @@ namespace Content.Server.GameTicking.GameRules
         {
             base.Removed();
 
-            EntitySystem.Get<ServerDoorSystem>().AccessType = ServerDoorSystem.AccessTypes.Id;
+            EntitySystem.Get<DoorSystem>().AccessType = DoorSystem.AccessTypes.Id;
             EntitySystem.Get<SuspicionEndTimerSystem>().EndTime = null;
 
             _checkTimerCancel.Cancel();

--- a/Content.Shared/GameObjects/Components/Buckle/SharedBuckleComponent.cs
+++ b/Content.Shared/GameObjects/Components/Buckle/SharedBuckleComponent.cs
@@ -13,13 +13,11 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Shared.GameObjects.Components.Buckle
 {
-    public abstract class SharedBuckleComponent : Component, IActionBlocker, IEffectBlocker, IDraggable, ICollideSpecial
+    public abstract class SharedBuckleComponent : Component, IActionBlocker, IEffectBlocker, IDraggable
     {
         public sealed override string Name => "Buckle";
 
         public sealed override uint? NetID => ContentNetIDs.BUCKLE;
-
-        [ComponentDependency] protected readonly IPhysBody? Physics;
 
         /// <summary>
         ///     The range from which this entity can buckle to a <see cref="SharedStrapComponent"/>.
@@ -40,17 +38,6 @@ namespace Content.Shared.GameObjects.Components.Buckle
         public bool DontCollide { get; set; }
 
         public abstract bool TryBuckle(IEntity? user, IEntity to);
-
-        bool ICollideSpecial.PreventCollide(IPhysBody collidedwith)
-        {
-            if (collidedwith.Owner.Uid == LastEntityBuckledTo)
-            {
-                IsOnStrapEntityThisFrame = true;
-                return Buckled || DontCollide;
-            }
-
-            return false;
-        }
 
         bool IActionBlocker.CanMove()
         {

--- a/Content.Shared/GameObjects/Components/Disposal/SharedDisposalUnitComponent.cs
+++ b/Content.Shared/GameObjects/Components/Disposal/SharedDisposalUnitComponent.cs
@@ -1,24 +1,19 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using Content.Shared.GameObjects.Components.Body;
 using Content.Shared.GameObjects.Components.Mobs.State;
 using Content.Shared.GameObjects.Components.Storage;
 using Content.Shared.Interfaces.GameObjects.Components;
-using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Physics;
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Shared.GameObjects.Components.Disposal
 {
-    public abstract class SharedDisposalUnitComponent : Component, ICollideSpecial, IDragDropOn
+    public abstract class SharedDisposalUnitComponent : Component, IDragDropOn
     {
         public override string Name => "DisposalUnit";
-
-        private readonly List<IEntity> _intersecting = new();
 
         [ViewVariables]
         public bool Anchored =>
@@ -73,44 +68,9 @@ namespace Content.Shared.GameObjects.Components.Disposal
             Pressurizing
         }
 
-        bool ICollideSpecial.PreventCollide(IPhysBody collided)
-        {
-            if (IsExiting(collided.Owner)) return true;
-            if (!Owner.TryGetComponent(out IContainerManager? manager)) return false;
-
-            if (manager.ContainsEntity(collided.Owner))
-            {
-                if (!_intersecting.Contains(collided.Owner))
-                {
-                    _intersecting.Add(collided.Owner);
-                }
-                return true;
-            }
-            return false;
-        }
-
         public virtual void Update(float frameTime)
         {
-            UpdateIntersecting();
-        }
-
-        private bool IsExiting(IEntity entity)
-        {
-            return _intersecting.Contains(entity);
-        }
-
-        private void UpdateIntersecting()
-        {
-            if(_intersecting.Count == 0) return;
-
-            // TODO: Yeah look this sucks but we'll fix it someday.
-            for (var i = _intersecting.Count - 1; i >= 0; i--)
-            {
-                var entity = _intersecting[i];
-
-                if (IoCManager.Resolve<IEntityLookup>().IsIntersecting(entity, Owner))
-                    _intersecting.RemoveAt(i);
-            }
+            return;
         }
 
         [Serializable, NetSerializable]

--- a/Content.Shared/GameObjects/Components/Doors/SharedDoorComponent.cs
+++ b/Content.Shared/GameObjects/Components/Doors/SharedDoorComponent.cs
@@ -11,7 +11,7 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Shared.GameObjects.Components.Doors
 {
-    public abstract class SharedDoorComponent : Component, ICollideSpecial
+    public abstract class SharedDoorComponent : Component
     {
         public override string Name => "Door";
         public override uint? NetID => ContentNetIDs.DOOR;
@@ -94,15 +94,14 @@ namespace Content.Shared.GameObjects.Components.Doors
         /// </summary>
         protected List<EntityUid> CurrentlyCrushing = new();
 
+        public bool IsCrushing(IEntity entity)
+        {
+            return CurrentlyCrushing.Contains(entity.Uid);
+        }
+
         protected void SetAppearance(DoorVisualState state)
         {
             AppearanceComponent?.SetData(DoorVisuals.VisualState, state);
-        }
-
-        // stops us colliding with people we're crushing, to prevent hitbox clipping and jank
-        public bool PreventCollide(IPhysBody collidedwith)
-        {
-            return CurrentlyCrushing.Contains(collidedwith.Owner.Uid);
         }
 
         /// <summary>

--- a/Content.Shared/GameObjects/Components/Projectiles/SharedProjectileComponent.cs
+++ b/Content.Shared/GameObjects/Components/Projectiles/SharedProjectileComponent.cs
@@ -6,13 +6,13 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.GameObjects.Components.Projectiles
 {
-    public abstract class SharedProjectileComponent : Component, ICollideSpecial
+    public abstract class SharedProjectileComponent : Component
     {
         private bool _ignoreShooter = true;
         public override string Name => "Projectile";
         public override uint? NetID => ContentNetIDs.PROJECTILE;
 
-        protected abstract EntityUid Shooter { get; }
+        public EntityUid Shooter { get; protected set; }
 
         public bool IgnoreShooter
         {
@@ -29,7 +29,7 @@ namespace Content.Shared.GameObjects.Components.Projectiles
         [NetSerializable, Serializable]
         protected class ProjectileComponentState : ComponentState
         {
-            public ProjectileComponentState(uint netId, EntityUid shooter, bool ignoreShooter) : base(netId)
+            public ProjectileComponentState(EntityUid shooter, bool ignoreShooter) : base(ContentNetIDs.PROJECTILE)
             {
                 Shooter = shooter;
                 IgnoreShooter = ignoreShooter;
@@ -37,11 +37,6 @@ namespace Content.Shared.GameObjects.Components.Projectiles
 
             public EntityUid Shooter { get; }
             public bool IgnoreShooter { get; }
-        }
-
-        public bool PreventCollide(IPhysBody collidedwith)
-        {
-            return IgnoreShooter && collidedwith.Owner.Uid == Shooter;
         }
     }
 }

--- a/Content.Shared/GameObjects/Components/Pulling/SharedPullableComponent.cs
+++ b/Content.Shared/GameObjects/Components/Pulling/SharedPullableComponent.cs
@@ -18,7 +18,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.GameObjects.Components.Pulling
 {
-    public abstract class SharedPullableComponent : Component, ICollideSpecial, IRelayMoveInput
+    public abstract class SharedPullableComponent : Component, IRelayMoveInput
     {
         public override string Name => "Pullable";
         public override uint? NetID => ContentNetIDs.PULLABLE;
@@ -356,16 +356,6 @@ namespace Content.Shared.GameObjects.Components.Pulling
             MovingTo = null;
 
             base.OnRemove();
-        }
-
-        public bool PreventCollide(IPhysBody collidedWith)
-        {
-            if (_puller == null || _physics == null)
-            {
-                return false;
-            }
-
-            return (_physics.CollisionLayer & collidedWith.CollisionMask) == (int) CollisionGroup.MobImpassable;
         }
 
         // TODO: Need a component bus relay so all entities can use this and not just players

--- a/Content.Shared/GameObjects/EntitySystems/ProjectileSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/ProjectileSystem.cs
@@ -1,0 +1,24 @@
+using Content.Shared.GameObjects.Components.Projectiles;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Dynamics;
+
+namespace Content.Shared.GameObjects.EntitySystems
+{
+    public sealed class ProjectileSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<SharedProjectileComponent, PreventCollideEvent>(PreventCollision);
+        }
+
+        private void PreventCollision(EntityUid uid, SharedProjectileComponent component, PreventCollideEvent args)
+        {
+            if (component.IgnoreShooter && args.BodyB.Owner.Uid == component.Shooter)
+            {
+                args.Cancel();
+                return;
+            }
+        }
+    }
+}

--- a/Content.Shared/GameObjects/EntitySystems/SharedBuckleSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedBuckleSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared.GameObjects.Components.Buckle;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Dynamics;
+
+namespace Content.Shared.GameObjects.EntitySystems
+{
+    public abstract class SharedBuckleSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<SharedBuckleComponent, PreventCollideEvent>(PreventCollision);
+        }
+
+        private void PreventCollision(EntityUid uid, SharedBuckleComponent component, PreventCollideEvent args)
+        {
+            if (args.BodyB.Owner.Uid != component.LastEntityBuckledTo) return;
+
+            component.IsOnStrapEntityThisFrame = true;
+            if (component.Buckled || component.DontCollide)
+            {
+                args.Cancel();
+            }
+        }
+    }
+}

--- a/Content.Shared/GameObjects/EntitySystems/SharedDoorSystem.cs
+++ b/Content.Shared/GameObjects/EntitySystems/SharedDoorSystem.cs
@@ -1,0 +1,23 @@
+using Content.Shared.GameObjects.Components.Doors;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Dynamics;
+
+namespace Content.Shared.GameObjects.EntitySystems
+{
+    public abstract class SharedDoorSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<SharedDoorComponent, PreventCollideEvent>(PreventCollision);
+        }
+
+        private void PreventCollision(EntityUid uid, SharedDoorComponent component, PreventCollideEvent args)
+        {
+            if (component.IsCrushing(args.BodyB.Owner))
+            {
+                args.Cancel();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Handled in an ECS way by PreventCollideEvent.
The disposals one doesn't work anyway and would've required a larger refactor of disposals to fix so out of scope.

Requires [test wtf is ci doing] https://github.com/space-wizards/RobustToolbox/pull/1782