### PR TITLE
Pass in ID to pulling joint

### DIFF
--- a/Content.Shared/GameObjects/Components/Pulling/SharedPullableComponent.cs
+++ b/Content.Shared/GameObjects/Components/Pulling/SharedPullableComponent.cs
@@ -158,7 +158,7 @@ namespace Content.Shared.GameObjects.Components.Pulling
                     var length = Math.Max(union.Size.X, union.Size.Y) * 0.75f;
 
                     _physics.WakeBody();
-                    _pullJoint = pullerPhysics.CreateDistanceJoint(_physics);
+                    _pullJoint = pullerPhysics.CreateDistanceJoint(_physics, $"pull-joint-{_physics.Owner.Uid}");
                     // _physics.BodyType = BodyType.Kinematic; // TODO: Need to consider their original bodytype
                     _pullJoint.CollideConnected = false;
                     _pullJoint.Length = length * 0.75f;


### PR DESCRIPTION
Makes handling network easier as you don't need to teardown the joint and re-create it.

Requires https://github.com/space-wizards/RobustToolbox/pull/1787