### PR TITLE
Fix buckle test

### DIFF
--- a/Content.Server/GameObjects/Components/Buckle/BuckleComponent.cs
+++ b/Content.Server/GameObjects/Components/Buckle/BuckleComponent.cs
@@ -390,13 +390,13 @@ namespace Content.Server.GameObjects.Components.Buckle
 
         public override void OnRemove()
         {
-            base.OnRemove();
-
             BuckledTo?.Remove(this);
             TryUnbuckle(Owner, true);
 
             _buckleTime = default;
             UpdateBuckleStatus();
+
+            base.OnRemove();
         }
 
         public override ComponentState GetComponentState(ICommonSession player)


### PR DESCRIPTION
AFAICT there's a directed event getting raised in TryUnbuckle from the parent change which then tries to GetComponent buckle which doesn't work.
