### PR TITLE
Make dead bodies use CollisionWake

### DIFF
--- a/Content.Server/GameObjects/Components/Mobs/State/DeadMobState.cs
+++ b/Content.Server/GameObjects/Components/Mobs/State/DeadMobState.cs
@@ -30,21 +30,6 @@ namespace Content.Server.GameObjects.Components.Mobs.State
             }
 
             EntitySystem.Get<StandingStateSystem>().Down(entity);
-
-            if (entity.TryGetComponent(out IPhysBody? physics))
-            {
-                physics.CanCollide = false;
-            }
-        }
-
-        public override void ExitState(IEntity entity)
-        {
-            base.ExitState(entity);
-
-            if (entity.TryGetComponent(out IPhysBody? physics))
-            {
-                physics.CanCollide = true;
-            }
         }
     }
 }

--- a/Content.Shared/GameObjects/Components/Mobs/State/SharedDeadMobState.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/State/SharedDeadMobState.cs
@@ -1,6 +1,5 @@
 ﻿using Robust.Shared.GameObjects;
 
-#nullable enable
 namespace Content.Shared.GameObjects.Components.Mobs.State
 {
     public abstract class SharedDeadMobState : BaseMobState

--- a/Content.Shared/GameObjects/Components/Mobs/State/SharedDeadMobState.cs
+++ b/Content.Shared/GameObjects/Components/Mobs/State/SharedDeadMobState.cs
@@ -1,9 +1,27 @@
-﻿#nullable enable
+﻿using Robust.Shared.GameObjects;
+
+#nullable enable
 namespace Content.Shared.GameObjects.Components.Mobs.State
 {
     public abstract class SharedDeadMobState : BaseMobState
     {
         protected override DamageState DamageState => DamageState.Dead;
+
+        public override void EnterState(IEntity entity)
+        {
+            base.EnterState(entity);
+            var wake = entity.EnsureComponent<CollisionWakeComponent>();
+            wake.Enabled = true;
+        }
+
+        public override void ExitState(IEntity entity)
+        {
+            base.ExitState(entity);
+            if (entity.HasComponent<CollisionWakeComponent>())
+            {
+                entity.RemoveComponent<CollisionWakeComponent>();
+            }
+        }
 
         public override bool CanInteract()
         {


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/1794

:cl:
- fix: Dead bodies can be pulled again

