### PR TITLE
Refactor MeleeWeaponComponent and related comps to be ECS

### DIFF
--- a/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
@@ -20,24 +20,16 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
         [Reflect(false)]
         private class TestAttackEntitySystem : EntitySystem
         {
-            public EntityEventHandler<AttackEvent> AttackEvent;
+            public EntityEventHandler<ClickAttackEvent> ClickAttackEvent;
             public EntityEventHandler<InteractUsingEvent> InteractUsingEvent;
             public EntityEventHandler<AttackHandEvent> InteractHandEvent;
 
             public override void Initialize()
             {
                 base.Initialize();
-                SubscribeLocalEvent<AttackEvent>((e) => AttackEvent?.Invoke(e));
+                SubscribeLocalEvent<ClickAttackEvent>((e) => ClickAttackEvent?.Invoke(e));
                 SubscribeLocalEvent<InteractUsingEvent>((e) => InteractUsingEvent?.Invoke(e));
                 SubscribeLocalEvent<AttackHandEvent>((e) => InteractHandEvent?.Invoke(e));
-            }
-
-            public override void Shutdown()
-            {
-                base.Shutdown();
-                UnsubscribeLocalEvent<AttackEvent>();
-                UnsubscribeLocalEvent<InteractUsingEvent>();
-                UnsubscribeLocalEvent<AttackHandEvent>();
             }
         }
 
@@ -88,7 +80,7 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
                 Assert.That(entitySystemManager.TryGetEntitySystem<InteractionSystem>(out var interactionSystem));
 
                 Assert.That(entitySystemManager.TryGetEntitySystem<TestAttackEntitySystem>(out var testAttackEntitySystem));
-                testAttackEntitySystem.AttackEvent = (ev) =>
+                testAttackEntitySystem.ClickAttackEvent = (ev) =>
                 {
                     Assert.That(ev.Target, Is.EqualTo(containerEntity.Uid));
                     attack = true;

--- a/Content.Server/Actions/DisarmAction.cs
+++ b/Content.Server/Actions/DisarmAction.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using Content.Server.GameObjects.EntitySystems;
 using Content.Server.GameObjects.EntitySystems.Click;
+using Content.Server.GameObjects.EntitySystems.Weapon.Melee;
 using Content.Server.Interfaces.GameObjects;
 using Content.Server.Utility;
 using Content.Shared.Actions;

--- a/Content.Server/GameObjects/Components/Chemistry/HyposprayComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/HyposprayComponent.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.Components.Mobs.State;
 using Content.Server.GameObjects.EntitySystems;
+using Content.Server.GameObjects.EntitySystems.Weapon.Melee;
 using Content.Shared.Chemistry;
 using Content.Shared.GameObjects.Components.Chemistry;
 using Content.Shared.GameObjects.EntitySystems;
@@ -23,7 +24,7 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Chemistry
 {
     [RegisterComponent]
-    public sealed class HyposprayComponent : SharedHyposprayComponent, IAttack, ISolutionChange, IAfterInteract
+    public sealed class HyposprayComponent : SharedHyposprayComponent, ISolutionChange, IAfterInteract
     {
         [DataField("ClumsyFailChance")]
         [ViewVariables(VVAccess.ReadWrite)]
@@ -42,14 +43,6 @@ namespace Content.Server.GameObjects.Components.Chemistry
             Dirty();
         }
 
-        bool IAttack.ClickAttack(AttackEvent eventArgs)
-        {
-            var target = eventArgs.TargetEntity;
-            var user = eventArgs.User;
-
-            return TryDoInject(target, user);
-        }
-
         async Task<bool> IAfterInteract.AfterInteract(AfterInteractEventArgs eventArgs)
         {
             if (!eventArgs.CanReach)
@@ -58,7 +51,7 @@ namespace Content.Server.GameObjects.Components.Chemistry
             return TryDoInject(eventArgs.Target, eventArgs.User);
         }
 
-        private bool TryDoInject(IEntity? target, IEntity user)
+        public bool TryDoInject(IEntity? target, IEntity user)
         {
             if (target == null || !EligibleEntity(target))
                 return false;

--- a/Content.Server/GameObjects/Components/Chemistry/HyposprayComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/HyposprayComponent.cs
@@ -24,7 +24,7 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Chemistry
 {
     [RegisterComponent]
-    public sealed class HyposprayComponent : SharedHyposprayComponent, ISolutionChange, IAfterInteract
+    public sealed class HyposprayComponent : SharedHyposprayComponent, ISolutionChange
     {
         [DataField("ClumsyFailChance")]
         [ViewVariables(VVAccess.ReadWrite)]
@@ -41,14 +41,6 @@ namespace Content.Server.GameObjects.Components.Chemistry
             base.Initialize();
 
             Dirty();
-        }
-
-        async Task<bool> IAfterInteract.AfterInteract(AfterInteractEventArgs eventArgs)
-        {
-            if (!eventArgs.CanReach)
-                return false;
-
-            return TryDoInject(eventArgs.Target, eventArgs.User);
         }
 
         public bool TryDoInject(IEntity? target, IEntity user)

--- a/Content.Server/GameObjects/Components/Chemistry/HyposprayComponent.cs
+++ b/Content.Server/GameObjects/Components/Chemistry/HyposprayComponent.cs
@@ -1,25 +1,18 @@
-using System.Threading.Tasks;
 using Content.Server.GameObjects.Components.Mobs;
 using Content.Server.GameObjects.Components.Mobs.State;
-using Content.Server.GameObjects.EntitySystems;
 using Content.Server.GameObjects.EntitySystems.Weapon.Melee;
 using Content.Shared.Chemistry;
 using Content.Shared.GameObjects.Components.Chemistry;
 using Content.Shared.GameObjects.EntitySystems;
 using Content.Shared.Interfaces;
-using Content.Shared.Interfaces.GameObjects.Components;
-using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
 using Robust.Shared.Player;
 using Robust.Shared.Players;
-using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
-
-#nullable enable
 
 namespace Content.Server.GameObjects.Components.Chemistry
 {

--- a/Content.Server/GameObjects/Components/Power/PowerCellSlotComponent.cs
+++ b/Content.Server/GameObjects/Components/Power/PowerCellSlotComponent.cs
@@ -150,7 +150,8 @@ namespace Content.Server.GameObjects.Components.Power
             {
                 SoundSystem.Play(Filter.Pvs(Owner), CellRemoveSound, Owner, AudioHelpers.WithVariation(0.125f));
             }
-            SendMessage(new PowerCellChangedMessage(true));
+
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new PowerCellChangedEvent(true), false);
             return cell;
         }
 
@@ -172,7 +173,8 @@ namespace Content.Server.GameObjects.Components.Power
             {
                 SoundSystem.Play(Filter.Pvs(Owner), CellInsertSound, Owner, AudioHelpers.WithVariation(0.125f));
             }
-            SendMessage(new PowerCellChangedMessage(false));
+
+            Owner.EntityManager.EventBus.RaiseLocalEvent(Owner.Uid, new PowerCellChangedEvent(false), false);
             return true;
         }
 
@@ -238,14 +240,14 @@ namespace Content.Server.GameObjects.Components.Power
         }
     }
 
-    public class PowerCellChangedMessage : ComponentMessage
+    public class PowerCellChangedEvent : EntityEventArgs
     {
         /// <summary>
         /// If true, the cell was ejected; if false, it was inserted.
         /// </summary>
         public bool Ejected { get; }
 
-        public PowerCellChangedMessage(bool ejected)
+        public PowerCellChangedEvent(bool ejected)
         {
             Ejected = ejected;
         }

--- a/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
@@ -17,127 +17,33 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Weapon.Melee
 {
     [RegisterComponent]
-    public class FlashComponent : MeleeWeaponComponent, IUse, IExamine
+    public class FlashComponent : Component
     {
         public override string Name => "Flash";
 
-        public FlashComponent() { Range = 7f; }
+        [DataField("duration")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public int FlashDuration = 5000;
 
-        [DataField("duration")] [ViewVariables(VVAccess.ReadWrite)] private int _flashDuration = 5000;
-        [DataField("uses")] [ViewVariables(VVAccess.ReadWrite)] private int _uses = 5;
-        [ViewVariables(VVAccess.ReadWrite)] private float _range => Range;
-        [ViewVariables(VVAccess.ReadWrite)] private int _aoeFlashDuration => _internalAoeFlashDuration ?? _flashDuration / 3;
-        [DataField("aoeFlashDuration")] private int? _internalAoeFlashDuration;
-        [DataField("slowTo")] [ViewVariables(VVAccess.ReadWrite)] private float _slowTo = 0.75f;
-        private bool _flashing;
+        [DataField("uses")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public int Uses = 5;
 
-        private int Uses
-        {
-            get => _uses;
-            set
-            {
-                _uses = value;
-                Dirty();
-            }
-        }
+        [DataField("range")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float Range = 7f;
 
-        private bool HasUses => _uses > 0;
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("aoeFlashDuration")]
+        public int AoeFlashDuration => FlashDuration / 3;
 
-        protected override bool OnHitEntities(IReadOnlyList<IEntity> entities, AttackEvent eventArgs)
-        {
-            if (entities.Count == 0)
-            {
-                return false;
-            }
+        [DataField("slowTo")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float SlowTo = 0.75f;
 
-            if (!Use(eventArgs.User))
-            {
-                return false;
-            }
+        public bool Flashing;
 
-            foreach (var entity in entities)
-            {
-                Flash(entity, eventArgs.User);
-            }
-
-            return true;
-        }
-
-        bool IUse.UseEntity(UseEntityEventArgs eventArgs)
-        {
-            if (!Use(eventArgs.User))
-            {
-                return false;
-            }
-
-            foreach (var entity in IoCManager.Resolve<IEntityLookup>().GetEntitiesInRange(Owner.Transform.Coordinates, _range))
-            {
-                Flash(entity, eventArgs.User, _aoeFlashDuration);
-            }
-
-            return true;
-        }
-
-        private bool Use(IEntity user)
-        {
-            if (HasUses)
-            {
-                var sprite = Owner.GetComponent<SpriteComponent>();
-                if (--Uses == 0)
-                {
-                    sprite.LayerSetState(0, "burnt");
-                    Owner.PopupMessage(user, Loc.GetString("flash-component-becomes-empty"));
-                }
-                else if (!_flashing)
-                {
-                    int animLayer = sprite.AddLayerWithState("flashing");
-                    _flashing = true;
-
-                    Owner.SpawnTimer(400, () =>
-                    {
-                        sprite.RemoveLayer(animLayer);
-                        _flashing = false;
-                    });
-                }
-
-                SoundSystem.Play(Filter.Pvs(Owner), "/Audio/Weapons/flash.ogg", Owner.Transform.Coordinates,
-                    AudioParams.Default);
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private void Flash(IEntity entity, IEntity user)
-        {
-            Flash(entity, user, _flashDuration);
-        }
-
-        // TODO: Check if target can be flashed (e.g. things like sunglasses would block a flash)
-        // TODO: Merge with the code in FlashableComponent
-        private void Flash(IEntity entity, IEntity user, int flashDuration)
-        {
-            if (entity.TryGetComponent<FlashableComponent>(out var flashable))
-            {
-                flashable.Flash(flashDuration / 1000d);
-            }
-
-            if (entity.TryGetComponent<StunnableComponent>(out var stunnableComponent))
-            {
-                stunnableComponent.Slowdown(flashDuration / 1000f, _slowTo, _slowTo);
-            }
-
-            if (entity != user)
-            {
-                user.PopupMessage(entity,
-                    Loc.GetString(
-                        "flash-component-user-blinds-you",
-                        ("user", user)
-                    )
-                );
-            }
-        }
+        public bool HasUses => Uses > 0;
 
         public void Examine(FormattedMessage message, bool inDetailsRange)
         {

--- a/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
@@ -35,11 +35,11 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("aoeFlashDuration")]
-        public int AoeFlashDuration => FlashDuration / 3;
+        public int AoeFlashDuration = 2000;
 
         [DataField("slowTo")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float SlowTo = 0.75f;
+        public float SlowTo = 0.5f;
 
         public bool Flashing;
 

--- a/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
@@ -1,17 +1,5 @@
-#nullable enable
-using System.Collections.Generic;
-using Content.Server.GameObjects.Components.Mobs;
-using Content.Shared.GameObjects.EntitySystems;
-using Content.Shared.Interfaces;
-using Content.Shared.Interfaces.GameObjects.Components;
-using Robust.Server.GameObjects;
-using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Player;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Weapon.Melee
@@ -23,46 +11,26 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
 
         [DataField("duration")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public int FlashDuration = 5000;
+        public int FlashDuration => 5000;
 
         [DataField("uses")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public int Uses = 5;
+        public int Uses { get; set; } = 5;
 
         [DataField("range")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float Range = 7f;
+        public float Range => 7f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("aoeFlashDuration")]
-        public int AoeFlashDuration = 2000;
+        public int AoeFlashDuration => 2000;
 
         [DataField("slowTo")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float SlowTo = 0.5f;
+        public float SlowTo => 0.5f;
 
         public bool Flashing;
 
         public bool HasUses => Uses > 0;
-
-        public void Examine(FormattedMessage message, bool inDetailsRange)
-        {
-            if (!HasUses)
-            {
-                message.AddText(Loc.GetString("flash-component-examine-empty"));
-                return;
-            }
-
-            if (inDetailsRange)
-            {
-                message.AddMarkup(
-                    Loc.GetString(
-                        "flash-component-examine-detail-count",
-                        ("count", Uses),
-                        ("markupCountColor", "green")
-                    )
-                );
-            }
-        }
     }
 }

--- a/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/FlashComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
 
         [DataField("duration")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public int FlashDuration => 5000;
+        public int FlashDuration { get; set; } = 5000;
 
         [DataField("uses")]
         [ViewVariables(VVAccess.ReadWrite)]
@@ -19,15 +19,15 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
 
         [DataField("range")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float Range => 7f;
+        public float Range { get; set; } = 7f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("aoeFlashDuration")]
-        public int AoeFlashDuration => 2000;
+        public int AoeFlashDuration { get; set; } = 2000;
 
         [DataField("slowTo")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float SlowTo => 0.5f;
+        public float SlowTo { get; set; } = 0.5f;
 
         public bool Flashing;
 

--- a/Content.Server/GameObjects/Components/Weapon/Melee/MeleeChemicalInjectorComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/MeleeChemicalInjectorComponent.cs
@@ -24,48 +24,8 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
 
         [ViewVariables(VVAccess.ReadWrite)]
         public float TransferEfficiency { get => _transferEfficiency; set => _transferEfficiency = Math.Clamp(value, 0, 1); }
+
         [DataField("transferEfficiency")]
         private float _transferEfficiency = 1f;
-
-        public override void HandleMessage(ComponentMessage message, IComponent? component)
-        {
-            base.HandleMessage(message, component);
-            switch (message)
-            {
-                case MeleeHitMessage meleeHit:
-                    InjectEntities(meleeHit.HitEntities);
-                    break;
-            }
-        }
-
-        private void InjectEntities(List<IEntity> hitEntities)
-        {
-            if (!Owner.TryGetComponent<SolutionContainerComponent>(out var solutionContainer))
-                return;
-
-            var hitBloodstreams = new List<BloodstreamComponent>();
-            foreach (var entity in hitEntities)
-            {
-                if (entity.Deleted)
-                    continue;
-
-                if (entity.TryGetComponent<BloodstreamComponent>(out var bloodstream))
-                    hitBloodstreams.Add(bloodstream);
-            }
-
-            if (!hitBloodstreams.Any())
-                return;
-
-            var removedSolution = solutionContainer.Solution.SplitSolution(TransferAmount * hitBloodstreams.Count);
-            var removedVol = removedSolution.TotalVolume;
-            var solutionToInject = removedSolution.SplitSolution(removedVol * TransferEfficiency);
-            var volPerBloodstream = solutionToInject.TotalVolume * (1 / hitBloodstreams.Count);
-
-            foreach (var bloodstream in hitBloodstreams)
-            {
-                var individualInjection = solutionToInject.SplitSolution(volPerBloodstream);
-                bloodstream.TryTransferSolution(individualInjection);
-            }
-        }
     }
 }

--- a/Content.Server/GameObjects/Components/Weapon/Melee/MeleeChemicalInjectorComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/MeleeChemicalInjectorComponent.cs
@@ -1,14 +1,7 @@
-﻿#nullable enable
-using Content.Server.GameObjects.Components.Body.Circulatory;
-using Content.Server.GameObjects.Components.Chemistry;
-using Content.Shared.Chemistry;
+﻿using Content.Shared.Chemistry;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Server.GameObjects.Components.Weapon.Melee

--- a/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
@@ -22,23 +22,25 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Weapon.Melee
 {
     [RegisterComponent]
-    public class MeleeWeaponComponent : Component, IAttack, IHandSelected
+    public class MeleeWeaponComponent : Component
     {
         [Dependency] private readonly IGameTiming _gameTiming = default!;
 
         public override string Name => "MeleeWeapon";
-        private TimeSpan _lastAttackTime;
-        private TimeSpan _cooldownEnd;
 
+        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("hitSound")]
-        private string _hitSound = "/Audio/Weapons/genhit1.ogg";
+        public string HitSound = "/Audio/Weapons/genhit1.ogg";
 
+        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("missSound")]
-        private string _missSound = "/Audio/Weapons/punchmiss.ogg";
+        public string MissSound = "/Audio/Weapons/punchmiss.ogg";
 
+        [ViewVariables]
         [DataField("arcCooldownTime")]
         public float ArcCooldownTime { get; private set; } = 1f;
 
+        [ViewVariables]
         [DataField("cooldownTime")]
         public float CooldownTime { get; private set; } = 1f;
 
@@ -50,7 +52,9 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
         [DataField("arc")]
         public string Arc { get; set; } = "default";
 
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("arcwidth")] public float ArcWidth { get; set; } = 90;
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("arcwidth")]
+        public float ArcWidth { get; set; } = 90;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("range")]
@@ -64,185 +68,11 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
         [DataField("damageType")]
         public DamageType DamageType { get; set; } = DamageType.Blunt;
 
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("clickAttackEffect")] public bool ClickAttackEffect { get; set; } = true;
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("clickAttackEffect")]
+        public bool ClickAttackEffect { get; set; } = true;
 
-        protected virtual bool OnHitEntities(IReadOnlyList<IEntity> entities, AttackEvent eventArgs)
-        {
-            return true;
-        }
-
-        bool IAttack.WideAttack(AttackEvent eventArgs)
-        {
-            if (!eventArgs.WideAttack) return true;
-
-            var curTime = _gameTiming.CurTime;
-
-            if (curTime < _cooldownEnd)
-                return true;
-
-            var location = eventArgs.User.Transform.Coordinates;
-            var diff = eventArgs.ClickLocation.ToMapPos(Owner.EntityManager) - location.ToMapPos(Owner.EntityManager);
-            var angle = Angle.FromWorldVec(diff);
-
-            // This should really be improved. GetEntitiesInArc uses pos instead of bounding boxes.
-            var entities = ArcRayCast(eventArgs.User.Transform.WorldPosition, angle, eventArgs.User);
-
-            if (entities.Count != 0)
-            {
-                SoundSystem.Play(Filter.Pvs(Owner), _hitSound, entities.First().Transform.Coordinates);
-            }
-            else
-            {
-                SoundSystem.Play(Filter.Pvs(Owner), _missSound, eventArgs.User.Transform.Coordinates);
-            }
-
-            var hitEntities = new List<IEntity>();
-            foreach (var entity in entities)
-            {
-                if (!entity.Transform.IsMapTransform || entity == eventArgs.User)
-                    continue;
-
-                if (entity.TryGetComponent(out IDamageableComponent? damageComponent))
-                {
-                    damageComponent.ChangeDamage(DamageType, Damage, false, Owner);
-                    hitEntities.Add(entity);
-                }
-            }
-            SendMessage(new MeleeHitMessage(hitEntities));
-
-            if (!OnHitEntities(hitEntities, eventArgs)) return false;
-
-            if (Arc != null)
-            {
-                var sys = EntitySystem.Get<MeleeWeaponSystem>();
-                sys.SendAnimation(Arc, angle, eventArgs.User, Owner, hitEntities);
-            }
-
-            _lastAttackTime = curTime;
-            _cooldownEnd = _lastAttackTime + TimeSpan.FromSeconds(ArcCooldownTime);
-
-            RefreshItemCooldown();
-
-            return true;
-        }
-
-        bool IAttack.ClickAttack(AttackEvent eventArgs)
-        {
-            if (eventArgs.WideAttack) return false;
-
-            var curTime = _gameTiming.CurTime;
-
-            if (curTime < _cooldownEnd || !eventArgs.Target.IsValid())
-                return true;
-
-            var target = eventArgs.TargetEntity;
-
-            var location = eventArgs.User.Transform.Coordinates;
-            var diff = eventArgs.ClickLocation.ToMapPos(Owner.EntityManager) - location.ToMapPos(Owner.EntityManager);
-            var angle = Angle.FromWorldVec(diff);
-
-            if (target != null)
-            {
-                SoundSystem.Play(Filter.Pvs(Owner), _hitSound, target);
-            }
-            else
-            {
-                SoundSystem.Play(Filter.Pvs(Owner), _missSound, eventArgs.User);
-                return false;
-            }
-
-            if (target.TryGetComponent(out IDamageableComponent? damageComponent))
-            {
-                damageComponent.ChangeDamage(DamageType, Damage, false, Owner);
-            }
-            SendMessage(new MeleeHitMessage(new List<IEntity> { target }));
-
-            var targets = new[] { target };
-
-            if (!OnHitEntities(targets, eventArgs))
-                return false;
-
-            if (ClickArc != null)
-            {
-                var sys = EntitySystem.Get<MeleeWeaponSystem>();
-                sys.SendAnimation(ClickArc, angle, eventArgs.User, Owner, targets, ClickAttackEffect, false);
-            }
-
-            _lastAttackTime = curTime;
-            _cooldownEnd = _lastAttackTime + TimeSpan.FromSeconds(CooldownTime);
-
-            RefreshItemCooldown();
-
-            return true;
-        }
-
-        private HashSet<IEntity> ArcRayCast(Vector2 position, Angle angle, IEntity ignore)
-        {
-            var widthRad = Angle.FromDegrees(ArcWidth);
-            var increments = 1 + 35 * (int) Math.Ceiling(widthRad / (2 * Math.PI));
-            var increment = widthRad / increments;
-            var baseAngle = angle - widthRad / 2;
-
-            var resSet = new HashSet<IEntity>();
-
-            var mapId = Owner.Transform.MapID;
-            for (var i = 0; i < increments; i++)
-            {
-                var castAngle = new Angle(baseAngle + increment * i);
-                var res = EntitySystem.Get<SharedBroadPhaseSystem>().IntersectRay(mapId,
-                    new CollisionRay(position, castAngle.ToWorldVec(),
-                        (int) (CollisionGroup.Impassable | CollisionGroup.MobImpassable)), Range, ignore).ToList();
-
-                if (res.Count != 0)
-                {
-                    resSet.Add(res[0].HitEntity);
-                }
-            }
-
-            return resSet;
-        }
-
-        void IHandSelected.HandSelected(HandSelectedEventArgs eventArgs)
-        {
-            var curTime = _gameTiming.CurTime;
-            var cool = TimeSpan.FromSeconds(CooldownTime * 0.5f);
-
-            if (curTime < _cooldownEnd)
-            {
-                if (_cooldownEnd - curTime < cool)
-                {
-                    _lastAttackTime = curTime;
-                    _cooldownEnd += cool;
-                }
-                else
-                    return;
-            }
-            else
-            {
-                _lastAttackTime = curTime;
-                _cooldownEnd = curTime + cool;
-            }
-
-            RefreshItemCooldown();
-        }
-
-        private void RefreshItemCooldown()
-        {
-            if (Owner.TryGetComponent(out ItemCooldownComponent? cooldown))
-            {
-                cooldown.CooldownStart = _lastAttackTime;
-                cooldown.CooldownEnd = _cooldownEnd;
-            }
-        }
-    }
-
-    public class MeleeHitMessage : ComponentMessage
-    {
-        public readonly List<IEntity> HitEntities;
-
-        public MeleeHitMessage(List<IEntity> hitEntities)
-        {
-            HitEntities = hitEntities;
-        }
+        public TimeSpan LastAttackTime;
+        public TimeSpan CooldownEnd;
     }
 }

--- a/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/MeleeWeaponComponent.cs
@@ -1,22 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using Content.Server.GameObjects.EntitySystems;
 using Content.Shared.Damage;
-using Content.Shared.GameObjects.Components.Damage;
-using Content.Shared.GameObjects.Components.Items;
-using Content.Shared.Interfaces.GameObjects.Components;
-using Content.Shared.Physics;
-using Robust.Server.GameObjects;
-using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
-using Robust.Shared.Physics;
-using Robust.Shared.Physics.Broadphase;
-using Robust.Shared.Player;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Timing;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Weapon.Melee
@@ -24,25 +9,23 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
     [RegisterComponent]
     public class MeleeWeaponComponent : Component
     {
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
-
         public override string Name => "MeleeWeapon";
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("hitSound")]
-        public string HitSound = "/Audio/Weapons/genhit1.ogg";
+        public string HitSound { get; set; } = "/Audio/Weapons/genhit1.ogg";
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("missSound")]
-        public string MissSound = "/Audio/Weapons/punchmiss.ogg";
+        public string MissSound { get; set; } = "/Audio/Weapons/punchmiss.ogg";
 
         [ViewVariables]
         [DataField("arcCooldownTime")]
-        public float ArcCooldownTime { get; private set; } = 1f;
+        public float ArcCooldownTime { get; } = 1f;
 
         [ViewVariables]
         [DataField("cooldownTime")]
-        public float CooldownTime { get; private set; } = 1f;
+        public float CooldownTime { get; } = 1f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("clickArc")]

--- a/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
@@ -25,195 +25,43 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Weapon.Melee
 {
     [RegisterComponent]
-    public class StunbatonComponent : MeleeWeaponComponent, IUse, IExamine, IInteractUsing, IThrowCollide
+    public class StunbatonComponent : Component, IInteractUsing
     {
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
 
         public override string Name => "Stunbaton";
 
-        private bool _activated = false;
+        public bool Activated = false;
 
-        [ViewVariables] private PowerCellSlotComponent _cellSlot = default!;
-        private PowerCellComponent? Cell => _cellSlot.Cell;
+        [ViewVariables]
+        [ComponentDependency]
+        public readonly PowerCellSlotComponent CellSlot = default!;
+        public PowerCellComponent? Cell => CellSlot.Cell;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeChanceNoSlowdown")]
-        private float _paralyzeChanceNoSlowdown = 0.35f;
+        public float ParalyzeChanceNoSlowdown = 0.35f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeChanceWithSlowdown")]
-        private float _paralyzeChanceWithSlowdown = 0.85f;
+        public float ParalyzeChanceWithSlowdown = 0.85f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeTime")]
-        private float _paralyzeTime = 10f;
+        public float ParalyzeTime = 10f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("slowdownTime")]
-        private float _slowdownTime = 5f;
+        public float SlowdownTime = 5f;
 
         [ViewVariables(VVAccess.ReadWrite)] public float EnergyPerUse { get; set; } = 50;
-
-        [ViewVariables]
-        public bool Activated => _activated;
-
-        public override void Initialize()
-        {
-            base.Initialize();
-            _cellSlot = Owner.EnsureComponent<PowerCellSlotComponent>();
-        }
-
-        public override void HandleMessage(ComponentMessage message, IComponent? component)
-        {
-            base.HandleMessage(message, component);
-            switch (message)
-            {
-                case PowerCellChangedMessage m:
-                    if (component is PowerCellSlotComponent slotComponent && slotComponent == _cellSlot)
-                    {
-                        if (m.Ejected)
-                        {
-                            TurnOff();
-                        }
-                    }
-                    break;
-            }
-        }
-
-        protected override bool OnHitEntities(IReadOnlyList<IEntity> entities, AttackEvent eventArgs)
-        {
-            if (!Activated || entities.Count == 0 || Cell == null)
-                return true;
-
-            if (!Cell.TryUseCharge(EnergyPerUse))
-                return true;
-
-            SoundSystem.Play(Filter.Pvs(Owner), "/Audio/Weapons/egloves.ogg", Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
-
-            foreach (var entity in entities)
-            {
-                if (!entity.TryGetComponent(out StunnableComponent? stunnable)) continue;
-
-                if(!stunnable.SlowedDown)
-                {
-                    if(_robustRandom.Prob(_paralyzeChanceNoSlowdown))
-                        stunnable.Paralyze(_paralyzeTime);
-                    else
-                        stunnable.Slowdown(_slowdownTime);
-                }
-                else
-                {
-                    if(_robustRandom.Prob(_paralyzeChanceWithSlowdown))
-                        stunnable.Paralyze(_paralyzeTime);
-                    else
-                        stunnable.Slowdown(_slowdownTime);
-                }
-            }
-
-            if (!(Cell.CurrentCharge < EnergyPerUse)) return true;
-
-            SoundSystem.Play(Filter.Pvs(Owner), AudioHelpers.GetRandomFileFromSoundCollection("sparks"), Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
-            TurnOff();
-
-            return true;
-        }
-
-        private bool ToggleStatus(IEntity user)
-        {
-            if (!ActionBlockerSystem.CanUse(user)) return false;
-            if (Activated)
-            {
-                TurnOff();
-            }
-            else
-            {
-                TurnOn(user);
-            }
-
-            return true;
-        }
-
-        private void TurnOff()
-        {
-            if (!_activated)
-            {
-                return;
-            }
-
-            var sprite = Owner.GetComponent<SpriteComponent>();
-            var item = Owner.GetComponent<ItemComponent>();
-
-            SoundSystem.Play(Filter.Pvs(Owner), AudioHelpers.GetRandomFileFromSoundCollection("sparks"), Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
-
-            item.EquippedPrefix = "off";
-            sprite.LayerSetState(0, "stunbaton_off");
-            _activated = false;
-        }
-
-        private void TurnOn(IEntity user)
-        {
-            if (_activated)
-            {
-                return;
-            }
-
-            var sprite = Owner.GetComponent<SpriteComponent>();
-            var item = Owner.GetComponent<ItemComponent>();
-
-            var playerFilter = Filter.Pvs(Owner);
-            if (Cell == null)
-            {
-                SoundSystem.Play(playerFilter, "/Audio/Machines/button.ogg", Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
-
-                Owner.PopupMessage(user, Loc.GetString("Cell missing..."));
-                return;
-            }
-
-            if (Cell.CurrentCharge < EnergyPerUse)
-            {
-                SoundSystem.Play(playerFilter, "/Audio/Machines/button.ogg", Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
-                Owner.PopupMessage(user, Loc.GetString("Dead cell..."));
-                return;
-            }
-
-            SoundSystem.Play(playerFilter, AudioHelpers.GetRandomFileFromSoundCollection("sparks"), Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
-
-            item.EquippedPrefix = "on";
-            sprite.LayerSetState(0, "stunbaton_on");
-            _activated = true;
-        }
-
-        bool IUse.UseEntity(UseEntityEventArgs eventArgs)
-        {
-            ToggleStatus(eventArgs.User);
-
-            return true;
-        }
 
         async Task<bool> IInteractUsing.InteractUsing(InteractUsingEventArgs eventArgs)
         {
             if (!ActionBlockerSystem.CanInteract(eventArgs.User)) return false;
-            if (!_cellSlot.InsertCell(eventArgs.Using)) return false;
+            if (!CellSlot.InsertCell(eventArgs.Using)) return false;
             Dirty();
             return true;
-        }
-
-        public void Examine(FormattedMessage message, bool inDetailsRange)
-        {
-            if (Activated)
-            {
-                message.AddMarkup(Loc.GetString("The light is currently [color=darkgreen]on[/color]."));
-            }
-        }
-
-        void IThrowCollide.DoHit(ThrowCollideEventArgs eventArgs)
-        {
-            if (!Activated || Cell == null || !Cell.TryUseCharge(EnergyPerUse) || !eventArgs.Target.TryGetComponent(out StunnableComponent? stunnable))
-                return;
-
-            SoundSystem.Play(Filter.Pvs(Owner), "/Audio/Weapons/egloves.ogg", Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
-
-            stunnable.Paralyze(_paralyzeTime);
         }
     }
 }

--- a/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
@@ -1,25 +1,6 @@
 #nullable enable
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Content.Server.GameObjects.Components.Items.Storage;
-using Content.Server.GameObjects.Components.Mobs;
-using Content.Server.GameObjects.Components.Power;
-using Content.Shared.Audio;
-using Content.Shared.GameObjects.EntitySystems;
-using Content.Shared.GameObjects.EntitySystems.ActionBlocker;
-using Content.Shared.Interfaces;
-using Content.Shared.Interfaces.GameObjects.Components;
-using Robust.Server.GameObjects;
-using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
-using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Utility;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameObjects.Components.Weapon.Melee
@@ -27,38 +8,28 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
     [RegisterComponent]
     public class StunbatonComponent : Component
     {
-        [Dependency] private readonly IRobustRandom _robustRandom = default!;
-
         public override string Name => "Stunbaton";
 
         public bool Activated = false;
 
-        [ViewVariables]
-        public PowerCellSlotComponent CellSlot = default!;
-        public PowerCellComponent? Cell => CellSlot.Cell;
-
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeChanceNoSlowdown")]
-        public float ParalyzeChanceNoSlowdown = 0.35f;
+        public float ParalyzeChanceNoSlowdown => 0.35f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeChanceWithSlowdown")]
-        public float ParalyzeChanceWithSlowdown = 0.85f;
+        public float ParalyzeChanceWithSlowdown => 0.85f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeTime")]
-        public float ParalyzeTime = 10f;
+        public float ParalyzeTime => 10f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("slowdownTime")]
-        public float SlowdownTime = 5f;
+        public float SlowdownTime => 5f;
 
-        [ViewVariables(VVAccess.ReadWrite)] public float EnergyPerUse { get; set; } = 50;
-
-        public override void Initialize()
-        {
-            base.Initialize();
-            CellSlot = Owner.EnsureComponent<PowerCellSlotComponent>();
-        }
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("energyPerUse")]
+        public float EnergyPerUse => 50;
     }
 }

--- a/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
@@ -14,22 +14,22 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeChanceNoSlowdown")]
-        public float ParalyzeChanceNoSlowdown => 0.35f;
+        public float ParalyzeChanceNoSlowdown { get; set; } = 0.35f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeChanceWithSlowdown")]
-        public float ParalyzeChanceWithSlowdown => 0.85f;
+        public float ParalyzeChanceWithSlowdown { get; set; } = 0.85f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeTime")]
-        public float ParalyzeTime => 10f;
+        public float ParalyzeTime { get; set; } = 10f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("slowdownTime")]
-        public float SlowdownTime => 5f;
+        public float SlowdownTime { get; set; } = 5f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("energyPerUse")]
-        public float EnergyPerUse => 50;
+        public float EnergyPerUse { get; set; } = 50;
     }
 }

--- a/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
+++ b/Content.Server/GameObjects/Components/Weapon/Melee/StunbatonComponent.cs
@@ -25,7 +25,7 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.GameObjects.Components.Weapon.Melee
 {
     [RegisterComponent]
-    public class StunbatonComponent : Component, IInteractUsing
+    public class StunbatonComponent : Component
     {
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
 
@@ -34,8 +34,7 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
         public bool Activated = false;
 
         [ViewVariables]
-        [ComponentDependency]
-        public readonly PowerCellSlotComponent CellSlot = default!;
+        public PowerCellSlotComponent CellSlot = default!;
         public PowerCellComponent? Cell => CellSlot.Cell;
 
         [ViewVariables(VVAccess.ReadWrite)]
@@ -56,12 +55,10 @@ namespace Content.Server.GameObjects.Components.Weapon.Melee
 
         [ViewVariables(VVAccess.ReadWrite)] public float EnergyPerUse { get; set; } = 50;
 
-        async Task<bool> IInteractUsing.InteractUsing(InteractUsingEventArgs eventArgs)
+        public override void Initialize()
         {
-            if (!ActionBlockerSystem.CanInteract(eventArgs.User)) return false;
-            if (!CellSlot.InsertCell(eventArgs.Using)) return false;
-            Dirty();
-            return true;
+            base.Initialize();
+            CellSlot = Owner.EnsureComponent<PowerCellSlotComponent>();
         }
     }
 }

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -817,7 +817,6 @@ namespace Content.Server.GameObjects.EntitySystems.Click
                 return;
             }
 
-
             // In a container where the target entity is not the container's owner
             if (player.TryGetContainer(out var playerContainer) &&
                 (!EntityManager.TryGetEntity(targetUid, out var target) ||
@@ -832,8 +831,6 @@ namespace Content.Server.GameObjects.EntitySystems.Click
                 }
             }
 
-            var eventArgs = new AttackEvent(player, coordinates, wideAttack, targetUid);
-
             // Verify player has a hand, and find what object he is currently holding in his active hand
             if (player.TryGetComponent<IHandsComponent>(out var hands))
             {
@@ -841,12 +838,10 @@ namespace Content.Server.GameObjects.EntitySystems.Click
 
                 if (item != null)
                 {
-                    RaiseLocalEvent(item.Uid, eventArgs, false);
-                    foreach (var attackComponent in item.GetAllComponents<IAttack>())
-                    {
-                        if (wideAttack ? attackComponent.WideAttack(eventArgs) : attackComponent.ClickAttack(eventArgs))
-                            return;
-                    }
+                    if(wideAttack)
+                        RaiseLocalEvent(item.Uid, new WideAttackEvent(player, coordinates), false);
+                    else
+                        RaiseLocalEvent(item.Uid, new NormalAttackEvent(player, coordinates, targetUid), false);
                 }
                 else
                 {
@@ -860,15 +855,6 @@ namespace Content.Server.GameObjects.EntitySystems.Click
                         }
                     }
                 }
-            }
-
-            RaiseLocalEvent(player.Uid, eventArgs);
-            foreach (var attackComponent in player.GetAllComponents<IAttack>())
-            {
-                if (wideAttack)
-                    attackComponent.WideAttack(eventArgs);
-                else
-                    attackComponent.ClickAttack(eventArgs);
             }
         }
     }

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -841,7 +841,7 @@ namespace Content.Server.GameObjects.EntitySystems.Click
                     if(wideAttack)
                         RaiseLocalEvent(item.Uid, new WideAttackEvent(player, coordinates), false);
                     else
-                        RaiseLocalEvent(item.Uid, new NormalAttackEvent(player, coordinates, targetUid), false);
+                        RaiseLocalEvent(item.Uid, new ClickAttackEvent(player, coordinates, targetUid), false);
                 }
                 else
                 {

--- a/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Click/InteractionSystem.cs
@@ -839,21 +839,15 @@ namespace Content.Server.GameObjects.EntitySystems.Click
                 if (item != null)
                 {
                     if(wideAttack)
-                        RaiseLocalEvent(item.Uid, new WideAttackEvent(player, coordinates), false);
+                        RaiseLocalEvent(item.Uid, new WideAttackEvent(item, player, coordinates), false);
                     else
-                        RaiseLocalEvent(item.Uid, new ClickAttackEvent(player, coordinates, targetUid), false);
+                        RaiseLocalEvent(item.Uid, new ClickAttackEvent(item, player, coordinates, targetUid), false);
                 }
                 else
                 {
                     // We pick up items if our hand is empty, even if we're in combat mode.
-                    if (EntityManager.TryGetEntity(targetUid, out var targetEnt))
-                    {
-                        if (targetEnt.HasComponent<ItemComponent>())
-                        {
-                            Interaction(player, targetEnt);
-                            return;
-                        }
-                    }
+                    if (!EntityManager.TryGetEntity(targetUid, out var targetEnt) || !targetEnt.HasComponent<ItemComponent>()) return;
+                    Interaction(player, targetEnt);
                 }
             }
         }

--- a/Content.Server/GameObjects/EntitySystems/HypospraySystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/HypospraySystem.cs
@@ -1,0 +1,25 @@
+﻿using Content.Server.GameObjects.Components.Chemistry;
+using Content.Server.GameObjects.EntitySystems.Weapon.Melee;
+using Content.Shared.Interfaces.GameObjects.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server.GameObjects.EntitySystems
+{
+    public class HypospraySystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<HyposprayComponent, ClickAttackEvent>(OnClickAttack);
+        }
+
+        public void OnClickAttack(EntityUid uid, HyposprayComponent comp, ClickAttackEvent args)
+        {
+            var target = args.TargetEntity;
+            var user = args.User;
+
+            comp.TryDoInject(target, user);
+        }
+    }
+}

--- a/Content.Server/GameObjects/EntitySystems/HypospraySystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/HypospraySystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Server.GameObjects.Components.Chemistry;
-using Content.Server.GameObjects.EntitySystems.Weapon.Melee;
 using Content.Shared.Interfaces.GameObjects.Components;
 using Robust.Shared.GameObjects;
 

--- a/Content.Server/GameObjects/EntitySystems/HypospraySystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/HypospraySystem.cs
@@ -11,7 +11,18 @@ namespace Content.Server.GameObjects.EntitySystems
         {
             base.Initialize();
 
+            SubscribeLocalEvent<HyposprayComponent, AfterInteractEvent>(OnAfterInteract);
             SubscribeLocalEvent<HyposprayComponent, ClickAttackEvent>(OnClickAttack);
+        }
+
+        public void OnAfterInteract(EntityUid uid, HyposprayComponent comp, AfterInteractEvent args)
+        {
+            if (!args.CanReach)
+                return;
+            var target = args.Target;
+            var user = args.User;
+
+            comp.TryDoInject(target, user);
         }
 
         public void OnClickAttack(EntityUid uid, HyposprayComponent comp, ClickAttackEvent args)

--- a/Content.Server/GameObjects/EntitySystems/ItemCooldownSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/ItemCooldownSystem.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Content.Shared.GameObjects.Components.Items;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server.GameObjects.EntitySystems
+{
+    public class ItemCooldownSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<ItemCooldownComponent, RefreshItemCooldownEvent>(OnItemCooldownRefreshed);
+        }
+
+        public void OnItemCooldownRefreshed(EntityUid uid, ItemCooldownComponent comp, RefreshItemCooldownEvent args)
+        {
+            comp.CooldownStart = args.LastAttackTime;
+            comp.CooldownEnd = args.CooldownEnd;
+        }
+    }
+
+    public class RefreshItemCooldownEvent : EntityEventArgs
+    {
+        public TimeSpan LastAttackTime { get; }
+        public TimeSpan CooldownEnd { get;  }
+
+        public RefreshItemCooldownEvent(TimeSpan lastAttackTime, TimeSpan cooldownEnd)
+        {
+            LastAttackTime = lastAttackTime;
+            CooldownEnd = cooldownEnd;
+        }
+    }
+}

--- a/Content.Server/GameObjects/EntitySystems/MeleeWeaponSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/MeleeWeaponSystem.cs
@@ -1,14 +1,202 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Content.Server.GameObjects.Components.Weapon.Melee;
+using Content.Shared.Damage;
+using Content.Shared.GameObjects.Components.Damage;
+using Content.Shared.GameObjects.Components.Items;
 using Content.Shared.GameObjects.EntitySystemMessages;
+using Content.Shared.Interfaces.GameObjects.Components;
+using Content.Shared.Physics;
+using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Broadphase;
 using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Server.GameObjects.EntitySystems
 {
     public sealed class MeleeWeaponSystem : EntitySystem
     {
+        [Dependency] private IGameTiming _gameTiming = default!;
+        [Dependency] private IEntityManager _entityManager = default!;
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<MeleeWeaponComponent, HandSelectedEvent>(OnHandSelected);
+            SubscribeLocalEvent<MeleeWeaponComponent, NormalAttackEvent>(OnNormalAttack);
+            SubscribeLocalEvent<MeleeWeaponComponent, WideAttackEvent>(OnWideAttack);
+            SubscribeLocalEvent<ItemCooldownComponent, RefreshItemCooldownEvent>(OnCooldownRefreshed);
+        }
+
+        private void OnHandSelected(EntityUid uid, MeleeWeaponComponent comp, HandSelectedEvent args)
+        {
+            var curTime = _gameTiming.CurTime;
+            var cool = TimeSpan.FromSeconds(comp.CooldownTime * 0.5f);
+
+            if (curTime < comp.CooldownEnd)
+            {
+                if (comp.CooldownEnd - curTime < cool)
+                {
+                    comp.LastAttackTime = curTime;
+                    comp.CooldownEnd += cool;
+                }
+                else
+                    return;
+            }
+            else
+            {
+                comp.LastAttackTime = curTime;
+                comp.CooldownEnd = curTime + cool;
+            }
+
+            RaiseLocalEvent(uid, new RefreshItemCooldownEvent(comp.LastAttackTime, comp.CooldownEnd));
+        }
+
+        private void OnNormalAttack(EntityUid uid, MeleeWeaponComponent comp, NormalAttackEvent args)
+        {
+            var curTime = _gameTiming.CurTime;
+            if (!_entityManager.TryGetEntity(uid, out var owner))
+            {
+                args.Succeeded = false;
+                return;
+            }
+
+            if (curTime < comp.CooldownEnd || !args.Target.IsValid())
+            {
+                args.Succeeded = false;
+                return;
+            }
+
+            var target = args.TargetEntity;
+
+            var location = args.User.Transform.Coordinates;
+            var diff = args.ClickLocation.ToMapPos(owner.EntityManager) - location.ToMapPos(owner.EntityManager);
+            var angle = Angle.FromWorldVec(diff);
+
+            if (target != null)
+            {
+                SoundSystem.Play(Filter.Pvs(owner), comp.HitSound, target);
+            }
+            else
+            {
+                SoundSystem.Play(Filter.Pvs(owner), comp.MissSound, args.User);
+                args.Succeeded = false;
+                return;
+            }
+
+            if (target.TryGetComponent(out IDamageableComponent? damageComponent))
+            {
+                damageComponent.ChangeDamage(comp.DamageType, comp.Damage, false, owner);
+            }
+
+            RaiseLocalEvent(uid, new MeleeHitEvent(new List<IEntity>() { target }), false);
+
+            var targets = new[] { target };
+
+            SendAnimation(comp.ClickArc, angle, args.User, owner, targets, comp.ClickAttackEffect, false);
+
+            comp.LastAttackTime = curTime;
+            comp.CooldownEnd = comp.LastAttackTime + TimeSpan.FromSeconds(comp.CooldownTime);
+
+            RaiseLocalEvent(uid, new RefreshItemCooldownEvent(comp.LastAttackTime, comp.CooldownEnd), false);
+            args.Succeeded = true;
+            return;
+        }
+
+        private void OnWideAttack(EntityUid uid, MeleeWeaponComponent comp, WideAttackEvent args)
+        {
+            var curTime = _gameTiming.CurTime;
+
+            if (curTime < comp.CooldownEnd)
+            {
+                args.Succeeded = false;
+                return;
+            }
+
+            if (!_entityManager.TryGetEntity(uid, out var owner))
+            {
+                args.Succeeded = false;
+                return;
+            }
+
+            var location = args.User.Transform.Coordinates;
+            var diff = args.ClickLocation.ToMapPos(owner.EntityManager) - location.ToMapPos(owner.EntityManager);
+            var angle = Angle.FromWorldVec(diff);
+
+            // This should really be improved. GetEntitiesInArc uses pos instead of bounding boxes.
+            var entities = ArcRayCast(args.User.Transform.WorldPosition, angle, comp.ArcWidth, comp.Range, owner.Transform.MapID, args.User);
+
+            if (entities.Count != 0)
+            {
+                SoundSystem.Play(Filter.Pvs(owner), comp.HitSound, entities.First().Transform.Coordinates);
+            }
+            else
+            {
+                SoundSystem.Play(Filter.Pvs(owner), comp.MissSound, args.User.Transform.Coordinates);
+            }
+
+            var hitEntities = new List<IEntity>();
+            foreach (var entity in entities)
+            {
+                if (!entity.Transform.IsMapTransform || entity == args.User)
+                    continue;
+
+                if (entity.TryGetComponent(out IDamageableComponent? damageComponent))
+                {
+                    damageComponent.ChangeDamage(comp.DamageType, comp.Damage, false, owner);
+                    hitEntities.Add(entity);
+                }
+            }
+
+            RaiseLocalEvent(uid, new MeleeHitEvent(hitEntities), false);
+
+            SendAnimation(comp.Arc, angle, args.User, owner, hitEntities);
+
+            comp.LastAttackTime = curTime;
+            comp.CooldownEnd = comp.LastAttackTime + TimeSpan.FromSeconds(comp.ArcCooldownTime);
+
+            RaiseLocalEvent(uid, new RefreshItemCooldownEvent(comp.LastAttackTime, comp.CooldownEnd), false);
+            args.Succeeded = true;
+            return;
+        }
+
+        private HashSet<IEntity> ArcRayCast(Vector2 position, Angle angle, float arcWidth, float range, MapId mapId, IEntity ignore)
+        {
+            var widthRad = Angle.FromDegrees(arcWidth);
+            var increments = 1 + 35 * (int) Math.Ceiling(widthRad / (2 * Math.PI));
+            var increment = widthRad / increments;
+            var baseAngle = angle - widthRad / 2;
+
+            var resSet = new HashSet<IEntity>();
+
+            for (var i = 0; i < increments; i++)
+            {
+                var castAngle = new Angle(baseAngle + increment * i);
+                var res = EntitySystem.Get<SharedBroadPhaseSystem>().IntersectRay(mapId,
+                    new CollisionRay(position, castAngle.ToWorldVec(),
+                        (int) (CollisionGroup.Impassable | CollisionGroup.MobImpassable)), range, ignore).ToList();
+
+                if (res.Count != 0)
+                {
+                    resSet.Add(res[0].HitEntity);
+                }
+            }
+
+            return resSet;
+        }
+
+        private void OnCooldownRefreshed(EntityUid uid, ItemCooldownComponent comp, RefreshItemCooldownEvent args)
+        {
+            comp.CooldownStart = args.LastAttackTime;
+            comp.CooldownEnd = args.CooldownEnd;
+        }
+
         public void SendAnimation(string arc, Angle angle, IEntity attacker, IEntity source, IEnumerable<IEntity> hits, bool textureEffect = false, bool arcFollowAttacker = true)
         {
             RaiseNetworkEvent(new MeleeWeaponSystemMessages.PlayMeleeWeaponAnimationMessage(arc, angle, attacker.Uid, source.Uid,
@@ -18,6 +206,28 @@ namespace Content.Server.GameObjects.EntitySystems
         public void SendLunge(Angle angle, IEntity source)
         {
             RaiseNetworkEvent(new MeleeWeaponSystemMessages.PlayLungeAnimationMessage(angle, source.Uid), Filter.Pvs(source, 1f));
+        }
+    }
+
+    public class MeleeHitEvent : EntityEventArgs
+    {
+        public readonly List<IEntity> HitEntities;
+
+        public MeleeHitEvent(List<IEntity> hitEntities)
+        {
+            HitEntities = hitEntities;
+        }
+    }
+
+    public class RefreshItemCooldownEvent : EntityEventArgs
+    {
+        public TimeSpan LastAttackTime;
+        public TimeSpan CooldownEnd;
+
+        public RefreshItemCooldownEvent(TimeSpan lastAttackTime, TimeSpan cooldownEnd)
+        {
+            LastAttackTime = lastAttackTime;
+            CooldownEnd = cooldownEnd;
         }
     }
 }

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
@@ -66,7 +66,9 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
             if (comp.HasUses)
             {
                 // TODO flash visualizer
-                var sprite = comp.Owner.GetComponent<SpriteComponent>();
+                if (!comp.Owner.TryGetComponent<SpriteComponent>(out var sprite))
+                    return false;
+
                 if (--comp.Uses == 0)
                 {
                     sprite.LayerSetState(0, "burnt");

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
@@ -20,6 +20,7 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
             base.Initialize();
 
             SubscribeLocalEvent<FlashComponent, ClickAttackEvent>(OnClickAttack);
+            SubscribeLocalEvent<FlashComponent, AfterInteractEvent>(OnAfterInteract);
             SubscribeLocalEvent<FlashComponent, UseInHandEvent>(OnUseInHand);
 
             SubscribeLocalEvent<FlashComponent, ExaminedEvent>(OnExamined);
@@ -34,6 +35,17 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
 
             if (args.TargetEntity != null)
                 FlashEntity(args.TargetEntity, args.User, comp.FlashDuration, comp.SlowTo);
+        }
+
+        public void OnAfterInteract(EntityUid uid, FlashComponent comp, AfterInteractEvent args)
+        {
+            if (!UseFlash(comp, args.User))
+            {
+                return;
+            }
+
+            if (args.Target != null)
+                FlashEntity(args.Target, args.User, comp.FlashDuration, comp.SlowTo);
         }
 
         public void OnUseInHand(EntityUid uid, FlashComponent comp, UseInHandEvent args)

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
@@ -19,28 +19,21 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
         {
             base.Initialize();
 
-            SubscribeLocalEvent<FlashComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<FlashComponent, ClickAttackEvent>(OnClickAttack);
             SubscribeLocalEvent<FlashComponent, UseInHandEvent>(OnUseInHand);
 
             SubscribeLocalEvent<FlashComponent, ExaminedEvent>(OnExamined);
         }
 
-        public void OnMeleeHit(EntityUid uid, FlashComponent comp, MeleeHitEvent args)
+        public void OnClickAttack(EntityUid uid, FlashComponent comp, ClickAttackEvent args)
         {
-            if (args.HitEntities.Count == 0)
-            {
-                return;
-            }
-
             if (!UseFlash(comp, args.User))
             {
                 return;
             }
 
-            foreach (var entity in args.HitEntities)
-            {
-                FlashEntity(entity, args.User, comp.FlashDuration, comp.SlowTo);
-            }
+            if (args.TargetEntity != null)
+                FlashEntity(args.TargetEntity, args.User, comp.FlashDuration, comp.SlowTo);
         }
 
         public void OnUseInHand(EntityUid uid, FlashComponent comp, UseInHandEvent args)

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
@@ -89,7 +89,8 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
         }
 
         // TODO: Check if target can be flashed (e.g. things like sunglasses would block a flash)
-        // TODO: Merge with the code in FlashableComponent
+        // TODO: Merge with the code in FlashableComponent--raise an event on the target, that FlashableComponent or
+        // another comp will catch
         private void FlashEntity(IEntity target, IEntity user, float flashDuration, float slowTo)
         {
             if (target.TryGetComponent<FlashableComponent>(out var flashable))

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
@@ -1,0 +1,138 @@
+﻿using Content.Server.GameObjects.Components.Mobs;
+using Content.Server.GameObjects.Components.Weapon;
+using Content.Server.GameObjects.Components.Weapon.Melee;
+using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.Interfaces;
+using Content.Shared.Interfaces.GameObjects.Components;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Player;
+
+namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
+{
+    public class FlashSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<FlashComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<FlashComponent, UseInHandEvent>(OnUseInHand);
+
+            SubscribeLocalEvent<FlashComponent, ExaminedEvent>(OnExamined);
+        }
+
+        public void OnMeleeHit(EntityUid uid, FlashComponent comp, MeleeHitEvent args)
+        {
+            if (args.HitEntities.Count == 0)
+            {
+                return;
+            }
+
+            if (!UseFlash(comp, args.User))
+            {
+                return;
+            }
+
+            foreach (var entity in args.HitEntities)
+            {
+                FlashEntity(entity, args.User, comp.FlashDuration, comp.SlowTo);
+            }
+        }
+
+        public void OnUseInHand(EntityUid uid, FlashComponent comp, UseInHandEvent args)
+        {
+            if (!UseFlash(comp, args.User))
+            {
+                return;
+            }
+
+            foreach (var entity in IoCManager.Resolve<IEntityLookup>().GetEntitiesInRange(comp.Owner.Transform.Coordinates, comp.Range))
+            {
+                FlashEntity(entity, args.User, comp.AoeFlashDuration, comp.SlowTo);
+            }
+        }
+
+        private bool UseFlash(FlashComponent comp, IEntity user)
+        {
+            if (comp.HasUses)
+            {
+                // TODO flash visualizer
+                var sprite = comp.Owner.GetComponent<SpriteComponent>();
+                if (--comp.Uses == 0)
+                {
+                    sprite.LayerSetState(0, "burnt");
+                    comp.Owner.PopupMessage(user, Loc.GetString("flash-component-becomes-empty"));
+                }
+                else if (!comp.Flashing)
+                {
+                    int animLayer = sprite.AddLayerWithState("flashing");
+                    comp.Flashing = true;
+
+                    comp.Owner.SpawnTimer(400, () =>
+                    {
+                        sprite.RemoveLayer(animLayer);
+                        comp.Flashing = false;
+                    });
+                }
+
+                SoundSystem.Play(Filter.Pvs(comp.Owner), "/Audio/Weapons/flash.ogg", comp.Owner.Transform.Coordinates,
+                    AudioParams.Default);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        // TODO: Check if target can be flashed (e.g. things like sunglasses would block a flash)
+        // TODO: Merge with the code in FlashableComponent
+        private void FlashEntity(IEntity target, IEntity user, float flashDuration, float slowTo)
+        {
+            if (target.TryGetComponent<FlashableComponent>(out var flashable))
+            {
+                flashable.Flash(flashDuration / 1000d);
+            }
+
+            if (target.TryGetComponent<StunnableComponent>(out var stunnableComponent))
+            {
+                stunnableComponent.Slowdown(flashDuration / 1000f, slowTo, slowTo);
+            }
+
+            if (target != user)
+            {
+                user.PopupMessage(target,
+                    Loc.GetString(
+                        "flash-component-user-blinds-you",
+                        ("user", user)
+                    )
+                );
+            }
+        }
+
+        private void OnExamined(EntityUid uid, FlashComponent comp, ExaminedEvent args)
+        {
+            if (!comp.HasUses)
+            {
+                args.Message.AddText("\n");
+                args.Message.AddText(Loc.GetString("flash-component-examine-empty"));
+                return;
+            }
+
+            if (args.IsInDetailsRange)
+            {
+                args.Message.AddText("\n");
+                args.Message.AddMarkup(
+                    Loc.GetString(
+                        "flash-component-examine-detail-count",
+                        ("count", comp.Uses),
+                        ("markupCountColor", "green")
+                    )
+                );
+            }
+        }
+    }
+}

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/FlashSystem.cs
@@ -19,33 +19,39 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
         {
             base.Initialize();
 
-            SubscribeLocalEvent<FlashComponent, ClickAttackEvent>(OnClickAttack);
-            SubscribeLocalEvent<FlashComponent, AfterInteractEvent>(OnAfterInteract);
+            SubscribeLocalEvent<FlashComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<FlashComponent, MeleeInteractEvent>(OnMeleeInteract);
             SubscribeLocalEvent<FlashComponent, UseInHandEvent>(OnUseInHand);
 
             SubscribeLocalEvent<FlashComponent, ExaminedEvent>(OnExamined);
         }
 
-        public void OnClickAttack(EntityUid uid, FlashComponent comp, ClickAttackEvent args)
+        public void OnMeleeHit(EntityUid uid, FlashComponent comp, MeleeHitEvent args)
         {
             if (!UseFlash(comp, args.User))
             {
                 return;
             }
 
-            if (args.TargetEntity != null)
-                FlashEntity(args.TargetEntity, args.User, comp.FlashDuration, comp.SlowTo);
+            args.Handled = true;
+            foreach (IEntity e in args.HitEntities)
+            {
+                FlashEntity(e, args.User, comp.FlashDuration, comp.SlowTo);
+            }
         }
 
-        public void OnAfterInteract(EntityUid uid, FlashComponent comp, AfterInteractEvent args)
+        private void OnMeleeInteract(EntityUid uid, FlashComponent comp, MeleeInteractEvent args)
         {
             if (!UseFlash(comp, args.User))
             {
                 return;
             }
 
-            if (args.Target != null)
-                FlashEntity(args.Target, args.User, comp.FlashDuration, comp.SlowTo);
+            if (args.Entity.HasComponent<FlashableComponent>())
+            {
+                args.CanInteract = true;
+                FlashEntity(args.Entity, args.User, comp.FlashDuration, comp.SlowTo);
+            }
         }
 
         public void OnUseInHand(EntityUid uid, FlashComponent comp, UseInHandEvent args)

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/MeleeWeaponSystem.cs
@@ -19,7 +19,7 @@ using Robust.Shared.Physics.Broadphase;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
-namespace Content.Server.GameObjects.EntitySystems
+namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
 {
     public sealed class MeleeWeaponSystem : EntitySystem
     {
@@ -32,8 +32,9 @@ namespace Content.Server.GameObjects.EntitySystems
             SubscribeLocalEvent<MeleeWeaponComponent, HandSelectedEvent>(OnHandSelected);
             SubscribeLocalEvent<MeleeWeaponComponent, ClickAttackEvent>(OnClickAttack);
             SubscribeLocalEvent<MeleeWeaponComponent, WideAttackEvent>(OnWideAttack);
-            SubscribeLocalEvent<MeleeChemicalInjectorComponent, MeleeHitEvent>(OnChemicalInjectorHit);
             SubscribeLocalEvent<ItemCooldownComponent, RefreshItemCooldownEvent>(OnCooldownRefreshed);
+
+            SubscribeLocalEvent<MeleeChemicalInjectorComponent, MeleeHitEvent>(OnChemicalInjectorHit);
         }
 
         private void OnHandSelected(EntityUid uid, MeleeWeaponComponent comp, HandSelectedEvent args)
@@ -97,7 +98,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 damageComponent.ChangeDamage(comp.DamageType, comp.Damage, false, owner);
             }
 
-            RaiseLocalEvent(uid, new MeleeHitEvent(new List<IEntity>() { target }), false);
+            RaiseLocalEvent(uid, new MeleeHitEvent(new List<IEntity>() { target }, args.User), false);
 
             var targets = new[] { target };
 
@@ -156,7 +157,7 @@ namespace Content.Server.GameObjects.EntitySystems
                 }
             }
 
-            RaiseLocalEvent(uid, new MeleeHitEvent(hitEntities), false);
+            RaiseLocalEvent(uid, new MeleeHitEvent(hitEntities, args.User), false);
 
             SendAnimation(comp.Arc, angle, args.User, owner, hitEntities);
 
@@ -244,10 +245,12 @@ namespace Content.Server.GameObjects.EntitySystems
     public class MeleeHitEvent : EntityEventArgs
     {
         public readonly List<IEntity> HitEntities;
+        public IEntity User;
 
-        public MeleeHitEvent(List<IEntity> hitEntities)
+        public MeleeHitEvent(List<IEntity> hitEntities, IEntity user)
         {
             HitEntities = hitEntities;
+            User = user;
         }
     }
 

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/MeleeWeaponSystem.cs
@@ -158,7 +158,6 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
             }
 
             RaiseLocalEvent(uid, new MeleeHitEvent(hitEntities, args.User), false);
-
             SendAnimation(comp.Arc, angle, args.User, owner, hitEntities);
 
             comp.LastAttackTime = curTime;

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/StunbatonSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/StunbatonSystem.cs
@@ -26,24 +26,13 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
         {
             base.Initialize();
 
-            SubscribeLocalEvent<StunbatonComponent, AfterInteractEvent>(OnAfterInteract);
             SubscribeLocalEvent<StunbatonComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<StunbatonComponent, MeleeInteractEvent>(OnMeleeInteract);
             SubscribeLocalEvent<StunbatonComponent, UseInHandEvent>(OnUseInHand);
             SubscribeLocalEvent<StunbatonComponent, ThrowCollideEvent>(OnThrowCollide);
             SubscribeLocalEvent<StunbatonComponent, PowerCellChangedEvent>(OnPowerCellChanged);
             SubscribeLocalEvent<StunbatonComponent, InteractUsingEvent>(OnInteractUsing);
             SubscribeLocalEvent<StunbatonComponent, ExaminedEvent>(OnExamined);
-        }
-
-        private void OnAfterInteract(EntityUid uid, StunbatonComponent comp, AfterInteractEvent args)
-        {
-            if (!comp.Activated || args.Target == null)
-                return;
-
-            if (!ComponentManager.TryGetComponent<PowerCellSlotComponent>(uid, out var slot) || slot.Cell == null || !slot.Cell.TryUseCharge(comp.EnergyPerUse))
-                return;
-
-            StunEntity(args.Target, comp);
         }
 
         private void OnMeleeHit(EntityUid uid, StunbatonComponent comp, MeleeHitEvent args)
@@ -57,6 +46,21 @@ namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
             foreach (IEntity entity in args.HitEntities)
             {
                 StunEntity(entity, comp);
+            }
+        }
+
+        private void OnMeleeInteract(EntityUid uid, StunbatonComponent comp, MeleeInteractEvent args)
+        {
+            if (!comp.Activated)
+                return;
+
+            if (!ComponentManager.TryGetComponent<PowerCellSlotComponent>(uid, out var slot) || slot.Cell == null || !slot.Cell.TryUseCharge(comp.EnergyPerUse))
+                return;
+
+            if (args.Entity.HasComponent<StunnableComponent>())
+            {
+                args.CanInteract = true;
+                StunEntity(args.Entity, comp);
             }
         }
 

--- a/Content.Server/GameObjects/EntitySystems/Weapon/Melee/StunbatonSystem.cs
+++ b/Content.Server/GameObjects/EntitySystems/Weapon/Melee/StunbatonSystem.cs
@@ -1,0 +1,164 @@
+﻿using Content.Server.GameObjects.Components.Items.Storage;
+using Content.Server.GameObjects.Components.Mobs;
+using Content.Server.GameObjects.Components.Power;
+using Content.Server.GameObjects.Components.Weapon.Melee;
+using Content.Shared.Audio;
+using Content.Shared.GameObjects.Components.Power;
+using Content.Shared.GameObjects.EntitySystems;
+using Content.Shared.GameObjects.EntitySystems.ActionBlocker;
+using Content.Shared.Interfaces;
+using Content.Shared.Interfaces.GameObjects.Components;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+
+namespace Content.Server.GameObjects.EntitySystems.Weapon.Melee
+{
+    public class StunbatonSystem : EntitySystem
+    {
+        [Dependency] private IRobustRandom _robustRandom = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<StunbatonComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<StunbatonComponent, UseInHandEvent>(OnUseInHand);
+            SubscribeLocalEvent<StunbatonComponent, ThrowCollideEvent>(OnThrowCollide);
+            SubscribeLocalEvent<StunbatonComponent, PowerCellChangedEvent>(OnPowerCellChanged);
+            SubscribeLocalEvent<StunbatonComponent, ExaminedEvent>(OnExamined);
+        }
+
+        private void OnMeleeHit(EntityUid uid, StunbatonComponent comp, MeleeHitEvent args)
+        {
+            if (!comp.Activated || args.HitEntities.Count == 0 || comp.Cell == null)
+                return;
+
+            if (!comp.Cell.TryUseCharge(comp.EnergyPerUse))
+                return;
+
+            foreach (var entity in args.HitEntities)
+            {
+                StunEntity(entity, comp);
+            }
+
+            if (!(comp.Cell.CurrentCharge < comp.EnergyPerUse)) return;
+
+            SoundSystem.Play(Filter.Pvs(comp.Owner), AudioHelpers.GetRandomFileFromSoundCollection("sparks"), comp.Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
+            TurnOff(comp);
+        }
+
+        private void OnUseInHand(EntityUid uid, StunbatonComponent comp, UseInHandEvent args)
+        {
+            if (!ActionBlockerSystem.CanUse(args.User)) return;
+            if (comp.Activated)
+            {
+                TurnOff(comp);
+            }
+            else
+            {
+                TurnOn(comp, args.User);
+            }
+        }
+
+        private void OnThrowCollide(EntityUid uid, StunbatonComponent comp, ThrowCollideEvent args)
+        {
+            if (!comp.Activated || comp.Cell == null || !comp.Cell.TryUseCharge(comp.EnergyPerUse) || !args.Target.TryGetComponent(out StunnableComponent? stunnable))
+                return;
+
+            StunEntity(args.Target, comp);
+        }
+
+        private void OnPowerCellChanged(EntityUid uid, StunbatonComponent comp, PowerCellChangedEvent args)
+        {
+            if (args.Ejected)
+            {
+                TurnOff(comp);
+            }
+        }
+
+        private void OnExamined(EntityUid uid, StunbatonComponent comp, ExaminedEvent args)
+        {
+            args.Message.AddText("\n");
+            var msg = comp.Activated
+                ? Loc.GetString("comp-stunbaton-examined-on")
+                : Loc.GetString("comp-stun-baton-examined-off");
+            args.Message.AddMarkup(msg);
+        }
+
+        private void StunEntity(IEntity entity, StunbatonComponent comp)
+        {
+            if (!entity.TryGetComponent(out StunnableComponent? stunnable)) return;
+
+            SoundSystem.Play(Filter.Pvs(comp.Owner), "/Audio/Weapons/egloves.ogg", comp.Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
+            if(!stunnable.SlowedDown)
+            {
+                if(_robustRandom.Prob(comp.ParalyzeChanceNoSlowdown))
+                    stunnable.Paralyze(comp.ParalyzeTime);
+                else
+                    stunnable.Slowdown(comp.SlowdownTime);
+            }
+            else
+            {
+                if(_robustRandom.Prob(comp.ParalyzeChanceWithSlowdown))
+                    stunnable.Paralyze(comp.ParalyzeTime);
+                else
+                    stunnable.Slowdown(comp.SlowdownTime);
+            }
+        }
+
+        private void TurnOff(StunbatonComponent comp)
+        {
+            if (!comp.Activated)
+            {
+                return;
+            }
+
+            var sprite = comp.Owner.GetComponent<SpriteComponent>();
+            var item = comp.Owner.GetComponent<ItemComponent>();
+
+            SoundSystem.Play(Filter.Pvs(comp.Owner), AudioHelpers.GetRandomFileFromSoundCollection("sparks"), comp.Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
+
+            item.EquippedPrefix = "off";
+            // TODO stunbaton visualizer
+            sprite.LayerSetState(0, "stunbaton_off");
+            comp.Activated = false;
+        }
+
+        private void TurnOn(StunbatonComponent comp, IEntity user)
+        {
+            if (comp.Activated)
+            {
+                return;
+            }
+
+            var sprite = comp.Owner.GetComponent<SpriteComponent>();
+            var item = comp.Owner.GetComponent<ItemComponent>();
+
+            var playerFilter = Filter.Pvs(comp.Owner);
+            if (comp.Cell == null)
+            {
+                SoundSystem.Play(playerFilter, "/Audio/Machines/button.ogg", comp.Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
+                user.PopupMessage(Loc.GetString("Cell missing..."));
+                return;
+            }
+
+            if (comp.Cell.CurrentCharge < comp.EnergyPerUse)
+            {
+                SoundSystem.Play(playerFilter, "/Audio/Machines/button.ogg", comp.Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
+                user.PopupMessage(Loc.GetString("Dead cell..."));
+                return;
+            }
+
+            SoundSystem.Play(playerFilter, AudioHelpers.GetRandomFileFromSoundCollection("sparks"), comp.Owner.Transform.Coordinates, AudioHelpers.WithVariation(0.25f));
+
+            item.EquippedPrefix = "on";
+            sprite.LayerSetState(0, "stunbaton_on");
+            comp.Activated = true;
+        }
+    }
+}

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/AttackEvent.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/AttackEvent.cs
@@ -8,9 +8,9 @@ using Robust.Shared.Map;
 namespace Content.Shared.Interfaces.GameObjects.Components
 {
     /// <summary>
-    ///     Raised when a target entity is attacked by a user.
+    ///     Raised when a target entity is click attacked by a user.
     /// </summary>
-    public class NormalAttackEvent : EntityEventArgs
+    public class ClickAttackEvent : EntityEventArgs
     {
         /// <summary>
         ///     Entity that triggered the attack.
@@ -37,7 +37,7 @@ namespace Content.Shared.Interfaces.GameObjects.Components
         /// </summary>
         public bool Succeeded { get; set;  }
 
-        public NormalAttackEvent(IEntity user, EntityCoordinates clickLocation, EntityUid target = default)
+        public ClickAttackEvent(IEntity user, EntityCoordinates clickLocation, EntityUid target = default)
         {
             User = user;
             ClickLocation = clickLocation;

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/AttackEvent.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/AttackEvent.cs
@@ -1,6 +1,3 @@
-#nullable enable
-using System;
-using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -8,10 +5,15 @@ using Robust.Shared.Map;
 namespace Content.Shared.Interfaces.GameObjects.Components
 {
     /// <summary>
-    ///     Raised when a target entity is click attacked by a user.
+    ///     Raised directed on the used entity when a target entity is click attacked by a user.
     /// </summary>
     public class ClickAttackEvent : EntityEventArgs
     {
+        /// <summary>
+        ///     Entity used to attack, for broadcast purposes.
+        /// </summary>
+        public IEntity Used { get; }
+
         /// <summary>
         ///     Entity that triggered the attack.
         /// </summary>
@@ -32,13 +34,9 @@ namespace Content.Shared.Interfaces.GameObjects.Components
         /// </summary>
         public IEntity? TargetEntity { get; }
 
-        /// <summary>
-        ///     Modified by the handler to indicate whether the attack succeeded.
-        /// </summary>
-        public bool Succeeded { get; set;  }
-
-        public ClickAttackEvent(IEntity user, EntityCoordinates clickLocation, EntityUid target = default)
+        public ClickAttackEvent(IEntity used, IEntity user, EntityCoordinates clickLocation, EntityUid target = default)
         {
+            Used = used;
             User = user;
             ClickLocation = clickLocation;
             Target = target;
@@ -49,10 +47,15 @@ namespace Content.Shared.Interfaces.GameObjects.Components
     }
 
     /// <summary>
-    ///     Raised when a target entity is wide attacked by a user.
+    ///     Raised directed on the used entity when a target entity is wide attacked by a user.
     /// </summary>
     public class WideAttackEvent : EntityEventArgs
     {
+        /// <summary>
+        ///     Entity used to attack, for broadcast purposes.
+        /// </summary>
+        public IEntity Used { get; }
+
         /// <summary>
         ///     Entity that triggered the attack.
         /// </summary>
@@ -63,13 +66,9 @@ namespace Content.Shared.Interfaces.GameObjects.Components
         /// </summary>
         public EntityCoordinates ClickLocation { get; }
 
-        /// <summary>
-        ///     Modified by the handler to indicate whether the attack succeeded.
-        /// </summary>
-        public bool Succeeded { get; set;  }
-
-        public WideAttackEvent(IEntity user, EntityCoordinates clickLocation)
+        public WideAttackEvent(IEntity used, IEntity user, EntityCoordinates clickLocation)
         {
+            Used = used;
             User = user;
             ClickLocation = clickLocation;
         }

--- a/Content.Shared/Interfaces/GameObjects/Components/Interaction/IAttack.cs
+++ b/Content.Shared/Interfaces/GameObjects/Components/Interaction/IAttack.cs
@@ -8,23 +8,9 @@ using Robust.Shared.Map;
 namespace Content.Shared.Interfaces.GameObjects.Components
 {
     /// <summary>
-    ///     This interface gives components behavior when being used to "attack".
-    /// </summary>
-    [RequiresExplicitImplementation]
-    public interface IAttack
-    {
-        // Redirects to ClickAttack by default.
-        [Obsolete("WideAttack")]
-        bool WideAttack(AttackEvent eventArgs) => ClickAttack(eventArgs);
-
-        [Obsolete("Use ClickAttack instead")]
-        bool ClickAttack(AttackEvent eventArgs);
-    }
-
-    /// <summary>
     ///     Raised when a target entity is attacked by a user.
     /// </summary>
-    public class AttackEvent : EntityEventArgs
+    public class NormalAttackEvent : EntityEventArgs
     {
         /// <summary>
         ///     Entity that triggered the attack.
@@ -37,11 +23,6 @@ namespace Content.Shared.Interfaces.GameObjects.Components
         public EntityCoordinates ClickLocation { get; }
 
         /// <summary>
-        ///     Indicates whether the attack creates a swing attack or attacks the target entity directly.
-        /// </summary>
-        public bool WideAttack { get; }
-
-        /// <summary>
         ///     UID of the entity that was attacked.
         /// </summary>
         public EntityUid Target { get; }
@@ -51,15 +32,46 @@ namespace Content.Shared.Interfaces.GameObjects.Components
         /// </summary>
         public IEntity? TargetEntity { get; }
 
-        public AttackEvent(IEntity user, EntityCoordinates clickLocation, bool wideAttack, EntityUid target = default)
+        /// <summary>
+        ///     Modified by the handler to indicate whether the attack succeeded.
+        /// </summary>
+        public bool Succeeded { get; set;  }
+
+        public NormalAttackEvent(IEntity user, EntityCoordinates clickLocation, EntityUid target = default)
         {
             User = user;
             ClickLocation = clickLocation;
-            WideAttack = wideAttack;
             Target = target;
 
             IoCManager.Resolve<IEntityManager>().TryGetEntity(Target, out var targetEntity);
             TargetEntity = targetEntity;
+        }
+    }
+
+    /// <summary>
+    ///     Raised when a target entity is wide attacked by a user.
+    /// </summary>
+    public class WideAttackEvent : EntityEventArgs
+    {
+        /// <summary>
+        ///     Entity that triggered the attack.
+        /// </summary>
+        public IEntity User { get; }
+
+        /// <summary>
+        ///     The original location that was clicked by the user.
+        /// </summary>
+        public EntityCoordinates ClickLocation { get; }
+
+        /// <summary>
+        ///     Modified by the handler to indicate whether the attack succeeded.
+        /// </summary>
+        public bool Succeeded { get; set;  }
+
+        public WideAttackEvent(IEntity user, EntityCoordinates clickLocation)
+        {
+            User = user;
+            ClickLocation = clickLocation;
         }
     }
 }

--- a/Resources/Locale/en-US/components/stunbaton-component.ftl
+++ b/Resources/Locale/en-US/components/stunbaton-component.ftl
@@ -1,0 +1,6 @@
+﻿### Stunbaton component
+
+## Used when examining the stunbaton
+
+comp-stunbaton-examined-on = The light is currently [color=darkgreen]on[/color].
+comp-stunbaton-examined-off = The light is currently [color=darkred]off[/color]

--- a/Resources/Locale/en-US/components/stunbaton-component.ftl
+++ b/Resources/Locale/en-US/components/stunbaton-component.ftl
@@ -4,3 +4,8 @@
 
 comp-stunbaton-examined-on = The light is currently [color=darkgreen]on[/color].
 comp-stunbaton-examined-off = The light is currently [color=darkred]off[/color]
+
+## Used when activating the stunbaton, depending on the state of its cell.
+
+comp-stunbaton-activated-dead-cell = Dead cell...
+comp-stunbaton-activated-missing-cell = Missing cell...

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -24,6 +24,7 @@
   - type: ItemCooldown
   - type: MeleeChemicalInjector
   - type: SolutionContainer
+    caps: Refillable
     maxVol: 5
   - type: SolutionTransfer
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -8,9 +8,10 @@
     sprite: Objects/Weapons/Melee/stunbaton.rsi
     state: stunbaton_off
   - type: Stunbaton
-    damage: 1
-    range: 0.75
-    arcwidth: 0
+  - type: MeleeWeapon
+    damage: 10
+    range: 1.5
+    arcwidth: 60
     arc: default
   - type: PowerCellSlot
     slotSize: Medium
@@ -34,10 +35,6 @@
       sprite: Objects/Weapons/Melee/flash.rsi
       state: flash
     - type: Flash
-      damage: 0
-      cooldownTime: 1
-      arc: smash
-      hitSound: /Audio/Weapons/flash.ogg
     - type: Item
       size: 2
       sprite: Objects/Weapons/Melee/flash.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -35,6 +35,11 @@
       sprite: Objects/Weapons/Melee/flash.rsi
       state: flash
     - type: Flash
+    - type: MeleeWeapon
+      damage: 0
+      range: 1
+      arcWidth: 10
+      arc: default
     - type: Item
       size: 2
       sprite: Objects/Weapons/Melee/flash.rsi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fully refactors:
- MeleeWeaponComponent (-> MeleeWeaponSystem)
- FlashComponent (-> FlashSystem)
- StunbatonComponent (-> StunbatonSystem)

Slightly refactors:
- HyposprayComponent (moves some interfaces to a new system)
- PowerCellSlotComponent (compmessage removed & replaced with directed event)

Misc changes:
- AttackEvent changed to ClickAttackEvent and WideAttackEvent
- IAttack completely removed (dab)
- Removed ugly component inheritance from MeleeWeapon stuff (dab)
- Slight tweaks to stunbaton and flash yaml

Behavior is all tested and works the same as before (with more stuff like flashes being able to flash people through both afterinteract and clickattack)