### PR TITLE
Remove InteractionOutline from full-tile entities

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Doors/airlock_base.yml
+++ b/Resources/Prototypes/Entities/Constructible/Doors/airlock_base.yml
@@ -5,6 +5,7 @@
   description: It opens, it closes, and maybe crushes you.
   components:
   - type: RCDDeconstructWhitelist
+  - type: InteractionOutline
   - type: Sprite
     netsync: false
     drawdepth: Mobs # They're on the same layer as mobs, perspective.
@@ -83,6 +84,7 @@
   components:
   - type: Clickable
   - type: RCDDeconstructWhitelist
+  - type: InteractionOutline
   - type: Sprite
     netsync: false
     drawdepth: Mobs

--- a/Resources/Prototypes/Entities/Constructible/Doors/airlock_base.yml
+++ b/Resources/Prototypes/Entities/Constructible/Doors/airlock_base.yml
@@ -5,7 +5,6 @@
   description: It opens, it closes, and maybe crushes you.
   components:
   - type: RCDDeconstructWhitelist
-  - type: InteractionOutline
   - type: Sprite
     netsync: false
     drawdepth: Mobs # They're on the same layer as mobs, perspective.
@@ -84,7 +83,6 @@
   components:
   - type: Clickable
   - type: RCDDeconstructWhitelist
-  - type: InteractionOutline
   - type: Sprite
     netsync: false
     drawdepth: Mobs

--- a/Resources/Prototypes/Entities/Constructible/Ground/catwalk.yml
+++ b/Resources/Prototypes/Entities/Constructible/Ground/catwalk.yml
@@ -6,7 +6,6 @@
     mode: SnapgridCenter
   components:
   - type: Clickable
-  - type: InteractionOutline
   - type: Physics
     canCollide: false
     fixtures:

--- a/Resources/Prototypes/Entities/Constructible/Walls/low_wall.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/low_wall.yml
@@ -6,7 +6,6 @@
   components:
   - type: RCDDeconstructWhitelist
   - type: CanBuildWindowOnTop
-  - type: InteractionOutline
   - type: Sprite
     netsync: false
     color: "#889192"

--- a/Resources/Prototypes/Entities/Constructible/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/walls.yml
@@ -13,7 +13,6 @@
   - type: Tag
     tags:
     - Wall
-  - type: InteractionOutline
   - type: Sprite
     netsync: false
     drawdepth: Walls

--- a/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
+++ b/Resources/Prototypes/Entities/Constructible/Walls/windows.yml
@@ -9,7 +9,6 @@
     - Window
   components:
   - type: RCDDeconstructWhitelist
-  - type: InteractionOutline
   - type: Sprite
     color: "#DDDDDD"
     netsync: false


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Many full or near-full tile entities like tables and bookshelves have their interaction outlines removed because its just useless and looks really bad, so I'm doing the same for walls, low walls, windows, catwalks and airlocks

Firelocks are technically full-tile entities but are untouched right now since it's useful for them sometimes (since they can be closed)

**Screenshots**

Before

https://user-images.githubusercontent.com/19853115/120874497-c43d9c80-c55b-11eb-8f57-699488fca0cd.mp4

After

https://user-images.githubusercontent.com/19853115/120874465-abcd8200-c55b-11eb-9bf7-7cbd952f7479.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Interaction outlines removed from full-tile objects like walls

