### PR TITLE
Nerfs Synaptizine to 6 damage per 1u instead of 15 per 1u

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -227,7 +227,7 @@
   color: "#d49a2f"
   metabolism:
     - !type:HealthChangeMetabolism 
-      healthChange: 3 #you probably need something else for the "two units is deadly".
+      healthChange: 0.70 #you probably need something else for the "two units is deadly".
       damageClass: Toxin
       rate: 0.2 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Synaptizine was absolutely busted killing anybody who drank only 7u of it with uncurbable radiation damage with 10 poison damage and 5 radiation damage per tick this nerfs the chemical into a more manageable form curing 1u of Synaptizine with 3u of Dylovene it still dangerous but more of a slow poison and not and insta kill machine 
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
5u examples
Before:
![SS14 Loader_ULAiA9Z7zv](https://user-images.githubusercontent.com/84478872/120935262-bbada900-c6b6-11eb-8b6a-a0c93ed39947.png)
After:

![](https://i.imgur.com/UVVWtDi.png)

**Changelog**

:cl:
- tweak: Synaptizine damage per unit nerfed from 15 to 6

<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

