### PR TITLE
"Fixes" crafting button not showing

### DIFF
--- a/Content.Client/HUD/GameHud.cs
+++ b/Content.Client/HUD/GameHud.cs
@@ -240,7 +240,7 @@ namespace Content.Client.HUD
             {
                 ToolTip = Loc.GetString("Open crafting menu."),
                 MinSize = topMinSize,
-                Visible = false,
+                Visible = true,
                 StyleClasses = {StyleBase.ButtonSquare}
             };
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Thought it would be simple to fix [this](#4210). :witheredwojak:

Found out that the crafting button was broken by https://github.com/space-wizards/space-station-14/commit/d3a611164b2df373947083233937a729015ff23f.

Spent 2 hours poring over the diffs and trying to suss out how the fuck it broke. No such luck. This is the only way i've found and it's WRONG.

My best guess is that ConstructionMenuPresenter.cs and ConstructionMenu.xaml.cs are some of the first bits of XamlUI contributed to the codebase and thus have something outdated in them that causes the GameTicker changes to not list the button in the GameHud.cs. 

I thought adding a `            IoCManager.Register<IConstructionMenuView, ConstructionMenu>();` to ClientContentIoC.cs would fix it since I assumed the crafting menu was not listing under IGameHud for some reason. No dice but I probably was doing it wrong.

Any help appreciated.

:cl: Swept
- fix: Fixed missing crafting button

