### PR TITLE
Losing a head doesn't mean you lose your eyes #3956 (Repaired version  #4061)

### DIFF
--- a/Content.Client/CharacterAppearance/HumanoidAppearanceComponent.cs
+++ b/Content.Client/CharacterAppearance/HumanoidAppearanceComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Cuffs.Components;
+using Content.Client.Cuffs.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.CharacterAppearance;
@@ -120,15 +120,10 @@ namespace Content.Client.CharacterAppearance
                 return;
             }
 
-            var layer = args.Part.ToHumanoidLayer();
-
-            if (layer == null)
-            {
-                return;
-            }
-
+            var layers = args.Part.ToHumanoidLayers();
             // TODO BODY Layer color, sprite and state
-            sprite.LayerSetVisible(layer, true);
+            foreach (var layer in layers)
+                sprite.LayerSetVisible(layer, true);
         }
 
         public void BodyPartRemoved(BodyPartRemovedEventArgs args)
@@ -143,15 +138,10 @@ namespace Content.Client.CharacterAppearance
                 return;
             }
 
-            var layer = args.Part.ToHumanoidLayer();
-
-            if (layer == null)
-            {
-                return;
-            }
-
+            var layers = args.Part.ToHumanoidLayers();
             // TODO BODY Layer color, sprite and state
-            sprite.LayerSetVisible(layer, false);
+            foreach (var layer in layers)
+                sprite.LayerSetVisible(layer, false);
         }
     }
 }

--- a/Content.Shared/CharacterAppearance/HumanoidVisualLayersExtension.cs
+++ b/Content.Shared/CharacterAppearance/HumanoidVisualLayersExtension.cs
@@ -1,47 +1,90 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using Content.Shared.Body.Part;
 
 namespace Content.Shared.CharacterAppearance
 {
     public static class HumanoidVisualLayersExtension
     {
-        public static HumanoidVisualLayers? ToHumanoidLayer(this SharedBodyPartComponent part)
+        public static IEnumerable<HumanoidVisualLayers> ToHumanoidLayers(this SharedBodyPartComponent part)
         {
-            return part.PartType switch
+            switch (part.PartType)
             {
-                BodyPartType.Other => null,
-                BodyPartType.Torso => HumanoidVisualLayers.Chest,
-                BodyPartType.Head => HumanoidVisualLayers.Head,
-                BodyPartType.Arm => part.Symmetry switch
-                {
-                    BodyPartSymmetry.None => null,
-                    BodyPartSymmetry.Left => HumanoidVisualLayers.LArm,
-                    BodyPartSymmetry.Right => HumanoidVisualLayers.RArm,
-                    _ => throw new ArgumentOutOfRangeException()
-                },
-                BodyPartType.Hand => part.Symmetry switch
-                {
-                    BodyPartSymmetry.None => null,
-                    BodyPartSymmetry.Left => HumanoidVisualLayers.LHand,
-                    BodyPartSymmetry.Right => HumanoidVisualLayers.RHand,
-                    _ => throw new ArgumentOutOfRangeException()
-                },
-                BodyPartType.Leg => part.Symmetry switch
-                {
-                    BodyPartSymmetry.None => null,
-                    BodyPartSymmetry.Left => HumanoidVisualLayers.LLeg,
-                    BodyPartSymmetry.Right => HumanoidVisualLayers.RLeg,
-                    _ => throw new ArgumentOutOfRangeException()
-                },
-                BodyPartType.Foot => part.Symmetry switch
-                {
-                    BodyPartSymmetry.None => null,
-                    BodyPartSymmetry.Left => HumanoidVisualLayers.LFoot,
-                    BodyPartSymmetry.Right => HumanoidVisualLayers.RFoot,
-                    _ => throw new ArgumentOutOfRangeException()
-                },
-                _ => throw new ArgumentOutOfRangeException()
-            };
+                case BodyPartType.Other:
+                    yield break;
+                case BodyPartType.Torso:
+                    yield return HumanoidVisualLayers.Chest;
+                    break;
+                case BodyPartType.Head:
+                    yield return HumanoidVisualLayers.Head;
+                    yield return HumanoidVisualLayers.Eyes;
+                    yield return HumanoidVisualLayers.FacialHair;
+                    yield return HumanoidVisualLayers.Hair;
+                    yield return HumanoidVisualLayers.StencilMask;
+                    break;
+                case BodyPartType.Arm:
+                    switch (part.Symmetry)
+                    {
+                        case BodyPartSymmetry.None:
+                            yield break;
+                        case BodyPartSymmetry.Left:
+                            yield return HumanoidVisualLayers.LArm;
+                            break;
+                        case BodyPartSymmetry.Right:
+                            yield return HumanoidVisualLayers.RArm;
+                            break;
+                        default:
+                            yield break;
+                    }
+                    yield break;
+                case BodyPartType.Hand:
+                    switch (part.Symmetry)
+                    {
+                        case BodyPartSymmetry.None:
+                            yield break;
+                        case BodyPartSymmetry.Left:
+                            yield return HumanoidVisualLayers.LHand;
+                            break;
+                        case BodyPartSymmetry.Right:
+                            yield return HumanoidVisualLayers.RHand;
+                            break;
+                        default:
+                            yield break;
+                    }
+                    yield break;
+                case BodyPartType.Leg:
+                    switch (part.Symmetry)
+                    {
+                        case BodyPartSymmetry.None:
+                            yield break;
+                        case BodyPartSymmetry.Left:
+                            yield return HumanoidVisualLayers.LLeg;
+                            break;
+                        case BodyPartSymmetry.Right:
+                            yield return HumanoidVisualLayers.RLeg;
+                            break;
+                        default:
+                            yield break;
+                    }
+                    yield break;
+                case BodyPartType.Foot:
+                    switch (part.Symmetry)
+                    {
+                        case BodyPartSymmetry.None:
+                            yield break;
+                        case BodyPartSymmetry.Left:
+                            yield return HumanoidVisualLayers.LFoot;
+                            break;
+                        case BodyPartSymmetry.Right:
+                            yield return HumanoidVisualLayers.RFoot;
+                            break;
+                        default:
+                            yield break;
+                    }
+                    yield break;
+                default:
+                    yield break;
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #3956 
I've debugged what happens when you Microwave your head. 
Your BodyPart Head drops (TryDropPart), which includes eyes and brain as 'mechanism' as well as transform children.
When the HumanoidAppearenceComponent of the head recieves the BodyPartRemovedEvent it searches for its humanoid layer, which only returns the 'head' layer, not the including sublayers for eyes, ears, hair.

The method 'ToHumanoidLayer' which only returns the base layer of the requested body part remains, maybe you want the primary corresonding layer, exculding the sublayers. Even though I've not seen it being referenced except from 'BodyPartAdded' and 'BodyPartRemoved'

So I've written a methods which returns all layers corresponding to the body part, iterate over them and make them invisible (as it has been done with the head)


**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![grafik](https://user-images.githubusercontent.com/1233646/119250439-65ae1100-bba0-11eb-98de-f015b8b8c16f.png)
_As BodyParts are concerned, there is only 'head' which contains the rest_

![grafik](https://user-images.githubusercontent.com/1233646/119250617-9fcbe280-bba1-11eb-91b4-8145faa31a1f.png)
_The head removal now removes the hair, ears and eyes._

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: 

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: When the head is detached from the body, the hair, eyes and ears will not remain at the body.

