### PR TITLE
Replace IResettingEntitySystem with RoundRestartCleanupEvent.

### DIFF
--- a/Content.Client/Atmos/EntitySystems/AtmosDebugOverlaySystem.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosDebugOverlaySystem.cs
@@ -13,7 +13,7 @@ using Robust.Shared.Maths;
 namespace Content.Client.Atmos.EntitySystems
 {
     [UsedImplicitly]
-    internal sealed class AtmosDebugOverlaySystem : SharedAtmosDebugOverlaySystem, IResettingEntitySystem
+    internal sealed class AtmosDebugOverlaySystem : SharedAtmosDebugOverlaySystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
 
@@ -37,6 +37,7 @@ namespace Content.Client.Atmos.EntitySystems
         {
             base.Initialize();
 
+            SubscribeNetworkEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeNetworkEvent<AtmosDebugOverlayMessage>(HandleAtmosDebugOverlayMessage);
             SubscribeNetworkEvent<AtmosDebugOverlayDisableMessage>(HandleAtmosDebugOverlayDisableMessage);
 
@@ -66,7 +67,7 @@ namespace Content.Client.Atmos.EntitySystems
                 overlayManager.RemoveOverlay<GasTileOverlay>();
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _tileData.Clear();
         }

--- a/Content.Client/HealthOverlay/HealthOverlaySystem.cs
+++ b/Content.Client/HealthOverlay/HealthOverlaySystem.cs
@@ -13,7 +13,7 @@ using Robust.Shared.IoC;
 namespace Content.Client.HealthOverlay
 {
     [UsedImplicitly]
-    public class HealthOverlaySystem : EntitySystem, IResettingEntitySystem
+    public class HealthOverlaySystem : EntitySystem
     {
         [Dependency] private readonly IEyeManager _eyeManager = default!;
 
@@ -44,10 +44,11 @@ namespace Content.Client.HealthOverlay
         {
             base.Initialize();
 
+            SubscribeNetworkEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<PlayerAttachSysMessage>(HandlePlayerAttached);
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             foreach (var gui in _guis.Values)
             {

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -28,7 +28,7 @@ using Timer = Robust.Shared.Timing.Timer;
 namespace Content.Client.Verbs
 {
     [UsedImplicitly]
-    public sealed class VerbSystem : SharedVerbSystem, IResettingEntitySystem
+    public sealed class VerbSystem : SharedVerbSystem
     {
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;

--- a/Content.IntegrationTests/Tests/ResettingEntitySystemTests.cs
+++ b/Content.IntegrationTests/Tests/ResettingEntitySystemTests.cs
@@ -9,15 +9,22 @@ using Robust.Shared.Reflection;
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
-    [TestOf(typeof(IResettingEntitySystem))]
+    [TestOf(typeof(RoundRestartCleanupEvent))]
     public class ResettingEntitySystemTests : ContentIntegrationTest
     {
         [Reflect(false)]
-        private class TestResettingEntitySystem : EntitySystem, IResettingEntitySystem
+        private class TestRoundRestartCleanupEvent : EntitySystem
         {
             public bool HasBeenReset { get; set; }
 
-            public void Reset()
+            public override void Initialize()
+            {
+                base.Initialize();
+
+                SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+            }
+
+            public void Reset(RoundRestartCleanupEvent ev)
             {
                 HasBeenReset = true;
             }
@@ -30,7 +37,7 @@ namespace Content.IntegrationTests.Tests
             {
                 ContentBeforeIoC = () =>
                 {
-                    IoCManager.Resolve<IEntitySystemManager>().LoadExtraSystemType<TestResettingEntitySystem>();
+                    IoCManager.Resolve<IEntitySystemManager>().LoadExtraSystemType<TestRoundRestartCleanupEvent>();
                 }
             });
 
@@ -43,7 +50,7 @@ namespace Content.IntegrationTests.Tests
             {
                 Assert.That(gameTicker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
 
-                var system = entitySystemManager.GetEntitySystem<TestResettingEntitySystem>();
+                var system = entitySystemManager.GetEntitySystem<TestRoundRestartCleanupEvent>();
 
                 system.HasBeenReset = false;
 

--- a/Content.IntegrationTests/Tests/StationEvents/StationEventsSystemTest.cs
+++ b/Content.IntegrationTests/Tests/StationEvents/StationEventsSystemTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Content.Server.StationEvents;
+using Content.Shared.GameTicking;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -33,7 +34,7 @@ namespace Content.IntegrationTests.Tests.StationEvents
                     Assert.That(stationEvent.Occurrences > 0);
                 }
 
-                stationEventsSystem.Reset();
+                stationEventsSystem.Reset(new RoundRestartCleanupEvent());
 
                 foreach (var stationEvent in stationEventsSystem.StationEvents)
                 {

--- a/Content.Server/AI/Pathfinding/Accessible/AiReachableSystem.cs
+++ b/Content.Server/AI/Pathfinding/Accessible/AiReachableSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Server.AI.Pathfinding.Accessible
     /// </summary>
     /// Long-term can be used to do hierarchical pathfinding
     [UsedImplicitly]
-    public sealed class AiReachableSystem : EntitySystem, IResettingEntitySystem
+    public sealed class AiReachableSystem : EntitySystem
     {
         /*
          * The purpose of this is to provide a higher-level / hierarchical abstraction of the actual pathfinding graph
@@ -81,6 +81,7 @@ namespace Content.Server.AI.Pathfinding.Accessible
         public override void Initialize()
         {
             _pathfindingSystem = Get<PathfindingSystem>();
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<PathfindingChunkUpdateMessage>(RecalculateNodeRegions);
 #if DEBUG
             SubscribeNetworkEvent<SharedAiDebug.SubscribeReachableMessage>(HandleSubscription);
@@ -699,7 +700,7 @@ namespace Content.Server.AI.Pathfinding.Accessible
 #endif
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _queuedUpdates.Clear();
             _regions.Clear();

--- a/Content.Server/AI/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/AI/Pathfinding/PathfindingSystem.cs
@@ -27,7 +27,7 @@ namespace Content.Server.AI.Pathfinding
     /// This system handles pathfinding graph updates as well as dispatches to the pathfinder
     /// (90% of what it's doing is graph updates so not much point splitting the 2 roles)
     /// </summary>
-    public class PathfindingSystem : EntitySystem, IResettingEntitySystem
+    public class PathfindingSystem : EntitySystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
@@ -201,6 +201,7 @@ namespace Content.Server.AI.Pathfinding
 
         public override void Initialize()
         {
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<CollisionChangeMessage>(QueueCollisionChangeMessage);
             SubscribeLocalEvent<MoveEvent>(QueueMoveEvent);
             SubscribeLocalEvent<AccessReaderChangeMessage>(QueueAccessChangeMessage);
@@ -385,7 +386,7 @@ namespace Content.Server.AI.Pathfinding
             return true;
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _graph.Clear();
             _collidableUpdateQueue.Clear();

--- a/Content.Server/APC/ApcNetSystem.cs
+++ b/Content.Server/APC/ApcNetSystem.cs
@@ -9,11 +9,18 @@ using Robust.Shared.Timing;
 namespace Content.Server.APC
 {
     [UsedImplicitly]
-    internal sealed class ApcNetSystem : EntitySystem, IResettingEntitySystem
+    internal sealed class ApcNetSystem : EntitySystem
     {
         [Dependency] private readonly IPauseManager _pauseManager = default!;
 
         private HashSet<IApcNet> _apcNets = new();
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+        }
 
         public override void Update(float frameTime)
         {
@@ -35,7 +42,7 @@ namespace Content.Server.APC
             _apcNets.Remove(apcNet);
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             // NodeGroupSystem does not remake ApcNets affected during restarting until a frame later,
             // when their grid is invalid. So, we are clearing them on round restart.

--- a/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -25,7 +25,7 @@ using Dependency = Robust.Shared.IoC.DependencyAttribute;
 namespace Content.Server.Atmos.EntitySystems
 {
     [UsedImplicitly]
-    internal sealed class GasTileOverlaySystem : SharedGasTileOverlaySystem, IResettingEntitySystem
+    internal sealed class GasTileOverlaySystem : SharedGasTileOverlaySystem
     {
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -66,6 +66,8 @@ namespace Content.Server.Atmos.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
 
             _atmosphereSystem = Get<AtmosphereSystem>();
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
@@ -479,7 +481,7 @@ namespace Content.Server.Atmos.EntitySystems
             }
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _invalidTiles.Clear();
             _overlay.Clear();

--- a/Content.Server/Body/Surgery/Components/SurgeryToolSystem.cs
+++ b/Content.Server/Body/Surgery/Components/SurgeryToolSystem.cs
@@ -10,7 +10,7 @@ using Robust.Shared.GameObjects;
 namespace Content.Server.Body.Surgery.Components
 {
     [UsedImplicitly]
-    public class SurgeryToolSystem : EntitySystem, IResettingEntitySystem
+    public class SurgeryToolSystem : EntitySystem
     {
         private readonly HashSet<SurgeryToolComponent> _openSurgeryUIs = new();
 
@@ -18,11 +18,12 @@ namespace Content.Server.Body.Surgery.Components
         {
             base.Initialize();
 
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<SurgeryWindowOpenMessage>(OnSurgeryWindowOpen);
             SubscribeLocalEvent<SurgeryWindowCloseMessage>(OnSurgeryWindowClose);
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _openSurgeryUIs.Clear();
         }

--- a/Content.Server/Cargo/CargoConsoleSystem.cs
+++ b/Content.Server/Cargo/CargoConsoleSystem.cs
@@ -7,7 +7,7 @@ using Robust.Shared.GameObjects;
 
 namespace Content.Server.Cargo
 {
-    public class CargoConsoleSystem : EntitySystem, IResettingEntitySystem
+    public class CargoConsoleSystem : EntitySystem
     {
         /// <summary>
         /// How much time to wait (in seconds) before increasing bank accounts balance.
@@ -45,6 +45,8 @@ namespace Content.Server.Cargo
 
         public override void Initialize()
         {
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+
             CreateBankAccount("Space Station 14", 1000);
             CreateOrderDatabase(0);
         }
@@ -64,7 +66,7 @@ namespace Content.Server.Cargo
             }
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _accountsDict.Clear();
             _databasesDict.Clear();

--- a/Content.Server/Climbing/ClimbSystem.cs
+++ b/Content.Server/Climbing/ClimbSystem.cs
@@ -8,9 +8,16 @@ using Robust.Shared.GameObjects;
 namespace Content.Server.Climbing
 {
     [UsedImplicitly]
-    internal sealed class ClimbSystem : EntitySystem, IResettingEntitySystem
+    internal sealed class ClimbSystem : EntitySystem
     {
         private readonly HashSet<ClimbingComponent> _activeClimbers = new();
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+        }
 
         public void AddActiveClimber(ClimbingComponent climbingComponent)
         {
@@ -30,7 +37,7 @@ namespace Content.Server.Climbing
             }
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _activeClimbers.Clear();
         }

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -16,7 +16,7 @@ using static Content.Shared.Cloning.SharedCloningPodComponent;
 
 namespace Content.Server.Cloning
 {
-    internal sealed class CloningSystem : EntitySystem, IResettingEntitySystem
+    internal sealed class CloningSystem : EntitySystem
     {
         [Dependency] private readonly IGameTiming _timing = default!;
         public readonly Dictionary<Mind.Mind, int> MindToId = new();
@@ -29,6 +29,7 @@ namespace Content.Server.Cloning
         {
             base.Initialize();
 
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<CloningPodComponent, ActivateInWorldEvent>(HandleActivate);
             SubscribeLocalEvent<BeingClonedComponent, MindAddedMessage>(HandleMindAdded);
         }
@@ -142,7 +143,7 @@ namespace Content.Server.Cloning
             return IdToDNA.ToDictionary(m => m.Key, m => m.Value.Mind.CharacterName);
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             MindToId.Clear();
             IdToDNA.Clear();

--- a/Content.Server/Damage/GodmodeSystem.cs
+++ b/Content.Server/Damage/GodmodeSystem.cs
@@ -12,11 +12,18 @@ using Robust.Shared.GameObjects;
 namespace Content.Server.Damage
 {
     [UsedImplicitly]
-    public class GodmodeSystem : EntitySystem, IResettingEntitySystem
+    public class GodmodeSystem : EntitySystem
     {
         private readonly Dictionary<IEntity, OldEntityInformation> _entities = new();
 
-        public void Reset()
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+        }
+
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _entities.Clear();
         }

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -11,6 +11,7 @@ using Robust.Server.Player;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Log;
+using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -296,13 +297,12 @@ namespace Content.Server.GameTicking
 
             _gameRules.Clear();
 
-            foreach (var system in _entitySystemManager.AllSystems)
-            {
-                if (system is IResettingEntitySystem resetting)
-                {
-                    resetting.Reset();
-                }
-            }
+            // Round restart cleanup event, so entity systems can reset.
+            var ev = new RoundRestartCleanupEvent();
+            RaiseLocalEvent(ev);
+
+            // So clients' entity systems can clean up too...
+            RaiseNetworkEvent(ev, Filter.Broadcast());
 
             _spawnedPositions.Clear();
             _manifest.Clear();

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -17,7 +17,7 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.Ghost.Roles
 {
     [UsedImplicitly]
-    public class GhostRoleSystem : EntitySystem, IResettingEntitySystem
+    public class GhostRoleSystem : EntitySystem
     {
         [Dependency] private readonly EuiManager _euiManager = default!;
 
@@ -33,6 +33,7 @@ namespace Content.Server.Ghost.Roles
         {
             base.Initialize();
 
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
         }
 
@@ -137,7 +138,7 @@ namespace Content.Server.Ghost.Roles
             CloseEui(message.Player);
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             foreach (var session in _openUis.Keys)
             {

--- a/Content.Server/Gravity/EntitySystems/WeightlessSystem.cs
+++ b/Content.Server/Gravity/EntitySystems/WeightlessSystem.cs
@@ -12,7 +12,7 @@ using Robust.Shared.Utility;
 namespace Content.Server.Gravity.EntitySystems
 {
     [UsedImplicitly]
-    public class WeightlessSystem : EntitySystem, IResettingEntitySystem
+    public class WeightlessSystem : EntitySystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
 
@@ -22,11 +22,12 @@ namespace Content.Server.Gravity.EntitySystems
         {
             base.Initialize();
 
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<GravityChangedMessage>(GravityChanged);
             SubscribeLocalEvent<EntParentChangedMessage>(EntParentChanged);
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _alerts.Clear();
         }

--- a/Content.Server/Plants/PlantSystem.cs
+++ b/Content.Server/Plants/PlantSystem.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.Plants
 {
     [UsedImplicitly]
-    public class PlantSystem : EntitySystem, IResettingEntitySystem
+    public class PlantSystem : EntitySystem
     {
         [Dependency] private readonly IComponentManager _componentManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -25,6 +25,8 @@ namespace Content.Server.Plants
         public override void Initialize()
         {
             base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
 
             PopulateDatabase();
         }
@@ -73,7 +75,7 @@ namespace Content.Server.Plants
             }
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             PopulateDatabase();
         }

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -13,7 +13,7 @@ using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.RoundEnd
 {
-    public class RoundEndSystem : EntitySystem, IResettingEntitySystem
+    public class RoundEndSystem : EntitySystem
     {
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IChatManager _chatManager = default!;
@@ -30,6 +30,7 @@ namespace Content.Server.RoundEnd
 
         public TimeSpan CallCooldown { get; } = TimeSpan.FromSeconds(30);
 
+        // TODO: Make these regular eventbus events...
         public delegate void RoundEndCountdownStarted();
         public event RoundEndCountdownStarted? OnRoundEndCountdownStarted;
 
@@ -42,7 +43,14 @@ namespace Content.Server.RoundEnd
         public delegate void CallCooldownEnded();
         public event CallCooldownEnded? OnCallCooldownEnded;
 
-        void IResettingEntitySystem.Reset()
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+        }
+
+        void Reset(RoundRestartCleanupEvent ev)
         {
             IsRoundEndCountdownStarted = false;
             _roundEndCancellationTokenSource.Cancel();

--- a/Content.Server/StationEvents/StationEventSystem.cs
+++ b/Content.Server/StationEvents/StationEventSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Server.StationEvents
 {
     [UsedImplicitly]
     // Somewhat based off of TG's implementation of events
-    public sealed class StationEventSystem : EntitySystem, IResettingEntitySystem
+    public sealed class StationEventSystem : EntitySystem
     {
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
         [Dependency] private readonly IServerNetManager _netManager = default!;
@@ -185,6 +185,8 @@ namespace Content.Server.StationEvents
 
             _netManager.RegisterNetMessage<MsgRequestStationEvents>(RxRequest);
             _netManager.RegisterNetMessage<MsgStationEvents>();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
         }
 
         private void RxRequest(MsgRequestStationEvents msg)
@@ -359,7 +361,7 @@ namespace Content.Server.StationEvents
             base.Shutdown();
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             if (CurrentEvent?.Running == true)
             {

--- a/Content.Server/Suspicion/EntitySystems/SuspicionEndTimerSystem.cs
+++ b/Content.Server/Suspicion/EntitySystems/SuspicionEndTimerSystem.cs
@@ -13,7 +13,7 @@ using Robust.Shared.IoC;
 namespace Content.Server.Suspicion.EntitySystems
 {
     [UsedImplicitly]
-    public sealed class SuspicionEndTimerSystem : EntitySystem, IResettingEntitySystem
+    public sealed class SuspicionEndTimerSystem : EntitySystem
     {
         [Dependency] private readonly IPlayerManager _playerManager = null!;
 
@@ -32,6 +32,8 @@ namespace Content.Server.Suspicion.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
 
             _playerManager.PlayerStatusChanged += PlayerManagerOnPlayerStatusChanged;
         }
@@ -69,7 +71,7 @@ namespace Content.Server.Suspicion.EntitySystems
             EntityManager.EntityNetManager?.SendSystemNetworkMessage(msg, player.ConnectedClient);
         }
 
-        void IResettingEntitySystem.Reset()
+        private void Reset(RoundRestartCleanupEvent ev)
         {
             EndTime = null;
         }

--- a/Content.Server/Suspicion/EntitySystems/SuspicionRoleSystem.cs
+++ b/Content.Server/Suspicion/EntitySystems/SuspicionRoleSystem.cs
@@ -7,7 +7,7 @@ using Robust.Shared.GameObjects;
 namespace Content.Server.Suspicion.EntitySystems
 {
     [UsedImplicitly]
-    public class SuspicionRoleSystem : EntitySystem, IResettingEntitySystem
+    public class SuspicionRoleSystem : EntitySystem
     {
         private readonly HashSet<SuspicionRoleComponent> _traitors = new();
 
@@ -19,6 +19,7 @@ namespace Content.Server.Suspicion.EntitySystems
         {
             base.Initialize();
 
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<SuspicionRoleComponent, PlayerAttachedEvent>((HandlePlayerAttached));
             SubscribeLocalEvent<SuspicionRoleComponent, PlayerDetachedEvent>((HandlePlayerDetached));
         }
@@ -71,7 +72,7 @@ namespace Content.Server.Suspicion.EntitySystems
             base.Shutdown();
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _traitors.Clear();
         }

--- a/Content.Server/Verbs/VerbSystem.cs
+++ b/Content.Server/Verbs/VerbSystem.cs
@@ -12,7 +12,7 @@ using static Content.Shared.Verbs.VerbSystemMessages;
 
 namespace Content.Server.Verbs
 {
-    public class VerbSystem : SharedVerbSystem, IResettingEntitySystem
+    public class VerbSystem : SharedVerbSystem
     {
         [Dependency] private readonly IPlayerManager _playerManager = default!;
 
@@ -24,6 +24,7 @@ namespace Content.Server.Verbs
 
             IoCManager.InjectDependencies(this);
 
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeNetworkEvent<RequestVerbsMessage>(RequestVerbs);
             SubscribeNetworkEvent<UseVerbMessage>(UseVerb);
 
@@ -38,7 +39,7 @@ namespace Content.Server.Verbs
             }
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _seesThroughContainers.Clear();
         }

--- a/Content.Server/Wires/WireHackingSystem.cs
+++ b/Content.Server/Wires/WireHackingSystem.cs
@@ -7,10 +7,17 @@ using static Content.Shared.Wires.SharedWiresComponent;
 
 namespace Content.Server.Wires
 {
-    public class WireHackingSystem : EntitySystem, IResettingEntitySystem
+    public class WireHackingSystem : EntitySystem
     {
         [ViewVariables] private readonly Dictionary<string, WireLayout> _layouts =
             new();
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+        }
 
         public bool TryGetLayout(string id, [NotNullWhen(true)] out WireLayout? layout)
         {
@@ -22,7 +29,7 @@ namespace Content.Server.Wires
             _layouts.Add(id, layout);
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _layouts.Clear();
         }

--- a/Content.Shared/GameTicking/IResettingEntitySystem.cs
+++ b/Content.Shared/GameTicking/IResettingEntitySystem.cs
@@ -1,9 +1,0 @@
-﻿#nullable enable
-
-namespace Content.Shared.GameTicking
-{
-    public interface IResettingEntitySystem
-    {
-        void Reset();
-    }
-}

--- a/Content.Shared/GameTicking/RoundRestartCleanupEvent.cs
+++ b/Content.Shared/GameTicking/RoundRestartCleanupEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+
+#nullable enable
+
+namespace Content.Shared.GameTicking
+{
+    [Serializable, NetSerializable]
+    public class RoundRestartCleanupEvent : EntityEventArgs
+    {
+    }
+}

--- a/Content.Shared/Pulling/SharedPullingSystem.cs
+++ b/Content.Shared/Pulling/SharedPullingSystem.cs
@@ -20,7 +20,7 @@ using Robust.Shared.Players;
 namespace Content.Shared.Pulling
 {
     [UsedImplicitly]
-    public abstract class SharedPullingSystem : EntitySystem, IResettingEntitySystem
+    public abstract class SharedPullingSystem : EntitySystem
     {
         /// <summary>
         ///     A mapping of pullers to the entity that they are pulling.
@@ -51,6 +51,7 @@ namespace Content.Shared.Pulling
         {
             base.Initialize();
 
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<PullStartedMessage>(OnPullStarted);
             SubscribeLocalEvent<PullStoppedMessage>(OnPullStopped);
             SubscribeLocalEvent<MoveEvent>(PullerMoved);
@@ -70,7 +71,7 @@ namespace Content.Shared.Pulling
             _stoppedMoving.Clear();
         }
 
-        public void Reset()
+        public void Reset(RoundRestartCleanupEvent ev)
         {
             _pullers.Clear();
             _moving.Clear();


### PR DESCRIPTION
Because implementing an interface in entity systems and iterating them all to call a single method is icky, and an event is cleaner.
- Removes IResettingEntitySystem
- Adds RoundRestartCleanupEvent
- RoundRestartCleanupEvent is raised locally and on the network on round restart cleanup, as its name implies.