### PR TITLE
Allows clown and mime to actually enter Theatre

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -5371,7 +5371,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 587
-  type: AirlockServiceLocked
+  type: AirlockTheatreLocked
   components:
   - name: Theatre
     type: MetaData

--- a/Resources/Prototypes/Entities/Constructible/Doors/airlock_access.yml
+++ b/Resources/Prototypes/Entities/Constructible/Doors/airlock_access.yml
@@ -8,6 +8,14 @@
     access: [["Service"]]
 
 - type: entity
+  parent: Airlock
+  id: AirlockTheatreLocked
+  suffix: Theatre, Locked
+  components:
+  - type: AccessReader
+    access: [["Theatre"]]
+
+- type: entity
   parent: AirlockExternal
   id: AirlockExternalLocked
   suffix: External, Locked


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CHANGES: MAP] [NO C#] [SIZE: 1 - TINY] [TYPE: BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For some reason the Theatre airlock on saltern had a "Service locked" type instead of a "Theatre" one. Tweaked.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: CrudeWax
- fix: Theatre is again accessible by clowns and mimes 
