### PR TITLE
Thirteen Loko causes toxin damage

### DIFF
--- a/Resources/Prototypes/Catalog/ReagentDispensers/beverage.yml
+++ b/Resources/Prototypes/Catalog/ReagentDispensers/beverage.yml
@@ -7,6 +7,7 @@
   - Ice
   - Tea
   - Water
+  - ThirteenLoko
 
 - type: reagentDispenserInventory
   id: BoozeDispenserInventory

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
@@ -111,6 +111,13 @@
   name: thirteen loko can
   description: The MBO has advised crew members that consumption of Thirteen Loko may result in seizures, blindness, drunkeness, or even death. Please Drink Responsibly.
   components:
+  - type: SolutionContainer
+    maxVol: 20
+    caps: None
+    contents:
+      reagents:
+      - ReagentId: ThirteenLoko
+        Quantity: 20
   - type: Sprite
     sprite: Objects/Consumable/Drinks/thirteen_loko.rsi
 

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -14,3 +14,23 @@
       amount: 1
     - !type:AdjustHealth
       amount: 0.1
+
+- type: reagent
+  id: ThirteenLoko
+  name: Thirteen Loko
+  desc: A highly processed liquid substance barely-passing intergalatic health standarts for a soft drink.
+  physicalDesc: fizzy
+  color: "#deb928"
+  metabolism:
+    - !type:DefaultDrink
+      rate: 1
+    - !type:HealthChangeMetabolism 
+      healthChange: 2
+      damageClass: Toxin
+  plantMetabolism:
+    - !type:AdjustNutrition
+      amount: 0.1
+    - !type:AdjustWater
+      amount: 1
+    - !type:AdjustHealth
+      amount: 0.1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[NO C#]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Thirteen Loko is a separate reagent (available through cans and soda dispensers) which does 2 toxin damage per tick, value chosen so a full can would leave you barely alive.
This adds a simple digestible poison for hijinks to ensue. The reagent is "fizzy" with a yellowish orange tint to distinguish it from other sodas.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: CrudeWax
- add: Thirteen Loko added to dispenser and now hazardous to your health

