### PR TITLE
"fix" potted plants bb

### DIFF
--- a/Resources/Prototypes/Entities/Constructible/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Constructible/Furniture/potted_plants.yml
@@ -9,7 +9,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-          bounds: "-0.5, -0.2, 0.5, 0.2"
+          bounds: "-0.2, -0.2, 0.2, 0.2"
       mass: 25
       mask:
         - MobImpassable


### PR DESCRIPTION
I believe it'd be one of the ones without worldrotation when we start doing rotated grids so I made it square for now.
Really I was just trying to stop the one at arrivals being jammed between the 2 walls constantly.

:cl:
- tweak: Reduce potted plant bounding box
