### PR TITLE
ContentTileDefinition defines the path where tile sprites are.

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -16,6 +16,8 @@ namespace Content.Shared.Maps
         [ViewVariables]
         string IPrototype.ID => Name;
 
+        public string Path => "/Textures/Constructible/Tiles/";
+
         [DataField("name", required: true)] public string Name { get; } = string.Empty;
 
         public ushort TileId { get; private set; }


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/1860