### PR TITLE
Add pipe coloring

### DIFF
--- a/Content.Client/Atmos/Visualizers/EnabledAtmosDeviceVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/EnabledAtmosDeviceVisualizer.cs
@@ -4,7 +4,7 @@ using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 
-namespace Content.Client.Atmos.Piping
+namespace Content.Client.Atmos.Visualizers
 {
     [UsedImplicitly]
     public abstract class EnabledAtmosDeviceVisualizer : AppearanceVisualizer

--- a/Content.Client/Atmos/Visualizers/OutletInjectorVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/OutletInjectorVisualizer.cs
@@ -2,13 +2,13 @@ using System;
 using Content.Shared.Atmos.Piping;
 using JetBrains.Annotations;
 
-namespace Content.Client.Atmos.Piping
+namespace Content.Client.Atmos.Visualizers
 {
     [UsedImplicitly]
-    public class PassiveVentVisualizer : EnabledAtmosDeviceVisualizer
+    public class OutletInjectorVisualizer : EnabledAtmosDeviceVisualizer
     {
         protected override object LayerMap => Layers.Enabled;
-        protected override Enum DataKey => PassiveVentVisuals.Enabled;
+        protected override Enum DataKey => OutletInjectorVisuals.Enabled;
 
         enum Layers
         {

--- a/Content.Client/Atmos/Visualizers/PassiveVentVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/PassiveVentVisualizer.cs
@@ -2,13 +2,13 @@ using System;
 using Content.Shared.Atmos.Piping;
 using JetBrains.Annotations;
 
-namespace Content.Client.Atmos.Piping
+namespace Content.Client.Atmos.Visualizers
 {
     [UsedImplicitly]
-    public class ThermoMachineVisualizer : EnabledAtmosDeviceVisualizer
+    public class PassiveVentVisualizer : EnabledAtmosDeviceVisualizer
     {
         protected override object LayerMap => Layers.Enabled;
-        protected override Enum DataKey => ThermoMachineVisuals.Enabled;
+        protected override Enum DataKey => PassiveVentVisuals.Enabled;
 
         enum Layers
         {

--- a/Content.Client/Atmos/Visualizers/PipeColorVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/PipeColorVisualizer.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Atmos.Piping;
+using JetBrains.Annotations;
+using Robust.Client.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+
+namespace Content.Client.Atmos.Visualizers
+{
+    [UsedImplicitly]
+    public class PipeColorVisualizer : AppearanceVisualizer
+    {
+        public override void OnChangeData(AppearanceComponent component)
+        {
+            base.OnChangeData(component);
+
+            if (!component.Owner.TryGetComponent(out SpriteComponent? sprite))
+                return;
+
+            if (component.TryGetData(PipeColorVisuals.Color, out Color color))
+            {
+                sprite.LayerSetColor(Layers.Pipe, color);
+            }
+        }
+
+        public enum Layers : byte
+        {
+            Pipe,
+        }
+    }
+}

--- a/Content.Client/Atmos/Visualizers/PipeConnectorVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/PipeConnectorVisualizer.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using Content.Shared.Atmos;
+using Content.Shared.Atmos.Piping;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -8,10 +9,11 @@ using Robust.Client.ResourceManagement;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 
-namespace Content.Client.Atmos.Piping
+namespace Content.Client.Atmos.Visualizers
 {
     [UsedImplicitly]
     public class PipeConnectorVisualizer : AppearanceVisualizer, ISerializationHooks
@@ -62,6 +64,9 @@ namespace Content.Client.Atmos.Piping
             if (!component.Owner.TryGetComponent<ISpriteComponent>(out var sprite))
                 return;
 
+            if (!component.TryGetData(PipeColorVisuals.Color, out Color color))
+                color = Color.White;
+
             if (!component.TryGetData(PipeVisuals.VisualState, out PipeVisualState state))
                 return;
 
@@ -72,6 +77,7 @@ namespace Content.Client.Atmos.Piping
 
                 var layer = sprite.LayerMapGet(layerKey);
                 sprite.LayerSetVisible(layer, layerVisible);
+                sprite.LayerSetColor(layer, color);
             }
         }
 

--- a/Content.Client/Atmos/Visualizers/PressurePumpVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/PressurePumpVisualizer.cs
@@ -2,13 +2,13 @@ using System;
 using Content.Shared.Atmos.Piping;
 using JetBrains.Annotations;
 
-namespace Content.Client.Atmos.Piping
+namespace Content.Client.Atmos.Visualizers
 {
     [UsedImplicitly]
-    public class OutletInjectorVisualizer : EnabledAtmosDeviceVisualizer
+    public class PressurePumpVisualizer : EnabledAtmosDeviceVisualizer
     {
         protected override object LayerMap => Layers.Enabled;
-        protected override Enum DataKey => OutletInjectorVisuals.Enabled;
+        protected override Enum DataKey => PressurePumpVisuals.Enabled;
 
         enum Layers
         {

--- a/Content.Client/Atmos/Visualizers/ScrubberVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/ScrubberVisualizer.cs
@@ -1,9 +1,8 @@
 using Content.Shared.Atmos.Piping.Unary.Visuals;
-using Content.Shared.Atmos.Visuals;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 
-namespace Content.Client.Atmos.Piping
+namespace Content.Client.Atmos.Visualizers
 {
     [UsedImplicitly]
     public class ScrubberVisualizer : AppearanceVisualizer

--- a/Content.Client/Atmos/Visualizers/ThermoMachineVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/ThermoMachineVisualizer.cs
@@ -2,13 +2,13 @@ using System;
 using Content.Shared.Atmos.Piping;
 using JetBrains.Annotations;
 
-namespace Content.Client.Atmos.Piping
+namespace Content.Client.Atmos.Visualizers
 {
     [UsedImplicitly]
-    public class PressurePumpVisualizer : EnabledAtmosDeviceVisualizer
+    public class ThermoMachineVisualizer : EnabledAtmosDeviceVisualizer
     {
         protected override object LayerMap => Layers.Enabled;
-        protected override Enum DataKey => PressurePumpVisuals.Enabled;
+        protected override Enum DataKey => ThermoMachineVisuals.Enabled;
 
         enum Layers
         {

--- a/Content.Client/Atmos/Visualizers/VentPumpVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/VentPumpVisualizer.cs
@@ -2,7 +2,7 @@ using Content.Shared.Atmos.Visuals;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 
-namespace Content.Client.Atmos.Piping
+namespace Content.Client.Atmos.Visualizers
 {
     [UsedImplicitly]
     public class VentPumpVisualizer : AppearanceVisualizer

--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -191,6 +191,7 @@ namespace Content.Client.Entry
             "GasCanisterPort",
             "GasPort",
             "GasPortable",
+            "AtmosPipeColor",
             "AtmosUnsafeUnanchor",
             "GasMixer",
             "Cleanable",

--- a/Content.Server/Atmos/Piping/Components/AtmosPipeColorComponent.cs
+++ b/Content.Server/Atmos/Piping/Components/AtmosPipeColorComponent.cs
@@ -1,0 +1,25 @@
+using Content.Server.Atmos.Piping.EntitySystems;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Server.Atmos.Piping.Components
+{
+    [RegisterComponent]
+    public class AtmosPipeColorComponent : Component
+    {
+        public override string Name => "AtmosPipeColor";
+
+        [DataField("color")]
+        public Color Color { get; set; } = Color.White;
+
+        [ViewVariables(VVAccess.ReadWrite), UsedImplicitly]
+        public Color ColorVV
+        {
+            get => Color;
+            set => EntitySystem.Get<AtmosPipeColorSystem>().SetColor(Owner.Uid, this, value);
+        }
+    }
+}

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosPipeColorSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosPipeColorSystem.cs
@@ -1,0 +1,45 @@
+using Content.Server.Atmos.Piping.Components;
+using Content.Shared.Atmos.Piping;
+using Robust.Server.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+
+namespace Content.Server.Atmos.Piping.EntitySystems
+{
+    public class AtmosPipeColorSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<AtmosPipeColorComponent, ComponentStartup>(OnStartup);
+            SubscribeLocalEvent<AtmosPipeColorComponent, ComponentShutdown>(OnShutdown);
+        }
+
+        private void OnStartup(EntityUid uid, AtmosPipeColorComponent component, ComponentStartup args)
+        {
+            if (!ComponentManager.TryGetComponent(uid, out AppearanceComponent? appearance))
+                return;
+
+            appearance.SetData(PipeColorVisuals.Color, component.Color);
+        }
+
+        private void OnShutdown(EntityUid uid, AtmosPipeColorComponent component, ComponentShutdown args)
+        {
+            if (!ComponentManager.TryGetComponent(uid, out AppearanceComponent? appearance))
+                return;
+
+            appearance.SetData(PipeColorVisuals.Color, Color.White);
+        }
+
+        public void SetColor(EntityUid uid, AtmosPipeColorComponent component, Color color)
+        {
+            component.Color = color;
+
+            if (!ComponentManager.TryGetComponent(uid, out AppearanceComponent? appearance))
+                return;
+
+            appearance.SetData(PipeColorVisuals.Color, color);
+        }
+    }
+}

--- a/Content.Shared/Atmos/Piping/PipeColorVisuals.cs
+++ b/Content.Shared/Atmos/Piping/PipeColorVisuals.cs
@@ -1,0 +1,11 @@
+using System;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Atmos.Piping
+{
+    [Serializable, NetSerializable]
+    public enum PipeColorVisuals
+    {
+        Color,
+    }
+}

--- a/Resources/Prototypes/Entities/Constructible/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/Atmospherics/binary.yml
@@ -31,10 +31,12 @@
     layers:
     - sprite: Constructible/Atmos/pipe.rsi
       state: pipeStraight
+      map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
     - state: pumpPressure
   - type: Appearance
     visuals:
     - type: PipeConnectorVisualizer
+    - type: PipeColorVisualizer
     - type: PressurePumpVisualizer
       enabledState: pumpPressureOn
   - type: GasPressurePump
@@ -53,10 +55,8 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeStraight
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: pumpVolume
-    - type: Appearance
-      visuals:
-        - type: PipeConnectorVisualizer
     - type: GasVolumePump
 
 - type: entity
@@ -73,10 +73,8 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeStraight
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: pumpPassiveGate
-    - type: Appearance
-      visuals:
-        - type: PipeConnectorVisualizer
     - type: GasPassiveGate
 
 - type: entity
@@ -94,10 +92,8 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeStraight
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: pumpPassiveGate
-    - type: Appearance
-      visuals:
-        - type: PipeConnectorVisualizer
     - type: GasValve
     - type: NodeContainer
       nodes:
@@ -120,10 +116,8 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeHalf
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: gasCanisterPort
-    - type: Appearance
-      visuals:
-        - type: PipeConnectorVisualizer
     - type: GasPort
     - type: NodeContainer
       nodes:

--- a/Resources/Prototypes/Entities/Constructible/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/Atmospherics/pipes.yml
@@ -29,8 +29,10 @@
   - type: Appearance
     visuals:
     - type: PipeConnectorVisualizer
+    - type: PipeColorVisualizer
   - type: NodeContainer
   - type: AtmosUnsafeUnanchor
+  - type: AtmosPipeColor
 
 #Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (south)
 
@@ -46,7 +48,9 @@
         nodeGroupID: Pipe
         pipeDirection: South
   - type: Sprite
-    state: pipeHalf
+    layers:
+      - state: pipeHalf
+        map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
 
 - type: entity
   parent: GasPipeBase
@@ -60,7 +64,9 @@
         nodeGroupID: Pipe
         pipeDirection: Longitudinal
   - type: Sprite
-    state: pipeStraight
+    layers:
+      - state: pipeStraight
+        map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
 
 - type: entity
   parent: GasPipeBase
@@ -74,7 +80,9 @@
         nodeGroupID: Pipe
         pipeDirection: SWBend
   - type: Sprite
-    state: pipeBend
+    layers:
+      - state: pipeBend
+        map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
 
 - type: entity
   parent: GasPipeBase
@@ -88,7 +96,9 @@
         nodeGroupID: Pipe
         pipeDirection: TSouth
   - type: Sprite
-    state: pipeTJunction
+    layers:
+      - state: pipeTJunction
+        map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
 
 - type: entity
   parent: GasPipeBase
@@ -102,4 +112,6 @@
         nodeGroupID: Pipe
         pipeDirection: Fourway
   - type: Sprite
-    state: pipeFourway
+    layers:
+      - state: pipeFourway
+        map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]

--- a/Resources/Prototypes/Entities/Constructible/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/Atmospherics/trinary.yml
@@ -36,10 +36,8 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeTJunction
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: gasFilter
-    - type: Appearance
-      visuals:
-        - type: PipeConnectorVisualizer
     - type: GasFilter
 
 - type: entity
@@ -57,10 +55,8 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeTJunction
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: gasFilter
-    - type: Appearance
-      visuals:
-        - type: PipeConnectorVisualizer
     - type: GasMixer
       inletOne: inlet
       inletTwo: filter

--- a/Resources/Prototypes/Entities/Constructible/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Constructible/Piping/Atmospherics/unary.yml
@@ -27,11 +27,13 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeHalf
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: vent_off
           map: ["enum.VentVisualLayers.Vent"]
     - type: Appearance
       visuals:
         - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
         - type: VentPumpVisualizer
     - type: GasVentPump
 
@@ -50,10 +52,12 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeHalf
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: vent_off
     - type: Appearance
       visuals:
         - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
     - type: GasPassiveVent
 
 - type: entity
@@ -70,11 +74,13 @@
       layers:
         - sprite: Constructible/Atmos/pipe.rsi
           state: pipeHalf
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: scrub_off
           map: ["enum.ScrubberVisualLayers.Scrubber"]
     - type: Appearance
       visuals:
         - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
         - type: ScrubberVisualizer
     - type: AtmosDevice
     - type: GasVentScrubber
@@ -91,9 +97,10 @@
     # TODO ATMOS: Actual sprite for this.
     - type: Sprite
       netsync: false
-      sprite: Constructible/Atmos/pipe.rsi
-      state: pipeHalf
-
+      layers:
+        - state: pipeHalf
+          sprite: Constructible/Atmos/pipe.rsi
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
 
 - type: entity
   parent: GasUnaryBase
@@ -125,6 +132,7 @@
         - state: pipe
     - type: Appearance
       visuals:
+        - type: PipeConnectorVisualizer
         - type: ThermoMachineVisualizer
           enabledState: freezer_on
     - type: GasThermoMachine
@@ -144,6 +152,7 @@
         - state: pipe
     - type: Appearance
       visuals:
+        - type: PipeConnectorVisualizer
         - type: ThermoMachineVisualizer
           enabledState: heater_on
     - type: GasThermoMachine


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a component with a `Color` property that allows you to change the color of pipes.
This works with atmos devices that have multiple layers, too.

Right now there's no in-game way of coloring pipes, you need to use VV for this. (I added a `ColorVV` property to make this simpler)

As to why this needs a server-side component and not just a visualizer, we need the component for serialization. 

**Screenshots**
![image](https://user-images.githubusercontent.com/6766154/125160695-a973ce80-e17e-11eb-8e70-83c98e5ffcb0.png)

