### PR TITLE
Grid-relative movement

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -175,6 +175,9 @@ namespace Content.Shared.CCVar
          * Physics
          */
 
+        public static readonly CVarDef<bool> RelativeMovement =
+            CVarDef.Create("physics.relative_movement", true, CVar.ARCHIVE | CVar.REPLICATED);
+
         public static readonly CVarDef<float> TileFrictionModifier =
             CVarDef.Create("physics.tilefriction", 15.0f);
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -175,6 +175,9 @@ namespace Content.Shared.CCVar
          * Physics
          */
 
+        /// <summary>
+        /// When a mob is walking should its X / Y movement be relative to its parent (true) or the map (false).
+        /// </summary>
         public static readonly CVarDef<bool> RelativeMovement =
             CVarDef.Create("physics.relative_movement", true, CVar.ARCHIVE | CVar.REPLICATED);
 


### PR DESCRIPTION
Might add a test for it, but not today as it's obvious when it's on / off.

:cl:
- add: Shuttle-relative movement for when we get shuttle rotation.

