### PR TITLE
"Fix" drag-drop

### DIFF
--- a/Content.Client/Clickable/ClickableComponent.cs
+++ b/Content.Client/Clickable/ClickableComponent.cs
@@ -84,7 +84,6 @@ namespace Content.Client.Clickable
                     var dirCount = sprite.GetLayerDirectionCount(layer);
                     var dir = layer.EffectiveDirection(worldRotation);
                     var modAngle = sprite.NoRotation ? SpriteComponent.CalcRectWorldAngle(worldRotation, dirCount) : Angle.Zero;
-                    modAngle += dir.Convert().ToAngle();
 
                     var layerPos = modAngle.RotateVec(localPos);
 


### PR DESCRIPTION
AFAICT the position being passed into the sprite already has its offset from the center of the spriteapplied so there's no need to modAngle it as each direction for iconsmoothing only has the corner sprite applied anyway?
Probably needs fixing for rotation but future Sloth problem.

I'll suss out the existing tests before merge.

:cl:
- fix: Fix drag-drop hitbox.
