### PR TITLE
Bug fixes for metabolisable reagents 

### DIFF
--- a/Content.Server/Body/Behavior/LiverBehavior.cs
+++ b/Content.Server/Body/Behavior/LiverBehavior.cs
@@ -96,7 +96,7 @@ namespace Content.Server.Body.Behavior
                 }
 
                 // How much reagent is available to metabolise?
-                // This needs to be passed to other functions that have metabolism rate information, such that they don't "overmetabolise" a reagant.
+                // This needs to be passed to other functions that have metabolism rate information, such that they don't "overmetabolise" a reagent.
                 var availableReagent = bloodstream.Solution.Solution.GetReagentQuantity(reagent.ReagentId);
 
                 //TODO BODY Check if it's a Toxin. If volume < _toxinTolerance, just remove it. If greater, add damage = volume * _toxinLethality

--- a/Content.Server/Body/Behavior/LiverBehavior.cs
+++ b/Content.Server/Body/Behavior/LiverBehavior.cs
@@ -95,6 +95,10 @@ namespace Content.Server.Body.Behavior
                     continue;
                 }
 
+                // How much reagent is available to metabolise?
+                // This needs to be passed to other functions that have metabolism rate information, such that they don't "overmetabolise" a reagant.
+                var availableReagent = bloodstream.Solution.Solution.GetReagentQuantity(reagent.ReagentId);
+
                 //TODO BODY Check if it's a Toxin. If volume < _toxinTolerance, just remove it. If greater, add damage = volume * _toxinLethality
                 //TODO BODY Check if it has BoozePower > 0. Affect drunkenness, apply damage. Proposed formula (SS13-derived): damage = sqrt(volume) * BoozePower^_alcoholExponent * _alcoholLethality / 10
                 //TODO BODY Liver failure.
@@ -104,8 +108,9 @@ namespace Content.Server.Body.Behavior
                 // Run metabolism code for each reagent
                 foreach (var metabolizable in prototype.Metabolism)
                 {
-                    var reagentDelta = metabolizable.Metabolize(Body.Owner, reagent.ReagentId, _updateInterval);
+                    var reagentDelta = metabolizable.Metabolize(Body.Owner, reagent.ReagentId, _updateInterval, availableReagent);
                     bloodstream.Solution.TryRemoveReagent(reagent.ReagentId, reagentDelta);
+                    availableReagent -= reagentDelta;
                 }
             }
         }

--- a/Content.Server/Body/Behavior/LiverBehavior.cs
+++ b/Content.Server/Body/Behavior/LiverBehavior.cs
@@ -18,9 +18,9 @@ namespace Content.Server.Body.Behavior
         private float _accumulatedFrameTime;
 
         /// <summary>
-        ///     How frequently to metabolise blood contents.
+        ///     Delay time that determines how often to metabolise blood contents (in seconds).
         /// </summary>
-        private float _updateInterval = 1.0f;
+        private float _updateIntervalSeconds = 1.0f;
 
         /// <summary>
         ///     Whether the liver is functional.
@@ -69,12 +69,12 @@ namespace Content.Server.Body.Behavior
             _accumulatedFrameTime += frameTime;
 
             // Update at most once every _updateInterval
-            if (_accumulatedFrameTime < _updateInterval)
+            if (_accumulatedFrameTime < _updateIntervalSeconds)
             {
                 return;
             }
 
-            _accumulatedFrameTime -= _updateInterval;
+            _accumulatedFrameTime -= _updateIntervalSeconds;
 
             if (!Body.Owner.TryGetComponent(out BloodstreamComponent? bloodstream))
             {
@@ -108,7 +108,7 @@ namespace Content.Server.Body.Behavior
                 // Run metabolism code for each reagent
                 foreach (var metabolizable in prototype.Metabolism)
                 {
-                    var reagentDelta = metabolizable.Metabolize(Body.Owner, reagent.ReagentId, _updateInterval, availableReagent);
+                    var reagentDelta = metabolizable.Metabolize(Body.Owner, reagent.ReagentId, _updateIntervalSeconds, availableReagent);
                     bloodstream.Solution.TryRemoveReagent(reagent.ReagentId, reagentDelta);
                     availableReagent -= reagentDelta;
                 }

--- a/Content.Server/Body/Behavior/LiverBehavior.cs
+++ b/Content.Server/Body/Behavior/LiverBehavior.cs
@@ -68,7 +68,7 @@ namespace Content.Server.Body.Behavior
 
             _accumulatedFrameTime += frameTime;
 
-            // Update at most once every _updateInterval
+            // Update at most once every _updateIntervalSeconds
             if (_accumulatedFrameTime < _updateIntervalSeconds)
             {
                 return;

--- a/Content.Server/Body/Behavior/LiverBehavior.cs
+++ b/Content.Server/Body/Behavior/LiverBehavior.cs
@@ -18,6 +18,11 @@ namespace Content.Server.Body.Behavior
         private float _accumulatedFrameTime;
 
         /// <summary>
+        ///     How frequently to metabolise blood contents.
+        /// </summary>
+        private float _updateInterval = 1.0f;
+
+        /// <summary>
         ///     Whether the liver is functional.
         /// </summary>
         //[ViewVariables] private bool _liverFailing = false;
@@ -63,13 +68,13 @@ namespace Content.Server.Body.Behavior
 
             _accumulatedFrameTime += frameTime;
 
-            // Update at most once per second
-            if (_accumulatedFrameTime < 1)
+            // Update at most once every _updateInterval
+            if (_accumulatedFrameTime < _updateInterval)
             {
                 return;
             }
 
-            _accumulatedFrameTime -= 1;
+            _accumulatedFrameTime -= _updateInterval;
 
             if (!Body.Owner.TryGetComponent(out BloodstreamComponent? bloodstream))
             {
@@ -99,7 +104,7 @@ namespace Content.Server.Body.Behavior
                 // Run metabolism code for each reagent
                 foreach (var metabolizable in prototype.Metabolism)
                 {
-                    var reagentDelta = metabolizable.Metabolize(Body.Owner, reagent.ReagentId, frameTime);
+                    var reagentDelta = metabolizable.Metabolize(Body.Owner, reagent.ReagentId, _updateInterval);
                     bloodstream.Solution.TryRemoveReagent(reagent.ReagentId, reagentDelta);
                 }
             }

--- a/Content.Server/Body/Behavior/StomachBehavior.cs
+++ b/Content.Server/Body/Behavior/StomachBehavior.cs
@@ -65,8 +65,19 @@ namespace Content.Server.Body.Behavior
                 delta.Increment(1);
                 if (delta.Lifetime > _digestionDelay)
                 {
-                    solution.TryRemoveReagent(delta.ReagentId, delta.Quantity);
-                    transferSolution.AddReagent(delta.ReagentId, delta.Quantity);
+                    // This reagant has been in the somach long enough, TRY to transfer it.
+                    // But first, check if the reagant still exists, and how much is left.
+                    // Some poort spessman may have washed down a potassium snack with some water.
+                    if (solution.Solution.ContainsReagent(delta.ReagentId, out ReagentUnit quantity)){
+
+                        if (quantity > delta.Quantity) {
+                            quantity = delta.Quantity;
+                        }
+
+                        solution.TryRemoveReagent(delta.ReagentId, quantity);
+                        transferSolution.AddReagent(delta.ReagentId, quantity);
+                    }
+
                     _reagentDeltas.Remove(delta);
                 }
             }

--- a/Content.Server/Body/Behavior/StomachBehavior.cs
+++ b/Content.Server/Body/Behavior/StomachBehavior.cs
@@ -65,8 +65,8 @@ namespace Content.Server.Body.Behavior
                 delta.Increment(1);
                 if (delta.Lifetime > _digestionDelay)
                 {
-                    // This reagant has been in the somach long enough, TRY to transfer it.
-                    // But first, check if the reagant still exists, and how much is left.
+                    // This reagent has been in the somach long enough, TRY to transfer it.
+                    // But first, check if the reagent still exists, and how much is left.
                     // Some poor spessman may have washed down a potassium snack with some water.
                     if (solution.Solution.ContainsReagent(delta.ReagentId, out ReagentUnit quantity)){
 

--- a/Content.Server/Body/Behavior/StomachBehavior.cs
+++ b/Content.Server/Body/Behavior/StomachBehavior.cs
@@ -30,6 +30,8 @@ namespace Content.Server.Body.Behavior
         /// </param>
         public override void Update(float frameTime)
         {
+
+            // Do not metabolise if the organ does not have a body.
             if (Body == null)
             {
                 return;
@@ -45,7 +47,9 @@ namespace Content.Server.Body.Behavior
 
             _accumulatedFrameTime -= 1;
 
-            if (!Body.Owner.TryGetComponent(out SolutionContainerComponent? solution) ||
+            // Note that "Owner" should be the organ that has this behaviour/mechanism, and it should have a dedicated
+            // solution container. "Body.Owner" is something else, and may have more than one solution container.
+            if (!Owner.TryGetComponent(out SolutionContainerComponent? solution) ||
                 !Body.Owner.TryGetComponent(out BloodstreamComponent? bloodstream))
             {
                 return;
@@ -135,10 +139,10 @@ namespace Content.Server.Body.Behavior
 
         public bool TryTransferSolution(Solution solution)
         {
-            if (Body == null || !CanTransferSolution(solution))
+            if (Owner == null || !CanTransferSolution(solution))
                 return false;
 
-            if (!Body.Owner.TryGetComponent(out SolutionContainerComponent? solutionComponent))
+            if (!Owner.TryGetComponent(out SolutionContainerComponent? solutionComponent))
             {
                 return false;
             }

--- a/Content.Server/Body/Behavior/StomachBehavior.cs
+++ b/Content.Server/Body/Behavior/StomachBehavior.cs
@@ -67,8 +67,10 @@ namespace Content.Server.Body.Behavior
                 }
             }
 
-            // Transfer digested reagents to bloodstream
-            bloodstream.TryTransferSolution(transferSolution);
+            // Transfer digested reagents to bloodstream, if there is something to actually transfer
+            if (transferSolution.TotalVolume > 0){ 
+                bloodstream.TryTransferSolution(transferSolution);
+            }
         }
 
         /// <summary>

--- a/Content.Server/Body/Behavior/StomachBehavior.cs
+++ b/Content.Server/Body/Behavior/StomachBehavior.cs
@@ -67,7 +67,7 @@ namespace Content.Server.Body.Behavior
                 {
                     // This reagant has been in the somach long enough, TRY to transfer it.
                     // But first, check if the reagant still exists, and how much is left.
-                    // Some poort spessman may have washed down a potassium snack with some water.
+                    // Some poor spessman may have washed down a potassium snack with some water.
                     if (solution.Solution.ContainsReagent(delta.ReagentId, out ReagentUnit quantity)){
 
                         if (quantity > delta.Quantity) {

--- a/Content.Server/Body/Behavior/StomachBehavior.cs
+++ b/Content.Server/Body/Behavior/StomachBehavior.cs
@@ -82,10 +82,8 @@ namespace Content.Server.Body.Behavior
                 }
             }
 
-            // Transfer digested reagents to bloodstream, if there is something to actually transfer
-            if (transferSolution.TotalVolume > 0){ 
-                bloodstream.TryTransferSolution(transferSolution);
-            }
+            // Transfer digested reagents to bloodstream
+            bloodstream.TryTransferSolution(transferSolution);
         }
 
         /// <summary>

--- a/Content.Server/Chemistry/Metabolism/DefaultDrink.cs
+++ b/Content.Server/Chemistry/Metabolism/DefaultDrink.cs
@@ -25,10 +25,10 @@ namespace Content.Server.Chemistry.Metabolism
         //Remove reagent at set rate, satiate thirst if a ThirstComponent can be found
         ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
-            // how much reagant should we metabolize
+            // how much reagent should we metabolize
             var metabolismAmount = MetabolismRate * tickTime;
 
-            // is that much reagant actually available?
+            // is that much reagent actually available?
             if (availableReagent < metabolismAmount)
             {
                 metabolismAmount = availableReagent;

--- a/Content.Server/Chemistry/Metabolism/DefaultDrink.cs
+++ b/Content.Server/Chemistry/Metabolism/DefaultDrink.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Nutrition.Components;
+using Content.Server.Nutrition.Components;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Metabolizable;
 using Content.Shared.Chemistry.Reagent;
@@ -23,9 +23,17 @@ namespace Content.Server.Chemistry.Metabolism
         public float HydrationFactor { get; set; } = 30.0f;
 
         //Remove reagent at set rate, satiate thirst if a ThirstComponent can be found
-        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime)
+        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
+            // how much reagant should we metabolize
             var metabolismAmount = MetabolismRate * tickTime;
+
+            // is that much reagant actually available?
+            if (availableReagent < metabolismAmount)
+            {
+                metabolismAmount = availableReagent;
+            }
+
             if (solutionEntity.TryGetComponent(out ThirstComponent? thirst))
                 thirst.UpdateThirst(metabolismAmount.Float() * HydrationFactor);
 

--- a/Content.Server/Chemistry/Metabolism/DefaultDrink.cs
+++ b/Content.Server/Chemistry/Metabolism/DefaultDrink.cs
@@ -9,31 +9,22 @@ namespace Content.Server.Chemistry.Metabolism
 {
     /// <summary>
     /// Default metabolism for drink reagents. Attempts to find a ThirstComponent on the target,
-    /// and to update it's thirst values.
+    /// and to update it's thirst values. Inherits metabolisation rate logic from DefaultMetabolizable.
     /// </summary>
     [DataDefinition]
-    public class DefaultDrink : IMetabolizable
+    public class DefaultDrink : DefaultMetabolizable
     {
-        //Rate of metabolism in units / second
-        [DataField("rate")]
-        public ReagentUnit MetabolismRate { get; set; } = ReagentUnit.New(1);
-
         //How much thirst is satiated when 1u of the reagent is metabolized
         [DataField("hydrationFactor")]
         public float HydrationFactor { get; set; } = 30.0f;
 
         //Remove reagent at set rate, satiate thirst if a ThirstComponent can be found
-        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
+        public override ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
-            // how much reagent should we metabolize
-            var metabolismAmount = MetabolismRate * tickTime;
+            // use DefaultMetabolism to determine how much reagent we should metabolize
+            var metabolismAmount = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
 
-            // is that much reagent actually available?
-            if (availableReagent < metabolismAmount)
-            {
-                metabolismAmount = availableReagent;
-            }
-
+            // If metabolizing entity has a ThirstComponent, hydrate them.
             if (solutionEntity.TryGetComponent(out ThirstComponent? thirst))
                 thirst.UpdateThirst(metabolismAmount.Float() * HydrationFactor);
 

--- a/Content.Server/Chemistry/Metabolism/DefaultDrink.cs
+++ b/Content.Server/Chemistry/Metabolism/DefaultDrink.cs
@@ -22,14 +22,14 @@ namespace Content.Server.Chemistry.Metabolism
         public override ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
             // use DefaultMetabolism to determine how much reagent we should metabolize
-            var metabolismAmount = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
+            var amountMetabolized = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
 
             // If metabolizing entity has a ThirstComponent, hydrate them.
             if (solutionEntity.TryGetComponent(out ThirstComponent? thirst))
-                thirst.UpdateThirst(metabolismAmount.Float() * HydrationFactor);
+                thirst.UpdateThirst(amountMetabolized.Float() * HydrationFactor);
 
             //Return amount of reagent to be removed, remove reagent regardless of ThirstComponent presence
-            return metabolismAmount;
+            return amountMetabolized;
         }
     }
 }

--- a/Content.Server/Chemistry/Metabolism/DefaultFood.cs
+++ b/Content.Server/Chemistry/Metabolism/DefaultFood.cs
@@ -25,14 +25,14 @@ namespace Content.Server.Chemistry.Metabolism
         public override ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
             // use DefaultMetabolism to determine how much reagent we should metabolize
-            var metabolismAmount = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
+            var amountMetabolized = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
 
             // If metabolizing entity has a HungerComponent, feed them.
             if (solutionEntity.TryGetComponent(out HungerComponent? hunger))
-                hunger.UpdateFood(metabolismAmount.Float() * NutritionFactor);
+                hunger.UpdateFood(amountMetabolized.Float() * NutritionFactor);
 
             //Return amount of reagent to be removed. Reagent is removed regardless of HungerComponent presence
-            return metabolismAmount;
+            return amountMetabolized;
         }
     }
 }

--- a/Content.Server/Chemistry/Metabolism/DefaultFood.cs
+++ b/Content.Server/Chemistry/Metabolism/DefaultFood.cs
@@ -27,10 +27,10 @@ namespace Content.Server.Chemistry.Metabolism
         //Remove reagent at set rate, satiate hunger if a HungerComponent can be found
         ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
-            // how much reagant should we metabolize
+            // how much reagent should we metabolize
             var metabolismAmount = MetabolismRate * tickTime;
 
-            // is that much reagant actually available?
+            // is that much reagent actually available?
             if (availableReagent < metabolismAmount)
             {
                 metabolismAmount = availableReagent;

--- a/Content.Server/Chemistry/Metabolism/DefaultFood.cs
+++ b/Content.Server/Chemistry/Metabolism/DefaultFood.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Nutrition.Components;
+using Content.Server.Nutrition.Components;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Metabolizable;
 using Content.Shared.Chemistry.Reagent;
@@ -25,9 +25,17 @@ namespace Content.Server.Chemistry.Metabolism
         [DataField("nutritionFactor")] public float NutritionFactor { get; set; } = 30.0f;
 
         //Remove reagent at set rate, satiate hunger if a HungerComponent can be found
-        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime)
+        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
+            // how much reagant should we metabolize
             var metabolismAmount = MetabolismRate * tickTime;
+
+            // is that much reagant actually available?
+            if (availableReagent < metabolismAmount)
+            {
+                metabolismAmount = availableReagent;
+            }
+
             if (solutionEntity.TryGetComponent(out HungerComponent? hunger))
                 hunger.UpdateFood(metabolismAmount.Float() * NutritionFactor);
 

--- a/Content.Server/Chemistry/Metabolism/DefaultFood.cs
+++ b/Content.Server/Chemistry/Metabolism/DefaultFood.cs
@@ -9,37 +9,29 @@ namespace Content.Server.Chemistry.Metabolism
 {
     /// <summary>
     /// Default metabolism for food reagents. Attempts to find a HungerComponent on the target,
-    /// and to update it's hunger values.
+    /// and to update it's hunger values. Inherits metabolisation rate logic from DefaultMetabolizable.
     /// </summary>
     [DataDefinition]
-    public class DefaultFood : IMetabolizable
+    public class DefaultFood : DefaultMetabolizable
     {
-        /// <summary>
-        ///     Rate of metabolism in units / second
-        /// </summary>
-        [DataField("rate")] public ReagentUnit MetabolismRate { get; private set; } = ReagentUnit.New(1.0);
 
         /// <summary>
         ///     How much hunger is satiated when 1u of the reagent is metabolized
         /// </summary>
         [DataField("nutritionFactor")] public float NutritionFactor { get; set; } = 30.0f;
 
+
         //Remove reagent at set rate, satiate hunger if a HungerComponent can be found
-        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
+        public override ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
-            // how much reagent should we metabolize
-            var metabolismAmount = MetabolismRate * tickTime;
+            // use DefaultMetabolism to determine how much reagent we should metabolize
+            var metabolismAmount = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
 
-            // is that much reagent actually available?
-            if (availableReagent < metabolismAmount)
-            {
-                metabolismAmount = availableReagent;
-            }
-
+            // If metabolizing entity has a HungerComponent, feed them.
             if (solutionEntity.TryGetComponent(out HungerComponent? hunger))
                 hunger.UpdateFood(metabolismAmount.Float() * NutritionFactor);
 
-            //Return amount of reagent to be removed, remove reagent regardless of HungerComponent presence
+            //Return amount of reagent to be removed. Reagent is removed regardless of HungerComponent presence
             return metabolismAmount;
         }
     }

--- a/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
+++ b/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
@@ -41,10 +41,19 @@ namespace Content.Server.Chemistry.Metabolism
         /// <param name="solutionEntity"></param>
         /// <param name="reagentId"></param>
         /// <param name="tickTime"></param>
+        /// <param name="availableReagant">Reagant available to be metabolized.</param>
         /// <returns></returns>
-        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime)
+        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
+            // how much reagant should we metabolize
             var metabolismAmount = MetabolismRate * tickTime;
+
+            // is that much reagant actually available?
+            if (availableReagent < metabolismAmount) {
+                metabolismAmount = availableReagent;
+            }
+
+            // how much does this much reagant heal for
             var healthChangeAmmount = HealthChange * metabolismAmount.Float();
 
             if (solutionEntity.TryGetComponent(out IDamageableComponent? health))

--- a/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
+++ b/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
@@ -41,19 +41,19 @@ namespace Content.Server.Chemistry.Metabolism
         /// <param name="solutionEntity"></param>
         /// <param name="reagentId"></param>
         /// <param name="tickTime"></param>
-        /// <param name="availableReagant">Reagant available to be metabolized.</param>
+        /// <param name="availableReagent">Reagent available to be metabolized.</param>
         /// <returns></returns>
         ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
-            // how much reagant should we metabolize
+            // how much reagent should we metabolize
             var metabolismAmount = MetabolismRate * tickTime;
 
-            // is that much reagant actually available?
+            // is that much reagent actually available?
             if (availableReagent < metabolismAmount) {
                 metabolismAmount = availableReagent;
             }
 
-            // how much does this much reagant heal for
+            // how much does this much reagent heal for
             var healthChangeAmount = HealthChange * metabolismAmount.Float();
 
             if (solutionEntity.TryGetComponent(out IDamageableComponent? health))

--- a/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
+++ b/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
@@ -44,11 +44,16 @@ namespace Content.Server.Chemistry.Metabolism
         /// <returns></returns>
         ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime)
         {
+            var metabolismAmount = MetabolismRate * tickTime;
+            var healthChangeAmmount = HealthChange * metabolismAmount.Float();
+
             if (solutionEntity.TryGetComponent(out IDamageableComponent? health))
             {
-                health.ChangeDamage(DamageType, (int)HealthChange, true);
-                float decHealthChange = (float) (HealthChange - (int) HealthChange);
-                _accumulatedHealth += decHealthChange;
+                // Heal damage by healthChangeAmmount, rounding down to nearest integer
+                health.ChangeDamage(DamageType, (int) healthChangeAmmount, true);
+
+                // Store decimal remainder of healthChangeAmmount in _accumulatedHealth
+                _accumulatedHealth += (healthChangeAmmount - (int) healthChangeAmmount);
 
                 if (_accumulatedHealth >= 1)
                 {
@@ -62,7 +67,7 @@ namespace Content.Server.Chemistry.Metabolism
                     _accumulatedHealth += 1;
                 }
             }
-            return MetabolismRate;
+            return metabolismAmount;
         }
     }
 }

--- a/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
+++ b/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
@@ -10,16 +10,11 @@ namespace Content.Server.Chemistry.Metabolism
 {
     /// <summary>
     /// Default metabolism for medicine reagents. Attempts to find a DamageableComponent on the target,
-    /// and to update its damage values.
+    /// and to update its damage values. Inherits metabolisation rate logic from DefaultMetabolizable.
     /// </summary>
     [DataDefinition]
-    public class HealthChangeMetabolism : IMetabolizable
+    public class HealthChangeMetabolism : DefaultMetabolizable
     {
-        /// <summary>
-        /// How much of the reagent should be metabolized each sec.
-        /// </summary>
-        [DataField("rate")]
-        public ReagentUnit MetabolismRate { get; set; } = ReagentUnit.New(1);
 
         /// <summary>
         /// How much damage is changed when 1u of the reagent is metabolized.
@@ -43,15 +38,10 @@ namespace Content.Server.Chemistry.Metabolism
         /// <param name="tickTime"></param>
         /// <param name="availableReagent">Reagent available to be metabolized.</param>
         /// <returns></returns>
-        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
+        public override ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
-            // how much reagent should we metabolize
-            var metabolismAmount = MetabolismRate * tickTime;
-
-            // is that much reagent actually available?
-            if (availableReagent < metabolismAmount) {
-                metabolismAmount = availableReagent;
-            }
+            // use DefaultMetabolism to determine how much reagent we should metabolize
+            var metabolismAmount = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
 
             // how much does this much reagent heal for
             var healthChangeAmount = HealthChange * metabolismAmount.Float();

--- a/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
+++ b/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
@@ -41,10 +41,10 @@ namespace Content.Server.Chemistry.Metabolism
         public override ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
             // use DefaultMetabolism to determine how much reagent we should metabolize
-            var metabolismAmount = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
+            var amountMetabolized = base.Metabolize(solutionEntity, reagentId, tickTime, availableReagent);
 
             // how much does this much reagent heal for
-            var healthChangeAmount = HealthChange * metabolismAmount.Float();
+            var healthChangeAmount = HealthChange * amountMetabolized.Float();
 
             if (solutionEntity.TryGetComponent(out IDamageableComponent? health))
             {
@@ -66,7 +66,7 @@ namespace Content.Server.Chemistry.Metabolism
                     _accumulatedHealth += 1;
                 }
             }
-            return metabolismAmount;
+            return amountMetabolized;
         }
     }
 }

--- a/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
+++ b/Content.Server/Chemistry/Metabolism/HealthChangeMetabolism.cs
@@ -54,15 +54,15 @@ namespace Content.Server.Chemistry.Metabolism
             }
 
             // how much does this much reagant heal for
-            var healthChangeAmmount = HealthChange * metabolismAmount.Float();
+            var healthChangeAmount = HealthChange * metabolismAmount.Float();
 
             if (solutionEntity.TryGetComponent(out IDamageableComponent? health))
             {
                 // Heal damage by healthChangeAmmount, rounding down to nearest integer
-                health.ChangeDamage(DamageType, (int) healthChangeAmmount, true);
+                health.ChangeDamage(DamageType, (int) healthChangeAmount, true);
 
                 // Store decimal remainder of healthChangeAmmount in _accumulatedHealth
-                _accumulatedHealth += (healthChangeAmmount - (int) healthChangeAmmount);
+                _accumulatedHealth += (healthChangeAmount - (int) healthChangeAmount);
 
                 if (_accumulatedHealth >= 1)
                 {

--- a/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
+++ b/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
@@ -5,7 +5,9 @@ using Robust.Shared.Serialization.Manager.Attributes;
 namespace Content.Shared.Chemistry.Metabolizable
 {
     /// <summary>
-    ///     Default metabolism for reagents. Metabolizes the reagent with no effects
+    ///     Default metabolization for reagents. Returns the amount of reagents metabolized without applying effects.
+    ///     Metabolizes reagents at a constant rate, limited by how much is available. Other classes are derived from
+    ///     this class, so that they do not need their own metabolization quantity calculation.
     /// </summary>
     [DataDefinition]
     public class DefaultMetabolizable : IMetabolizable
@@ -18,7 +20,8 @@ namespace Content.Shared.Chemistry.Metabolizable
         public virtual ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
 
-            // how much reagent should we metabolize
+            // How much reagent should we metabolize
+            // The default behaviour is to metabolize at a constant rate, independent of the quantity of reagents.
             var amountMetabolized = MetabolismRate * tickTime;
 
             // is that much reagent actually available?

--- a/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
+++ b/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
@@ -13,14 +13,13 @@ namespace Content.Shared.Chemistry.Metabolizable
         /// <summary>
         ///     Rate of metabolism in units / second
         /// </summary>
-        [DataField("rate")]
-        public double MetabolismRate { get; set; } = 1;
+        [DataField("rate")] public ReagentUnit MetabolismRate { get; set; } = ReagentUnit.New(1);
 
-        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
+        public virtual ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
 
             // how much reagent should we metabolize
-            var metabolismAmount = ReagentUnit.New(MetabolismRate * tickTime);
+            var metabolismAmount = MetabolismRate * tickTime;
 
             // is that much reagent actually available?
             if (availableReagent < metabolismAmount)

--- a/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
+++ b/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 
@@ -16,9 +16,19 @@ namespace Content.Shared.Chemistry.Metabolizable
         [DataField("rate")]
         public double MetabolismRate { get; set; } = 1;
 
-        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime)
+        ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
-            return ReagentUnit.New(MetabolismRate * tickTime);
+
+            // how much reagant should we metabolize
+            var metabolismAmount = ReagentUnit.New(MetabolismRate * tickTime);
+
+            // is that much reagant actually available?
+            if (availableReagent < metabolismAmount)
+            {
+                return availableReagent;
+            }
+
+            return metabolismAmount;
         }
     }
 }

--- a/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
+++ b/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
@@ -19,15 +19,15 @@ namespace Content.Shared.Chemistry.Metabolizable
         {
 
             // how much reagent should we metabolize
-            var metabolismAmount = MetabolismRate * tickTime;
+            var amountMetabolized = MetabolismRate * tickTime;
 
             // is that much reagent actually available?
-            if (availableReagent < metabolismAmount)
+            if (availableReagent < amountMetabolized)
             {
                 return availableReagent;
             }
 
-            return metabolismAmount;
+            return amountMetabolized;
         }
     }
 }

--- a/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
+++ b/Content.Shared/Chemistry/Metabolizable/DefaultMetabolizable.cs
@@ -19,10 +19,10 @@ namespace Content.Shared.Chemistry.Metabolizable
         ReagentUnit IMetabolizable.Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent)
         {
 
-            // how much reagant should we metabolize
+            // how much reagent should we metabolize
             var metabolismAmount = ReagentUnit.New(MetabolismRate * tickTime);
 
-            // is that much reagant actually available?
+            // is that much reagent actually available?
             if (availableReagent < metabolismAmount)
             {
                 return availableReagent;

--- a/Content.Shared/Chemistry/Metabolizable/IMetabolizable.cs
+++ b/Content.Shared/Chemistry/Metabolizable/IMetabolizable.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Chemistry.Metabolizable
@@ -16,7 +16,8 @@ namespace Content.Shared.Chemistry.Metabolizable
         /// <param name="solutionEntity">The entity containing the solution.</param>
         /// <param name="reagentId">The reagent id</param>
         /// <param name="tickTime">The time since the last metabolism tick in seconds.</param>
+        /// <param name="availableReagant">Reagant available to be metabolized.</param>
         /// <returns>The amount of reagent to be removed. The metabolizing organ should handle removing the reagent.</returns>
-        ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime);
+        ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagant);
     }
 }

--- a/Content.Shared/Chemistry/Metabolizable/IMetabolizable.cs
+++ b/Content.Shared/Chemistry/Metabolizable/IMetabolizable.cs
@@ -16,8 +16,8 @@ namespace Content.Shared.Chemistry.Metabolizable
         /// <param name="solutionEntity">The entity containing the solution.</param>
         /// <param name="reagentId">The reagent id</param>
         /// <param name="tickTime">The time since the last metabolism tick in seconds.</param>
-        /// <param name="availableReagant">Reagant available to be metabolized.</param>
+        /// <param name="availableReagent">Reagent available to be metabolized.</param>
         /// <returns>The amount of reagent to be removed. The metabolizing organ should handle removing the reagent.</returns>
-        ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagant);
+        ReagentUnit Metabolize(IEntity solutionEntity, string reagentId, float tickTime, ReagentUnit availableReagent);
     }
 }


### PR DESCRIPTION

## Fix some bugs in StomachBehaviour, LiverBehaviour, and various Metabolizable classes.

First time contributing, let me know ~if~ how I messed up. These changes started as a result a bug reported by Seþ on discord, that I was able to reproduce. However, this only covers the first two bugs that this should fix, and the the validity of the reported bugs were already contested, so someone should check this.

Bugs that were fixed:
- When ingesting reagents, SomachBehaviour would not necessarily store the reagents in the stomach.
While testing, it seems it would dump them directly into the bloodstream, bypassing the digestion delay.
- StomachBehaviour did not check if a reagent was still in the stomach before moving it to the bloodstream. When combined with the above, this effectively doubled the units of reagent entering the bloodstream, as it would re-add the reagent that was already metabolised. 
- LiverBehaviour metabolises reagents once every second. However, it passed the current frameTime to the metabolizable classes, as opposed to 1 second. This resulted in non-medical (see below) reagents metabolising very slowly. 
- HealthChangeMetabolism ignored the frameTime argument, effectively processing 1 seconds worth of reagents every time it was called. Coincidentally, this was not an issue due to the previous LiverBehaviour issue.
- HealthChangeMetabolism modified health by "HealthChange" units every time it was called. Effectively, the result was that instead of being the health ''changed when 1u of the reagent is metabolized" (as described), it was actually determining the health change per second.
- Metabolisable reagents would apply their effects, regardless of how much reagent remains. For example, consider 0.1u of reagent with a reaction rate of 2. When the LiverBehaviour metabolises this reagent, after 1 second, it would behave as if 2u  of reagent were consumed. This is fixed by making the IMetabolizable.Metabolize accept a new argument specifying the available reagent.

New Behaviours:
- Due to HealthChangeMetabolism changes, reagents with a metabolization rates != 1 now have a weaker or stronger effect than before.
- Drinking 1u of bicaridine from a beaker now correctly heals only 2 brute damage, after a 20 second digestion delay.
- If you drink 5u potassium, and 2u water, only 3u potassium are eventually metabolised (as the rest explodes). Previously it would explode twice and metabolise 6 potassium.

A bug that was not fixed:
- Drinking 1u potassium, 1u water will imediately explode. Drinking another 1u potassium after waiting 19 seconds (just below digestion delay), will incorrectly digest the second set of potassium after only 1 second.
- This occurs because the StomachBehaviour separatelty tracks the times at which reagents were added  and the actual contents. After a digestion delay, it tries to remove those contents. If those contents were 'removed' somehow (e.g., by a reaction), it may instead erroneously remove a 'fresh' bit of reagent. 
- Fixing this requires a rework of how the stomach tracks what went in and when it needs to go out, and is probably not worth it.