### PR TITLE
Add subfloor appearance data, pipes correctly render subfloor.

### DIFF
--- a/Content.Client/Atmos/Visualizers/PipeConnectorVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/PipeConnectorVisualizer.cs
@@ -1,6 +1,7 @@
 using System;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Piping;
+using Content.Shared.SubFloor;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -69,13 +70,16 @@ namespace Content.Client.Atmos.Visualizers
             if (!component.TryGetData(PipeVisuals.VisualState, out PipeVisualState state))
                 return;
 
+            if(!component.TryGetData(SubFloorVisuals.SubFloor, out bool subfloor))
+                subfloor = true;
+
             foreach (Layer layerKey in Enum.GetValues(typeof(Layer)))
             {
                 var dir = (PipeDirection) layerKey;
                 var layerVisible = state.ConnectedDirections.HasDirection(dir);
 
                 var layer = sprite.LayerMapGet(layerKey);
-                sprite.LayerSetVisible(layer, layerVisible);
+                sprite.LayerSetVisible(layer, layerVisible && subfloor);
                 sprite.LayerSetColor(layer, color);
             }
         }

--- a/Content.Client/SubFloor/SubFloorShowLayerVisualizer.cs
+++ b/Content.Client/SubFloor/SubFloorShowLayerVisualizer.cs
@@ -1,0 +1,40 @@
+using Content.Shared.SubFloor;
+using JetBrains.Annotations;
+using Robust.Client.GameObjects;
+
+namespace Content.Client.SubFloor
+{
+    [UsedImplicitly]
+    public class SubFloorShowLayerVisualizer : AppearanceVisualizer
+    {
+        public override void OnChangeData(AppearanceComponent component)
+        {
+            base.OnChangeData(component);
+
+            if (!component.Owner.TryGetComponent(out SpriteComponent? sprite))
+                return;
+
+            if (component.TryGetData(SubFloorVisuals.SubFloor, out bool subfloor))
+            {
+                sprite.Visible = true;
+
+                // Due to the way this visualizer works, you might want to specify it before any other
+                // visualizer that hides/shows layers depending on certain conditions, such as PipeConnectorVisualizer.
+                foreach (var layer in sprite.AllLayers)
+                {
+                    layer.Visible = subfloor;
+                }
+
+                if (sprite.LayerMapTryGet(Layers.FirstLayer, out var firstLayer))
+                {
+                    sprite.LayerSetVisible(firstLayer, true);
+                }
+            }
+        }
+
+        public enum Layers : byte
+        {
+            FirstLayer,
+        }
+    }
+}

--- a/Content.Shared/SubFloor/SubFloorHideSystem.cs
+++ b/Content.Shared/SubFloor/SubFloorHideSystem.cs
@@ -1,9 +1,11 @@
+using System;
 using Content.Shared.Maps;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Shared.SubFloor
@@ -146,10 +148,19 @@ namespace Content.Shared.SubFloor
                 subFloor = !transformComponent.Anchored;
             }
 
+            // Whether to show this entity as visible, visually.
+            var subFloorVisible = ShowAll || subFloor;
+
             // Show sprite
             if (ComponentManager.TryGetComponent(uid, out SharedSpriteComponent? spriteComponent))
             {
-                spriteComponent.Visible = ShowAll || subFloor;
+                spriteComponent.Visible = subFloorVisible;
+            }
+
+            // Set an appearance data value so visualizers can use this as needed.
+            if (ComponentManager.TryGetComponent(uid, out SharedAppearanceComponent? appearanceComponent))
+            {
+                appearanceComponent.SetData(SubFloorVisuals.SubFloor, subFloorVisible);
             }
 
             // So for collision all we care about is that the component is running.
@@ -168,5 +179,11 @@ namespace Content.Shared.SubFloor
         {
             SubFloor = subFloor;
         }
+    }
+
+    [Serializable, NetSerializable]
+    public enum SubFloorVisuals : byte
+    {
+        SubFloor,
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -33,8 +33,10 @@
       state: pipeStraight
       map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
     - state: pumpPressure
+      map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
   - type: Appearance
     visuals:
+    - type: SubFloorShowLayerVisualizer
     - type: PipeConnectorVisualizer
     - type: PipeColorVisualizer
     - type: PressurePumpVisualizer
@@ -57,6 +59,12 @@
           state: pipeStraight
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: pumpVolume
+          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
+    - type: Appearance
+      visuals:
+        - type: SubFloorShowLayerVisualizer
+        - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
     - type: GasVolumePump
 
 - type: entity
@@ -75,6 +83,12 @@
           state: pipeStraight
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: pumpPassiveGate
+          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
+    - type: Appearance
+      visuals:
+        - type: SubFloorShowLayerVisualizer
+        - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
     - type: GasPassiveGate
 
 - type: entity
@@ -94,6 +108,12 @@
           state: pipeStraight
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: pumpPassiveGate
+          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
+    - type: Appearance
+      visuals:
+        - type: SubFloorShowLayerVisualizer
+        - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
     - type: GasValve
     - type: NodeContainer
       nodes:
@@ -118,6 +138,12 @@
           state: pipeHalf
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: gasCanisterPort
+          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
+    - type: Appearance
+      visuals:
+        - type: SubFloorShowLayerVisualizer
+        - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
     - type: GasPort
     - type: NodeContainer
       nodes:
@@ -142,9 +168,10 @@
           state: pipeStraight
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: vent_off
-          map: ["enum.VentVisualLayers.Vent"]
+          map: [ "enum.VentVisualLayers.Vent", "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
     - type: Appearance
       visuals:
+        - type: SubFloorShowLayerVisualizer
         - type: PipeConnectorVisualizer
         - type: PipeColorVisualizer
         - type: VentPumpVisualizer

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -33,6 +33,7 @@
   - type: NodeContainer
   - type: AtmosUnsafeUnanchor
   - type: AtmosPipeColor
+  - type: SubFloorHide
 
 #Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (south)
 

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -38,6 +38,12 @@
           state: pipeTJunction
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: gasFilter
+          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
+    - type: Appearance
+      visuals:
+        - type: SubFloorShowLayerVisualizer
+        - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
     - type: GasFilter
 
 - type: entity
@@ -57,6 +63,12 @@
           state: pipeTJunction
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: gasFilter
+          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
+    - type: Appearance
+      visuals:
+        - type: SubFloorShowLayerVisualizer
+        - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
     - type: GasMixer
       inletOne: inlet
       inletTwo: filter

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -29,9 +29,10 @@
           state: pipeHalf
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: vent_off
-          map: ["enum.VentVisualLayers.Vent"]
+          map: [ "enum.VentVisualLayers.Vent", "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
     - type: Appearance
       visuals:
+        - type: SubFloorShowLayerVisualizer
         - type: PipeConnectorVisualizer
         - type: PipeColorVisualizer
         - type: VentPumpVisualizer
@@ -54,8 +55,10 @@
           state: pipeHalf
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: vent_off
+          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
     - type: Appearance
       visuals:
+        - type: SubFloorShowLayerVisualizer
         - type: PipeConnectorVisualizer
         - type: PipeColorVisualizer
     - type: GasPassiveVent
@@ -76,9 +79,10 @@
           state: pipeHalf
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: scrub_off
-          map: ["enum.ScrubberVisualLayers.Scrubber"]
+          map: [ "enum.ScrubberVisualLayers.Scrubber", "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
     - type: Appearance
       visuals:
+        - type: SubFloorShowLayerVisualizer
         - type: PipeConnectorVisualizer
         - type: PipeColorVisualizer
         - type: ScrubberVisualizer
@@ -93,18 +97,24 @@
   placement:
     mode: SnapgridCenter
   components:
-    - type: GasOutletInjector
+
     # TODO ATMOS: Actual sprite for this.
     - type: Sprite
       netsync: false
       layers:
         - state: pipeHalf
           sprite: Structures/Piping/Atmospherics/pipe.rsi
-          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe", "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
+    - type: Appearance
+      visuals:
+        - type: SubFloorShowLayerVisualizer
+        - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
+    - type: GasOutletInjector
 
 - type: entity
-  parent: GasUnaryBase
-  id: GasThermoMachineBase
+  parent: BaseMachinePowered
+  id: BaseGasThermoMachine
   name: thermomachine
   description: Heats or cools gas in connected pipes.
   abstract: true
@@ -117,10 +127,19 @@
     - type: Appearance
       visuals:
         - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
     - type: GasThermoMachine
+    - type: AtmosPipeColor
+    - type: AtmosDevice
+    - type: NodeContainer
+      nodes:
+        pipe:
+          !type:PipeNode
+          nodeGroupID: Pipe
+          pipeDirection: South
 
 - type: entity
-  parent: GasThermoMachineBase
+  parent: BaseGasThermoMachine
   id: GasThermoMachineFreezer
   name: freezer
   placement:
@@ -130,9 +149,11 @@
       layers:
         - state: freezer_off
         - state: pipe
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
     - type: Appearance
       visuals:
         - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
         - type: ThermoMachineVisualizer
           enabledState: freezer_on
     - type: GasThermoMachine
@@ -140,7 +161,7 @@
       minTemperature: 73.15
 
 - type: entity
-  parent: GasThermoMachineBase
+  parent: BaseGasThermoMachine
   id: GasThermoMachineHeater
   name: heater
   placement:
@@ -150,9 +171,11 @@
       layers:
         - state: heater_off
         - state: pipe
+          map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
     - type: Appearance
       visuals:
         - type: PipeConnectorVisualizer
+        - type: PipeColorVisualizer
         - type: ThermoMachineVisualizer
           enabledState: heater_on
     - type: GasThermoMachine


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pipes and atmos devices now correctly render with subfloorhide.
I added a new appearancecomp datum, SubFloor, which is set whenever the entity is hid/unhid due to subfloorsystem.
I added the `SubFloorShowLayerVisualizer` which hides every layer except for the ones you map with its layers.

**Screenshots**
![image](https://user-images.githubusercontent.com/6766154/127646915-3111b4f8-ff8b-4069-a182-ef7ca01f1d86.png)
![image](https://user-images.githubusercontent.com/6766154/127646921-6236f93f-7048-4adf-8607-1c6a8d7a6756.png)
