### PR TITLE
Fix opposite force when throwing objects

### DIFF
--- a/Content.Server/Throwing/ThrowHelper.cs
+++ b/Content.Server/Throwing/ThrowHelper.cs
@@ -69,7 +69,9 @@ namespace Content.Server.Throwing
                     EntitySystem.Get<InteractionSystem>().ThrownInteraction(user, entity);
             }
 
-            physicsComponent.ApplyLinearImpulse(direction.Normalized * strength * physicsComponent.Mass);
+            var impulseVector = direction.Normalized * strength * physicsComponent.Mass;
+            physicsComponent.ApplyLinearImpulse(impulseVector);
+            
             // Estimate time to arrival so we can apply OnGround status and slow it much faster.
             var time = (direction / strength).Length;
 
@@ -96,7 +98,7 @@ namespace Content.Server.Throwing
 
                 if (!msg.Cancelled)
                 {
-                    body.ApplyLinearImpulse(-direction.Normalized * strength * physicsComponent.Mass * pushbackRatio);
+                    body.ApplyLinearImpulse(-impulseVector * pushbackRatio);
                 }
             }
         }

--- a/Content.Server/Throwing/ThrowHelper.cs
+++ b/Content.Server/Throwing/ThrowHelper.cs
@@ -96,7 +96,7 @@ namespace Content.Server.Throwing
 
                 if (!msg.Cancelled)
                 {
-                    body.ApplyLinearImpulse(-direction * pushbackRatio);
+                    body.ApplyLinearImpulse(-direction.Normalized * strength * physicsComponent.Mass * pushbackRatio);
                 }
             }
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Corrects applied opposing impulse when throwing objects,  as described by/fixing #4392

I feel kind of lame that my first PR here is just a copypasta spelled out explicitly in the issue, but here we are.

<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Throwing items in space will now push you in the opposite direction to the thrown object
