### PR TITLE
Moved MagbootsComponent.cs from Cloning to Clothing

### DIFF
--- a/Content.Client/Clothing/MagbootsComponent.cs
+++ b/Content.Client/Clothing/MagbootsComponent.cs
@@ -1,7 +1,7 @@
-﻿using Content.Shared.Clothing;
+using Content.Shared.Clothing;
 using Robust.Shared.GameObjects;
 
-namespace Content.Client.Cloning
+namespace Content.Client.Clothing
 {
     [RegisterComponent]
     public sealed class MagbootsComponent : SharedMagbootsComponent


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## Magboots were under "Cloning" instead of "Clothing". Looked like a drag and drop error. <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

