### PR TITLE
Fix serv warnings

### DIFF
--- a/Content.Server/Chemistry/ReagentEntityReactions/AddToSolutionReaction.cs
+++ b/Content.Server/Chemistry/ReagentEntityReactions/AddToSolutionReaction.cs
@@ -10,7 +10,6 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.Chemistry.ReagentEntityReactions
 {
     [UsedImplicitly]
-    [DataDefinition]
     public class AddToSolutionReaction : ReagentEntityReaction
     {
         [DataField("reagents", true, customTypeSerializer:typeof(PrototypeIdHashSetSerializer<ReagentPrototype>))]

--- a/Content.Server/Chemistry/ReagentEntityReactions/ExtinguishReaction.cs
+++ b/Content.Server/Chemistry/ReagentEntityReactions/ExtinguishReaction.cs
@@ -10,7 +10,6 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.Chemistry.ReagentEntityReactions
 {
     [UsedImplicitly]
-    [DataDefinition]
     public class ExtinguishReaction : ReagentEntityReaction
     {
         [DataField("reagents", true, customTypeSerializer:typeof(PrototypeIdHashSetSerializer<ReagentPrototype>))]

--- a/Content.Server/Chemistry/ReagentEntityReactions/FlammableReaction.cs
+++ b/Content.Server/Chemistry/ReagentEntityReactions/FlammableReaction.cs
@@ -10,7 +10,6 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.Chemistry.ReagentEntityReactions
 {
     [UsedImplicitly]
-    [DataDefinition]
     public class FlammableReaction : ReagentEntityReaction
     {
         [DataField("reagents", true, customTypeSerializer:typeof(PrototypeIdHashSetSerializer<ReagentPrototype>))]

--- a/Content.Server/Chemistry/ReagentEntityReactions/WashCreamPieReaction.cs
+++ b/Content.Server/Chemistry/ReagentEntityReactions/WashCreamPieReaction.cs
@@ -10,7 +10,6 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.Chemistry.ReagentEntityReactions
 {
     [UsedImplicitly]
-    [DataDefinition]
     public class WashCreamPieReaction : ReagentEntityReaction
     {
         [DataField("reagents", true, customTypeSerializer:typeof(PrototypeIdHashSetSerializer<ReagentPrototype>))]

--- a/Content.Shared/Chemistry/Reagent/ReagentEntityReaction.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentEntityReaction.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Chemistry.Reagent
         Ingestion,
     }
 
-    [DataDefinition]
+    [ImplicitDataDefinitionForInheritors]
     public abstract class ReagentEntityReaction
     {
         [ViewVariables]

--- a/Content.Shared/Sound/SoundSpecifier.cs
+++ b/Content.Shared/Sound/SoundSpecifier.cs
@@ -8,13 +8,12 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Sound
 {
-    [DataDefinition]
+    [ImplicitDataDefinitionForInheritors]
     public abstract class SoundSpecifier
     {
         public abstract string GetSound();
     }
 
-    [DataDefinition]
     public sealed class SoundPathSpecifier : SoundSpecifier
     {
         public const string Node = "path";
@@ -42,7 +41,6 @@ namespace Content.Shared.Sound
         }
     }
 
-    [DataDefinition]
     public sealed class SoundCollectionSpecifier : SoundSpecifier
     {
         public const string Node = "collection";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

These were caused by abstract classes having DataDefinition rather than ImplicitDataDefinitionForInheritors

Doesn't require space-wizards/RobustToolbox#1915 but it should be merged alongside it
