### PR TITLE
Random offset for DefaultGrid every round

### DIFF
--- a/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
@@ -48,6 +48,8 @@ namespace Content.IntegrationTests.Tests.Utility
                 var mapId = new MapId(1);
                 var grid = sMapManager.GetGrid(new GridId(1));
                 grid.SetTile(new Vector2i(0, 0), new Tile(1));
+                var gridEnt = sEntityManager.GetEntity(grid.GridEntityId);
+                var gridPos = gridEnt.Transform.WorldPosition;
                 var entityCoordinates = new EntityCoordinates(grid.GridEntityId, 0, 0);
 
                 // Nothing blocking it, only entity is the grid
@@ -55,7 +57,7 @@ namespace Content.IntegrationTests.Tests.Utility
                 Assert.True(sEntityManager.TrySpawnIfUnobstructed(null, entityCoordinates, CollisionGroup.Impassable, out var entity));
                 Assert.NotNull(entity);
 
-                var mapCoordinates = new MapCoordinates(0, 0, mapId);
+                var mapCoordinates = new MapCoordinates(gridPos.X, gridPos.Y, mapId);
 
                 // Nothing blocking it, only entity is the grid
                 Assert.NotNull(sEntityManager.SpawnIfUnobstructed(null, mapCoordinates, CollisionGroup.Impassable));

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -11,6 +11,7 @@ using Robust.Server.Player;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Log;
+using Robust.Shared.Maths;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -61,6 +62,11 @@ namespace Content.Server.GameTicking
             {
                 throw new InvalidOperationException($"No grid found for map {map}");
             }
+
+            var maxStationOffset = _configurationManager.GetCVar(CCVars.MaxStationOffset);
+            var x = _robustRandom.NextFloat() * maxStationOffset * 2 - maxStationOffset;
+            var y = _robustRandom.NextFloat() * maxStationOffset * 2 - maxStationOffset;
+            _entityManager.GetEntity(grid.GridEntityId).Transform.LocalPosition = new Vector2(x, y);
 
             DefaultGridId = grid.Index;
             _spawnPoint = grid.ToCoordinates();

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -56,6 +56,12 @@ namespace Content.Shared.CCVar
             GameMap = CVarDef.Create("game.map", "Maps/saltern.yml", CVar.SERVERONLY);
 
         /// <summary>
+        /// When the default blueprint is loaded what is the maximum amount it can be offset from 0,0.
+        /// </summary>
+        public static readonly CVarDef<float> MaxStationOffset =
+            CVarDef.Create("game.maxstationoffset", 1000.0f);
+
+        /// <summary>
         ///     When enabled, guests will be assigned permanent UIDs and will have their preferences stored.
         /// </summary>
         public static readonly CVarDef<bool>

--- a/Content.Shared/Spawning/EntitySystemExtensions.cs
+++ b/Content.Shared/Spawning/EntitySystemExtensions.cs
@@ -32,7 +32,7 @@ namespace Content.Shared.Spawning
             in Box2? box = null,
             SharedBroadphaseSystem? collision = null)
         {
-            var boxOrDefault = box.GetValueOrDefault(Box2.UnitCentered);
+            var boxOrDefault = box.GetValueOrDefault(Box2.UnitCentered).Translated(coordinates.Position);
             collision ??= EntitySystem.Get<SharedBroadphaseSystem>();
 
             foreach (var body in collision.GetCollidingEntities(coordinates.MapId, in boxOrDefault))


### PR DESCRIPTION
This is useful to make coders aware of entitycoordinates and mapcoordinates being different and to help spot problems early. It also puts the onus of fixing positioning bugs back onto the original coder rather than someone else if they happen to spot it.

:cl:
- tweak: Station will spawn at a random position rather than 0,0.
