### PR TITLE
Fix can't return to body bug

### DIFF
--- a/Content.Server/Administration/Commands/AGhost.cs
+++ b/Content.Server/Administration/Commands/AGhost.cs
@@ -2,6 +2,7 @@
 using Content.Server.Ghost.Components;
 using Content.Server.Players;
 using Content.Shared.Administration;
+using Content.Shared.Ghost;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.GameObjects;
@@ -55,7 +56,8 @@ namespace Content.Server.Administration.Commands
                 mind.TransferTo(ghost);
             }
 
-            ghost.GetComponent<GhostComponent>().CanReturnToBody = canReturn;
+            var comp = ghost.GetComponent<GhostComponent>();
+            EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(comp, canReturn);
         }
     }
 }

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -13,6 +13,7 @@ using Content.Server.Roles;
 using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
 using Content.Shared.GameTicking;
+using Content.Shared.Ghost;
 using Content.Shared.Inventory;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
@@ -144,7 +145,8 @@ namespace Content.Server.GameTicking
 
             var mob = SpawnObserverMob();
             mob.Name = name;
-            mob.GetComponent<GhostComponent>().CanReturnToBody = false;
+            var ghost = mob.GetComponent<GhostComponent>();
+            EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(ghost, false);
             data.Mind.TransferTo(mob);
 
             _playersInLobby[player] = LobbyPlayerStatus.Observer;

--- a/Content.Server/GameTicking/Presets/GamePreset.cs
+++ b/Content.Server/GameTicking/Presets/GamePreset.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Content.Server.Ghost.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
+using Content.Shared.Ghost;
 using Content.Shared.MobState;
 using Content.Shared.Preferences;
 using Robust.Server.Player;
@@ -75,7 +76,7 @@ namespace Content.Server.GameTicking.Presets
             ghost.Name = mind.CharacterName ?? string.Empty;
 
             var ghostComponent = ghost.GetComponent<GhostComponent>();
-            ghostComponent.CanReturnToBody = canReturn;
+            EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(ghostComponent, canReturn);
 
             if (canReturn)
                 mind.Visit(ghost);

--- a/Content.Server/Mind/Components/MindComponent.cs
+++ b/Content.Server/Mind/Components/MindComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.GameTicking;
 using Content.Server.Ghost.Components;
 using Content.Shared.Examine;
+using Content.Shared.Ghost;
 using Content.Shared.MobState;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -86,7 +87,7 @@ namespace Content.Server.Mind.Components
                 {
                     if (visiting.TryGetComponent(out GhostComponent? ghost))
                     {
-                        ghost.CanReturnToBody = false;
+                        EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(ghost, false);
                     }
 
                     Mind!.TransferTo(visiting);
@@ -108,7 +109,7 @@ namespace Content.Server.Mind.Components
 
                         var ghost = Owner.EntityManager.SpawnEntity("MobObserver", spawnPosition);
                         var ghostComponent = ghost.GetComponent<GhostComponent>();
-                        ghostComponent.CanReturnToBody = false;
+                        EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(ghostComponent, false);
 
                         if (Mind != null)
                         {

--- a/Content.Shared/Ghost/SharedGhostComponent.cs
+++ b/Content.Shared/Ghost/SharedGhostComponent.cs
@@ -16,8 +16,9 @@ namespace Content.Shared.Ghost
         public override string Name => "Ghost";
 
         /// <summary>
-        ///     Changed by <see cref="GhostChangeCanReturnToBodyEvent"/>
+        ///     Changed by <see cref="SharedGhostSystem.SetCanReturnToBody"/>
         /// </summary>
+        // TODO MIRROR change this to use friend classes when thats merged
         [DataField("canReturnToBody")]
         [ViewVariables(VVAccess.ReadWrite)]
         public bool CanReturnToBody { get; set; }

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -10,34 +10,18 @@ namespace Content.Shared.Ghost
         public override void Initialize()
         {
             base.Initialize();
-
-            SubscribeLocalEvent<SharedGhostComponent, GhostChangeCanReturnToBodyEvent>(OnGhostChangeCanReturnToBody);
         }
 
-        private void OnGhostChangeCanReturnToBody(EntityUid uid, SharedGhostComponent component, GhostChangeCanReturnToBodyEvent args)
+        public void SetCanReturnToBody(SharedGhostComponent component, bool canReturn)
         {
-            if (component.CanReturnToBody == args.CanReturnToBody)
+            if (component.CanReturnToBody == canReturn)
             {
                 return;
             }
 
-            component.CanReturnToBody = args.CanReturnToBody;
+            component.CanReturnToBody = canReturn;
             component.Dirty();
         }
-    }
-
-    /// <summary>
-    ///     Raised to change the value of <see cref="SharedGhostComponent.CanReturnToBody"/>
-    /// </summary>
-    [Serializable, NetSerializable]
-    public class GhostChangeCanReturnToBodyEvent : EntityEventArgs
-    {
-        public GhostChangeCanReturnToBodyEvent(bool canReturnToBody)
-        {
-            CanReturnToBody = canReturnToBody;
-        }
-
-        public bool CanReturnToBody { get; }
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #4422

Ghost ECS added an event for changing whether or not a ghost can return to body. This changed the prop and dirtied the component, but nothing used it so it was never getting dirtied and thus the client just assumed it couldn't return to body. Replaced the event with a public entitysystem method (as I assume we don't really want method events) and changed all usages to go through there

Eventually this should use the Friend classes thing vera is working on if that gets merged

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Ghosts can now properly return to their body if applicable.

