### PR TITLE
Fixed Station Engineer Table Spawn

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -13994,7 +13994,7 @@ entities:
   type: SpawnPointStationEngineer
   components:
   - rot: 4.371139006309477E-08 rad
-    pos: 33.5,-2.5
+    pos: 33.5,-1.5
     parent: 853
     type: Transform
 - uid: 1024


### PR DESCRIPTION
User Laboredih123#7348 found an odd spawn inside of a table. I fixed the initial spawn coordinates from the one seen in the first image to the second.
Before:
![inside table](https://user-images.githubusercontent.com/86671825/128581901-95b38ae2-a8ef-40ae-8628-716f83626c19.png)
After:
![Screenshot (55)](https://user-images.githubusercontent.com/86671825/128581889-4c7ad6fb-f187-4606-9394-639f361d6239.png)
