### PR TITLE
Adds windoors for security and the brig.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -55,3 +55,12 @@
   components:
   - type: AccessReader
     access: [["Cargo"]]
+
+# Security windoor
+- type: entity
+  parent: WindoorSecure
+  id: WindoorSecurityLocked
+  suffix: Security, Locked
+  components:
+  - type: AccessReader
+    access: [["Security"]]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds windoors (based off the SecureWindoor prototype) that require security access to open. This is necessary for a planned re-mapping of Security to accommodate windoors. Please note that the mapping changes seen below are NOT part of this PR - this is simply the YAML for the windoor itself.

**Screenshots**

![image](https://user-images.githubusercontent.com/7907891/128609700-ada850ee-138b-4f10-ba56-cd1c65c5ed52.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Security windoors for planned mapping rework.
