### PR TITLE
Fix sound crash when making foam

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -113,6 +113,8 @@
       reagentDilutionFactor: 1
       reagentMaxConcentrationFactor: 2 #The reagents will get multiplied by this number if the range turns out to be 0
       prototypeId: Foam
+      sound:
+        path: /Audio/Effects/extinguish.ogg
 
 - type: reaction
   id: IronMetalFoam
@@ -136,6 +138,8 @@
       reagentDilutionFactor: 1
       reagentMaxConcentrationFactor: 2
       prototypeId: IronMetalFoam
+      sound:
+        path: /Audio/Effects/extinguish.ogg
 
 - type: reaction
   id: AluminiumMetalFoam
@@ -159,6 +163,8 @@
       reagentDilutionFactor: 1
       reagentMaxConcentrationFactor: 2
       prototypeId: AluminiumMetalFoam
+      sound:
+        path: /Audio/Effects/extinguish.ogg
 
 - type: reaction
   id: TableSalt
@@ -227,7 +233,7 @@
       amount: 1
   products:
     Fluorosurfactant: 5
-    
+
 - type: reaction
   id: Meth
   reactants:
@@ -241,7 +247,7 @@
      amount: 1
   products:
     Meth: 4 #I kinda remember having to heat this up, and if you heated it up too much, it went boom, I can't remember the specific values tho.
-    
+
 - type: reaction
   id: Ephedrine
   reactants:


### PR DESCRIPTION
## Fixes SoundSystem crash when because no sound was added
Steps to reproduce:
- Go to Chem section 
- Insert beaker
- Insert 2 carbon + 2 florine + 1 sulfuric acid + 1 water

Expect:
- Foam fun

Instead:
- Got exception during development

**Changelog**
:cl: YggOne

- fix: Added foaming agent sound to prevent a crash.