### PR TITLE
Fix PA construction crash, make it clear that PA construction needs LV cables

### DIFF
--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorPowerBoxSystem.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorPowerBoxSystem.cs
@@ -21,7 +21,8 @@ namespace Content.Server.ParticleAccelerator.EntitySystems
             ParticleAcceleratorPowerBoxComponent component,
             PowerConsumerReceivedChanged args)
         {
-            component.Master!.PowerBoxReceivedChanged(args);
+            if (component.Master != null)
+                component.Master.PowerBoxReceivedChanged(args);
         }
     }
 }

--- a/Resources/Prototypes/Stacks/power_stacks.yml
+++ b/Resources/Prototypes/Stacks/power_stacks.yml
@@ -1,6 +1,6 @@
 ﻿- type: stack
   id: Cable
-  name: cable
+  name: lv cable
   icon: "/Textures/Objects/Tools/cable-coils.rsi/coil-30.png"
   spawn: CableApcStack1
 


### PR DESCRIPTION
## About the PR

Particle Accelerator: Power box won't assume a master which may not be there.

Construction materials: Since 'cables' now only refers to LV cables, make it clear that only LV cables are accepted by renaming the material as such.

**Screenshots**

![image](https://user-images.githubusercontent.com/22304167/130321490-d3fa04b5-add2-476d-9acf-5113b4ea3731.png)

**Changelog**

:cl:
- fix: Particle Accelerator construction won't cause an error when finishing the power box.
- tweak: Cables are now called lv cables when referred to in a construction step for clarity.

