### PR TITLE
Fixes power crisis and lights up engineering some more

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -494,7 +494,7 @@ entities:
     pos: 39.53893,-0.77325034
     parent: 853
     type: Transform
-  - useSound:
+  - useSound: !type:SoundPathSpecifier
       path: /Audio/Items/jaws_pry.ogg
     type: Tool
 - uid: 54
@@ -6796,6 +6796,11 @@ entities:
   - containers:
       cellslot_cell_container: !type:ContainerSlot {}
     type: ContainerContainer
+  - cellInsertSound: !type:SoundPathSpecifier
+      path: /Audio/Items/pistol_magout.ogg
+    cellRemoveSound: !type:SoundPathSpecifier
+      path: /Audio/Items/pistol_magin.ogg
+    type: PowerCellSlot
 - uid: 708
   type: WallReinforced
   components:
@@ -12697,6 +12702,9 @@ entities:
       mass: 132
     bodyType: Dynamic
     type: Physics
+  - gravityShakeSound: !type:SoundPathSpecifier
+      path: /Audio/Effects/alert.ogg
+    type: Gravity
 - uid: 854
   type: Catwalk
   components:
@@ -42740,7 +42748,8 @@ entities:
 - uid: 4178
   type: Poweredlight
   components:
-  - pos: 38.499187,9.874689
+  - rot: 3.141592653589793 rad
+    pos: 50.5,-1
     parent: 853
     type: Transform
   - powerLoad: 0
@@ -43457,6 +43466,11 @@ entities:
   - containers:
       cellslot_cell_container: !type:ContainerSlot {}
     type: ContainerContainer
+  - cellInsertSound: !type:SoundPathSpecifier
+      path: /Audio/Items/pistol_magout.ogg
+    cellRemoveSound: !type:SoundPathSpecifier
+      path: /Audio/Items/pistol_magin.ogg
+    type: PowerCellSlot
 - uid: 4271
   type: Table
   components:
@@ -50828,4 +50842,50 @@ entities:
     type: Sprite
   - canCollide: False
     type: Physics
+- uid: 5150
+  type: CableHV
+  components:
+  - anchored: True
+    pos: 40.5,5.5
+    parent: 853
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 5151
+  type: CableHV
+  components:
+  - anchored: True
+    pos: 42.5,5.5
+    parent: 853
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 5152
+  type: Poweredlight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 38,9.5
+    parent: 853
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 5153
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 45,9.5
+    parent: 853
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
 ...


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

After visiting the server one night I realized that everything was powered except for the gravity generator, meaning anybody who spawned would see a lit station but be unable to move. 

I then discovered that someone hadn't bothered to actually hookup our generators or SMES' to the power network.

![Content Client_2021-08-21_17-40-33](https://user-images.githubusercontent.com/49448379/130338354-0b274437-b717-4f87-92b9-9b5dd8cf9d3d.png)

This means that the rest of the station was just running off of APCs and the grav-gen was just the first to go because it's the biggest single power draw on the station. 

I don't know if this is intentional but if so it's dumb and i'm fixing it. 

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Swept
- fix: Fix grav gen losing power after only a bit

