### PR TITLE
Saltern: fix wiring issues

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -25836,8 +25836,7 @@ entities:
   type: CableApcExtension
   components:
   - anchored: True
-    rot: 4.371139006309477E-08 rad
-    pos: -28.5,13.5
+    pos: -23.5,18.5
     parent: 853
     type: Transform
   - visible: False
@@ -26478,8 +26477,7 @@ entities:
   type: CableApcExtension
   components:
   - anchored: True
-    rot: 4.371139006309477E-08 rad
-    pos: 0.5,6.5
+    pos: -25.5,19.5
     parent: 853
     type: Transform
 - uid: 2605
@@ -41885,14 +41883,14 @@ entities:
   type: CableApcExtension
   components:
   - anchored: True
-    pos: 0.5,6.5
+    pos: -24.5,19.5
     parent: 853
     type: Transform
 - uid: 4075
   type: CableApcExtension
   components:
   - anchored: True
-    pos: -0.5,6.5
+    pos: -23.5,19.5
     parent: 853
     type: Transform
 - uid: 4076
@@ -49763,68 +49761,23 @@ entities:
   type: CableApcExtension
   components:
   - anchored: True
-    pos: -19.5,18.5
+    pos: -22.5,19.5
     parent: 853
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 5029
   type: CableApcExtension
   components:
   - anchored: True
-    pos: -20.5,18.5
+    pos: -21.5,19.5
     parent: 853
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 5030
   type: CableApcExtension
   components:
   - anchored: True
-    pos: -21.5,18.5
+    pos: -20.5,19.5
     parent: 853
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5031
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -22.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5032
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -23.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5033
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -23.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 5034
   type: PoweredSmallLight
   components:
@@ -50014,72 +49967,6 @@ entities:
     pos: -25.5,18.5
     parent: 853
     type: Transform
-- uid: 5054
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -24.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5055
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -23.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5056
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -22.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5057
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -21.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5058
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -23.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5059
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -24.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 5060
   type: Firelock
   components:
@@ -50814,6 +50701,39 @@ entities:
   - anchored: True
     rot: 1.5707963267948966 rad
     pos: 10.5,26.5
+    parent: 853
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 5150
+  type: CableHV
+  components:
+  - anchored: True
+    pos: 40.5,7.5
+    parent: 853
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 5151
+  type: CableHV
+  components:
+  - anchored: True
+    pos: 40.5,5.5
+    parent: 853
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 5152
+  type: CableHV
+  components:
+  - anchored: True
+    pos: 42.5,5.5
     parent: 853
     type: Transform
   - visible: False


### PR DESCRIPTION
## About the PR

See changelog, there's nothing much to it.
Something I'm not putting in the changelog: The wires underneath the generator/APC setup will definitely cause power to be available forever due to pow3r not being balanced yet. As it is, the servers don't seem to have any active engineers, so this is probably for the best.

**Changelog**

:cl:
- fix: Un-crosslink two APCs in saltern north-west maintenance
- tweak: Add wires underneath the generator/APC setup on Saltern
