### PR TITLE
Fix deconstruction when on a step in the middle of an edge

### DIFF
--- a/Content.Server/Construction/Components/ConstructionComponent.cs
+++ b/Content.Server/Construction/Components/ConstructionComponent.cs
@@ -137,7 +137,7 @@ namespace Content.Server.Construction.Components
                 TargetPathfinding.Dequeue();
 
             // If we went the wrong way, we stop pathfinding.
-            if (Edge != null && TargetNextEdge != Edge)
+            if (Edge != null && TargetNextEdge != Edge && EdgeStep >= Edge.Steps.Count)
             {
                 ClearTarget();
                 return;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes deconstruction verb so that it detects when on a step that is part of an edge. The current implementation only detected when it was on the first step of the edge and would say that it couldn't be deconstructed otherwise.

Copied from https://github.com/space-wizards/space-station-14/blob/77262bfc9ab7e8cf6f1823ff84839bf52ecf6d74/Content.Server/Construction/Components/ConstructionComponent.cs#L403 since deconstruction still works even though the examine text was denied.

Fixes #4464

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed deconstruction verb on partially deconstructed windows.

