### PR TITLE
Add examine, activate, and context menu to storage buttons

### DIFF
--- a/Content.Client/UserInterface/Controls/EntityListDisplay.cs
+++ b/Content.Client/UserInterface/Controls/EntityListDisplay.cs
@@ -15,8 +15,8 @@ namespace Content.Client.UserInterface.Controls
         public const string StylePropertySeparation = "separation";
 
         public int? SeparationOverride { get; set; }
-        public Action<EntityUid, Control>? GenerateItem;
-        public Action<EntityUid>? ItemPressed;
+        public Action<EntityUid, EntityContainerButton>? GenerateItem;
+        public Action<BaseButton.ButtonEventArgs, EntityUid>? ItemPressed;
 
         private const int DefaultSeparation = 3;
 
@@ -82,7 +82,7 @@ namespace Content.Client.UserInterface.Controls
         {
             if (args.Button is not EntityContainerButton button)
                 return;
-            ItemPressed?.Invoke(button.EntityUid);
+            ItemPressed?.Invoke(args, button.EntityUid);
         }
 
         [Pure]
@@ -136,7 +136,7 @@ namespace Content.Client.UserInterface.Controls
             #region Rebuild Children
             /*
              * Example:
-             * 
+             *
              * var _itemHeight = 32;
              * var separation = 3;
              *  32 | 32 | Control.Size.Y 0
@@ -146,13 +146,13 @@ namespace Content.Client.UserInterface.Controls
              * 102 | 32 | Control.Size.Y 2
              * 105 |  3 | Padding
              * 137 | 32 | Control.Size.Y 3
-             * 
+             *
              * If viewport height is 60
              * visible should be 2 items (start = 0, end = 1)
-             * 
+             *
              * scroll.Y = 11
              * visible should be 3 items (start = 0, end = 2)
-             * 
+             *
              * start expected: 11 (item: 0)
              * var start = (int) (scroll.Y
              *


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added ItemSlot functionality to storage UI buttons. This means that players can open the context menu, examine, and activate items inside storage entities.

The main thing is that boxes can now be opened while inside backpacks.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: The context menu, examining, and activating now works on items inside storage entities. (The last one means boxes can now be opened while still inside a backpack.)
