### PR TITLE
Some Saltern wiring fixes

### DIFF
--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -26486,8 +26486,7 @@ entities:
   type: CableApcExtension
   components:
   - anchored: True
-    rot: 4.371139006309477E-08 rad
-    pos: 0.5,6.5
+    pos: -25.5,19.5
     parent: 853
     type: Transform
 - uid: 2605
@@ -41893,14 +41892,14 @@ entities:
   type: CableApcExtension
   components:
   - anchored: True
-    pos: 0.5,6.5
+    pos: -24.5,19.5
     parent: 853
     type: Transform
 - uid: 4075
   type: CableApcExtension
   components:
   - anchored: True
-    pos: -0.5,6.5
+    pos: -22.5,19.5
     parent: 853
     type: Transform
 - uid: 4076
@@ -49735,28 +49734,21 @@ entities:
   type: CableApcExtension
   components:
   - anchored: True
-    pos: -27.5,14.5
+    pos: -20.5,19.5
     parent: 853
     type: Transform
 - uid: 5023
   type: CableApcExtension
   components:
   - anchored: True
-    pos: -26.5,14.5
+    pos: -21.5,19.5
     parent: 853
     type: Transform
 - uid: 5024
   type: CableApcExtension
   components:
   - anchored: True
-    pos: -25.5,14.5
-    parent: 853
-    type: Transform
-- uid: 5025
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -25.5,15.5
+    pos: -23.5,19.5
     parent: 853
     type: Transform
 - uid: 5026
@@ -49773,72 +49765,6 @@ entities:
     pos: -18.5,19.5
     parent: 853
     type: Transform
-- uid: 5028
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -19.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5029
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -20.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5030
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -21.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5031
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -22.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5032
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -23.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5033
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -23.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 5034
   type: PoweredSmallLight
   components:
@@ -50028,72 +49954,6 @@ entities:
     pos: -25.5,18.5
     parent: 853
     type: Transform
-- uid: 5054
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -24.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5055
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -23.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5056
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -22.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5057
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -21.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5058
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -23.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 5059
-  type: CableApcExtension
-  components:
-  - anchored: True
-    pos: -24.5,18.5
-    parent: 853
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 5060
   type: Firelock
   components:


### PR DESCRIPTION
## About the PR

Unbridges two APcs that shouldn't be bridged, removes some duplicate wires.

**Changelog**

:cl:
- fix: In Saltern, removed some duplicate APC wires and unbridged two APCs

