### PR TITLE
Fix bag visualizers syncing

### DIFF
--- a/Content.Client/Storage/ClientStorageComponent.cs
+++ b/Content.Client/Storage/ClientStorageComponent.cs
@@ -5,9 +5,11 @@ using Content.Client.Hands;
 using Content.Client.Items.Components;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.DragDrop;
-using Content.Shared.Stacks;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
+using Content.Shared.Storage.Events;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
@@ -158,15 +160,7 @@ namespace Content.Client.Storage
 
         private void ChangeStorageVisualization(SharedBagState state)
         {
-           
-            if (Owner.TryGetComponent<AppearanceComponent>(out var appearanceComponent))
-            {
-                appearanceComponent.SetData(SharedBagOpenVisuals.BagState, state);
-                if (Owner.HasComponent<ItemCounterComponent>())
-                {
-                    appearanceComponent.SetData(StackVisuals.Hide, state == SharedBagState.Close);
-                }
-            }
+            Owner.EntityManager.EntityNetManager?.SendSystemNetworkMessage(new OpenCloseBagEvent(Owner.Uid, state));
         }
 
         /// <summary>

--- a/Content.Client/Storage/ClientStorageComponent.cs
+++ b/Content.Client/Storage/ClientStorageComponent.cs
@@ -45,7 +45,7 @@ namespace Content.Client.Storage
             base.Initialize();
 
             // Hide stackVisualizer on start
-            ChangeStorageVisualization(SharedBagState.Close);
+            UpdateVisualizerAndNetwork(SharedBagState.Close);
         }
 
         protected override void OnAdd()
@@ -140,12 +140,12 @@ namespace Content.Client.Storage
             if (_window.IsOpen)
             {
                 _window.Close();
-                ChangeStorageVisualization(SharedBagState.Close);
+                UpdateVisualizerAndNetwork(SharedBagState.Close);
             }
             else
             {
                 _window.OpenCentered();
-                ChangeStorageVisualization(SharedBagState.Open);
+                UpdateVisualizerAndNetwork(SharedBagState.Open);
             }
         }
 
@@ -154,11 +154,11 @@ namespace Content.Client.Storage
             if (_window == null) return;
 
             _window.Close();
-            ChangeStorageVisualization(SharedBagState.Close);
+            UpdateVisualizerAndNetwork(SharedBagState.Close);
 
         }
 
-        private void ChangeStorageVisualization(SharedBagState state)
+        private void UpdateVisualizerAndNetwork(SharedBagState state)
         {
             Owner.EntityManager.EntityNetManager?.SendSystemNetworkMessage(new OpenCloseBagEvent(Owner.Uid, state));
         }

--- a/Content.Client/Storage/SharedStorageSystem.cs
+++ b/Content.Client/Storage/SharedStorageSystem.cs
@@ -1,0 +1,26 @@
+﻿using Content.Shared.Inventory.Events;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Storage.Events;
+using JetBrains.Annotations;
+
+namespace Content.Client.Storage
+{
+    [UsedImplicitly]
+    public sealed class StorageSystem : SharedStorageSystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeNetworkEvent<OpenCloseBagEvent>(OnOpenCloseBag);
+        }
+
+        private void OnOpenCloseBag(OpenCloseBagEvent ev)
+        {
+            if (!ComponentManager.HasComponent<ClientStorageComponent>(ev.Owner)) return;
+
+            OnOpenCloseEvent(ev);
+        }
+    }
+}

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -1,6 +1,10 @@
 using System.Collections.Generic;
 using Content.Server.Interaction;
 using Content.Server.Storage.Components;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Storage.Events;
 using JetBrains.Annotations;
 using Robust.Server.Player;
 using Robust.Shared.Containers;
@@ -9,7 +13,7 @@ using Robust.Shared.GameObjects;
 namespace Content.Server.Storage.EntitySystems
 {
     [UsedImplicitly]
-    internal sealed class StorageSystem : EntitySystem
+    internal sealed class StorageSystem : SharedStorageSystem
     {
         private readonly List<IPlayerSession> _sessionCache = new();
 
@@ -20,7 +24,16 @@ namespace Content.Server.Storage.EntitySystems
 
             SubscribeLocalEvent<EntRemovedFromContainerMessage>(HandleEntityRemovedFromContainer);
             SubscribeLocalEvent<EntInsertedIntoContainerMessage>(HandleEntityInsertedIntoContainer);
+            SubscribeNetworkEvent<OpenCloseBagEvent>(OnOpenCloseBag);
         }
+
+        private void OnOpenCloseBag(OpenCloseBagEvent ev)
+        {
+            if (!ComponentManager.HasComponent<ServerStorageComponent>(ev.Owner)) return;
+
+            OnOpenCloseEvent(ev);
+        }
+
 
         /// <inheritdoc />
         public override void Update(float frameTime)

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1,0 +1,24 @@
+﻿using Content.Shared.Stacks;
+using Content.Shared.Storage.Components;
+using Content.Shared.Storage.Events;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.Storage.EntitySystems
+{
+    [UsedImplicitly]
+    public class SharedStorageSystem : EntitySystem
+    {
+        protected void OnOpenCloseEvent(OpenCloseBagEvent args)
+        {
+            if (!ComponentManager.TryGetComponent<SharedAppearanceComponent>(args.Owner, out var appearanceComponent))
+                return;
+
+            appearanceComponent.SetData(SharedBagOpenVisuals.BagState, args.State);
+            if (ComponentManager.HasComponent<ItemCounterComponent>(args.Owner))
+            {
+                appearanceComponent.SetData(StackVisuals.Hide, args.IsClosed);
+            }
+        }
+    }
+}

--- a/Content.Shared/Storage/Events/OpenCloseBagEvent.cs
+++ b/Content.Shared/Storage/Events/OpenCloseBagEvent.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Content.Shared.Storage.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Storage.Events
+{
+    [Serializable, NetSerializable]
+    public class OpenCloseBagEvent : EntityEventArgs
+    {
+        public readonly SharedBagState State;
+        public readonly EntityUid Owner;
+
+        public OpenCloseBagEvent(EntityUid owner, SharedBagState state)
+        {
+            State = state;
+            Owner = owner;
+        }
+
+        public bool IsClosed => State == SharedBagState.Close;
+    }
+}


### PR DESCRIPTION
## About the PR 
Fixes open/close visualizer for bags that have an `ItemCounter` component.
**Screenshots**
***Before***
https://user-images.githubusercontent.com/1146204/132908578-c928d62f-6812-4dab-9376-54490acb8080.mp4

***After***
https://user-images.githubusercontent.com/1146204/132908697-b03cf8f6-e4b6-4572-9620-5b6a5920f7a2.mp4


**Changelog**
:cl: Ygg01
- fix: Fix visualizer for cigarettes and similar.


