### PR TITLE
Fix construction from inside containers

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.cs
+++ b/Content.Server/Construction/ConstructionSystem.cs
@@ -94,12 +94,6 @@ namespace Content.Server.Construction
 
         private async Task<IEntity?> Construct(IEntity user, string materialContainer, ConstructionGraphPrototype graph, ConstructionGraphEdge edge, ConstructionGraphNode targetNode)
         {
-            if (user.IsInContainer())
-            {
-                user.PopupMessageCursor(Loc.GetString("construction-system-inside-container"));
-                return null;
-            }
-
             // We need a place to hold our construction items!
             var container = ContainerHelpers.EnsureContainer<Container>(user, materialContainer, out var existed);
 
@@ -348,6 +342,7 @@ namespace Content.Server.Construction
 
         private async void HandleStartStructureConstruction(TryStartStructureConstructionMessage ev, EntitySessionEventArgs args)
         {
+
             if (!_prototypeManager.TryIndex(ev.PrototypeName, out ConstructionPrototype? constructionPrototype))
             {
                 Logger.Error($"Tried to start construction of invalid recipe '{ev.PrototypeName}'!");
@@ -367,6 +362,12 @@ namespace Content.Server.Construction
             if (user == null)
             {
                 Logger.Error($"Client sent {nameof(TryStartStructureConstructionMessage)} with no attached entity!");
+                return;
+            }
+
+            if (user.IsInContainer())
+            {
+                user.PopupMessageCursor(Loc.GetString("construction-system-inside-container"));
                 return;
             }
 

--- a/Content.Server/Construction/ConstructionSystem.cs
+++ b/Content.Server/Construction/ConstructionSystem.cs
@@ -94,14 +94,14 @@ namespace Content.Server.Construction
 
         private async Task<IEntity?> Construct(IEntity user, string materialContainer, ConstructionGraphPrototype graph, ConstructionGraphEdge edge, ConstructionGraphNode targetNode)
         {
-            // We need a place to hold our construction items!
-            var container = ContainerHelpers.EnsureContainer<Container>(user, materialContainer, out var existed);
-
             if (user.IsInContainer())
             {
                 user.PopupMessageCursor(Loc.GetString("construction-system-inside-container"));
                 return null;
             }
+
+            // We need a place to hold our construction items!
+            var container = ContainerHelpers.EnsureContainer<Container>(user, materialContainer, out var existed);
 
             if (existed)
             {

--- a/Content.Server/Construction/ConstructionSystem.cs
+++ b/Content.Server/Construction/ConstructionSystem.cs
@@ -97,6 +97,12 @@ namespace Content.Server.Construction
             // We need a place to hold our construction items!
             var container = ContainerHelpers.EnsureContainer<Container>(user, materialContainer, out var existed);
 
+            if (user.IsInContainer())
+            {
+                user.PopupMessageCursor(Loc.GetString("construction-system-inside-container"));
+                return null;
+            }
+
             if (existed)
             {
                 user.PopupMessageCursor(Loc.GetString("construction-system-construct-cannot-start-another-construction"));

--- a/Resources/Locale/en-US/construction/construction-system.ftl
+++ b/Resources/Locale/en-US/construction/construction-system.ftl
@@ -3,4 +3,4 @@
 construction-system-construct-cannot-start-another-construction = You can't start another construction now!
 construction-system-construct-no-materials = You don't have the materials to build that!
 construction-system-already-building = You are already building that!
-construction-system-inside-container = You can't build out of a container!
+construction-system-inside-container = You can't build while you're there!

--- a/Resources/Locale/en-US/construction/construction-system.ftl
+++ b/Resources/Locale/en-US/construction/construction-system.ftl
@@ -3,3 +3,4 @@
 construction-system-construct-cannot-start-another-construction = You can't start another construction now!
 construction-system-construct-no-materials = You don't have the materials to build that!
 construction-system-already-building = You are already building that!
+construction-system-inside-container = You can't build out of a container!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR the hilarious issue of being able to construct stuff while inside a container as described in https://github.com/space-wizards/space-station-14/issues/4473. Attempting construction is met with a message of disappointment.

Closes https://github.com/space-wizards/space-station-14/issues/4473

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![Screenshot 2021-09-12 at 18 25 12](https://user-images.githubusercontent.com/32570017/132996993-8f94930c-4efc-4559-836d-d58240ee7d3f.png)
![Screenshot 2021-09-12 at 18 23 52](https://user-images.githubusercontent.com/32570017/132996997-73ae4ce7-4d27-4535-84b0-d29cfc1ae827.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: replace being able to construct out of a container

