### PR TITLE
Generalize ResistanceSets into DamageModifierSets

### DIFF
--- a/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
@@ -53,14 +53,13 @@ namespace Content.IntegrationTests.Tests.Damageable
     - TestDamage3b
     - TestDamage3c
 
-- type: resistanceSet
+- type: damageModifierSet
   id: testResistances
 # this space is intentionally left blank
 
 # This container should not support TestDamage1 or TestDamage2b
 - type: damageContainer
   id: testDamageContainer
-  defaultResistanceSet: testResistances
   supportedGroups:
     - TestGroup3
   supportedTypes:
@@ -189,9 +188,9 @@ namespace Content.IntegrationTests.Tests.Damageable
                 Assert.That(sDamageableComponent.TotalDamage, Is.EqualTo(damageToDeal));
                 Assert.That(sDamageableComponent.DamagePerGroup[group3.ID], Is.EqualTo(damageToDeal));
                 // integer rounding. In this case, first member gets 1 less than others.
-                Assert.That(sDamageableComponent.Damage.DamageDict[type3a.ID], Is.EqualTo(damageToDeal / types.Count())); 
+                Assert.That(sDamageableComponent.Damage.DamageDict[type3a.ID], Is.EqualTo(damageToDeal / types.Count()));
                 Assert.That(sDamageableComponent.Damage.DamageDict[type3b.ID], Is.EqualTo(1 + damageToDeal / types.Count()));
-                Assert.That(sDamageableComponent.Damage.DamageDict[type3c.ID], Is.EqualTo(1 + damageToDeal / types.Count())); 
+                Assert.That(sDamageableComponent.Damage.DamageDict[type3c.ID], Is.EqualTo(1 + damageToDeal / types.Count()));
 
                 // Heal
                 sDamageableSystem.TryChangeDamage(uid, -damage);

--- a/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
@@ -53,10 +53,6 @@ namespace Content.IntegrationTests.Tests.Damageable
     - TestDamage3b
     - TestDamage3c
 
-- type: damageModifierSet
-  id: testResistances
-# this space is intentionally left blank
-
 # This container should not support TestDamage1 or TestDamage2b
 - type: damageContainer
   id: testDamageContainer

--- a/Content.Shared/Damage/DamageModifierSet.cs
+++ b/Content.Shared/Damage/DamageModifierSet.cs
@@ -1,27 +1,22 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using Robust.Shared.Prototypes;
+using Content.Shared.Damage.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
-using Robust.Shared.ViewVariables;
 
-namespace Content.Shared.Damage.Prototypes
+namespace Content.Shared.Damage
 {
     /// <summary>
-    ///     Prototype of damage resistance sets. Can be applied to <see cref="DamageSpecifier"/> using <see
-    ///     cref="DamageSpecifier.ApplyResistanceSet(ResistanceSetPrototype)"/>. This can be done several times as the
+    ///     A set of coefficients or flat modifiers to damage types.. Can be applied to <see cref="DamageSpecifier"/> using <see
+    ///     cref="DamageSpecifier.ApplyModifierSet(DamageSpecifier, DamageModifierSet)"/>. This can be done several times as the
     ///     <see cref="DamageSpecifier"/> is passed to it's final target. By default the receiving <see cref="DamageableComponent"/>, will
-    ///     also apply it's own <see cref="ResistanceSetPrototype"/>.
+    ///     also apply it's own <see cref="DamageModifierSet"/>.
     /// </summary>
-    [Prototype("resistanceSet")]
+    [DataDefinition]
     [Serializable, NetSerializable]
-    public class ResistanceSetPrototype : IPrototype
+    public class DamageModifierSet
     {
-        [ViewVariables]
-        [DataField("id", required: true)]
-        public string ID { get; } = default!;
-
         [DataField("coefficients", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, DamageTypePrototype>))]
         public Dictionary<string, float> Coefficients = new();
 

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -41,7 +41,7 @@ namespace Content.Shared.Damage
             {
                 if (_damageDict == null)
                     DeserializeDamage();
-                return _damageDict!; 
+                return _damageDict!;
             }
             set => _damageDict = value;
         }
@@ -120,7 +120,7 @@ namespace Content.Shared.Damage
                     // This can happen if deserialized before prototypes are loaded.
                     Logger.Error($"Unknown damage group given to DamageSpecifier: {entry.Key}");
                     continue;
-                }    
+                }
 
                 // Simply distribute evenly (except for rounding).
                 // We do this by reducing remaining the # of types and damage every loop.
@@ -141,12 +141,12 @@ namespace Content.Shared.Damage
         }
 
         /// <summary>
-        ///     Reduce (or increase) damages by applying a resistance set.
+        ///     Reduce (or increase) damages by applying a damage modifier set.
         /// </summary>
         /// <remarks>
         ///     Only applies resistance to a damage type if it is dealing damage, not healing.
         /// </remarks>
-        public static DamageSpecifier ApplyResistanceSet(DamageSpecifier damageSpec, ResistanceSetPrototype resistanceSet)
+        public static DamageSpecifier ApplyModifierSet(DamageSpecifier damageSpec, DamageModifierSet modifierSet)
         {
             // Make a copy of the given data. Don't modify the one passed to this function. I did this before, and weapons became
             // duller as you hit walls. Neat, but not intended. And confusing, when you realize your fists don't work no
@@ -159,9 +159,9 @@ namespace Content.Shared.Damage
 
                 float newValue = entry.Value;
 
-                if (resistanceSet.FlatReduction.TryGetValue(entry.Key, out var reduction))
+                if (modifierSet.FlatReduction.TryGetValue(entry.Key, out var reduction))
                 {
-                    newValue -= reduction; 
+                    newValue -= reduction;
                     if (newValue <= 0)
                     {
                         // flat reductions cannot heal you
@@ -170,7 +170,7 @@ namespace Content.Shared.Damage
                     }
                 }
 
-                if (resistanceSet.Coefficients.TryGetValue(entry.Key, out var coefficient))
+                if (modifierSet.Coefficients.TryGetValue(entry.Key, out var coefficient))
                 {
                     // negative coefficients **can** heal you.
                     newValue = MathF.Round(newValue*coefficient, MidpointRounding.AwayFromZero);

--- a/Content.Shared/Damage/DamageableComponent.cs
+++ b/Content.Shared/Damage/DamageableComponent.cs
@@ -19,7 +19,7 @@ namespace Content.Shared.Damage
     /// </summary>
     /// <remarks>
     ///     The supported damage types are specified using a <see cref="DamageContainerPrototype"/>s. DamageContainers
-    ///     may also have resistances to certain damage types, defined via a <see cref="ResistanceSetPrototype"/>.
+    ///     may also have resistances to certain damage types, defined via a <see cref="DamageModifierSetPrototype"/>.
     /// </remarks>
     [RegisterComponent]
     [NetworkedComponent()]
@@ -36,12 +36,16 @@ namespace Content.Shared.Damage
         public string? DamageContainerID;
 
         /// <summary>
-        ///     This <see cref="ResistanceSetPrototype"/> will be applied to any damage that is dealt to this container,
+        ///     This <see cref="DamageModifierSetPrototype"/> will be applied to any damage that is dealt to this container,
         ///     unless the damage explicitly ignores resistances.
         /// </summary>
+        /// <remarks>
+        ///     Though DamageModifierSets can be deserialized directly, we only want to use the prototype version here
+        ///     to reduce duplication.
+        /// </remarks>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("resistanceSet", customTypeSerializer: typeof(PrototypeIdSerializer<ResistanceSetPrototype>))]
-        public string? ResistanceSetID;
+        [DataField("damageModifierSet", customTypeSerializer: typeof(PrototypeIdSerializer<DamageModifierSetPrototype>))]
+        public string? DamageModifierSetId;
 
         /// <summary>
         ///     All the damage information is stored in this <see cref="DamageSpecifier"/>.
@@ -116,14 +120,14 @@ namespace Content.Shared.Damage
     public class DamageableComponentState : ComponentState
     {
         public readonly Dictionary<string, int> DamageDict;
-        public readonly string? ResistanceSetID;
+        public readonly string? ModifierSetId;
 
         public DamageableComponentState(
             Dictionary<string, int> damageDict,
-            string? resistanceSetID) 
+            string? modifierSetId)
         {
             DamageDict = damageDict;
-            ResistanceSetID = resistanceSetID;
+            ModifierSetId = modifierSetId;
         }
     }
 }

--- a/Content.Shared/Damage/DamageableSystem.cs
+++ b/Content.Shared/Damage/DamageableSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Shared.Damage
         /// </summary>
         private void DamageableInit(EntityUid uid, DamageableComponent component, ComponentInit _)
         {
-            if (component.DamageContainerID != null && 
+            if (component.DamageContainerID != null &&
                 _prototypeManager.TryIndex<DamageContainerPrototype>(component.DamageContainerID,
                 out var damageContainerPrototype))
             {
@@ -118,11 +118,11 @@ namespace Content.Shared.Damage
             }
 
             // Apply resistances
-            if (!ignoreResistances && damageable.ResistanceSetID != null)
+            if (!ignoreResistances && damageable.DamageModifierSetId != null)
             {
-                if (_prototypeManager.TryIndex<ResistanceSetPrototype>(damageable.ResistanceSetID, out var resistanceSet))
+                if (_prototypeManager.TryIndex<DamageModifierSetPrototype>(damageable.DamageModifierSetId, out var modifierSet))
                 {
-                    damage = DamageSpecifier.ApplyResistanceSet(damage, resistanceSet);
+                    damage = DamageSpecifier.ApplyModifierSet(damage, modifierSet);
                 }
 
                 if (damage.Empty)
@@ -174,7 +174,7 @@ namespace Content.Shared.Damage
 
         private void DamageableGetState(EntityUid uid, DamageableComponent component, ref ComponentGetState args)
         {
-            args.State = new DamageableComponentState(component.Damage.DamageDict, component.ResistanceSetID);
+            args.State = new DamageableComponentState(component.Damage.DamageDict, component.DamageModifierSetId);
         }
 
         private void DamageableHandleState(EntityUid uid, DamageableComponent component, ref ComponentHandleState args)
@@ -184,7 +184,7 @@ namespace Content.Shared.Damage
                 return;
             }
 
-            component.ResistanceSetID = state.ResistanceSetID;
+            component.DamageModifierSetId = state.ModifierSetId;
 
             // Has the damage actually changed?
             DamageSpecifier newDamage = new() { DamageDict = state.DamageDict };
@@ -202,7 +202,7 @@ namespace Content.Shared.Damage
     public class DamageChangedEvent : EntityEventArgs
     {
         /// <summary>
-        ///     This is the component whose damage was changed.  
+        ///     This is the component whose damage was changed.
         /// </summary>
         /// <remarks>
         ///     Given that nearly every component that cares about a change in the damage, needs to know the

--- a/Content.Shared/Damage/Prototypes/DamageModifierSetPrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageModifierSetPrototype.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Shared.Damage.Prototypes
+{
+    /// <summary>
+    ///     A version of DamageModifierSet that can be serialized as a prototype, but is functionally identical.
+    /// </summary>
+    /// <remarks>
+    ///     Done to avoid removing the 'required' tag on the ID and passing around a 'prototype' when we really
+    ///     just want normal data to be deserialized.
+    /// </remarks>
+    [Prototype("damageModifierSet")]
+    public class DamageModifierSetPrototype : DamageModifierSet, IPrototype
+    {
+        [ViewVariables]
+        [DataField("id", required: true)]
+        public string ID { get; } = default!;
+    }
+}

--- a/Content.Tests/Shared/DamageTest.cs
+++ b/Content.Tests/Shared/DamageTest.cs
@@ -11,7 +11,7 @@ namespace Content.Tests.Shared
     // Basic tests of various damage prototypes and classes.
     [TestFixture]
     [TestOf(typeof(DamageSpecifier))]
-    [TestOf(typeof(ResistanceSetPrototype))]
+    [TestOf(typeof(DamageModifierSetPrototype))]
     [TestOf(typeof(DamageGroupPrototype))]
     public class DamageTest : ContentUnitTest
     {
@@ -26,7 +26,7 @@ namespace Content.Tests.Shared
 
         static private Dictionary<string, float> _resistanceReductionDict = new()
         {
-            { "Blunt", - 5 }, 
+            { "Blunt", - 5 },
             // "missing" piercing entry
             { "Slash", 8 },
             { "Radiation", 0.5f },  // Fractional adjustment
@@ -132,13 +132,13 @@ namespace Content.Tests.Shared
 
         //Check that DamageSpecifier will be properly adjusted by a resistance set
         [Test]
-        public void ResistanceSetTest()
+        public void ModifierSetTest()
         {
             // Create a copy of the damage data
             DamageSpecifier damageSpec = 10 * new DamageSpecifier(_damageSpec);
 
-            // Create a resistance set
-            ResistanceSetPrototype resistanceSet = new()
+            // Create a modifier set
+            DamageModifierSetPrototype modifierSet = new()
             {
                 Coefficients = _resistanceCoefficientDict,
                 FlatReduction = _resistanceReductionDict
@@ -149,14 +149,14 @@ namespace Content.Tests.Shared
             //then multiply by       1 / -2 /  3 /  1.06
 
             // Apply once
-            damageSpec = DamageSpecifier.ApplyResistanceSet(damageSpec, resistanceSet);
+            damageSpec = DamageSpecifier.ApplyModifierSet(damageSpec, modifierSet);
             Assert.That(damageSpec.DamageDict["Blunt"], Is.EqualTo(25));
             Assert.That(damageSpec.DamageDict["Piercing"], Is.EqualTo(-40)); // became healing
             Assert.That(damageSpec.DamageDict["Slash"], Is.EqualTo(6));
             Assert.That(damageSpec.DamageDict["Radiation"], Is.EqualTo(31)); // would be 32 w/o fraction adjustment
 
             // And again, checking for some other behavior
-            damageSpec = DamageSpecifier.ApplyResistanceSet(damageSpec, resistanceSet);
+            damageSpec = DamageSpecifier.ApplyModifierSet(damageSpec, modifierSet);
             Assert.That(damageSpec.DamageDict["Blunt"], Is.EqualTo(30));
             Assert.That(damageSpec.DamageDict["Piercing"], Is.EqualTo(-40)); // resistances don't apply to healing
             Assert.That(!damageSpec.DamageDict.ContainsKey("Slash"));  // Reduction reduced to 0, and removed from specifier
@@ -241,7 +241,7 @@ namespace Content.Tests.Shared
   damageTypes:
     - Cellular
 
-- type: resistanceSet
+- type: damageModifierSet
   id: Metallic
   coefficients:
     Blunt: 0.7
@@ -251,7 +251,7 @@ namespace Content.Tests.Shared
   flatReductions:
     Blunt: 5
 
-- type: resistanceSet
+- type: damageModifierSet
   id: Inflatable
   coefficients:
     Blunt: 0.5
@@ -261,7 +261,7 @@ namespace Content.Tests.Shared
   flatReductions:
     Blunt: 5
 
-- type: resistanceSet
+- type: damageModifierSet
   id: Glass
   coefficients:
     Blunt: 0.5

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -1,4 +1,4 @@
-- type: resistanceSet
+- type: damageModifierSet
   id: Metallic
   coefficients:
     Blunt: 0.7
@@ -8,7 +8,7 @@
   flatReductions:
     Blunt: 5
 
-- type: resistanceSet
+- type: damageModifierSet
   id: Inflatable
   coefficients:
     Blunt: 0.5
@@ -18,7 +18,7 @@
   flatReductions:
     Blunt: 5
 
-- type: resistanceSet
+- type: damageModifierSet
   id: Glass
   coefficients:
     Blunt: 0.5

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -126,7 +126,7 @@
   - type: Airtight
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
@@ -30,7 +30,7 @@
     isOpen: true
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Glass
+    damageModifierSet: Glass
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -108,7 +108,7 @@
   - type: Anchorable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:
@@ -141,7 +141,7 @@
   - type: Anchorable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Misc/inflatable_wall.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/inflatable_wall.yml
@@ -22,7 +22,7 @@
       - SmallImpassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Inflatable
+    damageModifierSet: Inflatable
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -27,10 +27,10 @@
   - type: Lock
     locked: false
     lockOnClick: true # toggle lock just by clicking on barrier
-  - type: DeployableBarrier     
+  - type: DeployableBarrier
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -45,7 +45,7 @@
       fillBaseName: beaker
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Glass
+    damageModifierSet: Glass
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base.yml
@@ -30,7 +30,7 @@
   - type: Pullable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
@@ -27,7 +27,7 @@
     anchored: true
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base.yml
@@ -65,7 +65,7 @@
   - type: Occluder
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -7,7 +7,7 @@
     - type: InteractionOutline
     - type: Damageable
       damageContainer: Inorganic
-      resistanceSet: Metallic
+      damageModifierSet: Metallic
     - type: Destructible
       thresholds:
       - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
@@ -13,7 +13,7 @@
   - type: InteractionOutline
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/assembly.yml
@@ -25,7 +25,7 @@
   - type: Rotatable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base.yml
@@ -39,7 +39,7 @@
   - type: ApcPowerReceiver
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Glass
+    damageModifierSet: Glass
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base.yml
@@ -7,7 +7,7 @@
   components:
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: PlaceableSurface
   - type: Sprite
     netsync: false

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -10,7 +10,7 @@
     sprite: Structures/Furniture/Tables/frame.rsi
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:
@@ -43,7 +43,7 @@
     sprite: Structures/Furniture/Tables/generic.rsi
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -25,7 +25,7 @@
     rotation: -90
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Furniture/instruments.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/instruments.yml
@@ -13,7 +13,7 @@
     sprite: Structures/Furniture/instruments.rsi
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Furniture/seats.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/seats.yml
@@ -25,7 +25,7 @@
   - type: Pullable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -29,7 +29,7 @@
     state: 0
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Machines/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/base.yml
@@ -19,7 +19,7 @@
       - MobMask
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -33,7 +33,7 @@
       - MobImpassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Machines/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/frame.yml
@@ -32,7 +32,7 @@
       node: missingWires
     - type: Damageable
       damageContainer: Inorganic
-      resistanceSet: Metallic
+      damageModifierSet: Metallic
     - type: Destructible
       thresholds:
       - trigger:
@@ -80,7 +80,7 @@
       node: machineFrame
     - type: Damageable
       damageContainer: Inorganic
-      resistanceSet: Metallic
+      damageModifierSet: Metallic
     - type: Destructible
       thresholds:
       - trigger:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -13,7 +13,7 @@
       anchored: true
     - type: Damageable
       damageContainer: Inorganic
-      resistanceSet: Metallic
+      damageModifierSet: Metallic
     - type: Destructible
       thresholds:
         - trigger:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -13,7 +13,7 @@
     anchored: true
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Anchorable
   - type: Rotatable
   - type: Pullable

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -17,7 +17,7 @@
   - type: Anchorable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -46,7 +46,7 @@
         nodeGroupID: MVPower
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -26,7 +26,7 @@
       - SmallImpassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:
@@ -112,7 +112,7 @@
       - SmallImpassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
@@ -40,7 +40,7 @@
     anchored: true
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:
@@ -81,7 +81,7 @@
     anchored: true
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:
@@ -127,7 +127,7 @@
     anchored: true
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/cable_terminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cable_terminal.yml
@@ -22,7 +22,7 @@
       anchored: true
     - type: Damageable
       damageContainer: Inorganic
-      resistanceSet: Metallic
+      damageModifierSet: Metallic
     - type: Destructible
       thresholds:
         - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -20,7 +20,7 @@
     drawdepth: BelowFloor
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
@@ -39,7 +39,7 @@
     drawRate: 50
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -43,7 +43,7 @@
               acts: [ "Destruction" ]
     - type: Damageable
       damageContainer: Inorganic
-      resistanceSet: Metallic
+      damageModifierSet: Metallic
     - type: Physics
       bodyType: Dynamic
       fixtures:
@@ -364,7 +364,7 @@
           acts: [ "Destruction" ]
     - type: Damageable
       damageContainer: Inorganic
-      resistanceSet: Metallic
+      damageModifierSet: Metallic
     - type: InteractionOutline
     - type: Sprite
       sprite: Structures/Storage/canister.rsi

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base.yml
@@ -41,7 +41,7 @@
     placeCentered: true
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base.yml
@@ -36,7 +36,7 @@
   - type: PlaceableSurface
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -531,7 +531,7 @@
       state_closed: livestockcrate_door
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/base.yml
@@ -25,7 +25,7 @@
       - SmallImpassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/storage.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/storage.yml
@@ -27,7 +27,7 @@
   - type: Anchorable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base.yml
@@ -13,7 +13,7 @@
         !type:PhysShapeAabb {}
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -36,7 +36,7 @@
         type: SignalPortSelectorBoundUserInterface
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -11,7 +11,7 @@
     state: 0
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Walls/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/barricades.yml
@@ -25,7 +25,7 @@
     - ExplosivePassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Walls/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/base.yml
@@ -19,7 +19,7 @@
     state: full
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Physics
     bodyType: Static
     fixtures:

--- a/Resources/Prototypes/Entities/Structures/Walls/girder.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/girder.yml
@@ -29,7 +29,7 @@
     - ExplosivePassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Walls/low.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/low.yml
@@ -16,7 +16,7 @@
     state: metal
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -10,7 +10,7 @@
     sprite: Structures/Windows/plasma_window.rsi
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Glass
+    damageModifierSet: Glass
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -31,7 +31,7 @@
       - VaultImpassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Glass
+    damageModifierSet: Glass
   - type: Repairable
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
+++ b/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
@@ -20,7 +20,7 @@
     drawdepth: FloorObjects
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/meat_spike.yml
+++ b/Resources/Prototypes/Entities/Structures/meat_spike.yml
@@ -12,7 +12,7 @@
     state: spike
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/Entities/Structures/soil.yml
@@ -26,7 +26,7 @@
       - SmallImpassable
   - type: Damageable
     damageContainer: Inorganic
-    resistanceSet: Metallic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes ResistanceSetPrototype to DamageModifierSetPrototype; doesn't change any functionality, it just fits its usage much better (since I plan on this using this for #4554 for IncreaseDamageOnWield)

The main problem was that I wanted to be able to serialize the actual data (the coefficients and flat reductions) directly without having to define a prototype for it (for very basic usages, like adding 10 slash damage to an axe if it's wielded or multiplying all brute damage by 2). 

I accomplished this by creating the basic DamageModifierSet (can be serialized directly, not a prototype) and having DamageModifierSetPrototype inherit from that, so it keeps the same data but can then inherit from IPrototype and have an ID field, which DamageModifierSet doesn't need.

This is needed for #4554 to be merged
