### PR TITLE
SoundSpecifiers can now specify paths/collections as a value too.

### DIFF
--- a/Content.Shared/Sound/SoundSpecifierTypeSerializer.cs
+++ b/Content.Shared/Sound/SoundSpecifierTypeSerializer.cs
@@ -1,17 +1,29 @@
 using System;
+using Content.Shared.Audio;
+using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.Manager.Result;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Content.Shared.Sound
 {
     [TypeSerializer]
-    public class SoundSpecifierTypeSerializer : ITypeReader<SoundSpecifier, MappingDataNode>
+    public class SoundSpecifierTypeSerializer :
+        ITypeReader<SoundSpecifier, MappingDataNode>,
+        ITypeReader<SoundSpecifier, ValueDataNode>
     {
+        private readonly ResourcePathSerializer _resourcePathSerializer = new();
+        private readonly PrototypeIdSerializer<SoundCollectionPrototype> _prototypeIdSerializer = new();
+
         private Type GetType(MappingDataNode node)
         {
             var hasPath = node.Has(SoundPathSpecifier.Node);
@@ -33,6 +45,19 @@ namespace Content.Shared.Sound
             return serializationManager.Read(type, node, context, skipHook);
         }
 
+        public DeserializationResult Read(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, bool skipHook, ISerializationContext? context = null)
+        {
+            var value = node.Value;
+            if (dependencies.Resolve<IPrototypeManager>().HasIndex<SoundCollectionPrototype>(value))
+                return new DeserializedValue<SoundSpecifier>(new SoundCollectionSpecifier(value));
+
+            if (dependencies.Resolve<IResourceManager>().ContentFileExists(value))
+                return new DeserializedValue<SoundSpecifier>(new SoundPathSpecifier(value));
+
+            throw new InvalidMappingException("SoundSpecifier is neither a resource path or sound collection identifier");
+        }
+
         public ValidationNode Validate(ISerializationManager serializationManager, MappingDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
@@ -43,6 +68,16 @@ namespace Content.Shared.Sound
                 return new ErrorNode(node, "You need to specify either a sound path or a sound collection!");
 
             return serializationManager.ValidateNode(GetType(node), node, context);
+        }
+
+        public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, ISerializationContext? context = null)
+        {
+            if (_resourcePathSerializer.Validate(serializationManager, node, dependencies, context) is not ErrorNode
+                || _prototypeIdSerializer.Validate(serializationManager, node, dependencies, context) is not ErrorNode)
+                return new ValidatedValueNode(node);
+
+            return new ErrorNode(node, "SoundSpecifier value is neither a valid resource path nor an existing sound collection identifier!");
         }
     }
 }

--- a/Content.Shared/Sound/SoundSpecifierTypeSerializer.cs
+++ b/Content.Shared/Sound/SoundSpecifierTypeSerializer.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Sound
 {
@@ -21,9 +22,6 @@ namespace Content.Shared.Sound
         ITypeReader<SoundSpecifier, MappingDataNode>,
         ITypeReader<SoundSpecifier, ValueDataNode>
     {
-        private readonly ResourcePathSerializer _resourcePathSerializer = new();
-        private readonly PrototypeIdSerializer<SoundCollectionPrototype> _prototypeIdSerializer = new();
-
         private Type GetType(MappingDataNode node)
         {
             var hasPath = node.Has(SoundPathSpecifier.Node);
@@ -73,8 +71,8 @@ namespace Content.Shared.Sound
         public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
             IDependencyCollection dependencies, ISerializationContext? context = null)
         {
-            if (_resourcePathSerializer.Validate(serializationManager, node, dependencies, context) is not ErrorNode
-                || _prototypeIdSerializer.Validate(serializationManager, node, dependencies, context) is not ErrorNode)
+            if (serializationManager.ValidateNode<ResourcePath>(node, context) is not ErrorNode
+                || serializationManager.ValidateNodeWith<string, PrototypeIdSerializer<SoundCollectionPrototype>, ValueDataNode>(node, context) is not ErrorNode)
                 return new ValidatedValueNode(node);
 
             return new ErrorNode(node, "SoundSpecifier value is neither a valid resource path nor an existing sound collection identifier!");


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Now you can *also* specify sounds like this:

```yml
sound: /Audio/path/to/my/file.ogg
```

and

```yml
sound: MyFunnySoundCollection
```
