### PR TITLE
Fix Welder component interaction

### DIFF
--- a/Content.Server/Tools/Components/WelderComponent.cs
+++ b/Content.Server/Tools/Components/WelderComponent.cs
@@ -308,7 +308,7 @@ namespace Content.Server.Tools.Components
                     .TryGetDrainableSolution(eventArgs.Target.Uid, out var targetSolution)
                 && WelderSolution != null)
             {
-                if (WelderLit)
+                if (WelderLit && targetSolution.DrainAvailable > 0)
                 {
                     // Oh no no
                     eventArgs.Target.SpawnExplosion();
@@ -323,6 +323,11 @@ namespace Content.Server.Tools.Components
                     SoundSystem.Play(Filter.Pvs(Owner), WelderRefill.GetSound(), Owner);
                     eventArgs.Target.PopupMessage(eventArgs.User,
                         Loc.GetString("welder-component-after-interact-refueled-message"));
+                }
+                else
+                {
+                    eventArgs.Target.PopupMessage(eventArgs.User,
+                        Loc.GetString("welder-component-no-fuel-in-tank", ("owner", eventArgs.Target)));
                 }
             }
 

--- a/Resources/Locale/en-US/tools/components/welder-component.ftl
+++ b/Resources/Locale/en-US/tools/components/welder-component.ftl
@@ -1,6 +1,7 @@
 welder-component-welder-not-lit-message = The welder is turned off!
 welder-component-cannot-weld-message = The welder does not have enough fuel for that!
 welder-component-no-fuel-message = The welder has no fuel left!
+welder-component-no-fuel-in-tank = {$owner} is empty
 welder-component-on-examine-welder-lit-message = [color=orange]Lit[/color]
 welder-component-on-examine-welder-not-lit-message = Not lit
 welder-component-on-examine-detailed-message = Fuel: [color={$colorName}]{$fuelLeft}/{$fuelCapacity}[/color].

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -17,6 +17,7 @@
   id: WeldingFuelTankFull
   parent: WeldingFuelTank
   name: fuel tank
+  suffix: Full
   description: A storage tank containing welding fuel.
   components:
   - type: Explosive


### PR DESCRIPTION
## Fix welder and tank interaction
Ok, so this thing has two major parts.
First is fix to the wrong suffix used for the Full Welder tank.
Second fix is to Welder and Tank interaction. Before the Lit welder didn't check the tank for a solution before exploding. 
Now it will. And if no solution is available it will show a message that fuel tank is empty.

Fixes #4630

**Screenshots**
https://user-images.githubusercontent.com/1146204/133889134-6f73c504-9444-4caf-90ed-3e3337aa7b54.mp4

**Changelog**
:cl:
- fix: Fix welder tank suffix for admins
- fix: Welder and tank interaction now shows fuel tank is empty and doesn't explode.




