### PR TITLE
Changes most uses of Color.Green to Color.LimeGreen for better visual clarity

### DIFF
--- a/Content.Client/AI/ClientPathfindingDebugSystem.cs
+++ b/Content.Client/AI/ClientPathfindingDebugSystem.cs
@@ -270,7 +270,7 @@ namespace Content.Client.AI
                 }
                 else
                 {
-                    _cachedRegionColors[gridId][region] = Color.Green.WithAlpha(0.3f);
+                    _cachedRegionColors[gridId][region] = Color.LimeGreen.WithAlpha(0.3f);
                 }
 
                 Timer.Spawn(3000, () =>

--- a/Content.Client/Atmos/Overlays/AtmosDebugOverlay.cs
+++ b/Content.Client/Atmos/Overlays/AtmosDebugOverlay.cs
@@ -87,11 +87,11 @@ namespace Content.Client.Atmos.Overlays
                                     // Red-Green-Blue interpolation
                                     if (interp < 0.5f)
                                     {
-                                        res = Color.InterpolateBetween(Color.Red, Color.Green, interp * 2);
+                                        res = Color.InterpolateBetween(Color.Red, Color.LimeGreen, interp * 2);
                                     }
                                     else
                                     {
-                                        res = Color.InterpolateBetween(Color.Green, Color.Blue, (interp - 0.5f) * 2);
+                                        res = Color.InterpolateBetween(Color.LimeGreen, Color.Blue, (interp - 0.5f) * 2);
                                     }
                                 }
                                 res = res.WithAlpha(0.75f);

--- a/Content.Client/Chat/ChatHelper.cs
+++ b/Content.Client/Chat/ChatHelper.cs
@@ -9,7 +9,7 @@ namespace Content.Client.Chat
             channel switch
             {
                 ChatChannel.Server => Color.Orange,
-                ChatChannel.Radio => Color.Green,
+                ChatChannel.Radio => Color.LimeGreen,
                 ChatChannel.OOC => Color.LightSkyBlue,
                 ChatChannel.Dead => Color.MediumPurple,
                 ChatChannel.Admin => Color.Red,

--- a/Content.Client/Chat/UI/ChatBox.xaml.cs
+++ b/Content.Client/Chat/UI/ChatBox.xaml.cs
@@ -490,7 +490,7 @@ namespace Content.Client.Chat.UI
         {
             return channel switch
             {
-                ChatSelectChannel.Radio => Color.Green,
+                ChatSelectChannel.Radio => Color.LimeGreen,
                 ChatSelectChannel.OOC => Color.LightSkyBlue,
                 ChatSelectChannel.Dead => Color.MediumPurple,
                 ChatSelectChannel.Admin => Color.Red,

--- a/Content.Client/Cloning/UI/CloningPodWindow.cs
+++ b/Content.Client/Cloning/UI/CloningPodWindow.cs
@@ -116,7 +116,7 @@ namespace Content.Client.Cloning.UI
             _cloningProgressBar.MaxValue = state.Maximum;
             UpdateProgress();
             _mindState.Text = Loc.GetString(state.MindPresent ? "cloning-pod-mind-present-text" : "cloning-pod-no-activity-text");
-            _mindState.FontColorOverride = state.MindPresent ? Color.Green : Color.Red;
+            _mindState.FontColorOverride = state.MindPresent ? Color.LimeGreen : Color.Red;
         }
 
         protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Client/HealthOverlay/UI/HealthOverlayGui.cs
+++ b/Content.Client/HealthOverlay/UI/HealthOverlayGui.cs
@@ -34,7 +34,7 @@ namespace Content.Client.HealthOverlay.UI
             {
                 Visible = false,
                 VerticalAlignment = VAlignment.Center,
-                Color = Color.Green
+                Color = Color.LimeGreen
             };
 
             AddChild(Panel = new PanelContainer

--- a/Content.Client/Light/Components/HandheldLightComponent.cs
+++ b/Content.Client/Light/Components/HandheldLightComponent.cs
@@ -44,7 +44,7 @@ namespace Content.Client.Light.Components
 
             private static readonly StyleBoxFlat StyleBoxLit = new()
             {
-                BackgroundColor = Color.Green
+                BackgroundColor = Color.LimeGreen
             };
 
             private static readonly StyleBoxFlat StyleBoxUnlit = new()

--- a/Content.Client/PDA/PDABoundUserInterface.cs
+++ b/Content.Client/PDA/PDABoundUserInterface.cs
@@ -171,7 +171,7 @@ namespace Content.Client.PDA
             }
             if (x <= 5)
             {
-                weightedColor = Color.Green;
+                weightedColor = Color.LimeGreen;
             }
             else if (x > 5 && x < 10)
             {

--- a/Content.Client/StationEvents/RadiationPulseOverlay.cs
+++ b/Content.Client/StationEvents/RadiationPulseOverlay.cs
@@ -102,7 +102,7 @@ namespace Content.Client.StationEvents
             }
 
             _transitions[entity] = (!easingIn, transitionTime);
-            _colors[entity] = Color.Green.WithAlpha(0.0f);
+            _colors[entity] = Color.LimeGreen.WithAlpha(0.0f);
             _alphaRateOfChange[entity] = 1.0f / (float) (transitionTime - currentTime).TotalSeconds;
         }
 

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -375,7 +375,7 @@ namespace Content.Client.Stylesheets
             sliderForeBox.SetPatchMargin(StyleBox.Margin.All, 12);
             sliderGrabBox.SetPatchMargin(StyleBox.Margin.All, 12);
 
-            var sliderFillGreen = new StyleBoxTexture(sliderFillBox) {Modulate = Color.Green};
+            var sliderFillGreen = new StyleBoxTexture(sliderFillBox) {Modulate = Color.LimeGreen};
             var sliderFillRed = new StyleBoxTexture(sliderFillBox) {Modulate = Color.Red};
             var sliderFillBlue = new StyleBoxTexture(sliderFillBox) {Modulate = Color.Blue};
 

--- a/Content.Client/Suspicion/SuspicionGui.xaml.cs
+++ b/Content.Client/Suspicion/SuspicionGui.xaml.cs
@@ -111,7 +111,7 @@ namespace Content.Client.Suspicion
             buttonText = Loc.GetString(buttonText);
 
             RoleButton.Text = buttonText;
-            RoleButton.ModulateSelfOverride = _previousAntagonist ? Color.Red : Color.Green;
+            RoleButton.ModulateSelfOverride = _previousAntagonist ? Color.Red : Color.LimeGreen;
 
             Visible = true;
         }

--- a/Content.Client/Weapons/Ranged/Barrels/Components/ClientRevolverBarrelComponent.cs
+++ b/Content.Client/Weapons/Ranged/Barrels/Components/ClientRevolverBarrelComponent.cs
@@ -132,7 +132,7 @@ namespace Content.Client.Weapons.Ranged.Barrels.Components
                         {
                             Texture = texture,
                             TextureScale = (scale, scale),
-                            ModulateSelfOverride = Color.Green,
+                            ModulateSelfOverride = Color.LimeGreen,
                         });
                     }
                     Color color;

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -337,7 +337,7 @@ namespace Content.Server.ParticleAccelerator.Components
             }
 
             var powerBlock = _wirePowerBlocked;
-            var keyboardLight = new StatusLightData(Color.Green,
+            var keyboardLight = new StatusLightData(Color.LimeGreen,
                 _wireInterfaceBlocked
                     ? StatusLightState.BlinkingFast
                     : StatusLightState.On,

--- a/Content.Shared/Wires/SharedWiresComponent.cs
+++ b/Content.Shared/Wires/SharedWiresComponent.cs
@@ -208,7 +208,7 @@ namespace Content.Shared.Wires
             {
                 WireColor.Red => Color.Red,
                 WireColor.Blue => Color.Blue,
-                WireColor.Green => Color.Green,
+                WireColor.Green => Color.LimeGreen,
                 WireColor.Orange => Color.Orange,
                 WireColor.Brown => Color.Brown,
                 WireColor.Gold => Color.Gold,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I went round to most of the affected UIs and it looks great. The only exception is buttons on the grinder window but I expect that'll be refactored in xaml soon enough.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Before**
![image](https://user-images.githubusercontent.com/49448379/134056276-bb541ace-5cc3-4ab8-8fa4-139ef57fc8be.png)

**After**
![image](https://user-images.githubusercontent.com/49448379/134056232-77484ffc-cbef-4639-bb30-fdd248ecd5b7.png)



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Swept
- tweak: Most green text/buttons now looks better

