### PR TITLE
Singularity fixes, Bartender's Interlude Edition

### DIFF
--- a/Content.Server/Radiation/RadiationPulseSystem.cs
+++ b/Content.Server/Radiation/RadiationPulseSystem.cs
@@ -20,15 +20,15 @@ namespace Content.Server.Radiation
         {
             base.Update(frameTime);
 
-            _accumulator += RadiationCooldown;
+            _accumulator += frameTime;
 
             while (_accumulator > RadiationCooldown)
             {
                 _accumulator -= RadiationCooldown;
-
+                // All code here runs effectively every RadiationCooldown seconds, so use that as the "frame time".
                 foreach (var comp in ComponentManager.EntityQuery<RadiationPulseComponent>(true))
                 {
-                    comp.Update(frameTime);
+                    comp.Update(RadiationCooldown);
                     var ent = comp.Owner;
 
                     if (ent.Deleted) continue;

--- a/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
@@ -209,8 +209,10 @@ namespace Content.Server.Singularity.EntitySystems
         /// </summary>
         private void DestroyTiles(ServerSingularityComponent component, Vector2 worldPos)
         {
-            // The - 0.01f here is a margin of error to stop a singularity from eating the tiles under force field equipment.
-            var radius = DestroyTileRange(component) - 0.01f;
+            // The - 0.05f here is a margin of error to stop a singularity from eating force field equipment.
+            // Raised to 0.05f because 0.01f wasn't enough (it's around certain internal physics margins).
+            // Note that it has to be a margin like this because if the singularity *envelopes* a target, it should still be eating it regardless.
+            var radius = DestroyTileRange(component) - 0.05f;
 
             var circle = new Circle(worldPos, radius);
             var box = new Box2(worldPos - radius, worldPos + radius);

--- a/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
@@ -209,7 +209,8 @@ namespace Content.Server.Singularity.EntitySystems
         /// </summary>
         private void DestroyTiles(ServerSingularityComponent component, Vector2 worldPos)
         {
-            var radius = DestroyTileRange(component);
+            // The - 0.01f here is a margin of error to stop a singularity from eating the tiles under force field equipment.
+            var radius = DestroyTileRange(component) - 0.01f;
 
             var circle = new Circle(worldPos, radius);
             var box = new Box2(worldPos - radius, worldPos + radius);

--- a/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
@@ -121,12 +121,12 @@ namespace Content.Server.Singularity.EntitySystems
             if (entity == component.Owner ||
                    entity.HasComponent<IMapGridComponent>() ||
                    entity.HasComponent<GhostComponent>() ||
-                   entity.HasComponent<ContainmentFieldComponent>())
+                   entity.HasComponent<ContainmentFieldComponent>() ||
+                   (
+                       entity.TryGetComponent<ContainmentFieldGeneratorComponent>(out var field) &&
+                       field.CanRepell(component.Owner)
+                   ))
                 return false;
-            // Don't bother checking if the field itself can repel for now, we still can't destroy it.
-            if (entity.TryGetComponent<ContainmentFieldGeneratorComponent>(out var field))
-                if (field.CanRepell(component.Owner))
-                    return false;
             return true;
         }
 

--- a/Content.Server/Singularity/StartSingularityEngineCommand.cs
+++ b/Content.Server/Singularity/StartSingularityEngineCommand.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using Content.Server.Administration;
+using Content.Server.Construction.Components;
 using Content.Server.ParticleAccelerator.Components;
 using Content.Server.Singularity.Components;
 using Content.Server.Singularity.EntitySystems;
@@ -14,10 +16,10 @@ namespace Content.Server.Singularity
     public class StartSingularityEngineCommand : IConsoleCommand
     {
         public string Command => "startsingularityengine";
-        public string Description => "Automatically turns on the particle accelerator and containment field emitters.";
+        public string Description => "Automatically sets up the PA, turns on the particle accelerator and the containment field emitters.";
         public string Help => $"{Command}";
 
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        public async void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length != 0)
             {
@@ -26,6 +28,22 @@ namespace Content.Server.Singularity
             }
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
+            // Dear code reviewers: I don't think there's a good way to do this,
+            //  and the command exists to give fast turnaround time on testing singulo,
+            //  which, given all the singulo bugs, seems necessary,
+            //  so it can't just be removed.
+            // What this code does: Constructs all PA components by forcing node changes into the completed state.
+            foreach (var comp in entityManager.ComponentManager.EntityQuery<ConstructionComponent>().ToArray())
+            {
+                // Check for valid graph
+                var graph = comp.GraphPrototype;
+                if (graph == null)
+                    continue;
+                // Construct PAs
+                if (graph.ID.StartsWith("particleAccelerator") && graph.Nodes.ContainsKey("completed"))
+                    await comp.ChangeNode("completed");
+            }
+            // Turn on emitters and collectors.
             foreach (var comp in entityManager.ComponentManager.EntityQuery<EmitterComponent>())
             {
                 EntitySystem.Get<EmitterSystem>().SwitchOn(comp);
@@ -34,6 +52,7 @@ namespace Content.Server.Singularity
             {
                 comp.Collecting = true;
             }
+            // Actually turn on the PA.
             foreach (var comp in entityManager.ComponentManager.EntityQuery<ParticleAcceleratorControlBoxComponent>())
             {
                 comp.RescanParts();

--- a/Content.Shared/Damage/DamageableComponent.cs
+++ b/Content.Shared/Damage/DamageableComponent.cs
@@ -86,7 +86,7 @@ namespace Content.Shared.Damage
 
             // Radiation should really just be a damage group instead of a list of types.
             DamageSpecifier damage = new();
-            foreach (var typeID in ExplosionDamageTypeIDs)
+            foreach (var typeID in RadiationDamageTypeIDs)
             {
                 damage.DamageDict.Add(typeID, damageValue);
             }

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -23,6 +23,7 @@ namespace Content.Shared.Physics
         GhostImpassable = 1 <<  5, // 32 Things impassible by ghosts/observers, ie blessed tiles or forcefields
         Underplating    = 1 <<  6, // 64 Things that are under plating
         Passable        = 1 <<  7, // 128 Things that are passable
+        SingularityImpassable = 1 <<  8, // 256 Objects which are specifically impassable by the singularity
         MapGrid         = MapGridHelpers.CollisionGroup, // Map grids, like shuttles. This is the actual grid itself, not the walls or other entities connected to the grid.
 
         MobMask = Impassable | MobImpassable | VaultImpassable | SmallImpassable,

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -65,8 +65,6 @@
       - Impassable
       - MobImpassable
       - VaultImpassable
-  - type: Transform
-    anchored: true
   - type: Sprite
     sprite: Structures/Power/Generation/Singularity/containment_field.rsi
     state: field

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -18,11 +18,13 @@
       - Impassable
       - MobImpassable
       - VaultImpassable
+      - SingularityImpassable
       - Opaque
       mask:
       - Impassable
       - MobImpassable
       - VaultImpassable
+      - SingularityImpassable
   - type: Transform
     anchored: true
   - type: Sprite
@@ -60,11 +62,13 @@
       - Impassable
       - MobImpassable
       - VaultImpassable
+      - SingularityImpassable
       - Opaque
       mask:
       - Impassable
       - MobImpassable
       - VaultImpassable
+      - SingularityImpassable
   - type: Sprite
     sprite: Structures/Power/Generation/Singularity/containment_field.rsi
     state: field

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -17,9 +17,9 @@
         !type:PhysShapeCircle
           radius: 0.5
       restitution: 0.9
-      mask:
-      - AllMask
       layer:
+      - SingularityImpassable
+      mask:
       - AllMask
   - type: Singularity
   - type: SingularityDistortion


### PR DESCRIPTION
## About the PR

CC'ing @metalgearsloth as someone who interacted with this code (and therefore probably someone who should know about a PR touching it)

Covers several issues:

+ startsingularityengine now auto-constructs the PA for faster testing.
+ DestroyEntities is called every tick again so that particles can actually hit the singularity (the 0.5 second delay was causing issues as the particles could enter and leave without being hit).

And finally, this one will require some explaination:

RadiationPulseSystem and associated radiation code in DamageableComponent essentially made the singularity a deadly lazer capable of burning through literally anything.

Firstly, explosion damage types were incorrectly used instead of radiation damage types. This made the singularity's radiation pulse capable of damaging walls, the resulting items of which would fall into the singularity if so positioned.

Secondly, the cooldown timer on radiation acts was broken, causing the (minimum of 1 damage) radiation act to be executed every frame, causing any radiation exposure whatsoever to be a minimum of 60 DPS. In practice I saw rather high damage values, so I suspect there was more to the various timing bugs.

This has all been fixed.

Considerations for future work:
+ I saw a force field unanchor itself. I feel like the bug where automatic tile removal unanchor targets forcefields has either come back or was never fixed, but that is *not* confirmation.
+ DestroyEntities being called every tick isn't ideal but seems pretty required to make the singularity actually capable of eating *anything*, including physicsless objects or other things that won't collide.
+ Advisory for anyone who wants to try and fix that: There needs to be a dedicated collision flag that *basically everything* needs to have. The idea is effectively that the singulo is a roving 'area' that gets a firehose's worth of collision callbacks on everything, filters what it wants, and starts queuing deletions.
+ The simulation model assumes that any contact with the singularity (i.e. clipping a corner) is sufficient contact for deletion. The simulation model is also the only way to run quick balancing simulations on the PA without starting up the game and running them in real-time. Game or simulator can be changed according to whatever the policy ends up being, but accuracy should probably be checked.
+ Keep in mind the simulation only cares about forcefield (as effective horizontal movement zone of singularity) and particle (as singulo food) reactions, as these in their entirety are responsible for balancing a singulo under normal conditions.
+ Current results: Simulation and game both hold at 300 energy mark under same construction (`startsingularityengine` on Saltern is the default simulator setting). Slight inaccuracy on lack of dip below 300 presents itself that can be explained as timing differences between the theoretical simulation and the actual object-movement-tick-driven game, along with a lack of vertical position compensation in the simulator.

**Changelog**

:cl:
- fix: The singularity works stably again
