### PR TITLE
Fix various solution capability issues (syringes, drinks)

### DIFF
--- a/Content.Server/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Server/Chemistry/Components/InjectorComponent.cs
@@ -137,7 +137,7 @@ namespace Content.Server.Chemistry.Components
                 {
                     eventArgs.User.PopupMessage(eventArgs.User,
                         Loc.GetString("injector-component-cannot-transfer-message",
-                            ("owner", eventArgs.User)));
+                            ("target", targetEntity)));
                 }
             }
             else if (ToggleState == InjectorToggleMode.Draw)
@@ -150,7 +150,7 @@ namespace Content.Server.Chemistry.Components
                 {
                     eventArgs.User.PopupMessage(eventArgs.User,
                         Loc.GetString("injector-component-cannot-draw-message",
-                            ("owner", eventArgs.User)));
+                            ("target", targetEntity)));
                 }
             }
 
@@ -181,7 +181,7 @@ namespace Content.Server.Chemistry.Components
             if (realTransferAmount <= 0)
             {
                 Owner.PopupMessage(user,
-                    Loc.GetString("injector-component-cannot-inject-message", ("owner", targetBloodstream.Owner)));
+                    Loc.GetString("injector-component-cannot-inject-message", ("target", targetBloodstream.Owner)));
                 return;
             }
 

--- a/Resources/Locale/en-US/chemistry/components/injector-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/injector-component.ftl
@@ -9,9 +9,9 @@ injector-volume-label = Volume: [color=white]{$currentVolume}/{$totalVolume}[/co
 
 injector-component-drawing-text = Now drawing
 injector-component-injecting-text = Now injecting
-injector-component-cannot-transfer-message = You aren't able to transfer to {$owner}!
-injector-component-cannot-draw-message = You aren't able to draw from {$owner}!
-injector-component-cannot-inject-message = You aren't able to inject to {$owner}!
+injector-component-cannot-transfer-message = You aren't able to transfer to {$target}!
+injector-component-cannot-draw-message = You aren't able to draw from {$target}!
+injector-component-cannot-inject-message = You aren't able to inject to {$target}!
 injector-component-inject-success-message = You inject {$amount}u into {$target}!
 injector-component-transfer-success-message = You transfer {$amount}u into {$target}.
 injector-component-draw-success-message = You draw {$amount}u from {$target}.

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
@@ -58,6 +58,18 @@
     damage:
       types:
         Blunt: 5
+  - type: FitsInDispenser
+    solution: drink
+  - type: DrawableSolution
+    solution: drink
+  - type: InjectableSolution
+    solution: drink
+  - type: SolutionTransfer
+    canChangeTransferAmount: true
+  - type: UserInterface
+    interfaces:
+    - key: enum.TransferAmountUiKey.Key
+      type: TransferAmountBoundUserInterface
 
 # Transformable container - normal glass
 - type: entity
@@ -72,15 +84,7 @@
     solutions:
       drink:
         maxVol: 50
-  - type: FitsInDispenser
-    solution: drink
-  - type: SolutionTransfer
-    canChangeTransferAmount: true
   - type: TransformableContainer
-  - type: UserInterface
-    interfaces:
-    - key: enum.TransferAmountUiKey.Key
-      type: TransferAmountBoundUserInterface
 
 - type: entity
   parent: DrinkGlassBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
@@ -62,7 +62,7 @@
     solution: drink
   - type: DrawableSolution
     solution: drink
-  - type: InjectableSolution
+  - type: RefillableSolution
     solution: drink
   - type: SolutionTransfer
     canChangeTransferAmount: true

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_cups.yml
@@ -9,6 +9,12 @@
     solutions:
       drink:
         maxVol: 10
+  - type: FitsInDispenser
+    solution: drink
+  - type: DrawableSolution
+    solution: drink
+  - type: InjectableSolution
+    solution: drink
   - type: SolutionTransfer
     canChangeTransferAmount: true
     maxTransferAmount: 10

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_cups.yml
@@ -13,7 +13,7 @@
     solution: drink
   - type: DrawableSolution
     solution: drink
-  - type: InjectableSolution
+  - type: RefillableSolution
     solution: drink
   - type: SolutionTransfer
     canChangeTransferAmount: true

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -29,6 +29,10 @@
     solution: beaker
   - type: ExaminableSolution
     solution: beaker
+  - type: DrawableSolution
+    solution: beaker
+  - type: InjectableSolution
+    solution: beaker
   - type: SolutionTransfer
     canChangeTransferAmount: true
   - type: UserInterface


### PR DESCRIPTION
## About the PR

See changelog, really.

**Changelog**

:cl:
- fix: Syringes can inject into/draw from beakers and drinks again.
- fix: Syringe messages on failure to inject/draw are less confusing.
- fix: Drinks that have been transformed (i.e. beer glasses) can be put back into the dispenser.
