### PR TITLE
Fix chair rotations

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/seats.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/seats.yml
@@ -20,6 +20,7 @@
       - SmallImpassable
   - type: Sprite
     sprite: Structures/Furniture/furniture.rsi
+    noRot: true
   - type: Strap
     position: Stand
   - type: Pullable
@@ -43,13 +44,14 @@
   id: Chair
   parent: SeatBase
   components:
+  - type: Transform
+    anchored: true
   - type: Anchorable
   - type: Rotatable
   - type: Sprite
     state: chair
     color: "#8e9799"
   - type: Physics
-    bodyType: Static
     fixtures:
     - shape:
         !type:PhysShapeAabb
@@ -174,6 +176,7 @@
   - type: Sprite
     state: wooden_chair
     color: "white"
+  - type: Rotatable
   - type: Physics
     fixtures:
     - shape:


### PR DESCRIPTION
## About the PR

Wooden chairs are now rotatable (matching metal chairs), metal chairs have anchored set properly, all chairs and stools don't rotate weirdly visually (see screenshot for the original bug).

**Screenshots**
Screenshot of the bug with a stool on snow:
![image](https://user-images.githubusercontent.com/22304167/134591400-cac5b4d2-45ea-4388-b8d8-45e32d72479f.png)

The equivalent screenshot is basically just how things were before that bug happened.

**Changelog**

:cl:
- fix: Chairs, stools, etc. no longer rotate to unusual angles.
- fix: Metal chairs are properly anchored and so don't need to be re-anchored and unanchored again.

