### PR TITLE
Re-enable netsync on meatspike - fixes #4070

### DIFF
--- a/Resources/Prototypes/Entities/Structures/meat_spike.yml
+++ b/Resources/Prototypes/Entities/Structures/meat_spike.yml
@@ -6,8 +6,6 @@
   components:
   - type: InteractionOutline
   - type: Sprite
-    netsync: false
-    # temp to make clickmask work
     sprite: Structures/meat_spike.rsi
     state: spike
   - type: Damageable


### PR DESCRIPTION
## About the PR

Fixes #4070 by re-enabling netsync.

**Screenshots**

![image](https://user-images.githubusercontent.com/22304167/134597273-32d92dd4-2e26-48a3-97a1-15509ad4d723.png)

**Changelog**

:cl:
- fix: Dead bodies show up on meatspikes again.
