### PR TITLE
Pullability partial ECS refactor, monkey-gibbing error fix

### DIFF
--- a/Content.Server/Alert/Click/StopBeingPulled.cs
+++ b/Content.Server/Alert/Click/StopBeingPulled.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Alert;
 using Content.Shared.Pulling.Components;
+using Content.Shared.Pulling;
 using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Server.Alert.Click
@@ -14,7 +16,12 @@ namespace Content.Server.Alert.Click
     {
         public void AlertClicked(ClickAlertEventArgs args)
         {
-            args.Player.GetComponentOrNull<SharedPullableComponent>()?.TryStopPull(args.Player);
+            var ps = EntitySystem.Get<SharedPullingSystem>();
+            var playerPullable = args.Player.GetComponentOrNull<SharedPullableComponent>();
+            if (playerPullable != null)
+            {
+                ps.TryStopPull(playerPullable);
+            }
         }
     }
 }

--- a/Content.Server/Alert/Click/StopBeingPulled.cs
+++ b/Content.Server/Alert/Click/StopBeingPulled.cs
@@ -17,8 +17,7 @@ namespace Content.Server.Alert.Click
         public void AlertClicked(ClickAlertEventArgs args)
         {
             var ps = EntitySystem.Get<SharedPullingSystem>();
-            var playerPullable = args.Player.GetComponentOrNull<SharedPullableComponent>();
-            if (playerPullable != null)
+            if (args.Player.TryGetComponent<SharedPullableComponent>(out var playerPullable))
             {
                 ps.TryStopPull(playerPullable);
             }

--- a/Content.Server/Alert/Click/StopPulling.cs
+++ b/Content.Server/Alert/Click/StopPulling.cs
@@ -16,11 +16,13 @@ namespace Content.Server.Alert.Click
     {
         public void AlertClicked(ClickAlertEventArgs args)
         {
-            EntitySystem
-                .Get<SharedPullingSystem>()
-                .GetPulled(args.Player)?
-                .GetComponentOrNull<SharedPullableComponent>()?
-                .TryStopPull();
+            var ps = EntitySystem.Get<SharedPullingSystem>();
+            var playerTargetPullable = ps.GetPulled(args.Player)?
+                .GetComponentOrNull<SharedPullableComponent>();
+            if (playerTargetPullable != null)
+            {
+                ps.TryStopPull(playerTargetPullable);
+            }
         }
     }
 }

--- a/Content.Server/Buckle/Components/BuckleComponent.cs
+++ b/Content.Server/Buckle/Components/BuckleComponent.cs
@@ -268,7 +268,7 @@ namespace Content.Server.Buckle.Components
             {
                 if (ownerPullable.Puller != null)
                 {
-                    ownerPullable.TryStopPull();
+                    EntitySystem.Get<PullingSystem>().TryStopPull(ownerPullable);
                 }
             }
 
@@ -277,7 +277,7 @@ namespace Content.Server.Buckle.Components
                 if (toPullable.Puller == Owner)
                 {
                     // can't pull it and buckle to it at the same time
-                    toPullable.TryStopPull();
+                    EntitySystem.Get<PullingSystem>().TryStopPull(toPullable);
                 }
             }
 

--- a/Content.Server/Construction/Components/AnchorableComponent.cs
+++ b/Content.Server/Construction/Components/AnchorableComponent.cs
@@ -79,7 +79,7 @@ namespace Content.Server.Construction.Components
             {
                 if (pullableComponent.Puller != null)
                 {
-                    pullableComponent.TryStopPull();
+                    EntitySystem.Get<PullingSystem>().TryStopPull(pullableComponent);
                 }
             }
 

--- a/Content.Server/Hands/Components/HandsComponent.cs
+++ b/Content.Server/Hands/Components/HandsComponent.cs
@@ -166,7 +166,7 @@ namespace Content.Server.Hands.Components
                 || puller.Pulling == null || !puller.Pulling.TryGetComponent(out PullableComponent? pullable))
                 return false;
 
-            return pullable.TryStopPull();
+            return _entitySystemManager.GetEntitySystem<PullingSystem>().TryStopPull(pullable);
         }
 
         #endregion

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -47,6 +47,7 @@ namespace Content.Server.Interaction
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
+        [Dependency] private readonly PullingSystem _pullSystem = default!;
 
         public override void Initialize()
         {
@@ -313,7 +314,7 @@ namespace Content.Server.Interaction
             if (!pulledObject.TryGetComponent(out PullableComponent? pull))
                 return false;
 
-            return pull.TogglePull(userEntity);
+            return _pullSystem.TogglePull(userEntity, pull);
         }
 
         /// <summary>

--- a/Content.Server/Physics/Controllers/PullController.cs
+++ b/Content.Server/Physics/Controllers/PullController.cs
@@ -51,6 +51,10 @@ namespace Content.Server.Physics.Controllers
 
             foreach (var pullable in _pullableSystem.Moving)
             {
+                // There's a 1-frame delay between stopping moving something and it leaving the Moving set.
+                // This can include if leaving the Moving set due to not being pulled anymore,
+                //  or due to being deleted.
+
                 if (pullable.Deleted)
                 {
                     continue;
@@ -61,7 +65,12 @@ namespace Content.Server.Physics.Controllers
                     continue;
                 }
 
-                DebugTools.AssertNotNull(pullable.Puller);
+                if (pullable.Puller == null)
+                {
+                    continue;
+                }
+
+                // Now that's over with...
 
                 var pullerPosition = pullable.Puller!.Transform.MapPosition;
                 if (pullable.MovingTo.Value.MapId != pullerPosition.MapId)

--- a/Content.Server/Physics/Controllers/PullController.cs
+++ b/Content.Server/Physics/Controllers/PullController.cs
@@ -75,7 +75,7 @@ namespace Content.Server.Physics.Controllers
                 var pullerPosition = pullable.Puller!.Transform.MapPosition;
                 if (pullable.MovingTo.Value.MapId != pullerPosition.MapId)
                 {
-                    pullable.MovingTo = null;
+                    _pullableSystem.StopMoveTo(pullable);
                     continue;
                 }
 
@@ -83,22 +83,23 @@ namespace Content.Server.Physics.Controllers
                     physics.BodyType == BodyType.Static ||
                     pullable.MovingTo.Value.MapId != pullable.Owner.Transform.MapID)
                 {
-                    pullable.MovingTo = null;
+                    _pullableSystem.StopMoveTo(pullable);
                     continue;
                 }
 
                 var movingPosition = pullable.MovingTo.Value.Position;
                 var ownerPosition = pullable.Owner.Transform.MapPosition.Position;
 
-                if (movingPosition.EqualsApprox(ownerPosition, MaximumSettleDistance) && (physics.LinearVelocity.Length < MaximumSettleVelocity))
+                var diff = movingPosition - ownerPosition;
+                var diffLength = diff.Length;
+
+                if ((diffLength < MaximumSettleDistance) && (physics.LinearVelocity.Length < MaximumSettleVelocity))
                 {
                     physics.LinearVelocity = Vector2.Zero;
-                    pullable.MovingTo = null;
+                    _pullableSystem.StopMoveTo(pullable);
                     continue;
                 }
 
-                var diff = movingPosition - ownerPosition;
-                var diffLength = diff.Length;
                 var impulseModifierLerp = Math.Min(1.0f, Math.Max(0.0f, (physics.Mass - AccelModifierLowMass) / (AccelModifierHighMass - AccelModifierLowMass)));
                 var impulseModifier = MathHelper.Lerp(AccelModifierLow, AccelModifierHigh, impulseModifierLerp);
                 var multiplier = diffLength < 1 ? impulseModifier * diffLength : impulseModifier;
@@ -111,6 +112,7 @@ namespace Content.Server.Physics.Controllers
                     var scaling = (SettleShutdownDistance - diffLength) / SettleShutdownDistance;
                     accel -= physics.LinearVelocity * SettleShutdownMultiplier * scaling;
                 }
+                physics.WakeBody();
                 physics.ApplyLinearImpulse(accel * physics.Mass * frameTime);
             }
         }

--- a/Content.Server/Pulling/PullableComponent.cs
+++ b/Content.Server/Pulling/PullableComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Pulling.Components;
+using Content.Shared.Pulling;
 using Content.Shared.Verbs;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
@@ -50,11 +51,11 @@ namespace Content.Server.Pulling
                 // Why no reason? Because they're supposed to be performed in TryStartPull.
                 if (component.Puller == user)
                 {
-                    component.TryStopPull();
+                    EntitySystem.Get<SharedPullingSystem>().TryStopPull(component);
                 }
                 else
                 {
-                    component.TryStartPull(user);
+                    EntitySystem.Get<SharedPullingSystem>().TryStartPull(component.Owner, user);
                 }
             }
         }

--- a/Content.Server/Pulling/PullingSystem.cs
+++ b/Content.Server/Pulling/PullingSystem.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Pulling
                 return;
             }
 
-            pullable.TryStopPull();
+            TryStopPull(pullable);
         }
     }
 }

--- a/Content.Shared/Pulling/Components/SharedPullerComponent.cs
+++ b/Content.Shared/Pulling/Components/SharedPullerComponent.cs
@@ -10,31 +10,12 @@ namespace Content.Shared.Pulling.Components
     {
         public override string Name => "Puller";
 
-        private IEntity? _pulling;
+        public float WalkSpeedModifier => Pulling == null ? 1.0f : 0.75f;
 
-        public float WalkSpeedModifier => _pulling == null ? 1.0f : 0.75f;
-
-        public float SprintSpeedModifier => _pulling == null ? 1.0f : 0.75f;
+        public float SprintSpeedModifier => Pulling == null ? 1.0f : 0.75f;
 
         [ViewVariables]
-        public IEntity? Pulling
-        {
-            get => _pulling;
-            set
-            {
-                if (_pulling == value)
-                {
-                    return;
-                }
-
-                _pulling = value;
-
-                if (Owner.TryGetComponent(out MovementSpeedModifierComponent? speed))
-                {
-                    speed.RefreshMovementSpeedModifiers();
-                }
-            }
-        }
+        public IEntity? Pulling { get; set; }
 
         protected override void OnRemove()
         {

--- a/Content.Shared/Pulling/Components/SharedPullerComponent.cs
+++ b/Content.Shared/Pulling/Components/SharedPullerComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Movement.Components;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.ViewVariables;
+using Robust.Shared.Log;
 using Component = Robust.Shared.GameObjects.Component;
 
 namespace Content.Shared.Pulling.Components
@@ -13,6 +14,7 @@ namespace Content.Shared.Pulling.Components
     {
         public override string Name => "Puller";
 
+        // Before changing how this is updated, please see SharedPullerSystem.RefreshMovementSpeed
         public float WalkSpeedModifier => Pulling == null ? 1.0f : 0.75f;
 
         public float SprintSpeedModifier => Pulling == null ? 1.0f : 0.75f;
@@ -20,9 +22,19 @@ namespace Content.Shared.Pulling.Components
         [ViewVariables]
         public IEntity? Pulling { get; set; }
 
-        protected override void OnRemove()
+        protected override void Shutdown()
         {
             EntitySystem.Get<SharedPullingStateManagementSystem>().ForceDisconnectPuller(this);
+            base.Shutdown();
+        }
+
+        protected override void OnRemove()
+        {
+            if (Pulling != null)
+            {
+                // This is absolute paranoia but it's also absolutely necessary. Too many puller state bugs. - 20kdc
+                Logger.ErrorS("c.go.c.pulling", "PULLING STATE CORRUPTION IMMINENT IN PULLER {0} - OnRemove called when Pulling is set!", Owner);
+            }
             base.OnRemove();
         }
     }

--- a/Content.Shared/Pulling/Components/SharedPullerComponent.cs
+++ b/Content.Shared/Pulling/Components/SharedPullerComponent.cs
@@ -1,4 +1,6 @@
-﻿using Content.Shared.Movement.Components;
+﻿using Content.Shared.Pulling;
+using Content.Shared.Movement.Components;
+using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.ViewVariables;
 using Component = Robust.Shared.GameObjects.Component;
@@ -6,6 +8,7 @@ using Component = Robust.Shared.GameObjects.Component;
 namespace Content.Shared.Pulling.Components
 {
     [RegisterComponent]
+    [Friend(typeof(SharedPullingStateManagementSystem))]
     public class SharedPullerComponent : Component, IMoveSpeedModifier
     {
         public override string Name => "Puller";
@@ -19,12 +22,7 @@ namespace Content.Shared.Pulling.Components
 
         protected override void OnRemove()
         {
-            if (Pulling != null &&
-                Pulling.TryGetComponent(out SharedPullableComponent? pullable))
-            {
-                pullable.TryStopPull();
-            }
-
+            EntitySystem.Get<SharedPullingStateManagementSystem>().ForceDisconnectPuller(this);
             base.OnRemove();
         }
     }

--- a/Content.Shared/Pulling/Systems/SharedPullableSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullableSystem.cs
@@ -9,6 +9,7 @@ namespace Content.Shared.Pulling.Systems
     public class SharedPullableSystem : EntitySystem
     {
         [Dependency] private readonly ActionBlockerSystem _blocker = default!;
+        [Dependency] private readonly SharedPullingSystem _pullSystem = default!;
 
         public override void Initialize()
         {
@@ -20,7 +21,7 @@ namespace Content.Shared.Pulling.Systems
         {
             var entity = args.Session.AttachedEntity;
             if (entity == null || !_blocker.CanMove(entity)) return;
-            component.TryStopPull();
+            _pullSystem.TryStopPull(component);
         }
     }
 }

--- a/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
@@ -4,12 +4,15 @@ using Content.Shared.Physics.Pull;
 using Content.Shared.Pulling.Components;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 
 namespace Content.Shared.Pulling.Systems
 {
     [UsedImplicitly]
     public sealed class SharedPullerSystem : EntitySystem
     {
+        [Dependency] private readonly SharedPullingSystem _pullSystem = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -28,7 +31,7 @@ namespace Content.Shared.Pulling.Systems
             {
                 if (EntityManager.TryGetComponent<SharedPullableComponent>(args.BlockingEntity, out var comp))
                 {
-                    comp.TryStopPull(EntityManager.GetEntity(uid));
+                    _pullSystem.TryStopPull(comp, EntityManager.GetEntity(uid));
                 }
             }
         }

--- a/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Alert;
 using Content.Shared.Hands;
+using Content.Shared.Movement.Components;
 using Content.Shared.Physics.Pull;
 using Content.Shared.Pulling.Components;
 using JetBrains.Annotations;
@@ -46,6 +47,8 @@ namespace Content.Shared.Pulling.Systems
 
             if (component.Owner.TryGetComponent(out SharedAlertsComponent? alerts))
                 alerts.ShowAlert(AlertType.Pulling);
+
+            RefreshMovementSpeed(component);
         }
 
         private static void PullerHandlePullStopped(
@@ -58,6 +61,17 @@ namespace Content.Shared.Pulling.Systems
 
             if (component.Owner.TryGetComponent(out SharedAlertsComponent? alerts))
                 alerts.ClearAlert(AlertType.Pulling);
+
+            RefreshMovementSpeed(component);
+        }
+
+        private static void RefreshMovementSpeed(SharedPullerComponent component)
+        {
+            // Before changing how this is updated, please see SharedPullerComponent
+            if (component.Owner.TryGetComponent<MovementSpeedModifierComponent>(out var speed))
+            {
+                speed.RefreshMovementSpeedModifiers();
+            }
         }
     }
 }

--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.GameTicking;
@@ -41,7 +42,10 @@ namespace Content.Shared.Pulling
             ForceSetMovingTo(pullable, null);
 
             // Joint shutdown
-            pullerPhysics.RemoveJoint(pullable.PullJoint!);
+            if (pullerPhysics.Joints.Contains(pullable.PullJoint!))
+            {
+                pullerPhysics.RemoveJoint(pullable.PullJoint!);
+            }
             pullable.PullJoint = null;
 
             // State shutdown

--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -33,8 +33,6 @@ namespace Content.Shared.Pulling
         // They do not expect to be cancellable.
         private void ForceDisconnect(SharedPullerComponent puller, SharedPullableComponent pullable)
         {
-            var eventBus = pullable.Owner.EntityManager.EventBus;
-
             var pullerPhysics = puller.Owner.GetComponent<PhysicsComponent>();
             var pullablePhysics = pullable.Owner.GetComponent<PhysicsComponent>();
 
@@ -55,10 +53,10 @@ namespace Content.Shared.Pulling
             // Messaging
             var message = new PullStoppedMessage(pullerPhysics, pullablePhysics);
 
-            eventBus.RaiseLocalEvent(puller.Owner.Uid, message, broadcast: false);
+            RaiseLocalEvent(puller.Owner.Uid, message, broadcast: false);
 
             if (pullable.Owner.LifeStage <= EntityLifeStage.MapInitialized)
-                eventBus.RaiseLocalEvent(pullable.Owner.Uid, message);
+                RaiseLocalEvent(pullable.Owner.Uid, message);
 
             // Networking
             puller.Dirty();
@@ -91,8 +89,6 @@ namespace Content.Shared.Pulling
 
             if ((puller != null) && (pullable != null))
             {
-                var eventBus = pullable.Owner.EntityManager.EventBus;
-
                 var pullerPhysics = puller.Owner.GetComponent<PhysicsComponent>();
                 var pullablePhysics = pullable.Owner.GetComponent<PhysicsComponent>();
 
@@ -112,8 +108,8 @@ namespace Content.Shared.Pulling
                 // Messaging
                 var message = new PullStartedMessage(pullerPhysics, pullablePhysics);
 
-                eventBus.RaiseLocalEvent(puller.Owner.Uid, message, broadcast: false);
-                eventBus.RaiseLocalEvent(pullable.Owner.Uid, message);
+                RaiseLocalEvent(puller.Owner.Uid, message, broadcast: false);
+                RaiseLocalEvent(pullable.Owner.Uid, message);
 
                 // Networking
                 puller.Dirty();
@@ -153,11 +149,11 @@ namespace Content.Shared.Pulling
 
             if (movingTo == null)
             {
-                pullable.Owner.EntityManager.EventBus.RaiseLocalEvent(pullable.Owner.Uid, new PullableStopMovingMessage());
+                RaiseLocalEvent(pullable.Owner.Uid, new PullableStopMovingMessage());
             }
             else
             {
-                pullable.Owner.EntityManager.EventBus.RaiseLocalEvent(pullable.Owner.Uid, new PullableMoveMessage());
+                RaiseLocalEvent(pullable.Owner.Uid, new PullableMoveMessage());
             }
         }
     }

--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -56,7 +56,9 @@ namespace Content.Shared.Pulling
             var message = new PullStoppedMessage(pullerPhysics, pullablePhysics);
 
             eventBus.RaiseLocalEvent(puller.Owner.Uid, message, broadcast: false);
-            eventBus.RaiseLocalEvent(pullable.Owner.Uid, message);
+
+            if (pullable.Owner.LifeStage <= EntityLifeStage.MapInitialized)
+                eventBus.RaiseLocalEvent(pullable.Owner.Uid, message);
 
             // Networking
             puller.Dirty();

--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.GameTicking;
+using Content.Shared.Input;
+using Content.Shared.Movement.Components;
+using Content.Shared.Physics.Pull;
+using Content.Shared.Pulling.Components;
+using Content.Shared.Pulling.Events;
+using JetBrains.Annotations;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Dynamics.Joints;
+using Robust.Shared.Players;
+using Robust.Shared.Log;
+
+namespace Content.Shared.Pulling
+{
+    [UsedImplicitly]
+    public class SharedPullingStateManagementSystem : EntitySystem
+    {
+        // A WARNING:
+        // The following function is the most internal part of the pulling system's relationship management.
+        // It does not expect to be cancellable.
+
+        public static void ForceRelationship(SharedPullerComponent? puller, SharedPullableComponent? pullable)
+        {
+            if ((puller != null) && (puller.Pulling == pullable))
+            {
+                // Already done
+                return;
+            }
+
+            var eventBus = (pullable?.Owner ?? puller?.Owner)!.EntityManager.EventBus;
+
+            var pullerPhysics = puller?.Owner.GetComponent<PhysicsComponent>();
+            var pullablePhysics = pullable?.Owner.GetComponent<PhysicsComponent>();
+
+            // Start by disconnecting the puller from whatever it is currently connected to.
+            var pullerOldPullableE = puller?.Pulling;
+            if (pullerOldPullableE != null)
+            {
+                // Joint shutdown
+                var pullerOldPullable = pullerOldPullableE.GetComponent<SharedPullableComponent>();
+                if (pullerOldPullable._pullJoint != null)
+                {
+                    pullerPhysics!.RemoveJoint(pullerOldPullable._pullJoint);
+                }
+                pullerOldPullable._pullJoint = null;
+
+                // State shutdown
+                puller!.Pulling = null;
+                pullerOldPullable._puller = null;
+
+                // Messaging
+                var message = new PullStoppedMessage(pullerPhysics!, pullerOldPullableE.GetComponent<IPhysBody>());
+
+                eventBus.RaiseLocalEvent(puller.Owner.Uid, message, broadcast: false);
+                eventBus.RaiseLocalEvent(pullerOldPullableE.Uid, message);
+            }
+
+            // Continue by doing that with the pullable.
+            if (pullable?.Puller != null)
+            {
+                ForceRelationship(pullable.Puller.GetComponent<SharedPullerComponent>(), null);
+            }
+
+            // And now for the actual connection (if any).
+
+            if ((puller != null) && (pullable != null))
+            {
+                // State startup
+                puller.Pulling = pullable.Owner;
+                pullable._puller = puller.Owner;
+
+                // Messaging
+                var message = new PullStartedMessage(pullerPhysics!, pullablePhysics!);
+
+                eventBus.RaiseLocalEvent(puller.Owner.Uid, message, broadcast: false);
+                eventBus.RaiseLocalEvent(pullable.Owner.Uid, message);
+
+                // Joint startup
+                var union = pullerPhysics!.GetWorldAABB().Union(pullablePhysics!.GetWorldAABB());
+                var length = Math.Max(union.Size.X, union.Size.Y) * 0.75f;
+
+                pullable._pullJoint = pullerPhysics.CreateDistanceJoint(pullablePhysics, $"pull-joint-{pullablePhysics.Owner.Uid}");
+                pullable._pullJoint.CollideConnected = false;
+                pullable._pullJoint.Length = length * 0.75f;
+                pullable._pullJoint.MaxLength = length;
+            }
+
+            if (puller != null)
+            {
+                if (puller.Owner.TryGetComponent<MovementSpeedModifierComponent>(out var speed))
+                {
+                    speed.RefreshMovementSpeedModifiers();
+                }
+            }
+
+            puller?.Dirty();
+            pullable?.Dirty();
+        }
+
+        // The main "start pulling" function.
+        public static void StartPulling(SharedPullerComponent puller, SharedPullableComponent pullable)
+        {
+            if (puller.Pulling == pullable)
+                return;
+
+            var eventBus = pullable.Owner.EntityManager.EventBus;
+
+            // Pulling a new object : Perform sanity checks.
+
+            if (!EntitySystem.Get<SharedPullingSystem>().CanPull(puller.Owner, pullable.Owner))
+            {
+                return;
+            }
+
+            if (!puller.Owner.TryGetComponent<PhysicsComponent>(out var pullerPhysics))
+            {
+                return;
+            }
+
+            if (!pullable.Owner.TryGetComponent<PhysicsComponent>(out var pullablePhysics))
+            {
+                return;
+            }
+
+            // Ensure that the puller is not currently pulling anything.
+            // If this isn't done, then it happens too late, and the start/stop messages go out of order,
+            //  and next thing you know it thinks it's not pulling anything even though it is!
+
+            var oldPullable = puller.Pulling;
+            if (oldPullable != null)
+            {
+                if (oldPullable.TryGetComponent<SharedPullableComponent>(out var oldPullableComp))
+                {
+                    if (!oldPullableComp.TryStopPull())
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    Logger.WarningS("c.go.c.pulling", "Well now you've done it, haven't you? Someone transferred pulling (onto {0}) while presently pulling something that has no Pullable component (on {1})!", pullable.Owner, oldPullable);
+                    return;
+                }
+            }
+
+            // Ensure that the pullable is not currently being pulled.
+            // Same sort of reasons as before.
+
+            var oldPuller = pullable.Puller;
+            if (oldPuller != null)
+            {
+                if (!pullable.TryStopPull())
+                {
+                    return;
+                }
+            }
+
+            // Continue with pulling process.
+
+            var pullAttempt = new PullAttemptMessage(pullerPhysics, pullablePhysics);
+
+            eventBus.RaiseLocalEvent(puller.Owner.Uid, pullAttempt, broadcast: false);
+
+            if (pullAttempt.Cancelled)
+            {
+                return;
+            }
+
+            eventBus.RaiseLocalEvent(pullable.Owner.Uid, pullAttempt);
+
+            if (pullAttempt.Cancelled)
+            {
+                return;
+            }
+
+            ForceRelationship(puller, pullable);
+        }
+    }
+}

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -73,7 +73,7 @@ namespace Content.Shared.Pulling
             }
 
             var msg = new StopPullingEvent(user?.Uid);
-            pullable.Owner.EntityManager.EventBus.RaiseLocalEvent(pullable.Owner.Uid, msg);
+            RaiseLocalEvent(pullable.Owner.Uid, msg);
 
             if (msg.Cancelled) return false;
 
@@ -99,8 +99,6 @@ namespace Content.Shared.Pulling
         {
             if (puller.Pulling == pullable)
                 return true;
-
-            var eventBus = pullable.Owner.EntityManager.EventBus;
 
             // Pulling a new object : Perform sanity checks.
 
@@ -156,14 +154,14 @@ namespace Content.Shared.Pulling
 
             var pullAttempt = new PullAttemptMessage(pullerPhysics, pullablePhysics);
 
-            eventBus.RaiseLocalEvent(puller.Owner.Uid, pullAttempt, broadcast: false);
+            RaiseLocalEvent(puller.Owner.Uid, pullAttempt, broadcast: false);
 
             if (pullAttempt.Cancelled)
             {
                 return false;
             }
 
-            eventBus.RaiseLocalEvent(pullable.Owner.Uid, pullAttempt);
+            RaiseLocalEvent(pullable.Owner.Uid, pullAttempt);
 
             if (pullAttempt.Cancelled)
             {

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Alert;
+using Content.Shared.GameTicking;
+using Content.Shared.Input;
+using Content.Shared.Physics.Pull;
+using Content.Shared.Pulling.Components;
+using Content.Shared.Pulling.Events;
+using Content.Shared.Rotatable;
+using JetBrains.Annotations;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Players;
+using Robust.Shared.Log;
+
+namespace Content.Shared.Pulling
+{
+    public abstract partial class SharedPullingSystem : EntitySystem
+    {
+        public bool CanPull(IEntity puller, IEntity pulled)
+        {
+            if (!puller.HasComponent<SharedPullerComponent>())
+            {
+                return false;
+            }
+
+            if (!pulled.TryGetComponent<IPhysBody>(out var _physics))
+            {
+                return false;
+            }
+
+            if (_physics.BodyType == BodyType.Static)
+            {
+                return false;
+            }
+
+            if (puller == pulled)
+            {
+                return false;
+            }
+
+            if (!puller.IsInSameOrNoContainer(pulled))
+            {
+                return false;
+            }
+
+            var startPull = new StartPullAttemptEvent(puller, pulled);
+            RaiseLocalEvent(puller.Uid, startPull);
+            return !startPull.Cancelled;
+        }
+
+        public bool TogglePull(IEntity puller, SharedPullableComponent pullable)
+        {
+            if (pullable.Puller == puller)
+            {
+                return TryStopPull(pullable);
+            }
+            return TryStartPull(puller, pullable.Owner);
+        }
+
+        // -- Core attempted actions --
+
+        public bool TryStopPull(SharedPullableComponent pullable, IEntity? user = null)
+        {
+            if (!pullable.BeingPulled)
+            {
+                return false;
+            }
+
+            var msg = new StopPullingEvent(user?.Uid);
+            pullable.Owner.EntityManager.EventBus.RaiseLocalEvent(pullable.Owner.Uid, msg);
+
+            if (msg.Cancelled) return false;
+
+            _pullSm.ForceRelationship(null, pullable);
+            return true;
+        }
+
+        public bool TryStartPull(IEntity puller, IEntity pullable)
+        {
+            if (!puller.TryGetComponent<SharedPullerComponent>(out var pullerComp))
+            {
+                return false;
+            }
+            if (!pullable.TryGetComponent<SharedPullableComponent>(out var pullableComp))
+            {
+                return false;
+            }
+            return TryStartPull(pullerComp, pullableComp);
+        }
+
+        // The main "start pulling" function.
+        public bool TryStartPull(SharedPullerComponent puller, SharedPullableComponent pullable)
+        {
+            if (puller.Pulling == pullable)
+                return true;
+
+            var eventBus = pullable.Owner.EntityManager.EventBus;
+
+            // Pulling a new object : Perform sanity checks.
+
+            if (!EntitySystem.Get<SharedPullingSystem>().CanPull(puller.Owner, pullable.Owner))
+            {
+                return false;
+            }
+
+            if (!puller.Owner.TryGetComponent<PhysicsComponent>(out var pullerPhysics))
+            {
+                return false;
+            }
+
+            if (!pullable.Owner.TryGetComponent<PhysicsComponent>(out var pullablePhysics))
+            {
+                return false;
+            }
+
+            // Ensure that the puller is not currently pulling anything.
+            // If this isn't done, then it happens too late, and the start/stop messages go out of order,
+            //  and next thing you know it thinks it's not pulling anything even though it is!
+
+            var oldPullable = puller.Pulling;
+            if (oldPullable != null)
+            {
+                if (oldPullable.TryGetComponent<SharedPullableComponent>(out var oldPullableComp))
+                {
+                    if (!TryStopPull(oldPullableComp))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    Logger.WarningS("c.go.c.pulling", "Well now you've done it, haven't you? Someone transferred pulling (onto {0}) while presently pulling something that has no Pullable component (on {1})!", pullable.Owner, oldPullable);
+                    return false;
+                }
+            }
+
+            // Ensure that the pullable is not currently being pulled.
+            // Same sort of reasons as before.
+
+            var oldPuller = pullable.Puller;
+            if (oldPuller != null)
+            {
+                if (!TryStopPull(pullable))
+                {
+                    return false;
+                }
+            }
+
+            // Continue with pulling process.
+
+            var pullAttempt = new PullAttemptMessage(pullerPhysics, pullablePhysics);
+
+            eventBus.RaiseLocalEvent(puller.Owner.Uid, pullAttempt, broadcast: false);
+
+            if (pullAttempt.Cancelled)
+            {
+                return false;
+            }
+
+            eventBus.RaiseLocalEvent(pullable.Owner.Uid, pullAttempt);
+
+            if (pullAttempt.Cancelled)
+            {
+                return false;
+            }
+
+            _pullSm.ForceRelationship(puller, pullable);
+            return true;
+        }
+    }
+}

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -173,5 +173,26 @@ namespace Content.Shared.Pulling
             _pullSm.ForceRelationship(puller, pullable);
             return true;
         }
+
+        public bool TryMoveTo(SharedPullableComponent pullable, MapCoordinates to)
+        {
+            if (pullable.Puller == null)
+            {
+                return false;
+            }
+
+            if (!pullable.Owner.HasComponent<PhysicsComponent>())
+            {
+                return false;
+            }
+
+            _pullSm.ForceSetMovingTo(pullable, to);
+            return true;
+        }
+
+        public void StopMoveTo(SharedPullableComponent pullable)
+        {
+            _pullSm.ForceSetMovingTo(pullable, null);
+        }
     }
 }

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
@@ -125,7 +125,16 @@ namespace Content.Shared.Pulling
         private void PullerMoved(ref MoveEvent ev)
         {
             var puller = ev.Sender;
+
             if (!TryGetPulled(ev.Sender, out var pulled))
+            {
+                return;
+            }
+
+            // The pulled object may have already been deleted.
+            // TODO: Work out why. Monkey + meat spike is a good test for this,
+            //  assuming you're still pulling the monkey when it gets gibbed.
+            if (pulled.Deleted)
             {
                 return;
             }

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
@@ -241,6 +241,31 @@ namespace Content.Shared.Pulling
 
         public bool CanPull(IEntity puller, IEntity pulled)
         {
+            if (!puller.HasComponent<SharedPullerComponent>())
+            {
+                return false;
+            }
+
+            if (!pulled.TryGetComponent<IPhysBody>(out var _physics))
+            {
+                return false;
+            }
+
+            if (_physics.BodyType == BodyType.Static)
+            {
+                return false;
+            }
+
+            if (puller == pulled)
+            {
+                return false;
+            }
+
+            if (!puller.IsInSameOrNoContainer(pulled))
+            {
+                return false;
+            }
+
             var startPull = new StartPullAttemptEvent(puller, pulled);
             RaiseLocalEvent(puller.Uid, startPull);
             return !startPull.Cancelled;

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
@@ -150,7 +150,7 @@ namespace Content.Shared.Pulling
 
             if (pulled.TryGetComponent(out SharedPullableComponent? pullable))
             {
-                pullable.MovingTo = null;
+                _pullSm.ForceSetMovingTo(pullable, null);
             }
         }
 
@@ -194,7 +194,7 @@ namespace Content.Shared.Pulling
                 return false;
             }
 
-            pullable.TryMoveTo(coords.ToMap(EntityManager));
+            TryMoveTo(pullable, coords.ToMap(EntityManager));
 
             return false;
         }


### PR DESCRIPTION
## About the PR

Moves lots of logic out of the pulling components.
Fixes pulling bugs.
Undoes the weirdness the physics refactor did where it modified pulling state outside of the One True State Management Function.

Things this does do:
1. Makes use of F R I E N D S to properly secure the secure state management enclave this time around.
2. Removes all but the most critical logic from SharedPullableComponent and SharedPullerComponent in favour of migrating it between SharedPullingSystem (high-level) and SharedPullingStateManagementSystem (low-level).
3. Prevents errors when monkeys are deleted by moving stuff to Shutdown and applying advanced paranoia

Things this does not do:
1. This doesn't use the Resolve stuff yet.
2. This doesn't remove the exploit I just found where pull-to-location can be used to pull yourself around in zero-gravity. It seems like `SharedPullingSystem.PullerMoved` should be stopping this, but it doesn't.
3. This doesn't move the shutdown logic into events, mainly due to laziness on my part.

Specific test sequence to run on further edits to this PR:
1. Does pull move-to-location still work for various objects, *especially when those objects are not moving at the time move-to-location is activated*?
2. Does deleting something you are pulling crash?
3. Does killing a monkey and putting it in the meat spike crash?
4. Does pulling work when there is no gravity, and with what semantics?
5. Does pulling properly update walk and run speed?

This PR is immediately out-of-the-gate in "needs adoption" state.
It has been tested to work properly in it's current state, but I doubt it will pass code review.

**Changelog**

:cl:
- fix: Pull-to-location works again.
