### PR TITLE
3961 Hover item on hand switch

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Content.Client.Animations;
 using Content.Client.HUD;
+using Content.Client.Inventory;
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using JetBrains.Annotations;
@@ -46,6 +47,11 @@ namespace Content.Client.Hands
         {
             if (ev.Hands.Owner == _playerManager.LocalPlayer?.ControlledEntity)
                 GuiStateUpdated?.Invoke();
+
+            if (ev.Hands.Owner.TryGetComponent(out ClientInventoryComponent? inventory))
+            {
+               inventory.SendHoverMessage();
+            }
         }
 
         protected override void HandleContainerModified(EntityUid uid, SharedHandsComponent component, ContainerModifiedMessage args)

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -47,11 +47,6 @@ namespace Content.Client.Hands
         {
             if (ev.Hands.Owner == _playerManager.LocalPlayer?.ControlledEntity)
                 GuiStateUpdated?.Invoke();
-
-            if (ev.Hands.Owner.TryGetComponent(out ClientInventoryComponent? inventory))
-            {
-               inventory.SendHoverMessage();
-            }
         }
 
         protected override void HandleContainerModified(EntityUid uid, SharedHandsComponent component, ContainerModifiedMessage args)

--- a/Content.Client/Inventory/ClientInventoryComponent.cs
+++ b/Content.Client/Inventory/ClientInventoryComponent.cs
@@ -32,6 +32,7 @@ namespace Content.Client.Inventory
         private ISpriteComponent? _sprite;
 
         private bool _playerAttached = false;
+        private Slots _lastHoverSlot = Slots.NONE;
 
         [ViewVariables]
         [DataField("speciesId")] public string? SpeciesId { get; set; }
@@ -147,7 +148,9 @@ namespace Content.Client.Inventory
             if (state.HoverEntity != null)
             {
                 var (slot, (entityUid, fits)) = state.HoverEntity.Value;
-                var entity = Owner.EntityManager.GetEntity(entityUid);
+                var entity = entityUid == EntityUid.Invalid ? null : Owner.EntityManager.GetEntity(entityUid);
+
+                _lastHoverSlot = slot;
 
                 InterfaceController?.HoverInSlot(slot, entity, fits);
             }
@@ -239,6 +242,16 @@ namespace Content.Client.Inventory
         {
             var equipmessage = new ClientInventoryMessage(slot, ClientInventoryUpdate.Use);
             SendNetworkMessage(equipmessage);
+        }
+
+        public void SendHoverMessage()
+        {
+            if (_lastHoverSlot == Slots.NONE)
+            {
+                return;
+            }
+
+            SendNetworkMessage(new ClientInventoryMessage(_lastHoverSlot, ClientInventoryUpdate.Hover));
         }
 
         public void SendHoverMessage(Slots slot)

--- a/Content.Client/Inventory/HumanInventoryInterfaceController.cs
+++ b/Content.Client/Inventory/HumanInventoryInterfaceController.cs
@@ -184,7 +184,7 @@ namespace Content.Client.Inventory
             }
         }
 
-        public override void HoverInSlot(Slots slot, IEntity entity, bool fits)
+        public override void HoverInSlot(Slots slot, IEntity? entity, bool fits)
         {
             base.HoverInSlot(slot, entity, fits);
 

--- a/Content.Client/Inventory/InventoryInterfaceController.cs
+++ b/Content.Client/Inventory/InventoryInterfaceController.cs
@@ -50,7 +50,7 @@ namespace Content.Client.Inventory
         {
         }
 
-        public virtual void HoverInSlot(EquipmentSlotDefines.Slots slot, IEntity entity, bool fits)
+        public virtual void HoverInSlot(EquipmentSlotDefines.Slots slot, IEntity? entity, bool fits)
         {
         }
 

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -106,6 +106,8 @@ namespace Content.Server.Hands.Systems
                 return;
 
             hands.ActiveHand = nextHand;
+
+            UpdateHover(hands);
         }
 
         private bool DropPressed(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
@@ -124,7 +126,18 @@ namespace Content.Server.Hands.Systems
                 return false;
 
             hands.TryDropHand(activeHand, coords);
+
+            UpdateHover(hands);
+
             return false;
+        }
+
+        private static void UpdateHover(SharedHandsComponent hands)
+        {
+            if (hands.Owner.TryGetComponent(out InventoryComponent? component))
+            {
+                component.RaiseHoverMessage();
+            }
         }
 
         private void HandleMoveItemFromHand(MoveItemFromHandMsg msg, EntitySessionEventArgs args)

--- a/Content.Server/Inventory/Components/InventoryComponent.cs
+++ b/Content.Server/Inventory/Components/InventoryComponent.cs
@@ -521,6 +521,14 @@ namespace Content.Server.Inventory.Components
 
                         Dirty();
                     }
+                    else
+                    {
+                        _hoverEntity =
+                            new KeyValuePair<Slots, (EntityUid entity, bool fits)>(msg.Inventoryslot,
+                                (EntityUid.Invalid, false));
+
+                        Dirty();
+                    }
 
                     break;
                 }

--- a/Content.Server/Inventory/Components/InventoryComponent.cs
+++ b/Content.Server/Inventory/Components/InventoryComponent.cs
@@ -276,7 +276,13 @@ namespace Content.Server.Inventory.Components
                 reason = Loc.GetString("inventory-component-can-equip-cannot");
             }
 
-            var canEquip = pass && _slotContainers.ContainsKey(slot) && _slotContainers[slot].CanInsert(item.Owner);
+            var canInsert = false;
+            if (_slotContainers.TryGetValue(slot, out var containerSlot))
+            {
+                canInsert = containerSlot.CanInsert(item.Owner);
+            }
+
+            var canEquip = pass && canInsert;
 
             if (!canEquip)
             {
@@ -606,7 +612,11 @@ namespace Content.Server.Inventory.Components
                 slot = _lastHoveredSlot;
             }
 
-            var hands = Owner.GetComponent<HandsComponent>();
+            if (!Owner.TryGetComponent(out HandsComponent? hands))
+            {
+                return;
+            }
+
             var activeHand = hands.GetActiveHand;
             _lastHoveredSlot = slot;
             if (activeHand != null && GetSlotItem(slot) == null)

--- a/Content.Shared/Inventory/EquipmentSlotDefinitions.cs
+++ b/Content.Shared/Inventory/EquipmentSlotDefinitions.cs
@@ -119,6 +119,7 @@ namespace Content.Shared.Inventory
             {Slots.IDCARD, SlotFlags.IDCARD},
             {Slots.POCKET1, SlotFlags.POCKET},
             {Slots.POCKET2, SlotFlags.POCKET},
+            {Slots.NONE, SlotFlags.NONE},
         };
 
         // for shared string dict, since we don't define these anywhere in content


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #3961 

When switching hands, the client requests an update on the hover.

I do need some assistance on this, though- not sure if the update code is in the correct spot, because I get [WARN] net.ent: Got late MsgEntity! Diff: -3, msgT: 278, cT: 281, player: localhost@JoeGenero when the hands are switched and I'm not certain why.

**Screenshots**
![handswitch](https://user-images.githubusercontent.com/8854773/134929492-70b4535b-bf2b-4cc3-a741-6d687b48d15d.gif)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Moses
- fix: Hand switching updates hover icon

