### PR TITLE
Fix radiation dealing wrong damage type

### DIFF
--- a/Content.Shared/Damage/DamageableComponent.cs
+++ b/Content.Shared/Damage/DamageableComponent.cs
@@ -86,7 +86,7 @@ namespace Content.Shared.Damage
 
             // Radiation should really just be a damage group instead of a list of types.
             DamageSpecifier damage = new();
-            foreach (var typeID in ExplosionDamageTypeIDs)
+            foreach (var typeID in RadiationDamageTypeIDs)
             {
                 damage.DamageDict.Add(typeID, damageValue);
             }


### PR DESCRIPTION
Used the wrong damage types in `RadiationAct()`, sorry abut that. Radiation will be 50% less lethal to humans, and should no longer damage stuff it is not supposed to.

:cl:
- fix: Fixed radiation dealing wrong damage type.

