### PR TITLE
Fix time management bugs in RadiationPulseSystem

### DIFF
--- a/Content.Server/Radiation/RadiationPulseSystem.cs
+++ b/Content.Server/Radiation/RadiationPulseSystem.cs
@@ -20,15 +20,16 @@ namespace Content.Server.Radiation
         {
             base.Update(frameTime);
 
-            _accumulator += RadiationCooldown;
+            _accumulator += frameTime;
 
             while (_accumulator > RadiationCooldown)
             {
                 _accumulator -= RadiationCooldown;
 
+                // All code here runs effectively every RadiationCooldown seconds, so use that as the "frame time".
                 foreach (var comp in EntityManager.EntityQuery<RadiationPulseComponent>(true))
                 {
-                    comp.Update(frameTime);
+                    comp.Update(RadiationCooldown);
                     var ent = comp.Owner;
 
                     if (ent.Deleted) continue;


### PR DESCRIPTION
## About the PR

RadiationPulseSystem wasn't actually ticking every RadiationCooldown seconds, but was acting as if it was in some cases, making radiation rather instantly deadly.

**Changelog**

:cl:
- fix: Fixed radiation applying half a second's worth of damage each tick.
