### PR TITLE
atmos: fix AtmosDeviceSystem failing to join atmospheres

### DIFF
--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
@@ -32,7 +32,7 @@ namespace Content.Server.Atmos.Piping.EntitySystems
 
         private bool CanJoinAtmosphere(AtmosDeviceComponent component)
         {
-            return !component.RequireAnchored || !component.Owner.Transform.Anchored;
+            return !component.RequireAnchored || component.Owner.Transform.Anchored;
         }
 
         public void JoinAtmosphere(AtmosDeviceComponent component)


### PR DESCRIPTION
## About the PR
Atmos devices requiring anchoring refused to join the atmospheric system due to a typo. The typo'd version only permits atmos devices that do not require anchoring, or are *not* anchored. Obviously that doesn't work for anchored devices.

This PR fixes said typo.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
N/A

**Changelog**
:cl:
- fix: Anchored Atmos devices (Gas miners, etc.) refusing to work