### PR TITLE
Ghosts spawned specifically via map coordinates

### DIFF
--- a/Content.Server/GameTicking/Presets/GamePreset.cs
+++ b/Content.Server/GameTicking/Presets/GamePreset.cs
@@ -72,7 +72,7 @@ namespace Content.Server.GameTicking.Presets
             }
 
             var entityManager = IoCManager.Resolve<IEntityManager>();
-            var ghost = entityManager.SpawnEntity("MobObserver", position);
+            var ghost = entityManager.SpawnEntity("MobObserver", position.ToMap(entityManager));
             ghost.Name = mind.CharacterName ?? string.Empty;
 
             var ghostComponent = ghost.GetComponent<GhostComponent>();


### PR DESCRIPTION
## About the PR

Ought to fix #3987 (caused by ghost being parented to something it shouldn't), and ghost blackscreen (caused by PVS removal of that thing the ghost was parented to),

**Changelog**

:cl:
- fix: Ghosts should no longer go in weird directions and lose the ability to see when the body was inside something or buckled to something when the ghost was made.
