### PR TITLE
Set default Pow3r ramp rate/tolerance values

### DIFF
--- a/Content.Server/Power/Pow3r/PowerState.cs
+++ b/Content.Server/Power/Pow3r/PowerState.cs
@@ -350,8 +350,8 @@ namespace Content.Server.Power.Pow3r
             [ViewVariables(VVAccess.ReadWrite)] public bool Paused;
             [ViewVariables(VVAccess.ReadWrite)] public float MaxSupply;
 
-            [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampRate;
-            [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampTolerance;
+            [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampRate = 5000;
+            [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampTolerance = 5000;
 
             // == Runtime parameters ==
 
@@ -399,8 +399,8 @@ namespace Content.Server.Power.Pow3r
             [ViewVariables(VVAccess.ReadWrite)] public float MaxChargeRate;
             [ViewVariables(VVAccess.ReadWrite)] public float MaxThroughput; // 0 = infinite cuz imgui
             [ViewVariables(VVAccess.ReadWrite)] public float MaxSupply;
-            [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampTolerance;
-            [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampRate;
+            [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampTolerance = 5000;
+            [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampRate = 5000;
             [ViewVariables(VVAccess.ReadWrite)] public float Efficiency = 1;
 
             // == Runtime parameters ==


### PR DESCRIPTION

## About the PR

The AME wasn't actually generating power (ramp rate/tolerance were both 0)
It is probably safe to assume this is a general issue.

(Note to cover "but why put in defaults instead of fixing the prototypes?": Not having defaults here implies there needs to be a warning of some sort - consider that nobody knew AME was completely useless.)

**Changelog**

:cl:
- fix: Anti-matter engine actually generates power again.
