### PR TITLE
Lower Saltern generator power to balance things out

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/saltern_power.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/saltern_power.yml
@@ -3,7 +3,7 @@
   id: SalternGenerator
   components:
   - type: PowerSupplier
-    supplyRate: 30000
+    supplyRate: 3000
 
 - type: entity
   parent: BaseSmes


### PR DESCRIPTION
## About the PR

Means engineering actually have to setup AME again.

*Big Very Obvious Warning: This PR REQUIRES https://github.com/space-wizards/space-station-14/pull/4748 because otherwise the station will be left without any way to get power.*
*Most importantly, the AME must be capable of producing power. It doesn't matter if it's more power than the station will ever need, it's just important that if Engineering turn on the AME, it should be expected to hold station power for now.*

I have determined through repeatedly using `drainallbatteries` with different generator values that at present, Saltern's power budget is around 11k to 13kw. (Keep in mind that at the absolute edge, it will take a while for batteries to charge.)

This PR has been marked as a draft until that PR is merged to prevent any accidents.

**Changelog**

:cl:
- fix: Saltern default generators no longer act as effectively an infinite source of power.
