### PR TITLE
Update UI when the AME node group is changed, fix AME connection issues

### DIFF
--- a/Content.Server/AME/AMENodeGroup.cs
+++ b/Content.Server/AME/AMENodeGroup.cs
@@ -46,11 +46,6 @@ namespace Content.Server.AME
             foreach (var node in groupNodes)
             {
                 var nodeOwner = node.Owner;
-                if (nodeOwner.TryGetComponent(out AMEControllerComponent? controller))
-                {
-                    _masterController = controller;
-                }
-
                 if (nodeOwner.TryGetComponent(out AMEShieldComponent? shield))
                 {
                     var nodeNeighbors = grid.GetCellsInSquareArea(nodeOwner.Transform.Coordinates, 1)
@@ -66,6 +61,21 @@ namespace Content.Server.AME
                     {
                         shield.UnsetCore();
                     }
+                }
+            }
+
+            // Separate to ensure core count is correctly updated.
+            foreach (var node in groupNodes)
+            {
+                var nodeOwner = node.Owner;
+                if (nodeOwner.TryGetComponent(out AMEControllerComponent? controller))
+                {
+                    if (_masterController == null)
+                    {
+                        // Has to be the first one, as otherwise IsMasterController will return true on them all for this first update.
+                        _masterController = controller;
+                    }
+                    controller.OnAMENodeGroupUpdate();
                 }
             }
         }

--- a/Content.Server/AME/AMENodeGroup.cs
+++ b/Content.Server/AME/AMENodeGroup.cs
@@ -56,6 +56,7 @@ namespace Content.Server.AME
                     {
                         _cores.Add(shield);
                         shield.SetCore();
+                        // Core visuals will be updated later.
                     }
                     else
                     {
@@ -78,10 +79,21 @@ namespace Content.Server.AME
                     controller.OnAMENodeGroupUpdate();
                 }
             }
+
+            UpdateCoreVisuals();
         }
 
-        public void UpdateCoreVisuals(int injectionAmount, bool injecting)
+        public void UpdateCoreVisuals()
         {
+            var injectionAmount = 0;
+            var injecting = false;
+
+            if (_masterController != null)
+            {
+                injectionAmount = _masterController.InjectionAmount;
+                injecting = _masterController.Injecting;
+            }
+
             var injectionStrength = CoreCount > 0 ? injectionAmount / CoreCount : 0;
 
             foreach (AMEShieldComponent core in _cores)

--- a/Content.Server/AME/Components/AMEControllerComponent.cs
+++ b/Content.Server/AME/Components/AMEControllerComponent.cs
@@ -137,6 +137,12 @@ namespace Content.Server.AME.Components
             UpdateUserInterface();
         }
 
+        // Used to update core count
+        public void OnAMENodeGroupUpdate()
+        {
+            UpdateUserInterface();
+        }
+
         private AMEControllerBoundUserInterfaceState GetUserInterfaceState()
         {
             var jar = _jarSlot.ContainedEntity;

--- a/Content.Server/AME/Components/AMEControllerComponent.cs
+++ b/Content.Server/AME/Components/AMEControllerComponent.cs
@@ -27,7 +27,8 @@ namespace Content.Server.AME.Components
     public class AMEControllerComponent : SharedAMEControllerComponent, IActivate, IInteractUsing
     {
         [ViewVariables] private BoundUserInterface? UserInterface => Owner.GetUIOrNull(AMEControllerUiKey.Key);
-        [ViewVariables] private bool _injecting;
+        private bool _injecting;
+        [ViewVariables] public bool Injecting => _injecting;
         [ViewVariables] public int InjectionAmount;
 
         private AppearanceComponent? _appearance;
@@ -222,7 +223,7 @@ namespace Content.Server.AME.Components
                     break;
             }
 
-            GetAMENodeGroup()?.UpdateCoreVisuals(InjectionAmount, _injecting);
+            GetAMENodeGroup()?.UpdateCoreVisuals();
 
             UpdateUserInterface();
             ClickSound();

--- a/Content.Server/AME/Components/AMEShieldComponent.cs
+++ b/Content.Server/AME/Components/AMEShieldComponent.cs
@@ -36,6 +36,7 @@ namespace Content.Server.AME.Components
         {
             _isCore = false;
             _appearance?.SetData(AMEShieldVisuals.Core, "isNotCore");
+            UpdateCoreVisuals(0, false);
         }
 
         public void UpdateCoreVisuals(int injectionStrength, bool injecting)

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -56,7 +56,7 @@
     examinable: true
     nodes:
       ame:
-        !type:CableDeviceNode
+        !type:AdjacentNode
         nodeGroupID: AMEngine
       input:
         !type:CableDeviceNode


### PR DESCRIPTION
This fixes the AME core count indicator being out of date, and fixes the node setup so they all use AdjacentNode instead of the AME itself using CableDeviceNode.

## About the PR

**Changelog**

:cl:
- fix: Updates AME core count indicator as the layout changes.
- fix: AME connection issues shouldn't occur anymore.
