### PR TITLE
Singularity is much more visible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -36,6 +36,9 @@
     sprite: Structures/Power/Generation/Singularity/singularity_1.rsi
     state: singularity_1
     drawdepth: Items
+  - type: PointLight
+    enabled: true
+    radius: 10
   - type: Appearance
     visuals:
     - type: SingularityVisualizer

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -30,6 +30,7 @@
   - type: Sprite
     sprite: Structures/Power/Generation/Singularity/singularity_1.rsi
     state: singularity_1
+    shader: unshaded
     netsync: false
   - type: Icon
     sprite: Structures/Power/Generation/Singularity/singularity_1.rsi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Closes #4721.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

Before
![Content Client_2021-10-03_14-31-28](https://user-images.githubusercontent.com/49448379/135772185-fa2fad39-5194-400d-9d05-2b915d3e0d9d.png)
After
![Content Client_2021-10-03_14-30-36](https://user-images.githubusercontent.com/49448379/135772189-3857adce-808a-480c-9b41-101fdc0a500c.png)
Before
![Content Client_2021-10-03_14-31-24](https://user-images.githubusercontent.com/49448379/135772178-d9b132ef-d972-4d71-820b-a6f75cb2930a.png)
After
![Content Client_2021-10-03_14-30-41](https://user-images.githubusercontent.com/49448379/135772183-43172feb-2066-41ec-9b4b-3b02240399aa.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Swept
- tweak: Singularity should be much easier to see now


