### PR TITLE
Tiny bugfix to prevent double popup message on unlock attempt.

### DIFF
--- a/Content.Server/Lock/LockSystem.cs
+++ b/Content.Server/Lock/LockSystem.cs
@@ -46,11 +46,13 @@ namespace Content.Server.Lock
             // Only attempt an unlock by default on Activate
             if (lockComp.Locked)
             {
-                args.Handled = TryUnlock(uid, args.User, lockComp);
+                TryUnlock(uid, args.User, lockComp);
+                args.Handled = true;
             }
             else if (lockComp.LockOnClick)
             {
-                args.Handled = TryLock(uid, args.User, lockComp);
+                TryLock(uid, args.User, lockComp);
+                args.Handled = true;
             }
         }
 


### PR DESCRIPTION
I introduced a bug in #4594 which results in a double-popup when attempting to unlock something without permission.

The lock system was just not properly marking an interaction as handled, resulting in it generating a "Access denied" popup while the `EntityStorageComponent` resulted in a "It's Locked!" popup.

Currently:
![bug](https://user-images.githubusercontent.com/60421075/136038939-15183466-b135-493f-b0cb-6485d58da9a2.png)
Fixed:
![after_fix](https://user-images.githubusercontent.com/60421075/136038950-ff8c634c-591c-4e63-83b1-54cb7fb082d0.png)