### PR TITLE
Various improvements to job greetings.

### DIFF
--- a/Content.Server/Roles/Job.cs
+++ b/Content.Server/Roles/Job.cs
@@ -1,6 +1,7 @@
 using Content.Server.Chat.Managers;
 using Content.Shared.Roles;
 using Robust.Shared.IoC;
+using Robust.Shared.Localization;
 
 namespace Content.Server.Roles
 {
@@ -26,7 +27,16 @@ namespace Content.Server.Roles
             if (Mind.TryGetSession(out var session))
             {
                 var chat = IoCManager.Resolve<IChatManager>();
-                chat.DispatchServerMessage(session, $"You're a new {Name}. Do your best!");
+                chat.DispatchServerMessage(session, Loc.GetString("job-greet-introduce-job-name", ("jobName", Name)));
+
+                if(Prototype.RequireAdminNotify)
+                    chat.DispatchServerMessage(session, Loc.GetString("job-greet-important-disconnect-admin-notify"));
+
+                chat.DispatchServerMessage(session, Loc.GetString("job-greet-supervisors-warning", ("jobName", Name), ("supervisors", Prototype.Supervisors)));
+
+                if(Prototype.JoinNotifyCrew && Mind.CharacterName != null)
+                    chat.DispatchStationAnnouncement(Loc.GetString("job-greet-join-notify-crew", ("jobName", Name), ("characterName", Mind.CharacterName)),
+                        Loc.GetString("job-greet-join-notify-crew-announcer"));
             }
         }
     }

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -18,11 +18,20 @@ namespace Content.Shared.Roles
         [DataField("id", required: true)]
         public string ID { get; } = default!;
 
+        [DataField("supervisors")]
+        public string Supervisors { get; } = "nobody";
+
         /// <summary>
         ///     The name of this job as displayed to players.
         /// </summary>
         [DataField("name")]
         public string Name { get; } = string.Empty;
+
+        [DataField("joinNotifyCrew")]
+        public bool JoinNotifyCrew { get; } = false;
+
+        [DataField("requireAdminNotify")]
+        public bool RequireAdminNotify { get; } = false;
 
         /// <summary>
         ///     Whether this job is a head.

--- a/Resources/Locale/en-US/job/job.ftl
+++ b/Resources/Locale/en-US/job/job.ftl
@@ -1,0 +1,5 @@
+job-greet-introduce-job-name = You are the {$jobName}.
+job-greet-important-disconnect-admin-notify = You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins.
+job-greet-supervisors-warning = As the {$jobName} you answer directly to {$supervisors}. Special circumstances may change this.
+job-greet-join-notify-crew = { CAPITALIZE($jobName)} {$characterName} on deck!
+job-greet-join-notify-crew-announcer = Station

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -7,6 +7,7 @@
   departments:
   - Cargo
   icon: "CargoTechnician"
+  supervisors: "the head of personnel" # TODO: Change this to include the QM when it gets in.
   access:
   - Cargo
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -7,6 +7,7 @@
 #  departments:
 #  - Cargo
 #  icon: "QuarterMaster"
+#  supervisors: "the head of personnel"
 #  access:
 #  - Cargo
 #  - Quartermaster

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -6,6 +6,7 @@
   departments:
   - Civilian
   icon: "Assistant"
+  supervisors: "absolutely everyone"
   access:
   - Maintenance
 

--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -6,6 +6,7 @@
   departments:
   - Civilian
   icon: "Bartender"
+  supervisors: "the head of personnel"
   access:
   - Service
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
@@ -7,6 +7,7 @@
   departments:
   - Civilian
   icon: "Botanist"
+  supervisors: "the head of personnel"
   access:
   - Service
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -6,6 +6,7 @@
 #  departments:
 #  - Civilian
 #  icon: "Chaplain"
+#  supervisors: "the head of personnel"
 #  access:
 #  - Chapel
 #  - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -6,6 +6,7 @@
   departments:
   - Civilian
   icon: "Chef"
+  supervisors: "the head of personnel"
   access:
   - Service
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -6,6 +6,7 @@
   departments:
   - Civilian
   icon: "Clown"
+  supervisors: "the head of personnel"
   access:
   - Theatre
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -6,6 +6,7 @@
   departments:
   - Civilian
   icon: "Janitor"
+  supervisors: "the head of personnel"
   access:
   - Janitor
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -6,6 +6,7 @@
   departments:
   - Civilian
   icon: "Mime"
+  supervisors: "the head of personnel"
   access:
   - Theatre
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -7,6 +7,9 @@
   departments:
   - Command
   icon: "Captain"
+  requireAdminNotify: true
+  joinNotifyCrew: true
+  supervisors: "Nanotrasen officials"
   access:
   # All of em.
   # Could probably do with some kind of wildcard or whatever to automate this.

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -7,6 +7,8 @@
   - Command
   - Civilian
   icon: "HeadOfPersonnel"
+  requireAdminNotify: true
+  supervisors: "the captain"
   access:
   - Command
   - HeadOfPersonnel

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -8,6 +8,8 @@
   - Command
   - Engineering
   icon: "ChiefEngineer"
+  requireAdminNotify: true
+  supervisors: "the captain"
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -7,6 +7,7 @@
   departments:
   - Engineering
   icon: "StationEngineer"
+  supervisors: "the chief engineer"
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -10,6 +10,8 @@
   - Command
   - Medical
   icon: "ChiefMedicalOfficer"
+  requireAdminNotify: true
+  supervisors: "the captain"
   access:
   - Medical
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -7,6 +7,7 @@
   departments:
   - Medical
   icon: "MedicalDoctor"
+  supervisors: "the chief medical officer"
   access:
   - Medical
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -8,6 +8,8 @@
   - Command
   - Science
   icon: "ResearchDirector"
+  requireAdminNotify: true
+  supervisors: "the captain"
   access:
   - Research
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -7,6 +7,7 @@
   departments:
   - Science
   icon: "Scientist"
+  supervisors: "the research director"
   access:
   - Research
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -8,6 +8,8 @@
   - Command
   - Security
   icon: "HeadOfSecurity"
+  requireAdminNotify: true
+  supervisors: "the captain"
   access:
   - Command
   - Brig

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -7,6 +7,7 @@
   departments:
   - Security
   icon: "SecurityOfficer"
+  supervisors: "the head of security"
   access:
   - Security
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -7,6 +7,7 @@
 #   departments:
 #   - Security
 #   icon: "Warden"
+#   supervisors: "the head of security"
 #   access:
 #   - Security
 #   - Brig


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR improves the job greet significantly.
- Added a text telling the player who their supervisors are.
- Added a text telling players with head jobs to notify admins if they have to disconnect.
- Added a station announcement when there's a captain on deck.

**Screenshots**
Roundstart "captain on deck" announcement:
![image](https://user-images.githubusercontent.com/6766154/136189985-6e87d8a4-2da2-447b-a402-5c5c507a7194.png)
Latejoin janitor greeting.
![image](https://user-images.githubusercontent.com/6766154/136190128-ed7dd00f-b52d-4af0-bdab-fdaa06bbafe7.png)

**Changelog**
:cl:
- tweak: Improved the join greeting text. Now you can easily know who your supervisors are!
- tweak: A station announcement will be sent when there's a captain on deck.

