### PR TITLE
Change Offset to take AtmosDirection instead of Direction

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Grid.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Grid.cs
@@ -304,7 +304,7 @@ namespace Content.Server.Atmos.EntitySystems
                 for (var i = 0; i < Atmospherics.Directions; i++)
                 {
                     var direction = (AtmosDirection) (1 << i);
-                    var otherIndices = indices.Offset(direction.ToDirection());
+                    var otherIndices = indices.Offset(direction);
                     var otherTile = GetTileAtmosphereOrCreateSpace(mapGrid, gridAtmosphere, otherIndices);
                     if (otherTile != null)
                         AddActiveTile(gridAtmosphere, otherTile);
@@ -1100,7 +1100,7 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 var direction = (AtmosDirection) (1 << i);
 
-                var otherIndices = tileAtmosphere.GridIndices.Offset(direction.ToDirection());
+                var otherIndices = tileAtmosphere.GridIndices.Offset(direction);
 
                 var adjacent = GetTileAtmosphereOrCreateSpace(mapGrid, gridAtmosphere, otherIndices);
                 tileAtmosphere.AdjacentTiles[direction.ToIndex()] = adjacent;
@@ -1168,9 +1168,9 @@ namespace Content.Server.Atmos.EntitySystems
         /// <param name="direction">Direction to be updated.</param>
         private void UpdateAdjacent(IMapGrid mapGrid, GridAtmosphereComponent gridAtmosphere, TileAtmosphere tile, AtmosDirection direction)
         {
-            tile.AdjacentTiles[direction.ToIndex()] = GetTileAtmosphereOrCreateSpace(mapGrid, gridAtmosphere, tile.GridIndices.Offset(direction.ToDirection()));
+            tile.AdjacentTiles[direction.ToIndex()] = GetTileAtmosphereOrCreateSpace(mapGrid, gridAtmosphere, tile.GridIndices.Offset(direction));
 
-            if (!tile.BlockedAirflow.IsFlagSet(direction) && !IsTileAirBlocked(mapGrid, tile.GridIndices.Offset(direction.ToDirection()), direction.GetOpposite()))
+            if (!tile.BlockedAirflow.IsFlagSet(direction) && !IsTileAirBlocked(mapGrid, tile.GridIndices.Offset(direction), direction.GetOpposite()))
             {
                 tile.AdjacentBits |= direction;
             }

--- a/Content.Shared/Atmos/AtmosDirection.cs
+++ b/Content.Shared/Atmos/AtmosDirection.cs
@@ -143,24 +143,24 @@ namespace Content.Shared.Atmos
             return (direction & other) == other;
         }
 
-        public static Vector2i CardinalToIntVec(this Direction dir)
+        public static Vector2i CardinalToIntVec(this AtmosDirection dir)
         {
             switch (dir)
             {
-                case Direction.North:
+                case AtmosDirection.North:
                     return new Vector2i(0, 1);
-                case Direction.East:
+                case AtmosDirection.East:
                     return new Vector2i(1, 0);
-                case Direction.South:
+                case AtmosDirection.South:
                     return new Vector2i(0, -1);
-                case Direction.West:
+                case AtmosDirection.West:
                     return new Vector2i(-1, 0);
                 default:
                     throw new ArgumentException($"Direction dir {dir} is not a cardinal direction", nameof(dir));
             }
         }
 
-        public static Vector2i Offset(this Vector2i pos, Direction dir)
+        public static Vector2i Offset(this Vector2i pos, AtmosDirection dir)
         {
             return pos + dir.CardinalToIntVec();
         }


### PR DESCRIPTION
## About the PR 
Changes `Offset(this Vector2i pos, Direction dir)` to `Offset(this Vector2i pos, AtmosDirection)` which clears things a bit
and prepares for some changes in space-wizards/RobustToolbox#2093

**Changelog**
Just a tiny refactor. No obvious impact should be there.

