### PR TITLE
RSI Diff Bot

### DIFF
--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -3,8 +3,8 @@ name: Diff RSIs
 on:
   pull_request:
     paths:
-      - *.rsi*
-      - *.RSI*
+      - '*.rsi*'
+      - '*.RSI*'
 
 jobs:
   diff:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Closes #4491

Relevant repo/actual code: https://github.com/mirrorcult/RSIDiffBot

RSIDiffBot is a github action for generating a nice pretty table of all changes to an RSI. It only runs on PRs, comments the table (but updates it on further commits, doesn't make more comments) and only runs when an RSI actually changes.

Some things to note:
- Needs to be tested with this repository, I am having Swept make a PR for this so we can test the diff
- Might want to fork my RSIDiffBot and move it to the space-wizards org

**Screenshots**

![image](https://user-images.githubusercontent.com/19853115/136316029-675d1443-70df-49e2-aba8-eb08592f707e.png)

