### PR TITLE
Normalizes the permissions of some commands.

### DIFF
--- a/Content.Server/Administration/Commands/DeleteComponent.cs
+++ b/Content.Server/Administration/Commands/DeleteComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.Administration.Commands
 {
-    [AdminCommand(AdminFlags.Admin)]
+    [AdminCommand(AdminFlags.VarEdit)]
     public class DeleteComponent : IConsoleCommand
     {
         public string Command => "deletecomponent";

--- a/Content.Server/Administration/Commands/DeleteEntitiesWithComponent.cs
+++ b/Content.Server/Administration/Commands/DeleteEntitiesWithComponent.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Localization;
 
 namespace Content.Server.Administration.Commands
 {
-    [AdminCommand(AdminFlags.Admin)]
+    [AdminCommand(AdminFlags.VarEdit)]
     class DeleteEntitiesWithComponent : IConsoleCommand
     {
         public string Command => "deleteewc";

--- a/Content.Server/Administration/Commands/DeleteEntitiesWithId.cs
+++ b/Content.Server/Administration/Commands/DeleteEntitiesWithId.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Content.Server.Administration.Commands
 {
-    [AdminCommand(AdminFlags.Admin)]
+    [AdminCommand(AdminFlags.Spawn)]
     public class DeleteEntitiesWithId : IConsoleCommand
     {
         public string Command => "deleteewi";

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -3,7 +3,7 @@
   - help
   - list
 
-- Flags: FUN
+- Flags: VAREDIT
   Commands:
   - addcomp
   - rmcomp


### PR DESCRIPTION

## About the PR
`deletecomponent` has moved to VarEdit, `deleteewc` has moved to VarEdit, `deleteewi` has moved to Spawn, `addcomp` and `rmcomp` have moved to VarEdit.

The VV menu implements functionality using `addcomp` and `rmcomp`, so they should be usable by anyone with VV rights.
`deletecomponent` and `deleteewc` both have to deal with manipulating components, so they felt like they belonged under VV rights too. `deleteewi` has to deal with deleting entities with specific prototypes, so it felt like it belonged under Spawn, but the line is a bit blurry.