### PR TITLE
Doors no longer have murderous intent

### DIFF
--- a/Content.Server/Doors/Components/ServerDoorComponent.cs
+++ b/Content.Server/Doors/Components/ServerDoorComponent.cs
@@ -446,7 +446,8 @@ namespace Content.Server.Doors.Components
                 // Use this version so we can ignore the CanCollide being false
                 foreach(var e in broadPhaseSystem.GetCollidingEntities(physicsComponent.Owner.Transform.MapID, physicsComponent.GetWorldAABB()))
                 {
-                    if ((physicsComponent.CollisionMask & e.CollisionLayer) != 0 && broadPhaseSystem.IntersectionPercent(physicsComponent, e) > 0.01f) return true;
+                    if (((physicsComponent.CollisionMask & e.CollisionLayer) | (e.CollisionMask & physicsComponent.CollisionLayer)) != 0
+                        && broadPhaseSystem.IntersectionPercent(physicsComponent, e) > 0.01f) return true;
                 }
             }
             return false;


### PR DESCRIPTION
## About the PR
doors no longer violently crush people for no apparent reason

**Changelog**
:cl: moony
- fix: Fixed doors having murderous intent on unrotated stations.

