### PR TITLE
Add verb to reset rotation of rotatable entities

### DIFF
--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -42,12 +42,21 @@ namespace Content.Server.Rotatable
                 physics.BodyType == BodyType.Static)
                 return;
 
+            Verb resetRotation = new();
+            resetRotation.Act = () => component.Owner.Transform.LocalRotation = Angle.Zero;
+            resetRotation.Category = VerbCategory.Rotate;
+            resetRotation.IconTexture = "/Textures/Interface/VerbIcons/refresh.svg.192dpi.png";
+            resetRotation.Text = "Reset";
+            resetRotation.Priority = -2; // show CCW, then CW, then reset
+            resetRotation.CloseMenu = false;
+            args.Verbs.Add(resetRotation);
+
             // rotate clockwise
             Verb rotateCW = new();
             rotateCW.Act = () => component.Owner.Transform.LocalRotation += Angle.FromDegrees(-90);
             rotateCW.Category = VerbCategory.Rotate;
             rotateCW.IconTexture =  "/Textures/Interface/VerbIcons/rotate_cw.svg.192dpi.png";
-            rotateCW.Priority = -2; // show CCW, then CW
+            rotateCW.Priority = -1;
             rotateCW.CloseMenu = false; // allow for easy double rotations.
             args.Verbs.Add(rotateCW);
 
@@ -56,7 +65,7 @@ namespace Content.Server.Rotatable
             rotateCCW.Act = () => component.Owner.Transform.LocalRotation += Angle.FromDegrees(90);
             rotateCCW.Category = VerbCategory.Rotate;
             rotateCCW.IconTexture = "/Textures/Interface/VerbIcons/rotate_ccw.svg.192dpi.png";
-            rotateCCW.Priority = -1;
+            rotateCCW.Priority = 0;
             rotateCCW.CloseMenu = false; // allow for easy double rotations.
             args.Verbs.Add(rotateCCW);
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

An issue that T-Stalker pointed out is that rotatable entities like pianos and such can be rotated to non-cardinal angles by pulling them or having them be thrown (causing them to be essentially permanently offset), so this adds a simple verb to the rotate menu that lets you reset rotation to 0.

**Screenshots**
![image](https://user-images.githubusercontent.com/19853115/136633749-03bb7305-8ad4-45b7-8958-c7abe89e37ea.png)

**Changelog**

:cl:
- add: Added a verb to rotatable entities to reset rotation back to 0.

