### PR TITLE
Ensure pulling maximum length is at least 1 to avoid errors

### DIFF
--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -108,9 +108,10 @@ namespace Content.Shared.Pulling
 
                 pullable.PullJoint = _jointSystem.CreateDistanceJoint(pullablePhysics.Owner.Uid, pullerPhysics.Owner.Uid, id:$"pull-joint-{pullablePhysics.Owner.Uid}");
                 pullable.PullJoint.CollideConnected = false;
+                // This maximum has to be there because if the object is constrained too closely, the clamping goes backwards and asserts.
+                pullable.PullJoint.MaxLength = Math.Max(1.0f, length);
                 pullable.PullJoint.Length = length * 0.75f;
                 pullable.PullJoint.MinLength = 0f;
-                pullable.PullJoint.MaxLength = length;
                 pullable.PullJoint.Stiffness = 1f;
 
                 // Messaging


### PR DESCRIPTION
This bit of the logic is weird, honestly.

## About the PR

To recreate the bug, pull something that you are abnormally close to.
(It seems to be possible to pull something you're buckled to - not sure what's going on there, but that's an example I suppose.)

**Changelog**

:cl:
- fix: Pulling an abnormally close object shouldn't cause errors

