### PR TITLE
Fix puddle spilling properly

### DIFF
--- a/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
@@ -214,8 +214,14 @@ namespace Content.IntegrationTests.Tests.Fluids
                 // Check that the puddle is unpaused
                 Assert.False(sPuddle.Owner.Paused);
 
-                // By now, the puddle should have evaporated and deleted.
-                Assert.True(sPuddle.Deleted);
+                // Check that the puddle has evaporated some of its volume
+                Assert.That(sPuddle.CurrentVolume, Is.LessThan(sPuddleStartingVolume));
+
+                // If its new volume is zero it should have been deleted
+                if (sPuddle.CurrentVolume == ReagentUnit.Zero)
+                {
+                    Assert.True(sPuddle.Deleted);
+                }
             });
         }
     }

--- a/Content.Shared/Chemistry/EntitySystems/SolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionContainerSystem.cs
@@ -50,9 +50,12 @@ namespace Content.Shared.Chemistry.EntitySystems
             foreach (var keyValue in component.Solutions)
             {
                 var solutionHolder = keyValue.Value;
-                solutionHolder.MaxVolume = solutionHolder.TotalVolume > solutionHolder.InitialMaxVolume
-                    ? solutionHolder.TotalVolume
-                    : solutionHolder.InitialMaxVolume;
+                if (solutionHolder.MaxVolume == ReagentUnit.Zero)
+                {
+                    solutionHolder.MaxVolume = solutionHolder.TotalVolume > solutionHolder.InitialMaxVolume
+                        ? solutionHolder.TotalVolume
+                        : solutionHolder.InitialMaxVolume;
+                }
 
                 UpdateAppearance(uid, solutionHolder);
             }


### PR DESCRIPTION
## About the PR 
Back when 478909dcbbf547be31e0305c06099ea251e41203 was being added, I wondered why tests were falling. The tests were removed. Apparently, the reason was that `maxVol` is being set in puddles, but if puddles set their values to `1000u` on init. Without this, puddles don't start properly.

**Screenshots**
Before
![Content Client_C3PjY0f8ZN](https://user-images.githubusercontent.com/1146204/136661297-0e8a7232-93e0-4ac5-8974-162663a475d5.png)
After
![Content Client_QleLCjMtIz](https://user-images.githubusercontent.com/1146204/136661302-53bb6b50-174d-479a-8dc1-0e9ae42d8c6b.png)


**Changelog**
:cl:
- fix: Fixed puddles not spilling into neighboring tiles.

