### PR TITLE
Makes announcements a +ADMIN command instead of a +FUN command.

### DIFF
--- a/Content.Server/Administration/Commands/AnnounceUiCommand.cs
+++ b/Content.Server/Administration/Commands/AnnounceUiCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.Administration.Commands
 {
-    [AdminCommand(AdminFlags.Fun)]
+    [AdminCommand(AdminFlags.Admin)]
     public class AnnounceUiCommand : IConsoleCommand
     {
         public string Command => "announceui";

--- a/Content.Server/Administration/UI/AdminAnnounceEui.cs
+++ b/Content.Server/Administration/UI/AdminAnnounceEui.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Administration.UI
                     Close();
                     break;
                 case AdminAnnounceEuiMsg.DoAnnounce doAnnounce:
-                    if (!_adminManager.HasAdminFlag(Player, AdminFlags.Fun))
+                    if (!_adminManager.HasAdminFlag(Player, AdminFlags.Admin))
                     {
                         Close();
                         break;

--- a/Content.Server/Announcements/AnnounceCommand.cs
+++ b/Content.Server/Announcements/AnnounceCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.Announcements
 {
-    [AdminCommand(AdminFlags.Fun)]
+    [AdminCommand(AdminFlags.Admin)]
     public class AnnounceCommand : IConsoleCommand
     {
         public string Command => "announce";


### PR DESCRIPTION
## About the PR
Anyone with `aghost` can waltz up to a shuttle console and use it, so made sense to simply make announcement access +ADMIN. Also makes administration easier, as `announceui` permits making server announcements.
