### PR TITLE
client/atmos: Fix pipe overlay rotation

### DIFF
--- a/Content.Client/Atmos/Visualizers/PipeConnectorVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/PipeConnectorVisualizer.cs
@@ -61,6 +61,8 @@ namespace Content.Client.Atmos.Visualizers
         {
             base.OnChangeData(component);
 
+            if (!component.Owner.TryGetComponent<ITransformComponent>(out var xform))
+                return;
             if (!component.Owner.TryGetComponent<ISpriteComponent>(out var sprite))
                 return;
 
@@ -75,7 +77,7 @@ namespace Content.Client.Atmos.Visualizers
 
             foreach (Layer layerKey in Enum.GetValues(typeof(Layer)))
             {
-                var dir = (PipeDirection) layerKey;
+                var dir = ((PipeDirection) layerKey).RotatePipeDirection(xform.WorldRotation);
                 var layerVisible = state.ConnectedDirections.HasDirection(dir);
 
                 var layer = sprite.LayerMapGet(layerKey);


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The Pipe Connection Visualizer failed to account for entity rotation,
making the connection overlay sprites appear out of sync with the actual
entity connections.

**NB:** I don't know if it should technically be `WorldRotation` or `LocalRotation`, but `WorldRotation` seems to work fine, incl. on spinning grids, so I'm calling it done.

**Screenshots**
_Before_:
![Screenshot from 2021-10-10 02-55-55](https://user-images.githubusercontent.com/602406/136688037-08063a7a-f517-4139-966d-1b87066ea08c.png)
![Screenshot from 2021-10-10 02-55-37](https://user-images.githubusercontent.com/602406/136688039-a9ed6264-cf0a-4b89-ade7-0dc74afed0ec.png)

_After_:
![Screenshot from 2021-10-10 04-18-22](https://user-images.githubusercontent.com/602406/136688161-d0e01026-9fb8-4ff1-95e4-738e19c32185.png)
![Screenshot from 2021-10-10 04-17-58](https://user-images.githubusercontent.com/602406/136688164-d677ee3f-99a7-435d-995b-6180cf9d591c.png)
(No I don't know why they're offset like that. I'm blaming the sprites.)

**Changelog**

N/A