### PR TITLE
protoypes/atmos: fix trinary port directions

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -11,15 +11,15 @@
         inlet:
           !type:PipeNode
           nodeGroupID: Pipe
-          pipeDirection: North
+          pipeDirection: West
         filter:
           !type:PipeNode
           nodeGroupID: Pipe
-          pipeDirection: East
+          pipeDirection: South
         outlet:
           !type:PipeNode
           nodeGroupID: Pipe
-          pipeDirection: South
+          pipeDirection: East
 
 - type: entity
   parent: GasTrinaryBase


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The trinary prototypes' ports were assigned N/W/S, but the current sprite uses E/S/W.

**Screenshots**
N/A

**Changelog**
N/A