### PR TITLE
Fold Produce's "produce" solution into the "food" solution to fix empty food

### DIFF
--- a/Content.Server/Botany/Components/PlantHolderComponent.cs
+++ b/Content.Server/Botany/Components/PlantHolderComponent.cs
@@ -798,7 +798,7 @@ namespace Content.Server.Botany.Components
                 return DoHarvest(user);
             }
 
-            if (usingItem.HasComponent<ProduceComponent>())
+            if (usingItem.TryGetComponent<ProduceComponent>(out var produce))
             {
                 user.PopupMessageCursor(Loc.GetString("plant-holder-component-compost-message",
                     ("owner", Owner),
@@ -808,7 +808,7 @@ namespace Content.Server.Botany.Components
                     ("usingItem", usingItem),
                     ("owner", Owner)));
 
-                if (solutionSystem.TryGetSolution(usingItem, ProduceComponent.SolutionName, out var solution2))
+                if (solutionSystem.TryGetSolution(usingItem, produce.SolutionName, out var solution2))
                 {
                     // This deliberately discards overfill.
                     solutionSystem.TryAddSolution(usingItem.Uid, solution2,

--- a/Content.Server/Botany/Components/ProduceComponent.cs
+++ b/Content.Server/Botany/Components/ProduceComponent.cs
@@ -16,7 +16,7 @@ namespace Content.Server.Botany.Components
     public class ProduceComponent : Component, ISerializationHooks
     {
         public override string Name => "Produce";
-        public const string SolutionName = "produce";
+        [DataField("targetSolution")] public string SolutionName { get; set; } = "food";
 
         [DataField("seed")] private string? _seedName;
 
@@ -40,7 +40,6 @@ namespace Content.Server.Botany.Components
                 sprite.LayerSetState(0, Seed.PlantIconState);
             }
 
-            EntitySystem.Get<SolutionContainerSystem>().RemoveAllSolution(Owner.Uid);
             var solutionContainer = EntitySystem.Get<SolutionContainerSystem>().EnsureSolution(Owner, SolutionName);
             if (solutionContainer == null)
             {
@@ -48,6 +47,7 @@ namespace Content.Server.Botany.Components
                 return;
             }
 
+            solutionContainer.RemoveAllSolution();
             foreach (var (chem, quantity) in Seed.Chemicals)
             {
                 var amount = ReagentUnit.New(quantity.Min);

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
@@ -30,7 +30,7 @@
     count: 1
   - type: SolutionContainerManager
     solutions:
-      produce:
+      food:
         reagents:
         - ReagentId: THC
           Quantity: 2
@@ -50,7 +50,7 @@
     count: 1
   - type: SolutionContainerManager
     solutions:
-      produce:
+      food:
         reagents:
         - ReagentId: THC
           Quantity: 10
@@ -85,7 +85,7 @@
     count: 1
   - type: SolutionContainerManager
     solutions:
-      produce:
+      food:
         reagents:
         - ReagentId: Nicotine
           Quantity: 2
@@ -105,7 +105,7 @@
     count: 1
   - type: SolutionContainerManager
     solutions:
-      produce:
+      food:
         reagents:
         - ReagentId: Nicotine
           Quantity: 10


### PR DESCRIPTION
## About the PR

One of these was going to have to be folded into the other for it to work.

Note that this might still leave smokable tampering broken in any way in which it was already broken, but it shouldn't break it if it wasn't.

TESTED: Grown apples, carrots, something I forgot, bananas, *client crash due to slipping*

**Changelog**

:cl:
- fix: Grown food isn't empty anymore - "Long monkey" no longer the only long-term option
