### PR TITLE
Use Uid for standingstate methods

### DIFF
--- a/Content.Server/Buckle/Components/BuckleComponent.cs
+++ b/Content.Server/Buckle/Components/BuckleComponent.cs
@@ -130,11 +130,11 @@ namespace Content.Server.Buckle.Components
                     ownTransform.WorldRotation = strapTransform.WorldRotation;
                     break;
                 case StrapPosition.Stand:
-                    EntitySystem.Get<StandingStateSystem>().Stand(Owner);
+                    EntitySystem.Get<StandingStateSystem>().Stand(Owner.Uid);
                     ownTransform.WorldRotation = strapTransform.WorldRotation;
                     break;
                 case StrapPosition.Down:
-                    EntitySystem.Get<StandingStateSystem>().Down(Owner, false, false);
+                    EntitySystem.Get<StandingStateSystem>().Down(Owner.Uid, false, false);
                     ownTransform.LocalRotation = Angle.Zero;
                     break;
             }
@@ -339,11 +339,11 @@ namespace Content.Server.Buckle.Components
             if (_stunnable is { KnockedDown: true }
                 || (_mobState?.IsIncapacitated() ?? false))
             {
-                EntitySystem.Get<StandingStateSystem>().Down(Owner);
+                EntitySystem.Get<StandingStateSystem>().Down(Owner.Uid);
             }
             else
             {
-                EntitySystem.Get<StandingStateSystem>().Stand(Owner);
+                EntitySystem.Get<StandingStateSystem>().Stand(Owner.Uid);
             }
 
             _mobState?.CurrentState?.EnterState(Owner);

--- a/Content.Server/Instruments/InstrumentComponent.cs
+++ b/Content.Server/Instruments/InstrumentComponent.cs
@@ -362,7 +362,7 @@ namespace Content.Server.Instruments
                 if (mob != null)
                 {
                     if (Handheld)
-                        EntitySystem.Get<StandingStateSystem>().Down(mob, false);
+                        EntitySystem.Get<StandingStateSystem>().Down(mob.Uid, false);
 
                     if (mob.TryGetComponent(out StunnableComponent? stun))
                     {

--- a/Content.Server/Morgue/Components/BodyBagEntityStorageComponent.cs
+++ b/Content.Server/Morgue/Components/BodyBagEntityStorageComponent.cs
@@ -40,7 +40,7 @@ namespace Content.Server.Morgue.Components
 
         protected override bool AddToContents(IEntity entity)
         {
-            if (entity.HasComponent<SharedBodyComponent>() && !EntitySystem.Get<StandingStateSystem>().IsDown(entity)) return false;
+            if (entity.HasComponent<SharedBodyComponent>() && !EntitySystem.Get<StandingStateSystem>().IsDown(entity.Uid)) return false;
             return base.AddToContents(entity);
         }
 

--- a/Content.Server/Morgue/Components/CrematoriumEntityStorageComponent.cs
+++ b/Content.Server/Morgue/Components/CrematoriumEntityStorageComponent.cs
@@ -142,7 +142,7 @@ namespace Content.Server.Morgue.Components
             if (CanInsert(victim))
             {
                 Insert(victim);
-                EntitySystem.Get<StandingStateSystem>().Down(victim, false);
+                EntitySystem.Get<StandingStateSystem>().Down(victim.Uid, false);
             }
             else
             {

--- a/Content.Server/Morgue/Components/MorgueEntityStorageComponent.cs
+++ b/Content.Server/Morgue/Components/MorgueEntityStorageComponent.cs
@@ -68,7 +68,7 @@ namespace Content.Server.Morgue.Components
 
         protected override bool AddToContents(IEntity entity)
         {
-            if (entity.HasComponent<SharedBodyComponent>() && !EntitySystem.Get<StandingStateSystem>().IsDown(entity))
+            if (entity.HasComponent<SharedBodyComponent>() && !EntitySystem.Get<StandingStateSystem>().IsDown(entity.Uid))
                 return false;
             return base.AddToContents(entity);
         }

--- a/Content.Shared/Body/Components/SharedBodyComponent.cs
+++ b/Content.Shared/Body/Components/SharedBodyComponent.cs
@@ -186,7 +186,7 @@ namespace Content.Shared.Body.Components
             if (part.PartType == BodyPartType.Leg &&
                 GetPartsOfType(BodyPartType.Leg).ToArray().Length == 0)
             {
-                EntitySystem.Get<StandingStateSystem>().Down(Owner);
+                EntitySystem.Get<StandingStateSystem>().Down(Owner.Uid);
             }
 
             if (part.IsVital && SlotParts.Count(x => x.Value.PartType == part.PartType) == 0)

--- a/Content.Shared/MobState/State/SharedCriticalMobState.cs
+++ b/Content.Shared/MobState/State/SharedCriticalMobState.cs
@@ -33,7 +33,7 @@ namespace Content.Shared.MobState.State
         {
             base.ExitState(entity);
 
-            EntitySystem.Get<StandingStateSystem>().Stand(entity);
+            EntitySystem.Get<StandingStateSystem>().Stand(entity.Uid);
         }
 
         public override bool CanInteract()

--- a/Content.Shared/MobState/State/SharedDeadMobState.cs
+++ b/Content.Shared/MobState/State/SharedDeadMobState.cs
@@ -14,9 +14,9 @@ namespace Content.Shared.MobState.State
             var wake = entity.EnsureComponent<CollisionWakeComponent>();
             wake.Enabled = true;
             var standingState = EntitySystem.Get<StandingStateSystem>();
-            standingState.Down(entity);
+            standingState.Down(entity.Uid);
 
-            if (standingState.IsDown(entity) && entity.TryGetComponent(out PhysicsComponent? physics))
+            if (standingState.IsDown(entity.Uid) && entity.TryGetComponent(out PhysicsComponent? physics))
             {
                 physics.CanCollide = false;
             }
@@ -36,9 +36,9 @@ namespace Content.Shared.MobState.State
             }
 
             var standingState = EntitySystem.Get<StandingStateSystem>();
-            standingState.Stand(entity);
+            standingState.Stand(entity.Uid);
 
-            if (!standingState.IsDown(entity) && entity.TryGetComponent(out PhysicsComponent? physics))
+            if (!standingState.IsDown(entity.Uid) && entity.TryGetComponent(out PhysicsComponent? physics))
             {
                 physics.CanCollide = true;
             }

--- a/Content.Shared/MobState/State/SharedNormalMobState.cs
+++ b/Content.Shared/MobState/State/SharedNormalMobState.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.MobState.State
         public override void EnterState(IEntity entity)
         {
             base.EnterState(entity);
-            EntitySystem.Get<StandingStateSystem>().Stand(entity);
+            EntitySystem.Get<StandingStateSystem>().Stand(entity.Uid);
 
             if (entity.TryGetComponent(out SharedAppearanceComponent? appearance))
             {

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -14,24 +14,12 @@ namespace Content.Shared.Standing
     {
         [Dependency] private readonly SharedHandsSystem _sharedHandsSystem = default!;
 
-        [Obsolete("Use the EntityUid overloads instead.")]
-        public bool IsDown(IEntity entity)
-        {
-            return IsDown(entity.Uid);
-        }
-
         public bool IsDown(EntityUid uid, StandingStateComponent? standingState = null)
         {
             if (!Resolve(uid, ref standingState, false))
                 return false;
 
             return !standingState.Standing;
-        }
-
-        [Obsolete("Use the EntityUid overloads instead.")]
-        public void Down(IEntity entity, bool playSound = true, bool dropHeldItems = true)
-        {
-            Down(entity.Uid, playSound, dropHeldItems);
         }
 
         public bool Down(EntityUid uid, bool playSound = true, bool dropHeldItems = true,
@@ -80,12 +68,6 @@ namespace Content.Shared.Standing
             return true;
         }
 
-        [Obsolete("Use the EntityUid overloads instead.")]
-        public void Stand(IEntity entity)
-        {
-            Stand(entity.Uid);
-        }
-
         public bool Stand(EntityUid uid,
             StandingStateComponent? standingState = null,
             SharedAppearanceComponent? appearance = null)
@@ -120,7 +102,6 @@ namespace Content.Shared.Standing
     /// </summary>
     public sealed class DownAttemptEvent : CancellableEntityEventArgs
     {
-
     }
 
     /// <summary>
@@ -128,7 +109,6 @@ namespace Content.Shared.Standing
     /// </summary>
     public sealed class StandAttemptEvent : CancellableEntityEventArgs
     {
-
     }
 
     /// <summary>


### PR DESCRIPTION
@Zumorica 

Figure if we do it now then whoever refactors what calls these (mobstates and suicide) has less work to do.