### PR TITLE
Add monkey cubes to Cargo

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -239,6 +239,7 @@
       - HydroponicsTools
       - HydroponicsSeeds
       - HydroponicsSeedsExotic
+      - LivestockMonkeyCube
       - ServiceJanitorial
       - ServiceLightsReplacement
       - EngineeringCableLv


### PR DESCRIPTION
## About the PR

Without these, the Chef kinda just has to deal with only having fruit eventually.

I suspect these were removed by accident with the other livestock, close if there's a reason not to re-add these

**Changelog**

:cl:
- add: Monkey cubes are available to Cargo

