### PR TITLE
Radiation pulse damage reduction

### DIFF
--- a/Content.Server/Radiation/RadiationPulseComponent.cs
+++ b/Content.Server/Radiation/RadiationPulseComponent.cs
@@ -20,7 +20,7 @@ namespace Content.Server.Radiation
         [Dependency] private readonly IRobustRandom _random = default!;
 
         private float _duration;
-        private float _radsPerSecond = 40f;
+        private float _radsPerSecond = 8f;
         private float _range = 5f;
         private TimeSpan _endTime;
         private bool _draw = true;


### PR DESCRIPTION

## About the PR

Each pulse does around 20 damage now.

**Changelog**

:cl:
- tweak: Reduced radiation pulse damage to be around 20 for a direct sustained hit.
