### PR TITLE
Storage: fix Storage insert animation with _quickInsert or _areaInsert set

### DIFF
--- a/Content.Server/Storage/Components/ServerStorageComponent.cs
+++ b/Content.Server/Storage/Components/ServerStorageComponent.cs
@@ -543,11 +543,11 @@ namespace Content.Server.Storage.Components
                         || entity == eventArgs.User
                         || !entity.HasComponent<SharedItemComponent>())
                         continue;
-                    var coords = entity.Transform.Coordinates;
+                    var position = EntityCoordinates.FromMap(Owner.Transform.Parent?.Owner ?? Owner, entity.Transform.MapPosition);
                     if (PlayerInsertEntityInWorld(eventArgs.User, entity))
                     {
                         successfullyInserted.Add(entity.Uid);
-                        successfullyInsertedPositions.Add(coords);
+                        successfullyInsertedPositions.Add(position);
                     }
                 }
 
@@ -572,7 +572,7 @@ namespace Content.Server.Storage.Components
                     || eventArgs.Target == eventArgs.User
                     || !eventArgs.Target.HasComponent<SharedItemComponent>())
                     return false;
-                var position = eventArgs.Target.Transform.Coordinates;
+                var position = EntityCoordinates.FromMap(Owner.Transform.Parent?.Owner ?? Owner, eventArgs.Target.Transform.MapPosition);
                 if (PlayerInsertEntityInWorld(eventArgs.User, eventArgs.Target))
                 {
                     SendNetworkMessage(new AnimateInsertingEntitiesMessage(


### PR DESCRIPTION
## About the PR

Turns out the final position calculations for the animations were wrong, so I copied/pasted from the equivalent parts of the Hands components.

Unfortunately, this means that picking up trash with a trash bag no longer causes said trash to rapidly zoom to 0,0.

**Screenshots**
N/A

**Changelog**

:cl:
- fix: NT took the tele-trashbags back. At least they left some normal ones for us...