### PR TITLE
Movable containment field generators

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -11,8 +11,12 @@
     bodyType: Static
     fixtures:
     - shape:
-        !type:PhysShapeAabb
-          bounds: "-0.5,-0.5,0.5,0.5"
+        # Using a circle here makes it a lot easier to pull it all the way from Cargo
+        # However keep in mind that this will affect singulo collision as well,
+        #  when people inevitably physicsify that,
+        #  so it can't just be 0.1 or something
+        !type:PhysShapeCircle
+          radius: 0.45
       mass: 25
       layer:
       - Impassable


### PR DESCRIPTION
## About the PR

Makes containment field generators physics shapes circular matching singulo generators.

Not expected to have a significant effect on the singularity itself given it's current state.

Just prevents the door-stuck kinda situation if Engineering decides to gut the singulo containment for fancy defensive uses elsewhere.

**Changelog**

:cl:
- tweak: Singularity field generators should be easier to move around.

