### PR TITLE
Makes many thing that update on paused *not* do that.

### DIFF
--- a/Content.Server/AME/AntimatterEngineSystem.cs
+++ b/Content.Server/AME/AntimatterEngineSystem.cs
@@ -15,7 +15,7 @@ namespace Content.Server.AME
             _accumulatedFrameTime += frameTime;
             if (_accumulatedFrameTime >= 10)
             {
-                foreach (var comp in EntityManager.EntityQuery<AMEControllerComponent>(true))
+                foreach (var comp in EntityManager.EntityQuery<AMEControllerComponent>())
                 {
                     comp.OnUpdate(frameTime);
                 }

--- a/Content.Server/Arcade/BlockGameSystem.cs
+++ b/Content.Server/Arcade/BlockGameSystem.cs
@@ -64,7 +64,7 @@ namespace Content.Server.Arcade
 
         public override void Update(float frameTime)
         {
-            foreach (var comp in EntityManager.EntityQuery<BlockGameArcadeComponent>(true))
+            foreach (var comp in EntityManager.EntityQuery<BlockGameArcadeComponent>())
             {
                 comp.DoGameTick(frameTime);
             }

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -78,7 +78,7 @@ namespace Content.Server.Chemistry.EntitySystems
         public override void Update(float frameTime)
         {
             foreach (var (vaporComp, solution) in EntityManager
-                .EntityQuery<VaporComponent, SolutionContainerManagerComponent>(true))
+                .EntityQuery<VaporComponent, SolutionContainerManagerComponent>())
             {
                 foreach (var (_, value) in solution.Solutions)
                 {

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -72,7 +72,7 @@ namespace Content.Server.Cloning
 
         public override void Update(float frameTime)
         {
-            foreach (var (cloning, power) in EntityManager.EntityQuery<CloningPodComponent, ApcPowerReceiverComponent>(true))
+            foreach (var (cloning, power) in EntityManager.EntityQuery<CloningPodComponent, ApcPowerReceiverComponent>())
             {
                 if (cloning.UiKnownPowerState != power.Powered)
                 {
@@ -127,7 +127,7 @@ namespace Content.Server.Cloning
 
         public void OnChangeMadeToDnaScans()
         {
-            foreach (var cloning in EntityManager.EntityQuery<CloningPodComponent>(true))
+            foreach (var cloning in EntityManager.EntityQuery<CloningPodComponent>())
                 UpdateUserInterface(cloning);
         }
 

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
 
         public override void Update(float frameTime)
         {
-            foreach (var comp in EntityManager.EntityQuery<DisposalHolderComponent>(true))
+            foreach (var comp in EntityManager.EntityQuery<DisposalHolderComponent>())
             {
                 comp.Update(frameTime);
             }

--- a/Content.Server/DoAfter/DoAfterSystem.cs
+++ b/Content.Server/DoAfter/DoAfterSystem.cs
@@ -41,7 +41,7 @@ namespace Content.Server.DoAfter
         {
             base.Update(frameTime);
 
-            foreach (var comp in EntityManager.EntityQuery<DoAfterComponent>(true))
+            foreach (var comp in EntityManager.EntityQuery<DoAfterComponent>())
             {
                 foreach (var doAfter in comp.DoAfters.ToArray())
                 {

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -192,7 +192,7 @@ namespace Content.Server.Ghost
 
         private IEnumerable<string> GetLocationNames()
         {
-            foreach (var warp in EntityManager.EntityQuery<WarpPointComponent>())
+            foreach (var warp in EntityManager.EntityQuery<WarpPointComponent>(true))
             {
                 if (warp.Location != null)
                 {

--- a/Content.Server/Gravity/EntitySystems/GravitySystem.cs
+++ b/Content.Server/Gravity/EntitySystems/GravitySystem.cs
@@ -59,7 +59,7 @@ namespace Content.Server.Gravity.EntitySystems
             var gridId = component.Owner.Transform.GridID;
             GravityChangedMessage message;
 
-            foreach (var generator in EntityManager.EntityQuery<GravityGeneratorComponent>(true))
+            foreach (var generator in EntityManager.EntityQuery<GravityGeneratorComponent>())
             {
                 if (generator.Owner.Transform.GridID == gridId && generator.Status == GravityGeneratorStatus.On)
                 {
@@ -78,7 +78,7 @@ namespace Content.Server.Gravity.EntitySystems
         public override void Update(float frameTime)
         {
             // TODO: Pointless iteration, just make both of these event-based PLEASE
-            foreach (var generator in EntityManager.EntityQuery<GravityGeneratorComponent>(true))
+            foreach (var generator in EntityManager.EntityQuery<GravityGeneratorComponent>())
             {
                 if (generator.NeedsUpdate)
                 {

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Kitchen.EntitySystems
         public override void Update(float frameTime)
         {
             base.Update(frameTime);
-            foreach (var comp in EntityManager.EntityQuery<MicrowaveComponent>(true))
+            foreach (var comp in EntityManager.EntityQuery<MicrowaveComponent>())
             {
                 comp.OnUpdate();
             }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -9,7 +9,7 @@ namespace Content.Server.Lathe
     {
         public override void Update(float frameTime)
         {
-            foreach (var comp in EntityManager.EntityQuery<LatheComponent>(true))
+            foreach (var comp in EntityManager.EntityQuery<LatheComponent>())
             {
                 if (comp.Producing == false && comp.Queue.Count > 0)
                 {

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Light.EntitySystems
     {
         public override void Update(float frameTime)
         {
-            foreach (var light in EntityManager.EntityQuery<ExpendableLightComponent>(true))
+            foreach (var light in EntityManager.EntityQuery<ExpendableLightComponent>())
             {
                 light.Update(frameTime);
             }

--- a/Content.Server/Medical/MedicalScannerSystem.cs
+++ b/Content.Server/Medical/MedicalScannerSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Medical
         {
             base.Initialize();
 
-            SubscribeLocalEvent<MedicalScannerComponent, RelayMovementEntityEvent>(OnRelayMovement);            
+            SubscribeLocalEvent<MedicalScannerComponent, RelayMovementEntityEvent>(OnRelayMovement);
             SubscribeLocalEvent<MedicalScannerComponent, GetInteractionVerbsEvent>(AddInsertOtherVerb);
             SubscribeLocalEvent<MedicalScannerComponent, GetAlternativeVerbsEvent>(AddAlternativeVerbs);
         }
@@ -90,7 +90,7 @@ namespace Content.Server.Medical
 
         public override void Update(float frameTime)
         {
-            foreach (var comp in EntityManager.EntityQuery<MedicalScannerComponent>(true))
+            foreach (var comp in EntityManager.EntityQuery<MedicalScannerComponent>())
             {
                 comp.Update(frameTime);
             }

--- a/Content.Server/Morgue/MorgueSystem.cs
+++ b/Content.Server/Morgue/MorgueSystem.cs
@@ -54,7 +54,7 @@ namespace Content.Server.Morgue
 
             if (_accumulatedFrameTime >= 10)
             {
-                foreach (var morgue in EntityManager.EntityQuery<MorgueEntityStorageComponent>(true))
+                foreach (var morgue in EntityManager.EntityQuery<MorgueEntityStorageComponent>())
                 {
                     morgue.Update();
                 }

--- a/Content.Server/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/HungerSystem.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
             if (_accumulatedFrameTime > 1)
             {
-                foreach (var comp in EntityManager.EntityQuery<HungerComponent>(true))
+                foreach (var comp in EntityManager.EntityQuery<HungerComponent>())
                 {
                     comp.OnUpdate(_accumulatedFrameTime);
                 }

--- a/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
             if (_accumulatedFrameTime > 1)
             {
-                foreach (var component in EntityManager.EntityQuery<ThirstComponent>(true))
+                foreach (var component in EntityManager.EntityQuery<ThirstComponent>())
                 {
                     component.OnUpdate(_accumulatedFrameTime);
                 }

--- a/Content.Server/Plants/PlantSystem.cs
+++ b/Content.Server/Plants/PlantSystem.cs
@@ -68,7 +68,7 @@ namespace Content.Server.Plants
 
             _timer = 0f;
 
-            foreach (var plantHolder in EntityManager.EntityQuery<PlantHolderComponent>(true))
+            foreach (var plantHolder in EntityManager.EntityQuery<PlantHolderComponent>())
             {
                 plantHolder.Update();
             }

--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -225,7 +225,7 @@ namespace Content.Server.Pointing.EntitySystems
 
         public override void Update(float frameTime)
         {
-            foreach (var component in EntityManager.EntityQuery<PointingArrowComponent>(true))
+            foreach (var component in EntityManager.EntityQuery<PointingArrowComponent>())
             {
                 component.Update(frameTime);
             }

--- a/Content.Server/Pointing/EntitySystems/RoguePointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/RoguePointingSystem.cs
@@ -9,7 +9,7 @@ namespace Content.Server.Pointing.EntitySystems
     {
         public override void Update(float frameTime)
         {
-            foreach (var component in EntityManager.EntityQuery<RoguePointingArrowComponent>(true))
+            foreach (var component in EntityManager.EntityQuery<RoguePointingArrowComponent>())
             {
                 component.Update(frameTime);
             }

--- a/Content.Server/Power/EntitySystems/BaseChargerSystem.cs
+++ b/Content.Server/Power/EntitySystems/BaseChargerSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Power.EntitySystems
 
         public override void Update(float frameTime)
         {
-            foreach (var comp in EntityManager.EntityQuery<BaseCharger>(true))
+            foreach (var comp in EntityManager.EntityQuery<BaseCharger>())
             {
                 comp.OnUpdate(frameTime);
             }

--- a/Content.Server/Radiation/RadiationPulseSystem.cs
+++ b/Content.Server/Radiation/RadiationPulseSystem.cs
@@ -27,7 +27,7 @@ namespace Content.Server.Radiation
                 _accumulator -= RadiationCooldown;
 
                 // All code here runs effectively every RadiationCooldown seconds, so use that as the "frame time".
-                foreach (var comp in EntityManager.EntityQuery<RadiationPulseComponent>(true))
+                foreach (var comp in EntityManager.EntityQuery<RadiationPulseComponent>())
                 {
                     comp.Update(RadiationCooldown);
                     var ent = comp.Owner;

--- a/Content.Server/Solar/EntitySystems/PowerSolarControlConsoleSystem.cs
+++ b/Content.Server/Solar/EntitySystems/PowerSolarControlConsoleSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Solar.EntitySystems
             if (_updateTimer >= 1)
             {
                 _updateTimer -= 1;
-                foreach (var component in EntityManager.EntityQuery<SolarControlConsoleComponent>(true))
+                foreach (var component in EntityManager.EntityQuery<SolarControlConsoleComponent>())
                 {
                     component.UpdateUIState();
                 }

--- a/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
+++ b/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
@@ -86,7 +86,7 @@ namespace Content.Server.Solar.EntitySystems
 
             TotalPanelPower = 0;
 
-            foreach (var panel in EntityManager.EntityQuery<SolarPanelComponent>(false))
+            foreach (var panel in EntityManager.EntityQuery<SolarPanelComponent>())
             {
                 // There's supposed to be rotational logic here, but that implies putting it somewhere.
                 panel.Owner.Transform.WorldRotation = TargetPanelRotation;

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -53,7 +53,7 @@ namespace Content.Server.Storage.EntitySystems
         /// <inheritdoc />
         public override void Update(float frameTime)
         {
-            foreach (var component in EntityManager.EntityQuery<ServerStorageComponent>(true))
+            foreach (var component in EntityManager.EntityQuery<ServerStorageComponent>())
             {
                 CheckSubscribedEntities(component);
             }

--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -92,7 +92,7 @@ namespace Content.Server.Tabletop
         {
             base.Update(frameTime);
 
-            foreach (var gamer in EntityManager.EntityQuery<TabletopGamerComponent>(true))
+            foreach (var gamer in EntityManager.EntityQuery<TabletopGamerComponent>())
             {
                 if (!EntityManager.TryGetEntity(gamer.Tabletop, out var table))
                     continue;


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So there are many things that updated entities even when they were paused. This is bad.
See 1b84ee05ae400cd0f74203a9e8c0bfb7e3895d28, that single line was the cause for integration tests failing for the last few days.
Let's be careful with the paused things we update, ye?