### PR TITLE
Make freezers rotatable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -54,7 +54,7 @@
     sprite: Structures/Piping/Atmospherics/pipe.rsi
     drawdepth: BelowFloor
     netsync: false
-    noRot: true # TODO: This is a hack so pipe connectors don't look wrong.
+    noRot: true # TODO: This is a hack so pipe connectors don't look wrong. Also see BaseGasThermoMachine.
   - type: Appearance
     visuals:
     - type: PipeConnectorVisualizer

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -124,6 +124,7 @@
     - type: Sprite
       netsync: false
       sprite: Structures/Piping/Atmospherics/thermomachine.rsi
+      noRot: true # TODO: This is a hack so pipe connectors don't look wrong. Also see GasPipeBase.
     - type: Appearance
       visuals:
         - type: PipeConnectorVisualizer


### PR DESCRIPTION
## About the PR

This is one of those "I found it while playing" bugs.
Freezers are unary devices.
One looks like it's facing south on Saltern, but isn't.
It also can't be rotated, which makes things even more confusing...

**Changelog**

:cl:
- fix: freezers are rotatable now.

