### PR TITLE
Various food/rehydratable things

### DIFF
--- a/Content.Server/AI/Utility/Considerations/Nutrition/Food/FoodValueCon.cs
+++ b/Content.Server/AI/Utility/Considerations/Nutrition/Food/FoodValueCon.cs
@@ -12,8 +12,8 @@ namespace Content.Server.AI.Utility.Considerations.Nutrition.Food
         {
             var target = context.GetState<TargetEntityState>().GetValue();
 
-            if (target == null || target.Deleted ||
-                !EntitySystem.Get<SolutionContainerSystem>().TryGetSolution(target, FoodComponent.SolutionName, out var food))
+            if (target == null || target.Deleted || !target.TryGetComponent<FoodComponent>(out var foodComp) ||
+                !EntitySystem.Get<SolutionContainerSystem>().TryGetSolution(target, foodComp.SolutionName, out var food))
             {
                 return 0.0f;
             }

--- a/Content.Server/Botany/Components/PlantHolderComponent.cs
+++ b/Content.Server/Botany/Components/PlantHolderComponent.cs
@@ -37,7 +37,6 @@ namespace Content.Server.Botany.Components
     {
         public const float HydroponicsSpeedMultiplier = 1f;
         public const float HydroponicsConsumptionMultiplier = 4f;
-        private const string SoilSolutionName = "soil";
 
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -119,6 +118,9 @@ namespace Content.Server.Botany.Components
 
         [ViewVariables(VVAccess.ReadWrite)]
         public bool ForceUpdate { get; set; }
+
+        [DataField("solution")]
+        public string SoilSolutionName { get; set; } = "soil";
 
         public void WeedInvasion()
         {

--- a/Content.Server/Chemistry/ReagentEntityReactions/AddToSolutionReaction.cs
+++ b/Content.Server/Chemistry/ReagentEntityReactions/AddToSolutionReaction.cs
@@ -12,6 +12,9 @@ namespace Content.Server.Chemistry.ReagentEntityReactions
     [UsedImplicitly]
     public class AddToSolutionReaction : ReagentEntityReaction
     {
+        [DataField("solution")]
+        private string _solution = "reagents";
+
         [DataField("reagents", true, customTypeSerializer: typeof(PrototypeIdHashSetSerializer<ReagentPrototype>))]
         // ReSharper disable once CollectionNeverUpdated.Local
         private readonly HashSet<string> _reagents = new();
@@ -20,7 +23,7 @@ namespace Content.Server.Chemistry.ReagentEntityReactions
         {
             // TODO see if this is correct
             if (!EntitySystem.Get<SolutionContainerSystem>()
-                    .TryGetSolution(entity, "reagents", out var solutionContainer)
+                    .TryGetSolution(entity, _solution, out var solutionContainer)
                 || (_reagents.Count > 0 && !_reagents.Contains(reagent.ID))) return;
 
             if (EntitySystem.Get<SolutionContainerSystem>()

--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -28,7 +28,9 @@ namespace Content.Server.Nutrition.Components
     public class FoodComponent : Component, IUse, IAfterInteract
     {
         public override string Name => "Food";
-        public static string SolutionName = "food";
+
+        [DataField("solution")]
+        public string SolutionName { get; set; } = "food";
 
         [ViewVariables]
         [DataField("useSound")]

--- a/Content.Server/Nutrition/Components/SliceableFoodComponent.cs
+++ b/Content.Server/Nutrition/Components/SliceableFoodComponent.cs
@@ -44,9 +44,9 @@ namespace Content.Server.Nutrition.Components
         {
             base.Initialize();
             Count = _totalCount;
-            Owner.EnsureComponent<FoodComponent>();
+            var foodComp = Owner.EnsureComponent<FoodComponent>();
             Owner.EnsureComponent<SolutionContainerManagerComponent>();
-            EntitySystem.Get<SolutionContainerSystem>().EnsureSolution(Owner, FoodComponent.SolutionName);
+            EntitySystem.Get<SolutionContainerSystem>().EnsureSolution(Owner, foodComp.SolutionName);
         }
 
         async Task<bool> IInteractUsing.InteractUsing(InteractUsingEventArgs eventArgs)
@@ -56,7 +56,9 @@ namespace Content.Server.Nutrition.Components
                 return false;
             }
 
-            if (!EntitySystem.Get<SolutionContainerSystem>().TryGetSolution(Owner, FoodComponent.SolutionName, out var solution))
+            var scs = EntitySystem.Get<SolutionContainerSystem>();
+
+            if (!Owner.TryGetComponent<FoodComponent>(out var foodComp) || !scs.TryGetSolution(Owner, foodComp.SolutionName, out var solution))
             {
                 return false;
             }
@@ -67,6 +69,20 @@ namespace Content.Server.Nutrition.Components
             }
 
             var itemToSpawn = Owner.EntityManager.SpawnEntity(_slice, Owner.Transform.Coordinates);
+            // This is done this way so that... food additives (read: poisons) remain in the system.
+            // Basically, we want to:
+            // 1. Split off a representative chunk
+            var lostSolution = scs.SplitSolution(Owner.Uid, solution,
+                solution.CurrentVolume / ReagentUnit.New(Count));
+            // 2. Delete the Nutriment (it's already in the target) so we just have additives
+            // It might be an idea to remove the removal of Nutriment & clear the food
+            lostSolution.RemoveReagent("Nutriment", lostSolution.GetReagentQuantity("Nutriment"));
+            // 3. Dump whatever we can into the slice
+            if (itemToSpawn.TryGetComponent<FoodComponent>(out var itsFoodComp) && scs.TryGetSolution(itemToSpawn, itsFoodComp.SolutionName, out var itsSolution))
+            {
+                var lostSolutionPart = lostSolution.SplitSolution(itsSolution.AvailableVolume);
+                scs.TryAddSolution(itemToSpawn.Uid, itsSolution, lostSolutionPart);
+            }
             if (eventArgs.User.TryGetComponent(out HandsComponent? handsComponent))
             {
                 if (ContainerHelpers.IsInContainer(Owner))
@@ -82,11 +98,7 @@ namespace Content.Server.Nutrition.Components
             if (Count < 1)
             {
                 Owner.Delete();
-                return true;
             }
-
-            EntitySystem.Get<SolutionContainerSystem>().TryRemoveReagent(Owner.Uid, solution, "Nutriment",
-                solution.CurrentVolume / ReagentUnit.New(Count + 1));
             return true;
         }
 

--- a/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Server.Nutrition.EntitySystems
         {
             SoundSystem.Play(Filter.Pvs(creamPie.Owner), creamPie.Sound.GetSound(), creamPie.Owner, AudioHelpers.WithVariation(0.125f));
 
-            if (_solutionsSystem.TryGetSolution(creamPie.Owner, FoodComponent.SolutionName, out var solution))
+            if (creamPie.Owner.TryGetComponent<FoodComponent>(out var foodComp) && _solutionsSystem.TryGetSolution(creamPie.Owner, foodComp.SolutionName, out var solution))
             {
                 solution.SpillAt(creamPie.Owner, "PuddleSmear", false);
             }

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -11,6 +11,8 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 10
+  - type: Food
+    solution: cube
   - type: RefillableSolution
     solution: cube
   - type: Sprite
@@ -19,6 +21,7 @@
   - type: Reactive
     reactions:
       - !type:AddToSolutionReaction
+        solution: cube
         touch: true
         ingestion: true
         injection: true
@@ -56,10 +59,11 @@
         - ReagentId: Nutriment
           Quantity: 10
   - type: RefillableSolution
-    solution: cube
+    solution: plushie
   - type: Reactive
     reactions:
     - !type:AddToSolutionReaction
+      solution: plushie
       touch: true
       ingestion: true
       injection: true

--- a/Resources/Prototypes/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/Entities/Structures/soil.yml
@@ -52,6 +52,7 @@
   - type: Reactive
     reactions:
       - !type:AddToSolutionReaction
+        solution: soil
   - type: Appearance
     visuals:
       - type: PlantHolderVisualizer


### PR DESCRIPTION
## About the PR

Fixes spraying monkey cubes and rehydratable space carp.
Also adds a solution name into food stuff.
While I'm at it, poisoning something that can be sliced now poisons the slices.

**Changelog**

:cl:
- fix: Monkey cubes and rehydratable space carp work properly and don't rely on the RefillableSolution workaround.
- tweak: Poisoning something that can be sliced now poisons the slices.

