### PR TITLE
More informative warning for if FluidSynth is not installed

### DIFF
--- a/Content.Client/Instruments/UI/InstrumentMenu.xaml
+++ b/Content.Client/Instruments/UI/InstrumentMenu.xaml
@@ -27,6 +27,6 @@
         </PanelContainer.PanelOverride>
         <Label VerticalAlignment="Center" HorizontalAlignment="Center" Align="Center"
                StyleClasses="LabelBig"
-               Text="{Loc 'MIDI support is currently&#x0a;not available on your platform.'}" />
+               Text="{Loc instruments-component-menu-no-midi-support}" />
     </PanelContainer>
 </SS14Window>

--- a/Resources/Locale/en-US/instruments/instruments-component.ftl
+++ b/Resources/Locale/en-US/instruments/instruments-component.ftl
@@ -2,3 +2,9 @@
 instrument-component-finger-cramps-light-message = Your fingers are beginning to a cramp a little!
 instrument-component-finger-cramps-serious-message = Your fingers are seriously cramping up!
 instrument-component-finger-cramps-max-message = Your fingers cramp up from playing!
+instruments-component-menu-no-midi-support = MIDI support is currently not
+                                             available on your system.
+                                             If on Linux, you may need to install
+                                             FluidSynth or a development package
+                                             for FluidSynth.
+


### PR DESCRIPTION
## About the PR

See screenshot. "Or a development package for FluidSynth" is designed to get someone on Ubuntu to try `apt search fluidsynth development package`, which will lead them to `libfluidsynth-dev` (the correct package to install).

Anyone else, good luck ig, there's only so much room in the dialog

**Screenshots**
![image](https://user-images.githubusercontent.com/22304167/138355085-2f84d311-54af-48d6-928f-e005b7b863ed.png)

**Changelog**

:cl:
- tweak: Make warning for if FluidSynth is not installed more informative

