### PR TITLE
Add maximum to barotrauma damage

### DIFF
--- a/Content.Server/Atmos/Components/BarotraumaComponent.cs
+++ b/Content.Server/Atmos/Components/BarotraumaComponent.cs
@@ -16,5 +16,9 @@ namespace Content.Server.Atmos.Components
         [DataField("damage", required: true)]
         [ViewVariables(VVAccess.ReadWrite)]
         public DamageSpecifier Damage = default!;
+
+        [DataField("maxDamage")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public int MaxDamage = 200;
     }
 }

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using Content.Server.Alert;
 using Content.Server.Atmos.Components;
 using Content.Shared.Alert;
@@ -68,8 +69,16 @@ namespace Content.Server.Atmos.EntitySystems
 
             _timer -= UpdateTimer;
 
-            foreach (var (barotrauma, transform) in EntityManager.EntityQuery<BarotraumaComponent, ITransformComponent>())
+            foreach (var (barotrauma, damageable, transform) in EntityManager.EntityQuery<BarotraumaComponent, DamageableComponent, ITransformComponent>())
             {
+                var totalDamage = 0;
+                foreach (var (barotraumaDamageType, _) in barotrauma.Damage.DamageDict)
+                {
+                    totalDamage += damageable.Damage.DamageDict[barotraumaDamageType];
+                }
+                if (totalDamage > barotrauma.MaxDamage)
+                    continue;
+
                 var uid = barotrauma.Owner.Uid;
 
                 var status = barotrauma.Owner.GetComponentOrNull<ServerAlertsComponent>();


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a maximum damage total to the barotrauma component to prevent mobs exposed to space from gibbing when they only took barotrauma damage.

Not sure if this is the best way to go about this. Could make it a per damage type maximum. Or maybe just make it do some other type of damage that doesn't cause gibbing.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed being spaced causing the player to gib

