### PR TITLE
Power/Cables: Add a single(-ish) tile APC power cable for mapping

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -153,3 +153,48 @@
     visuals:
     - type: CableVisualizer
       base: lvcable_
+
+- type: entity
+  parent: CableBase
+  id: CableApcExtensionLocal
+  name: LV extension cable
+  description: A cable used to directly connect machines to an APC.
+  components:
+  - type: Sprite
+    color: Green
+    sprite: Structures/Power/Cables/lv_cable.rsi
+    state: lvcable_0
+  - type: Icon
+    color: Green
+    sprite: Structures/Power/Cables/lv_cable.rsi
+    state: lvcable_4
+  - type: NodeContainer
+    nodes:
+      power:
+        !type:CableNode
+        nodeGroupID: Apc
+  - type: Cable
+    cableDroppedOnCutPrototype: CableApcStack1
+    cableType: Apc
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          CableApcStack1:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Appearance
+    visuals:
+    - type: CableVisualizer
+      base: lvcable_
+  - type: ExtensionCableProvider
+    transferRange: 1
+  - type: PowerProvider
+    voltage: Apc
+    powerTransferRange: 1


### PR DESCRIPTION
## About the PR
It Works... Sometimes!™
Do NOT use outside of mapping. It behaves... oddly.

Powers a "single" (±1) tile.

Since it's meant for internal use only, cutting it results in a **normal LV cable** being produced.

**Screenshots**
It's just a LV cable. Seriously.

**Changelog**
N/A