### PR TITLE
Fix ghost interactions

### DIFF
--- a/Content.Client/Ghost/GhostComponent.cs
+++ b/Content.Client/Ghost/GhostComponent.cs
@@ -7,7 +7,8 @@ using Robust.Shared.IoC;
 namespace Content.Client.Ghost
 {
     [RegisterComponent]
-    public class GhostComponent : SharedGhostComponent
+    [ComponentReference(typeof(SharedGhostComponent))]
+    public sealed class GhostComponent : SharedGhostComponent
     {
         [Dependency] private readonly IPlayerManager _playerManager = default!;
 

--- a/Content.Server/Ghost/Components/GhostComponent.cs
+++ b/Content.Server/Ghost/Components/GhostComponent.cs
@@ -5,7 +5,8 @@ using Robust.Shared.GameObjects;
 namespace Content.Server.Ghost.Components
 {
     [RegisterComponent]
-    public class GhostComponent : SharedGhostComponent
+    [ComponentReference(typeof(SharedGhostComponent))]
+    public sealed class GhostComponent : SharedGhostComponent
     {
         public TimeSpan TimeOfDeath { get; set; } = TimeSpan.Zero;
     }


### PR DESCRIPTION
Small fix for ghost interactions. Ghost components were missing a `ComponentReference`, so the ghost system was not not actually blocking/cancelling interactions.

fixes #4990

:cl:
- fix: Fixed ghosts being able interact with objects.