### PR TITLE
Truncate long name / job titles for IDs

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
+++ b/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.Shared.Access;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -40,6 +41,12 @@ namespace Content.Client.Access.UI
 
         public void SubmitData(string newFullName, string newJobTitle, List<string> newAccessList)
         {
+            if (newFullName.Length > MaxFullNameLength)
+                newFullName = newFullName[..MaxFullNameLength];
+
+            if (newJobTitle.Length > MaxJobTitleLength)
+                newJobTitle = newJobTitle[..MaxJobTitleLength];
+
             SendMessage(new WriteToTargetIdMessage(
                 newFullName,
                 newJobTitle,

--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Access.Components;
+using Content.Shared.Access;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 
@@ -23,6 +24,10 @@ namespace Content.Server.Access.Systems
             if (!Resolve(uid, ref id))
                 return false;
 
+            // TODO: Whenever we get admin logging these should be logged
+            if (jobTitle.Length > SharedIdCardConsoleComponent.MaxJobTitleLength)
+                jobTitle = jobTitle[..SharedIdCardConsoleComponent.MaxJobTitleLength];
+
             id.JobTitle = jobTitle;
             UpdateEntityName(uid, id);
             return true;
@@ -32,6 +37,9 @@ namespace Content.Server.Access.Systems
         {
             if (!Resolve(uid, ref id))
                 return false;
+
+            if (fullName.Length > SharedIdCardConsoleComponent.MaxFullNameLength)
+                fullName = fullName[..SharedIdCardConsoleComponent.MaxFullNameLength];
 
             id.FullName = fullName;
             UpdateEntityName(uid, id);

--- a/Content.Shared/Access/SharedIdCardConsoleComponent.cs
+++ b/Content.Shared/Access/SharedIdCardConsoleComponent.cs
@@ -9,6 +9,9 @@ namespace Content.Shared.Access
     {
         public override string Name => "IdCardConsole";
 
+        public const int MaxFullNameLength = 256;
+        public const int MaxJobTitleLength = 256;
+
         public enum UiButton
         {
             PrivilegedId,


### PR DESCRIPTION
1. SharedIdCardConsoleComponent was the only piece of shared ID code I could find and I didn't feel like making a cvar.
2. When we get admin logging this should probably be logged.

Addresses part of https://github.com/space-wizards/space-station-14/issues/4996

Also: This doesn't stop the field itself from having the massive amount of text and just lags their client locally which sounds like a feature.

:cl:
- fix: You can no longer paste the contents of Moby Dick into someone's ID.
