### PR TITLE
spray bottle fix

### DIFF
--- a/Content.Client/Chemistry/Visualizers/VaporVisualizer.cs
+++ b/Content.Client/Chemistry/Visualizers/VaporVisualizer.cs
@@ -37,11 +37,6 @@ namespace Content.Client.Chemistry.Visualizers
         {
             base.OnChangeData(component);
 
-            if (component.TryGetData<Angle>(VaporVisuals.Rotation, out var radians))
-            {
-                SetRotation(component, radians);
-            }
-
             if (component.TryGetData<Color>(VaporVisuals.Color, out var color))
             {
                 SetColor(component, color);
@@ -61,13 +56,6 @@ namespace Content.Client.Chemistry.Visualizers
 
             if(!animPlayer.HasRunningAnimation(AnimationKey))
                 animPlayer.Play(VaporFlick, AnimationKey);
-        }
-
-        private void SetRotation(AppearanceComponent component, Angle rotation)
-        {
-            var sprite = component.Owner.GetComponent<ISpriteComponent>();
-
-            sprite.Rotation = rotation;
         }
 
         private void SetColor(AppearanceComponent component, Color color)

--- a/Content.Server/Fluids/Components/SprayComponent.cs
+++ b/Content.Server/Fluids/Components/SprayComponent.cs
@@ -164,9 +164,6 @@ namespace Content.Server.Fluids.Components
 
                 if (vapor.TryGetComponent(out AppearanceComponent? appearance))
                 {
-                    // entity & collision box is already rotated to face in the correct direction.
-                    // but sprite needs to be rotated 90 degrees.
-                    appearance.SetData(VaporVisuals.Rotation, Angle.FromDegrees(90));
                     appearance.SetData(VaporVisuals.Color, contents.Color.WithAlpha(1f));
                     appearance.SetData(VaporVisuals.State, true);
                 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -75,6 +75,7 @@
   - type: Sprite
     netsync: false
     sprite: Effects/chempuff.rsi
+    rotation: 90
     layers:
     - state: chempuff
       map: ["enum.VaporVisualLayers.Base"]


### PR DESCRIPTION
Minor fixes for spray bottles / vapor entities.

- The vapor entities now collide with players. This makes things like the `WashCreamPieReaction` work again.
- Fixed vapor sprite rotation & velocity when the station is rotated. The corriolis effect actually makes a janitor's job harder.
- Spray bottles are no longer spillable, so you don't spill all the space cleaner when you slip.
  - This is inline with their in game description "A spray bottle with an unscrewable top."

This **partially** fixes #5002, you just have to spray while running, so that the vapor collides with yourself.