### PR TITLE
Bugfix: ExtensionCableReceiver anchoring

### DIFF
--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -104,7 +104,10 @@ namespace Content.Server.Power.EntitySystems
             RaiseLocalEvent(uid, new ProviderDisconnectedEvent(provider), broadcast: false);
 
             if (provider != null)
+            {
                 RaiseLocalEvent(provider.Owner.Uid, new ReceiverDisconnectedEvent(receiver), broadcast: false);
+                provider.LinkedReceivers.Remove(receiver);
+            }
 
             receiver.ReceptionRange = range;
             TryFindAndSetProvider(receiver);
@@ -146,9 +149,11 @@ namespace Content.Server.Power.EntitySystems
             {
                 receiver.Connectable = false;
                 RaiseLocalEvent(uid, new ProviderDisconnectedEvent(receiver.Provider), broadcast: false);
-
                 if (receiver.Provider != null)
+                {
                     RaiseLocalEvent(receiver.Provider.Owner.Uid, new ReceiverDisconnectedEvent(receiver), broadcast: false);
+                    receiver.Provider.LinkedReceivers.Remove(receiver);
+                }
 
                 receiver.Provider = null;
             }
@@ -159,6 +164,7 @@ namespace Content.Server.Power.EntitySystems
             if (!TryFindAvailableProvider(receiver.Owner, receiver.ReceptionRange, out var provider)) return;
 
             receiver.Provider = provider;
+            provider.LinkedReceivers.Add(receiver);
             RaiseLocalEvent(receiver.Owner.Uid, new ProviderConnectedEvent(provider), broadcast: false);
             RaiseLocalEvent(provider.Owner.Uid, new ReceiverConnectedEvent(receiver), broadcast: false);
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes LinkedReceivers on the ExtensionCableProviderComponent not being updated when the anchor state changes on for ExtensionCableRecevier components

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

