### PR TITLE
Fix gas pipe rotation rendering

### DIFF
--- a/Content.Client/Atmos/Visualizers/PipeConnectorVisualizer.cs
+++ b/Content.Client/Atmos/Visualizers/PipeConnectorVisualizer.cs
@@ -63,6 +63,7 @@ namespace Content.Client.Atmos.Visualizers
 
             if (!component.Owner.TryGetComponent<ITransformComponent>(out var xform))
                 return;
+
             if (!component.Owner.TryGetComponent<ISpriteComponent>(out var sprite))
                 return;
 
@@ -75,10 +76,18 @@ namespace Content.Client.Atmos.Visualizers
             if(!component.TryGetData(SubFloorVisuals.SubFloor, out bool subfloor))
                 subfloor = true;
 
+            var rotation = xform.LocalRotation;
+
             foreach (Layer layerKey in Enum.GetValues(typeof(Layer)))
             {
                 var layer = sprite.LayerMapGet(layerKey);
-                sprite.LayerSetVisible(layer, state.ConnectedDirections.HasDirection(((PipeDirection)layerKey)) && subfloor);
+                var dir = (PipeDirection) layerKey;
+                var visible = subfloor && state.ConnectedDirections.HasDirection(dir);
+                sprite.LayerSetVisible(layer, visible);
+
+                if (!visible) continue;
+
+                sprite.LayerSetRotation(layer, -rotation);
                 sprite.LayerSetColor(layer, color);
             }
         }

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -53,7 +53,6 @@
     sprite: Structures/Piping/Atmospherics/pipe.rsi
     drawdepth: BelowFloor
     netsync: false
-    noRot: true # TODO: This is a hack so pipe connectors don't look wrong. Also see BaseGasThermoMachine.
   - type: Appearance
     visuals:
     - type: PipeConnectorVisualizer

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -124,7 +124,6 @@
     - type: Sprite
       netsync: false
       sprite: Structures/Piping/Atmospherics/thermomachine.rsi
-      noRot: true # TODO: This is a hack so pipe connectors don't look wrong. Also see GasPipeBase.
     - type: Appearance
       visuals:
         - type: PipeConnectorVisualizer


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/2159

Connectors are still cooked when viewed off-grid but this is because pipes are directional whereas connectors are not (solution is make connectors directional as well afaik)

:cl:
- fix: Pipes look 90% less jank on rotated shuttles.
