### PR TITLE
Health Analyzer item

### DIFF
--- a/Content.Client/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Client/Medical/Components/HealthAnalyzerComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Medical.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.Client.Medical.Components
+{
+    [RegisterComponent]
+    internal class HealthAnalyzerComponent : SharedHealthAnalyzerComponent
+    {
+
+    }
+}

--- a/Content.Client/Medical/UI/HealthAnalyzerBoundUserInterface.cs
+++ b/Content.Client/Medical/UI/HealthAnalyzerBoundUserInterface.cs
@@ -1,0 +1,43 @@
+using Robust.Client.GameObjects;
+using Robust.Shared.GameObjects;
+using static Content.Shared.Medical.Components.SharedHealthAnalyzerComponent;
+
+namespace Content.Client.Medical.UI
+{
+    public class HealthAnalyzerBoundUserInterface : BoundUserInterface
+    {
+        public HealthAnalyzerBoundUserInterface(ClientUserInterfaceComponent owner, object uiKey) : base(owner, uiKey)
+        {
+        }
+
+        private HealthAnalyzerWindow? _menu;
+
+        protected override void Open()
+        {
+            base.Open();
+
+            _menu = new HealthAnalyzerWindow(this);
+            _menu.OnClose += Close;
+            _menu.OpenCentered();
+        }
+
+        protected override void UpdateState(BoundUserInterfaceState state)
+        {
+            base.UpdateState(state);
+
+            _menu?.Populate((HealthAnalyzerBoundUserInterfaceState) state);
+        }
+
+        public void Refresh()
+        {
+            SendMessage(new HealthAnalyzerRefreshMessage());
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing) _menu?.Dispose();
+        }
+    }
+}

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -1,0 +1,243 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Hands.Components;
+using Content.Server.UserInterface;
+using Content.Shared.Atmos;
+using Content.Shared.Medical.Components;
+using Content.Shared.DragDrop;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Robust.Server.GameObjects;
+using Robust.Server.Player;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.Map;
+using Robust.Shared.Players;
+using Robust.Shared.ViewVariables;
+using Content.Shared.Damage;
+using Content.Shared.Body.Components;
+using Content.Shared.MobState;
+
+namespace Content.Server.Medical.Components
+{
+    [RegisterComponent]
+    public class HealthAnalyzerComponent : SharedHealthAnalyzerComponent, IAfterInteract, IDropped, IUse
+    {
+
+        private float _timeSinceSync;
+        private const float TimeBetweenSyncs = 2f;
+        private IEntity? _target; // Scan target
+        private AppearanceComponent? _appearance;
+
+        [ViewVariables] private BoundUserInterface? UserInterface => Owner.GetUIOrNull(HealthAnalyzerUiKey.Key);
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            if (UserInterface != null)
+            {
+                UserInterface.OnReceiveMessage += UserInterfaceOnReceiveMessage;
+                UserInterface.OnClosed += UserInterfaceOnClose;
+            }
+
+            Owner.TryGetComponent(out _appearance);
+        }
+
+        public void OpenInterface(IPlayerSession session, IEntity? target)
+        {
+            _target = target;
+            UserInterface?.Open(session);
+            UpdateUserInterface();
+            UpdateAppearance(true);
+            Resync();
+        }
+
+        public void ToggleInterface(IPlayerSession session)
+        {
+            if (UserInterface == null)
+                return;
+
+            if (UserInterface.SessionHasOpen(session))
+                CloseInterface(session);
+            else
+                OpenInterface(session, null);
+        }
+
+        public void CloseInterface(IPlayerSession session)
+        {
+            _target = null;
+            UserInterface?.Close(session);
+            // Our OnClose will do the appearance stuff
+            Resync();
+        }
+
+        private void UserInterfaceOnClose(IPlayerSession obj)
+        {
+            UpdateAppearance(false);
+        }
+
+        private void UpdateAppearance(bool open)
+        {
+            _appearance?.SetData(GasAnalyzerVisuals.VisualState,
+                open ? GasAnalyzerVisualState.Working : GasAnalyzerVisualState.Off);
+        }
+
+        public void Update(float frameTime)
+        {
+            _timeSinceSync += frameTime;
+            if (_timeSinceSync > TimeBetweenSyncs)
+            {
+                Resync();
+                UpdateUserInterface();
+            }
+        }
+
+        private void Resync()
+        {
+            // Already get the pressure before Dirty(), because we can't get the EntitySystem in that thread or smth
+            Dirty();
+            _timeSinceSync = 0f;
+        }
+
+        private void UpdateUserInterface()
+        {
+            if (UserInterface == null)
+            {
+                return;
+            }
+
+            string? error = null;
+
+            // Check if the player is still holding the gas analyzer => if not, don't update
+            foreach (var session in UserInterface.SubscribedSessions)
+            {
+                if (session.AttachedEntity == null)
+                    return;
+
+                if (!session.AttachedEntity.TryGetComponent(out IHandsComponent? handsComponent))
+                    return;
+
+                var activeHandEntity = handsComponent?.GetActiveHand?.Owner;
+                if (activeHandEntity == null || !activeHandEntity.TryGetComponent(out HealthAnalyzerComponent? healthAnalyzer))
+                {
+                    return;
+                }
+            }
+
+            var pos = Owner.Transform.Coordinates;
+            if (_target == null)
+            {
+                error = "No organic matter detected";
+                UserInterface.SetState(
+                new HealthAnalyzerBoundUserInterfaceState(
+                    0,
+                    error));
+                return;
+            }
+
+            if (_target.TryGetComponent(out IMobStateComponent? mobState) &&
+                _target.TryGetComponent(out DamageableComponent? damageable) &&
+                _target.TryGetComponent(out SharedBodyComponent? body)
+            ){
+
+                /*foreach (var (part, _) in body.Parts){
+                    part.
+                }*/
+                int threshold;
+                if (!mobState.TryGetEarliestDeadState(damageable.TotalDamage, out _, out threshold)){
+                    error = "No vital signs detected";
+                    UserInterface.SetState(
+                    new HealthAnalyzerBoundUserInterfaceState(
+                        0,
+                        error));
+                    return;
+                }
+                var health = (1 - (float) damageable.TotalDamage / threshold) * 100;
+
+                //get health data and organs of the entity
+                UserInterface.SetState(
+                    new HealthAnalyzerBoundUserInterfaceState(
+                        health,
+                        error));
+            } else {
+                error = "No vital signs detected";
+                UserInterface.SetState(
+                new HealthAnalyzerBoundUserInterfaceState(
+                    0,
+                    error));
+                return;
+            }
+
+
+        }
+
+        private void UserInterfaceOnReceiveMessage(ServerBoundUserInterfaceMessage serverMsg)
+        {
+            var message = serverMsg.Message;
+            switch (message)
+            {
+                case HealthAnalyzerRefreshMessage msg:
+                    var player = serverMsg.Session.AttachedEntity;
+                    if (player == null)
+                    {
+                        return;
+                    }
+
+                    if (!player.TryGetComponent(out IHandsComponent? handsComponent))
+                    {
+                        Owner.PopupMessage(player, Loc.GetString("health-analyzer-component-player-has-no-hands-message"));
+                        return;
+                    }
+
+                    var activeHandEntity = handsComponent.GetActiveHand?.Owner;
+                    if (activeHandEntity == null || !activeHandEntity.TryGetComponent(out HealthAnalyzerComponent? healthAnalyzer))
+                    {
+                        serverMsg.Session.AttachedEntity?.PopupMessage(Loc.GetString("health-analyzer-component-need-gas-analyzer-in-hand-message"));
+                        return;
+                    }
+
+                    UpdateUserInterface();
+                    Resync();
+                    break;
+            }
+        }
+
+        async Task<bool> IAfterInteract.AfterInteract(AfterInteractEventArgs eventArgs)
+        {
+            if (!eventArgs.CanReach)
+            {
+                eventArgs.User.PopupMessage(Loc.GetString("health-analyzer-component-player-cannot-reach-message"));
+                return true;
+            }
+
+            if (eventArgs.User.TryGetComponent(out ActorComponent? actor))
+            {
+                OpenInterface(actor.PlayerSession, eventArgs.Target);
+            }
+
+            return true;
+        }
+
+
+
+        void IDropped.Dropped(DroppedEventArgs eventArgs)
+        {
+            if (eventArgs.User.TryGetComponent(out ActorComponent? actor))
+            {
+                CloseInterface(actor.PlayerSession);
+            }
+        }
+
+        bool IUse.UseEntity(UseEntityEventArgs eventArgs)
+        {
+            if (eventArgs.User.TryGetComponent(out ActorComponent? actor))
+            {
+                ToggleInterface(actor.PlayerSession);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -24,9 +24,6 @@ namespace Content.Server.Medical.Components
     [RegisterComponent]
     public class HealthAnalyzerComponent : SharedHealthAnalyzerComponent, IAfterInteract, IDropped, IUse
     {
-
-        private float _timeSinceSync;
-        private const float TimeBetweenSyncs = 2f;
         private IEntity? _target; // Scan target
         private AppearanceComponent? _appearance;
 
@@ -84,21 +81,9 @@ namespace Content.Server.Medical.Components
                 open ? GasAnalyzerVisualState.Working : GasAnalyzerVisualState.Off);
         }
 
-        public void Update(float frameTime)
-        {
-            _timeSinceSync += frameTime;
-            if (_timeSinceSync > TimeBetweenSyncs)
-            {
-                Resync();
-                UpdateUserInterface();
-            }
-        }
-
         private void Resync()
         {
-            // Already get the pressure before Dirty(), because we can't get the EntitySystem in that thread or smth
             Dirty();
-            _timeSinceSync = 0f;
         }
 
         private void UpdateUserInterface()

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -77,8 +77,8 @@ namespace Content.Server.Medical.Components
 
         private void UpdateAppearance(bool open)
         {
-            _appearance?.SetData(GasAnalyzerVisuals.VisualState,
-                open ? GasAnalyzerVisualState.Working : GasAnalyzerVisualState.Off);
+            _appearance?.SetData(HealthAnalyzerVisuals.VisualState,
+                open ? HealthAnalyzerVisualState.Working : HealthAnalyzerVisualState.Off);
         }
 
         private void Resync()

--- a/Content.Shared/Medical/SharedHealthAnalyzerComponent.cs
+++ b/Content.Shared/Medical/SharedHealthAnalyzerComponent.cs
@@ -39,14 +39,14 @@ namespace Content.Shared.Medical.Components
 
     [NetSerializable]
     [Serializable]
-    public enum GasAnalyzerVisuals
+    public enum HealthAnalyzerVisuals
     {
         VisualState,
     }
 
     [NetSerializable]
     [Serializable]
-    public enum GasAnalyzerVisualState
+    public enum HealthAnalyzerVisualState
     {
         Off,
         Working,

--- a/Content.Shared/Medical/SharedHealthAnalyzerComponent.cs
+++ b/Content.Shared/Medical/SharedHealthAnalyzerComponent.cs
@@ -1,0 +1,54 @@
+using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+using Robust.Shared.Localization;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Medical.Components
+{
+    [NetworkedComponent()]
+    public class SharedHealthAnalyzerComponent : Component
+    {
+        public override string Name => "HealthAnalyzer";
+
+        [Serializable, NetSerializable]
+        public enum HealthAnalyzerUiKey
+        {
+            Key,
+        }
+
+        [Serializable, NetSerializable]
+        public class HealthAnalyzerBoundUserInterfaceState : BoundUserInterfaceState
+        {
+            public float Health;
+            //public OrganEntry[]? Organs;
+            public string? Error;
+            public HealthAnalyzerBoundUserInterfaceState(float health, string? error = null)
+            {
+                Health = health;
+                Error = error;
+            }
+        }
+
+        [Serializable, NetSerializable]
+        public class HealthAnalyzerRefreshMessage : BoundUserInterfaceMessage
+        {
+            public HealthAnalyzerRefreshMessage() {}
+        }
+    }
+
+    [NetSerializable]
+    [Serializable]
+    public enum GasAnalyzerVisuals
+    {
+        VisualState,
+    }
+
+    [NetSerializable]
+    [Serializable]
+    public enum GasAnalyzerVisualState
+    {
+        Off,
+        Working,
+    }
+}

--- a/Resources/Locale/en-US/medical/components/health-analyzer.ftl
+++ b/Resources/Locale/en-US/medical/components/health-analyzer.ftl
@@ -1,0 +1,11 @@
+health-analyzer-window-name = Health Analyzer
+health-analyzer-window-refresh-button = Refresh
+
+health-analyzer-window-error-text = Error: {$errorText}
+
+health-analyzer-entity = Target: {$target}
+health-analyzer-overall-status = Overall status: {$health}% healthy
+
+health-analyzer-component-player-cannot-reach-message = You can't reach there.
+health-analyzer-component-need-gas-analyzer-in-hand-message = You need a Health Analyzer in your hand!
+health-analyzer-component-player-has-no-hands-message = You have no hands.

--- a/Resources/Prototypes/Entities/Objects/Tools/medical.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/medical.yml
@@ -1,0 +1,19 @@
+- type: entity
+  name: health analyzer
+  parent: BaseItem
+  id: HealthAnalyzer
+  description: Scan humans or monkeys to get a report of their health, damage taken, any viruses and other ailments.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Atmos/gasanalyzer.rsi
+    state: icon
+  - type: HealthAnalyzer
+  - type: UserInterface
+    interfaces:
+    - key: enum.HealthAnalyzerUiKey.Key
+      type: HealthAnalyzerBoundUserInterface
+  - type: Appearance
+    visuals:
+    - type: GasAnalyzerVisualizer
+      state_off: icon
+      state_working: working


### PR DESCRIPTION
This PR adds a portable health analyzer.

Background: as per guides like https://tgstation13.org/wiki/Medical_items, a first item that medic supposed to use for triage is a portable health analyzer. Adding one similar to the gas analyzer.

![analyzer](https://user-images.githubusercontent.com/621312/138642743-e5ba06fa-e635-4f7d-b7f1-b19cecb0bf1f.jpg)


This PR is mostly a copy of gas analyzer with some tweaks, and the health information is still a wip. Will add more stuff like organs data in the next update.

The scan functionality somewhat duplicates MedicalScanner and BodyScanner - neither are particularly fleshed out (also both are stationary) and maybe we can try to unify the UI code in further PR's.