### PR TITLE
Fix construction to some extent on rotated grids

### DIFF
--- a/Content.Shared/Maps/TurfHelpers.cs
+++ b/Content.Shared/Maps/TurfHelpers.cs
@@ -155,12 +155,7 @@ namespace Content.Shared.Maps
             if (!GetWorldTileBox(turf, out var worldBox))
                 return Enumerable.Empty<IEntity>();
 
-            // NOTE: If you are dealing with rotation-related bugs with this function,
-            //  such as it having variable levels of excess area based on grid rotation,
-            //  you are PROBABLY LOOKING FOR THIS BIT!
-            // Unfortunately lookupSystem doesn't handle Box2Rotated.
-            var worldBoxUnrotated = worldBox.CalcBoundingBox();
-            return lookupSystem.GetEntitiesIntersecting(turf.MapIndex, worldBoxUnrotated, flags);
+            return lookupSystem.GetEntitiesIntersecting(turf.MapIndex, worldBox, flags);
         }
 
         /// <summary>


### PR DESCRIPTION
## About the PR

The bug is that Construction, which uses IsBlockedTurf, doesn't work near walls on rotated grids.

The reason is that IsBlockedTurf uses a world-space AABB.
Without anything better, the present solution is this.

This also makes GetEntitiesInTile return too many results rather than a mixture of too many and too few.

I have tested that:
+ Wall placement now works on a rotated grid
+ AME expansion still works
+ Cable placement still works
+ Wrenching objects still works
+ Spilling more or less works, although for some reason it feels offset (not sure if a change caused by this PR, if it *is* then it's probably not actually fixable without engine intervention or breaking even more stuff)

Requires https://github.com/space-wizards/RobustToolbox/pull/2164

**Changelog**
:cl:
- fix: Construction works on rotated grids
