### PR TITLE
Power: Allow measuring Pow3r stats with Multitools

### DIFF
--- a/Content.Server/Power/PowerStats.cs
+++ b/Content.Server/Power/PowerStats.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.NodeContainer;
+using Content.Server.Power.Components;
+using Content.Server.Power.Nodes;
+using Content.Server.Power.NodeGroups;
+using Content.Shared.Localizations;
+using Content.Shared.Localizations.Units;
+using Robust.Shared.Localization;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Power
+{
+    public class PowerStats
+    {
+        public static string FormatPowerStats(NodeContainerComponent ncc)
+        {
+            var buf = "";
+            foreach (var node in ncc.Nodes)
+            {
+                if (node.Value is not CableNode || node.Value.NodeGroup is null)
+                    continue;
+
+                switch (node.Value.NodeGroup)
+                {
+                    case PowerNet ng:
+                        {
+                            var sup = ng.Suppliers.Sum(s => s.CurrentSupply);
+                            var dmd = ng.Consumers.Sum(c => c.DrawRate);
+
+                            var chgdmd = ng.Chargers
+                                .Sum((c) =>
+                                {
+                                    c.Owner.TryGetComponent<PowerNetworkBatteryComponent>(out var x);
+                                    return x?.CurrentReceiving ?? 0f;
+                                });
+
+                            var batdischg = ng.Dischargers
+                                .Select((d) =>
+                                {
+                                    d.Owner.TryGetComponent<BatteryComponent>(out var x);
+                                    return x;
+                                })
+                                .Where((x) => x is not null);
+
+                            var batstat = batdischg
+                                .Aggregate(
+                                    (tot: 0f, max: 0f),
+                                    (a, b) => (a.tot + (b?.CurrentCharge ?? 0), a.max + (b?.MaxCharge ?? 0))
+                                );
+
+                            Units.Power.TryGetUnit(batstat.max, out var bmu);
+                            DebugTools.AssertNotNull(bmu);
+                            buf += Loc.GetString("power-measure-report",
+                                    ("outlet", node.Key),
+                                    ("supply", Units.Power.Format(sup, "N2")),
+                                    ("demand", Units.Power.Format(dmd, "N2")),
+                                    ("chgdmd", Units.Power.Format(chgdmd, "N2")),
+                                    ("batprc", (batstat.tot / batstat.max).ToString("P1")),
+                                    ("battot", (batstat.tot * bmu!.Factor).ToString("N2")),
+                                    ("batmax", Units.Power.Format(batstat.max, "N2"))
+                            ) + "\n";
+                        }
+                        break;
+
+                    case ApcNet ng:
+                        {
+                            var sup = ng.Apcs.Sum(a => a.Battery?.CurrentCharge ?? 0);
+
+                            var dmd = ng.Providers
+                                .Aggregate(
+                                    new List<ApcPowerReceiverComponent>(),
+                                    (a, p) => { a.AddRange(p.LinkedReceivers); return a; }
+                                )
+                                .Sum(c => c.NetworkLoad.DesiredPower);
+
+                            var batstat = ng.Apcs
+                                .Select(a => a.Battery)
+                                .Aggregate(
+                                    (tot: 0f, max: 0f),
+                                    (a, b) => (a.tot + b?.CurrentCharge ?? 0, a.max + b?.MaxCharge ?? 0)
+                                );
+
+                            Units.Power.TryGetUnit(batstat.max, out var bmu);
+                            DebugTools.AssertNotNull(bmu);
+                            buf += Loc.GetString("power-measure-report-apc",
+                                    ("outlet", node.Key),
+                                    ("supply", Units.Power.Format(sup, "N2")),
+                                    ("demand", Units.Power.Format(dmd, "N2")),
+                                    ("batprc", (batstat.tot / batstat.max).ToString("P1")),
+                                    ("battot", (batstat.tot * bmu!.Factor).ToString("N2")),
+                                    ("batmax", Units.Power.Format(batstat.max, "N2"))
+                            ) + "\n";
+                        }
+                        break;
+                }
+            }
+            return buf;
+        }
+    }
+}

--- a/Content.Shared/Localizations/Units.cs
+++ b/Content.Shared/Localizations/Units.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Content.Shared.Localizations.Units
+{
+    public static class Units
+    {
+        public sealed class TypeTable
+        {
+            public readonly Entry[] E;
+
+            public TypeTable(params Entry[] e) => E = e;
+
+            public sealed class Entry
+            {
+                public readonly (float? Min, float? Max) Range;
+                public readonly float Factor;
+                public readonly string Unit;
+
+                public Entry(ValueTuple<float?, float?> range, float factor, string unit)
+                {
+                    Range = range;
+                    Factor = factor;
+                    Unit = unit;
+                }
+            }
+
+            public bool TryGetUnit(float val, [NotNullWhen(true)] out Entry? winner)
+            {
+                Entry? w = default!;
+                foreach (var e in E)
+                    if ((e.Range.Min == null || e.Range.Min <= val) && (e.Range.Max == null || val < e.Range.Max))
+                        w = e;
+
+                winner = w;
+                return w != null;
+            }
+
+            public string Format(float val)
+            {
+                if (TryGetUnit(val, out var w))
+                    return (val * w.Factor).ToString() + " " + w.Unit;
+
+                return val.ToString();
+            }
+
+            public string Format(float val, string fmt)
+            {
+                if (TryGetUnit(val, out var w))
+                    return (val * w.Factor).ToString(fmt) + " " + w.Unit;
+
+                return val.ToString(fmt);
+            }
+        }
+
+        // Someone should probably port this to YAML, but it ain't gonna be me.
+
+        public static readonly TypeTable Pressure = new TypeTable
+        (
+            new TypeTable.Entry(range: (null, 1e-3f), factor: 1e6f, unit: "µPa"),
+            new TypeTable.Entry(range: (1e-3f, 1f), factor: 1e3f, unit: "mPa"),
+            new TypeTable.Entry(range: (1f, 1000f), factor: 1f, unit: "Pa"),
+            new TypeTable.Entry(range: (1000f, 1e6f), factor: 1e-4f, unit: "kPa"),
+            new TypeTable.Entry(range: (1e6f, 1e9f), factor: 1e-6f, unit: "MPa"),
+            new TypeTable.Entry(range: (1e9f, null), factor: 1e-9f, unit: "GPa")
+        );
+
+        public static readonly TypeTable Power = new TypeTable
+        (
+            new TypeTable.Entry(range: (null, 1e-3f), factor: 1e6f, unit: "µW"),
+            new TypeTable.Entry(range: (1e-3f, 1f), factor: 1e3f, unit: "mW"),
+            new TypeTable.Entry(range: (1f, 1000f), factor: 1f, unit: "W"),
+            new TypeTable.Entry(range: (1000f, 1e6f), factor: 1e-4f, unit: "KW"),
+            new TypeTable.Entry(range: (1e6f, 1e9f), factor: 1e-6f, unit: "MW"),
+            new TypeTable.Entry(range: (1e9f, null), factor: 1e-9f, unit: "GW")
+        );
+    }
+}

--- a/Resources/Locale/en-US/tools/power-measure.ftl
+++ b/Resources/Locale/en-US/tools/power-measure.ftl
@@ -1,0 +1,2 @@
+power-measure-report = Outlet: {$outlet} / SUP: {$supply} / DMD: {$demand}+{$chgdmd} / BAT: {$batprc} ({$battot}/{$batmax})
+power-measure-report-apc = Outlet: {$outlet} / SUP: {$supply} / DMD: {$demand} / BAT: {$batprc} ({$battot}/{$batmax})

--- a/Resources/Locale/en-US/tools/tool-qualities.ftl
+++ b/Resources/Locale/en-US/tools/tool-qualities.ftl
@@ -15,3 +15,6 @@ tool-quality-welding-tool-name = Welder
 
 tool-quality-pulsing-name = Pulsing
 tool-quality-pulsing-tool-name = Multitool
+
+tool-quality-pulsing-name = Power Measuring
+tool-quality-pulsing-tool-name = Multitool

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -178,6 +178,7 @@
   - type: Tool
     qualities:
       - Pulsing
+      - PowerMeasuring
   - type: SignalLinker
 
 - type: entity

--- a/Resources/Prototypes/tool_qualities.yml
+++ b/Resources/Prototypes/tool_qualities.yml
@@ -39,3 +39,10 @@
   toolName: tool-quality-pulsing-tool-name
   spawn: Multitool
   icon: Objects/Tools/multitool.rsi/icon.png
+
+- type: tool
+  id: PowerMeasuring
+  name: tool-quality-power-measuring-name
+  toolName: tool-quality-power-measuring-tool-name
+  spawn: Multitool
+  icon: Objects/Tools/multitool.rsi/icon.png


### PR DESCRIPTION
## About the PR
Just click a cable and read! _Coming soon to devices near you._
(You will, however, have to learn to read rising text quickly...)

 - Adds a "Power Measuring" tool quality
 - Adds a helper to format Pow3r network stats
 - Adds a hacky unit formatter at Content.Shared.Localizations.Units

**Screenshots**
![Screenshot from 2021-10-26 05-21-48](https://user-images.githubusercontent.com/602406/138849936-c8bf22b4-0b27-4593-87b1-a7c7f6ae94c5.png)
**Outlet**: Node name
**SUP**: Supply
**DMD**: Demand + Battery charging demand
**BAT**: Battery Full% (Stored Power / Total Capacity)

**Changelog**
:cl:
- add: Multitools can now measure the power in cables.