### PR TITLE
Fix morgue rotation by using more EntityCoordinates

### DIFF
--- a/Content.Server/Morgue/Components/MorgueEntityStorageComponent.cs
+++ b/Content.Server/Morgue/Components/MorgueEntityStorageComponent.cs
@@ -16,6 +16,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -106,8 +107,7 @@ namespace Content.Server.Morgue.Components
                 TrayContainer?.Remove(_tray);
             }
 
-            _tray.Transform.WorldPosition = Owner.Transform.WorldPosition + Owner.Transform.LocalRotation.GetCardinalDir().ToVec();
-            _tray.Transform.AttachParent(Owner);
+            _tray.Transform.Coordinates = new EntityCoordinates(Owner.Uid, 0, -1);
 
             base.OpenStorage();
         }


### PR DESCRIPTION
## About the PR

Fixes the bug where morgue trays wouldn't extend in the correct direction.
The calculations were being done in world coordinates and then reparented for some reason.

**Screenshots**
![image](https://user-images.githubusercontent.com/22304167/138910227-4a572db2-dc8b-43f2-b368-f9faeabfdeef.png)
Taken at a random rotation (near 180-degrees this test it seems)

**Changelog**

:cl:
- fix: Morgue trays now extend to the proper position.

