### PR TITLE
Max Item Size for Storages

### DIFF
--- a/Content.Server/Storage/Components/ServerStorageComponent.cs
+++ b/Content.Server/Storage/Components/ServerStorageComponent.cs
@@ -68,10 +68,7 @@ namespace Content.Server.Storage.Components
         private int _storageCapacityMax = 10000;
 
         [DataField("maxItemSize")]
-        private int _storageMaxItemSize = 10000;
-
-        [DataField("maxItemSizeWhitelistBypass")]
-        private bool _storageMaxItemSizeWhitelistBypass = false;
+        private int? _storageMaxItemSize;
         public readonly HashSet<IPlayerSession> SubscribedSessions = new();
 
         [DataField("storageSoundCollection")]
@@ -140,17 +137,22 @@ namespace Content.Server.Storage.Components
                 return false;
             }
 
-            // Is this item below the max item size for this container?
-            bool maxItemSizeCheck = (store?.Size <= _storageMaxItemSize);
-
-            if (_whitelist != null && !_whitelist.IsValid(entity))
+            if (_whitelist != null && !_whitelist.IsValid(entity) && (_storageMaxItemSize == null))
             {
-                // If item is not whitelisted, but passes the maximum item size check,
-                // it succeeds - if it's allowed to bypass the whitelist.
-                return (maxItemSizeCheck && _storageMaxItemSizeWhitelistBypass) ? true : false;
+                return false;
             }
 
-            return maxItemSizeCheck;
+            if (store?.Size > _storageMaxItemSize)
+            {
+                return false;
+            }
+
+            if (entity.Transform.Anchored)
+            {
+                return false;
+            }
+            
+            return true;
         }
 
         /// <summary>

--- a/Content.Server/Storage/Components/ServerStorageComponent.cs
+++ b/Content.Server/Storage/Components/ServerStorageComponent.cs
@@ -137,21 +137,27 @@ namespace Content.Server.Storage.Components
                 return false;
             }
 
+            // Item is not in whitelist & there is no max item size.
             if (_whitelist != null && !_whitelist.IsValid(entity) && (_storageMaxItemSize == null))
             {
                 return false;
             }
 
-            if (store?.Size > _storageMaxItemSize)
+            // Item is above max item size
+            if (_storageMaxItemSize != null && store?.Size > _storageMaxItemSize)
             {
-                return false;
+                // Item is not whitelisted or there isn't a whitelist.
+                if (_whitelist == null || (_whitelist != null && !_whitelist.IsValid(entity)))
+                {
+                    return false;
+                }
             }
 
             if (entity.Transform.Anchored)
             {
                 return false;
             }
-            
+
             return true;
         }
 

--- a/Content.Server/Storage/Components/ServerStorageComponent.cs
+++ b/Content.Server/Storage/Components/ServerStorageComponent.cs
@@ -66,6 +66,12 @@ namespace Content.Server.Storage.Components
         private int _storageUsed;
         [DataField("capacity")]
         private int _storageCapacityMax = 10000;
+
+        [DataField("maxItemSize")]
+        private int _storageMaxItemSize = 10000;
+
+        [DataField("maxItemSizeWhitelistBypass")]
+        private bool _storageMaxItemSizeWhitelistBypass = false;
         public readonly HashSet<IPlayerSession> SubscribedSessions = new();
 
         [DataField("storageSoundCollection")]
@@ -136,6 +142,13 @@ namespace Content.Server.Storage.Components
 
             if (_whitelist != null && !_whitelist.IsValid(entity))
             {
+                // Item is not whitelisted, but passes the maximum item size check.
+                if (store?.Size <= _storageMaxItemSize)
+                {
+                    // Succeed if allowed to bypass the whitelist.
+                    return _storageMaxItemSizeWhitelistBypass ? true : false;
+                }
+
                 return false;
             }
 

--- a/Content.Server/Storage/Components/ServerStorageComponent.cs
+++ b/Content.Server/Storage/Components/ServerStorageComponent.cs
@@ -140,19 +140,17 @@ namespace Content.Server.Storage.Components
                 return false;
             }
 
+            // Is this item below the max item size for this container?
+            bool maxItemSizeCheck = (store?.Size <= _storageMaxItemSize);
+
             if (_whitelist != null && !_whitelist.IsValid(entity))
             {
-                // Item is not whitelisted, but passes the maximum item size check.
-                if (store?.Size <= _storageMaxItemSize)
-                {
-                    // Succeed if allowed to bypass the whitelist.
-                    return _storageMaxItemSizeWhitelistBypass ? true : false;
-                }
-
-                return false;
+                // If item is not whitelisted, but passes the maximum item size check,
+                // it succeeds - if it's allowed to bypass the whitelist.
+                return (maxItemSizeCheck && _storageMaxItemSizeWhitelistBypass) ? true : false;
             }
 
-            return true;
+            return maxItemSizeCheck;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Implemented a "Max Item Size" for storages; allowing to balance out some storages where we might want a large amount of only small items, without using a **whitelist**.
Bypassing an existing whitelist with this is possible as it also includes a bool for **whitelist bypass**.
Should not affect the current storages until the storage items get a "maxItemSize" value set in the YML.

This should allow for more balancing options on storages. 

**Example usage:**
A hypothetical purse storage item holds 30 of space. A mop takes 10 of space. It would be possible to fit a mop inside a purse, which is unrealistic and counterintuitive. For this we might come to a few solutions in mind:

- A whitelist, but then, only allowed items would be let in the purse. And as more and more items get added, maintaining such whitelists can become tiring and unefficient, as there could potentially be hundreds of  small sized items that _should_ fit inside a purse.
- Lowering the purse's storage capacity. Sure! But now we can only fit like 5 coins inside a purse... (Assuming coins would t ake up 1 in space)

Then, what do we do? Well. I propose a maximum item size for storages. In addition to checking if the item can fit the capacity and does not surpass it, we can also check if it's below the storage's Max Item Size.

Back to our purse. Our purse has a capacity of 30, but a max item size of 5. This means that even though a mop's size is 10, it's above the purse's maximum size for an item to be put inside it. So it will not fit. And we can fit 30 coins inside (and probably more with changes to those variables).
In theory, you could have a coin purse with 100 space but a max item size of 1, so only a coin or a cigarrete will fit inside it

In short, this is just another suggestion on a new way to balance certain storages.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: TheLife
- add: Added a maximum item size for storages.

