### PR TITLE
Give the Engi-Vend insulated gloves (only one machine in engineering)

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -7,3 +7,5 @@
     ClothingEyesGlassesMeson: 4
     Multitool: 4
     PowerCellSmallHigh: 5
+    ClothingHandsGlovesColorYellow: 6
+


### PR DESCRIPTION
## About the PR
This is because engineers end up not having enough insulated gloves to go around.
Kinda bad.

**Changelog**

:cl:
- add: Engi-Vend has insulated gloves so engineering don't run out with latejoins or just a lot of roundstart engineers

