### PR TITLE
Use conversion instead of a constructor for NetUserId

### DIFF
--- a/Content.Client/Commands/OpenAHelpCommand.cs
+++ b/Content.Client/Commands/OpenAHelpCommand.cs
@@ -32,7 +32,7 @@ namespace Content.Client.Commands
             {
                 if (Guid.TryParse(args[0], out var guid))
                 {
-                    EntitySystem.Get<BwoinkSystem>().EnsureWindow(new NetUserId(guid));
+                    EntitySystem.Get<BwoinkSystem>().EnsureWindow((NetUserId) guid);
                 }
                 else
                 {

--- a/Content.Server/Administration/Commands/BanListCommand.cs
+++ b/Content.Server/Administration/Commands/BanListCommand.cs
@@ -36,7 +36,7 @@ namespace Content.Server.Administration.Commands
             }
             else if (Guid.TryParse(target, out var targetGuid))
             {
-                targetUid = new NetUserId(targetGuid);
+                targetUid = (NetUserId) targetGuid;
             }
             else
             {

--- a/Content.Server/Administration/PlayerLocator.cs
+++ b/Content.Server/Administration/PlayerLocator.cs
@@ -85,7 +85,7 @@ namespace Content.Server.Administration
                 return null;
             }
 
-            return new LocatedPlayerData(new NetUserId(responseData.UserId), null, null);
+            return new LocatedPlayerData((NetUserId) responseData.UserId, null, null);
         }
 
         public async Task<LocatedPlayerData?> LookupIdAsync(NetUserId userId, CancellationToken cancel = default)
@@ -125,7 +125,7 @@ namespace Content.Server.Administration
         {
             if (Guid.TryParse(playerName, out var guid))
             {
-                var userId = new NetUserId(guid);
+                var userId = (NetUserId) guid;
 
                 return await LookupIdAsync(userId, cancel);
             }

--- a/Content.Server/Administration/UI/PermissionsEui.cs
+++ b/Content.Server/Administration/UI/PermissionsEui.cs
@@ -76,7 +76,7 @@ namespace Content.Server.Administration.UI
                     NegFlags = AdminFlagsHelper.NamesToFlags(p.a.Flags.Where(f => f.Negative).Select(f => f.Flag)),
                     Title = p.a.Title,
                     RankId = p.a.AdminRankId,
-                    UserId = new NetUserId(p.a.UserId),
+                    UserId = (NetUserId) p.a.UserId,
                     UserName = p.lastUserName
                 }).ToArray(),
 
@@ -293,7 +293,7 @@ namespace Content.Server.Administration.UI
             NetUserId userId;
             if (Guid.TryParse(ca.UserNameOrId, out var guid))
             {
-                userId = new NetUserId(guid);
+                userId = (NetUserId) guid;
                 var playerRecord = await _db.GetPlayerRecordByUserId(userId);
                 if (playerRecord == null)
                 {

--- a/Content.Server/Commands/CommandUtils.cs
+++ b/Content.Server/Commands/CommandUtils.cs
@@ -25,7 +25,7 @@ namespace Content.Server.Commands
             if (plyMgr.TryGetSessionByUsername(usernameOrId, out session)) return true;
             if (Guid.TryParse(usernameOrId, out var targetGuid))
             {
-                if (plyMgr.TryGetSessionById(new NetUserId(targetGuid), out session)) return true;
+                if (plyMgr.TryGetSessionById((NetUserId) targetGuid, out session)) return true;
                 shell.WriteLine("Unable to find user with that name/id.");
                 return false;
             }

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -109,7 +109,7 @@ The ban reason is: ""{ban.Reason}""
                 return userId;
             }
 
-            var assigned = new NetUserId(Guid.NewGuid());
+            var assigned = (NetUserId) Guid.NewGuid();
             await _db.AssignUserIdAsync(name, assigned);
             return assigned;
         }

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -229,7 +229,7 @@ namespace Content.Server.Database
             await using var db = await GetDb();
 
             var assigned = await db.DbContext.AssignedUserId.SingleOrDefaultAsync(p => p.UserName == name);
-            return assigned?.UserId is { } g ? new NetUserId(g) : default(NetUserId?);
+            return assigned?.UserId is { } g ? (NetUserId) g : default(NetUserId?);
         }
 
         public async Task AssignUserIdAsync(string name, NetUserId netUserId)

--- a/Content.Server/Database/ServerDbPostgres.cs
+++ b/Content.Server/Database/ServerDbPostgres.cs
@@ -148,13 +148,13 @@ namespace Content.Server.Database
             NetUserId? uid = null;
             if (ban.UserId is {} guid)
             {
-                uid = new NetUserId(guid);
+                uid = (NetUserId) guid;
             }
 
             NetUserId? aUid = null;
             if (ban.BanningAdmin is {} aGuid)
             {
-                aUid = new NetUserId(aGuid);
+                aUid = (NetUserId) aGuid;
             }
 
             var unbanDef = ConvertUnban(ban.Unban);
@@ -181,7 +181,7 @@ namespace Content.Server.Database
             NetUserId? aUid = null;
             if (unban.UnbanningAdmin is {} aGuid)
             {
-                aUid = new NetUserId(aGuid);
+                aUid = (NetUserId) aGuid;
             }
 
             return new ServerUnbanDef(
@@ -280,7 +280,7 @@ namespace Content.Server.Database
             }
 
             return new PlayerRecord(
-                new NetUserId(record.UserId),
+                (NetUserId) record.UserId,
                 new DateTimeOffset(record.FirstSeenTime),
                 record.LastSeenUserName,
                 new DateTimeOffset(record.LastSeenTime),

--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -218,7 +218,7 @@ namespace Content.Server.Database
             }
 
             return new PlayerRecord(
-                new NetUserId(record.UserId),
+                (NetUserId) record.UserId,
                 new DateTimeOffset(record.FirstSeenTime, TimeSpan.Zero),
                 record.LastSeenUserName,
                 new DateTimeOffset(record.LastSeenTime, TimeSpan.Zero),
@@ -236,13 +236,13 @@ namespace Content.Server.Database
             NetUserId? uid = null;
             if (ban.UserId is { } guid)
             {
-                uid = new NetUserId(guid);
+                uid = (NetUserId) guid;
             }
 
             NetUserId? aUid = null;
             if (ban.BanningAdmin is { } aGuid)
             {
-                aUid = new NetUserId(aGuid);
+                aUid = (NetUserId) aGuid;
             }
 
             (IPAddress, int)? addrTuple = null;
@@ -277,7 +277,7 @@ namespace Content.Server.Database
             NetUserId? aUid = null;
             if (unban.UnbanningAdmin is { } aGuid)
             {
-                aUid = new NetUserId(aGuid);
+                aUid = (NetUserId) aGuid;
             }
 
             return new ServerUnbanDef(

--- a/Content.Tests/Server/Preferences/ServerDbSqliteTests.cs
+++ b/Content.Tests/Server/Preferences/ServerDbSqliteTests.cs
@@ -85,7 +85,7 @@ namespace Content.Tests.Server.Preferences
         public async Task TestInitPrefs()
         {
             var db = GetDb();
-            var username = new NetUserId(new Guid("640bd619-fc8d-4fe2-bf3c-4a5fb17d6ddd"));
+            var username = (NetUserId) new Guid("640bd619-fc8d-4fe2-bf3c-4a5fb17d6ddd");
             const int slot = 0;
             var originalProfile = CharlieCharlieson();
             await db.InitPrefsAsync(username, originalProfile);
@@ -97,7 +97,7 @@ namespace Content.Tests.Server.Preferences
         public async Task TestDeleteCharacter()
         {
             var db = GetDb();
-            var username = new NetUserId(new Guid("640bd619-fc8d-4fe2-bf3c-4a5fb17d6ddd"));
+            var username = (NetUserId) new Guid("640bd619-fc8d-4fe2-bf3c-4a5fb17d6ddd");
             IoCManager.Resolve<ISerializationManager>().Initialize();
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
             prototypeManager.Initialize();


### PR DESCRIPTION
Literally just a code style change, I guess, as it still technically calls `new blahblahblah` but it looks nicer and it is still explicit enough to not look jarring?