### PR TITLE
Fix stuck in-hand sprites

### DIFF
--- a/Content.Client/Hands/HandsComponent.cs
+++ b/Content.Client/Hands/HandsComponent.cs
@@ -28,15 +28,12 @@ namespace Content.Client.Hands
 
             ActiveHand = state.ActiveHand;
 
-            UpdateHandContainers();
-            UpdateHandVisualizer();
-            Owner.EntityManager.EventBus.RaiseEvent(EventSource.Local, new HandsModifiedMessage { Hands = this });
+            HandsModified();
         }
 
         public override void HandsModified()
         {
             UpdateHandContainers();
-            UpdateHandVisualizer();
 
             base.HandsModified();
         }
@@ -54,29 +51,6 @@ namespace Content.Client.Hands
                     hand.Container = container;
                 }
             }
-        }
-
-        public void UpdateHandVisualizer()
-        {
-            if (Owner.TryGetComponent(out SharedAppearanceComponent? appearance))
-                appearance.SetData(HandsVisuals.VisualState, GetHandsVisualState());
-        }
-
-        private HandsVisualState GetHandsVisualState()
-        {
-            var hands = new List<HandVisualState>();
-            foreach (var hand in Hands)
-            {
-                if (hand.HeldEntity == null)
-                    continue;
-
-                if (!hand.HeldEntity.TryGetComponent(out SharedItemComponent? item) || item.RsiPath == null)
-                    continue;
-
-                var handState = new HandVisualState(item.RsiPath, item.EquippedPrefix, hand.Location, item.Color);
-                hands.Add(handState);
-            }
-            return new(hands);
         }
     }
 }

--- a/Content.Client/Hands/HandsVisualizer.cs
+++ b/Content.Client/Hands/HandsVisualizer.cs
@@ -61,38 +61,4 @@ namespace Content.Client.Hands
             return location.ToString();
         }
     }
-
-    public enum HandsVisuals : byte
-    {
-        VisualState
-    }
-
-    public class HandsVisualState
-    {
-        public List<HandVisualState> Hands { get; } = new();
-
-        public HandsVisualState(List<HandVisualState> hands)
-        {
-            Hands = hands;
-        }
-    }
-
-    public class HandVisualState
-    {
-        public string RsiPath { get; }
-
-        public string? EquippedPrefix { get; }
-
-        public HandLocation Location { get; }
-
-        public Color Color { get; }
-
-        public HandVisualState(string rsiPath, string? equippedPrefix, HandLocation location, Color color)
-        {
-            RsiPath = rsiPath;
-            EquippedPrefix = equippedPrefix;
-            Location = location;
-            Color = color;
-        }
-    }
 }


### PR DESCRIPTION
This PR moves `HandsVisuals` and various hand-visual related code over to `SharedHandsComponent`.

Currently the `AppearanceComponent` data used by the `HandsVisualizer` (`HandsVisuals.VisualState`) is only defined and set client-side (not networked). This results in the in-hand sprites occasionally getting stuck (see #4233), and afaict this also causes the in-hand sprites of other players to not be accurate unless the held-entity is updated while they are in view of the local client.

As to how the local stuck sprite stuff happens
Because the `HandsVisuals.VisualState` is only clientside, when the server marks the `AppearanceComponent` as dirty, the  state handling results in that data being lost. Then, when `HandVisualizer` attempts `AppearanceComponent.TryGetData`, it fails and just stops updating the visualizer until the `HandsVisuals.VisualState` data is set again by some client-side function.  slipping or being stunned just causes that to happen.

fixes #4233 (1. on the list is was apparently fixed by #4259)

:cl:
- fix: Fixes in-hand sprites not properly updating.

