### PR TITLE
Adds support for unlimited stacks

### DIFF
--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -62,6 +62,8 @@ namespace Content.Server.Stack
             {
                 // Set the split stack's count.
                 SetCount(entity.Uid, amount, stackComp);
+                // Don't let people dupe unlimited stacks
+                stackComp.Unlimited = false;
             }
 
             return entity;

--- a/Content.Shared/Stacks/SharedStackComponent.cs
+++ b/Content.Shared/Stacks/SharedStackComponent.cs
@@ -15,6 +15,7 @@ namespace Content.Shared.Stacks
     {
         public sealed override string Name => "Stack";
 
+
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("stackType", required:true, customTypeSerializer:typeof(PrototypeIdSerializer<StackPrototype>))]
         public string StackTypeId { get; private set; } = string.Empty;
@@ -28,11 +29,19 @@ namespace Content.Shared.Stacks
         public int Count { get; set; } = 30;
 
         /// <summary>
-        ///     Max amount of things that can be in the stack.
+        ///     Max amount of things that can be in the stack. Set to -1 for unlimited.
         /// </summary>
+        [DataField("max")] private int _maxCount = 30;
         [ViewVariables(VVAccess.ReadOnly)]
-        [DataField("max")]
-        public int MaxCount { get; set; } = 30;
+        public int MaxCount
+        {
+            get
+            {
+                if(_maxCount == -1) return int.MaxValue;
+                return _maxCount;
+            }
+            set => _maxCount = value;
+        }
 
         [ViewVariables]
         public int AvailableSpace => MaxCount - Count;

--- a/Content.Shared/Stacks/SharedStackComponent.cs
+++ b/Content.Shared/Stacks/SharedStackComponent.cs
@@ -36,14 +36,14 @@ namespace Content.Shared.Stacks
         public int MaxCount  { get; set; } = 30;
 
         /// <summary>
-        ///     Set to true to have an unlimited max count.
+        ///     Set to true to not reduce the count when used.
         /// </summary>
         [DataField("unlimited")]
         [ViewVariables(VVAccess.ReadOnly)]
-        public bool UnlimitedCount { get; set; }
+        public bool Unlimited { get; set; }
 
         [ViewVariables]
-        public int AvailableSpace => UnlimitedCount ? int.MaxValue - Count : MaxCount - Count;
+        public int AvailableSpace => MaxCount - Count;
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Stacks/SharedStackComponent.cs
+++ b/Content.Shared/Stacks/SharedStackComponent.cs
@@ -29,22 +29,21 @@ namespace Content.Shared.Stacks
         public int Count { get; set; } = 30;
 
         /// <summary>
-        ///     Max amount of things that can be in the stack. Set to -1 for unlimited.
+        ///     Max amount of things that can be in the stack.
         /// </summary>
-        [DataField("max")] private int _maxCount = 30;
         [ViewVariables(VVAccess.ReadOnly)]
-        public int MaxCount
-        {
-            get
-            {
-                if(_maxCount == -1) return int.MaxValue;
-                return _maxCount;
-            }
-            set => _maxCount = value;
-        }
+        [DataField("max")]
+        public int MaxCount  { get; set; } = 30;
+
+        /// <summary>
+        ///     Set to true to have an unlimited max count.
+        /// </summary>
+        [DataField("unlimited")]
+        [ViewVariables(VVAccess.ReadOnly)]
+        public bool UnlimitedCount { get; set; }
 
         [ViewVariables]
-        public int AvailableSpace => MaxCount - Count;
+        public int AvailableSpace => UnlimitedCount ? int.MaxValue - Count : MaxCount - Count;
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -73,7 +73,11 @@ namespace Content.Shared.Stacks
             }
 
             // We do have enough things in the stack, so remove them and change.
-            SetCount(uid, stack.Count - amount, stack);
+            if (!stack.Unlimited)
+            {
+                SetCount(uid, stack.Count - amount, stack);
+            }
+
             return true;
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes #5082 

Setting a stack's `unlimited` to true will make the stack "unlimited" in that it won't reduce the count on use.

I did some basic testing and it seems fine.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

No CL since it's not really relevant unless someone added like... sandbox stacks.