### PR TITLE
Fix cable blocking not working properly due to inconsistent field naming

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -37,7 +37,7 @@
     HeldPrefix: coilhv
   - type: CablePlacer
     cablePrototypeID: CableHV
-    blockingCableType: HighVoltage
+    blockingWireType: HighVoltage
   - type: Appearance
     visuals:
       - type: StackVisualizer
@@ -73,7 +73,7 @@
     HeldPrefix: coilmv
   - type: CablePlacer
     cablePrototypeID: CableMV
-    blockingCableType: MediumVoltage
+    blockingWireType: MediumVoltage
   - type: Appearance
     visuals:
       - type: StackVisualizer
@@ -108,7 +108,7 @@
     HeldPrefix: coillv
   - type: CablePlacer
     cablePrototypeID: CableApcExtension
-    blockingCableType: Apc
+    blockingWireType: Apc
   - type: Appearance
     visuals:
       - type: StackVisualizer


### PR DESCRIPTION
## About the PR

YAML-only change

**Changelog**

:cl:
- fix: can no longer place multiple wires of the same type on one spot, HV no longer blocks other wires.

