### PR TITLE
Extractible tweak - Allow grinding and juicing

### DIFF
--- a/Content.Server/Kitchen/Components/ExtractableComponent.cs
+++ b/Content.Server/Kitchen/Components/ExtractableComponent.cs
@@ -17,11 +17,11 @@ namespace Content.Server.Kitchen.Components
         public override string Name => "Extractable";
 
         [ViewVariables]
-        [DataField("result")] 
-        public Solution ResultSolution = new();
+        [DataField("juiceSolution")] 
+        public Solution? JuiceSolution;
 
         [ViewVariables] 
-        [DataField("extractableSolution")]
+        [DataField("grindableSolutionName")]
         public string? GrindableSolution;
     }
 }

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -227,8 +227,9 @@ namespace Content.Server.Kitchen.EntitySystems
                     {
                         if (canJuice || !entity.TryGetComponent(out ExtractableComponent? component)) continue;
 
-                        canJuice = component.GrindableSolution == null;
-                        canGrind = component.GrindableSolution != null;
+                        canJuice = component.JuiceSolution != null;
+                        canGrind = component.GrindableSolution != null 
+                                   && _solutionsSystem.TryGetSolution(entity.Uid, component.GrindableSolution, out _);
                     }
                 }
 
@@ -340,10 +341,10 @@ namespace Content.Server.Kitchen.EntitySystems
                             }
 
                             if (component.HeldBeaker.CurrentVolume +
-                                juiceMe.ResultSolution.TotalVolume * juiceEvent.Scalar >
+                                juiceMe.JuiceSolution!.TotalVolume * juiceEvent.Scalar >
                                 component.HeldBeaker.MaxVolume) continue;
-                            juiceMe.ResultSolution.ScaleSolution(juiceEvent.Scalar);
-                            _solutionsSystem.TryAddSolution(beakerEntity.Uid, component.HeldBeaker, juiceMe.ResultSolution);
+                            juiceMe.JuiceSolution.ScaleSolution(juiceEvent.Scalar);
+                            _solutionsSystem.TryAddSolution(beakerEntity.Uid, component.HeldBeaker, juiceMe.JuiceSolution);
                             item.Delete();
                         }
 

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Log;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
@@ -333,7 +334,12 @@ namespace Content.Server.Kitchen.EntitySystems
                     {
                         foreach (var item in component.Chamber.ContainedEntities.ToList())
                         {
-                            if (!item.TryGetComponent<ExtractableComponent>(out var juiceMe)) continue;
+                            if (!item.TryGetComponent<ExtractableComponent>(out var juiceMe)
+                                || juiceMe.JuiceSolution == null)
+                            {
+                                Logger.Warning("Couldn't find a juice solution on entityUid:{0}", item.Uid);
+                                continue;
+                            }
                             var juiceEvent = new ExtractableScalingEvent(); // default of scalar is always 1.0
                             if (item.HasComponent<StackComponent>())
                             {
@@ -341,7 +347,7 @@ namespace Content.Server.Kitchen.EntitySystems
                             }
 
                             if (component.HeldBeaker.CurrentVolume +
-                                juiceMe.JuiceSolution!.TotalVolume * juiceEvent.Scalar >
+                                juiceMe.JuiceSolution.TotalVolume * juiceEvent.Scalar >
                                 component.HeldBeaker.MaxVolume) continue;
                             juiceMe.JuiceSolution.ScaleSolution(juiceEvent.Scalar);
                             _solutionsSystem.TryAddSolution(beakerEntity.Uid, component.HeldBeaker, juiceMe.JuiceSolution);

--- a/Resources/Prototypes/Body/Mechanisms/human.yml
+++ b/Resources/Prototypes/Body/Mechanisms/human.yml
@@ -9,7 +9,7 @@
   - type: Mechanism
   - type: Food
   - type: Extractable
-    extractableSolution: extractableSolution
+    grindableSolutionName: organ
   - type: SolutionContainerManager
     solutions:
       organ:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -385,7 +385,7 @@
 # a mob is dead or something idk
   - type: Food
   - type: Extractable
-    extractableSolution: food
+    grindableSolutionName: food
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -11,7 +11,7 @@
     state: produce
   - type: Produce
   - type: Extractable
-    extractableSolution: food
+    grindableSolutionName: food
 
 # For produce that can be immediately eaten
 
@@ -26,7 +26,6 @@
     state: produce
   - type: Produce
   - type: Extractable
-    extractableSolution: food
 
 # Subclasses
 
@@ -64,7 +63,7 @@
   - type: Produce
     seed: oat
   - type: Extractable
-    result:
+    juiceSolution:
       reagents:
       - ReagentId: MilkOat
         Quantity: 5
@@ -123,7 +122,7 @@
   - type: Produce
     seed: banana
   - type: Extractable
-    result:
+    juiceSolution:
       reagents:
       - ReagentId: JuiceBanana
         Quantity: 10
@@ -181,7 +180,7 @@
   - type: Produce
     seed: carrots
   - type: Extractable
-    result:
+    juiceSolution:
       reagents:
       - ReagentId: JuiceCarrot
         Quantity: 10
@@ -204,7 +203,7 @@
   - type: Produce
     seed: lemon
   - type: Extractable
-    result:
+    juiceSolution:
       reagents:
       - ReagentId: JuiceLime
         Quantity: 10
@@ -227,7 +226,7 @@
   - type: Produce
     seed: pineapple
   - type: Extractable
-    result:
+    juiceSolution:
       reagents:
       - ReagentId: JuicePineapple
         Quantity: 10
@@ -269,7 +268,8 @@
   - type: Produce
     seed: tomato
   - type: Extractable
-    result:
+    grindableSolutionName: food
+    juiceSolution:
       reagents:
       - ReagentId: JuiceTomato
         Quantity: 10
@@ -364,7 +364,7 @@
   - type: Produce
     seed: apple
   - type: Extractable
-    result:
+    juiceSolution:
       reagents:
       - ReagentId: JuiceApple
         Quantity: 10
@@ -477,7 +477,7 @@
     netsync: false
     state: slice
   - type: Extractable
-    extractableSolution: food
+    grindableSolutionName: food
 
 - type: entity
   name: pineapple slice
@@ -488,7 +488,7 @@
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/pineapple.rsi
   - type: Extractable
-    result:
+    juiceSolution:
       reagents:
       - ReagentId: JuicePineapple
         Quantity: 2

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -93,7 +93,7 @@
       - plasma_2
       - plasma_3
   - type: Extractable
-    extractableSolution: plasma
+    grindableSolutionName: plasma
   - type: SolutionContainerManager
     solutions:
       plasma:


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR does two things:
Renames fields to make more sense:

1.  `result` -> `juiceableSolution`
2. `extractableSolution` -> `grindableSolutioName`

Changes logic a bit so things can be both juiceable and grindable. Implemented this on Tomato. It just creates Nutriment.

**Screenshots**
![Grindable](https://user-images.githubusercontent.com/1146204/139561146-bca75ecc-217f-4784-8116-0373064438eb.mp4)

**Changelog**

:cl:
- tweak: Make tomato juiceable and grindable. Finally, more nutritious juice is possible.

