### PR TITLE
Make humans move based on their last grid's angle

### DIFF
--- a/Content.Server/AI/Components/AiControllerComponent.cs
+++ b/Content.Server/AI/Components/AiControllerComponent.cs
@@ -87,6 +87,8 @@ namespace Content.Server.AI.Components
             }
         }
 
+        public Angle LastGridAngle { get => Angle.Zero; set {} }
+
         /// <inheritdoc />
         [ViewVariables(VVAccess.ReadWrite)]
         public float PushStrength { get; set; } = IMobMoverComponent.PushStrengthDefault;

--- a/Content.Shared/Movement/Components/IMoverComponent.cs
+++ b/Content.Shared/Movement/Components/IMoverComponent.cs
@@ -22,6 +22,8 @@ namespace Content.Shared.Movement.Components
         /// </summary>
         bool Sprinting { get; }
 
+        Angle LastGridAngle { get; set; }
+
         /// <summary>
         ///     Calculated linear velocity direction of the entity.
         /// </summary>

--- a/Content.Shared/Movement/Components/SharedDummyInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/SharedDummyInputMoverComponent.cs
@@ -12,6 +12,8 @@ namespace Content.Shared.Movement.Components
         public float CurrentWalkSpeed => 0f;
         public float CurrentSprintSpeed => 0f;
 
+        public Angle LastGridAngle { get => Angle.Zero; set {} }
+
         public bool Sprinting => false;
         public (Vector2 walking, Vector2 sprinting) VelocityDir => (Vector2.Zero, Vector2.Zero);
 

--- a/Content.Shared/Movement/Components/SharedPlayerInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/SharedPlayerInputMoverComponent.cs
@@ -50,6 +50,8 @@ namespace Content.Shared.Movement.Components
 
         private MoveButtons _heldMoveButtons = MoveButtons.None;
 
+        public Angle LastGridAngle { get; set; } = new(0);
+
         public float CurrentWalkSpeed => _movementSpeed?.CurrentWalkSpeed ?? MovementSpeedModifierComponent.DefaultBaseWalkSpeed;
 
         public float CurrentSprintSpeed => _movementSpeed?.CurrentSprintSpeed ?? MovementSpeedModifierComponent.DefaultBaseSprintSpeed;

--- a/Content.Shared/Movement/Components/SharedPlayerInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/SharedPlayerInputMoverComponent.cs
@@ -119,6 +119,7 @@ namespace Content.Shared.Movement.Components
         {
             base.Initialize();
             Owner.EnsureComponentWarn<PhysicsComponent>();
+            LastGridAngle = Owner.Transform.Parent?.WorldRotation ?? new Angle(0);
         }
 
         /// <summary>

--- a/Content.Shared/Movement/SharedMoverController.cs
+++ b/Content.Shared/Movement/SharedMoverController.cs
@@ -119,7 +119,7 @@ namespace Content.Shared.Movement
             // Regular movement.
             // Target velocity.
             // This is relative to the map / grid we're on.
-            var total = (walkDir * mover.CurrentWalkSpeed + sprintDir * mover.CurrentSprintSpeed);
+            var total = walkDir * mover.CurrentWalkSpeed + sprintDir * mover.CurrentSprintSpeed;
 
             var worldTotal = _relativeMovement ?
                 new Angle(transform.Parent!.WorldRotation.Theta).RotateVec(total) :
@@ -131,6 +131,11 @@ namespace Content.Shared.Movement
             {
                 worldTotal *= mobMover.WeightlessStrength;
             }
+
+            if (transform.GridID == GridId.Invalid)
+                worldTotal = mover.LastGridAngle.RotateVec(worldTotal);
+            else
+                mover.LastGridAngle = transform.Parent!.WorldRotation;
 
             if (worldTotal != Vector2.Zero)
             {

--- a/Content.Shared/Movement/SharedMoverController.cs
+++ b/Content.Shared/Movement/SharedMoverController.cs
@@ -67,16 +67,21 @@ namespace Content.Shared.Movement
         {
             var (walkDir, sprintDir) = mover.VelocityDir;
 
+            var transform = mover.Owner.Transform;
+
             // Regular movement.
             // Target velocity.
-            var total = (walkDir * mover.CurrentWalkSpeed + sprintDir * mover.CurrentSprintSpeed);
+            var total = walkDir * mover.CurrentWalkSpeed + sprintDir * mover.CurrentSprintSpeed;
 
-            var worldTotal = _relativeMovement ? new Angle(mover.Owner.Transform.Parent!.WorldRotation.Theta).RotateVec(total) : total;
+            var worldTotal = _relativeMovement ? transform.Parent!.WorldRotation.RotateVec(total) : total;
+
+            if (transform.GridID == GridId.Invalid)
+                worldTotal = mover.LastGridAngle.RotateVec(worldTotal);
+            else
+                mover.LastGridAngle = transform.Parent!.WorldRotation;
 
             if (worldTotal != Vector2.Zero)
-            {
-                mover.Owner.Transform.WorldRotation = worldTotal.GetDir().ToAngle();
-            }
+                transform.WorldRotation = worldTotal.GetDir().ToAngle();
 
             physicsComponent.LinearVelocity = worldTotal;
         }
@@ -111,6 +116,8 @@ namespace Content.Shared.Movement
 
                 if (!touching)
                 {
+                    if (transform.GridID != GridId.Invalid)
+                        mover.LastGridAngle = transform.Parent!.WorldRotation;
                     transform.WorldRotation = physicsComponent.LinearVelocity.GetDir().ToAngle();
                     return;
                 }
@@ -121,16 +128,12 @@ namespace Content.Shared.Movement
             // This is relative to the map / grid we're on.
             var total = walkDir * mover.CurrentWalkSpeed + sprintDir * mover.CurrentSprintSpeed;
 
-            var worldTotal = _relativeMovement ?
-                new Angle(transform.Parent!.WorldRotation.Theta).RotateVec(total) :
-                total;
+            var worldTotal = _relativeMovement ? transform.Parent!.WorldRotation.RotateVec(total) : total;
 
             DebugTools.Assert(MathHelper.CloseToPercent(total.Length, worldTotal.Length));
 
             if (weightless)
-            {
                 worldTotal *= mobMover.WeightlessStrength;
-            }
 
             if (transform.GridID == GridId.Invalid)
                 worldTotal = mover.LastGridAngle.RotateVec(worldTotal);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Todo!
- [x] Make ghosts follow this as well, need to hunt down their movement methods

**Changelog**
:cl: Saphire
- add: Make movement in space actually make sense, somewhat!
- add: And make the camera not spaz out when you go into space. Still flips around a bunch, but it isn't jarring anymore!
- fix: Oh and spawning in won't have your camera flipped around anymore for a split second, either

