### PR TITLE
Server/Power: Add a more comprehensive PowerNetBatteryEvent

### DIFF
--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -307,6 +307,10 @@ namespace Content.Server.Power.EntitySystems
                     if (ev != lastEv)
                         RaiseLocalEvent(powerNetBattery.Owner.Uid, ev);
 
+                    // TODO: Remove with PowerNetBatterySupplyEvent
+                    if (ev.Supplying != lastEv.Supplying)
+                        RaiseLocalEvent(powerNetBattery.Owner.Uid, new PowerNetBatterySupplyEvent{ Supply=ev.Supplying });
+
                     _lastBatteryEvent[powerNetBattery] = ev;
                 }
 


### PR DESCRIPTION
## About the PR
Deprecates `PowerNetBatterySupplyEvent`, replaces it with Something Better™.

**Screenshots**
![Screenshot from 2021-11-01 19-17-10](https://user-images.githubusercontent.com/602406/139755022-f2fa30d3-5b89-4207-b5a0-c9773374e6fe.png)


**Changelog**
N/A