### PR TITLE
Update overlays to use WorldAABB instead

### DIFF
--- a/Content.Client/NodeContainer/NodeVisualizationOverlay.cs
+++ b/Content.Client/NodeContainer/NodeVisualizationOverlay.cs
@@ -113,8 +113,8 @@ namespace Content.Client.NodeContainer
             var cursorBox = Box2.CenteredAround(mouseWorldPos, (nodeSize, nodeSize));
 
             // Group visible nodes by grid tiles.
-            var worldBounds = overlayDrawArgs.WorldBounds;
-            _lookup.FastEntitiesIntersecting(map, ref worldBounds, entity =>
+            var worldAABB = overlayDrawArgs.WorldAABB;
+            _lookup.FastEntitiesIntersecting(map, ref worldAABB, entity =>
             {
                 if (!_system.Entities.TryGetValue(entity.Uid, out var nodeData))
                     return;

--- a/Content.Client/Parallax/ParallaxOverlay.cs
+++ b/Content.Client/Parallax/ParallaxOverlay.cs
@@ -50,7 +50,7 @@ namespace Content.Client.Parallax
             var o = new Vector2(posX * Slowness, posY * Slowness);
 
             // Remove offset so we can floor.
-            var (l, b) = args.WorldBounds.BottomLeft - o;
+            var (l, b) = args.WorldAABB.BottomLeft - o;
 
             // Floor to background size.
             l = sizeX * MathF.Floor(l / sizeX);
@@ -60,9 +60,9 @@ namespace Content.Client.Parallax
             l += o.X;
             b += o.Y;
 
-            for (var x = l; x < args.WorldBounds.Right; x += sizeX)
+            for (var x = l; x < args.WorldAABB.Right; x += sizeX)
             {
-                for (var y = b; y < args.WorldBounds.Top; y += sizeY)
+                for (var y = b; y < args.WorldAABB.Top; y += sizeY)
                 {
                     screenHandle.DrawTexture(_parallaxTexture, (x, y));
                 }


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/2190

:cl:
- fix: Fix parallax viewport when the eye is rotated.
