### PR TITLE
Pulling rotation adjustment, newton's third law, entitycoordinates for moveto

### DIFF
--- a/Content.Server/Physics/Controllers/PullController.cs
+++ b/Content.Server/Physics/Controllers/PullController.cs
@@ -74,7 +74,8 @@ namespace Content.Server.Physics.Controllers
                 // Now that's over with...
 
                 var pullerPosition = puller.Transform.MapPosition;
-                if (pullable.MovingTo.Value.MapId != pullerPosition.MapId)
+                var movingTo = pullable.MovingTo.Value.ToMap(pullable.Owner.EntityManager);
+                if (movingTo.MapId != pullerPosition.MapId)
                 {
                     _pullableSystem.StopMoveTo(pullable);
                     continue;
@@ -82,13 +83,13 @@ namespace Content.Server.Physics.Controllers
 
                 if (!pullable.Owner.TryGetComponent<PhysicsComponent>(out var physics) ||
                     physics.BodyType == BodyType.Static ||
-                    pullable.MovingTo.Value.MapId != pullable.Owner.Transform.MapID)
+                    movingTo.MapId != pullable.Owner.Transform.MapID)
                 {
                     _pullableSystem.StopMoveTo(pullable);
                     continue;
                 }
 
-                var movingPosition = pullable.MovingTo.Value.Position;
+                var movingPosition = movingTo.Position;
                 var ownerPosition = pullable.Owner.Transform.MapPosition.Position;
 
                 var diff = movingPosition - ownerPosition;

--- a/Content.Server/Physics/Controllers/PullController.cs
+++ b/Content.Server/Physics/Controllers/PullController.cs
@@ -65,14 +65,15 @@ namespace Content.Server.Physics.Controllers
                     continue;
                 }
 
-                if (pullable.Puller == null)
+                var puller = pullable.Puller;
+                if (puller == null)
                 {
                     continue;
                 }
 
                 // Now that's over with...
 
-                var pullerPosition = pullable.Puller!.Transform.MapPosition;
+                var pullerPosition = puller.Transform.MapPosition;
                 if (pullable.MovingTo.Value.MapId != pullerPosition.MapId)
                 {
                     _pullableSystem.StopMoveTo(pullable);
@@ -113,7 +114,14 @@ namespace Content.Server.Physics.Controllers
                     accel -= physics.LinearVelocity * SettleShutdownMultiplier * scaling;
                 }
                 physics.WakeBody();
-                physics.ApplyLinearImpulse(accel * physics.Mass * frameTime);
+                var impulse = accel * physics.Mass * frameTime;
+                physics.ApplyLinearImpulse(impulse);
+
+                if (puller.TryGetComponent<PhysicsComponent>(out var pullerPhysics))
+                {
+                    pullerPhysics.WakeBody();
+                    pullerPhysics.ApplyLinearImpulse(-impulse);
+                }
             }
         }
     }

--- a/Content.Shared/Pulling/Components/PullableComponent.cs
+++ b/Content.Shared/Pulling/Components/PullableComponent.cs
@@ -36,7 +36,7 @@ namespace Content.Shared.Pulling.Components
 
         public bool BeingPulled => Puller != null;
 
-        public MapCoordinates? MovingTo { get; set; }
+        public EntityCoordinates? MovingTo { get; set; }
 
         public override ComponentState GetComponentState(ICommonSession player)
         {

--- a/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
@@ -12,6 +12,8 @@ namespace Content.Shared.Pulling.Systems
     [UsedImplicitly]
     public sealed class SharedPullerSystem : EntitySystem
     {
+        [Dependency] private readonly SharedPullingSystem _pullSystem = default!;
+
         public override void Initialize()
         {
             base.Initialize();

--- a/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
@@ -12,8 +12,6 @@ namespace Content.Shared.Pulling.Systems
     [UsedImplicitly]
     public sealed class SharedPullerSystem : EntitySystem
     {
-        [Dependency] private readonly SharedPullingSystem _pullSystem = default!;
-
         public override void Initialize()
         {
             base.Initialize();

--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -140,7 +140,7 @@ namespace Content.Shared.Pulling
             ForceRelationship(null, pullable);
         }
 
-        public void ForceSetMovingTo(SharedPullableComponent pullable, MapCoordinates? movingTo)
+        public void ForceSetMovingTo(SharedPullableComponent pullable, EntityCoordinates? movingTo)
         {
             if (pullable.MovingTo == movingTo)
             {

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -172,7 +172,7 @@ namespace Content.Shared.Pulling
             return true;
         }
 
-        public bool TryMoveTo(SharedPullableComponent pullable, MapCoordinates to)
+        public bool TryMoveTo(SharedPullableComponent pullable, EntityCoordinates to)
         {
             if (pullable.Puller == null)
             {

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
@@ -220,7 +220,7 @@ namespace Content.Shared.Pulling
                 return false;
             }
 
-            TryMoveTo(pullable, coords.ToMap(EntityManager));
+            TryMoveTo(pullable, coords);
 
             return false;
         }

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
@@ -47,8 +47,9 @@ namespace Content.Shared.Pulling
         ///     If difference between puller and pulled angle  lower that this threshold,
         ///     pulled entity will not change its rotation.
         ///     Helps with diagonal movement jittering
+        ///     As of further adjustments, should divide cleanly into 90 degrees
         /// </summary>
-        private const float ThresholdRotAngle = 30;
+        private const float ThresholdRotAngle = 22.5f;
 
         public IReadOnlySet<SharedPullableComponent> Moving => _moving;
 
@@ -177,11 +178,6 @@ namespace Content.Shared.Pulling
             UpdatePulledRotation(puller, pulled);
 
             physics.WakeBody();
-
-            if (pulled.TryGetComponent(out SharedPullableComponent? pullable))
-            {
-                _pullSm.ForceSetMovingTo(pullable, null);
-            }
         }
 
         // TODO: When Joint networking is less shitcodey fix this to use a dedicated joints message.
@@ -270,8 +266,17 @@ namespace Content.Shared.Pulling
                 var newAngle = Angle.FromWorldVec(dir);
 
                 var diff = newAngle - oldAngle;
-                if (Math.Abs(diff.Degrees) > ThresholdRotAngle)
-                    pulled.Transform.WorldRotation = newAngle;
+                if (Math.Abs(diff.Degrees) > (ThresholdRotAngle / 2f))
+                {
+                    // Ok, so this bit is difficult because ideally it would look like it's snapping to sane angles.
+                    // Otherwise PIANO DOOR STUCK! happens.
+                    // But it also needs to work with station rotation / align to the local parent.
+                    // So...
+                    var baseRotation = pulled.Transform.Parent?.WorldRotation ?? 0f;
+                    var localRotation = newAngle - baseRotation;
+                    var localRotationSnapped = Angle.FromDegrees(Math.Floor((localRotation.Degrees / ThresholdRotAngle) + 0.5f) * ThresholdRotAngle);
+                    pulled.Transform.LocalRotation = localRotationSnapped;
+                }
             }
         }
     }


### PR DESCRIPTION
## About the PR
see changelog, fixes #5139

**Changelog**

:cl:
- tweak: Pulling to a specific location now pushes the player doing the pulling
- tweak: Pulled object rotation snaps cleanly to (grid-relative) angles so pianos don't get stuck as often
- fix: Moved more pulling code server-side to prevent desyncs
