### PR TITLE
Small bug fixes and tweaks on reagents and food/drinks content

### DIFF
--- a/Resources/Prototypes/Body/Mechanisms/human.yml
+++ b/Resources/Prototypes/Body/Mechanisms/human.yml
@@ -447,9 +447,6 @@
       BraveBull:
         effects:
         - !type:SatiateThirst
-      BrownStar:
-        effects:
-        - !type:SatiateThirst
       CubaLibre:
         effects:
         - !type:SatiateThirst
@@ -563,6 +560,9 @@
         effects:
         - !type:SatiateThirst
       SnowWhite:
+        effects:
+        - !type:SatiateThirst
+      Starkist:
         effects:
         - !type:SatiateThirst
       SuiDream:

--- a/Resources/Prototypes/Body/Mechanisms/human.yml
+++ b/Resources/Prototypes/Body/Mechanisms/human.yml
@@ -534,7 +534,7 @@
       Moonshine:
         effects:
         - !type:SatiateThirst
-      Neurotoxin: #This should be moved out of alcohol eventually
+      Neurotoxin:
         effects:
         - !type:SatiateThirst
         - !type:HealthChange

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
@@ -5,6 +5,7 @@
   spriteName: cola
   startingInventory:
     DrinkColaCan: 10
+    DrinkEnergyDrinkCan: 10
     DrinkGrapeCan: 10
     DrinkIcedTeaCan: 10
     DrinkLemonLimeCan: 10

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -250,6 +250,11 @@
     sprite: Objects/Specific/Hydroponics/potato.rsi
   - type: Produce
     seed: potato
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: JuicePotato
+        Quantity: 10
 
 - type: entity
   name: tomato

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
@@ -453,23 +453,6 @@
 
 - type: entity
   parent: DrinkGlassBase
-  id: DrinkBrownStar
-  name: brown star
-  description: It's not what it sounds like...
-  components:
-  - type: Drink
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 50
-        reagents:
-        - ReagentId: BrownStar
-          Quantity: 50
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/brownstar.rsi
-
-- type: entity
-  parent: DrinkGlassBase
   id: DrinkCarrotJuice
   name: carrot juice
   description: It is just like a carrot but without crunching.

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
@@ -12,11 +12,11 @@
       drink:
         reagents:
         - ReagentId: Cola
-          Quantity: 20
-        maxVol: 20
+          Quantity: 30
+        maxVol: 30
   - type: SolutionTransfer
     canChangeTransferAmount: true
-    maxTransferAmount: 10
+    maxTransferAmount: 15
   - type: UserInterface
     interfaces:
     - key: enum.TransferAmountUiKey.Key
@@ -44,10 +44,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: Cola
-          Quantity: 20
+          Quantity: 30
   - type: Tag
     tags:
     - Cola
@@ -65,10 +65,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: IcedTea
-          Quantity: 20
+          Quantity: 30
   - type: Sprite
     sprite: Objects/Consumable/Drinks/ice_tea_can.rsi
   - type: Item
@@ -83,10 +83,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: LemonLime
-          Quantity: 20
+          Quantity: 30
   - type: Sprite
     sprite: Objects/Consumable/Drinks/lemon-lime.rsi
   - type: Item
@@ -98,6 +98,13 @@
   name: grape soda can
   description: Sweetened drink with a grape flavor and a deep purple color.
   components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: GrapeSoda
+          Quantity: 30
   - type: Sprite
     sprite: Objects/Consumable/Drinks/purple_can.rsi
   - type: Item
@@ -112,10 +119,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 50
         reagents:
         - ReagentId: SodaWater
-          Quantity: 20
+          Quantity: 50
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/sodawater.rsi
@@ -129,10 +136,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: SpaceMountainWind
-          Quantity: 20
+          Quantity: 30
   - type: Sprite
     sprite: Objects/Consumable/Drinks/space_mountain_wind.rsi
   - type: Item
@@ -147,10 +154,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: SpaceUp
-          Quantity: 20
+          Quantity: 30
   - type: Sprite
     sprite: Objects/Consumable/Drinks/space-up.rsi
   - type: Item
@@ -162,6 +169,13 @@
   name: starkist can
   description: The taste of a star in liquid form. And, a bit of tuna...?
   components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Starkist
+          Quantity: 30
   - type: Sprite
     sprite: Objects/Consumable/Drinks/starkist.rsi
   - type: Item
@@ -176,10 +190,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 50
         reagents:
         - ReagentId: TonicWater
-          Quantity: 20
+          Quantity: 50
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/tonic.rsi
@@ -193,10 +207,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: FourteenLoko
-          Quantity: 20
+          Quantity: 30
   - type: Sprite
     sprite: Objects/Consumable/Drinks/fourteen_loko.rsi
   - type: Item
@@ -211,10 +225,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: ChangelingSting
-          Quantity: 20
+          Quantity: 30
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/changelingsting.rsi
@@ -230,10 +244,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: DrGibb
-          Quantity: 20
+          Quantity: 30
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/dr_gibb.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
@@ -256,10 +256,17 @@
 
 - type: entity
   parent: DrinkCanBaseFull
-  id: DrinkEnergyDrink
+  id: DrinkEnergyDrinkCan
   name: red bool energy drink
   description: A can of Red Bool, with enough caffeine to kill a horse.
   components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: EnergyDrink
+          Quantity: 30
   - type: Drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/energy_drink.rsi

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -287,14 +287,6 @@
   spritePath: bravebullglass.rsi
 
 - type: reagent
-  id: BrownStar
-  name: brown star
-  desc: It's not what it sounds like...
-  physicalDesc: strong-smelling
-  color: "#9F3400"
-  spritePath: brownstar.rsi
-
-- type: reagent
   id: CubaLibre
   name: cuba libre
   desc: Rum, mixed with cola. Viva la revolucion.

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -41,6 +41,20 @@
       amount: 0.1
 
 - type: reagent
+  id: EnergyDrink
+  name: Energy Drink
+  desc: A dose of energy! Nanotrasen is not responsible if you grow avian appendages.
+  physicalDesc: fizzy
+  color: "#ffffbf"
+  plantMetabolism:
+    - !type:AdjustNutrition
+      amount: 0.1
+    - !type:AdjustWater
+      amount: 1
+    - !type:AdjustHealth
+      amount: 0.1
+
+- type: reagent
   id: GrapeSoda
   name: grape soda
   desc: It's Graaaaaape!

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -41,6 +41,20 @@
       amount: 0.1
 
 - type: reagent
+  id: GrapeSoda
+  name: grape soda
+  desc: It's Graaaaaape!
+  physicalDesc: fizzy
+  color: "#ae94a6"
+  plantMetabolism:
+    - !type:AdjustNutrition
+      amount: 0.1
+    - !type:AdjustWater
+      amount: 1
+    - !type:AdjustHealth
+      amount: 0.1
+
+- type: reagent
   id: LemonLime
   name: lemon-lime
   desc: tangy lime and lemon soda
@@ -90,6 +104,20 @@
   physicalDesc: fizzy
   color: "#00FF00"
   plantMetabolism:
+    - !type:AdjustNutrition
+      amount: 0.1
+    - !type:AdjustWater
+      amount: 1
+    - !type:AdjustHealth
+      amount: 0.1
+
+- type: reagent
+  id: Starkist
+  name: starkist
+  desc: A sweet, orange flavored soft drink.
+  physicalDesc: fizzy
+  color: "#9F3400"
+    plantMetabolism:
     - !type:AdjustNutrition
       amount: 0.1
     - !type:AdjustWater

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -131,7 +131,7 @@
   desc: A sweet, orange flavored soft drink.
   physicalDesc: fizzy
   color: "#9F3400"
-    plantMetabolism:
+  plantMetabolism:
     - !type:AdjustNutrition
       amount: 0.1
     - !type:AdjustWater

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -113,16 +113,6 @@
     BraveBull: 3
 
 - type: reaction
-  id: Starkist
-  reactants:
-    Cola:
-      amount: 1
-    JuiceOrange:
-      amount: 2
-  products:
-    Starkist: 3
-
-- type: reaction
   id: CafeLatte
   reactants:
     Coffee:
@@ -469,6 +459,16 @@
       amount: 1
   products:
     SoyLatte: 2
+
+- type: reaction
+  id: Starkist
+  reactants:
+    Cola:
+      amount: 1
+    JuiceOrange:
+      amount: 2
+  products:
+    Starkist: 3
 
 - type: reaction
   id: SyndicateBomb

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -113,14 +113,14 @@
     BraveBull: 3
 
 - type: reaction
-  id: BrownStar
+  id: Starkist
   reactants:
     Cola:
       amount: 1
     JuiceOrange:
       amount: 2
   products:
-    BrownStar: 3
+    Starkist: 3
 
 - type: reaction
   id: CafeLatte


### PR DESCRIPTION
## About the PR
Small bug fixes and tweaks on reagents and food/drinks content

Fixed some drink cans not having the correct reagent
Fixed being unable to juice potato in grinder
SodaWater and TonicWater cans were too small (20u to 50u)
Tweaked cans to be larger, 20u to 30u
Changed BrownStar reagent to Starkist
Added energy drink reagent and can object to vending machine

:cl: Daemon
- fix: Fixed some drink cans not having correct drink/size
- fix: Fixed being unable to juice potato in grinder
- tweak: Changed BrownStar to Starkist
- add: Added energy drink reagent and can object to vending machine