### PR TITLE
Draw depth fixes.

### DIFF
--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -9,40 +9,36 @@ namespace Content.Shared.DrawDepth
         /// <summary>
         ///     This is for sub-floors, the floors you see after prying off a tile.
         /// </summary>
-        LowFloors = DrawDepthTag.Default - 7,
+        LowFloors = DrawDepthTag.Default - 6,
 
         /// <summary>
         ///     Things that are beneath regular floors, such as wires or pipes. vents/scrubbers also use this to ensure
         ///     that they appear below carpets.
         /// </summary>
-        BelowFloor = DrawDepthTag.Default - 6,
+        BelowFloor = DrawDepthTag.Default - 5,
 
         /// <summary>
         ///     Used for entities like carpets.
         /// </summary>
-        FloorTiles = DrawDepthTag.Default - 5,
+        FloorTiles = DrawDepthTag.Default - 4,
 
         /// <summary>
         ///     Things that are actually right on the floor, like puddles. This does not mean objects like
         ///     tables, even though they are technically "on the floor".
         /// </summary>
-        FloorObjects = DrawDepthTag.Default - 4,
+        FloorObjects = DrawDepthTag.Default - 3,
 
-        Walls = DrawDepthTag.Default - 3,
+        Walls = DrawDepthTag.Default - 2,
 
         /// <summary>
         ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
         ///     of some wall-art or something.
         /// </summary>
-        WallTops = DrawDepthTag.Default - 2,
+        WallTops = DrawDepthTag.Default - 1,
 
         /// <summary>
-        ///     Posters, APCs, air alarms, etc.
-        /// </summary>
-        WallMountedItems = DrawDepthTag.Default - 1,
-
-        /// <summary>
-        ///     Furniture, crates, etc.
+        ///     Furniture, crates, tables. etc. If an entity should be drawn on top of a table, it needs a draw depth
+        ///     that is higher than this.
         /// </summary>
         Objects = DrawDepthTag.Default,
 
@@ -54,25 +50,30 @@ namespace Content.Shared.DrawDepth
         SmallObjects = DrawDepthTag.Default + 1,
 
         /// <summary>
+        ///     Posters, APCs, air alarms, etc. This also includes most lights & lamps.
+        /// </summary>
+        WallMountedItems = DrawDepthTag.Default + 2,
+
+        /// <summary>
         ///     Generic items. Things that should be above crates & tables, but underneath mobs.
         /// </summary>
-        Items = DrawDepthTag.Default + 2,
+        Items = DrawDepthTag.Default + 3,
 
-        Mobs = DrawDepthTag.Default + 3,
+        Mobs = DrawDepthTag.Default + 4,
 
-        Doors = DrawDepthTag.Default + 4,
+        Doors = DrawDepthTag.Default + 5,
 
         /// <summary>
         ///     Explosions, fire, melee swings. Whatever.
         /// </summary>
-        Effects = DrawDepthTag.Default + 5,
+        Effects = DrawDepthTag.Default + 6,
 
-        Ghosts = DrawDepthTag.Default + 6,
+        Ghosts = DrawDepthTag.Default + 7,
 
         /// <summary>
         ///    Use this selectively if it absolutely needs to be drawn above (almost) everything else. Examples include
         ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
         /// </summary>
-        Overlays = DrawDepthTag.Default + 7,
+        Overlays = DrawDepthTag.Default + 8,
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -7,6 +7,7 @@
   - type: Rotatable
   - type: Sprite
     sprite: Structures/dispensers.rsi
+    drawdepth: SmallObjects
     state: booze
   - type: ReagentDispenser
     pack: BoozeDispenserInventory

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -7,6 +7,7 @@
   - type: Rotatable
   - type: Sprite
     sprite: Structures/dispensers.rsi
+    drawdepth: SmallObjects
     state: soda
   - type: ReagentDispenser
     pack: SodaDispenserInventory

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/emergency_light.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/emergency_light.yml
@@ -19,7 +19,6 @@
   - type: EmergencyLight
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/emergency_light.rsi
-    drawdepth: WallMountedItems
     layers:
     - state: emergency_light_off
   - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/emergency_light.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/emergency_light.yml
@@ -19,6 +19,7 @@
   - type: EmergencyLight
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/emergency_light.rsi
+    drawdepth: WallMountedItems
     layers:
     - state: emergency_light_off
   - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -18,6 +18,7 @@
       layer: [ Passable ]
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/light_tube.rsi
+    drawdepth: WallMountedItems
     layers:
     - state: on
       map: ["enum.PoweredLightLayers.Base"]


### PR DESCRIPTION
I introduced some draw depth issues in #5130 . This fixes the issues I currently know of: that lights and bar-machines use the default draw depth, and so they appear on the same depth as tables/furniture.

This PR:
- Gives bar machines the small-object draw depth (same as microwaves, above tables, below items & mobs).
- Gives lights the wall-mounted draw depth.
- Moves the wall-mounted draw depth so that it is above small objects (but still under mobs & items).

Given that draw depths are actually just consecutive integers, the last point means that all existing values have to be shifted. As long as the default (`Object`/0) stays reasonable and all the draw depths are defined using this enum, this shouldn't cause any issues. At the very least, least nothing stands out to me when ghosting around the station.

Also, just ctrl+f-ing `sprite: Structures/Wallmounts/`, reveals that there are a bunch of other wall-mounts that use the default draw depth. However (afaik) none of them stick out of the wall like the various lights do, so it doesn't really matter and it keeps the PR smaller.  If there is something else that sticks out, or I should just ensure that wall mounts are consistent I can update this PR.

fixes #5143

:cl:
- fix: Draw depth issues for the bar dispensers & wall mounted lights.