### PR TITLE
Fix for death timer resetting after returning to body.

### DIFF
--- a/Content.Server/Body/BodySystem.cs
+++ b/Content.Server/Body/BodySystem.cs
@@ -5,12 +5,14 @@ using Content.Shared.MobState.State;
 using Content.Shared.Movement.EntitySystems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Body
 {
     public sealed class BodySystem : EntitySystem
     {
         [Dependency] private readonly GameTicker _ticker = default!;
+        [Dependency] private readonly IGameTiming _gameTiming = default!;
 
         public override void Initialize()
         {
@@ -25,6 +27,11 @@ namespace Content.Server.Body
                 EntityManager.TryGetComponent<MindComponent>(uid, out var mind) &&
                 mind.HasMind)
             {
+                if (!mind.Mind!.TimeOfDeath.HasValue)
+                {
+                    mind.Mind.TimeOfDeath = _gameTiming.RealTime;
+                }
+
                 _ticker.OnGhostAttempt(mind.Mind!, true);
             }
         }

--- a/Content.Server/GameTicking/Presets/GamePreset.cs
+++ b/Content.Server/GameTicking/Presets/GamePreset.cs
@@ -83,6 +83,12 @@ namespace Content.Server.GameTicking.Presets
                 ghost.Name = mind.Session.Name;
 
             var ghostComponent = ghost.GetComponent<GhostComponent>();
+
+            if (mind.TimeOfDeath.HasValue)
+            {
+                ghostComponent.TimeOfDeath = mind.TimeOfDeath!.Value;
+            }
+
             EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(ghostComponent, canReturn);
 
             if (canReturn)

--- a/Content.Server/Mind/Mind.cs
+++ b/Content.Server/Mind/Mind.cs
@@ -64,6 +64,12 @@ namespace Content.Server.Mind
         public string? CharacterName { get; set; }
 
         /// <summary>
+        ///     The time of death for this Mind.
+        ///     Can be null - will be null if the Mind is not considered "dead".
+        /// </summary>
+        [ViewVariables] public TimeSpan? TimeOfDeath { get; set; } = null;
+
+        /// <summary>
         ///     The component currently owned by this mind.
         ///     Can be null.
         /// </summary>
@@ -116,6 +122,7 @@ namespace Content.Server.Mind
         /// </summary>
         [ViewVariables]
         public bool CharacterDeadIC => CharacterDeadPhysically;
+
         /// <summary>
         ///     True if the OwnedEntity of this mind is physically dead.
         ///     This specific definition, as opposed to CharacterDeadIC, is used to determine if ghosting should allow return.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Fixes #5076 

Minor change to how `TimeOfDeath` is populated for Ghost Components.

If `TimeOfDeath` value is present on a mind, it will use that one. Otherwise it will revert to previous `TimeOfDeath` populated on component creation.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->


![timer](https://user-images.githubusercontent.com/19313344/140573741-61bca003-2141-4da6-a6ad-b05bd990bc04.gif)
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed the death timer resetting when returning to body as a ghost.
