### PR TITLE
Ghost roles create new minds, better tracking of roles at round end screen

### DIFF
--- a/Content.Client/Administration/UI/Tabs/RoundTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/RoundTab.xaml
@@ -4,9 +4,10 @@
     Margin="4"
     MinSize="50 50">
     <GridContainer
-        Columns="4">
+        Columns="3">
         <cc:CommandButton Command="startround" Text="{Loc Start Round}" />
         <cc:CommandButton Command="endround" Text="{Loc End Round}" />
         <cc:CommandButton Command="restartround" Text="{Loc Restart Round}" />
+        <cc:CommandButton Command="restartroundnow" Text="{Loc administration-ui-round-tab-restart-round-now}" />
     </GridContainer>
 </Control>

--- a/Content.IntegrationTests/Tests/MindEntityDeletionTest.cs
+++ b/Content.IntegrationTests/Tests/MindEntityDeletionTest.cs
@@ -39,7 +39,7 @@ namespace Content.IntegrationTests.Tests
                 mind = new Mind(player.UserId);
                 mind.ChangeOwningPlayer(player.UserId);
 
-                mind.TransferTo(playerEnt);
+                mind.TransferTo(playerEnt.Uid);
                 mind.Visit(visitEnt);
 
                 Assert.That(player.AttachedEntity, Is.EqualTo(visitEnt));
@@ -83,7 +83,7 @@ namespace Content.IntegrationTests.Tests
                 mind = new Mind(player.UserId);
                 mind.ChangeOwningPlayer(player.UserId);
 
-                mind.TransferTo(playerEnt);
+                mind.TransferTo(playerEnt.Uid);
 
                 Assert.That(mind.CurrentEntity, Is.EqualTo(playerEnt));
             });
@@ -132,7 +132,7 @@ namespace Content.IntegrationTests.Tests
                 mind = new Mind(player.UserId);
                 mind.ChangeOwningPlayer(player.UserId);
 
-                mind.TransferTo(playerEnt);
+                mind.TransferTo(playerEnt.Uid);
 
                 Assert.That(mind.CurrentEntity, Is.EqualTo(playerEnt));
             });

--- a/Content.IntegrationTests/Tests/MindEntityDeletionTest.cs
+++ b/Content.IntegrationTests/Tests/MindEntityDeletionTest.cs
@@ -37,7 +37,7 @@ namespace Content.IntegrationTests.Tests
                 visitEnt = entMgr.SpawnEntity(null, MapCoordinates.Nullspace);
 
                 mind = new Mind(player.UserId);
-                player.ContentData().Mind = mind;
+                mind.ChangeOwningPlayer(player.UserId);
 
                 mind.TransferTo(playerEnt);
                 mind.Visit(visitEnt);
@@ -81,7 +81,7 @@ namespace Content.IntegrationTests.Tests
                 playerEnt = entMgr.SpawnEntity(null, MapCoordinates.Nullspace);
 
                 mind = new Mind(player.UserId);
-                player.ContentData().Mind = mind;
+                mind.ChangeOwningPlayer(player.UserId);
 
                 mind.TransferTo(playerEnt);
 
@@ -130,7 +130,7 @@ namespace Content.IntegrationTests.Tests
                 playerEnt = entMgr.SpawnEntity(null, grid.ToCoordinates());
 
                 mind = new Mind(player.UserId);
-                player.ContentData().Mind = mind;
+                mind.ChangeOwningPlayer(player.UserId);
 
                 mind.TransferTo(playerEnt);
 

--- a/Content.Server/Administration/AdminVerbSystem.cs
+++ b/Content.Server/Administration/AdminVerbSystem.cs
@@ -93,7 +93,7 @@ namespace Content.Server.Administration
                 // TODO VERB ICON control mob icon
                 verb.Act = () =>
                 {
-                    player.ContentData()?.Mind?.TransferTo(args.Target, ghostCheckOverride: true);
+                    player.ContentData()?.Mind?.TransferTo(args.Target.Uid, ghostCheckOverride: true);
                 };
                 args.Verbs.Add(verb);
             }

--- a/Content.Server/Administration/Commands/AGhost.cs
+++ b/Content.Server/Administration/Commands/AGhost.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Administration.Commands
             else
             {
                 ghost.Name = player.Name;
-                mind.TransferTo(ghost);
+                mind.TransferTo(ghost.Uid);
             }
 
             var comp = ghost.GetComponent<GhostComponent>();

--- a/Content.Server/Administration/Commands/ControlMob.cs
+++ b/Content.Server/Administration/Commands/ControlMob.cs
@@ -60,7 +60,7 @@ namespace Content.Server.Administration.Commands
 
             DebugTools.AssertNotNull(mind);
 
-            mind!.TransferTo(target);
+            mind!.TransferTo(target.Uid);
         }
     }
 }

--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -73,7 +73,7 @@ namespace Content.Server.Administration.Commands
                 };
                 mind.ChangeOwningPlayer(session.UserId);
             }
-            mind.TransferTo(target);
+            mind.TransferTo(target.Uid);
         }
     }
 }

--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -71,7 +71,7 @@ namespace Content.Server.Administration.Commands
                 {
                     CharacterName = target.Name
                 };
-                playerCData.Mind = mind;
+                mind.ChangeOwningPlayer(session.UserId);
             }
             mind.TransferTo(target);
         }

--- a/Content.Server/Body/Systems/BrainSystem.cs
+++ b/Content.Server/Body/Systems/BrainSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Server.Body.Systems
             if (!EntityManager.HasComponent<IMoverComponent>(newEntity))
                 EntityManager.AddComponent<SharedDummyInputMoverComponent>(newEntity);
 
-            oldMind.Mind?.TransferTo(EntityManager.GetEntity(newEntity));
+            oldMind.Mind?.TransferTo(newEntity);
         }
     }
 }

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -40,7 +40,7 @@ namespace Content.Server.Cloning
                 mindComp.Mind != null)
                 return;
 
-            mind.TransferTo(entity, ghostCheckOverride: true);
+            mind.TransferTo(entity.Uid, ghostCheckOverride: true);
             mind.UnVisit();
             ClonesWaitingForMind.Remove(mind);
         }

--- a/Content.Server/GameTicking/Commands/RestartRoundCommand.cs
+++ b/Content.Server/GameTicking/Commands/RestartRoundCommand.cs
@@ -17,6 +17,14 @@ namespace Content.Server.GameTicking.Commands
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
+            var ticker = EntitySystem.Get<GameTicker>();
+
+            if (ticker.RunLevel != GameRunLevel.InRound)
+            {
+                shell.WriteLine("This can only be executed while the game is in a round - try restartroundnow");
+                return;
+            }
+
             EntitySystem.Get<RoundEndSystem>().EndRound();
         }
     }

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -37,7 +37,7 @@ namespace Content.Server.GameTicking
                 {
                     // Always make sure the client has player data. Mind gets assigned on spawn.
                     if (session.Data.ContentDataUncast == null)
-                        session.Data.ContentDataUncast = new PlayerData(session.UserId);
+                        session.Data.ContentDataUncast = new PlayerData(session.UserId, args.Session.Name);
 
                     // Make the player actually join the game.
                     // timer time must be > tick length

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Server.Players;
+using Content.Server.Mind;
+using Content.Server.Ghost;
 using Content.Shared.CCVar;
 using Content.Shared.Coordinates;
 using Content.Shared.GameTicking;
@@ -210,29 +212,50 @@ namespace Content.Server.GameTicking
 
             //Generate a list of basic player info to display in the end round summary.
             var listOfPlayerInfo = new List<RoundEndMessageEvent.RoundEndPlayerInfo>();
-            foreach (var ply in _playerManager.GetAllPlayers().OrderBy(p => p.Name))
+            // Grab the great big book of all the Minds, we'll need them for this.
+            var allMinds = EntitySystem.Get<MindTrackerSystem>().AllMinds;
+            foreach (var mind in allMinds)
             {
-                var mind = ply.ContentData()?.Mind;
-
                 if (mind != null)
                 {
-                    _playersInLobby.TryGetValue(ply, out var status);
+                    // Some basics assuming things fail
+                    var userId = mind.OriginalOwnerUserId;
+                    var playerOOCName = userId.ToString();
+                    var connected = false;
+                    var observer = mind.AllRoles.Any(role => role is ObserverRole);
+                    // Continuing
+                    if (_playerManager.TryGetSessionById(userId, out var ply))
+                    {
+                        connected = true;
+                    }
+                    PlayerData? contentPlayerData = null;
+                    if (_playerManager.TryGetPlayerData(userId, out var playerData))
+                    {
+                        contentPlayerData = playerData.ContentData();
+                    }
+                    // Finish
                     var antag = mind.AllRoles.Any(role => role.Antagonist);
                     var playerEndRoundInfo = new RoundEndMessageEvent.RoundEndPlayerInfo()
                     {
-                        PlayerOOCName = ply.Name,
-                        PlayerICName = mind.CurrentEntity?.Name,
+                        // Note that contentPlayerData?.Name sticks around after the player is disconnected.
+                        // This is as opposed to ply?.Name which doesn't.
+                        PlayerOOCName = contentPlayerData?.Name ?? "(IMPOSSIBLE: REGISTERED MIND WITH NO OWNER)",
+                        // Character name takes precedence over current entity name
+                        PlayerICName = mind.CharacterName ?? mind.CurrentEntity?.Name,
                         Role = antag
                             ? mind.AllRoles.First(role => role.Antagonist).Name
                             : mind.AllRoles.FirstOrDefault()?.Name ?? Loc.GetString("game-ticker-unknown-role"),
                         Antag = antag,
-                        Observer = status == LobbyPlayerStatus.Observer,
+                        Observer = observer,
+                        Connected = connected
                     };
                     listOfPlayerInfo.Add(playerEndRoundInfo);
                 }
             }
+            // This ordering mechanism isn't great (no ordering of minds) but functions
+            var listOfPlayerInfoFinal = listOfPlayerInfo.OrderBy(pi => pi.PlayerOOCName).ToArray();
 
-            RaiseNetworkEvent(new RoundEndMessageEvent(gamemodeTitle, roundEndText, roundDuration, listOfPlayerInfo.Count, listOfPlayerInfo.ToArray()));
+            RaiseNetworkEvent(new RoundEndMessageEvent(gamemodeTitle, roundEndText, roundDuration, listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal));
         }
 
         public void RestartRound()

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using Content.Server.Access.Components;
 using Content.Server.Access.Systems;
 using Content.Server.CharacterAppearance.Components;
+using Content.Server.Ghost;
 using Content.Server.Ghost.Components;
 using Content.Server.Hands.Components;
 using Content.Server.Inventory.Components;
@@ -153,6 +154,7 @@ namespace Content.Server.GameTicking
             data!.WipeMind();
             var newMind = new Mind.Mind(data.UserId);
             newMind.ChangeOwningPlayer(data.UserId);
+            newMind.AddRole(new ObserverRole(newMind));
 
             var mob = SpawnObserverMob();
             mob.Name = name;

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -94,7 +94,7 @@ namespace Content.Server.GameTicking
             }
 
             var mob = SpawnPlayerMob(job, character, lateJoin);
-            newMind.TransferTo(mob);
+            newMind.TransferTo(mob.Uid);
 
             if (player.UserId == new Guid("{e887eb93-f503-4b65-95b6-2f282c014192}"))
             {
@@ -160,7 +160,7 @@ namespace Content.Server.GameTicking
             mob.Name = name;
             var ghost = mob.GetComponent<GhostComponent>();
             EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(ghost, false);
-            newMind.TransferTo(mob);
+            newMind.TransferTo(mob.Uid);
 
             _playersInLobby[player] = LobbyPlayerStatus.Observer;
             RaiseNetworkEvent(GetStatusSingle(player, LobbyPlayerStatus.Observer));

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -70,17 +70,18 @@ namespace Content.Server.GameTicking
             DebugTools.AssertNotNull(data);
 
             data!.WipeMind();
-            data.Mind = new Mind.Mind(player.UserId)
+            var newMind = new Mind.Mind(data.UserId)
             {
                 CharacterName = character.Name
             };
+            newMind.ChangeOwningPlayer(data.UserId);
 
             // Pick best job best on prefs.
             jobId ??= PickBestAvailableJob(character);
 
             var jobPrototype = _prototypeManager.Index<JobPrototype>(jobId);
-            var job = new Job(data.Mind, jobPrototype);
-            data.Mind.AddRole(job);
+            var job = new Job(newMind, jobPrototype);
+            newMind.AddRole(job);
 
             if (lateJoin)
             {
@@ -92,7 +93,7 @@ namespace Content.Server.GameTicking
             }
 
             var mob = SpawnPlayerMob(job, character, lateJoin);
-            data.Mind.TransferTo(mob);
+            newMind.TransferTo(mob);
 
             if (player.UserId == new Guid("{e887eb93-f503-4b65-95b6-2f282c014192}"))
             {
@@ -150,13 +151,14 @@ namespace Content.Server.GameTicking
             DebugTools.AssertNotNull(data);
 
             data!.WipeMind();
-            data.Mind = new Mind.Mind(player.UserId);
+            var newMind = new Mind.Mind(data.UserId);
+            newMind.ChangeOwningPlayer(data.UserId);
 
             var mob = SpawnObserverMob();
             mob.Name = name;
             var ghost = mob.GetComponent<GhostComponent>();
             EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(ghost, false);
-            data.Mind.TransferTo(mob);
+            newMind.TransferTo(mob);
 
             _playersInLobby[player] = LobbyPlayerStatus.Observer;
             RaiseNetworkEvent(GetStatusSingle(player, LobbyPlayerStatus.Observer));

--- a/Content.Server/GameTicking/Presets/GamePreset.cs
+++ b/Content.Server/GameTicking/Presets/GamePreset.cs
@@ -94,7 +94,7 @@ namespace Content.Server.GameTicking.Presets
             if (canReturn)
                 mind.Visit(ghost);
             else
-                mind.TransferTo(ghost);
+                mind.TransferTo(ghost.Uid);
             return true;
         }
 

--- a/Content.Server/Ghost/ObserverRole.cs
+++ b/Content.Server/Ghost/ObserverRole.cs
@@ -1,0 +1,18 @@
+﻿using Content.Server.Roles;
+﻿using Robust.Shared.Localization;
+
+namespace Content.Server.Ghost
+{
+    /// <summary>
+    /// This is used to mark Observers properly, as they get Minds
+    /// </summary>
+    public class ObserverRole : Role
+    {
+        public override string Name => Loc.GetString("observer-role-name");
+        public override bool Antagonist => false;
+
+        public ObserverRole(Mind.Mind mind) : base(mind)
+        {
+        }
+    }
+}

--- a/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Ghost.Roles.Components
             mob.EnsureComponent<MindComponent>();
 
             var ghostRoleSystem = EntitySystem.Get<GhostRoleSystem>();
-            ghostRoleSystem.GhostRoleInternalCreateMindAndTransfer(session, this, mob);
+            ghostRoleSystem.GhostRoleInternalCreateMindAndTransfer(session, OwnerUid, mob.Uid, this);
 
             if (++_currentTakeovers < _availableTakeovers)
                 return true;

--- a/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
@@ -51,11 +51,8 @@ namespace Content.Server.Ghost.Roles.Components
 
             mob.EnsureComponent<MindComponent>();
 
-            var mind = session.ContentData()?.Mind;
-
-            DebugTools.AssertNotNull(mind);
-
-            mind!.TransferTo(mob);
+            var ghostRoleSystem = EntitySystem.Get<GhostRoleSystem>();
+            ghostRoleSystem.GhostRoleInternalCreateMindAndTransfer(session, this, mob);
 
             if (++_currentTakeovers < _availableTakeovers)
                 return true;

--- a/Content.Server/Ghost/Roles/Components/GhostTakeoverAvailableComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostTakeoverAvailableComponent.cs
@@ -27,13 +27,10 @@ namespace Content.Server.Ghost.Roles.Components
             if (mind.HasMind)
                 return false;
 
-            var sessionMind = session.ContentData()?.Mind;
+            var ghostRoleSystem = EntitySystem.Get<GhostRoleSystem>();
+            ghostRoleSystem.GhostRoleInternalCreateMindAndTransfer(session, this, this.Owner);
 
-            DebugTools.AssertNotNull(sessionMind);
-
-            sessionMind!.TransferTo(Owner);
-
-            EntitySystem.Get<GhostRoleSystem>().UnregisterGhostRole(this);
+            ghostRoleSystem.UnregisterGhostRole(this);
 
             return true;
         }

--- a/Content.Server/Ghost/Roles/Components/GhostTakeoverAvailableComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostTakeoverAvailableComponent.cs
@@ -28,7 +28,7 @@ namespace Content.Server.Ghost.Roles.Components
                 return false;
 
             var ghostRoleSystem = EntitySystem.Get<GhostRoleSystem>();
-            ghostRoleSystem.GhostRoleInternalCreateMindAndTransfer(session, this, this.Owner);
+            ghostRoleSystem.GhostRoleInternalCreateMindAndTransfer(session, OwnerUid, OwnerUid, this);
 
             ghostRoleSystem.UnregisterGhostRole(this);
 

--- a/Content.Server/Ghost/Roles/GhostRoleMarkerRole.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleMarkerRole.cs
@@ -1,0 +1,21 @@
+﻿using Content.Server.Roles;
+﻿using Robust.Shared.Localization;
+
+namespace Content.Server.Ghost.Roles
+{
+    /// <summary>
+    /// This is used for round end display of ghost roles.
+    /// It may also be used to ensure some ghost roles count as antagonists in future.
+    /// </summary>
+    public class GhostRoleMarkerRole : Role
+    {
+        private readonly string _name;
+        public override string Name => _name;
+        public override bool Antagonist => false;
+
+        public GhostRoleMarkerRole(Mind.Mind mind, string name) : base(mind)
+        {
+            _name = name;
+        }
+    }
+}

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -155,15 +155,17 @@ namespace Content.Server.Ghost.Roles
             CloseEui(player);
         }
 
-        public void GhostRoleInternalCreateMindAndTransfer(IPlayerSession player, GhostRoleComponent role, IEntity mob)
+        public void GhostRoleInternalCreateMindAndTransfer(IPlayerSession player, EntityUid roleUid, EntityUid mob, GhostRoleComponent? role = null)
         {
+            if (!Resolve(roleUid, ref role)) return;
+
             var contentData = player.ContentData();
 
             DebugTools.AssertNotNull(contentData);
 
             var newMind = new Mind.Mind(player.UserId)
             {
-                CharacterName = mob.Name
+                CharacterName = EntityManager.GetComponent<MetaDataComponent>(mob).EntityName
             };
             newMind.AddRole(new GhostRoleMarkerRole(newMind, role.RoleName));
 

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.EUI;
 using Content.Server.Ghost.Components;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Ghost.Roles.UI;
+using Content.Server.Players;
 using Content.Shared.GameTicking;
 using Content.Shared.Ghost.Roles;
 using Content.Shared.Ghost;
@@ -14,6 +15,7 @@ using Robust.Shared.Console;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.ViewVariables;
+using Robust.Shared.Utility;
 using Robust.Shared.Enums;
 
 namespace Content.Server.Ghost.Roles
@@ -151,6 +153,21 @@ namespace Content.Server.Ghost.Roles
             if (!_ghostRoles.TryGetValue(identifier, out var role)) return;
             if (!role.Take(player)) return;
             CloseEui(player);
+        }
+
+        public void GhostRoleInternalCreateMindAndTransfer(IPlayerSession player, GhostRoleComponent role, IEntity mob)
+        {
+            var contentData = player.ContentData();
+
+            DebugTools.AssertNotNull(contentData);
+
+            var newMind = new Mind.Mind(player.UserId)
+            {
+                CharacterName = mob.Name
+            };
+
+            newMind.ChangeOwningPlayer(player.UserId);
+            newMind.TransferTo(mob);
         }
 
         public GhostRoleInfo[] GetGhostRolesInfo()

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -165,6 +165,7 @@ namespace Content.Server.Ghost.Roles
             {
                 CharacterName = mob.Name
             };
+            newMind.AddRole(new GhostRoleMarkerRole(newMind, role.RoleName));
 
             newMind.ChangeOwningPlayer(player.UserId);
             newMind.TransferTo(mob);

--- a/Content.Server/Mind/Components/MindComponent.cs
+++ b/Content.Server/Mind/Components/MindComponent.cs
@@ -92,7 +92,7 @@ namespace Content.Server.Mind.Components
                         EntitySystem.Get<SharedGhostSystem>().SetCanReturnToBody(ghost, false);
                     }
 
-                    Mind!.TransferTo(visiting);
+                    Mind!.TransferTo(visiting.Uid);
                 }
                 else if (GhostOnShutdown)
                 {
@@ -116,7 +116,7 @@ namespace Content.Server.Mind.Components
                         if (Mind != null)
                         {
                             ghost.Name = Mind.CharacterName ?? string.Empty;
-                            Mind.TransferTo(ghost);
+                            Mind.TransferTo(ghost.Uid);
                         }
                     });
                 }

--- a/Content.Server/Mind/Mind.cs
+++ b/Content.Server/Mind/Mind.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Mind
         ///     The provided UserId is solely for tracking of intended owner.
         /// </summary>
         /// <param name="userId">The session ID of the original owner (may get credited).</param>
-        public Mind(NetUserId? userId)
+        public Mind(NetUserId userId)
         {
             OriginalOwnerUserId = userId;
         }
@@ -59,7 +59,7 @@ namespace Content.Server.Mind
         ///     May end up used for round-end information (as the owner may have abandoned Mind since)
         /// </summary>
         [ViewVariables]
-        public NetUserId? OriginalOwnerUserId { get; }
+        public NetUserId OriginalOwnerUserId { get; }
 
         [ViewVariables]
         public bool IsVisitingEntity => VisitingEntity != null;

--- a/Content.Server/Mind/MindTrackerSystem.cs
+++ b/Content.Server/Mind/MindTrackerSystem.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using Content.Server.GameTicking;
+using Content.Server.Mind.Components;
+using Content.Shared.GameTicking;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.ViewVariables;
+using Robust.Shared.Player;
+
+namespace Content.Server.Mind
+{
+    /// <summary>
+    /// This is absolutely evil.
+    /// It tracks all mind changes and logs all the Mind objects.
+    /// This is so that when round end comes around, there's a coherent list of all Minds that were in play during the round.
+    /// The Minds themselves contain metadata about their owners.
+    /// Anyway, this is because disconnected people and ghost roles have been breaking round end statistics for way too long.
+    /// </summary>
+    public class MindTrackerSystem : EntitySystem
+    {
+        [ViewVariables]
+        public readonly HashSet<Mind> AllMinds = new();
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+            SubscribeLocalEvent<MindComponent, MindAddedMessage>(OnMindAdded);
+        }
+
+        void Reset(RoundRestartCleanupEvent ev)
+        {
+            AllMinds.Clear();
+        }
+
+        void OnMindAdded(EntityUid uid, MindComponent mc, MindAddedMessage args)
+        {
+            var mind = mc.Mind;
+            if (mind != null)
+                AllMinds.Add(mind);
+        }
+    }
+}
+

--- a/Content.Server/Objectives/Conditions/KillPersonCondition.cs
+++ b/Content.Server/Objectives/Conditions/KillPersonCondition.cs
@@ -9,7 +9,7 @@ namespace Content.Server.Objectives.Conditions
         protected Mind.Mind? Target;
         public abstract IObjectiveCondition GetAssigned(Mind.Mind mind);
 
-        public string Title => Loc.GetString("objective-condition-kill-person-title", ("targetName", Target?.OwnedEntity?.Name ?? string.Empty));
+        public string Title => Loc.GetString("objective-condition-kill-person-title", ("targetName", Target?.CharacterName ?? Target?.OwnedEntity?.Name ?? string.Empty));
 
         public string Description => Loc.GetString("objective-condition-kill-person-description");
 

--- a/Content.Server/Players/PlayerData.cs
+++ b/Content.Server/Players/PlayerData.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Players
         ///     DO NOT DIRECTLY SET THIS UNLESS YOU KNOW WHAT YOU'RE DOING.
         /// </summary>
         [ViewVariables]
-        public Mind.Mind? Mind { get; set; }
+        public Mind.Mind? Mind { get; private set; }
 
         /// <summary>
         ///     If true, the player is an admin and they explicitly de-adminned mid-game,
@@ -32,8 +32,13 @@ namespace Content.Server.Players
         public void WipeMind()
         {
             Mind?.TransferTo(null);
-            Mind?.RemoveOwningPlayer();
-            Mind = null;
+            // This will ensure Mind == null
+            Mind?.ChangeOwningPlayer(null);
+        }
+
+        public void UpdateMindFromMindChangeOwningPlayer(Mind.Mind? mind)
+        {
+            Mind = mind;
         }
 
         public PlayerData(NetUserId userId)

--- a/Content.Server/Players/PlayerData.cs
+++ b/Content.Server/Players/PlayerData.cs
@@ -17,6 +17,13 @@ namespace Content.Server.Players
         public NetUserId UserId { get; }
 
         /// <summary>
+        ///     This is a backup copy of the player name stored on connection.
+        ///     This is useful in the event the player disconnects.
+        /// </summary>
+        [ViewVariables]
+        public string Name { get; }
+
+        /// <summary>
         ///     The currently occupied mind of the player owning this data.
         ///     DO NOT DIRECTLY SET THIS UNLESS YOU KNOW WHAT YOU'RE DOING.
         /// </summary>
@@ -36,14 +43,18 @@ namespace Content.Server.Players
             Mind?.ChangeOwningPlayer(null);
         }
 
+        /// <summary>
+        /// Called from Mind.ChangeOwningPlayer *and nowhere else.*
+        /// </summary>
         public void UpdateMindFromMindChangeOwningPlayer(Mind.Mind? mind)
         {
             Mind = mind;
         }
 
-        public PlayerData(NetUserId userId)
+        public PlayerData(NetUserId userId, string name)
         {
             UserId = userId;
+            Name = name;
         }
     }
 

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -128,6 +128,7 @@ namespace Content.Shared.GameTicking
             public string Role;
             public bool Antag;
             public bool Observer;
+            public bool Connected;
         }
 
         public string GamemodeTitle { get; }

--- a/Resources/Locale/en-US/administration/ui/tabs/round-tab.ftl
+++ b/Resources/Locale/en-US/administration/ui/tabs/round-tab.ftl
@@ -1,0 +1,2 @@
+administration-ui-round-tab-restart-round-now = Restart NOW
+

--- a/Resources/Locale/en-US/ghost/observer-role.ftl
+++ b/Resources/Locale/en-US/ghost/observer-role.ftl
@@ -1,0 +1,2 @@
+observer-role-name = Observer
+


### PR DESCRIPTION
## About the PR

A side effect of this is that traitor objectives should break less (they're mind-keyed like they should be)

Recommended testing procedure:
1. Join two clients
2. pAI client A (activate, ghost, accept role)
3. Restart Round, read report, check all 3 entries present (client A, client A pAI, client B)
4. Disconnect either client
5. Restart Round, both clients should still be visible in full (including OOC names)

Recommended testing procedure 2:
1. Ensure that lobby is enabled `--cvar game.lobbyenabled=true`
2. Join two clients ASAP during server startup
3. ready up both clients
4. `forcepreset Traitor`
5. hopefully one client got a kill objective, if not you can add it via addobjective
6. do whatever you think will break things, etc
7. end round

**Screenshots**
![image](https://user-images.githubusercontent.com/22304167/140583712-889998f5-02dd-430b-bfec-fc43f04c7305.png)
![image](https://user-images.githubusercontent.com/22304167/140584786-ee106af2-350b-48db-afcf-f3104c592fa4.png)

**Changelog**

:cl:
- fix: Much more accurate tracking of ghost roles.
- tweak: Ghost roles can no longer be revived as the original player.
