### PR TITLE
Fixed wire control hit test to work properly when the UI is scaled

### DIFF
--- a/Content.Client/Wires/UI/WiresMenu.cs
+++ b/Content.Client/Wires/UI/WiresMenu.cs
@@ -370,7 +370,7 @@ namespace Content.Client.Wires.UI
                     return;
                 }
 
-                if (args.RelativePixelPosition.Y > 20 && args.RelativePixelPosition.Y < 60)
+                if (args.RelativePosition.Y > 20 && args.RelativePosition.Y < 60)
                 {
                     WireClicked?.Invoke();
                 }


### PR DESCRIPTION
This fixes #5181: when checking whether the wire or the contacts were hit, the wire control used args.RelativePixelPosition instead of args.RelativePosition.