### PR TITLE
Prevent drag and drop if the user can't perform interactions. (fixes #5144)

### DIFF
--- a/Content.Client/DragDrop/DragDropSystem.cs
+++ b/Content.Client/DragDrop/DragDropSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Content.Client.State;
 using Content.Client.Viewport;
+using Content.Shared.ActionBlocker;
 using Content.Shared.DragDrop;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Helpers;
@@ -37,6 +38,7 @@ namespace Content.Client.DragDrop
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
         [Dependency] private readonly InputSystem _inputSystem = default!;
+        [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
 
         // how often to recheck possible targets (prevents calling expensive
         // check logic each update)
@@ -413,6 +415,11 @@ namespace Content.Client.DragDrop
         /// <returns>null if the target doesn't support IDragDropOn</returns>
         private bool? ValidDragDrop(DragDropEvent eventArgs)
         {
+            if (!_actionBlockerSystem.CanInteract(eventArgs.User))
+            {
+                return false;
+            }
+
             bool? valid = null;
 
             foreach (var comp in eventArgs.Target.GetAllComponents<IDragDropOn>())

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -139,6 +139,9 @@ namespace Content.Server.Interaction
                 return;
             }
 
+            if (!_actionBlockerSystem.CanInteract(userEntity))
+                return;
+
             if (!EntityManager.TryGetEntity(msg.Dropped, out var dropped))
                 return;
             if (!EntityManager.TryGetEntity(msg.Target, out var target))


### PR DESCRIPTION
After testing, it turned out that it is possible to drag yourself to other things while dead, such as the medical scanner.

I have added calls to ActionBlockerSystem's CanInteract directly in the drag and drop code, both on the client and server. It seemed the right thing to do given that other interactions are also checked this way in the common interaction code.