### PR TITLE
Fix door error

### DIFF
--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -58,6 +58,7 @@ namespace Content.Client.Doors
                 if (comp.Deleted)
                 {
                     _activeDoors.RemoveAt(i);
+                    continue;
                 }
                 comp.OnUpdate();
             }


### PR DESCRIPTION
Currently the client errors when a door is deleted/destroyed while opening or closing. This is just a 1 line edit to fix that.

Given that the error is not noticeable when building in release, this doesn't really need a changelog entry.
