### PR TITLE
fix: powercells now use proper physics

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -6,12 +6,6 @@
   abstract: true
   parent: BaseItem
   components:
-  - type: Physics
-    bodyType: Dynamic
-    fixtures:
-    - shape:
-        !type:PhysShapeAabb
-          bounds: "-0.3,-0.15,0.3,0.2" # TODO: these are placeholder values
   - type: PowerCell
   - type: Sprite
     netsync: false


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Fix for #5137 

Power Cell prototypes had a duplicated Physics component. I tested and saw no issues by removing it but someone more experienced should confirm

**Changelog**

:cl:
- fix: power cells now properly bounce off walls
