### PR TITLE
Fix examine bug

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -73,19 +73,19 @@ namespace Content.Client.Examine
 
         private bool HandleExamine(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
         {
-            if (!uid.IsValid() || !EntityManager.TryGetEntity(uid, out _examinedEntity))
+            if (!uid.IsValid() || !EntityManager.TryGetEntity(uid, out var entity))
             {
                 return false;
             }
 
             _playerEntity = _playerManager.LocalPlayer?.ControlledEntity;
 
-            if (_playerEntity == null || !CanExamine(_playerEntity, _examinedEntity))
+            if (_playerEntity == null || !CanExamine(_playerEntity, entity))
             {
                 return false;
             }
 
-            DoExamine(_examinedEntity);
+            DoExamine(entity);
             return true;
         }
 
@@ -106,6 +106,9 @@ namespace Content.Client.Examine
         {
             // Close any examine tooltip that might already be opened
             CloseTooltip();
+
+            // cache entity for Update function
+            _examinedEntity = entity;
 
             const float minWidth = 300;
             var popupPos = _userInterfaceManager.MousePositionScaled;


### PR DESCRIPTION
There's a bug that will make it so that you can no longer examine entities in your inventory or via the verb menu. If you shift-examine an entity in the world, then walk away and try to examine items in the inventory or via the verb menu, the popup closes instantly.

Currently the examine system stores the examined entity in a private variable `_examinedEntity`. It checks the visibility of this entity and closes the popup if it's no longer visible. However this variable is set in the handle-keybinding function (`HandleExamine`), but not in the actual `DoExamine` function that is used by `ItemSlotManager` and the examine verb. So once this variable is non-null, those examine methods no longer work. This PR just makes it so that `_examinedEntity` is set in the `DoExamine` function.

:cl:
- fix: Fix a bug that causes the examine-popup to close immediately after opening.
