### PR TITLE
Keybinds: enable "tab complete" in SCSI

### DIFF
--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -298,6 +298,9 @@ binds:
   type: State
   key: Delete
   canRepeat: true
+- function: TextTabComplete
+  type: State
+  key: Tab
 - function: OpenEntitySpawnWindow
   type: State
   key: F5


### PR DESCRIPTION
## About the PR
guys it's 3 lines of yaml

**Screenshots**
![tab-key-](https://user-images.githubusercontent.com/602406/140742261-20b1abf2-e1da-42cd-b837-3169f2bd16d2.jpeg)

**Changelog**
:cl:
- add: Enabled tab complete in the Server-side C# Interpreter