### PR TITLE
Make ChemMaster bottles drawable by syringes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -24,6 +24,8 @@
     solution: drink
   - type: ExaminableSolution
     solution: drink
+  - type: DrawableSolution
+    solution: drink
   - type: SolutionTransfer
     maxTransferAmount: 30
     canChangeTransferAmount: true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Make ChemMaster bottles drawable by syringes <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is a small change to fix an annoyance playing a chemist role. Right now the two outputs for the ChemMaster are pills and bottles and this makes a change to the `BaseChemistryEmptyBottle` by making it a `DrawableSolution`. Right now the `DrawableSolution` component is in a lot of things like cups, humans, buckets, and a bunch of other things but is not on the ChemMaster bottles which is annoying, especially if you want to use bottles + syringes to administer medicine. I'm classing this as a bug because it's probably an oversight.

Repro steps:
- go to medbay and make 20u of water
- transfer 10u to a bottle
- eject beaker
- use syringe to try and draw 5u from the bottle (you can't)
- use syringe to try and draw 5u from the beaker (you can)
- use syringe to try and inject 5u from the bottle (you can, it counts as a `RefillableSolution`)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Syringes now can draw from ChemMaster 4000 bottles

