### PR TITLE
cmo and doctors start with filled medkits

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/Starter Gear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/Starter Gear/backpack.yml
@@ -34,7 +34,7 @@
   - type: StorageFill
     contents:
       - id: BoxSurvival
-      - id: Medkit
+      - id: MedkitFilled
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## CMO and Doctor Jobs start with Filled Medkits <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Resolves issue #5253 where **both** Medical Doctors and CMO spawn with empty medkits. I'm not sure what the observed behaviour was in #5253 but this changes `ClothingBackpackMedicalFilled` which is shared by both the Medical Doctor and CMO starting inventories. By changing the `Medkit` to `MedkitFilled` we solve both cases.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![issue-5253](https://user-images.githubusercontent.com/94037592/141215359-5a76f79f-f6c9-47b9-9bce-9c309b0f4234.png)
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Backpacks for CMO and Medical Doctors spawn with filled first aid kits

