### PR TITLE
Nerf hacking speed

### DIFF
--- a/Content.Server/Doors/Components/ServerDoorComponent.cs
+++ b/Content.Server/Doors/Components/ServerDoorComponent.cs
@@ -184,7 +184,7 @@ namespace Content.Server.Doors.Components
         /// Default time that the door should take to pry open.
         /// </summary>
         [DataField("pryTime")]
-        public float PryTime = 0.5f;
+        public float PryTime = 1.5f;
 
         /// <summary>
         ///     Minimum interval allowed between deny sounds in milliseconds.

--- a/Content.Server/WireHacking/WireHackingSystem.cs
+++ b/Content.Server/WireHacking/WireHackingSystem.cs
@@ -12,6 +12,8 @@ namespace Content.Server.WireHacking
         [ViewVariables] private readonly Dictionary<string, WireLayout> _layouts =
             new();
 
+        public const float ScrewTime = 2.5f;
+
         public override void Initialize()
         {
             base.Initialize();

--- a/Content.Server/WireHacking/WiresComponent.cs
+++ b/Content.Server/WireHacking/WiresComponent.cs
@@ -522,7 +522,7 @@ namespace Content.Server.WireHacking
 
             // screws the panel open if the tool can do so
             else if (await toolSystem.UseTool(tool.Owner.Uid, eventArgs.User.Uid, Owner.Uid,
-                0f, 0.5f, _screwingQuality, toolComponent:tool))
+                0f, WireHackingSystem.ScrewTime, _screwingQuality, toolComponent:tool))
             {
                 IsPanelOpen = !IsPanelOpen;
                 if (IsPanelOpen)


### PR DESCRIPTION
Adds at least 12 seconds onto an armoury breakin (3s per door).

I made the airlock pry time 1.5s so you actually have time to respond and don't just get gimped because your ping is 300ms. It also means people can't just speedrun everywhere (cough armoury again) when the power goes out.

If it were up to me I'd make screwing 4s, prying 2s and increase autoclose timer but that's a more controversial change.

:cl:
- tweak: Increase door prying and door screwing timers from 0.5s / 0.5s to 1.5s / 2.5s
