### PR TITLE
Add "Syndicate Puddle-Jumper" blueprint for admins to spawn in

### DIFF
--- a/Resources/Maps/syndipuddle.yml
+++ b/Resources/Maps/syndipuddle.yml
@@ -1,0 +1,1735 @@
+meta:
+  format: 2
+  name: DemoStation
+  author: Space-Wizards
+  postmapinit: false
+tilemap:
+  0: space
+  1: floor_asteroid_coarse_sand0
+  2: floor_asteroid_coarse_sand1
+  3: floor_asteroid_coarse_sand2
+  4: floor_asteroid_coarse_sand_dug
+  5: floor_asteroid_sand
+  6: floor_asteroid_tile
+  7: floor_blue
+  8: floor_blue_circuit
+  9: floor_dark
+  10: floor_elevator_shaft
+  11: floor_freezer
+  12: floor_glass
+  13: floor_gold
+  14: floor_green_circuit
+  15: floor_hydro
+  16: floor_lino
+  17: floor_mono
+  18: floor_reinforced
+  19: floor_rglass
+  20: floor_rock_vault
+  21: floor_showroom
+  22: floor_silver
+  23: floor_snow
+  24: floor_steel
+  25: floor_steel_dirty
+  26: floor_techmaint
+  27: floor_white
+  28: floor_wood
+  29: lattice
+  30: plating
+  31: underplating
+grids:
+- settings:
+    chunksize: 16
+    tilesize: 1
+  chunks:
+  - ind: "-1,-1"
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHQAAAAAAAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0AAAAAAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdAAAAAAAAAB4AAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHQAAAAAAAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0AAAAdAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdAAAAAAAAAB4AAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHQAAAAAAAAAeAAAAEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0AAAAAAAAAHgAAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdAAAAAAAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHQAAAAAAAAAeAAAAEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0AAAAAAAAAHgAAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdAAAAHQAAAB4AAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHQAAAAAAAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAA==
+  - ind: "0,-1"
+    tiles: HgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAASAAAAEgAAABIAAAAeAAAAAAAAAB0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAABIAAAASAAAAHgAAAAAAAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAASAAAAHgAAAB4AAAAeAAAAHQAAAB0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAEgAAAB4AAAAeAAAAHgAAAAAAAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAABIAAAAeAAAAHgAAAB4AAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAASAAAAHgAAABIAAAAeAAAAAAAAAB0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAASAAAAHgAAAAAAAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAABIAAAASAAAAEgAAAB4AAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAASAAAAEgAAABIAAAAeAAAAAAAAAB0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAEgAAABIAAAASAAAAHgAAAB0AAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgAAABIAAAASAAAAHgAAAB4AAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABIAAAASAAAAEgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAEgAAABIAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: "0,-2"
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: "-1,-2"
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHQAAAAAAAAAeAAAAHgAAAA==
+entities:
+- uid: 0
+  components:
+  - pos: 0.64252126,4.1776605
+    parent: null
+    type: Transform
+  - index: 0
+    type: MapGrid
+  - angularDamping: 0.3
+    fixedRotation: False
+    fixtures:
+    - shape: !type:PolygonShape
+        vertices:
+        - -3,-16
+        - -3,-12
+        - -4,-12
+        - -4,-16
+      id: grid_chunk--4--16
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 4
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,-16
+        - 0,-12
+        - -2,-12
+        - -2,-16
+      id: grid_chunk--2--16
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 8
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,-12
+        - 0,-11
+        - -4,-11
+        - -4,-12
+      id: grid_chunk--4--12
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 4
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - -3,-11
+        - -3,-5
+        - -4,-5
+        - -4,-11
+      id: grid_chunk--4--11
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 6
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,-11
+        - 0,-5
+        - -2,-5
+        - -2,-11
+      id: grid_chunk--2--11
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 12
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,-5
+        - 0,-4
+        - -4,-4
+        - -4,-5
+      id: grid_chunk--4--5
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 4
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - -3,-4
+        - -3,-3
+        - -4,-3
+        - -4,-4
+      id: grid_chunk--4--4
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 1
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,-4
+        - 0,-3
+        - -2,-3
+        - -2,-4
+      id: grid_chunk--2--4
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 2
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,-3
+        - 0,0
+        - -1,0
+        - -1,-3
+      id: grid_chunk--1--3
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 3
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - -3,-17
+        - -3,-16
+        - -4,-16
+        - -4,-17
+      id: grid_chunk--4--17
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 1
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,-17
+        - 0,-16
+        - -2,-16
+        - -2,-17
+      id: grid_chunk--2--17
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 2
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 5,-16
+        - 5,-12
+        - 0,-12
+        - 0,-16
+      id: grid_chunk-0--16
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 20
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 7,-16
+        - 7,-12
+        - 6,-12
+        - 6,-16
+      id: grid_chunk-6--16
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 4
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 7,-12
+        - 7,-11
+        - 0,-11
+        - 0,-12
+      id: grid_chunk-0--12
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 7
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 5,-11
+        - 5,-5
+        - 0,-5
+        - 0,-11
+      id: grid_chunk-0--11
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 30
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 7,-11
+        - 7,-5
+        - 6,-5
+        - 6,-11
+      id: grid_chunk-6--11
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 6
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 7,-5
+        - 7,-4
+        - 0,-4
+        - 0,-5
+      id: grid_chunk-0--5
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 7
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 5,-4
+        - 5,-3
+        - 0,-3
+        - 0,-4
+      id: grid_chunk-0--4
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 5
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 7,-4
+        - 7,-3
+        - 6,-3
+        - 6,-4
+      id: grid_chunk-6--4
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 1
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 4,-3
+        - 4,0
+        - 0,0
+        - 0,-3
+      id: grid_chunk-0--3
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 12
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 5,-17
+        - 5,-16
+        - 0,-16
+        - 0,-17
+      id: grid_chunk-0--17
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 5
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 7,-17
+        - 7,-16
+        - 6,-16
+        - 6,-17
+      id: grid_chunk-6--17
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 1
+      restitution: 0.1
+    bodyType: Dynamic
+    type: Physics
+  - gravityShakeSound: !type:SoundPathSpecifier
+      path: /Audio/Effects/alert.ogg
+    type: Gravity
+  - tiles:
+      -4,-16: 0
+      -4,-15: 0
+      -4,-14: 0
+      -4,-13: 0
+      -4,-12: 0
+      -4,-11: 0
+      -4,-10: 0
+      -4,-9: 0
+      -4,-8: 0
+      -4,-7: 0
+      -4,-6: 0
+      -4,-5: 0
+      -4,-4: 0
+      -3,-12: 0
+      -3,-5: 0
+      -2,-16: 0
+      -2,-15: 0
+      -2,-14: 0
+      -2,-13: 0
+      -2,-12: 0
+      -2,-11: 0
+      -2,-10: 0
+      -2,-9: 0
+      -2,-8: 0
+      -2,-7: 0
+      -2,-6: 0
+      -2,-5: 0
+      -2,-4: 0
+      -1,-16: 0
+      -1,-15: 0
+      -1,-14: 0
+      -1,-13: 0
+      -1,-12: 0
+      -1,-11: 0
+      -1,-10: 0
+      -1,-9: 0
+      -1,-8: 0
+      -1,-7: 0
+      -1,-6: 0
+      -1,-5: 0
+      -1,-4: 0
+      -1,-3: 0
+      -1,-2: 0
+      -1,-1: 0
+      0,-16: 0
+      0,-15: 0
+      0,-14: 0
+      0,-13: 0
+      0,-12: 0
+      0,-11: 0
+      0,-10: 0
+      0,-9: 0
+      0,-8: 0
+      0,-7: 0
+      0,-6: 0
+      0,-5: 0
+      0,-4: 0
+      0,-3: 0
+      0,-2: 0
+      0,-1: 0
+      1,-16: 0
+      1,-15: 0
+      1,-14: 0
+      1,-13: 0
+      1,-12: 0
+      1,-11: 0
+      1,-10: 0
+      1,-9: 0
+      1,-8: 0
+      1,-7: 0
+      1,-6: 0
+      1,-5: 0
+      1,-4: 0
+      1,-3: 0
+      1,-2: 0
+      1,-1: 0
+      2,-16: 0
+      2,-15: 0
+      2,-14: 0
+      2,-13: 0
+      2,-12: 0
+      2,-11: 0
+      2,-10: 0
+      2,-9: 0
+      2,-8: 0
+      2,-7: 0
+      2,-6: 0
+      2,-5: 0
+      2,-4: 0
+      2,-3: 0
+      2,-2: 0
+      2,-1: 0
+      3,-16: 0
+      3,-15: 0
+      3,-14: 0
+      3,-13: 0
+      3,-12: 0
+      3,-11: 0
+      3,-10: 0
+      3,-9: 0
+      3,-8: 0
+      3,-7: 0
+      3,-6: 0
+      3,-5: 0
+      3,-4: 0
+      3,-3: 0
+      3,-2: 0
+      3,-1: 0
+      4,-16: 0
+      4,-15: 0
+      4,-14: 0
+      4,-13: 0
+      4,-12: 0
+      4,-11: 0
+      4,-10: 0
+      4,-9: 0
+      4,-8: 0
+      4,-7: 0
+      4,-6: 0
+      4,-5: 0
+      4,-4: 0
+      5,-12: 0
+      5,-5: 0
+      6,-16: 0
+      6,-15: 0
+      6,-14: 0
+      6,-13: 0
+      6,-12: 0
+      6,-11: 0
+      6,-10: 0
+      6,-9: 0
+      6,-8: 0
+      6,-7: 0
+      6,-6: 0
+      6,-5: 0
+      6,-4: 0
+      0,-17: 0
+      1,-17: 0
+      2,-17: 0
+      3,-17: 0
+      4,-17: 0
+      6,-17: 0
+      -4,-17: 0
+      -2,-17: 0
+      -1,-17: 0
+    uniqueMixes:
+    - volume: 2500
+      temperature: 293.15
+      moles:
+      - 21.824879
+      - 82.10312
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    type: GridAtmosphere
+- uid: 1
+  type: ReinforcedWindow
+  components:
+  - pos: -0.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 2
+  type: ReinforcedWindow
+  components:
+  - pos: 0.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 3
+  type: ReinforcedWindow
+  components:
+  - pos: 1.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 4
+  type: ReinforcedWindow
+  components:
+  - pos: 2.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 5
+  type: ReinforcedWindow
+  components:
+  - pos: 3.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 6
+  type: ReinforcedWindow
+  components:
+  - pos: 3.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 7
+  type: ReinforcedWindow
+  components:
+  - pos: 3.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 8
+  type: ReinforcedWindow
+  components:
+  - pos: -0.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 9
+  type: ReinforcedWindow
+  components:
+  - pos: -0.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 10
+  type: WallReinforced
+  components:
+  - pos: -0.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 11
+  type: WallReinforced
+  components:
+  - pos: -1.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 12
+  type: WallReinforced
+  components:
+  - pos: -1.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 13
+  type: ReinforcedWindow
+  components:
+  - pos: 4.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 14
+  type: ReinforcedWindow
+  components:
+  - pos: 4.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 15
+  type: WallReinforced
+  components:
+  - pos: -1.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 16
+  type: WallReinforced
+  components:
+  - pos: -1.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 17
+  type: WallReinforced
+  components:
+  - pos: 0.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 18
+  type: WallReinforced
+  components:
+  - pos: 1.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 19
+  type: WallReinforced
+  components:
+  - pos: -0.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 20
+  type: WallReinforced
+  components:
+  - pos: 2.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 21
+  type: ComputerShuttleSyndie
+  components:
+  - pos: 1.5,-1.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 22
+  type: WallReinforced
+  components:
+  - pos: 4.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 23
+  type: WallReinforced
+  components:
+  - pos: 4.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 24
+  type: ReinforcedWindow
+  components:
+  - pos: -1.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 25
+  type: ReinforcedWindow
+  components:
+  - pos: -1.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 26
+  type: WallReinforced
+  components:
+  - pos: 4.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 27
+  type: WallReinforced
+  components:
+  - pos: 4.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 28
+  type: WallReinforced
+  components:
+  - pos: 3.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 29
+  type: WallReinforced
+  components:
+  - pos: 2.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 30
+  type: WallReinforced
+  components:
+  - pos: 2.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 31
+  type: GravityGenerator
+  components:
+  - pos: 0.5,-9.5
+    parent: 0
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - powerLoad: 500
+    type: ApcPowerReceiver
+  - radius: 2.5
+    type: PointLight
+- uid: 32
+  type: WallReinforced
+  components:
+  - pos: 2.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 33
+  type: WallReinforced
+  components:
+  - pos: 1.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 34
+  type: WallReinforced
+  components:
+  - pos: 0.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 35
+  type: WallReinforced
+  components:
+  - pos: -0.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 36
+  type: WallReinforced
+  components:
+  - pos: -1.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 37
+  type: WallReinforced
+  components:
+  - pos: -1.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 38
+  type: WallReinforced
+  components:
+  - pos: -1.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 39
+  type: WallReinforced
+  components:
+  - pos: -1.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 40
+  type: WallReinforced
+  components:
+  - pos: 2.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 41
+  type: WallReinforced
+  components:
+  - pos: -1.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 42
+  type: WallReinforced
+  components:
+  - pos: 4.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 43
+  type: AirlockExternal
+  components:
+  - pos: 4.5,-11.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 44
+  type: WallReinforced
+  components:
+  - pos: 4.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 45
+  type: WallReinforced
+  components:
+  - pos: 4.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 46
+  type: ChairPilotSeat
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 1.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 47
+  type: AirlockExternal
+  components:
+  - pos: 2.5,-11.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 48
+  type: AirlockExternal
+  components:
+  - pos: 3.5,-9.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 49
+  type: PoweredSmallLight
+  components:
+  - pos: -0.5,-4.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 50
+  type: PoweredSmallLight
+  components:
+  - pos: 3.5,-4.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 51
+  type: ApcNetSwitch
+  components:
+  - pos: 3.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 52
+  type: PoweredSmallLight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-11.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 53
+  type: SalternApc
+  components:
+  - pos: -0.5,-3.5
+    parent: 0
+    type: Transform
+  - startingCharge: 12000
+    type: Battery
+  - loadingNetworkDemand: 720
+    currentReceiving: 720.00287
+    currentSupply: 720
+    type: PowerNetworkBattery
+- uid: 54
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 55
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 56
+  type: CableApcExtension
+  components:
+  - pos: -0.5,-3.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 57
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 58
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 59
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 60
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 61
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 62
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 63
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-7.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 64
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-8.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 65
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-9.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 66
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-10.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 67
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 68
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 69
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-11.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 70
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 71
+  type: CableMV
+  components:
+  - pos: -0.5,-3.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 72
+  type: CableMV
+  components:
+  - pos: -0.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 73
+  type: CableMV
+  components:
+  - pos: -0.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 74
+  type: SalternSubstation
+  components:
+  - pos: -0.5,-5.5
+    parent: 0
+    type: Transform
+  - loadingNetworkDemand: 720.00287
+    currentReceiving: 720.00287
+    currentSupply: 720.00287
+    type: PowerNetworkBattery
+- uid: 75
+  type: SalternGenerator
+  components:
+  - pos: -0.5,-6.5
+    parent: 0
+    type: Transform
+  - supplyRampPosition: 720.00287
+    type: PowerSupplier
+- uid: 76
+  type: CableHV
+  components:
+  - pos: -0.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 77
+  type: CableHV
+  components:
+  - pos: -0.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 78
+  type: NuclearBomb
+  components:
+  - pos: 1.5,-5.5
+    parent: 0
+    type: Transform
+  - containers:
+      DiskSlot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 79
+  type: PinpointerNuclear
+  components:
+  - pos: 1.8490864,-4.5920672
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 80
+  type: ClothingHeadHelmetHardsuitSyndie
+  components:
+  - pos: 2.4037523,-3.5996041
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      cellslot_cell_container: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 81
+  type: ClothingHeadHelmetHardsuitSyndie
+  components:
+  - pos: 0.48049557,-3.5069442
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      cellslot_cell_container: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 82
+  type: ClothingOuterHardsuitSyndie
+  components:
+  - pos: 0.44668686,-3.5181909
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 83
+  type: ClothingOuterHardsuitSyndie
+  components:
+  - pos: 2.4506273,-3.4828653
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 84
+  type: OxygenTankFilled
+  components:
+  - pos: 2.448688,-3.4381218
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 85
+  type: OxygenTankFilled
+  components:
+  - pos: 0.46431315,-3.4537468
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 86
+  type: ClothingMaskBreath
+  components:
+  - pos: 0.41543686,-3.4244409
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 87
+  type: ClothingMaskBreath
+  components:
+  - pos: 2.5287523,-3.6308541
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 88
+  type: ToolboxSyndicateFilled
+  components:
+  - pos: 0.39226615,-2.5604596
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 89
+  type: ToolboxSyndicateFilled
+  components:
+  - pos: 2.5016413,-2.5917096
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 90
+  type: Grille
+  components:
+  - pos: -0.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 91
+  type: Grille
+  components:
+  - pos: -0.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 92
+  type: Grille
+  components:
+  - pos: -0.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 93
+  type: Grille
+  components:
+  - pos: 0.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 94
+  type: Grille
+  components:
+  - pos: 1.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 95
+  type: Grille
+  components:
+  - pos: 2.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 96
+  type: Grille
+  components:
+  - pos: 3.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 97
+  type: Grille
+  components:
+  - pos: 3.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 98
+  type: Grille
+  components:
+  - pos: 3.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 99
+  type: CableApcExtension
+  components:
+  - pos: -0.5,-2.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 100
+  type: CableApcExtension
+  components:
+  - pos: -0.5,-1.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 101
+  type: CableApcExtension
+  components:
+  - pos: -0.5,-0.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 102
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-0.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 103
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-0.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 104
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-0.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 105
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-0.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 106
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-1.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 107
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-2.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 108
+  type: WallReinforced
+  components:
+  - pos: -1.5,-14.5
+    parent: 0
+    type: Transform
+- uid: 109
+  type: WallReinforced
+  components:
+  - pos: -1.5,-15.5
+    parent: 0
+    type: Transform
+- uid: 110
+  type: WallReinforced
+  components:
+  - pos: -1.5,-16.5
+    parent: 0
+    type: Transform
+- uid: 111
+  type: WallReinforced
+  components:
+  - pos: -0.5,-16.5
+    parent: 0
+    type: Transform
+- uid: 112
+  type: WallReinforced
+  components:
+  - pos: 0.5,-16.5
+    parent: 0
+    type: Transform
+- uid: 113
+  type: WallReinforced
+  components:
+  - pos: 1.5,-16.5
+    parent: 0
+    type: Transform
+- uid: 114
+  type: WallReinforced
+  components:
+  - pos: 2.5,-16.5
+    parent: 0
+    type: Transform
+- uid: 115
+  type: WallReinforced
+  components:
+  - pos: 3.5,-16.5
+    parent: 0
+    type: Transform
+- uid: 116
+  type: WallReinforced
+  components:
+  - pos: 4.5,-16.5
+    parent: 0
+    type: Transform
+- uid: 117
+  type: WallReinforced
+  components:
+  - pos: 4.5,-15.5
+    parent: 0
+    type: Transform
+- uid: 118
+  type: WallReinforced
+  components:
+  - pos: 4.5,-14.5
+    parent: 0
+    type: Transform
+- uid: 119
+  type: WallReinforced
+  components:
+  - pos: 4.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 120
+  type: GasPort
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -0.5,-15.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 121
+  type: PoweredSmallLight
+  components:
+  - pos: 1.5,-13.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 122
+  type: ClothingHandsGlovesColorYellow
+  components:
+  - pos: 0.4250747,-1.8422356
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 123
+  type: GasPipeTJunction
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-13.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 124
+  type: GasValve
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-15.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 125
+  type: GasPassiveGate
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-15.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 126
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 127
+  type: Grille
+  components:
+  - pos: -1.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 128
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-13.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 129
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-14.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 130
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-14.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 131
+  type: PoweredSmallLight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-15.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 132
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 133
+  type: GasPipeTJunction
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 0.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 134
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-10.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 135
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-9.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 136
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-8.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 137
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-7.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 138
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-6.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 139
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-14.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 140
+  type: GasVentPump
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -0.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 141
+  type: GasVentPump
+  components:
+  - pos: 0.5,-5.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 142
+  type: AirlockExternal
+  components:
+  - pos: 3.5,-12.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 143
+  type: PoweredSmallLight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -0.5,-15.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 144
+  type: OxygenCanister
+  components:
+  - pos: -0.5,-13.5
+    parent: 0
+    type: Transform
+  - releasePressure: 10.1325
+    type: GasCanister
+- uid: 145
+  type: Grille
+  components:
+  - pos: -1.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 146
+  type: Grille
+  components:
+  - pos: 4.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 147
+  type: GasValve
+  components:
+  - pos: 0.5,-14.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 148
+  type: Grille
+  components:
+  - pos: 4.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 149
+  type: GasPipeTJunction
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-15.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 150
+  type: GasPort
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,-15.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 151
+  type: NukeCodePaper
+  components:
+  - pos: 2.495934,-5.116844
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 152
+  type: ClothingHandsGlovesColorYellow
+  components:
+  - pos: 2.5500746,-1.8891106
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 153
+  type: GasVentPump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-13.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 154
+  type: PoweredSmallLight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 3.5,-10.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+...


### PR DESCRIPTION
## About the PR
Serves as a way to let admins cause nukies.

Admin usage guide (and testing procedure):

1. Ensure 0, 0 is clear of obstructions
2. `loadbp 1 Maps/syndipuddle.yml`
3. teleport nukies to 0, 0 (where it will have shown up)
4. Supply uplinks if applicable
5. Make sure to forcibly end the round when the nuke goes off

Specific shuttle features:

+ Has a "technically feasible to win" roundstart kit - arguably ready-to-use uplinks-or-not
+ Has a tiny atmos setup to recover from airlock accidents - first person to work out the intended use-case of the one-way injection port and valve setup gets a metaphorical biscuit
+ Has power and gravity

Nothing worth changelogging here

**Screenshots**
![image](https://user-images.githubusercontent.com/22304167/141355059-4f2e1ba5-7d57-42dd-a037-6735add2f378.png)
![image](https://user-images.githubusercontent.com/22304167/141355095-34d8902c-72a5-43c0-b43e-928fbf6ace3e.png)
