### PR TITLE
latex gloves allow medical consumables to be more effective

### DIFF
--- a/Content.Server/Clothing/Components/ClothingComponent.cs
+++ b/Content.Server/Clothing/Components/ClothingComponent.cs
@@ -33,11 +33,17 @@ namespace Content.Server.Clothing.Components
         [DataField("HeatResistance")]
         private int _heatResistance = 323;
 
+        [DataField("Sterile")]
+        private int _sterile = 0;
+
         [DataField("EquipSound")]
         public SoundSpecifier? EquipSound { get; set; } = default!;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public int HeatResistance => _heatResistance;
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public int Sterile => _sterile;
 
         [DataField("ClothingPrefix")]
         private string? _clothingEquippedPrefix;

--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -1,9 +1,12 @@
 using System.Threading.Tasks;
+using Content.Server.Clothing.Components;
+using Content.Server.Inventory.Components;
 using Content.Server.Stack;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Helpers;
+using Content.Shared.Inventory;
 using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -48,7 +51,13 @@ namespace Content.Server.Medical.Components
                 return true;
             }
 
-            EntitySystem.Get<DamageableSystem>().TryChangeDamage(eventArgs.Target.Uid, Damage, true);
+            var scale = 1;
+            if (eventArgs.User.GetComponent<InventoryComponent>().TryGetSlotItem(EquipmentSlotDefines.Slots.GLOVES, out ClothingComponent? gloves))
+            {
+                scale = gloves?.Sterile ?? 1;
+            }
+
+            EntitySystem.Get<DamageableSystem>().TryChangeDamage(eventArgs.Target.Uid, Damage * scale, true);
 
             return true;
         }

--- a/Content.Server/Medical/Components/SterileComponent.cs
+++ b/Content.Server/Medical/Components/SterileComponent.cs
@@ -1,0 +1,17 @@
+using Content.Server.Clothing.Components;
+using Content.Server.Inventory.Components;
+using Content.Shared.Inventory;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server.Medical.Components
+{
+    /// <summary>
+    /// Tag clothing component that denotes an entity as Sterile in the medical context
+    /// </summary>
+    [RegisterComponent]
+
+    public class SterileComponent : Component
+    {
+        public override string Name => "Sterile";
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -82,6 +82,7 @@
     sprite: Clothing/Hands/Gloves/latex.rsi
   - type: Clothing
     sprite: Clothing/Hands/Gloves/latex.rsi
+    Sterile: 2 # mutliplier for healing consumables like BrutePacks
 
 - type: entity
   parent: ClothingHandsBase


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Latex gloves allow medical consumables to be more effective <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Right now latex gloves are kind of a dud item aside from RP purposes. Instead it makes sense to me that if you are using the latex gloves in a medical context your medical outcome should be more effective. This doesn't touch any of the other kinds of gloves in this PR but it makes sense that someone wearing some other kinds of gloves instead of even bare hands should be less effective. In theory this also could be used eventually to make the gloves 'dirty' and less effective so there would be need to dispose of them and get fresh ones from cargo over the course of a round.

This mirrors the currently existing `HeatResistanceComponent` in adding itself as a potential data field of a `ClothingComponent`, and the actual value comes into play during the `HealingComponent`'s application of effects. After all of the existing checks we look at the source entity, check to see if it has gloves on its hands and then applies the scaling value accordingly.

Right now the `HealingComponent` is only used by brutepacks, ointments, and gauze so there should be no side effects beyond that.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![starting](https://user-images.githubusercontent.com/94037592/141381740-cd51dc9b-fcf0-477a-a948-77f8c223c790.png)
![healing without gloves](https://user-images.githubusercontent.com/94037592/141381749-840a9d1c-b580-48b1-b20e-5f1235c93551.png)
![healing with gloves](https://user-images.githubusercontent.com/94037592/141381751-54dace59-631c-4000-ab23-3de290eff2a2.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: latex gloves now double the effectiveness of brutepacks and ointments

