### PR TITLE
Adds skin color to preferences

### DIFF
--- a/Content.Client/CharacterAppearance/Systems/HumanoidAppearanceSystem.cs
+++ b/Content.Client/CharacterAppearance/Systems/HumanoidAppearanceSystem.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Content.Client.Cuffs.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.CharacterAppearance;
@@ -25,6 +26,19 @@ namespace Content.Client.CharacterAppearance.Systems
             SubscribeLocalEvent<HumanoidAppearanceBodyPartRemovedEvent>(BodyPartRemoved);
         }
 
+        private List<HumanoidVisualLayers> _bodyPartLayers = new List<HumanoidVisualLayers>
+        {
+            HumanoidVisualLayers.Chest,
+            HumanoidVisualLayers.Head,
+            HumanoidVisualLayers.Eyes,
+            HumanoidVisualLayers.RArm,
+            HumanoidVisualLayers.LArm,
+            HumanoidVisualLayers.RHand,
+            HumanoidVisualLayers.LHand,
+            HumanoidVisualLayers.RLeg,
+            HumanoidVisualLayers.LLeg,
+        };
+
         private void UpdateLooks(EntityUid uid, HumanoidAppearanceComponent component, ChangedHumanoidAppearanceEvent args)
         {
             if(!EntityManager.TryGetComponent(uid, out SpriteComponent? sprite))
@@ -46,6 +60,9 @@ namespace Content.Client.CharacterAppearance.Systems
                 component.CanColorHair ? component.Appearance.HairColor : Color.White);
             sprite.LayerSetColor(HumanoidVisualLayers.FacialHair,
                 component.CanColorFacialHair ? component.Appearance.FacialHairColor : Color.White);
+
+            foreach (var layer in _bodyPartLayers)
+                sprite.LayerSetColor(layer, component.Appearance.SkinColor);
 
             sprite.LayerSetColor(HumanoidVisualLayers.Eyes, component.Appearance.EyeColor);
 

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.Random.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.Random.cs
@@ -22,6 +22,8 @@ namespace Content.Client.Preferences.UI
             UpdateNameEdit();
             UpdateHairPickers();
             UpdateEyePickers();
+
+            _skinColor.Value = _random.Next(0, 100);
         }
 
         private void RandomizeName()

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml
@@ -76,6 +76,13 @@
                                     </BoxContainer>
                                 </prefUi:HighlightedContainer>
                             </BoxContainer>
+                            <!-- Skin -->
+                            <prefUi:HighlightedContainer>
+                                <BoxContainer HorizontalExpand="True">
+                                    <Label Text="{Loc 'humanoid-profile-editor-skin-color-label'}" />
+                                    <Slider HorizontalExpand="True" Name="CSkin" MinValue="0" MaxValue="100" Value="20" />
+                                </BoxContainer>
+                            </prefUi:HighlightedContainer>
                             <!-- Hair -->
                             <prefUi:HighlightedContainer>
                                 <BoxContainer Orientation="Horizontal">

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -179,9 +179,9 @@ namespace Content.Client.Preferences.UI
             //
             // 0 - 20 changes the hue
             // 20 - 100 changes the value
-            // 0 is 45 - 25 - 100
-            // 20 is 25 - 25 - 100
-            // 100 is 25 - 25 - 20
+            // 0 is 45 - 20 - 100
+            // 20 is 25 - 20 - 100
+            // 100 is 25 - 100 - 20
             _skinColor.OnValueChanged += range =>
             {
                 if (Profile is null)

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
@@ -59,6 +60,7 @@ namespace Content.Client.Preferences.UI
         private Button _sexFemaleButton => CSexFemale;
         private Button _sexMaleButton => CSexMale;
         private OptionButton _genderButton => CPronounsButton;
+        private Slider _skinColor => CSkin;
         private OptionButton _clothingButton => CClothingButton;
         private OptionButton _backpackButton => CBackpackButton;
         private HairStylePicker _hairPicker => CHairStylePicker;
@@ -169,6 +171,46 @@ namespace Content.Client.Preferences.UI
             };
 
             #endregion Gender
+
+            #region Skin
+
+            // 0 - 100, 0 being gold/yellowish and 100 being dark
+            // HSV based
+            //
+            // 0 - 20 changes the hue
+            // 20 - 100 changes the value
+            // 0 is 45 - 25 - 100
+            // 20 is 25 - 25 - 100
+            // 100 is 25 - 25 - 20
+            _skinColor.OnValueChanged += range =>
+            {
+                if (Profile is null)
+                    return;
+
+                int rangeOffset = (int) range.Value - 20;
+
+                float hue = 25;
+                float sat = 20;
+                float val = 100;
+
+                if (rangeOffset < 0)
+                {
+                    hue += Math.Abs(rangeOffset);
+                }
+                else if (rangeOffset > 0)
+                {
+                    sat += rangeOffset;
+                    val -= rangeOffset;
+                }
+
+                var color = Color.FromHsv(new Vector4(hue / 360, sat / 100, val / 100, 1.0f));
+
+                Profile = Profile.WithCharacterAppearance(
+                    Profile.Appearance.WithSkinColor(color));
+                IsDirty = true;
+            };
+
+            #endregion
 
             #region Hair
 
@@ -528,6 +570,27 @@ namespace Content.Client.Preferences.UI
                 _sexFemaleButton.Pressed = true;
         }
 
+        private void UpdateSkinColor()
+        {
+            if (Profile == null)
+                return;
+
+            var color = Color.ToHsv(Profile.Appearance.SkinColor);
+            // check for hue/value first, if hue is lower than this percentage
+            // and value is 1.0
+            // then it'll be hue
+            if (Math.Clamp(color.X, 25f / 360f, 1) > 25f / 360f
+                && color.Z == 1.0)
+            {
+                _skinColor.Value = Math.Abs(45 - (color.X * 360));
+            }
+            // otherwise it'll directly be the saturation
+            else
+            {
+                _skinColor.Value = color.Y * 100;
+            }
+        }
+
         private void UpdateGenderControls()
         {
             if (Profile == null)
@@ -607,6 +670,7 @@ namespace Content.Client.Preferences.UI
             UpdateNameEdit();
             UpdateSexControls();
             UpdateGenderControls();
+            UpdateSkinColor();
             UpdateClothingControls();
             UpdateBackpackControls();
             UpdateAgeEdit();

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -6,6 +6,7 @@ humanoid-profile-editor-sex-label = Sex:
 humanoid-profile-editor-sex-male-button = Male
 humanoid-profile-editor-sex-female-button = Female
 humanoid-profile-editor-age-label = Age:
+humanoid-profile-editor-skin-color-label = Skin color:
 humanoid-profile-editor-pronouns-label = Pronouns:
 humanoid-profile-editor-pronouns-male-text = He / Him
 humanoid-profile-editor-pronouns-female-text = She / Her


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds skin color to preferences. Colors range from golden-pale -> pale -> dark.


https://user-images.githubusercontent.com/76629141/141412967-78b8d342-4d91-46e5-b8ff-8b03e5a7841f.mp4



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Nanotrasen has extended its outreach, and has finally sent the person who decided to hire people of exactly one skin color out an airlock. Expect more variety in the co-workers you meet.

