### PR TITLE
fixrotations fixes rotations properly again

### DIFF
--- a/Content.Server/Construction/Commands/FixRotationsCommand.cs
+++ b/Content.Server/Construction/Commands/FixRotationsCommand.cs
@@ -88,6 +88,8 @@ namespace Content.Server.Construction.Commands
                 valid |= childEntity.HasComponent<CableComponent>();
                 // anything else that might need this forced
                 valid |= childEntity.HasTag("ForceFixRotations");
+                // override
+                valid &= !childEntity.HasTag("ForceNoFixRotations");
 
                 if (!valid)
                 {

--- a/Content.Server/Construction/Commands/FixRotationsCommand.cs
+++ b/Content.Server/Construction/Commands/FixRotationsCommand.cs
@@ -1,7 +1,9 @@
 using Content.Server.Administration;
 using Content.Server.Window;
+using Content.Server.Power.Components;
 using Content.Shared.Administration;
 using Content.Shared.Construction;
+using Content.Shared.Tag;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.GameObjects;
@@ -74,9 +76,18 @@ namespace Content.Server.Construction.Commands
 
                 var valid = false;
 
-                valid |= childEntity.HasComponent<OccluderComponent>();
+                // Occluders should only count if the state of it right now is enabled.
+                // This prevents issues with edge firelocks.
+                if (entityManager.TryGetComponent<OccluderComponent>(childUid, out var occluder))
+                {
+                    valid |= occluder.Enabled;
+                }
+                // low walls & grilles
                 valid |= childEntity.HasComponent<SharedCanBuildWindowOnTopComponent>();
-                valid |= childEntity.HasComponent<WindowComponent>();
+                // cables
+                valid |= childEntity.HasComponent<CableComponent>();
+                // anything else that might need this forced
+                valid |= childEntity.HasTag("ForceFixRotations");
 
                 if (!valid)
                 {

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -77,6 +77,8 @@
     snap:
     - Window
   components:
+    # Attention! If adding tags here:
+    # Keep WindowTintedDirectional in mind
   - type: Sprite
     netsync: false
     drawdepth: WallTops
@@ -139,6 +141,9 @@
     drawdepth: WallTops
     sprite: Structures/Windows/directional.rsi
     state: tinted_window
+  - type: Tag
+    tags:
+      - ForceNoFixRotations
   - type: Icon
     sprite: Structures/Windows/directional.rsi
     state: tinted_window

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -11,6 +11,7 @@
   - type: Tag
     tags:
       - RCDDeconstructWhitelist
+      - ForceFixRotations
   - type: Sprite
     netsync: false
     drawdepth: WallTops

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1,3 +1,5 @@
+# Alphabetical order is now apparently required.
+
 - type: Tag
   id: Baguette
 
@@ -89,6 +91,9 @@
   id: Egg
 
 - type: Tag
+  id: EmitterBolt
+
+- type: Tag
   id: ExplosivePassable
 
 - type: Tag
@@ -107,6 +112,12 @@
   id: FootstepSound
 
 - type: Tag
+  id: ForceFixRotations # fixrotations command WILL target this
+
+- type: Tag
+  id: ForceNoFixRotations # fixrotations command WON'T target this
+
+- type: Tag
   id: Gauze
 
 - type: Tag
@@ -114,6 +125,9 @@
 
 - type: Tag
   id: Handcuffs
+  
+- type: Tag
+  id: HideContextMenu
 
 - type: Tag
   id: Hoe
@@ -143,6 +157,9 @@
   id: NoSpinOnThrow
 
 - type: Tag
+  id: NukeDisk
+
+- type: Tag
   id: Ointment
 
 - type: Tag
@@ -168,6 +185,9 @@
 
 - type: Tag
   id: Powerdrill
+
+- type: Tag
+  id: RCDDeconstructWhitelist
 
 - type: Tag
   id: RodMetal1
@@ -206,29 +226,11 @@
   id: Wirecutter
 
 - type: Tag
+  id: Wooden # just like our atmos
+
+- type: Tag
   id: Wrench
 
 - type: Tag
   id: Write
-
-- type: Tag
-  id: RCDDeconstructWhitelist
-
-- type: Tag
-  id: Wooden # just like our atmos
-
-- type: Tag
-  id: EmitterBolt
-  
-- type: Tag
-  id: HideContextMenu
-
-- type: Tag
-  id: NukeDisk
-
-- type: Tag
-  id: ForceFixRotations # fixrotations command WILL target this
-
-- type: Tag
-  id: ForceNoFixRotations # fixrotations command WON'T target this
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -229,3 +229,6 @@
 - type: Tag
   id: ForceFixRotations # fixrotations command WILL target this
 
+- type: Tag
+  id: ForceNoFixRotations # fixrotations command WON'T target this
+

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -225,3 +225,7 @@
 
 - type: Tag
   id: NukeDisk
+
+- type: Tag
+  id: ForceFixRotations # fixrotations command WILL target this
+


### PR DESCRIPTION
## About the PR

For packedstation mapping mainly

Specific objects fixrotations will now mess with:
- Anything with a *round-start enabled* OccluderComponent (done this way so it'll ignore edge firelocks/etc.)
- Anything with a CableComponent (implicitly assuming this is paired with CableVis)
- Anything with a SharedCanBuildWindowOnTopComponent
- There's now a tag to force fixrotation on anything

no changelog notes, only relevant to mappers
