### PR TITLE
Properly reset the solars system each round, solar panels perf fix

### DIFF
--- a/Content.Server/Solar/Components/SolarControlConsoleComponent.cs
+++ b/Content.Server/Solar/Components/SolarControlConsoleComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using Content.Shared.Solar;
 using Content.Server.Solar.EntitySystems;
 using Content.Server.GameObjects.Components;
@@ -5,6 +6,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.ViewVariables;
+using Robust.Shared.Maths;
 
 namespace Content.Server.Solar.Components
 {
@@ -42,7 +44,9 @@ namespace Content.Server.Solar.Components
                     }
                     if (double.IsFinite(msg.AngularVelocity))
                     {
-                        _powerSolarSystem.TargetPanelVelocity = msg.AngularVelocity.Reduced();
+                        var degrees = msg.AngularVelocity.Degrees;
+                        degrees = Math.Clamp(degrees, -PowerSolarSystem.MaxPanelVelocityDegrees, PowerSolarSystem.MaxPanelVelocityDegrees);
+                        _powerSolarSystem.TargetPanelVelocity = Angle.FromDegrees(degrees);
                     }
                     break;
             }

--- a/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
+++ b/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Content.Server.Power.Components;
 using Content.Server.Solar.Components;
 using Content.Shared.Physics;
+using Content.Shared.GameTicking;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -72,7 +73,20 @@ namespace Content.Server.Solar.EntitySystems
         public override void Initialize()
         {
             SubscribeLocalEvent<SolarPanelComponent, MapInitEvent>(OnMapInit);
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
+            RandomizeSun();
+        }
 
+        public void Reset(RoundRestartCleanupEvent ev)
+        {
+            RandomizeSun();
+            TargetPanelRotation = Angle.Zero;
+            TargetPanelVelocity = Angle.Zero;
+            TotalPanelPower = 0;
+        }
+
+        private void RandomizeSun()
+        {
             // Initialize the sun to something random
             TowardsSun = MathHelper.TwoPi * _robustRandom.NextDouble();
             SunAngularVelocity = Angle.FromDegrees(0.1 + ((_robustRandom.NextDouble() - 0.5) * 0.05));

--- a/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
+++ b/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
@@ -24,6 +24,11 @@ namespace Content.Server.Solar.EntitySystems
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
 
         /// <summary>
+        /// Maximum panel angular velocity range - used to stop people rotating panels fast enough that the lag prevention becomes noticable
+        /// </summary>
+        public const float MaxPanelVelocityDegrees = 1f;
+
+        /// <summary>
         /// The current sun angle.
         /// </summary>
         public Angle TowardsSun = Angle.Zero;
@@ -45,12 +50,12 @@ namespace Content.Server.Solar.EntitySystems
         /// to within sane boundaries.
         /// Keep in mind, this is not exact, as the random interval is also applied.
         /// </summary>
-        public TimeSpan SolarCoverageUpdateInterval = TimeSpan.FromSeconds(0.5);
+        public TimeSpan SolarCoverageUpdateInterval = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// A random interval used to stagger solar coverage updates reliably.
         /// </summary>
-        public TimeSpan SolarCoverageUpdateRandomInterval = TimeSpan.FromSeconds(0.5);
+        public TimeSpan SolarCoverageUpdateRandomInterval = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// TODO: *Should be moved into the solar tracker when powernet allows for it.*
@@ -109,11 +114,11 @@ namespace Content.Server.Solar.EntitySystems
 
             foreach (var panel in EntityManager.EntityQuery<SolarPanelComponent>())
             {
-                // There's supposed to be rotational logic here, but that implies putting it somewhere.
-                panel.Owner.Transform.WorldRotation = TargetPanelRotation;
-
                 if (panel.TimeOfNextCoverageUpdate < _gameTiming.CurTime)
                 {
+                    // Coverage update time!
+                    // There's supposed to be rotational logic here, but that implies putting it somewhere.
+                    panel.Owner.Transform.WorldRotation = TargetPanelRotation;
                     // Setup the next coverage check.
                     TimeSpan future = SolarCoverageUpdateInterval + (SolarCoverageUpdateRandomInterval * _robustRandom.NextDouble());
                     panel.TimeOfNextCoverageUpdate = _gameTiming.CurTime + future;


### PR DESCRIPTION
## About the PR

I still need to remember what the relation between solar panels, tracker and console is. Then the trackers could be properly isolated.

**Changelog**

:cl:
- fix: Solar panels and the related systems will no longer hold state between rounds.

