### PR TITLE
Change handcuff and handcuff box size

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
@@ -15,7 +15,7 @@
 
   - type: Item
   - type: Storage
-    capacity: 6
+    capacity: 20
 
 - type: entity
   name: flashbang box

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -4,6 +4,8 @@
   id: Handcuffs
   parent: BaseItem
   components:
+  - type: Item
+    size: 3
   - type: Handcuff
     cuffTime: 3.0
     uncuffTime: 3.0
@@ -24,6 +26,8 @@
   id: Cablecuffs
   parent: Handcuffs
   components:
+  - type: Item
+    size: 5
   - type: Handcuff
     cuffTime: 3.5
     uncuffTime: 3.5


### PR DESCRIPTION
## About the PR
Makes handcuffs smaller and handcuff box the same size as other sec boxes, keeps cable cuffs at size 5 to nerf and separate from regular cuffs

Fixes: #5317
**Changelog**

:cl: Daemon
- fix: Handcuff box has too little of a storing size

