### PR TITLE
Block Game Ghosts

### DIFF
--- a/Content.Client/Arcade/BlockGameMenu.cs
+++ b/Content.Client/Arcade/BlockGameMenu.cs
@@ -682,17 +682,7 @@ namespace Content.Client.Arcade
             var matchingBlock = blocks.FirstOrNull(b => b.Position.X == x && b.Position.Y == y);
             if (matchingBlock.HasValue)
             {
-                c = matchingBlock.Value.GameBlockColor switch
-                {
-                    BlockGameBlock.BlockGameBlockColor.Red => Color.Red,
-                    BlockGameBlock.BlockGameBlockColor.Orange => Color.Orange,
-                    BlockGameBlock.BlockGameBlockColor.Yellow => Color.Yellow,
-                    BlockGameBlock.BlockGameBlockColor.Green => Color.LimeGreen,
-                    BlockGameBlock.BlockGameBlockColor.Blue => Color.Blue,
-                    BlockGameBlock.BlockGameBlockColor.Purple => Color.Purple,
-                    BlockGameBlock.BlockGameBlockColor.LightBlue => Color.LightBlue,
-                    _ => Color.Olive //olive is error
-                };
+                c = BlockGameBlock.ToColor(matchingBlock.Value.GameBlockColor);
             }
 
             return c;

--- a/Content.Server/Arcade/Components/BlockGameArcadeComponent.cs
+++ b/Content.Server/Arcade/Components/BlockGameArcadeComponent.cs
@@ -700,6 +700,22 @@ namespace Content.Server.Arcade.Components
                 var result = new List<BlockGameBlock>();
                 result.AddRange(_field);
                 result.AddRange(_currentPiece.Blocks(_currentPiecePosition, _currentRotation));
+
+                var dropGhostPosition = _currentPiecePosition;
+                while (_currentPiece.Positions(dropGhostPosition.AddToY(1), _currentRotation)
+                       .All(DropCheck))
+                {
+                    dropGhostPosition = dropGhostPosition.AddToY(1);
+                }
+
+                if (dropGhostPosition != _currentPiecePosition)
+                {
+                    var blox = _currentPiece.Blocks(dropGhostPosition, _currentRotation);
+                    for (var i = 0; i < blox.Length; i++)
+                    {
+                        result.Add(new BlockGameBlock(blox[i].Position, BlockGameBlock.ToGhostBlockColor(blox[i].GameBlockColor)));
+                    }
+                }
                 return result;
             }
 

--- a/Content.Shared/Arcade/BlockGameBlock.cs
+++ b/Content.Shared/Arcade/BlockGameBlock.cs
@@ -25,7 +25,51 @@ namespace Content.Shared.Arcade
             Green,
             Blue,
             LightBlue,
-            Purple
+            Purple,
+            GhostRed,
+            GhostOrange,
+            GhostYellow,
+            GhostGreen,
+            GhostBlue,
+            GhostLightBlue,
+            GhostPurple,
+        }
+
+        public static BlockGameBlockColor ToGhostBlockColor(BlockGameBlockColor inColor)
+        {
+            return inColor switch
+            {
+                BlockGameBlockColor.Red => BlockGameBlockColor.GhostRed,
+                BlockGameBlockColor.Orange => BlockGameBlockColor.GhostOrange,
+                BlockGameBlockColor.Yellow => BlockGameBlockColor.GhostYellow,
+                BlockGameBlockColor.Green => BlockGameBlockColor.GhostGreen,
+                BlockGameBlockColor.Blue => BlockGameBlockColor.GhostBlue,
+                BlockGameBlockColor.LightBlue => BlockGameBlockColor.GhostLightBlue,
+                BlockGameBlockColor.Purple => BlockGameBlockColor.GhostPurple,
+                _ => inColor
+            };
+        }
+
+        public static Color ToColor(BlockGameBlockColor inColor)
+        {
+            return inColor switch
+            {
+                BlockGameBlockColor.Red => Color.Red,
+                BlockGameBlockColor.Orange => Color.Orange,
+                BlockGameBlockColor.Yellow => Color.Yellow,
+                BlockGameBlockColor.Green => Color.Lime,
+                BlockGameBlockColor.Blue => Color.Blue,
+                BlockGameBlockColor.Purple => Color.DarkOrchid,
+                BlockGameBlockColor.LightBlue => Color.Cyan,
+                BlockGameBlockColor.GhostRed => Color.Red.WithAlpha(0.33f),
+                BlockGameBlockColor.GhostOrange => Color.Orange.WithAlpha(0.33f),
+                BlockGameBlockColor.GhostYellow => Color.Yellow.WithAlpha(0.33f),
+                BlockGameBlockColor.GhostGreen => Color.Lime.WithAlpha(0.33f),
+                BlockGameBlockColor.GhostBlue => Color.Blue.WithAlpha(0.33f),
+                BlockGameBlockColor.GhostPurple => Color.DarkOrchid.WithAlpha(0.33f),
+                BlockGameBlockColor.GhostLightBlue => Color.Cyan.WithAlpha(0.33f),
+                _ => Color.Olive //olive is error
+            };
         }
     }
 


### PR DESCRIPTION
## About the PR
Adds ghosts/preview for NT Block Game
Slightly tweaks block colors

**Screenshots**
![Content Client_HnEVihIpLa](https://user-images.githubusercontent.com/2501151/141656053-b3169fed-67ae-4632-b74f-88f6d71c4871.png)

**Changelog**
:cl:
- add: Added hard-drop ghosts to Nanotrasen Block Game

