### PR TITLE
Fix infinite loop in explosions

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -306,9 +306,9 @@ namespace Content.Server.Explosion.EntitySystems
             }
             else
             {
-                while (EntityManager.TryGetComponent(entity, out ContainerManagerComponent? container))
+                while (EntityManager.TryGetEntity(entity, out var e) && e.TryGetContainer(out var container))
                 {
-                    entity = container.OwnerUid;
+                    entity = container.Owner.Uid;
                 }
 
                 if (!EntityManager.TryGetComponent(entity, out transform))


### PR DESCRIPTION
Fixes #5329 , where an infinite loop in explosion code causes the server to crash. 

This loop only occurs when an entity that has a container is exploded. If you inject potassium+water into a player, the server dies. If you drink potassium+water, the stomach-entity explodes (not the player), so this does not trigger the infinite loop.

This this adds more code that uses IEntity rather than EntityUid, but doing it "properly" requires making changes to `ContainerHelpers` in the toolbox, and I'd rather just get this server-crashing bug fixed quickly.

:cl:
- fix: Fixed a bug where Potassium + Water explosions in the bloodstream would crash the server

