### PR TITLE
mixed use medical-science door for genetics

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -145,6 +145,14 @@
     access: [["Research"]]
 
 - type: entity
+  parent: AirlockScienceGlass
+  id: AirlockMedicalScienceGlassLocked
+  suffix: Medical/Science, Locked
+  components:
+  - type: AccessReader
+    access: [["Research"], ["Medical"]]
+
+- type: entity
   parent: AirlockCommandGlass
   id: AirlockCommandGlassLocked
   suffix: Command, Locked
@@ -232,6 +240,14 @@
   components:
   - type: AccessReader
     access: [["Research"]]
+
+- type: entity
+  parent: AirlockMaint
+  id: AirlockMaintRnDMedLocked
+  suffix: Med/RnD, Locked
+  components:
+  - type: AccessReader
+    access: [["Research"], ["Medical"]]
 
 - type: entity
   parent: AirlockMaint


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes issue #5315 by providing mappers an entity that is coded for medical and science. Based on a [ss13 map](https://game.ss13.moe/minimaps/images/maps/PackedStation/#l=273,230,1;z=1.8) it should be using the science sprite.
![image](https://user-images.githubusercontent.com/94037592/141701716-1c0f6f7b-2f7b-4e6d-8687-a07c52acd7ca.png)

This second door also needs to have a Medical/Research alternative for a maintenance airlock.
![image](https://user-images.githubusercontent.com/94037592/141701827-07df94ab-8c4c-4388-8d60-9cc48a53cefe.png)

This just uses the existing `AccessReaderComponent` and everything works fine.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![door-in-entity-spawner](https://user-images.githubusercontent.com/94037592/141701735-c18dd1e7-16c9-49e8-92f2-5927b0e4555f.png)
![research-card](https://user-images.githubusercontent.com/94037592/141701736-6355bae0-d93c-403f-8ea6-e6d9207f2ff1.png)
![medical-card](https://user-images.githubusercontent.com/94037592/141701738-002285e7-eaf2-4b87-a8bd-12c49b3ba934.png)
![assistant-card](https://user-images.githubusercontent.com/94037592/141701739-600c5182-2f42-4a9c-b2bc-7ba0fb509807.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:

