### PR TITLE
Fix flashlight interaction with chargers

### DIFF
--- a/Content.Server/Light/EntitySystems/HandHeldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandHeldLightSystem.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Content.Server.Light.Components;
 using Content.Server.Power.Components;
-using Content.Server.PowerCell.Components;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;

--- a/Content.Server/Power/Components/BaseCharger.cs
+++ b/Content.Server/Power/Components/BaseCharger.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Content.Server.Hands.Components;
 using Content.Server.Items;
+using Content.Server.Light.Components;
 using Content.Server.Weapon.Ranged.Barrels.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
@@ -144,7 +145,13 @@ namespace Content.Server.Power.Components
             {
                 return false;
             }
+            // turn off flashlights to prevent continuous drain and never fully charging
+            if (entity.TryGetComponent(out HandheldLightComponent? light))
+            {
+                light.TurnOff(false);
+            }
             _heldBattery = GetBatteryFrom(entity);
+
             UpdateStatus();
             return true;
         }

--- a/Content.Server/Power/Components/BaseCharger.cs
+++ b/Content.Server/Power/Components/BaseCharger.cs
@@ -2,8 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Content.Server.Hands.Components;
 using Content.Server.Items;
-using Content.Server.Light.Components;
-using Content.Server.PowerCell.Components;
 using Content.Server.Weapon.Ranged.Barrels.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;

--- a/Content.Server/Power/Components/BaseCharger.cs
+++ b/Content.Server/Power/Components/BaseCharger.cs
@@ -155,7 +155,6 @@ namespace Content.Server.Power.Components
                 light.TurnOff(false);
             }
             _heldBattery = GetBatteryFrom(entity);
-
             UpdateStatus();
             return true;
         }

--- a/Content.Server/Power/Components/BaseCharger.cs
+++ b/Content.Server/Power/Components/BaseCharger.cs
@@ -109,6 +109,10 @@ namespace Content.Server.Power.Components
                 batteryBarrelComponent.UpdateAppearance();
             }
 
+            if (heldItem.TryGetComponent(out HandheldLightComponent? handheldLightComponent)) {
+                handheldLightComponent.Dirty();
+            }
+
             UpdateStatus();
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Fix flashlight interaction with chargers <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This addresses #5339. There are actually two problems here:

### `HandheldLight` entities can be inserted in a charger 'on'

While not actually broken the user experience is confusing. If you leave a flashlight on and put it in the charger it will continually drain and so it never actually gets 'charged.' See the two screenshots below from viewing variables and clicking refresh. This means that the charger never enters the 'charged' state and gets stuck in `charging` forever. The fix proposed here is that when you insert the entity into the charger and it has the `HandheldLightComponent`, it automatically is switched off.

![charge-can-get-stuck](https://user-images.githubusercontent.com/94037592/141716725-59cd1260-be8f-402e-83a8-d7b59f27f521.png)
![charge-can-get-stuck2](https://user-images.githubusercontent.com/94037592/141716729-667aab91-e164-41cb-bc61-16e4d1e4747b.png)

### `HandheldLight` entities never get marked dirty at removal

See the existing workaround for charged weapons like tasers:
https://github.com/space-wizards/space-station-14/blob/3f32f9f87c37557d961d625652712479db119ca0/Content.Server/Power/Components/BaseCharger.cs#L106-L109

In this you see that `SetData()` is called and then `Dirty()` which syncs it:
https://github.com/space-wizards/space-station-14/blob/6cb58e608b8a2c484f0064c1d53bf3bd186cbb71/Content.Server/Weapon/Ranged/Barrels/Components/ServerBatteryBarrelComponent.cs#L122-L128

There's no natural equivalent for `HandheldLightComponent` objects right now to update the appearance, and because of how the `BaseCharger` works the moment in which the battery-powered device is put in the charger it takes ownership of the battery directly. It also doesn't make sense in general to update both entities the entire time of a charging because it's not useful information, it only matters when the device is removed from the container.

I think this could be generalized to a component/interface where this can be simplified but I wanted to put this fix up for discussion first in case I did it in the wrong area.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: flashlights switch off after being put in a charger

