### PR TITLE
Add variables to prevent voting of various kinds

### DIFF
--- a/Content.Client/Voting/UI/VoteCallMenu.xaml.cs
+++ b/Content.Client/Voting/UI/VoteCallMenu.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Content.Client.Stylesheets;
 using Content.Shared.Voting;
 using JetBrains.Annotations;
@@ -104,8 +105,15 @@ namespace Content.Client.Voting.UI
 
             if (!isAvailable)
             {
-                var remaining = timeout - _gameTiming.RealTime;
-                VoteTypeTimeoutLabel.Text = Loc.GetString("ui-vote-type-timeout", ("remaining", remaining.ToString("mm\\:ss")));
+                if (timeout == TimeSpan.Zero)
+                {
+                    VoteTypeTimeoutLabel.Text = Loc.GetString("ui-vote-type-not-available");
+                }
+                else
+                {
+                    var remaining = timeout - _gameTiming.RealTime;
+                    VoteTypeTimeoutLabel.Text = Loc.GetString("ui-vote-type-timeout", ("remaining", remaining.ToString("mm\\:ss")));
+                }
             }
         }
 

--- a/Content.Client/Voting/VoteManager.cs
+++ b/Content.Client/Voting/VoteManager.cs
@@ -186,7 +186,8 @@ namespace Content.Client.Voting
             _standardVoteTimeouts.Clear();
             foreach (var (type, time) in message.VotesUnavailable)
             {
-                _standardVoteTimeouts.Add(type, _gameTiming.RealServerToLocal(time));
+                var fixedTime = (time == TimeSpan.Zero) ? time : _gameTiming.RealServerToLocal(time);
+                _standardVoteTimeouts.Add(type, fixedTime);
             }
 
             CanCallStandardVotesChanged?.Invoke();

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -16,6 +16,13 @@ namespace Content.Server.Voting.Managers
 {
     public sealed partial class VoteManager
     {
+        public void SetupStandardVoteTypeEnableCVars()
+        {
+            _voteTypesToEnableCVars[StandardVoteType.Restart] = CCVars.VoteRestartEnabled;
+            _voteTypesToEnableCVars[StandardVoteType.Preset] = CCVars.VotePresetEnabled;
+            _voteTypesToEnableCVars[StandardVoteType.Map] = CCVars.VoteMapEnabled;
+        }
+
         public void CreateStandardVote(IPlayerSession? initiator, StandardVoteType voteType)
         {
             switch (voteType)

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -7,6 +7,7 @@ using Content.Server.RoundEnd;
 using Content.Shared.CCVar;
 using Content.Shared.Voting;
 using Robust.Server.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
@@ -16,12 +17,12 @@ namespace Content.Server.Voting.Managers
 {
     public sealed partial class VoteManager
     {
-        public void SetupStandardVoteTypeEnableCVars()
+        private static readonly Dictionary<StandardVoteType, CVarDef<bool>> _voteTypesToEnableCVars = new()
         {
-            _voteTypesToEnableCVars[StandardVoteType.Restart] = CCVars.VoteRestartEnabled;
-            _voteTypesToEnableCVars[StandardVoteType.Preset] = CCVars.VotePresetEnabled;
-            _voteTypesToEnableCVars[StandardVoteType.Map] = CCVars.VoteMapEnabled;
-        }
+            {StandardVoteType.Restart, CCVars.VoteRestartEnabled},
+            {StandardVoteType.Preset, CCVars.VotePresetEnabled},
+            {StandardVoteType.Map, CCVars.VoteMapEnabled},
+        };
 
         public void CreateStandardVote(IPlayerSession? initiator, StandardVoteType voteType)
         {

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -46,7 +46,6 @@ namespace Content.Server.Voting.Managers
         private readonly Dictionary<StandardVoteType, TimeSpan> _standardVoteTimeout = new();
         private readonly Dictionary<NetUserId, TimeSpan> _voteTimeout = new();
         private readonly HashSet<IPlayerSession> _playerCanCallVoteDirty = new();
-        private readonly Dictionary<StandardVoteType, CVarDef<bool>> _voteTypesToEnableCVars = new();
         private readonly StandardVoteType[] _standardVoteTypeValues = Enum.GetValues<StandardVoteType>();
 
         public void Initialize()
@@ -61,7 +60,6 @@ namespace Content.Server.Voting.Managers
                 DirtyCanCallVoteAll();
             });
 
-            SetupStandardVoteTypeEnableCVars();
             foreach (var kvp in _voteTypesToEnableCVars)
             {
                 _cfg.OnValueChanged(kvp.Value, value => {

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -10,6 +10,7 @@ using Content.Server.Afk;
 using Content.Server.Chat.Managers;
 using Content.Server.Maps;
 using Content.Shared.Administration;
+using Content.Shared.CCVar;
 using Content.Shared.Voting;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
@@ -53,6 +54,9 @@ namespace Content.Server.Voting.Managers
 
             _playerManager.PlayerStatusChanged += PlayerManagerOnPlayerStatusChanged;
             _adminMgr.OnPermsChanged += AdminPermsChanged;
+            _cfg.OnValueChanged(CCVars.VoteEnabled, value => {
+                DirtyCanCallVoteAll();
+            });
         }
 
         private void AdminPermsChanged(AdminPermsChangedEventArgs obj)
@@ -284,6 +288,10 @@ namespace Content.Server.Voting.Managers
                 isAdmin = true;
                 return true;
             }
+
+            // If voting is disabled, block votes.
+            if (!_cfg.GetCVar(CCVars.VoteEnabled))
+                return false;
 
             // Cannot start vote if vote is already active (as non-admin).
             if (_votes.Count != 0)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -432,6 +432,12 @@ namespace Content.Shared.CCVar
          */
 
         /// <summary>
+        ///     Allows disabling all votes for ultimate authority
+        /// </summary>
+        public static readonly CVarDef<bool> VoteEnabled =
+            CVarDef.Create("vote.enabled", true, CVar.SERVERONLY);
+
+        /// <summary>
         ///     The required ratio of the server that must agree for a restart round vote to go through.
         /// </summary>
         public static readonly CVarDef<float> VoteRestartRequiredRatio =

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -432,10 +432,28 @@ namespace Content.Shared.CCVar
          */
 
         /// <summary>
-        ///     Allows disabling all votes for ultimate authority
+        ///     Allows enabling/disabling player-started votes for ultimate authority
         /// </summary>
         public static readonly CVarDef<bool> VoteEnabled =
             CVarDef.Create("vote.enabled", true, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     See vote.enabled, but specific to restart votes
+        /// </summary>
+        public static readonly CVarDef<bool> VoteRestartEnabled =
+            CVarDef.Create("vote.restart_enabled", true, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     See vote.enabled, but specific to preset votes
+        /// </summary>
+        public static readonly CVarDef<bool> VotePresetEnabled =
+            CVarDef.Create("vote.preset_enabled", true, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     See vote.enabled, but specific to map votes
+        /// </summary>
+        public static readonly CVarDef<bool> VoteMapEnabled =
+            CVarDef.Create("vote.map_enabled", true, CVar.SERVERONLY);
 
         /// <summary>
         ///     The required ratio of the server that must agree for a restart round vote to go through.

--- a/Content.Shared/Voting/MsgVoteCanCall.cs
+++ b/Content.Shared/Voting/MsgVoteCanCall.cs
@@ -18,6 +18,7 @@ namespace Content.Shared.Voting
         public TimeSpan WhenCanCallVote;
 
         // Which standard votes are currently unavailable, and when will they become available.
+        // The whenAvailable can be null if the reason is something not timeout related.
         public (StandardVoteType type, TimeSpan whenAvailable)[] VotesUnavailable = default!;
 
         // It's possible to be able to call votes but all standard votes to be timed out.

--- a/Resources/Locale/en-US/voting/ui/vote-call-menu.ftl
+++ b/Resources/Locale/en-US/voting/ui/vote-call-menu.ftl
@@ -11,6 +11,9 @@ ui-vote-create-button = Call Vote
 # Timeout text if a standard vote type is currently on timeout.
 ui-vote-type-timeout = This vote was called too recently ({$remaining})
 
+# Unavailable text if a vote type has been disabled manually.
+ui-vote-type-not-available = This vote type has been disabled
+
 # Hue hue hue
 ui-vote-fluff = Powered by Robust™ Anti-Tamper Technology
 


### PR DESCRIPTION
## About the PR

This adds a few cvars:
```
vote.enabled - Controls if users are allowed to start votes, ever
vote.restart_enabled - Controls if restart votes are allowed
vote.preset_enabled - Controls if preset votes are allowed
vote.map_enabled - Controls if map votes are allowed
```
Useful for personal servers.
