### PR TITLE
PackedStation: More markers

### DIFF
--- a/Resources/Maps/packedstation.yml
+++ b/Resources/Maps/packedstation.yml
@@ -112523,6 +112523,8 @@ entities:
   - pos: 71.5,43.5
     parent: 0
     type: Transform
+  - location: North-East Solars
+    type: WarpPoint
 - uid: 11478
   type: WarpPoint
   components:
@@ -116362,4 +116364,268 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
+- uid: 11967
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 0.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 11968
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 54.5,-17.5
+    parent: 0
+    type: Transform
+- uid: 11969
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 86.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 11970
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 69.5,34.5
+    parent: 0
+    type: Transform
+- uid: 11971
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 22.5,18.5
+    parent: 0
+    type: Transform
+- uid: 11972
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 9.5,-22.5
+    parent: 0
+    type: Transform
+- uid: 11973
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 70.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 11974
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 56.5,6.5
+    parent: 0
+    type: Transform
+- uid: 11975
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 41.5,42.5
+    parent: 0
+    type: Transform
+- uid: 11976
+  type: RandomSpawner
+  components:
+  - pos: 57.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 11977
+  type: RandomSpawner
+  components:
+  - pos: 62.5,-15.5
+    parent: 0
+    type: Transform
+- uid: 11978
+  type: RandomSpawner
+  components:
+  - pos: 59.5,-16.5
+    parent: 0
+    type: Transform
+- uid: 11979
+  type: RandomSpawner
+  components:
+  - pos: 31.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 11980
+  type: RandomSpawner
+  components:
+  - pos: 27.5,2.5
+    parent: 0
+    type: Transform
+- uid: 11981
+  type: RandomSpawner
+  components:
+  - pos: -6.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 11982
+  type: RandomSpawner
+  components:
+  - pos: -7.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 11983
+  type: RandomSpawner
+  components:
+  - pos: -7.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 11984
+  type: RandomSpawner
+  components:
+  - pos: 12.5,15.5
+    parent: 0
+    type: Transform
+- uid: 11985
+  type: RandomSpawner
+  components:
+  - pos: 8.5,32.5
+    parent: 0
+    type: Transform
+- uid: 11986
+  type: RandomSpawner
+  components:
+  - pos: 20.5,26.5
+    parent: 0
+    type: Transform
+- uid: 11987
+  type: RandomSpawner
+  components:
+  - pos: 27.5,6.5
+    parent: 0
+    type: Transform
+- uid: 11988
+  type: RandomSpawner
+  components:
+  - pos: 31.5,-14.5
+    parent: 0
+    type: Transform
+- uid: 11989
+  type: RandomSpawner
+  components:
+  - pos: 84.5,10.5
+    parent: 0
+    type: Transform
+- uid: 11990
+  type: RandomSpawner
+  components:
+  - pos: 83.5,7.5
+    parent: 0
+    type: Transform
+- uid: 11991
+  type: RandomSpawner
+  components:
+  - pos: 68.5,11.5
+    parent: 0
+    type: Transform
+- uid: 11992
+  type: RandomSpawner
+  components:
+  - pos: 57.5,5.5
+    parent: 0
+    type: Transform
+- uid: 11993
+  type: RandomSpawner
+  components:
+  - pos: 70.5,29.5
+    parent: 0
+    type: Transform
+- uid: 11994
+  type: RandomSpawner
+  components:
+  - pos: 70.5,28.5
+    parent: 0
+    type: Transform
+- uid: 11995
+  type: RandomSpawner
+  components:
+  - pos: 71.5,37.5
+    parent: 0
+    type: Transform
+- uid: 11996
+  type: RandomSpawner
+  components:
+  - pos: 38.5,35.5
+    parent: 0
+    type: Transform
+- uid: 11997
+  type: RandomSpawner
+  components:
+  - pos: 37.5,33.5
+    parent: 0
+    type: Transform
+- uid: 11998
+  type: RandomSpawner
+  components:
+  - pos: 40.5,30.5
+    parent: 0
+    type: Transform
+- uid: 11999
+  type: RandomSpawner
+  components:
+  - pos: 36.5,30.5
+    parent: 0
+    type: Transform
+- uid: 12000
+  type: RandomSpawner
+  components:
+  - pos: 4.5,11.5
+    parent: 0
+    type: Transform
+- uid: 12001
+  type: RandomSpawner
+  components:
+  - pos: -1.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 12002
+  type: RandomSpawner
+  components:
+  - pos: 6.5,11.5
+    parent: 0
+    type: Transform
+- uid: 12003
+  type: RandomSpawner
+  components:
+  - pos: -1.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 12004
+  type: RandomSpawner
+  components:
+  - pos: 18.5,36.5
+    parent: 0
+    type: Transform
+- uid: 12005
+  type: RandomSpawner
+  components:
+  - pos: 22.5,36.5
+    parent: 0
+    type: Transform
+- uid: 12006
+  type: RandomSpawner
+  components:
+  - pos: 21.5,37.5
+    parent: 0
+    type: Transform
+- uid: 12007
+  type: RandomSpawner
+  components:
+  - pos: 28.5,35.5
+    parent: 0
+    type: Transform
+- uid: 12008
+  type: RandomSpawner
+  components:
+  - pos: 27.5,12.5
+    parent: 0
+    type: Transform
+- uid: 12009
+  type: RandomSpawner
+  components:
+  - pos: 45.5,18.5
+    parent: 0
+    type: Transform
+- uid: 12010
+  type: RandomSpawner
+  components:
+  - pos: 34.5,41.5
+    parent: 0
+    type: Transform
 ...

--- a/Resources/Maps/packedstation.yml
+++ b/Resources/Maps/packedstation.yml
@@ -13940,26 +13940,14 @@ entities:
   - pos: 3.5,-5.5
     parent: 0
     type: Transform
-  - solutions:
-      tank:
-        maxVol: 1500
-    type: SolutionContainerManager
 - uid: 191
   type: Bucket
   components:
   - pos: 4.506517,-6.45683
     parent: 0
     type: Transform
-  - solutions:
-      drink:
-        reagents: []
-    type: SolutionContainerManager
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: RefillableSolution
-  - solution: drink
-    type: DrainableSolution
 - uid: 192
   type: MopBucket
   components:
@@ -13986,16 +13974,8 @@ entities:
   - pos: 4.506517,-5.45683
     parent: 0
     type: Transform
-  - solutions:
-      drink:
-        reagents: []
-    type: SolutionContainerManager
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: RefillableSolution
-  - solution: drink
-    type: DrainableSolution
 - uid: 196
   type: AirlockMaint
   components:
@@ -14182,20 +14162,12 @@ entities:
   - pos: 0.5,-16.5
     parent: 0
     type: Transform
-  - solutions:
-      tank:
-        maxVol: 1500
-    type: SolutionContainerManager
 - uid: 223
   type: WaterTankFull
   components:
   - pos: 1.5,-16.5
     parent: 0
     type: Transform
-  - solutions:
-      tank:
-        maxVol: 1500
-    type: SolutionContainerManager
 - uid: 224
   type: AirCanister
   components:
@@ -15823,10 +15795,6 @@ entities:
   - pos: 5.5,17.5
     parent: 0
     type: Transform
-  - solutions:
-      tank:
-        maxVol: 1500
-    type: SolutionContainerManager
 - uid: 458
   type: WallSolid
   components:
@@ -17066,10 +17034,6 @@ entities:
   - pos: 23.5,-2.5
     parent: 0
     type: Transform
-  - solutions:
-      tank:
-        maxVol: 1500
-    type: SolutionContainerManager
 - uid: 629
   type: Rack
   components:
@@ -18318,10 +18282,6 @@ entities:
   - pos: 14.5,-28.5
     parent: 0
     type: Transform
-  - solutions:
-      tank:
-        maxVol: 1500
-    type: SolutionContainerManager
 - uid: 823
   type: SalternGenerator
   components:
@@ -19980,20 +19940,12 @@ entities:
   - pos: 25.5,-38.5
     parent: 0
     type: Transform
-  - solutions:
-      tank:
-        maxVol: 1500
-    type: SolutionContainerManager
 - uid: 1054
   type: WeldingFuelTankFull
   components:
   - pos: 17.5,-38.5
     parent: 0
     type: Transform
-  - solutions:
-      tank:
-        maxVol: 1500
-    type: SolutionContainerManager
 - uid: 1055
   type: WallReinforced
   components:
@@ -23354,8 +23306,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
 - uid: 1570
   type: Screwdriver
   components:
@@ -23792,8 +23742,6 @@ entities:
     pos: 38.68019,-9.265098
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 1630
@@ -23802,10 +23750,6 @@ entities:
   - pos: 38.102627,-9.408541
     parent: 0
     type: Transform
-  - solutions:
-      drink:
-        reagents: []
-    type: SolutionContainerManager
   - canCollide: False
     type: Physics
 - uid: 1631
@@ -23814,10 +23758,6 @@ entities:
   - pos: 38.352627,-9.361666
     parent: 0
     type: Transform
-  - solutions:
-      drink:
-        reagents: []
-    type: SolutionContainerManager
   - canCollide: False
     type: Physics
 - uid: 1632
@@ -24410,8 +24350,6 @@ entities:
   - pos: 47.69512,-4.6144257
     parent: 0
     type: Transform
-  - solution: bucket
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 1704
@@ -24468,8 +24406,6 @@ entities:
   - pos: 47.273247,-4.3644257
     parent: 0
     type: Transform
-  - solution: bucket
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 1710
@@ -28902,10 +28838,6 @@ entities:
   - pos: 40.48547,34.690247
     parent: 0
     type: Transform
-  - solutions:
-      drink:
-        reagents: []
-    type: SolutionContainerManager
   - canCollide: False
     type: Physics
 - uid: 2343
@@ -32269,7 +32201,7 @@ entities:
   type: Poweredlight
   components:
   - rot: -1.5707963267948966 rad
-    pos: 24.961098,42.657097
+    pos: 24.5,42.5
     parent: 0
     type: Transform
   - powerLoad: 0
@@ -33131,10 +33063,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
-  - solution: drink
-    type: RefillableSolution
 - uid: 2934
   type: DrinkTequilaBottleFull
   components:
@@ -49472,10 +49400,6 @@ entities:
       machine_parts: !type:Container
         ents: []
     type: ContainerContainer
-  - solutions:
-      buffer:
-        reagents: []
-    type: SolutionContainerManager
 - uid: 5076
   type: chem_master
   components:
@@ -49489,10 +49413,6 @@ entities:
       machine_parts: !type:Container
         ents: []
     type: ContainerContainer
-  - solutions:
-      buffer:
-        reagents: []
-    type: SolutionContainerManager
 - uid: 5077
   type: Table
   components:
@@ -49554,8 +49474,6 @@ entities:
   - pos: 53.494926,-3.5615807
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5084
@@ -49565,8 +49483,6 @@ entities:
     pos: 51.51046,-4.265004
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5085
@@ -49576,8 +49492,6 @@ entities:
     pos: 51.26308,-4.2650537
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5086
@@ -49586,8 +49500,6 @@ entities:
   - pos: 51.744926,-4.2649984
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5087
@@ -49596,8 +49508,6 @@ entities:
   - pos: 49.463676,-5.5459557
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5088
@@ -51965,8 +51875,6 @@ entities:
   - pos: 54.42104,17.661463
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5347
@@ -51975,8 +51883,6 @@ entities:
   - pos: 54.76479,17.614588
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5348
@@ -52475,8 +52381,6 @@ entities:
   - pos: 50.52205,11.657994
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5403
@@ -52485,8 +52389,6 @@ entities:
   - pos: 50.52205,11.657994
     parent: 0
     type: Transform
-  - solution: beaker
-    type: Drink
   - canCollide: False
     type: Physics
 - uid: 5404
@@ -52821,8 +52723,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
 - uid: 5444
   type: Bed
   components:
@@ -53072,8 +52972,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
 - uid: 5475
   type: DrinkLemonadeGlass
   components:
@@ -53082,8 +52980,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
 - uid: 5476
   type: Carpet
   components:
@@ -53480,8 +53376,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: food
-    type: DrainableSolution
 - uid: 5531
   type: TableCarpet
   components:
@@ -107684,8 +107578,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
 - uid: 10870
   type: FoodCakeChocolateSlice
   components:
@@ -116108,8 +116000,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
 - uid: 11938
   type: DrinkGlass
   components:
@@ -116118,8 +116008,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
 - uid: 11939
   type: MonkeyCubeWrapped
   components:
@@ -116136,8 +116024,6 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - solution: drink
-    type: DrainableSolution
 - uid: 11941
   type: CrateNPCCow
   components:


### PR DESCRIPTION
## About the PR

Janitor tries to sweep everything, but there's nothing for them to clean up.
Give them something to do by adding more messes.

I also added some TraitorDM PDA redemption machine markers while I was at it, since I needed to add them anyway.

**Changelog**

:cl:
- add: The litterbugs have been summoned to PackedStation to give the Janitor something to do. If they like it is not under consideration.
- fix: The delivery delay causing welding tanks in PackedStation to not be fuelled has been solved.
- fix: A light in PackedStation no longer occupies the interior of a wall.
