### PR TITLE
hardsuit clothing should be large and not fit in pockets

### DIFF
--- a/Content.Server/Inventory/Components/InventoryComponent.cs
+++ b/Content.Server/Inventory/Components/InventoryComponent.cs
@@ -231,9 +231,10 @@ namespace Content.Server.Inventory.Components
                 reason = controllerReason ?? reason;
             }
 
-            if (!pass && reason == null)
+            if (!pass)
             {
-                reason = Loc.GetString("inventory-component-can-equip-cannot");
+                reason = reason ?? Loc.GetString("inventory-component-can-equip-cannot");
+                return false;
             }
 
             var canEquip = pass && _slotContainers[slot].CanInsert(item.Owner);

--- a/Resources/Prototypes/Entities/Clothing/Head/base.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base.yml
@@ -26,6 +26,8 @@
   id: ClothingHeadHardsuitBase
   name: base hardsuit helmet
   components:
+  - type: Clothing
+    size: 15
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 100

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base.yml
@@ -18,6 +18,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.75
     lowPressureMultiplier: 100
+  - type: Clothing
+    size: 25
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Hardsuits fit in pockets <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I made hardsuit helmets size 15 and hardsuits size 25 which is still enough room for a breath mask 5 units and an oxygen tank of 15 for a 60 unit backpack for smuggling enough junk for an EVA.

This also fixes a logic path in `CanEquip()` that doesn't actually use the detailed messages from trying to stuff said hardsuit in pockets or wear a hardsuit helmet as shoes. I searched all the references for `CanInsert()` that we now don't try and couldn't find a reason why we would test to insert something after it was determined that it could not be equipped.

Closes #5357.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![hardsuit-sizes](https://user-images.githubusercontent.com/94037592/141923770-4abfedfa-5078-42a2-bd74-6e5fcd804c5d.png)
![fixed-can-equip-messages](https://user-images.githubusercontent.com/94037592/141923773-2e1787a2-be6a-4765-8c85-85e73e6b552c.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: hardsuits and hardsuit helmets now are bigger and no longer fit in pockets

