### PR TITLE
change up the join message to explicitly mention the rules.

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -8,7 +8,7 @@ game-ticker-unknown-role = Unknown
 game-ticker-delay-start = Round start has been delayed for {$seconds} seconds.
 game-ticker-pause-start = Round start has been paused.
 game-ticker-pause-start-resumed = Round start countdown is now resumed.
-game-ticker-player-join-game-message = Welcome to Space Station 14! If this is your first time checking out the game, be sure to check out the tutorial in the top left!
+game-ticker-player-join-game-message = Welcome to Space Station 14! If this is your first time playing, be sure to press F1 on your keyboard and read the game rules, and don't be afraid to ask for help in OOC.
 game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/color]
                             The current game mode is: [color=white]{$gmTitle}[/color].
                             >[color=yellow]{$desc}[/color]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
No longer just says "read the tutorial", and provides the keybind to do it instead of where to look, to make absolutely sure that if someone reads the chat, they'll know how to open the rules.