### PR TITLE
"Knightship" map - ultra-lowpop intended for ~5 people

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -150,7 +150,6 @@ namespace Content.Server.Voting.Managers
             {
                 ["Maps/saltern.yml"] = "Saltern",
                 ["Maps/packedstation.yml"] = "PackedStation",
-                ["Maps/knightship.yml"] = "Knightship",
             };
 
             var alone = _playerManager.PlayerCount == 1 && initiator != null;

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -150,6 +150,7 @@ namespace Content.Server.Voting.Managers
             {
                 ["Maps/saltern.yml"] = "Saltern",
                 ["Maps/packedstation.yml"] = "PackedStation",
+                ["Maps/knightship.yml"] = "Knightship",
             };
 
             var alone = _playerManager.PlayerCount == 1 && initiator != null;

--- a/Resources/Maps/knightship.yml
+++ b/Resources/Maps/knightship.yml
@@ -42,9 +42,9 @@ grids:
     tilesize: 1
   chunks:
   - ind: "-1,-1"
-    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAGAAAABgAAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAABgAAAAYAAAAGAAAABgAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAYAAAAGAAAABgAAAAYAAAAHgAAAA==
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAGAAAABgAAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAABgAAAAYAAAAGAAAABgAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAYAAAAGAAAABgAAAAYAAAAHgAAAA==
   - ind: "0,-1"
-    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAB4AAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAeAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAHgAAABsAAAAbAAAAGwAAAB4AAAAeAAAAHAAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHAAAABwAAAAcAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAGAAAABgAAAAYAAAAHAAAABwAAAAcAAAAHAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAGAAAAB4AAAAcAAAAHAAAABwAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAcAAAAHAAAABwAAAAcAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAeAAAAHgAAABsAAAAeAAAAHgAAABwAAAAcAAAAHAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAHgAAABsAAAAbAAAAGwAAAB4AAAAbAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAB4AAAAbAAAAGwAAAB4AAAAeAAAAGwAAABsAAAAbAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAeAAAAHgAAAB4AAAAeAAAAGwAAABsAAAAbAAAAGwAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAHgAAABgAAAAYAAAAHgAAAB4AAAAbAAAAGwAAABsAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAeAAAAGAAAABgAAAAYAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAeAAAAHAAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAABwAAAAcAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAGAAAABgAAAAYAAAAHgAAABwAAAAcAAAAHAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAGAAAAB4AAAAcAAAAHAAAABwAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAcAAAAHAAAABwAAAAcAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAeAAAAHgAAABsAAAAeAAAAHgAAABwAAAAcAAAAHAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAHgAAABsAAAAbAAAAGwAAAB4AAAAbAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAB4AAAAbAAAAGwAAAB4AAAAeAAAAGwAAABsAAAAbAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAeAAAAHgAAAB4AAAAeAAAAGwAAABsAAAAbAAAAGwAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAHgAAABgAAAAYAAAAHgAAAB4AAAAbAAAAGwAAABsAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAeAAAAGAAAABgAAAAYAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
   - ind: "0,0"
     tiles: GAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAGAAAABgAAAAYAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAHgAAABgAAAAYAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
   - ind: "-1,0"
@@ -252,7 +252,7 @@ entities:
       -2,-12: 0
       -2,-13: 0
       0,-9: 0
-      0,-11: 0
+      0,-11: 1
       0,-12: 0
       0,-13: 0
       1,-9: 0
@@ -322,7 +322,7 @@ entities:
       3,3: 0
       3,4: 0
       3,5: 0
-      8,3: 1
+      8,3: 2
       -6,-14: 0
       -6,-13: 0
       -6,-12: 0
@@ -472,6 +472,17 @@ entities:
       - 21.824879
       - 82.10312
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 293.15
+      moles:
+      - 21.780092
+      - 82.10312
+      - 0.011053398
       - 0
       - 0
       - 0
@@ -1050,17 +1061,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 93
-  type: WallSolid
+  type: Bucket
   components:
-  - pos: 6.5,-10.5
+  - pos: 2.6408663,-12.303808
     parent: 0
     type: Transform
+  - solution: bucket
+    type: Drink
+  - canCollide: False
+    type: Physics
 - uid: 94
-  type: WallSolid
+  type: CableApcExtension
   components:
-  - pos: 5.5,-10.5
+  - pos: 7.5,-10.5
     parent: 0
     type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
 - uid: 95
   type: WallSolid
   components:
@@ -1086,21 +1105,33 @@ entities:
     parent: 0
     type: Transform
 - uid: 98
-  type: WallSolid
+  type: hydroponicsTray
   components:
-  - pos: 1.5,-10.5
+  - pos: 1.5,-12.5
     parent: 0
     type: Transform
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 99
-  type: WallSolid
+  type: AirlockEngineeringGlassLocked
   components:
-  - pos: 1.5,-11.5
+  - name: Engineering Storage
+    type: MetaData
+  - pos: -0.5,-2.5
     parent: 0
     type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 100
   type: WallSolid
   components:
-  - pos: 1.5,-12.5
+  - pos: -0.5,-12.5
     parent: 0
     type: Transform
 - uid: 101
@@ -1149,20 +1180,16 @@ entities:
     parent: 0
     type: Transform
 - uid: 108
-  type: AirlockMaintEngiLocked
+  type: WallSolid
   components:
-  - name: Gravity Generator And Anti-Matter Engine
-    type: MetaData
-  - pos: -0.5,-12.5
+  - pos: 0.5,-9.5
     parent: 0
     type: Transform
-  - containers:
-      board: !type:Container
-        ents: []
-    type: ContainerContainer
 - uid: 109
   type: AirlockServiceGlassLocked
   components:
+  - name: Hydroponics/Kitchen/Bar
+    type: MetaData
   - pos: 3.5,-9.5
     parent: 0
     type: Transform
@@ -1240,11 +1267,15 @@ entities:
       labelSlot: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 117
-  type: WallSolid
+  type: CableApcExtension
   components:
-  - pos: -0.5,-7.5
+  - pos: 2.5,-11.5
     parent: 0
     type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
 - uid: 118
   type: WallSolid
   components:
@@ -1324,17 +1355,11 @@ entities:
     parent: 0
     type: Transform
 - uid: 131
-  type: AirlockEngineeringGlass
+  type: SpawnPointBotanist
   components:
-  - name: Engineering Storage
-    type: MetaData
-  - pos: -0.5,-2.5
+  - pos: 1.5,-11.5
     parent: 0
     type: Transform
-  - containers:
-      board: !type:Container
-        ents: []
-    type: ContainerContainer
 - uid: 132
   type: CableHV
   components:
@@ -1472,25 +1497,26 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 149
-  type: CableMV
+  type: VendingMachineDinnerware
   components:
-  - pos: -0.5,-12.5
+  - name: Dinnerware
+    type: MetaData
+  - pos: 8.5,-11.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
+  - enabled: False
+    type: AmbientSound
 - uid: 150
-  type: CableMV
+  type: Poweredlight
   components:
-  - pos: 0.5,-12.5
+  - pos: 1.5,-10.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
 - uid: 151
   type: CableMV
   components:
@@ -1650,19 +1676,21 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 170
-  type: CableMV
+  type: ClosetChefFilled
   components:
-  - pos: 0.5,-11.5
+  - pos: 5.5,-10.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 171
-  type: CableMV
+  type: CableApcExtension
   components:
-  - pos: 0.5,-10.5
+  - pos: 1.5,-11.5
     parent: 0
     type: Transform
   - visible: False
@@ -1670,15 +1698,16 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 172
-  type: CableMV
+  type: KitchenReagentGrinder
   components:
-  - pos: 0.5,-9.5
+  - pos: 5.5,-12.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
+  - containers:
+      ReagentGrinder-reagentContainerContainer: !type:ContainerSlot {}
+      ReagentGrinder-entityContainerContainer: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 173
   type: CableMV
   components:
@@ -2222,9 +2251,78 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 237
-  type: ClosetChefFilled
+  type: AirlockMaintEngiLocked
   components:
-  - pos: 8.5,-11.5
+  - name: Anti-Matter Engine and Gravity Generator
+    type: MetaData
+  - pos: -0.5,-7.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 238
+  type: WallSolid
+  components:
+  - pos: 5.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 239
+  type: CableApcExtension
+  components:
+  - pos: 7.5,-9.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 240
+  type: WeldingFuelTankFull
+  components:
+  - pos: -1.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 241
+  type: SalternApc
+  components:
+  - pos: 6.5,-9.5
+    parent: 0
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - loadingNetworkDemand: 25
+    supplyRampPosition: 0.010999783
+    type: PowerNetworkBattery
+- uid: 242
+  type: WallSolid
+  components:
+  - pos: 6.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 243
+  type: WallSolid
+  components:
+  - pos: 6.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 244
+  type: hydroponicsTray
+  components:
+  - pos: 0.5,-11.5
+    parent: 0
+    type: Transform
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 245
+  type: LockerBotanistFilled
+  components:
+  - pos: 1.5,-10.5
     parent: 0
     type: Transform
   - isPlaceable: False
@@ -2233,94 +2331,18 @@ entities:
       EntityStorageComponent: !type:Container
         ents: []
     type: ContainerContainer
-- uid: 238
-  type: hydroponicsTray
-  components:
-  - pos: 2.5,-12.5
-    parent: 0
-    type: Transform
-  - containers:
-      machine_board: !type:Container
-        ents: []
-      machine_parts: !type:Container
-        ents: []
-    type: ContainerContainer
-- uid: 239
-  type: Table
-  components:
-  - pos: 4.5,-11.5
-    parent: 0
-    type: Transform
-- uid: 240
-  type: hydroponicsTray
-  components:
-  - pos: 2.5,-11.5
-    parent: 0
-    type: Transform
-  - containers:
-      machine_board: !type:Container
-        ents: []
-      machine_parts: !type:Container
-        ents: []
-    type: ContainerContainer
-- uid: 241
-  type: Table
-  components:
-  - pos: 6.5,-11.5
-    parent: 0
-    type: Transform
-- uid: 242
-  type: KitchenMicrowave
-  components:
-  - pos: 6.5,-11.5
-    parent: 0
-    type: Transform
-  - containers:
-      microwave_entity_container: !type:Container
-        ents: []
-    type: ContainerContainer
-- uid: 243
-  type: Table
-  components:
-  - pos: 5.5,-11.5
-    parent: 0
-    type: Transform
-- uid: 244
-  type: KitchenReagentGrinder
-  components:
-  - pos: 5.5,-11.5
-    parent: 0
-    type: Transform
-  - containers:
-      ReagentGrinder-reagentContainerContainer: !type:ContainerSlot {}
-      ReagentGrinder-entityContainerContainer: !type:Container
-        ents: []
-    type: ContainerContainer
-- uid: 245
-  type: HydroponicsToolMiniHoe
-  components:
-  - pos: 4.901165,-11.371086
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
 - uid: 246
-  type: HydroponicsToolSpade
+  type: SpawnPointChef
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 4.66679,-11.480461
+  - pos: 3.5,-11.5
     parent: 0
     type: Transform
-  - canCollide: False
-    type: Physics
 - uid: 247
-  type: HydroponicsToolHatchet
+  type: KitchenSpike
   components:
-  - pos: 4.276165,-11.558586
+  - pos: 8.5,-12.5
     parent: 0
     type: Transform
-  - canCollide: False
-    type: Physics
 - uid: 248
   type: WallSolid
   components:
@@ -2344,6 +2366,8 @@ entities:
 - uid: 251
   type: AirlockServiceGlassLocked
   components:
+  - name: Bar
+    type: MetaData
   - pos: 7.5,-10.5
     parent: 0
     type: Transform
@@ -2376,14 +2400,15 @@ entities:
     parent: 0
     type: Transform
 - uid: 256
-  type: AirlockBarGlassLocked
+  type: Poweredlight
   components:
-  - pos: 5.5,-8.5
+  - pos: 1.5,-6.5
     parent: 0
     type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
   - containers:
-      board: !type:Container
-        ents: []
+      light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 257
   type: soda_dispenser
@@ -2395,13 +2420,11 @@ entities:
       ReagentDispenser-reagentContainerContainer: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 258
-  type: VendingMachineBooze
+  type: TraitorDMRedemptionMachineSpawner
   components:
-  - pos: 6.5,-9.5
+  - pos: 7.5,-5.5
     parent: 0
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 259
   type: SpawnPointBartender
   components:
@@ -2728,17 +2751,14 @@ entities:
       BoltActionBarrel-chamber-container: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 297
-  type: LockerAtmosphericsFilled
+  type: GasPipeBend
   components:
-  - pos: -1.5,-0.5
+  - rot: -1.5707963267948966 rad
+    pos: -1.5,-12.5
     parent: 0
     type: Transform
-  - isPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent: !type:Container
-        ents: []
-    type: ContainerContainer
+  - canCollide: False
+    type: Physics
 - uid: 298
   type: Table
   components:
@@ -3395,17 +3415,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 374
-  type: SalternApc
+  type: GasVentPump
   components:
-  - pos: 6.5,-10.5
+  - pos: -1.5,-6.5
     parent: 0
     type: Transform
-  - startingCharge: 12000
-    type: Battery
-  - loadingNetworkDemand: 55
-    currentReceiving: 55.01975
-    currentSupply: 55
-    type: PowerNetworkBattery
+  - canCollide: False
+    type: Physics
 - uid: 375
   type: CableApcExtension
   components:
@@ -3457,9 +3473,9 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 380
-  type: CableApcExtension
+  type: CableMV
   components:
-  - pos: 6.5,-10.5
+  - pos: -0.5,-7.5
     parent: 0
     type: Transform
   - canCollide: False
@@ -3470,8 +3486,6 @@ entities:
   - pos: 6.5,-9.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
   - canCollide: False
     type: Physics
 - uid: 382
@@ -3540,14 +3554,13 @@ entities:
   - pos: 6.5,-9.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
   - canCollide: False
     type: Physics
 - uid: 389
-  type: CableMV
+  type: GasPipeTJunction
   components:
-  - pos: 6.5,-10.5
+  - rot: 1.5707963267948966 rad
+    pos: -1.5,-7.5
     parent: 0
     type: Transform
   - canCollide: False
@@ -3559,11 +3572,14 @@ entities:
     parent: 0
     type: Transform
 - uid: 391
-  type: FirelockGlass
+  type: GasPipeStraight
   components:
-  - pos: 0.5,-9.5
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,-7.5
     parent: 0
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 392
   type: SpawnPointCaptain
   components:
@@ -3577,9 +3593,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 394
-  type: SpawnPointBotanist
+  type: Table
   components:
-  - pos: 3.5,-12.5
+  - pos: 2.5,-12.5
     parent: 0
     type: Transform
 - uid: 395
@@ -3589,21 +3605,24 @@ entities:
     parent: 0
     type: Transform
 - uid: 396
-  type: SpawnPointChef
+  type: HydroponicsToolSpade
   components:
-  - pos: 5.5,-12.5
+  - pos: 2.2928503,-12.218507
     parent: 0
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 397
-  type: VendingMachineDinnerware
+  type: GasPipeBend
   components:
-  - name: Dinnerware
-    type: MetaData
-  - pos: 8.5,-12.5
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-8.5
     parent: 0
     type: Transform
-  - enabled: False
-    type: AmbientSound
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
 - uid: 398
   type: SpawnPointChiefMedicalOfficer
   components:
@@ -3791,17 +3810,16 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 419
-  type: Poweredlight
+  type: GasPipeTJunction
   components:
-  - rot: 1.5707963267948966 rad
+  - rot: -1.5707963267948966 rad
     pos: 0.5,-7.5
     parent: 0
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-  - containers:
-      light_bulb: !type:ContainerSlot {}
-    type: ContainerContainer
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
 - uid: 420
   type: Poweredlight
   components:
@@ -3815,17 +3833,13 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 421
-  type: Poweredlight
+  type: VendingMachineYouTool
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 0.5,-11.5
+  - pos: 8.5,-5.5
     parent: 0
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-  - containers:
-      light_bulb: !type:ContainerSlot {}
-    type: ContainerContainer
+  - enabled: False
+    type: AmbientSound
 - uid: 422
   type: Poweredlight
   components:
@@ -3925,11 +3939,17 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 431
-  type: TraitorDMRedemptionMachineSpawner
+  type: hydroponicsTray
   components:
-  - pos: 8.5,-5.5
+  - pos: 0.5,-12.5
     parent: 0
     type: Transform
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 432
   type: SuspicionRevolverSpawner
   components:
@@ -3973,11 +3993,14 @@ entities:
     parent: 0
     type: Transform
 - uid: 439
-  type: SuspicionRevolverSpawner
+  type: HydroponicsToolMiniHoe
   components:
-  - pos: 7.5,-12.5
+  - rot: -1.5707963267948966 rad
+    pos: 2.3866003,-12.437257
     parent: 0
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 440
   type: AirCanister
   components:
@@ -4094,22 +4117,22 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 452
-  type: GasPipeTJunction
+  type: HydroponicsToolHatchet
   components:
-  - rot: 3.141592653589793 rad
-    pos: -1.5,-12.5
+  - rot: -1.5707963267948966 rad
+    pos: 2.7928503,-12.374757
     parent: 0
     type: Transform
   - canCollide: False
     type: Physics
 - uid: 453
-  type: GasVentPump
+  type: VendingMachineBooze
   components:
-  - pos: -1.5,-7.5
+  - pos: 6.5,-8.5
     parent: 0
     type: Transform
-  - canCollide: False
-    type: Physics
+  - enabled: False
+    type: AmbientSound
 - uid: 454
   type: GasVentPump
   components:
@@ -4120,27 +4143,17 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 455
-  type: GasPipeStraight
+  type: SuspicionRevolverSpawner
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -0.5,-12.5
+  - pos: 2.5,-12.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 456
-  type: GasPipeBend
+  type: WaterTankFull
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 0.5,-12.5
+  - pos: 3.4999998,-12.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 457
   type: GasPipeStraight
   components:
@@ -4170,35 +4183,23 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 460
-  type: GasPipeStraight
+  type: Table
   components:
-  - pos: 0.5,-11.5
+  - pos: 4.5,-12.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 461
-  type: GasPipeStraight
+  type: Table
   components:
-  - pos: 0.5,-10.5
+  - pos: 5.5,-12.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 462
-  type: GasPipeStraight
+  type: Table
   components:
-  - pos: 0.5,-9.5
+  - pos: 6.5,-12.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
 - uid: 463
   type: GasPipeTJunction
   components:
@@ -4455,26 +4456,15 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 487
-  type: GasPipeTJunction
+  type: KitchenMicrowave
   components:
-  - rot: 1.5707963267948966 rad
-    pos: 0.5,-8.5
+  - pos: 6.5,-12.5
     parent: 0
     type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-- uid: 488
-  type: GasPipeStraight
-  components:
-  - pos: 0.5,-7.5
-    parent: 0
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
+  - containers:
+      microwave_entity_container: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 489
   type: GasVentPump
   components:
@@ -4587,4 +4577,10 @@ entities:
       machine_parts: !type:Container
         ents: []
     type: ContainerContainer
+- uid: 499
+  type: CrateNPCCow
+  components:
+  - pos: 0.5,-10.5
+    parent: 0
+    type: Transform
 ...

--- a/Resources/Maps/knightship.yml
+++ b/Resources/Maps/knightship.yml
@@ -1,0 +1,4590 @@
+meta:
+  format: 2
+  name: DemoStation
+  author: Space-Wizards
+  postmapinit: false
+tilemap:
+  0: space
+  1: floor_asteroid_coarse_sand0
+  2: floor_asteroid_coarse_sand1
+  3: floor_asteroid_coarse_sand2
+  4: floor_asteroid_coarse_sand_dug
+  5: floor_asteroid_sand
+  6: floor_asteroid_tile
+  7: floor_blue
+  8: floor_blue_circuit
+  9: floor_dark
+  10: floor_elevator_shaft
+  11: floor_freezer
+  12: floor_glass
+  13: floor_gold
+  14: floor_green_circuit
+  15: floor_hydro
+  16: floor_lino
+  17: floor_mono
+  18: floor_reinforced
+  19: floor_rglass
+  20: floor_rock_vault
+  21: floor_showroom
+  22: floor_silver
+  23: floor_snow
+  24: floor_steel
+  25: floor_steel_dirty
+  26: floor_techmaint
+  27: floor_white
+  28: floor_wood
+  29: lattice
+  30: plating
+  31: underplating
+grids:
+- settings:
+    chunksize: 16
+    tilesize: 1
+  chunks:
+  - ind: "-1,-1"
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAGAAAABgAAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAABgAAAAYAAAAGAAAABgAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAYAAAAGAAAABgAAAAYAAAAHgAAAA==
+  - ind: "0,-1"
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAB4AAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAeAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAHgAAABsAAAAbAAAAGwAAAB4AAAAeAAAAHAAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHAAAABwAAAAcAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAGAAAABgAAAAYAAAAHAAAABwAAAAcAAAAHAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAGAAAAB4AAAAcAAAAHAAAABwAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAcAAAAHAAAABwAAAAcAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAeAAAAHgAAABsAAAAeAAAAHgAAABwAAAAcAAAAHAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAHgAAABsAAAAbAAAAGwAAAB4AAAAbAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAB4AAAAbAAAAGwAAAB4AAAAeAAAAGwAAABsAAAAbAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAeAAAAHgAAAB4AAAAeAAAAGwAAABsAAAAbAAAAGwAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAHgAAABgAAAAYAAAAHgAAAB4AAAAbAAAAGwAAABsAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAeAAAAGAAAABgAAAAYAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: "0,0"
+    tiles: GAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAGAAAABgAAAAYAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAHgAAABgAAAAYAAAAHgAAAB4AAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: "-1,0"
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAeAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAHgAAABgAAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAGAAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAABgAAAAYAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAGAAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAB4AAAAeAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+entities:
+- uid: 0
+  components:
+  - pos: 0.54646134,0.50643754
+    parent: null
+    type: Transform
+  - index: 0
+    type: MapGrid
+  - angularDamping: 0.3
+    fixedRotation: False
+    fixtures:
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,0
+        - 0,3
+        - -6,3
+        - -6,0
+      id: grid_chunk--6-0
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 18
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,3
+        - 0,7
+        - -4,7
+        - -4,3
+      id: grid_chunk--4-3
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 16
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 0,-14
+        - 0,0
+        - -6,0
+        - -6,-14
+      id: grid_chunk--6--14
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 84
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 10,-14
+        - 10,0
+        - 0,0
+        - 0,-14
+      id: grid_chunk-0--14
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 140
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 10,0
+        - 10,3
+        - 0,3
+        - 0,0
+      id: grid_chunk-0-0
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 30
+      restitution: 0.1
+    - shape: !type:PolygonShape
+        vertices:
+        - 8,3
+        - 8,7
+        - 0,7
+        - 0,3
+      id: grid_chunk-0-3
+      mask:
+      - MapGrid
+      layer:
+      - MapGrid
+      mass: 32
+      restitution: 0.1
+    bodyType: Dynamic
+    type: Physics
+  - gravityShakeSound: !type:SoundPathSpecifier
+      path: /Audio/Effects/alert.ogg
+    type: Gravity
+  - tiles:
+      -5,-8: 0
+      -5,-7: 0
+      -5,-6: 0
+      -5,-5: 0
+      -5,-3: 0
+      -5,-2: 0
+      -5,-1: 0
+      -4,-8: 0
+      -4,-7: 0
+      -4,-6: 0
+      -4,-5: 0
+      -4,-3: 0
+      -4,-2: 0
+      -4,-1: 0
+      -3,-8: 0
+      -3,-7: 0
+      -3,-6: 0
+      -3,-5: 0
+      -3,-3: 0
+      -3,-2: 0
+      -3,-1: 0
+      -2,-8: 0
+      -2,-7: 0
+      -2,-6: 0
+      -2,-5: 0
+      -2,-3: 0
+      -2,-2: 0
+      -2,-1: 0
+      0,-8: 0
+      0,-7: 0
+      0,-5: 0
+      0,-4: 0
+      0,-3: 0
+      0,-2: 0
+      0,-1: 0
+      1,-8: 0
+      1,-7: 0
+      1,-5: 0
+      2,-8: 0
+      2,-7: 0
+      2,-5: 0
+      2,-4: 0
+      2,-2: 0
+      2,-1: 0
+      3,-8: 0
+      3,-7: 0
+      3,-5: 0
+      3,-4: 0
+      3,-2: 0
+      3,-1: 0
+      4,-8: 0
+      4,-7: 0
+      4,-5: 0
+      4,-1: 0
+      0,1: 0
+      0,2: 0
+      0,3: 0
+      0,4: 0
+      0,5: 0
+      1,1: 0
+      1,2: 0
+      1,3: 0
+      1,4: 0
+      1,5: 0
+      2,1: 0
+      2,2: 0
+      2,3: 0
+      2,4: 0
+      2,5: 0
+      3,1: 0
+      3,2: 0
+      -5,1: 0
+      -3,1: 0
+      -3,2: 0
+      -3,3: 0
+      -3,4: 0
+      -3,5: 0
+      -2,1: 0
+      -2,2: 0
+      -2,3: 0
+      -2,4: 0
+      -2,5: 0
+      -1,1: 0
+      -1,2: 0
+      -1,3: 0
+      -1,4: 0
+      -1,5: 0
+      -5,-9: 0
+      -5,-10: 0
+      -5,-11: 0
+      -5,-12: 0
+      -5,-13: 0
+      -4,-9: 0
+      -4,-10: 0
+      -4,-11: 0
+      -4,-12: 0
+      -4,-13: 0
+      -3,-9: 0
+      -3,-10: 0
+      -3,-11: 0
+      -3,-12: 0
+      -3,-13: 0
+      -2,-9: 0
+      -2,-10: 0
+      -2,-11: 0
+      -2,-12: 0
+      -2,-13: 0
+      0,-9: 0
+      0,-11: 0
+      0,-12: 0
+      0,-13: 0
+      1,-9: 0
+      2,-9: 0
+      2,-11: 0
+      2,-12: 0
+      2,-13: 0
+      3,-9: 0
+      3,-11: 0
+      3,-12: 0
+      3,-13: 0
+      4,-9: 0
+      4,-11: 0
+      4,-12: 0
+      4,-13: 0
+      5,-13: 0
+      5,-12: 0
+      6,-13: 0
+      6,-12: 0
+      6,-10: 0
+      6,-9: 0
+      6,-8: 0
+      6,-7: 0
+      6,-6: 0
+      7,-13: 0
+      7,-12: 0
+      7,-10: 0
+      7,-9: 0
+      7,-8: 0
+      7,-7: 0
+      7,-6: 0
+      8,-13: 0
+      8,-12: 0
+      8,-10: 0
+      8,-9: 0
+      8,-8: 0
+      8,-7: 0
+      8,-6: 0
+      5,-3: 0
+      5,1: 0
+      5,2: 0
+      6,-4: 0
+      6,-3: 0
+      6,-2: 0
+      6,-1: 0
+      6,0: 0
+      6,1: 0
+      6,2: 0
+      7,-4: 0
+      7,-3: 0
+      7,-2: 0
+      7,-1: 0
+      7,0: 0
+      7,1: 0
+      8,-4: 0
+      8,-3: 0
+      8,-2: 0
+      8,-1: 0
+      8,0: 0
+      8,1: 0
+      6,4: 0
+      6,5: 0
+      5,4: 0
+      5,5: 0
+      4,4: 0
+      4,5: 0
+      3,3: 0
+      3,4: 0
+      3,5: 0
+      8,3: 1
+      -6,-14: 0
+      -6,-13: 0
+      -6,-12: 0
+      -6,-11: 0
+      -6,-10: 0
+      -6,-9: 0
+      -6,-8: 0
+      -6,-7: 0
+      -6,-6: 0
+      -6,-5: 0
+      -6,-4: 0
+      -6,-3: 0
+      -6,-2: 0
+      -6,-1: 0
+      -5,-14: 0
+      -5,-4: 0
+      -4,-14: 0
+      -4,-4: 0
+      -3,-14: 0
+      -3,-4: 0
+      -2,-14: 0
+      -2,-4: 0
+      -1,-14: 0
+      -1,-13: 0
+      -1,-12: 0
+      -1,-11: 0
+      -1,-10: 0
+      -1,-9: 0
+      -1,-8: 0
+      -1,-7: 0
+      -1,-6: 0
+      -1,-5: 0
+      -1,-4: 0
+      -1,-3: 0
+      -1,-2: 0
+      -1,-1: 0
+      0,-14: 0
+      0,-10: 0
+      0,-6: 0
+      1,-14: 0
+      1,-13: 0
+      1,-12: 0
+      1,-11: 0
+      1,-10: 0
+      1,-6: 0
+      1,-4: 0
+      1,-3: 0
+      1,-2: 0
+      1,-1: 0
+      2,-14: 0
+      2,-10: 0
+      2,-6: 0
+      2,-3: 0
+      3,-14: 0
+      3,-10: 0
+      3,-6: 0
+      3,-3: 0
+      4,-14: 0
+      4,-10: 0
+      4,-6: 0
+      4,-4: 0
+      4,-3: 0
+      4,-2: 0
+      5,-14: 0
+      5,-11: 0
+      5,-10: 0
+      5,-9: 0
+      5,-8: 0
+      5,-7: 0
+      5,-6: 0
+      5,-5: 0
+      5,-4: 0
+      5,-2: 0
+      5,-1: 0
+      6,-14: 0
+      6,-11: 0
+      6,-5: 0
+      7,-14: 0
+      7,-11: 0
+      7,-5: 0
+      8,-14: 0
+      8,-11: 0
+      8,-5: 0
+      9,-14: 0
+      9,-13: 0
+      9,-12: 0
+      9,-11: 0
+      9,-10: 0
+      9,-9: 0
+      9,-8: 0
+      9,-7: 0
+      9,-6: 0
+      9,-5: 0
+      9,-4: 0
+      9,-3: 0
+      9,-2: 0
+      9,-1: 0
+      0,0: 0
+      0,6: 0
+      1,0: 0
+      1,6: 0
+      2,0: 0
+      2,6: 0
+      3,0: 0
+      3,6: 0
+      4,0: 0
+      4,1: 0
+      4,2: 0
+      4,3: 0
+      4,6: 0
+      5,0: 0
+      5,3: 0
+      5,6: 0
+      6,3: 0
+      6,6: 0
+      7,2: 0
+      7,3: 0
+      7,4: 0
+      7,5: 0
+      7,6: 0
+      8,2: 0
+      9,0: 0
+      9,1: 0
+      9,2: 0
+      -6,0: 0
+      -6,1: 0
+      -6,2: 0
+      -5,0: 0
+      -5,2: 0
+      -4,0: 0
+      -4,1: 0
+      -4,2: 0
+      -4,3: 0
+      -4,4: 0
+      -4,5: 0
+      -4,6: 0
+      -3,0: 0
+      -3,6: 0
+      -2,0: 0
+      -2,6: 0
+      -1,0: 0
+      -1,6: 0
+    uniqueMixes:
+    - volume: 2500
+      temperature: 293.15
+      moles:
+      - 21.824879
+      - 82.10312
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      immutable: True
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    type: GridAtmosphere
+- uid: 1
+  type: Grille
+  components:
+  - pos: -3.5,3.5
+    parent: 0
+    type: Transform
+- uid: 2
+  type: Grille
+  components:
+  - pos: -3.5,4.5
+    parent: 0
+    type: Transform
+- uid: 3
+  type: Grille
+  components:
+  - pos: -3.5,5.5
+    parent: 0
+    type: Transform
+- uid: 4
+  type: Grille
+  components:
+  - pos: -3.5,6.5
+    parent: 0
+    type: Transform
+- uid: 5
+  type: Grille
+  components:
+  - pos: -2.5,6.5
+    parent: 0
+    type: Transform
+- uid: 6
+  type: Grille
+  components:
+  - pos: -1.5,6.5
+    parent: 0
+    type: Transform
+- uid: 7
+  type: Grille
+  components:
+  - pos: -0.5,6.5
+    parent: 0
+    type: Transform
+- uid: 8
+  type: Grille
+  components:
+  - pos: 0.5,6.5
+    parent: 0
+    type: Transform
+- uid: 9
+  type: Grille
+  components:
+  - pos: 1.5,6.5
+    parent: 0
+    type: Transform
+- uid: 10
+  type: Grille
+  components:
+  - pos: 2.5,6.5
+    parent: 0
+    type: Transform
+- uid: 11
+  type: WallReinforced
+  components:
+  - pos: 9.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 12
+  type: WallReinforced
+  components:
+  - pos: 9.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 13
+  type: WallReinforced
+  components:
+  - pos: 9.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 14
+  type: ReinforcedWindow
+  components:
+  - pos: -3.5,3.5
+    parent: 0
+    type: Transform
+- uid: 15
+  type: ReinforcedWindow
+  components:
+  - pos: -3.5,4.5
+    parent: 0
+    type: Transform
+- uid: 16
+  type: ReinforcedWindow
+  components:
+  - pos: -3.5,5.5
+    parent: 0
+    type: Transform
+- uid: 17
+  type: ReinforcedWindow
+  components:
+  - pos: -3.5,6.5
+    parent: 0
+    type: Transform
+- uid: 18
+  type: ReinforcedWindow
+  components:
+  - pos: -2.5,6.5
+    parent: 0
+    type: Transform
+- uid: 19
+  type: ReinforcedWindow
+  components:
+  - pos: -1.5,6.5
+    parent: 0
+    type: Transform
+- uid: 20
+  type: ReinforcedWindow
+  components:
+  - pos: -0.5,6.5
+    parent: 0
+    type: Transform
+- uid: 21
+  type: ReinforcedWindow
+  components:
+  - pos: 0.5,6.5
+    parent: 0
+    type: Transform
+- uid: 22
+  type: ReinforcedWindow
+  components:
+  - pos: 1.5,6.5
+    parent: 0
+    type: Transform
+- uid: 23
+  type: ReinforcedWindow
+  components:
+  - pos: 2.5,6.5
+    parent: 0
+    type: Transform
+- uid: 24
+  type: WallReinforced
+  components:
+  - pos: 9.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 25
+  type: WallReinforced
+  components:
+  - pos: 9.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 26
+  type: WallReinforced
+  components:
+  - pos: 9.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 27
+  type: WallReinforced
+  components:
+  - pos: -3.5,2.5
+    parent: 0
+    type: Transform
+- uid: 28
+  type: WallReinforced
+  components:
+  - pos: -4.5,2.5
+    parent: 0
+    type: Transform
+- uid: 29
+  type: WallReinforced
+  components:
+  - pos: -5.5,2.5
+    parent: 0
+    type: Transform
+- uid: 30
+  type: WallReinforced
+  components:
+  - pos: 9.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 31
+  type: WallReinforced
+  components:
+  - pos: 9.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 32
+  type: WallReinforced
+  components:
+  - pos: 6.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 33
+  type: AirlockExternalLocked
+  components:
+  - pos: -5.5,1.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 34
+  type: AirlockExternalLocked
+  components:
+  - pos: -3.5,1.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 35
+  type: WallReinforced
+  components:
+  - pos: -5.5,0.5
+    parent: 0
+    type: Transform
+- uid: 36
+  type: WallReinforced
+  components:
+  - pos: -4.5,0.5
+    parent: 0
+    type: Transform
+- uid: 37
+  type: WallReinforced
+  components:
+  - pos: -3.5,0.5
+    parent: 0
+    type: Transform
+- uid: 38
+  type: WallReinforced
+  components:
+  - pos: 7.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 39
+  type: WallReinforced
+  components:
+  - pos: 8.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 40
+  type: WallReinforced
+  components:
+  - pos: -3.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 41
+  type: WallReinforced
+  components:
+  - pos: -2.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 42
+  type: WallReinforced
+  components:
+  - pos: -1.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 43
+  type: WallReinforced
+  components:
+  - pos: -0.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 44
+  type: WallReinforced
+  components:
+  - pos: 0.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 45
+  type: WallReinforced
+  components:
+  - pos: 1.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 46
+  type: WallReinforced
+  components:
+  - pos: 2.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 47
+  type: WallReinforced
+  components:
+  - pos: 3.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 48
+  type: WallReinforced
+  components:
+  - pos: 4.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 49
+  type: WallReinforced
+  components:
+  - pos: 5.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 50
+  type: WallReinforced
+  components:
+  - pos: -5.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 51
+  type: WallReinforced
+  components:
+  - pos: -5.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 52
+  type: WallReinforced
+  components:
+  - pos: -5.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 53
+  type: WallReinforced
+  components:
+  - pos: -5.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 54
+  type: WallReinforced
+  components:
+  - pos: -5.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 55
+  type: WallReinforced
+  components:
+  - pos: -5.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 56
+  type: WallReinforced
+  components:
+  - pos: -4.5,-13.5
+    parent: 0
+    type: Transform
+- uid: 57
+  type: WallReinforced
+  components:
+  - pos: -5.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 58
+  type: WallReinforced
+  components:
+  - pos: -5.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 59
+  type: WallReinforced
+  components:
+  - pos: -5.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 60
+  type: WallReinforced
+  components:
+  - pos: -5.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 61
+  type: WallReinforced
+  components:
+  - pos: -5.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 62
+  type: WallReinforced
+  components:
+  - pos: -5.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 63
+  type: WallReinforced
+  components:
+  - pos: -5.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 64
+  type: WallReinforced
+  components:
+  - pos: -5.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 65
+  type: WallReinforced
+  components:
+  - pos: 9.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 66
+  type: WallReinforced
+  components:
+  - pos: 9.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 67
+  type: WallReinforced
+  components:
+  - pos: 9.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 68
+  type: WallReinforced
+  components:
+  - pos: 9.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 69
+  type: WallReinforced
+  components:
+  - pos: 9.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 70
+  type: WallReinforced
+  components:
+  - pos: 9.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 71
+  type: WallReinforced
+  components:
+  - pos: 9.5,0.5
+    parent: 0
+    type: Transform
+- uid: 72
+  type: WallReinforced
+  components:
+  - pos: 9.5,1.5
+    parent: 0
+    type: Transform
+- uid: 73
+  type: WallReinforced
+  components:
+  - pos: 9.5,2.5
+    parent: 0
+    type: Transform
+- uid: 74
+  type: WallReinforced
+  components:
+  - pos: 8.5,2.5
+    parent: 0
+    type: Transform
+- uid: 75
+  type: WallReinforced
+  components:
+  - pos: 7.5,2.5
+    parent: 0
+    type: Transform
+- uid: 76
+  type: ReinforcedWindow
+  components:
+  - pos: 4.5,6.5
+    parent: 0
+    type: Transform
+- uid: 77
+  type: ReinforcedWindow
+  components:
+  - pos: 3.5,6.5
+    parent: 0
+    type: Transform
+- uid: 78
+  type: ReinforcedWindow
+  components:
+  - pos: 5.5,6.5
+    parent: 0
+    type: Transform
+- uid: 79
+  type: ReinforcedWindow
+  components:
+  - pos: 6.5,6.5
+    parent: 0
+    type: Transform
+- uid: 80
+  type: ReinforcedWindow
+  components:
+  - pos: 7.5,6.5
+    parent: 0
+    type: Transform
+- uid: 81
+  type: ReinforcedWindow
+  components:
+  - pos: 7.5,5.5
+    parent: 0
+    type: Transform
+- uid: 82
+  type: ReinforcedWindow
+  components:
+  - pos: 7.5,4.5
+    parent: 0
+    type: Transform
+- uid: 83
+  type: WallReinforced
+  components:
+  - pos: 7.5,3.5
+    parent: 0
+    type: Transform
+- uid: 84
+  type: Grille
+  components:
+  - pos: 3.5,6.5
+    parent: 0
+    type: Transform
+- uid: 85
+  type: Grille
+  components:
+  - pos: 4.5,6.5
+    parent: 0
+    type: Transform
+- uid: 86
+  type: Grille
+  components:
+  - pos: 5.5,6.5
+    parent: 0
+    type: Transform
+- uid: 87
+  type: Grille
+  components:
+  - pos: 6.5,6.5
+    parent: 0
+    type: Transform
+- uid: 88
+  type: Grille
+  components:
+  - pos: 7.5,6.5
+    parent: 0
+    type: Transform
+- uid: 89
+  type: Grille
+  components:
+  - pos: 7.5,5.5
+    parent: 0
+    type: Transform
+- uid: 90
+  type: Grille
+  components:
+  - pos: 7.5,4.5
+    parent: 0
+    type: Transform
+- uid: 91
+  type: ResearchAndDevelopmentServer
+  components:
+  - pos: 8.5,1.5
+    parent: 0
+    type: Transform
+- uid: 92
+  type: WallSolid
+  components:
+  - pos: 8.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 93
+  type: WallSolid
+  components:
+  - pos: 6.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 94
+  type: WallSolid
+  components:
+  - pos: 5.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 95
+  type: WallSolid
+  components:
+  - pos: 5.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 96
+  type: GravityGenerator
+  components:
+  - pos: -3.5,-10.5
+    parent: 0
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - powerLoad: 500
+    type: ApcPowerReceiver
+  - radius: 2.5
+    type: PointLight
+- uid: 97
+  type: WallSolid
+  components:
+  - pos: 4.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 98
+  type: WallSolid
+  components:
+  - pos: 1.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 99
+  type: WallSolid
+  components:
+  - pos: 1.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 100
+  type: WallSolid
+  components:
+  - pos: 1.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 101
+  type: WallSolid
+  components:
+  - pos: -0.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 102
+  type: WallSolid
+  components:
+  - pos: -0.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 103
+  type: WallSolid
+  components:
+  - pos: -0.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 104
+  type: WallSolid
+  components:
+  - pos: -0.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 105
+  type: WindowReinforcedDirectional
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 106
+  type: WindowReinforcedDirectional
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -3.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 107
+  type: WindowReinforcedDirectional
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 108
+  type: AirlockMaintEngiLocked
+  components:
+  - name: Gravity Generator And Anti-Matter Engine
+    type: MetaData
+  - pos: -0.5,-12.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 109
+  type: AirlockServiceGlassLocked
+  components:
+  - pos: 3.5,-9.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 110
+  type: WallSolid
+  components:
+  - pos: 2.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 111
+  type: ChairPilotSeat
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 1.5,4.5
+    parent: 0
+    type: Transform
+- uid: 112
+  type: ComputerShuttle
+  components:
+  - pos: 1.5,5.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 113
+  type: WindoorSecure
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 114
+  type: CrateEngineeringAMEJar
+  components:
+  - pos: -4.5,-7.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+      labelSlot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 115
+  type: CrateEngineeringAMEControl
+  components:
+  - pos: -3.5,-7.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+      labelSlot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 116
+  type: CrateEngineeringAMEShielding
+  components:
+  - pos: -2.5,-7.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+      labelSlot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 117
+  type: WallSolid
+  components:
+  - pos: -0.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 118
+  type: WallSolid
+  components:
+  - pos: -0.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 119
+  type: WallSolid
+  components:
+  - pos: -0.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 120
+  type: WallSolid
+  components:
+  - pos: -0.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 121
+  type: WallSolid
+  components:
+  - pos: -4.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 122
+  type: WallSolid
+  components:
+  - pos: -3.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 123
+  type: WallSolid
+  components:
+  - pos: -2.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 124
+  type: WallSolid
+  components:
+  - pos: -1.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 125
+  type: WallSolid
+  components:
+  - pos: -0.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 126
+  type: WallSolid
+  components:
+  - pos: -2.5,0.5
+    parent: 0
+    type: Transform
+- uid: 127
+  type: WallSolid
+  components:
+  - pos: -1.5,0.5
+    parent: 0
+    type: Transform
+- uid: 128
+  type: WallSolid
+  components:
+  - pos: -0.5,0.5
+    parent: 0
+    type: Transform
+- uid: 129
+  type: WallSolid
+  components:
+  - pos: -0.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 130
+  type: WallSolid
+  components:
+  - pos: -0.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 131
+  type: AirlockEngineeringGlass
+  components:
+  - name: Engineering Storage
+    type: MetaData
+  - pos: -0.5,-2.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 132
+  type: CableHV
+  components:
+  - pos: -3.5,-7.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 133
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-4.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 134
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-3.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 135
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-5.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 136
+  type: CableHV
+  components:
+  - pos: -1.5,-8.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 137
+  type: CableHV
+  components:
+  - pos: -1.5,-9.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 138
+  type: CableHV
+  components:
+  - pos: -1.5,-10.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 139
+  type: CableHV
+  components:
+  - pos: -1.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 140
+  type: CableMV
+  components:
+  - pos: -1.5,-4.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 141
+  type: CableMV
+  components:
+  - pos: -1.5,-5.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 142
+  type: CableMV
+  components:
+  - pos: -1.5,-6.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 143
+  type: CableMV
+  components:
+  - pos: -1.5,-7.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 144
+  type: CableMV
+  components:
+  - pos: -1.5,-8.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 145
+  type: CableMV
+  components:
+  - pos: -1.5,-9.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 146
+  type: CableMV
+  components:
+  - pos: -1.5,-10.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 147
+  type: CableMV
+  components:
+  - pos: -1.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 148
+  type: CableMV
+  components:
+  - pos: -1.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 149
+  type: CableMV
+  components:
+  - pos: -0.5,-12.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 150
+  type: CableMV
+  components:
+  - pos: 0.5,-12.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 151
+  type: CableMV
+  components:
+  - pos: -1.5,-3.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 152
+  type: SalternApc
+  components:
+  - pos: -1.5,-3.5
+    parent: 0
+    type: Transform
+  - startingCharge: 12000
+    type: Battery
+  - loadingNetworkDemand: 520
+    currentReceiving: 520.0216
+    currentSupply: 520
+    type: PowerNetworkBattery
+- uid: 153
+  type: CableHV
+  components:
+  - pos: -1.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 154
+  type: CableHV
+  components:
+  - pos: -2.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 155
+  type: CableHV
+  components:
+  - pos: -3.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 156
+  type: CableHV
+  components:
+  - pos: -4.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 157
+  type: SalternSubstation
+  components:
+  - pos: -4.5,-12.5
+    parent: 0
+    type: Transform
+  - loadingNetworkDemand: 1285.0833
+    currentSupply: 1285.0833
+    supplyRampPosition: 1285.0833
+    type: PowerNetworkBattery
+- uid: 158
+  type: CableMV
+  components:
+  - pos: -2.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 159
+  type: CableMV
+  components:
+  - pos: -3.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 160
+  type: CableMV
+  components:
+  - pos: -4.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 161
+  type: CableHV
+  components:
+  - pos: -3.5,-8.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 162
+  type: CableHV
+  components:
+  - pos: -2.5,-8.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 163
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-6.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 164
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-7.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 165
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-8.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 166
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-9.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 167
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-10.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 168
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 169
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 170
+  type: CableMV
+  components:
+  - pos: 0.5,-11.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 171
+  type: CableMV
+  components:
+  - pos: 0.5,-10.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 172
+  type: CableMV
+  components:
+  - pos: 0.5,-9.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 173
+  type: CableMV
+  components:
+  - pos: 0.5,-8.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 174
+  type: CableMV
+  components:
+  - pos: 0.5,-7.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 175
+  type: CableMV
+  components:
+  - pos: 0.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 176
+  type: CableMV
+  components:
+  - pos: 0.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 177
+  type: CableMV
+  components:
+  - pos: 0.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 178
+  type: CableMV
+  components:
+  - pos: 0.5,-3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 179
+  type: CableMV
+  components:
+  - pos: 0.5,-2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 180
+  type: CableMV
+  components:
+  - pos: 0.5,-1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 181
+  type: CableMV
+  components:
+  - pos: 0.5,-0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 182
+  type: CableMV
+  components:
+  - pos: 0.5,0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 183
+  type: CableMV
+  components:
+  - pos: 0.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 184
+  type: CableMV
+  components:
+  - pos: 0.5,2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 185
+  type: CableMV
+  components:
+  - pos: -0.5,0.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 186
+  type: SalternApc
+  components:
+  - pos: -0.5,0.5
+    parent: 0
+    type: Transform
+  - startingCharge: 12000
+    type: Battery
+  - loadingNetworkDemand: 250
+    currentReceiving: 250.02052
+    currentSupply: 250
+    type: PowerNetworkBattery
+- uid: 187
+  type: CableApcExtension
+  components:
+  - pos: 1.5,4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 188
+  type: CableApcExtension
+  components:
+  - pos: -0.5,0.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 189
+  type: CableApcExtension
+  components:
+  - pos: 0.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 190
+  type: CableApcExtension
+  components:
+  - pos: 0.5,2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 191
+  type: CableApcExtension
+  components:
+  - pos: 0.5,3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 192
+  type: CableApcExtension
+  components:
+  - pos: 0.5,4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 193
+  type: CableApcExtension
+  components:
+  - pos: -0.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 194
+  type: CableApcExtension
+  components:
+  - pos: -1.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 195
+  type: CableApcExtension
+  components:
+  - pos: -2.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 196
+  type: CableApcExtension
+  components:
+  - pos: -3.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 197
+  type: CableApcExtension
+  components:
+  - pos: -4.5,1.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 198
+  type: LockerCaptainFilled
+  components:
+  - pos: 6.5,5.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 199
+  type: LockerHeadOfPersonnelFilled
+  components:
+  - pos: 5.5,5.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 200
+  type: ComputerId
+  components:
+  - pos: 3.5,5.5
+    parent: 0
+    type: Transform
+  - containers:
+      IdCardConsole-privilegedId: !type:ContainerSlot {}
+      IdCardConsole-targetId: !type:ContainerSlot {}
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 201
+  type: ComputerComms
+  components:
+  - pos: 4.5,5.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 202
+  type: WallSolid
+  components:
+  - pos: 5.5,3.5
+    parent: 0
+    type: Transform
+- uid: 203
+  type: WindowReinforcedDirectional
+  components:
+  - pos: -1.5,3.5
+    parent: 0
+    type: Transform
+- uid: 204
+  type: WindowReinforcedDirectional
+  components:
+  - pos: -0.5,3.5
+    parent: 0
+    type: Transform
+- uid: 205
+  type: WindoorCommandLocked
+  components:
+  - pos: 0.5,3.5
+    parent: 0
+    type: Transform
+- uid: 206
+  type: WindowReinforcedDirectional
+  components:
+  - pos: -2.5,3.5
+    parent: 0
+    type: Transform
+- uid: 207
+  type: WallSolid
+  components:
+  - pos: 6.5,3.5
+    parent: 0
+    type: Transform
+- uid: 208
+  type: WallSolid
+  components:
+  - pos: 4.5,3.5
+    parent: 0
+    type: Transform
+- uid: 209
+  type: WindoorCommandLocked
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,3.5
+    parent: 0
+    type: Transform
+- uid: 210
+  type: WindowReinforcedDirectional
+  components:
+  - pos: 1.5,3.5
+    parent: 0
+    type: Transform
+- uid: 211
+  type: WindowReinforcedDirectional
+  components:
+  - pos: 2.5,3.5
+    parent: 0
+    type: Transform
+- uid: 212
+  type: CableApcExtension
+  components:
+  - pos: 2.5,4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 213
+  type: CableApcExtension
+  components:
+  - pos: 3.5,4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 214
+  type: BoozeDispenser
+  components:
+  - pos: 8.5,-8.5
+    parent: 0
+    type: Transform
+  - containers:
+      ReagentDispenser-reagentContainerContainer: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 215
+  type: StoolBar
+  components:
+  - pos: 8.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 216
+  type: StoolBar
+  components:
+  - pos: 7.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 217
+  type: StoolBar
+  components:
+  - pos: 6.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 218
+  type: WallSolid
+  components:
+  - pos: 5.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 219
+  type: AirlockMedicalGlassLocked
+  components:
+  - name: Cloning
+    type: MetaData
+  - pos: 6.5,-4.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 220
+  type: WallSolid
+  components:
+  - pos: 7.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 221
+  type: WallSolid
+  components:
+  - pos: 8.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 222
+  type: CableApcExtension
+  components:
+  - pos: 4.5,4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 223
+  type: WindoorSecure
+  components:
+  - pos: 3.5,3.5
+    parent: 0
+    type: Transform
+- uid: 224
+  type: WindowReinforcedDirectional
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 2.5,3.5
+    parent: 0
+    type: Transform
+- uid: 225
+  type: WindowReinforcedDirectional
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 8.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 226
+  type: TableReinforced
+  components:
+  - pos: 3.5,3.5
+    parent: 0
+    type: Transform
+- uid: 227
+  type: ChairOfficeLight
+  components:
+  - pos: 3.4999998,4.5
+    parent: 0
+    type: Transform
+- uid: 228
+  type: ChairOfficeDark
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,4.5
+    parent: 0
+    type: Transform
+- uid: 229
+  type: Table
+  components:
+  - pos: -0.5,5.5
+    parent: 0
+    type: Transform
+- uid: 230
+  type: Table
+  components:
+  - pos: -1.5,5.5
+    parent: 0
+    type: Transform
+- uid: 231
+  type: Table
+  components:
+  - pos: -2.5,5.5
+    parent: 0
+    type: Transform
+- uid: 232
+  type: ClothingBeltSecurityFilled
+  components:
+  - pos: -0.5959408,5.612088
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 233
+  type: Paper
+  components:
+  - pos: -2.4396908,5.471463
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 234
+  type: Paper
+  components:
+  - pos: -2.5646908,5.549588
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 235
+  type: Pen
+  components:
+  - rot: -0.00019281315326225013 rad
+    pos: -2.0646908,5.734951
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 236
+  type: Paper
+  components:
+  - pos: -2.6428158,5.612088
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 237
+  type: ClosetChefFilled
+  components:
+  - pos: 8.5,-11.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 238
+  type: hydroponicsTray
+  components:
+  - pos: 2.5,-12.5
+    parent: 0
+    type: Transform
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 239
+  type: Table
+  components:
+  - pos: 4.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 240
+  type: hydroponicsTray
+  components:
+  - pos: 2.5,-11.5
+    parent: 0
+    type: Transform
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 241
+  type: Table
+  components:
+  - pos: 6.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 242
+  type: KitchenMicrowave
+  components:
+  - pos: 6.5,-11.5
+    parent: 0
+    type: Transform
+  - containers:
+      microwave_entity_container: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 243
+  type: Table
+  components:
+  - pos: 5.5,-11.5
+    parent: 0
+    type: Transform
+- uid: 244
+  type: KitchenReagentGrinder
+  components:
+  - pos: 5.5,-11.5
+    parent: 0
+    type: Transform
+  - containers:
+      ReagentGrinder-reagentContainerContainer: !type:ContainerSlot {}
+      ReagentGrinder-entityContainerContainer: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 245
+  type: HydroponicsToolMiniHoe
+  components:
+  - pos: 4.901165,-11.371086
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 246
+  type: HydroponicsToolSpade
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.66679,-11.480461
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 247
+  type: HydroponicsToolHatchet
+  components:
+  - pos: 4.276165,-11.558586
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 248
+  type: WallSolid
+  components:
+  - pos: 1.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 249
+  type: SeedExtractor
+  components:
+  - pos: 2.5,-10.5
+    parent: 0
+    type: Transform
+- uid: 250
+  type: VendingMachineSeeds
+  components:
+  - pos: 4.5,-10.5
+    parent: 0
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 251
+  type: AirlockServiceGlassLocked
+  components:
+  - pos: 7.5,-10.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 252
+  type: Table
+  components:
+  - pos: 7.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 253
+  type: Table
+  components:
+  - pos: 6.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 254
+  type: Table
+  components:
+  - pos: 8.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 255
+  type: WallSolid
+  components:
+  - pos: 5.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 256
+  type: AirlockBarGlassLocked
+  components:
+  - pos: 5.5,-8.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 257
+  type: soda_dispenser
+  components:
+  - pos: 8.5,-9.5
+    parent: 0
+    type: Transform
+  - containers:
+      ReagentDispenser-reagentContainerContainer: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 258
+  type: VendingMachineBooze
+  components:
+  - pos: 6.5,-9.5
+    parent: 0
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 259
+  type: SpawnPointBartender
+  components:
+  - pos: 7.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 260
+  type: WallSolid
+  components:
+  - pos: 1.5,0.5
+    parent: 0
+    type: Transform
+- uid: 261
+  type: FirelockGlass
+  components:
+  - pos: 5.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 262
+  type: WallSolid
+  components:
+  - pos: 5.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 263
+  type: CableApcExtension
+  components:
+  - pos: 4.5,-1.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 264
+  type: WallSolid
+  components:
+  - pos: 5.5,0.5
+    parent: 0
+    type: Transform
+- uid: 265
+  type: Autolathe
+  components:
+  - pos: 5.5,2.5
+    parent: 0
+    type: Transform
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 266
+  type: WallSolid
+  components:
+  - pos: 4.5,0.5
+    parent: 0
+    type: Transform
+- uid: 267
+  type: ComputerResearchAndDevelopment
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 7.5,1.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 268
+  type: WallSolid
+  components:
+  - pos: 4.5,2.5
+    parent: 0
+    type: Transform
+- uid: 269
+  type: SpawnPointHeadOfSecurity
+  components:
+  - pos: -2.5,4.5
+    parent: 0
+    type: Transform
+- uid: 270
+  type: SpawnPointSecurityOfficer
+  components:
+  - pos: -0.5,4.5
+    parent: 0
+    type: Transform
+- uid: 271
+  type: SpawnPointStationEngineer
+  components:
+  - pos: -3.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 272
+  type: SpawnPointLatejoin
+  components:
+  - pos: -1.5,1.5
+    parent: 0
+    type: Transform
+- uid: 273
+  type: SpawnPointObserver
+  components:
+  - pos: -2.5,1.5
+    parent: 0
+    type: Transform
+- uid: 274
+  type: Protolathe
+  components:
+  - pos: 6.5,2.5
+    parent: 0
+    type: Transform
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 275
+  type: AirlockScienceGlassLocked
+  components:
+  - name: Research & Manufacturing
+    type: MetaData
+  - pos: 4.5,1.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 276
+  type: ChairOfficeLight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 6.495001,1.5
+    parent: 0
+    type: Transform
+- uid: 277
+  type: SpawnPointScientist
+  components:
+  - pos: 5.5,1.5
+    parent: 0
+    type: Transform
+- uid: 278
+  type: SpawnPointResearchDirector
+  components:
+  - pos: 6.5,1.5
+    parent: 0
+    type: Transform
+- uid: 279
+  type: WindowReinforcedDirectional
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 7.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 280
+  type: WindowReinforcedDirectional
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 6.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 281
+  type: SalternApc
+  components:
+  - pos: 7.5,2.5
+    parent: 0
+    type: Transform
+  - startingCharge: 12000
+    type: Battery
+  - loadingNetworkDemand: 415
+    currentReceiving: 415.02118
+    currentSupply: 415
+    type: PowerNetworkBattery
+- uid: 282
+  type: CableApcExtension
+  components:
+  - pos: 7.5,2.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 283
+  type: CableApcExtension
+  components:
+  - pos: 7.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 284
+  type: CableApcExtension
+  components:
+  - pos: 6.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 285
+  type: CableApcExtension
+  components:
+  - pos: 5.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 286
+  type: CableMV
+  components:
+  - pos: 7.5,2.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 287
+  type: CableMV
+  components:
+  - pos: 7.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 288
+  type: CableMV
+  components:
+  - pos: 6.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 289
+  type: CableMV
+  components:
+  - pos: 5.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 290
+  type: CableMV
+  components:
+  - pos: 4.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 291
+  type: CableMV
+  components:
+  - pos: 3.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 292
+  type: CableMV
+  components:
+  - pos: 2.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 293
+  type: CableMV
+  components:
+  - pos: 1.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 294
+  type: SLMagnum
+  components:
+  - pos: -1.4842365,5.37097
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      SpeedLoader-container: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 295
+  type: SLMagnum
+  components:
+  - pos: -1.1404865,5.355345
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      SpeedLoader-container: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 296
+  type: RevolverDeckard
+  components:
+  - pos: -1.4003668,5.6217813
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BoltActionBarrel-ammo-container: !type:Container
+        ents: []
+      BoltActionBarrel-chamber-container: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 297
+  type: LockerAtmosphericsFilled
+  components:
+  - pos: -1.5,-0.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 298
+  type: Table
+  components:
+  - pos: 1.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 299
+  type: WallSolid
+  components:
+  - pos: 1.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 300
+  type: WallSolid
+  components:
+  - pos: 4.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 301
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 6.5,0.5
+    parent: 0
+    type: Transform
+- uid: 302
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 2.5,5.5
+    parent: 0
+    type: Transform
+- uid: 303
+  type: WallSolid
+  components:
+  - pos: 3.5,0.5
+    parent: 0
+    type: Transform
+- uid: 304
+  type: WallSolid
+  components:
+  - pos: 2.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 305
+  type: WallSolid
+  components:
+  - pos: 3.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 306
+  type: AirlockCargoGlassLocked
+  components:
+  - name: Cargo
+    type: MetaData
+  - pos: 1.5,-0.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 307
+  type: cargoTelepad
+  components:
+  - pos: 3.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 308
+  type: ComputerSupplyOrdering
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,-0.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 309
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 310
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 311
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 312
+  type: WallSolid
+  components:
+  - pos: 4.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 313
+  type: WallSolid
+  components:
+  - pos: 1.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 314
+  type: WallSolid
+  components:
+  - pos: 2.5,0.5
+    parent: 0
+    type: Transform
+- uid: 315
+  type: WallSolid
+  components:
+  - pos: 5.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 316
+  type: CableMV
+  components:
+  - pos: 4.5,-1.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 317
+  type: SalternApc
+  components:
+  - pos: 4.5,-1.5
+    parent: 0
+    type: Transform
+  - startingCharge: 12000
+    type: Battery
+  - loadingNetworkDemand: 20
+    currentReceiving: 19.980549
+    currentSupply: 20
+    supplyRampPosition: 0.019451141
+    type: PowerNetworkBattery
+- uid: 318
+  type: CableMV
+  components:
+  - pos: 3.5,-1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 319
+  type: CableMV
+  components:
+  - pos: 3.5,-0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 320
+  type: CableMV
+  components:
+  - pos: 2.5,-0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 321
+  type: CableMV
+  components:
+  - pos: 1.5,-0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 322
+  type: WallSolid
+  components:
+  - pos: 5.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 323
+  type: WallSolid
+  components:
+  - pos: 4.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 324
+  type: AirlockMedicalGlassLocked
+  components:
+  - name: Chemistry
+    type: MetaData
+  - pos: 3.5,-5.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 325
+  type: WallSolid
+  components:
+  - pos: 2.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 326
+  type: WallSolid
+  components:
+  - pos: 1.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 327
+  type: WallSolid
+  components:
+  - pos: 1.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 328
+  type: LockerChiefEngineerFilled
+  components:
+  - pos: -2.5,-0.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 329
+  type: SpawnPointChiefEngineer
+  components:
+  - pos: -4.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 330
+  type: ClosetToolFilled
+  components:
+  - pos: -3.5,-0.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 331
+  type: LockerEngineerFilled
+  components:
+  - pos: -4.5,-0.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 332
+  type: VendingMachineEngivend
+  components:
+  - pos: -2.5,-2.5
+    parent: 0
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 333
+  type: CrateMaterialSteel
+  components:
+  - pos: 6.5,-0.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+      labelSlot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 334
+  type: CrateMaterialPlastic
+  components:
+  - pos: 7.5,-0.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+      labelSlot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 335
+  type: CrateMaterialGlass
+  components:
+  - pos: 8.5,-0.5
+    parent: 0
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+      labelSlot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 336
+  type: BaseResearchAndDevelopmentPointSource
+  components:
+  - pos: 8.5,0.5
+    parent: 0
+    type: Transform
+- uid: 337
+  type: chem_dispenser
+  components:
+  - pos: 2.5,-3.5
+    parent: 0
+    type: Transform
+  - containers:
+      ReagentDispenser-reagentContainerContainer: !type:ContainerSlot {}
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 338
+  type: chem_master
+  components:
+  - pos: 3.5,-3.5
+    parent: 0
+    type: Transform
+  - containers:
+      ChemMaster-reagentContainerContainer: !type:ContainerSlot {}
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+  - solutions:
+      buffer:
+        reagents: []
+    type: SolutionContainerManager
+- uid: 339
+  type: WallSolid
+  components:
+  - pos: 4.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 340
+  type: WallSolid
+  components:
+  - pos: 5.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 341
+  type: Table
+  components:
+  - pos: 4.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 342
+  type: BoxBeaker
+  components:
+  - pos: 4.7005863,-4.369149
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 343
+  type: HandLabeler
+  components:
+  - pos: 4.2005863,-4.306649
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 344
+  type: WindoorMedicalLocked
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 1.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 345
+  type: WindoorSecure
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 346
+  type: ChairOfficeDark
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.4999998,-4.5
+    parent: 0
+    type: Transform
+- uid: 347
+  type: ChairOfficeLight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 3.4950006,-0.5
+    parent: 0
+    type: Transform
+- uid: 348
+  type: ChairOfficeLight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 7.5,-8.5
+    parent: 0
+    type: Transform
+- uid: 349
+  type: Table
+  components:
+  - pos: 1.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 350
+  type: Table
+  components:
+  - pos: 2.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 351
+  type: ChairOfficeLight
+  components:
+  - pos: 2.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 352
+  type: ChairOfficeLight
+  components:
+  - pos: 1.5,-6.5
+    parent: 0
+    type: Transform
+- uid: 353
+  type: ChairOfficeLight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.4999998,-7.5
+    parent: 0
+    type: Transform
+- uid: 354
+  type: FirelockGlass
+  components:
+  - pos: 0.5,0.5
+    parent: 0
+    type: Transform
+- uid: 355
+  type: SalternApc
+  components:
+  - pos: 5.5,-3.5
+    parent: 0
+    type: Transform
+  - startingCharge: 12000
+    type: Battery
+  - loadingNetworkDemand: 25
+    currentReceiving: 25.01963
+    currentSupply: 25
+    type: PowerNetworkBattery
+- uid: 356
+  type: CableApcExtension
+  components:
+  - pos: 5.5,-3.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 357
+  type: CableApcExtension
+  components:
+  - pos: 6.5,-3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 358
+  type: CableApcExtension
+  components:
+  - pos: 6.5,-2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 359
+  type: CableApcExtension
+  components:
+  - pos: 7.5,-2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 360
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 361
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 362
+  type: CableApcExtension
+  components:
+  - pos: 4.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 363
+  type: CableApcExtension
+  components:
+  - pos: 4.5,-3.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 364
+  type: CableMV
+  components:
+  - pos: 5.5,-3.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 365
+  type: CableMV
+  components:
+  - pos: 6.5,-3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 366
+  type: CableMV
+  components:
+  - pos: 6.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 367
+  type: CableMV
+  components:
+  - pos: 6.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 368
+  type: CableMV
+  components:
+  - pos: 6.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 369
+  type: CableMV
+  components:
+  - pos: 5.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 370
+  type: CableMV
+  components:
+  - pos: 4.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 371
+  type: CableMV
+  components:
+  - pos: 3.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 372
+  type: CableMV
+  components:
+  - pos: 2.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 373
+  type: CableMV
+  components:
+  - pos: 1.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 374
+  type: SalternApc
+  components:
+  - pos: 6.5,-10.5
+    parent: 0
+    type: Transform
+  - startingCharge: 12000
+    type: Battery
+  - loadingNetworkDemand: 55
+    currentReceiving: 55.01975
+    currentSupply: 55
+    type: PowerNetworkBattery
+- uid: 375
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-11.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 376
+  type: CableApcExtension
+  components:
+  - pos: 4.5,-11.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 377
+  type: CableApcExtension
+  components:
+  - pos: 5.5,-11.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 378
+  type: CableApcExtension
+  components:
+  - pos: 6.5,-11.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 379
+  type: CableApcExtension
+  components:
+  - pos: 7.5,-11.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 380
+  type: CableApcExtension
+  components:
+  - pos: 6.5,-10.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 381
+  type: CableApcExtension
+  components:
+  - pos: 6.5,-9.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 382
+  type: CableApcExtension
+  components:
+  - pos: 6.5,-8.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 383
+  type: CableApcExtension
+  components:
+  - pos: 6.5,-7.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 384
+  type: CableApcExtension
+  components:
+  - pos: 7.5,-7.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 385
+  type: CableApcExtension
+  components:
+  - pos: 6.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 386
+  type: CableMV
+  components:
+  - pos: 6.5,-7.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 387
+  type: CableMV
+  components:
+  - pos: 6.5,-8.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 388
+  type: CableMV
+  components:
+  - pos: 6.5,-9.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 389
+  type: CableMV
+  components:
+  - pos: 6.5,-10.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 390
+  type: FirelockGlass
+  components:
+  - pos: 0.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 391
+  type: FirelockGlass
+  components:
+  - pos: 0.5,-9.5
+    parent: 0
+    type: Transform
+- uid: 392
+  type: SpawnPointCaptain
+  components:
+  - pos: 6.5,4.5
+    parent: 0
+    type: Transform
+- uid: 393
+  type: SpawnPointHeadOfPersonnel
+  components:
+  - pos: 5.5,4.5
+    parent: 0
+    type: Transform
+- uid: 394
+  type: SpawnPointBotanist
+  components:
+  - pos: 3.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 395
+  type: SpawnPointCargoTechnician
+  components:
+  - pos: 2.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 396
+  type: SpawnPointChef
+  components:
+  - pos: 5.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 397
+  type: VendingMachineDinnerware
+  components:
+  - name: Dinnerware
+    type: MetaData
+  - pos: 8.5,-12.5
+    parent: 0
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 398
+  type: SpawnPointChiefMedicalOfficer
+  components:
+  - pos: 3.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 399
+  type: SpawnPointMedicalDoctor
+  components:
+  - pos: 8.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 400
+  type: SpawnPointClown
+  components:
+  - pos: 2.5,2.5
+    parent: 0
+    type: Transform
+- uid: 401
+  type: SpawnPointMime
+  components:
+  - pos: 1.5,2.5
+    parent: 0
+    type: Transform
+- uid: 402
+  type: SpawnPointJanitor
+  components:
+  - pos: -0.5,2.5
+    parent: 0
+    type: Transform
+- uid: 403
+  type: SpawnPointAssistant
+  components:
+  - pos: -2.5,2.5
+    parent: 0
+    type: Transform
+- uid: 404
+  type: d20Dice
+  components:
+  - pos: 1.3482966,-7.302723
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 405
+  type: Paper
+  components:
+  - pos: 2.0201716,-7.302723
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 406
+  type: Paper
+  components:
+  - pos: 2.1764216,-7.474598
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 407
+  type: Paper
+  components:
+  - pos: 2.3014216,-7.365223
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 408
+  type: Paper
+  components:
+  - pos: 2.4732966,-7.521473
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 409
+  type: Pen
+  components:
+  - pos: 2.6451716,-7.162098
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 410
+  type: PersonalAI
+  components:
+  - pos: 1.5982966,-7.583973
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 411
+  type: Poweredlight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -3.5,-2.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 412
+  type: Poweredlight
+  components:
+  - pos: 7.5,1.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 413
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 8.5,-2.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 414
+  type: Poweredlight
+  components:
+  - pos: 7.5,-5.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 415
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 8.5,-8.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 416
+  type: Poweredlight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-12.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 417
+  type: Poweredlight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 7.5,-12.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 418
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,-7.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 419
+  type: Poweredlight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-7.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 420
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 0.5,-2.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 421
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 0.5,-11.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 422
+  type: Poweredlight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,1.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 423
+  type: Poweredlight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,1.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 424
+  type: Poweredlight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,4.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 425
+  type: Poweredlight
+  components:
+  - pos: 3.5,-0.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 426
+  type: Poweredlight
+  components:
+  - pos: 3.5,-3.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 427
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -1.5,-10.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 428
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -1.5,-5.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 429
+  type: CableApcExtension
+  components:
+  - pos: -2.5,-7.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 430
+  type: CableApcExtension
+  components:
+  - pos: -3.5,-7.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 431
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: 8.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 432
+  type: SuspicionRevolverSpawner
+  components:
+  - pos: 3.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 433
+  type: SuspicionRevolverSpawner
+  components:
+  - pos: -2.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 434
+  type: SuspicionRevolverSpawner
+  components:
+  - pos: -0.5,5.5
+    parent: 0
+    type: Transform
+- uid: 435
+  type: SuspicionRevolverSpawner
+  components:
+  - pos: 7.5,0.5
+    parent: 0
+    type: Transform
+- uid: 436
+  type: SuspicionRevolverSpawner
+  components:
+  - pos: 8.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 437
+  type: SuspicionRevolverSpawner
+  components:
+  - pos: 8.5,-7.5
+    parent: 0
+    type: Transform
+- uid: 438
+  type: TraitorDMRedemptionMachineSpawner
+  components:
+  - pos: -1.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 439
+  type: SuspicionRevolverSpawner
+  components:
+  - pos: 7.5,-12.5
+    parent: 0
+    type: Transform
+- uid: 440
+  type: AirCanister
+  components:
+  - pos: -4.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 441
+  type: GasPort
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -3.5,-2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 442
+  type: GasVentPump
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,-1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 443
+  type: GasPipeTJunction
+  components:
+  - pos: -3.5,-1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 444
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,-1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 445
+  type: GasPipeBend
+  components:
+  - pos: -1.5,-1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 446
+  type: GasPipeStraight
+  components:
+  - pos: 6.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 447
+  type: GasPipeStraight
+  components:
+  - pos: 6.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 448
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-8.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 449
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-9.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 450
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-10.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 451
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-11.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 452
+  type: GasPipeTJunction
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 453
+  type: GasVentPump
+  components:
+  - pos: -1.5,-7.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 454
+  type: GasVentPump
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -2.5,-12.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 455
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,-12.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 456
+  type: GasPipeBend
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 0.5,-12.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 457
+  type: GasPipeStraight
+  components:
+  - pos: 3.5,-9.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 458
+  type: GasPipeStraight
+  components:
+  - pos: 3.5,-8.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 459
+  type: GasPipeStraight
+  components:
+  - pos: 3.5,-7.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 460
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,-11.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 461
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,-10.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 462
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,-9.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 463
+  type: GasPipeTJunction
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 464
+  type: GasPipeTJunction
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 6.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 465
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 5.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 466
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 467
+  type: GasPipeTJunction
+  components:
+  - pos: 3.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 468
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 469
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 470
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-4.5
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 471
+  type: GasPipeTJunction
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 472
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 473
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 474
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 475
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 476
+  type: GasPipeBend
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 477
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,-2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 478
+  type: GasPipeTJunction
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 479
+  type: GasPipeTJunction
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 480
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 481
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 482
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 483
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,-1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 484
+  type: GasPipeTJunction
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 0.5,-2.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 485
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,-3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 486
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,-5.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 487
+  type: GasPipeTJunction
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-8.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 488
+  type: GasPipeStraight
+  components:
+  - pos: 0.5,-7.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 489
+  type: GasVentPump
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-10.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 490
+  type: GasVentPump
+  components:
+  - pos: 6.5,-3.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 491
+  type: GasVentPump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 7.5,-6.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 492
+  type: GasVentPump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 493
+  type: GasVentPump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-0.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 494
+  type: GasVentPump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 5.5,1.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 495
+  type: GasVentPump
+  components:
+  - pos: 0.5,4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 496
+  type: GasVentPump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-8.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+- uid: 497
+  type: MedicalScanner
+  components:
+  - pos: 6.5,-2.5
+    parent: 0
+    type: Transform
+  - containers:
+      MedicalScanner-bodyContainer: !type:ContainerSlot {}
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 498
+  type: CloningPod
+  components:
+  - pos: 7.5,-2.5
+    parent: 0
+    type: Transform
+  - containers:
+      CloningPod-bodyContainer: !type:ContainerSlot {}
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+...


### PR DESCRIPTION
## About the PR

Adds a new map for ultra-low-pop.
Named "knightship" because ~~frankly I couldn't think of a better name~~ one person could run the whole thing and it would function or something IDK.

Intended for possibly 5 people, it's intended to be "compact but functional".

Expected "Standard" Crew (though as always roles are variable):
```
1 Captain (expected to act as cargo, HoP and security)
1 "Chief" Medical Officer (expected to know chemistry)
1 Research Director
1 "Chief" Engineer
1 Chef
```

Features:

+ The map is setup such that an Assistant *should* be able to escalate access to get the whole ship running in a pinch.
+ *There are no SMESes, so setting up an engine is imperative.* This isn't Saltern, the ship will run out of power without someone to setup and maintain the engine.
+ The ship has basic atmos, enough that the ship is refillable but not the endless regenerating atmos of stations.
+ Engineering have something to do: figure out how to expand the ship. Because if they *don't*, the people will get claustrophobic very, very quickly.
+ Mapped out spawns for Suspicion and TraitorDM

TODO:
+ I need to check if this name is already occupied and if so figure out a new name

**Screenshots**
![image](https://user-images.githubusercontent.com/22304167/142253561-09d6413e-3d86-46d7-8ef5-8475be2b55f7.png)

**Changelog**

:cl:
- add: Added a new map, "Knightship", meant for very low populations.

