### PR TITLE
Stop BatterySystem from iterating over every battery just to recharge micro-reactors

### DIFF
--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -72,6 +72,7 @@ namespace Content.Client.Entry
             "Mop",
             "Bucket",
             "CableVis",
+            "BatterySelfRecharger",
             "Puddle",
             "Stomach",
             "CanSpill",

--- a/Content.Server/Power/Components/BatteryComponent.cs
+++ b/Content.Server/Power/Components/BatteryComponent.cs
@@ -34,10 +34,6 @@ namespace Content.Server.Power.Components
         /// </summary>
         [ViewVariables] public bool IsFullyCharged => MathHelper.CloseToPercent(CurrentCharge, MaxCharge);
 
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRecharge")] public bool AutoRecharge { get; set; }
-
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRechargeRate")] public float AutoRechargeRate { get; set; }
-
         /// <summary>
         ///     If sufficient charge is avaiable on the battery, use it. Otherwise, don't.
         /// </summary>
@@ -88,13 +84,6 @@ namespace Content.Server.Power.Components
         {
             _currentCharge = MathHelper.Clamp(newChargeAmount, 0, MaxCharge);
             OnChargeChanged();
-        }
-
-        public void OnUpdate(float frameTime)
-        {
-            if (!AutoRecharge) return;
-            if (IsFullyCharged) return;
-            CurrentCharge += AutoRechargeRate * frameTime;
         }
     }
 }

--- a/Content.Server/Power/Components/BatterySelfRechargerComponent.cs
+++ b/Content.Server/Power/Components/BatterySelfRechargerComponent.cs
@@ -1,0 +1,21 @@
+using System;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.ViewVariables;
+
+namespace Content.Server.Power.Components
+{
+    /// <summary>
+    ///     Self-recharging battery.
+    /// </summary>
+    [RegisterComponent]
+    public class BatterySelfRechargerComponent : Component
+    {
+        public override string Name => "BatterySelfRecharger";
+
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRecharge")] public bool AutoRecharge { get; set; }
+
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("autoRechargeRate")] public float AutoRechargeRate { get; set; }
+    }
+}

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -17,7 +17,7 @@ namespace Content.Server.Power.EntitySystems
 
         private void PreSync(NetworkBatteryPreSync ev)
         {
-            foreach (var (bat, netBat) in EntityManager.EntityQuery<BatteryComponent, PowerNetworkBatteryComponent>())
+            foreach (var (netBat, bat) in EntityManager.EntityQuery<PowerNetworkBatteryComponent, BatteryComponent>())
             {
                 netBat.NetworkBattery.Capacity = bat.MaxCharge;
                 netBat.NetworkBattery.CurrentStorage = bat.CurrentCharge;
@@ -26,7 +26,7 @@ namespace Content.Server.Power.EntitySystems
 
         private void PostSync(NetworkBatteryPostSync ev)
         {
-            foreach (var (bat, netBat) in EntityManager.EntityQuery<BatteryComponent, PowerNetworkBatteryComponent>())
+            foreach (var (netBat, bat) in EntityManager.EntityQuery<PowerNetworkBatteryComponent, BatteryComponent>())
             {
                 bat.CurrentCharge = netBat.NetworkBattery.CurrentStorage;
             }
@@ -34,9 +34,11 @@ namespace Content.Server.Power.EntitySystems
 
         public override void Update(float frameTime)
         {
-            foreach (var comp in EntityManager.EntityQuery<BatteryComponent>())
+            foreach (var (comp, batt) in EntityManager.EntityQuery<BatterySelfRechargerComponent, BatteryComponent>())
             {
-                comp.OnUpdate(frameTime);
+                if (!comp.AutoRecharge) continue;
+                if (batt.IsFullyCharged) continue;
+                batt.CurrentCharge += comp.AutoRechargeRate * frameTime;
             }
         }
     }

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -145,6 +145,7 @@
     - type: PowerCell
       maxCharge: 50
       startingCharge: 50
+    - type: BatterySelfRecharger
       autoRecharge: true
       autoRechargeRate: 0.16667 #takes about 5 minutes to charge itself back to full
     - type: Appearance
@@ -165,6 +166,7 @@
     - type: PowerCell
       maxCharge: 600 #lights drain 3/s but recharge of 2 makes this 1/s. Therefore 600 is 10 minutes of light.
       startingCharge: 600
+    - type: BatterySelfRecharger
       autoRecharge: true
       autoRechargeRate: 2 #recharge of 2 makes total drain 1w / s so max charge is 1:1 with time. Time to fully charge should be 5 minutes. Having recharge gives light an extended flicker period which gives you some warning to return to light area.
     - type: Appearance


### PR DESCRIPTION
## About the PR

Self-recharging batteries are the exception, not the rule, so only iterate over those.
Inspired by something I noticed on some profiler output.

Also rearranges EntityQueries in line with the guidance that the first component should be the less prevalent one.