### PR TITLE
Change over solar panel breakage to use more construction graphs

### DIFF
--- a/Content.Server/Solar/Components/SolarPanelComponent.cs
+++ b/Content.Server/Solar/Components/SolarPanelComponent.cs
@@ -1,7 +1,6 @@
 using System;
 using Content.Server.Power.Components;
 using Content.Server.Solar.EntitySystems;
-using Content.Shared.Acts;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -16,67 +15,33 @@ namespace Content.Server.Solar.Components
     ///     It generates power from the sun based on coverage.
     /// </summary>
     [RegisterComponent]
-    public class SolarPanelComponent : Component, IBreakAct
+    public class SolarPanelComponent : Component
     {
         public override string Name => "SolarPanel";
 
         /// <summary>
         /// Maximum supply output by this panel (coverage = 1)
         /// </summary>
-        [DataField("maxsupply")]
+        [DataField("maxSupply")]
         private int _maxSupply = 1500;
+
         [ViewVariables(VVAccess.ReadWrite)]
         public int MaxSupply
         {
             get => _maxSupply;
             set {
                 _maxSupply = value;
-                UpdateSupply();
+                // This should almost never be called, shush.
+                EntitySystem.Get<PowerSolarSystem>().UpdateSupply(OwnerUid, this);
             }
         }
 
         /// <summary>
         /// Current coverage of this panel (from 0 to 1).
         /// This is updated by <see cref='PowerSolarSystem'/>.
-        /// </summary>
-        private float _coverage = 0;
-        [ViewVariables]
-        public float Coverage
-        {
-            get => _coverage;
-            set {
-                // This gets updated once-per-tick, so avoid updating it if truly unnecessary
-                if (_coverage != value) {
-                    _coverage = value;
-                    UpdateSupply();
-                }
-            }
-        }
-
-        /// <summary>
-        /// The game time (<see cref='IGameTiming'/>) of the next coverage update.
-        /// This may have a random offset applied.
-        /// This is used to reduce solar panel updates and stagger them to prevent lagspikes.
-        /// This should only be updated by the PowerSolarSystem but is viewable for debugging.
+        /// DO NOT WRITE WITHOUT CALLING UpdateSupply()!
         /// </summary>
         [ViewVariables]
-        public TimeSpan TimeOfNextCoverageUpdate = TimeSpan.MinValue;
-
-        private void UpdateSupply()
-        {
-            if (Owner.TryGetComponent<PowerSupplierComponent>(out var supplier))
-            {
-                supplier.MaxSupply = (int) (_maxSupply * _coverage);
-            }
-        }
-
-        public void OnBreak(BreakageEventArgs args)
-        {
-            if (!Owner.TryGetComponent<SpriteComponent>(out var sprite))
-                return;
-
-            sprite.LayerSetState(0, "broken");
-            MaxSupply = 0;
-        }
+        public float Coverage { get; set; } = 0;
     }
 }

--- a/Content.Server/Solar/Components/SolarPanelComponent.cs
+++ b/Content.Server/Solar/Components/SolarPanelComponent.cs
@@ -2,6 +2,7 @@ using System;
 using Content.Server.Power.Components;
 using Content.Server.Solar.EntitySystems;
 using Robust.Server.GameObjects;
+using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Timing;
@@ -15,6 +16,7 @@ namespace Content.Server.Solar.Components
     ///     It generates power from the sun based on coverage.
     /// </summary>
     [RegisterComponent]
+    [Friend(typeof(PowerSolarSystem))]
     public class SolarPanelComponent : Component
     {
         public override string Name => "SolarPanel";
@@ -23,18 +25,8 @@ namespace Content.Server.Solar.Components
         /// Maximum supply output by this panel (coverage = 1)
         /// </summary>
         [DataField("maxSupply")]
-        private int _maxSupply = 1500;
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public int MaxSupply
-        {
-            get => _maxSupply;
-            set {
-                _maxSupply = value;
-                // This should almost never be called, shush.
-                EntitySystem.Get<PowerSolarSystem>().UpdateSupply(OwnerUid, this);
-            }
-        }
+        [ViewVariables]
+        public int MaxSupply = 1500;
 
         /// <summary>
         /// Current coverage of this panel (from 0 to 1).

--- a/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
+++ b/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
@@ -154,7 +154,6 @@ namespace Content.Server.Solar.EntitySystems
             if (coverage > 0)
             {
                 // Determine if the solar panel is occluded, and zero out coverage if so.
-                // FIXME: The "Opaque" collision group doesn't seem to work right now.
                 var ray = new CollisionRay(entity.Transform.WorldPosition, TowardsSun.ToWorldVec(), (int) CollisionGroup.Opaque);
                 var rayCastResults = _physicsSystem.IntersectRayWithPredicate(
                     entity.Transform.MapID,
@@ -167,9 +166,10 @@ namespace Content.Server.Solar.EntitySystems
 
             // Total coverage calculated; apply it to the panel.
             panel.Coverage = coverage;
+            UpdateSupply(panel.OwnerUid, panel);
         }
 
-        private void UpdateSupply(
+        public void UpdateSupply(
             EntityUid uid,
             SolarPanelComponent? solar = null,
             PowerSupplierComponent? supplier = null)

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
@@ -1,11 +1,14 @@
 - type: entity
-  id: SolarPanel
+  id: SolarPanelBasePhysSprite
+  abstract: true
   name: solar panel
   placement:
     mode: SnapgridCenter
   components:
   - type: Clickable
   - type: InteractionOutline
+  - type: Transform
+    anchored: true
   - type: Physics
     bodyType: Static
     fixtures:
@@ -32,13 +35,18 @@
       output:
         !type:CableDeviceNode
         nodeGroupID: HVPower
+  - type: Anchorable
+  - type: Pullable
+
+- type: entity
+  id: SolarPanel
+  parent: SolarPanelBasePhysSprite
+  name: solar panel
+  components:
   - type: PowerSupplier
     supplyRampTolerance: 500
     supplyRampRate: 500
   - type: SolarPanel
-    supply: 1500
-  - type: Transform
-    anchored: true
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
@@ -48,13 +56,47 @@
         !type:DamageTrigger
         damage: 100
       behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:ChangeConstructionNodeBehavior
+        node: solarpanel_broken
       - !type:DoActsBehavior
         acts: ["Breakage"]
-  - type: Anchorable
-  - type: Pullable
   - type: Construction
     graph: solarpanel
     node: solarpanel
+
+- type: entity
+  id: SolarPanelBroken
+  parent: SolarPanelBasePhysSprite
+  name: solar panel
+  suffix: Broken
+  components:
+  - type: Sprite
+    state: broken
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlass:
+            min: 1
+            max: 2
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Construction
+    graph: solarpanel
+    node: solarpanel_broken
 
 - type: entity
   id: SolarAssembly
@@ -69,7 +111,8 @@
     bodyType: Static
     fixtures:
     - shape:
-        !type:PhysShapeAabb {}
+        !type:PhysShapeCircle
+        radius: 0.25
       mass: 75
       mask:
       - VaultImpassable

--- a/Resources/Prototypes/Recipes/Construction/Graphs/solarpanel.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/solarpanel.yml
@@ -59,6 +59,8 @@
       edges:
         - to: solarassembly
           completed:
+            - !type:SnapToGrid
+              southRotation: true
             - !type:SpawnPrototype
               prototype: SheetGlass1
               amount: 2
@@ -68,12 +70,31 @@
           steps:
             - tool: Prying
               doAfter: 0.5
-            
+
+    - node: solarpanel_broken
+      entity: SolarPanelBroken
+      edges:
+        - to: solarassembly
+          completed:
+            - !type:SnapToGrid
+              southRotation: true
+            - !type:SpawnPrototype
+              prototype: ShardGlass
+              amount: 2
+          conditions:
+            - !type:EntityAnchored
+              anchored: true
+          steps:
+            - tool: Prying
+              doAfter: 0.5
+
     - node: solartracker
       entity: SolarTracker
       edges:
         - to: solarassembly
           completed:
+            - !type:SnapToGrid
+              southRotation: true
             - !type:SpawnPrototype
               prototype: SheetGlass1
               amount: 2


### PR DESCRIPTION
## About the PR

Construction graphs 1, IBreakAct 0.

More or less see changelog.

**Changelog**

:cl:
- tweak: Broken solar panels now spit out shards when deconstructed.
- fix: Solar assemblies are now de-rotated when deconstructing.
