### PR TITLE
Fix thermoregulation + rebalance/refactor FlammableComponent

### DIFF
--- a/Content.Server/Atmos/Components/FlammableComponent.cs
+++ b/Content.Server/Atmos/Components/FlammableComponent.cs
@@ -31,5 +31,9 @@ namespace Content.Server.Atmos.Components
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("canResistFire")]
         public bool CanResistFire { get; private set; } = false;
+
+        [DataField("damage", required: true)]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public DamageSpecifier Damage = default!;
     }
 }

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Content.Server.Alert;
 using Content.Server.Atmos.Components;
 using Content.Server.Stunnable;
@@ -25,16 +26,23 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
         [Dependency] private readonly StunSystem _stunSystem = default!;
         [Dependency] private readonly TemperatureSystem _temperatureSystem = default!;
+        [Dependency] private readonly DamageableSystem _damageableSystem = default!;
 
         private const float MinimumFireStacks = -10f;
         private const float MaximumFireStacks = 20f;
         private const float UpdateTime = 1f;
 
+        private const float MinIgnitionTemperature = 373.15f;
+
         private float _timer = 0f;
+
+        private Dictionary<FlammableComponent, float> _fireEvents = new();
 
         // TODO: Port the rest of Flammable.
         public override void Initialize()
         {
+            UpdatesAfter.Add(typeof(AtmosphereSystem));
+
             SubscribeLocalEvent<FlammableComponent, InteractUsingEvent>(OnInteractUsingEvent);
             SubscribeLocalEvent<FlammableComponent, StartCollideEvent>(OnCollideEvent);
             SubscribeLocalEvent<FlammableComponent, IsHotEvent>(OnIsHotEvent);
@@ -94,8 +102,13 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnTileFireEvent(EntityUid uid, FlammableComponent flammable, TileFireEvent args)
         {
-            AdjustFireStacks(uid, 3, flammable);
-            Ignite(uid, flammable);
+            var tempDelta = args.Temperature - MinIgnitionTemperature;
+
+            var maxTemp = 0f;
+            _fireEvents.TryGetValue(flammable, out maxTemp);
+
+            if (tempDelta > maxTemp)
+                _fireEvents[flammable] = tempDelta;
         }
 
         public void UpdateAppearance(EntityUid uid, FlammableComponent? flammable = null, AppearanceComponent? appearance = null)
@@ -168,13 +181,28 @@ namespace Content.Server.Atmos.EntitySystems
             flammable.Owner.SpawnTimer(2000, () =>
             {
                 flammable.Resisting = false;
-                flammable.FireStacks -= 3f;
+                flammable.FireStacks -= 1f;
                 UpdateAppearance(uid, flammable);
             });
         }
 
         public override void Update(float frameTime)
         {
+            // process all fire events
+            foreach (var flammable in _fireEvents.Keys)
+            {
+                var deltaTemp = _fireEvents[flammable];
+                // 100 -> 1, 200 -> 2, 400 -> 3...
+                var fireStackMod = Math.Max(MathF.Log2(deltaTemp / 100) + 1, 0);
+                var fireStackDelta = fireStackMod - flammable.FireStacks;
+                if (fireStackDelta > 0)
+                {
+                    AdjustFireStacks(flammable.OwnerUid, fireStackDelta, flammable);
+                }
+                Ignite(flammable.OwnerUid, flammable);
+            }
+            _fireEvents.Clear();
+
             _timer += frameTime;
 
             if (_timer < UpdateTime)
@@ -205,7 +233,11 @@ namespace Content.Server.Atmos.EntitySystems
 
                 if (flammable.FireStacks > 0)
                 {
-                    _temperatureSystem.ChangeHeat(uid, 80000 * flammable.FireStacks);
+                    // TODO FLAMMABLE: further balancing
+                    var damageScale = Math.Min((int)flammable.FireStacks, 5);
+                    _temperatureSystem.ChangeHeat(uid, 12500 * damageScale);
+                    _damageableSystem.TryChangeDamage(uid, flammable.Damage * damageScale);
+
                     AdjustFireStacks(uid, -0.1f * (flammable.Resisting ? 10f : 1f), flammable);
                 }
                 else

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -189,9 +189,8 @@ namespace Content.Server.Atmos.EntitySystems
         public override void Update(float frameTime)
         {
             // process all fire events
-            foreach (var flammable in _fireEvents.Keys)
+            foreach (var (flammable, deltaTemp) in _fireEvents)
             {
-                var deltaTemp = _fireEvents[flammable];
                 // 100 -> 1, 200 -> 2, 400 -> 3...
                 var fireStackMod = Math.Max(MathF.Log2(deltaTemp / 100) + 1, 0);
                 var fireStackDelta = fireStackMod - flammable.FireStacks;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -63,6 +63,9 @@
   - type: Flammable
     fireSpread: true
     canResistFire: true
+    damage:
+      types:
+        Heat: 1 #per second, scales with number of fire 'stacks'
   - type: Temperature
     heatDamageThreshold: 360
     coldDamageThreshold: 260

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -173,6 +173,9 @@
   - type: Flammable
     fireSpread: true
     canResistFire: true
+    damage:
+      types:
+        Heat: 1 #per second, scales with number of fire 'stacks'
   - type: Temperature
     heatDamageThreshold: 360
     coldDamageThreshold: 260


### PR DESCRIPTION
## About the PR
Fixes thermoregulation by sweating in RespiratorComponent, removes messages
Changes FlammableSystem considerably
Firestacks are now batch-processed per FlammableSystem update, taking the maximum temperature per intersected hotspot
Firestacks are applied based on a logarithmic scale according to the hotspot temperature above a flammability threshold (currently 100°C, 1 firestack at 200°C)
Fire damage and heat applied was rebalanced and capped at 5 firestacks
Stop drop & roll now removes 1 firestack

**Changelog**
:cl:
- fix: Fixed thermoregulation by sweating.
- tweak: Rebalanced fire damage.
