### PR TITLE
Allow players to stand on medical scanners and cloning pods as they exit

### DIFF
--- a/Content.Server/Climbing/ClimbSystem.cs
+++ b/Content.Server/Climbing/ClimbSystem.cs
@@ -27,6 +27,14 @@ namespace Content.Server.Climbing
             SubscribeLocalEvent<ClimbableComponent, GetAlternativeVerbsEvent>(AddClimbVerb);
         }
 
+        public void ForciblySetClimbing(EntityUid uid, ClimbingComponent? component = null)
+        {
+            if (!Resolve(uid, ref component, false))
+                return;
+            component.IsClimbing = true;
+            UnsetTransitionBoolAfterBufferTime(uid, component);
+        }
+
         private void AddClimbVerb(EntityUid uid, ClimbableComponent component, GetAlternativeVerbsEvent args)
         {
             if (!args.CanAccess || !args.CanInteract || !_actionBlockerSystem.CanMove(args.User.Uid))
@@ -53,6 +61,17 @@ namespace Content.Server.Climbing
         public void RemoveActiveClimber(ClimbingComponent climbingComponent)
         {
             _activeClimbers.Remove(climbingComponent);
+        }
+
+        public void UnsetTransitionBoolAfterBufferTime(EntityUid uid, ClimbingComponent? component = null)
+        {
+            if (!Resolve(uid, ref component, false))
+                return;
+            component.Owner.SpawnTimer((int) (SharedClimbingComponent.BufferTime * 1000), () =>
+            {
+                if (component.Deleted) return;
+                component.OwnerIsTransitioning = false;
+            });
         }
 
         public override void Update(float frameTime)

--- a/Content.Server/Climbing/Components/ClimbingComponent.cs
+++ b/Content.Server/Climbing/Components/ClimbingComponent.cs
@@ -85,11 +85,7 @@ namespace Content.Server.Climbing.Components
             Body.ApplyLinearImpulse((to - from).Normalized * velocity * Body.Mass * 5);
             OwnerIsTransitioning = true;
 
-            Owner.SpawnTimer((int) (BufferTime * 1000), () =>
-            {
-                if (Deleted) return;
-                OwnerIsTransitioning = false;
-            });
+            EntitySystem.Get<ClimbSystem>().UnsetTransitionBoolAfterBufferTime(OwnerUid, this);
         }
 
         public void Update()

--- a/Content.Server/Cloning/Components/CloningPodComponent.cs
+++ b/Content.Server/Cloning/Components/CloningPodComponent.cs
@@ -1,5 +1,6 @@
 using System;
 using Content.Server.EUI;
+using Content.Server.Climbing;
 using Content.Server.Mind.Components;
 using Content.Server.Power.Components;
 using Content.Server.UserInterface;
@@ -175,6 +176,7 @@ namespace Content.Server.Cloning.Components
             CapturedMind = null;
             CloningProgress = 0f;
             UpdateStatus(CloningPodStatus.Idle);
+            EntitySystem.Get<ClimbSystem>().ForciblySetClimbing(entity.Uid);
         }
 
         public void UpdateStatus(CloningPodStatus status)

--- a/Content.Server/Medical/Components/MedicalScannerComponent.cs
+++ b/Content.Server/Medical/Components/MedicalScannerComponent.cs
@@ -1,4 +1,5 @@
 using System;
+using Content.Server.Climbing;
 using Content.Server.Cloning;
 using Content.Server.Mind.Components;
 using Content.Server.Power.Components;
@@ -34,7 +35,6 @@ namespace Content.Server.Medical.Components
         public TimeSpan LastInternalOpenAttempt;
 
         private ContainerSlot _bodyContainer = default!;
-        private readonly Vector2 _ejectOffset = new(0f, 0f);
 
         [ViewVariables]
         private bool Powered => !Owner.TryGetComponent(out ApcPowerReceiverComponent? receiver) || receiver.Powered;
@@ -177,9 +177,9 @@ namespace Content.Server.Medical.Components
             var containedEntity = _bodyContainer.ContainedEntity;
             if (containedEntity == null) return;
             _bodyContainer.Remove(containedEntity);
-            containedEntity.Transform.WorldPosition += _ejectOffset;
             UpdateUserInterface();
             UpdateAppearance();
+            EntitySystem.Get<ClimbSystem>().ForciblySetClimbing(containedEntity.Uid);
         }
 
         public void Update(float frameTime)

--- a/Content.Shared/Climbing/SharedClimbingComponent.cs
+++ b/Content.Shared/Climbing/SharedClimbingComponent.cs
@@ -58,7 +58,7 @@ namespace Content.Shared.Climbing
         /// <summary>
         ///     We'll launch the mob onto the table and give them at least this amount of time to be on it.
         /// </summary>
-        protected const float BufferTime = 0.3f;
+        public const float BufferTime = 0.3f;
 
         public virtual bool IsClimbing
         {

--- a/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
@@ -14,6 +14,18 @@
       map: ["enum.MedicalScannerVisualLayers.Machine"]
     - state: idle_unlit
       map: ["enum.MedicalScannerVisualLayers.Terminal"]
+  - type: Physics
+    bodyType: Static
+    fixtures:
+    - shape:
+        !type:PhysShapeAabb
+          bounds: "-0.25,-0.5,0.25,0.5"
+      mass: 25
+      layer:
+      - SmallImpassable
+      - Opaque
+      mask:
+      - MobMask
   - type: Construction
     graph: machine
     node: machine


### PR DESCRIPTION
## About the PR

This is being done because people kept getting sent into walls and "unwrench the medical scanner" has become medical standard procedure at this point.
This is handled via climbing, because frankly the functionality is close enough to be a duplicate otherwise.

**Changelog**

:cl:
- fix: Medical scanners and cloning pods will now not push you into walls.
