### PR TITLE
Entity menu tweaks

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuPresenterGrouping.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuPresenterGrouping.cs
@@ -20,7 +20,7 @@ namespace Content.Client.ContextMenu.UI
         {
             if (GroupingContextMenuType == 0)
             {
-                var newEntities = entities.GroupBy(e => e, new PrototypeContextMenuComparer()).ToList();
+                var newEntities = entities.GroupBy(e => e.Name + (e.Prototype?.ID ?? string.Empty)).ToList();
                 return newEntities.Select(grp => grp.ToList()).ToList();
             }
             else
@@ -78,43 +78,6 @@ namespace Content.Client.ContextMenu.UI
             public int GetHashCode(IEntity e)
             {
                 return GetHashCodeList[_depth](e);
-            }
-        }
-
-        private sealed class PrototypeContextMenuComparer : IEqualityComparer<IEntity>
-        {
-            public bool Equals(IEntity? x, IEntity? y)
-            {
-                if (x == null)
-                {
-                    return y == null;
-                }
-                if (y != null)
-                {
-                    if (x.Prototype?.ID == y.Prototype?.ID)
-                    {
-                        var xStates = x.GetComponent<ISpriteComponent>().AllLayers.Where(e => e.Visible).Select(s => s.RsiState.Name);
-                        var yStates = y.GetComponent<ISpriteComponent>().AllLayers.Where(e => e.Visible).Select(s => s.RsiState.Name);
-
-                        return xStates.OrderBy(t => t).SequenceEqual(yStates.OrderBy(t => t));
-                    }
-                }
-                return false;
-            }
-
-            public int GetHashCode(IEntity e)
-            {
-                var hash = EqualityComparer<string>.Default.GetHashCode(e.Prototype?.ID!);
-
-                if (e.TryGetComponent<ISpriteComponent>(out var sprite))
-                {
-                    foreach (var element in sprite.AllLayers.Where(obj => obj.Visible).Select(s => s.RsiState.Name))
-                    {
-                        hash ^= EqualityComparer<string>.Default.GetHashCode(element!);
-                    }
-                }
-
-                return hash;
             }
         }
     }

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -32,7 +32,7 @@ namespace Content.Client.Verbs
         /// <summary>
         ///     When a user right clicks somewhere, how large is the box we use to get entities for the context menu?
         /// </summary>
-        public const float EntityMenuLookupSize = 1f;
+        public const float EntityMenuLookupSize = 0.2f;
 
         public EntityMenuPresenter EntityMenu = default!;
         public VerbMenuPresenter VerbMenu = default!;
@@ -100,9 +100,7 @@ namespace Content.Client.Verbs
                 return false;
 
             // Get entities
-            var entities = _entityLookup.GetEntitiesIntersecting(
-                    targetPos.MapId,
-                    Box2.CenteredAround(targetPos.Position, (EntityMenuLookupSize, EntityMenuLookupSize)))
+            var entities = _entityLookup.GetEntitiesInRange(targetPos.MapId, targetPos.Position, EntityMenuLookupSize)
                 .ToList();
 
             if (entities.Count == 0)

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -32,7 +32,7 @@ namespace Content.Client.Verbs
         /// <summary>
         ///     When a user right clicks somewhere, how large is the box we use to get entities for the context menu?
         /// </summary>
-        public const float EntityMenuLookupSize = 0.2f;
+        public const float EntityMenuLookupSize = 0.25f;
 
         public EntityMenuPresenter EntityMenu = default!;
         public VerbMenuPresenter VerbMenu = default!;


### PR DESCRIPTION
This PR tweaks the entity menu's entity lookup area and changes how the entities are grouped in the menu.

## Lookup area
Currently the entity menu uses a 1x1 box and would include any entities that clipped that box. IMO this usually leads to many entities appearing on the menu that the user does not want to interact with. This is particularly bad on some tables where there are many entities in close proximity, and this just generally makes the menu more tedious to use.

This PR just changes the lookup to use a just get the entities in a 0.25 unit radius around the clicked location. I think this lookup size is a good balance between not including too many entities and not making it too hard for users to click on moving entities.

Maybe the radius should just be an option or a cvar?

## Grouping too much
Currently the entity menu groups entities if they have the same prototype ID and the same sprite RSI state name.

This leads to an issue (reported by "ga" on discord) where some entities would be grouped in a way that is potentially confusing. For example, the seed extractor spawns `BaseSeed` prototypes, and each seed's sprite has the 'seed' RSI state name, leading to grouping like this:
![bad grouping](https://user-images.githubusercontent.com/60421075/142711825-56ea4683-74c2-4c74-8aca-4068c5e8b1a3.png)

This is just fixed by making the grouping also consider the entity name in addition to the prototype ID. 

## Not grouping enough

Because the RSI state name is included when deciding whether to group entities, this means that some entities are not grouped, when I believe they should be. This usually comes up when trying to interact with some item near windows or wires, e.g:
![too_little_grouping](https://user-images.githubusercontent.com/60421075/142712222-0060e6b7-1823-448f-ad12-3caa29531516.png)

This if fixed by just not considering the sprite during the initial grouping. I think the name & prototype check should be sufficient. The above example is now grouped like:
![better_grouping](https://user-images.githubusercontent.com/60421075/142712296-aa0f98e0-670a-41b3-90a9-38cecd81c3ed.png)


:cl:
- tweak: Tweaked right-click entity menu. The entity lookup range is smaller and the entity grouping has been changed.