### PR TITLE
Restrict examine/context-menu usage when incapacitated.

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuPresenter.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuPresenter.cs
@@ -46,6 +46,7 @@ namespace Content.Client.ContextMenu.UI
         [Dependency] private readonly IEyeManager _eyeManager = default!;
 
         private readonly VerbSystem _verbSystem;
+        private readonly ExamineSystem _examineSystem;
 
         /// <summary>
         ///     This maps the currently displayed entities to the actual GUI elements.
@@ -60,6 +61,7 @@ namespace Content.Client.ContextMenu.UI
             IoCManager.InjectDependencies(this);
 
             _verbSystem = verbSystem;
+            _examineSystem = EntitySystem.Get<ExamineSystem>();
 
             _cfg.OnValueChanged(CCVars.EntityMenuGroupingType, OnGroupingChanged, true);
 
@@ -157,10 +159,9 @@ namespace Content.Client.ContextMenu.UI
 
             var coords = args.Coordinates.ToMap(_entityManager);
 
-            if (!_verbSystem.TryGetEntityMenuEntities(coords, out var entities))
-                return false;
+            if (_verbSystem.TryGetEntityMenuEntities(coords, out var entities))
+                OpenRootMenu(entities);
 
-            OpenRootMenu(entities);
             return true;
         }
 
@@ -183,7 +184,7 @@ namespace Content.Client.ContextMenu.UI
 
             foreach (var entity in Elements.Keys.ToList())
             {
-                if (entity.Deleted || !ignoreFov && !player.InRangeUnOccluded(entity))
+                if (entity.Deleted || !ignoreFov && !_examineSystem.CanExamine(player, entity))
                     RemoveEntity(entity);
             }
         }

--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Input;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
@@ -28,6 +29,7 @@ namespace Content.Client.Examine
     {
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
+        [Dependency] private readonly IEyeManager _eyeManager = default!;
 
         public const string StyleClassEntityTooltip = "entity-tooltip";
 
@@ -52,23 +54,23 @@ namespace Content.Client.Examine
             if (_examineTooltipOpen == null || !_examineTooltipOpen.Visible) return;
             if (_examinedEntity == null || _playerEntity == null) return;
 
-            Ignored predicate = entity => entity == _playerEntity || entity == _examinedEntity;
-
-            if (_playerEntity.TryGetContainer(out var container))
-            {
-                predicate += entity => entity == container.Owner;
-            }
-
-            if (!InRangeUnOccluded(_playerEntity, _examinedEntity, ExamineRange, predicate))
-            {
+            if (!CanExamine(_playerEntity, _examinedEntity))
                 CloseTooltip();
-            }
         }
 
         public override void Shutdown()
         {
             CommandBinds.Unregister<ExamineSystem>();
             base.Shutdown();
+        }
+
+        public override bool CanExamine(IEntity examiner, MapCoordinates target, Ignored? predicate = null)
+        {
+            var b = _eyeManager.GetWorldViewbounds();
+            if (!b.Contains(target.Position))
+                return false;
+
+            return base.CanExamine(examiner, target, predicate);
         }
 
         private bool HandleExamine(ICommonSession? session, EntityCoordinates coords, EntityUid uid)

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -10,6 +10,7 @@ using Content.Client.Viewport;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Interaction.Helpers;
+using Content.Shared.MobState.Components;
 using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
@@ -99,24 +100,20 @@ namespace Content.Client.Verbs
             if (player == null)
                 return false;
 
+            // If FOV drawing is disabled, we will modify the visibility option to ignore visiblity checks.
             var visibility = _eyeManager.CurrentEye.DrawFov
                 ? Visibility
                 : Visibility | MenuVisibility.NoFov;
 
-
-            // Check if we have LOS to the clicked-location.
+            // Do we have to do FoV checks?
             if ((visibility & MenuVisibility.NoFov) == 0)
             {
                 var entitiesUnderMouse = gameScreenBase.GetEntitiesUnderPosition(targetPos);
                 Ignored? predicate = e => e == player || entitiesUnderMouse.Contains(e);
-                var range = ExamineSystemShared.ExamineRange;
-
-
+                if (!_examineSystem.CanExamine(player, targetPos, predicate))
+                    return false;
             }
-               !player.InRangeUnOccluded(targetPos, range: ))
-                return false;
-
-           
+                          
             // Get entities
             var entities = _entityLookup.GetEntitiesIntersecting(
                     targetPos.MapId,

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -9,8 +9,6 @@ using Content.Client.Verbs.UI;
 using Content.Client.Viewport;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
-using Content.Shared.Interaction.Helpers;
-using Content.Shared.MobState.Components;
 using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;


### PR DESCRIPTION
This PR limits the ability to use the examine-popup or the context menu to examine your surroundings while incapacitated by restricting it to just the visible part of the world (fixes #4097). As @mirrorcult mentioned, maybe incapacitated players should just not be allowed to use those tools at all? I could just change the incapacitated checks around to completely disable them if preferred.

This PR also prevents examine/context usage for entities outside of the player's `WorldViewbounds`. This was done in an **attempt** address #4651, but it doesn't actually work as the black bars are part of the view-bounds.

requires space-wizards/RobustToolbox/pull/2248

:cl:
- fix: You can no longer inspecting your surroundings using the examine popup or context menu while incapacitated
