### PR TITLE
Fixes ActivateItemInWorld working with things outside your container

### DIFF
--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -184,6 +184,9 @@ namespace Content.Server.Interaction
             if (!EntityManager.TryGetEntity(uid, out var used))
                 return false;
 
+            if (user.IsInContainer())
+                return false;
+
             InteractionActivate(user, used);
             return true;
         }

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -15,6 +15,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Map;
+using Robust.Shared.Containers;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Random;
@@ -445,6 +446,9 @@ namespace Content.Shared.Interaction
             }
 
             if (!_actionBlockerSystem.CanInteract(user.Uid) || !_actionBlockerSystem.CanUse(user.Uid))
+                return;
+
+            if (user.IsInContainer())
                 return;
 
             // all activates should only fire when in range / unobstructed

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -15,7 +15,6 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Map;
-using Robust.Shared.Containers;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics;
 using Robust.Shared.Random;
@@ -446,9 +445,6 @@ namespace Content.Shared.Interaction
             }
 
             if (!_actionBlockerSystem.CanInteract(user.Uid) || !_actionBlockerSystem.CanUse(user.Uid))
-                return;
-
-            if (user.IsInContainer())
                 return;
 
             // all activates should only fire when in range / unobstructed


### PR DESCRIPTION
## About the PR 
Fixes #505

**Changelog**
:cl:
- fix: You can no longer use the E key to interact with things outside lockers/crates while inside one.

