### PR TITLE
Docked airlocks no longer depressurize the room when opened.

### DIFF
--- a/Content.Server/Doors/Components/ServerDoorComponent.cs
+++ b/Content.Server/Doors/Components/ServerDoorComponent.cs
@@ -55,6 +55,9 @@ namespace Content.Server.Doors.Components
         [ViewVariables(VVAccess.ReadWrite)]
         public DamageSpecifier CrushDamage = default!;
 
+        [DataField("changeAirtight")]
+        public bool ChangeAirtight = true;
+
         public override DoorState State
         {
             get => base.State;
@@ -366,7 +369,7 @@ namespace Content.Server.Doors.Components
                 occluder.Enabled = false;
             }
 
-            if (Owner.TryGetComponent(out AirtightComponent? airtight))
+            if (ChangeAirtight && Owner.TryGetComponent(out AirtightComponent? airtight))
             {
                 EntitySystem.Get<AirtightSystem>().SetAirblocked(airtight, false);
             }
@@ -394,7 +397,7 @@ namespace Content.Server.Doors.Components
         {
             base.OnPartialOpen();
 
-            if (Owner.TryGetComponent(out AirtightComponent? airtight))
+            if (ChangeAirtight && Owner.TryGetComponent(out AirtightComponent? airtight))
             {
                 EntitySystem.Get<AirtightSystem>().SetAirblocked(airtight, false);
             }
@@ -537,7 +540,7 @@ namespace Content.Server.Doors.Components
             base.OnPartialClose();
 
             // if safety is off, crushes people inside of the door, temporarily turning off collisions with them while doing so.
-            var becomeairtight = SafetyCheck() || !TryCrush();
+            var becomeairtight = ChangeAirtight && (SafetyCheck() || !TryCrush());
 
             if (becomeairtight && Owner.TryGetComponent(out AirtightComponent? airtight))
             {

--- a/Content.Server/Shuttles/EntitySystems/DockingSystem.cs
+++ b/Content.Server/Shuttles/EntitySystems/DockingSystem.cs
@@ -1,3 +1,5 @@
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Doors.Components;
 using Content.Server.Power.Components;
 using Content.Server.Shuttles.Components;
@@ -21,6 +23,7 @@ namespace Content.Server.Shuttles.EntitySystems
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly SharedBroadphaseSystem _broadphaseSystem = default!;
         [Dependency] private readonly SharedJointSystem _jointSystem = default!;
+        [Dependency] private readonly AirtightSystem _airtightSystem = default!;
 
         private const string DockingFixture = "docking";
         private const string DockingJoint = "docking";
@@ -346,11 +349,13 @@ namespace Content.Server.Shuttles.EntitySystems
 
             if (EntityManager.TryGetComponent(dockA.OwnerUid, out ServerDoorComponent? doorA))
             {
+                doorA.ChangeAirtight = false;
                 doorA.Open();
             }
 
             if (EntityManager.TryGetComponent(dockB.OwnerUid, out ServerDoorComponent? doorB))
             {
+                doorB.ChangeAirtight = false;
                 doorB.Open();
             }
 
@@ -425,11 +430,13 @@ namespace Content.Server.Shuttles.EntitySystems
 
             if (EntityManager.TryGetComponent(dock.OwnerUid, out ServerDoorComponent? doorA))
             {
+                doorA.ChangeAirtight = true;
                 doorA.Close();
             }
 
             if (EntityManager.TryGetComponent(dock.DockedWith.OwnerUid, out ServerDoorComponent? doorB))
             {
+                doorB.ChangeAirtight = true;
                 doorB.Close();
             }
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -67,6 +67,8 @@
   #    type: WiresBoundUserInterface
   - type: Airtight
     fixVacuum: true
+    airBlockedDirection:
+      - South
   - type: Occluder
   - type: Damageable
     damageContainer: Inorganic


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
**NOTE: This is NOT cross-grid atmos.**
Docked airlocks no longer change their airtight status when opened/closed, making it so opening a docked airlock no longer depressurizes anything. When undocked though, they work the same as any other airlock.
This is a temporary workaround until I work on cross-grid atmosphere (which is gonna be a VERY big undertaking...)

**Screenshots**
![image](https://user-images.githubusercontent.com/6766154/142761034-37edba09-b771-43e3-8fde-f7ba583fba8c.png)
As you can see, the docked airlocks have their blocked airflow direction set so the station/shuttle doesn't depressurize.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Opening a docked airlock no longer depressurizes the room/shuttle.
