### PR TITLE
Fix Livestock crate error.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -515,6 +515,9 @@
   name: livestock crate
   parent: CrateGeneric
   components:
+  - type: EntityStorage
+    Capacity: 500
+    CanWeldShut: false
   - type: Sprite
     sprite: Structures/Storage/Crates/livestock.rsi
     layers:


### PR DESCRIPTION
Currently spawning in a livestock crate raises a client-side error because the crate can be welded shut, but has no corresponding welded sprite. This just makes them non-weldable. 

:cl:
- tweak: Livestock crates can no longer be welded shut. You can't weld wood.

