### PR TITLE
Fix antag shitcurity

### DIFF
--- a/Content.Server/GameTicking/Presets/PresetTraitor.cs
+++ b/Content.Server/GameTicking/Presets/PresetTraitor.cs
@@ -8,6 +8,7 @@ using Content.Server.Items;
 using Content.Server.Objectives.Interfaces;
 using Content.Server.PDA;
 using Content.Server.Players;
+using Content.Server.Roles;
 using Content.Server.Traitor;
 using Content.Server.Traitor.Uplink;
 using Content.Server.Traitor.Uplink.Account;
@@ -72,7 +73,10 @@ namespace Content.Server.GameTicking.Presets
                 return false;
             }
 
-            var list = new List<IPlayerSession>(readyPlayers);
+            var list = new List<IPlayerSession>(readyPlayers).Where(x =>
+                x.Data.ContentData()?.Mind?.AllRoles.All(role => role is not Job {CanBeAntag: false}) ?? false
+            );
+
             var prefList = new List<IPlayerSession>();
 
             foreach (var player in list)

--- a/Content.Server/GameTicking/Presets/PresetTraitor.cs
+++ b/Content.Server/GameTicking/Presets/PresetTraitor.cs
@@ -75,7 +75,7 @@ namespace Content.Server.GameTicking.Presets
 
             var list = new List<IPlayerSession>(readyPlayers).Where(x =>
                 x.Data.ContentData()?.Mind?.AllRoles.All(role => role is not Job {CanBeAntag: false}) ?? false
-            );
+            ).ToList();
 
             var prefList = new List<IPlayerSession>();
 

--- a/Content.Server/Roles/Job.cs
+++ b/Content.Server/Roles/Job.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Roles
 
         public string? StartingGear => Prototype.StartingGear;
 
-        public bool CanBeAntag = true;
+        public bool CanBeAntag;
 
         public Job(Mind.Mind mind, JobPrototype jobPrototype) : base(mind)
         {

--- a/Content.Server/Roles/Job.cs
+++ b/Content.Server/Roles/Job.cs
@@ -14,10 +14,13 @@ namespace Content.Server.Roles
 
         public string? StartingGear => Prototype.StartingGear;
 
+        public bool CanBeAntag = true;
+
         public Job(Mind.Mind mind, JobPrototype jobPrototype) : base(mind)
         {
             Prototype = jobPrototype;
             Name = jobPrototype.Name;
+            CanBeAntag = jobPrototype.CanBeAntag;
         }
 
         public override void Greet()

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -34,7 +34,7 @@ namespace Content.Shared.Roles
         public bool RequireAdminNotify { get; } = false;
 
         [DataField("canBeAntag")]
-        public bool CanBeAntag { get; } = false;
+        public bool CanBeAntag { get; } = true;
 
         /// <summary>
         ///     Whether this job is a head.

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -33,6 +33,9 @@ namespace Content.Shared.Roles
         [DataField("requireAdminNotify")]
         public bool RequireAdminNotify { get; } = false;
 
+        [DataField("canBeAntag")]
+        public bool CanBeAntag { get; } = false;
+
         /// <summary>
         ///     Whether this job is a head.
         ///     The job system will try to pick heads before other jobs on the same priority level.

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -10,6 +10,7 @@
   requireAdminNotify: true
   joinNotifyCrew: true
   supervisors: "Nanotrasen officials"
+  canBeAntag: false
   access:
   # All of em.
   # Could probably do with some kind of wildcard or whatever to automate this.

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -9,6 +9,7 @@
   icon: "HeadOfPersonnel"
   requireAdminNotify: true
   supervisors: "the captain"
+  canBeAntag: false
   access:
   - Command
   - HeadOfPersonnel

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -10,6 +10,7 @@
   icon: "ChiefEngineer"
   requireAdminNotify: true
   supervisors: "the captain"
+  canBeAntag: false
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -12,6 +12,7 @@
   icon: "ChiefMedicalOfficer"
   requireAdminNotify: true
   supervisors: "the captain"
+  canBeAntag: false
   access:
   - Medical
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -10,6 +10,7 @@
   icon: "ResearchDirector"
   requireAdminNotify: true
   supervisors: "the captain"
+  canBeAntag: false
   access:
   - Research
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -10,6 +10,7 @@
   icon: "HeadOfSecurity"
   requireAdminNotify: true
   supervisors: "the captain"
+  canBeAntag: false
   access:
   - Command
   - Brig

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -8,6 +8,7 @@
   - Security
   icon: "SecurityOfficer"
   supervisors: "the head of security"
+  canBeAntag: false
   access:
   - Security
   - Maintenance


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Simply banned security from being an antagonist.

:cl: moony
- add: Security, Captain, Head of Personnel, Chief Engineer, Chief Medial Officer, and the Research Director are no longer capable of being antagonists due to expanded NT screening programs. You can now trust your leadership!
