### PR TITLE
Reduce default metabolism rate from 1 to 0.5

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/HealthChange.cs
+++ b/Content.Server/Chemistry/ReagentEffects/HealthChange.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Chemistry.ReagentEffects
 
         public override void Effect(ReagentEffectArgs args)
         {
-            EntitySystem.Get<DamageableSystem>().TryChangeDamage(args.SolutionEntity, Damage * args.Quantity, true);
+            EntitySystem.Get<DamageableSystem>().TryChangeDamage(args.SolutionEntity, Damage, true);
         }
     }
 }

--- a/Content.Server/Chemistry/ReagentEffects/MovespeedModifier.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MovespeedModifier.cs
@@ -48,7 +48,7 @@ namespace Content.Server.Chemistry.ReagentEffects
             status.WalkSpeedModifier = WalkSpeedModifier;
             status.SprintSpeedModifier = SprintSpeedModifier;
 
-            IncreaseTimer(status, StatusLifetime * args.Quantity.Float());
+            IncreaseTimer(status, StatusLifetime);
 
             if (modified)
                 EntitySystem.Get<MovementSpeedModifierSystem>().RefreshMovementSpeedModifiers(args.SolutionEntity);

--- a/Content.Server/Chemistry/ReagentEffects/SatiateThirst.cs
+++ b/Content.Server/Chemistry/ReagentEffects/SatiateThirst.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Chemistry.ReagentEffects
         public override void Effect(ReagentEffectArgs args)
         {
             if (args.EntityManager.TryGetComponent(args.SolutionEntity, out ThirstComponent? thirst))
-                thirst.UpdateThirst(HydrationFactor * (float) args.Quantity);
+                thirst.UpdateThirst(HydrationFactor);
         }
     }
 }

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -132,7 +132,7 @@ namespace Content.Shared.Chemistry.Reagent
         ///     Amount of reagent to metabolize, per metabolism cycle.
         /// </summary>
         [DataField("metabolismRate")]
-        public FixedPoint2 MetabolismRate = FixedPoint2.New(1.0f);
+        public FixedPoint2 MetabolismRate = FixedPoint2.New(0.5f);
 
         /// <summary>
         ///     A list of effects to apply when these reagents are metabolized.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is more in line with SS13 and makes medicines (and poisons) more effective

Everything I've added so far has been balanced around the SS13 metabolism rate which is usually 0.4 to 0.8, so

:cl:
- tweak: Chemicals metabolizing in the body now last twice as long, meaning most medicines and poisons will have a greater effect over a longer timespan.
