### PR TITLE
Fix solution area effect bullshit

### DIFF
--- a/Content.Server/Chemistry/Components/FoamSolutionAreaEffectComponent.cs
+++ b/Content.Server/Chemistry/Components/FoamSolutionAreaEffectComponent.cs
@@ -16,7 +16,7 @@ namespace Content.Server.Chemistry.Components
     public class FoamSolutionAreaEffectComponent : SolutionAreaEffectComponent
     {
         public override string Name => "FoamSolutionAreaEffect";
-        public new const string SolutionName = "foam";
+        public new const string SolutionName = "solutionArea";
 
         [DataField("foamedMetalPrototype")] private string? _foamedMetalPrototype;
 

--- a/Content.Server/Chemistry/Components/SmokeSolutionAreaEffectComponent.cs
+++ b/Content.Server/Chemistry/Components/SmokeSolutionAreaEffectComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Chemistry.Components
     public class SmokeSolutionAreaEffectComponent : SolutionAreaEffectComponent
     {
         public override string Name => "SmokeSolutionAreaEffect";
-        public new const string SolutionName = "smoke";
+        public new const string SolutionName = "solutionArea";
 
         protected override void UpdateVisuals()
         {

--- a/Content.Server/Chemistry/ReactionEffects/AreaReactionEffect.cs
+++ b/Content.Server/Chemistry/ReactionEffects/AreaReactionEffect.cs
@@ -41,16 +41,9 @@ namespace Content.Server.Chemistry.ReactionEffects
         [DataField("diluteReagents")] private bool _diluteReagents;
 
         /// <summary>
-        /// At what range should the reagents volume stay the same. If the effect range is higher than this then the reagents
-        /// will get diluted. If the effect range is lower than this then the reagents will get concentrated.
+        /// Used to calculate dilution. Increasing this makes the reagents more diluted.
         /// </summary>
-        [DataField("reagentDilutionStart")] private int _reagentDilutionStart = 4;
-
-        /// <summary>
-        /// Used to calculate dilution. Increasing this makes the reagents get more diluted. This means that a lower range
-        /// will be needed to make the reagents volume get closer to zero.
-        /// </summary>
-        [DataField("reagentDilutionFactor")] private float _reagentDilutionFactor = 1;
+        [DataField("reagentDilutionFactor")] private float _reagentDilutionFactor = 1f;
 
         /// <summary>
         /// Used to calculate concentration. Reagents get linearly more concentrated as the range goes from
@@ -105,20 +98,10 @@ namespace Content.Server.Chemistry.ReactionEffects
                 // The maximum value of solutionFraction is _reagentMaxConcentrationFactor, achieved when amount = 0
                 // The infimum of solutionFraction is 0, which is approached when amount tends to infinity
                 // solutionFraction is equal to 1 only when amount equals _reagentDilutionStart
-                float solutionFraction;
-                if (amount >= _reagentDilutionStart)
-                {
-                    // Weird formulas here but basically when amount increases, solutionFraction gets closer to 0 in a reciprocal manner
-                    // _reagentDilutionFactor defines how fast solutionFraction gets closer to 0
-                    solutionFraction = 1 / (_reagentDilutionFactor*(amount - _reagentDilutionStart) + 1);
-                }
-                else
-                {
-                    // Here when amount decreases, solutionFraction gets closer to _reagentMaxConcentrationFactor in a linear manner
-                    solutionFraction = amount * (1 - _reagentMaxConcentrationFactor) / _reagentDilutionStart +
-                                       _reagentMaxConcentrationFactor;
-                }
-                splitSolution.RemoveSolution(splitSolution.TotalVolume * solutionFraction);
+                // Weird formulas here but basically when amount increases, solutionFraction gets closer to 0 in a reciprocal manner
+                // _reagentDilutionFactor defines how fast solutionFraction gets closer to 0
+                float solutionFraction = 1 / (_reagentDilutionFactor*(amount) + 1);
+                splitSolution.RemoveSolution(splitSolution.TotalVolume * (1 - solutionFraction));
             }
 
             var transform = args.EntityManager.GetComponent<TransformComponent>(args.SolutionEntity);

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -16,7 +16,7 @@
   - type: SmokeSolutionAreaEffect
   - type: SolutionContainerManager
     solutions:
-      smoke:
+      solutionArea:
         maxVol: 600
 
 - type: entity
@@ -43,7 +43,8 @@
     anchored: true
   - type: Physics
     fixtures:
-    - shape:
+    - hard: false
+      shape:
         !type:PhysShapeAabb
           bounds: "-0.4,-0.4,0.4,0.4"
       layer:
@@ -51,7 +52,7 @@
   - type: FoamSolutionAreaEffect
   - type: SolutionContainerManager
     solutions:
-      foam:
+      solutionArea:
         maxVol: 600
   - type: Slippery
 
@@ -66,6 +67,14 @@
     layers:
     - state: mfoam
       map: ["enum.FoamVisualLayers.Base"]
+  - type: Physics
+    fixtures:
+    - hard: true
+      shape:
+        !type:PhysShapeAabb
+        bounds: "-0.4,-0.4,0.4,0.4"
+      layer:
+      - MobImpassable
   - type: Appearance
     visuals:
     - type: FoamVisualizer
@@ -85,6 +94,14 @@
     layers:
       - state: mfoam
         map: ["enum.FoamVisualLayers.Base"]
+  - type: Physics
+    fixtures:
+    - hard: true
+      shape:
+        !type:PhysShapeAabb
+        bounds: "-0.4,-0.4,0.4,0.4"
+      layer:
+      - MobImpassable
   - type: Appearance
     visuals:
       - type: FoamVisualizer


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

two things here:
- solution refactor did a number on this, neglect made it worse, a bunch of solution names were wrong
- the chem splitting code appears to have never worked so i just used what kind of made sense and dropped the shit that made absolutely no sense

:cl:
- tweak: Foam and smoke now properly carry reagents, and are colored by their reagents.

