### PR TITLE
Pressure & Asphyxiation damage now won't interrupt doafters

### DIFF
--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -103,7 +103,7 @@ namespace Content.Server.Atmos.EntitySystems
                             goto default;
 
                         // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                        _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true);
+                        _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false);
 
                         if (status == null) break;
 
@@ -126,7 +126,7 @@ namespace Content.Server.Atmos.EntitySystems
                         var damageScale = MathF.Min((pressure / Atmospherics.HazardHighPressure) * Atmospherics.PressureDamageCoefficient, Atmospherics.MaxHighPressureDamage);
 
                         // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                        _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true);
+                        _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false);
 
                         if (status == null) break;
 

--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -320,7 +320,7 @@ namespace Content.Server.Body.Components
                 alertsComponent.ShowAlert(AlertType.LowOxygen);
             }
 
-            EntitySystem.Get<DamageableSystem>().TryChangeDamage(Owner.Uid, Damage, true);
+            EntitySystem.Get<DamageableSystem>().TryChangeDamage(Owner.Uid, Damage, true, false);
         }
 
         private void StopSuffocation()

--- a/Content.Server/DoAfter/DoAfterSystem.cs
+++ b/Content.Server/DoAfter/DoAfterSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.DoAfter
 
         public void HandleDamage(EntityUid _, DoAfterComponent component, DamageChangedEvent args)
         {
-            if (component.DoAfters.Count == 0 || !args.DamageIncreased)
+            if (component.DoAfters.Count == 0 || !args.InterruptsDoAfters)
             {
                 return;
             }


### PR DESCRIPTION
## About the PR

@DogZeroX requested this.
My own personal summary would be that (without this PR) you get 'stunlocked' (not actually stunned but prying doafters get interrupted) by vaccums resulting in guaranteed death.

**Changelog**

:cl:
- tweak: You are no longer interrupted by damage during prying a firelock or airlock.
