### PR TITLE
Reaction & reagent effect logging

### DIFF
--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -162,7 +162,7 @@ namespace Content.Server.Body.Systems
 
                         var entity = EntityManager.GetEntity(args.SolutionEntity);
                         _logSystem.Add(LogType.ReagentEffect, LogImpact.Low,
-                            $"Metabolism effect {effect.GetType().Name} of reagent {args.Reagent.Name:reagent} applied on entity {entity}");
+                            $"Metabolism effect {effect.GetType().Name} of reagent {args.Reagent.Name:reagent} applied on entity {entity} at {entity.Transform.Coordinates}");
                         effect.Effect(args);
                     }
                 }

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server.Body.Components;
 using Content.Server.Chemistry.Components.SolutionManager;
 using Content.Server.Chemistry.EntitySystems;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
@@ -20,6 +21,7 @@ namespace Content.Server.Body.Systems
         [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] private readonly SharedAdminLogSystem _logSystem = default!;
 
         public override void Initialize()
         {
@@ -158,6 +160,9 @@ namespace Content.Server.Body.Systems
                         if (!effect.ShouldApply(args, _random))
                             continue;
 
+                        var entity = EntityManager.GetEntity(args.SolutionEntity);
+                        _logSystem.Add(LogType.ReagentEffect, LogImpact.Low,
+                            $"Metabolism effect {effect.GetType().Name} of reagent {args.Reagent.Name:reagent} applied on entity {entity}");
                         effect.Effect(args);
                     }
                 }

--- a/Content.Server/Chemistry/EntitySystems/ChemicalReactionSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemicalReactionSystem.cs
@@ -17,7 +17,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             var entity = EntityManager.GetEntity(ownerUid);
             _logSystem.Add(LogType.ChemicalReaction, reaction.Impact,
-                $"Chemical reaction {reaction.ID} occurred with strength {unitReactions:strength} on entity {entity}");
+                $"Chemical reaction {reaction.ID} occurred with strength {unitReactions:strength} on entity {entity} at {entity.Transform.Coordinates}");
 
             SoundSystem.Play(Filter.Pvs(ownerUid, entityManager:EntityManager), reaction.Sound.GetSound(), ownerUid);
         }

--- a/Content.Server/Chemistry/EntitySystems/ChemicalReactionSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemicalReactionSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Chemistry.Reagent;
@@ -13,6 +14,10 @@ namespace Content.Server.Chemistry.EntitySystems
         protected override void OnReaction(Solution solution, ReactionPrototype reaction, ReagentPrototype randomReagent, EntityUid ownerUid, FixedPoint2 unitReactions)
         {
             base.OnReaction(solution, reaction,  randomReagent, ownerUid, unitReactions);
+
+            var entity = EntityManager.GetEntity(ownerUid);
+            _logSystem.Add(LogType.ChemicalReaction, reaction.Impact,
+                $"Chemical reaction {reaction.ID} occurred with strength {unitReactions:strength} on entity {entity}");
 
             SoundSystem.Play(Filter.Pvs(ownerUid, entityManager:EntityManager), reaction.Sound.GetSound(), ownerUid);
         }

--- a/Content.Shared/Administration/Logs/LogImpact.cs
+++ b/Content.Shared/Administration/Logs/LogImpact.cs
@@ -1,6 +1,10 @@
-﻿namespace Content.Shared.Administration.Logs;
+﻿using System;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Administration.Logs;
 
 // DO NOT CHANGE THE NUMERIC VALUES OF THESE
+[Serializable, NetSerializable]
 public enum LogImpact : sbyte
 {
     Low = -1,

--- a/Content.Shared/Administration/Logs/LogType.cs
+++ b/Content.Shared/Administration/Logs/LogType.cs
@@ -15,4 +15,5 @@ public enum LogType
     ShuttleCalled = 8,
     ShuttleRecalled = 9,
     ChemicalReaction = 17,
+    ReagentEffect = 18,
 }

--- a/Content.Shared/Administration/Logs/LogType.cs
+++ b/Content.Shared/Administration/Logs/LogType.cs
@@ -14,4 +14,5 @@ public enum LogType
     EventStopped = 7,
     ShuttleCalled = 8,
     ShuttleRecalled = 9,
+    ChemicalReaction = 17,
 }

--- a/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Content.Shared.Sound;
@@ -35,6 +36,12 @@ namespace Content.Shared.Chemistry.Reaction
         /// Effects to be triggered when the reaction occurs.
         /// </summary>
         [DataField("effects", serverOnly: true)] public List<ReagentEffect> Effects = new();
+
+        /// <summary>
+        /// How dangerous is this effect? Stuff like bicaridine should be low, while things like methamphetamine
+        /// or potas/water should be high.
+        /// </summary>
+        [DataField("impact", serverOnly: true)] public LogImpact Impact = LogImpact.Low;
 
         // TODO SERV3: Empty on the client, (de)serialize on the server with module manager is server module
         [DataField("sound", serverOnly: true)] public SoundSpecifier Sound { get; private set; } = new SoundPathSpecifier("/Audio/Effects/Chemistry/bubbles.ogg");

--- a/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
@@ -18,6 +19,7 @@ namespace Content.Shared.Chemistry.Reaction
 
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] protected readonly SharedAdminLogSystem _logSystem = default!;
 
         public override void Initialize()
         {

--- a/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
@@ -101,7 +101,7 @@ namespace Content.Shared.Chemistry.Reaction
 
                 var entity = EntityManager.GetEntity(args.SolutionEntity);
                 _logSystem.Add(LogType.ReagentEffect, LogImpact.Low,
-                    $"Reaction effect {effect.GetType().Name} of reaction ${reaction.ID:reaction} applied on entity {entity}");
+                    $"Reaction effect {effect.GetType().Name} of reaction ${reaction.ID:reaction} applied on entity {entity} at {entity.Transform.Coordinates}");
                 effect.Effect(args);
             }
         }

--- a/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
@@ -99,6 +99,9 @@ namespace Content.Shared.Chemistry.Reaction
                 if (!effect.ShouldApply(args))
                     continue;
 
+                var entity = EntityManager.GetEntity(args.SolutionEntity);
+                _logSystem.Add(LogType.ReagentEffect, LogImpact.Low,
+                    $"Reaction effect {effect.GetType().Name} of reaction ${reaction.ID:reaction} applied on entity {entity}");
                 effect.Effect(args);
             }
         }

--- a/Content.Shared/Chemistry/ReactiveSystem.cs
+++ b/Content.Shared/Chemistry/ReactiveSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Chemistry.Reagent;
@@ -15,6 +16,7 @@ namespace Content.Shared.Chemistry
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
+        [Dependency] private readonly SharedAdminLogSystem _logSystem = default!;
 
         public void ReactionEntity(EntityUid uid, ReactionMethod method, Solution solution)
         {
@@ -59,6 +61,9 @@ namespace Content.Shared.Chemistry
                         if (!effect.ShouldApply(args, _robustRandom))
                             continue;
 
+                        var entity = EntityManager.GetEntity(args.SolutionEntity);
+                        _logSystem.Add(LogType.ReagentEffect, LogImpact.Medium,
+                            $"Reactive effect {effect.GetType().Name} of reagent {reagent.ID:reagent} with method {method} applied on entity {entity}");
                         effect.Effect(args);
                     }
                 }
@@ -80,6 +85,9 @@ namespace Content.Shared.Chemistry
                         if (!effect.ShouldApply(args, _robustRandom))
                             continue;
 
+                        var entity = EntityManager.GetEntity(args.SolutionEntity);
+                        _logSystem.Add(LogType.ReagentEffect, LogImpact.Low,
+                            $"Reactive effect {effect.GetType().Name} of {entity} using reagent {reagent.ID} with method {method} applied");
                         effect.Effect(args);
                     }
                 }

--- a/Content.Shared/Chemistry/ReactiveSystem.cs
+++ b/Content.Shared/Chemistry/ReactiveSystem.cs
@@ -63,7 +63,7 @@ namespace Content.Shared.Chemistry
 
                         var entity = EntityManager.GetEntity(args.SolutionEntity);
                         _logSystem.Add(LogType.ReagentEffect, LogImpact.Medium,
-                            $"Reactive effect {effect.GetType().Name} of reagent {reagent.ID:reagent} with method {method} applied on entity {entity}");
+                            $"Reactive effect {effect.GetType().Name} of reagent {reagent.ID:reagent} with method {method} applied on entity {entity} at {entity.Transform.Coordinates}");
                         effect.Effect(args);
                     }
                 }
@@ -87,7 +87,7 @@ namespace Content.Shared.Chemistry
 
                         var entity = EntityManager.GetEntity(args.SolutionEntity);
                         _logSystem.Add(LogType.ReagentEffect, LogImpact.Low,
-                            $"Reactive effect {effect.GetType().Name} of {entity} using reagent {reagent.ID} with method {method} applied");
+                            $"Reactive effect {effect.GetType().Name} of {entity} using reagent {reagent.ID} with method {method} at {entity.Transform.Coordinates}");
                         effect.Effect(args);
                     }
                 }

--- a/Content.Shared/Chemistry/Reagent/ReagentEffect.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentEffect.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -122,7 +122,7 @@ namespace Content.Shared.Chemistry.Reagent
 
                 var entity = entMan.GetEntity(args.SolutionEntity);
                 EntitySystem.Get<SharedAdminLogSystem>().Add(LogType.ReagentEffect, LogImpact.Low,
-                    $"Plant metabolism effect {plantMetabolizable.GetType().Name:effect} of reagent {ID} applied on entity {entity}");
+                    $"Plant metabolism effect {plantMetabolizable.GetType().Name:effect} of reagent {ID} applied on entity {entity} at {entity.Transform.Coordinates}");
                 plantMetabolizable.Effect(args);
             }
         }

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Body.Prototypes;
 using Content.Shared.Botany;
 using Content.Shared.Chemistry.Components;
@@ -119,6 +120,9 @@ namespace Content.Shared.Chemistry.Reagent
                 if (!plantMetabolizable.ShouldApply(args, random))
                     continue;
 
+                var entity = entMan.GetEntity(args.SolutionEntity);
+                EntitySystem.Get<SharedAdminLogSystem>().Add(LogType.ReagentEffect, LogImpact.Low,
+                    $"Plant metabolism effect {plantMetabolizable.GetType().Name:effect} of reagent {ID} applied on entity {entity}");
                 plantMetabolizable.Effect(args);
             }
         }

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -56,6 +56,7 @@
 
 - type: reaction
   id: PotassiumExplosion
+  impact: High
   reactants:
     Water:
       amount: 1
@@ -73,6 +74,7 @@
 
 - type: reaction
   id: Smoke
+  impact: High
   reactants:
     Phosphorus:
       amount: 1
@@ -95,6 +97,7 @@
 
 - type: reaction
   id: Foam
+  impact: High
   reactants:
     Fluorosurfactant:
       amount: 1
@@ -118,6 +121,7 @@
 
 - type: reaction
   id: IronMetalFoam
+  impact: High
   reactants:
     Iron:
       amount: 3
@@ -143,6 +147,7 @@
 
 - type: reaction
   id: AluminiumMetalFoam
+  impact: High
   reactants:
     Aluminium:
       amount: 3
@@ -178,6 +183,7 @@
 
 - type: reaction
   id: Thermite
+  impact: Medium
   reactants:
     Iron:
       amount: 1
@@ -224,6 +230,7 @@
 
 - type: reaction
   id: Fluorosurfactant
+  impact: Medium
   reactants:
     Carbon:
       amount: 2
@@ -236,6 +243,7 @@
 
 - type: reaction
   id: Meth
+  impact: Medium
   reactants:
     Ephedrine:
       amount: 1
@@ -250,6 +258,7 @@
 
 - type: reaction
   id: Ephedrine
+  impact: Medium
   reactants:
     Oil:
       amount: 1

--- a/Resources/Prototypes/Recipes/Reactions/cleaning.yml
+++ b/Resources/Prototypes/Recipes/Reactions/cleaning.yml
@@ -22,6 +22,7 @@
 
 - type: reaction
   id: SpaceLube
+  impact: Medium
   reactants:
     Water:
       amount: 1

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -370,6 +370,7 @@
 
 - type: reaction
   id: Lexorin
+  impact: High
   reactants:
     Ammonia:
       amount: 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reaction proto has a field for log impact

Reagent effects are all low/medium depending on whether they're metabolized/reactive/etc. Doing it any other way is annoying and will leave that for later

![image](https://user-images.githubusercontent.com/19853115/142949389-206ec7b9-9cd3-4243-93ba-a9c11af1699b.png)
![image](https://user-images.githubusercontent.com/19853115/142949396-31086d33-8d76-40f8-8ec0-a29836fd18fa.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Admins are now fully knowledgeable of every potassium/water bomb you make.
