### PR TITLE
Log explosive depressurization.

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.Temperature.Components;
@@ -18,6 +19,7 @@ namespace Content.Server.Atmos.EntitySystems
     public partial class AtmosphereSystem : SharedAtmosphereSystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly AdminLogSystem _adminLog = default!;
 
         private const float ExposedUpdateDelay = 1f;
         private float _exposedTimer = 0f;

--- a/Content.Shared/Administration/Logs/LogType.cs
+++ b/Content.Shared/Administration/Logs/LogType.cs
@@ -15,6 +15,7 @@ public enum LogType
     Verb = 19,
     ShuttleCalled = 8,
     ShuttleRecalled = 9,
+    ExplosiveDepressurization = 10,
     ChemicalReaction = 17,
     ReagentEffect = 18,
 }


### PR DESCRIPTION
Logs explosive depressurizations above 1000~ moles (approx 10 standard roundstart tiles being vented)