### PR TITLE
Refactor slip dropping to use throwing

### DIFF
--- a/Content.Server/Fluids/Components/SpillableComponent.cs
+++ b/Content.Server/Fluids/Components/SpillableComponent.cs
@@ -3,25 +3,13 @@ using Content.Shared.Interaction;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 
-namespace Content.Server.Fluids.Components
+namespace Content.Server.Fluids.Components;
+
+[RegisterComponent]
+public class SpillableComponent : Component
 {
-    [RegisterComponent]
-    public class SpillableComponent : Component, IDropped
-    {
-        public override string Name => "Spillable";
+    public override string Name => "Spillable";
 
-        [DataField("solution")]
-        public string SolutionName = "puddle";
-
-        void IDropped.Dropped(DroppedEventArgs eventArgs)
-        {
-            if (!eventArgs.Intentional
-                && EntitySystem.Get<SolutionContainerSystem>().TryGetSolution(Owner.Uid, SolutionName, out var solutionComponent))
-            {
-                EntitySystem.Get<SolutionContainerSystem>()
-                    .Drain(Owner.Uid, solutionComponent, solutionComponent.DrainAvailable)
-                    .SpillAt(Owner.Transform.Coordinates, "PuddleSmear");
-            }
-        }
-    }
+    [DataField("solution")]
+    public string SolutionName = "puddle";
 }

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -23,7 +23,7 @@ public class SpillableSystem : EntitySystem
         {
             Get<SolutionContainerSystem>()
                 .Drain(uid, solutionComponent, solutionComponent.DrainAvailable)
-                .SpillAt(EntityManager.GetEntity(uid).Transform.Coordinates, "PuddleSmear");
+                .SpillAt(EntityManager.GetComponent<TransformComponent>(uid).Coordinates, "PuddleSmear");
         }
     }
 

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -14,14 +14,16 @@ namespace Content.Server.Fluids.EntitySystems;
 public class SpillableSystem : EntitySystem
 {
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
+
     public override void Initialize() {
         base.Initialize();
         SubscribeLocalEvent<SpillableComponent, LandEvent>(SpillOnLand);
     }
+
     void SpillOnLand(EntityUid uid, SpillableComponent component, LandEvent args) {
-        if (args.User != null && Get<SolutionContainerSystem>().TryGetSolution(uid, component.SolutionName, out var solutionComponent))
+        if (args.User != null && _solutionContainerSystem.TryGetSolution(uid, component.SolutionName, out var solutionComponent))
         {
-            Get<SolutionContainerSystem>()
+            _solutionContainerSystem
                 .Drain(uid, solutionComponent, solutionComponent.DrainAvailable)
                 .SpillAt(EntityManager.GetComponent<TransformComponent>(uid).Coordinates, "PuddleSmear");
         }

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -15,7 +15,8 @@ public class SpillableSystem : EntitySystem
 {
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
 
-    public override void Initialize() {
+    public override void Initialize() 
+    {
         base.Initialize();
         SubscribeLocalEvent<SpillableComponent, LandEvent>(SpillOnLand);
     }

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -1,0 +1,30 @@
+using Content.Server.Chemistry.EntitySystems;
+using Content.Server.Construction.Components;
+using Content.Server.Fluids.Components;
+using Content.Shared.Examine;
+using Content.Shared.Throwing;
+using Content.Shared.Verbs;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+
+namespace Content.Server.Fluids.EntitySystems;
+
+[UsedImplicitly]
+public class SpillableSystem : EntitySystem
+{
+    [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
+    public override void Initialize() {
+        base.Initialize();
+        SubscribeLocalEvent<SpillableComponent, LandEvent>(SpillOnLand);
+    }
+    void SpillOnLand(EntityUid uid, SpillableComponent component, LandEvent args) {
+        if (args.User != null && Get<SolutionContainerSystem>().TryGetSolution(uid, component.SolutionName, out var solutionComponent))
+        {
+            Get<SolutionContainerSystem>()
+                .Drain(uid, solutionComponent, solutionComponent.DrainAvailable)
+                .SpillAt(EntityManager.GetEntity(uid).Transform.Coordinates, "PuddleSmear");
+        }
+    }
+
+}

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -166,18 +166,6 @@ namespace Content.Server.Hands.Systems
             hands.ActivateHeldEntity(msg.HandName);
         }
 
-        protected override void DropAllItemsInHands(IEntity entity, bool doMobChecks = true)
-        {
-            base.DropAllItemsInHands(entity, doMobChecks);
-
-            if (!entity.TryGetComponent(out HandsComponent? hands)) return;
-
-            foreach (var heldItem in hands.GetAllHeldItems())
-            {
-                hands.Drop(heldItem.Owner, doMobChecks, false);
-            }
-        }
-
         //TODO: Actually shows all items/clothing/etc.
         private void HandleExamined(EntityUid uid, HandsComponent component, ExaminedEvent args)
         {

--- a/Content.Server/Standing/StandingStateSystem.cs
+++ b/Content.Server/Standing/StandingStateSystem.cs
@@ -1,0 +1,41 @@
+using Content.Server.Hands.Components;
+using Content.Shared.Standing;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using Robust.Shared.Random;
+
+namespace Content.Server.Standing;
+
+public class StandingStateSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    private void FallOver(EntityUid uid, StandingStateComponent component, DropHandItemsEvent args)
+    {
+        var direction = EntityManager.TryGetComponent(uid, out PhysicsComponent? comp) ? comp.LinearVelocity / 50 : Vector2.Zero;
+        var dropAngle = _random.NextFloat(0.8f, 1.2f);
+
+        if (EntityManager.TryGetComponent(uid, out HandsComponent? hands))
+        {
+            foreach (var heldItem in hands.GetAllHeldItems())
+            {
+                if (hands.Drop(heldItem.Owner))
+                {
+                    Throwing.ThrowHelper.TryThrow(heldItem.Owner,
+                        _random.NextAngle().RotateVec(direction / dropAngle +
+                                                      EntityManager.GetEntity(uid).Transform.WorldRotation.ToVec() / 50),
+                        0.5f * dropAngle * _random.NextFloat(-0.9f, 1.1f),
+                        EntityManager.GetEntity(uid), 0);
+                }
+            }
+        }
+    }
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<StandingStateComponent, DropHandItemsEvent>(FallOver);
+    }
+
+}

--- a/Content.Server/Throwing/ThrowHelper.cs
+++ b/Content.Server/Throwing/ThrowHelper.cs
@@ -33,7 +33,6 @@ namespace Content.Server.Throwing
         internal static void TryThrow(this IEntity entity, Vector2 direction, float strength = 1.0f, IEntity? user = null, float pushbackRatio = 1.0f)
         {
             if (entity.Deleted ||
-                direction == Vector2.Zero ||
                 strength <= 0f ||
                 !entity.TryGetComponent(out PhysicsComponent? physicsComponent))
             {
@@ -61,7 +60,7 @@ namespace Content.Server.Throwing
                 {
                     physicsComponent.ApplyAngularImpulse(ThrowAngularImpulse);
                 }
-                else
+                else if(direction != Vector2.Zero)
                 {
                     entity.Transform.LocalRotation = direction.ToWorldAngle() - Math.PI;
                 }
@@ -79,6 +78,7 @@ namespace Content.Server.Throwing
             if (time < FlyTime)
             {
                 physicsComponent.BodyStatus = BodyStatus.OnGround;
+                EntitySystem.Get<ThrownItemSystem>().LandComponent(comp);
             }
             else
             {

--- a/Content.Shared/Hands/Components/SharedHandsComponent.cs
+++ b/Content.Shared/Hands/Components/SharedHandsComponent.cs
@@ -146,7 +146,7 @@ namespace Content.Shared.Hands.Components
 
         private void RemoveHand(Hand hand)
         {
-            DropHeldEntityToFloor(hand, intentionalDrop: false);
+            DropHeldEntityToFloor(hand);
             hand.Container?.Shutdown();
             Hands.Remove(hand);
 
@@ -306,34 +306,34 @@ namespace Content.Shared.Hands.Components
         /// <summary>
         ///     Tries to drop the contents of the active hand to the target location.
         /// </summary>
-        public bool TryDropActiveHand(EntityCoordinates targetDropLocation, bool doMobChecks = true, bool intentional = true)
+        public bool TryDropActiveHand(EntityCoordinates targetDropLocation, bool doMobChecks = true)
         {
             if (!TryGetActiveHand(out var hand))
                 return false;
 
-            return TryDropHeldEntity(hand, targetDropLocation, doMobChecks, intentional);
+            return TryDropHeldEntity(hand, targetDropLocation, doMobChecks);
         }
 
         /// <summary>
         ///     Tries to drop the contents of a hand to the target location.
         /// </summary>
-        public bool TryDropHand(string handName, EntityCoordinates targetDropLocation, bool checkActionBlocker = true, bool intentional = true)
+        public bool TryDropHand(string handName, EntityCoordinates targetDropLocation, bool checkActionBlocker = true)
         {
             if (!TryGetHand(handName, out var hand))
                 return false;
 
-            return TryDropHeldEntity(hand, targetDropLocation, checkActionBlocker, intentional);
+            return TryDropHeldEntity(hand, targetDropLocation, checkActionBlocker);
         }
 
         /// <summary>
         ///     Tries to drop a held entity to the target location.
         /// </summary>
-        public bool TryDropEntity(IEntity entity, EntityCoordinates coords, bool doMobChecks = true, bool intentional = true)
+        public bool TryDropEntity(IEntity entity, EntityCoordinates coords, bool doMobChecks = true)
         {
             if (!TryGetHandHoldingEntity(entity, out var hand))
                 return false;
 
-            return TryDropHeldEntity(hand, coords, doMobChecks, intentional);
+            return TryDropHeldEntity(hand, coords, doMobChecks);
         }
 
         /// <summary>
@@ -369,23 +369,23 @@ namespace Content.Shared.Hands.Components
         /// <summary>
         ///     Tries to drop the contents of a hand directly under the player.
         /// </summary>
-        public bool Drop(string handName, bool checkActionBlocker = true, bool intentionalDrop = true)
+        public bool Drop(string handName, bool checkActionBlocker = true)
         {
             if (!TryGetHand(handName, out var hand))
                 return false;
 
-            return TryDropHeldEntity(hand, Owner.Transform.Coordinates, checkActionBlocker, intentionalDrop);
+            return TryDropHeldEntity(hand, Owner.Transform.Coordinates, checkActionBlocker);
         }
 
         /// <summary>
         ///     Tries to drop a held entity directly under the player.
         /// </summary>
-        public bool Drop(IEntity entity, bool checkActionBlocker = true, bool intentionalDrop = true)
+        public bool Drop(IEntity entity, bool checkActionBlocker = true)
         {
             if (!TryGetHandHoldingEntity(entity, out var hand))
                 return false;
 
-            return TryDropHeldEntity(hand, Owner.Transform.Coordinates, checkActionBlocker, intentionalDrop);
+            return TryDropHeldEntity(hand, Owner.Transform.Coordinates, checkActionBlocker);
         }
 
         /// <summary>
@@ -467,7 +467,7 @@ namespace Content.Shared.Hands.Components
         /// <summary>
         ///     Drops a hands contents to the target location.
         /// </summary>
-        public void DropHeldEntity(Hand hand, EntityCoordinates targetDropLocation, bool intentionalDrop = true)
+        public void DropHeldEntity(Hand hand, EntityCoordinates targetDropLocation)
         {
             var heldEntity = hand.HeldEntity;
 
@@ -476,7 +476,7 @@ namespace Content.Shared.Hands.Components
 
             RemoveHeldEntityFromHand(hand);
 
-            EntitySystem.Get<SharedInteractionSystem>().DroppedInteraction(Owner, heldEntity, intentionalDrop);
+            EntitySystem.Get<SharedInteractionSystem>().DroppedInteraction(Owner, heldEntity);
 
             heldEntity.Transform.WorldPosition = GetFinalDropCoordinates(targetDropLocation);
 
@@ -510,7 +510,7 @@ namespace Content.Shared.Hands.Components
         /// <summary>
         ///     Tries to drop a hands contents to the target location.
         /// </summary>
-        private bool TryDropHeldEntity(Hand hand, EntityCoordinates location, bool checkActionBlocker, bool intentionalDrop = true)
+        private bool TryDropHeldEntity(Hand hand, EntityCoordinates location, bool checkActionBlocker)
         {
             if (!CanRemoveHeldEntityFromHand(hand))
                 return false;
@@ -518,16 +518,16 @@ namespace Content.Shared.Hands.Components
             if (checkActionBlocker && !PlayerCanDrop())
                 return false;
 
-            DropHeldEntity(hand, location, intentionalDrop);
+            DropHeldEntity(hand, location);
             return true;
         }
 
         /// <summary>
         ///     Drops the contents of a hand directly under the player.
         /// </summary>
-        private void DropHeldEntityToFloor(Hand hand, bool intentionalDrop = true)
+        private void DropHeldEntityToFloor(Hand hand)
         {
-            DropHeldEntity(hand, Owner.Transform.Coordinates, intentionalDrop);
+            DropHeldEntity(hand, Owner.Transform.Coordinates);
         }
 
         private bool CanPutHeldEntityIntoContainer(Hand hand, IContainer targetContainer, bool checkActionBlocker)

--- a/Content.Shared/Hands/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/SharedHandsSystem.cs
@@ -18,47 +18,6 @@ namespace Content.Shared.Hands
             SubscribeAllEvent<RequestSetHandEvent>(HandleSetHand);
         }
 
-        public void DropHandItems(IEntity entity, bool doMobChecks = true)
-        {
-            DropHandItems(entity.Uid, doMobChecks);
-        }
-
-        public void DropHandItems(EntityUid uid, bool doMobChecks = true, SharedHandsComponent? hands = null)
-        {
-            if (!Resolve(uid, ref hands))
-                return;
-
-            DropHandItems(hands, doMobChecks);
-        }
-
-        private void DropHandItems(SharedHandsComponent handsComponent, bool doMobChecks = true)
-        {
-            var msg = new DropHandItemsAttemptEvent();
-            var entity = handsComponent.Owner;
-            var uid = entity.Uid;
-            var eventBus = EntityManager.EventBus;
-
-            eventBus.RaiseLocalEvent(uid, msg);
-
-            if (msg.Cancelled)
-                return;
-
-            if (entity.TryGetContainerMan(out var containerManager))
-            {
-                var parentMsg = new ContainedEntityDropHandItemsAttemptEvent(uid);
-                eventBus.RaiseLocalEvent(containerManager.OwnerUid, parentMsg);
-
-                if (parentMsg.Cancelled)
-                    return;
-            }
-
-            DropAllItemsInHands(entity, doMobChecks);
-        }
-
-        protected virtual void DropAllItemsInHands(IEntity entity, bool doMobChecks = true)
-        {
-        }
-
         private static void HandleSetHand(RequestSetHandEvent msg, EntitySessionEventArgs eventArgs)
         {
             var entity = eventArgs.SenderSession.AttachedEntity;
@@ -77,18 +36,6 @@ namespace Content.Shared.Hands
             component.Dirty();
         }
     }
-
-    public sealed class ContainedEntityDropHandItemsAttemptEvent : CancellableEntityEventArgs
-    {
-        public EntityUid EntityUid { get; }
-
-        public ContainedEntityDropHandItemsAttemptEvent(EntityUid uid)
-        {
-            EntityUid = uid;
-        }
-    }
-
-    public sealed class DropHandItemsAttemptEvent : CancellableEntityEventArgs {}
 
     [Serializable, NetSerializable]
     public class RequestSetHandEvent : EntityEventArgs

--- a/Content.Shared/Interaction/IDropped.cs
+++ b/Content.Shared/Interaction/IDropped.cs
@@ -17,15 +17,12 @@ namespace Content.Shared.Interaction
 
     public class DroppedEventArgs : EventArgs
     {
-        public DroppedEventArgs(IEntity user, bool intentional)
+        public DroppedEventArgs(IEntity user)
         {
             User = user;
-            Intentional = intentional;
         }
 
         public IEntity User { get; }
-
-        public bool Intentional { get; }
     }
 
     /// <summary>
@@ -44,16 +41,10 @@ namespace Content.Shared.Interaction
         /// </summary>
         public EntityUid DroppedUid { get; }
 
-        /// <summary>
-        ///     If the item was dropped intentionally.
-        /// </summary>
-        public bool Intentional { get; }
-
-        public DroppedEvent(EntityUid user, EntityUid dropped, bool intentional)
+        public DroppedEvent(EntityUid user, EntityUid dropped)
         {
             UserUid = user;
             DroppedUid = dropped;
-            Intentional = intentional;
         }
     }
 }

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -658,11 +658,11 @@ namespace Content.Shared.Interaction
         /// Activates the Dropped behavior of an object
         /// Verifies that the user is capable of doing the drop interaction first
         /// </summary>
-        public bool TryDroppedInteraction(IEntity user, IEntity item, bool intentional)
+        public bool TryDroppedInteraction(IEntity user, IEntity item)
         {
             if (user == null || item == null || !_actionBlockerSystem.CanDrop(user.Uid)) return false;
 
-            DroppedInteraction(user, item, intentional);
+            DroppedInteraction(user, item);
             return true;
         }
 
@@ -670,21 +670,21 @@ namespace Content.Shared.Interaction
         ///     Calls Dropped on all components that implement the IDropped interface
         ///     on an entity that has been dropped.
         /// </summary>
-        public void DroppedInteraction(IEntity user, IEntity item, bool intentional)
+        public void DroppedInteraction(IEntity user, IEntity item)
         {
-            var dropMsg = new DroppedEvent(user.Uid, item.Uid, intentional);
+            var dropMsg = new DroppedEvent(user.Uid, item.Uid);
             RaiseLocalEvent(item.Uid, dropMsg);
             if (dropMsg.Handled)
                 return;
 
-            item.Transform.LocalRotation = intentional ? Angle.Zero : (_random.Next(0, 100) / 100f) * MathHelper.TwoPi;
+            item.Transform.LocalRotation = Angle.Zero;
 
             var comps = item.GetAllComponents<IDropped>().ToList();
 
             // Call Land on all components that implement the interface
             foreach (var comp in comps)
             {
-                comp.Dropped(new DroppedEventArgs(user, intentional));
+                comp.Dropped(new DroppedEventArgs(user));
             }
         }
         #endregion

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Shared.Standing
             // and ultimately this is just to avoid boilerplate in Down callers + keep their behavior consistent.
             if (dropHeldItems && hands != null)
             {
-                _sharedHandsSystem.DropHandItems(uid, false, hands);
+                RaiseLocalEvent(uid, new DropHandItemsEvent(), false);
             }
 
             var msg = new DownAttemptEvent();
@@ -95,6 +95,10 @@ namespace Content.Shared.Standing
             appearance?.SetData(RotationVisuals.RotationState, RotationState.Vertical);
             return true;
         }
+    }
+
+    public sealed class DropHandItemsEvent : EventArgs
+    {
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Dropping hand items while slipping now reuses throwing code, which already has a LandEvent.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Reworked how dropping items by slipping works.

