### PR TITLE
Tiny pulling fixes

### DIFF
--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -71,7 +71,7 @@ namespace Content.Shared.Pulling
 
         public void ForceRelationship(SharedPullerComponent? puller, SharedPullableComponent? pullable)
         {
-            if ((puller != null) && (puller.Pulling == pullable))
+            if (pullable != null && puller != null && (puller.Pulling == pullable.Owner))
             {
                 // Already done
                 return;

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -116,7 +116,7 @@ namespace Content.Shared.Pulling
         // The main "start pulling" function.
         public bool TryStartPull(SharedPullerComponent puller, SharedPullableComponent pullable)
         {
-            if (puller.Pulling == pullable)
+            if (puller.Pulling == pullable.Owner)
                 return true;
 
             // Pulling a new object : Perform sanity checks.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the `puller.Pulling` checks.