### PR TITLE
Fix Breaking Bottles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_bottles.yml
@@ -25,7 +25,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Blunt: 10
+        Blunt: 4
   - type: Spillable
     solution: drink
   - type: Damageable

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_bottles.yml
@@ -42,9 +42,9 @@
       - !type:SpillBehavior { }
       - !type:SpawnEntitiesBehavior
         spawn:
-          ShardGlass:
+          BrokenBottle:
             min: 1
-            max: 2
+            max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/trash_drinks.yml
@@ -30,7 +30,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Blunt: 10
+        Blunt: 4
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Consumable/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/trash_drinks.yml
@@ -11,7 +11,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 10
+        maxVol: 50
   - type: SolutionTransfer
     canChangeTransferAmount: true
     maxTransferAmount: 5
@@ -23,7 +23,33 @@
     interfaces:
     - key: enum.TransferAmountUiKey.Key
       type: TransferAmountBoundUserInterface
-
+  - type: DamageOnLand
+    damage:
+      types:
+        Blunt: 5
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 5
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpillBehavior { }
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          BrokenBottle:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 
 # Containers
@@ -61,15 +87,6 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/TrashDrinks/beer_empty.rsi
-
-
-- type: entity
-  name: broken bottle
-  parent: DrinkBottleBaseEmpty  # Can't hold liquids
-  id: DrinkBrokenBottle
-  components:
-  - type: Sprite
-    sprite: Objects/Consumable/TrashDrinks/broken_bottle.rsi
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
@@ -2,7 +2,7 @@
   name: broken bottle
   parent: BaseItem 
   id: BrokenBottle
-  description: In Space Glasgow this is called a "conversation starter"
+  description: In Space Glasgow this is called a conversation starter
   components:
   - type: ItemCooldown
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
@@ -1,0 +1,21 @@
+- type: entity
+  name: broken bottle
+  parent: BaseItem 
+  id: BrokenBottle
+  description: In Space Glasgow this is called a "conversation starter"
+  components:
+  - type: ItemCooldown
+  - type: MeleeWeapon
+    damage:
+      types:
+        Slash: 7
+    hitSound:
+      path: /Audio/Weapons/bladeslice.ogg
+  - type: Sprite
+    sprite: Objects/Consumable/TrashDrinks/broken_bottle.rsi
+    state: icon
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 2
+


### PR DESCRIPTION
There is not a bar fight without broken bottles 

## About the PR

Changed bottles breaking from glass shards into the actual broken bottle item that deals 7 slash damage and has an actual description now. this PR was also made to fix #5388

**Screenshots**

https://user-images.githubusercontent.com/80334192/143155829-525c286d-9e5b-4f8f-a0aa-5766f495bfd5.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Leander
- add: added broken bottles for bar fights
- tweak: tweaked bottles so that they spawn actual broken bottles instead of glass when thrown
- tweak: nerfed bottle throwing damage


