### PR TITLE
Speedy event patches to make events less ass

### DIFF
--- a/Content.Server/StationEvents/StationEventSystem.cs
+++ b/Content.Server/StationEvents/StationEventSystem.cs
@@ -32,7 +32,7 @@ namespace Content.Server.StationEvents
         [Dependency] private readonly IServerNetManager _netManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IConGroupController _conGroupController = default!;
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
+        [Dependency] private readonly GameTicker _gameTicker = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
 
         [Dependency] private readonly AdminLogSystem _adminLog = default!;
@@ -247,7 +247,8 @@ namespace Content.Server.StationEvents
                 return;
             }
 
-            if (_timeUntilNextEvent > 0)
+            // Make sure we only count down when no event is running.
+            if (_timeUntilNextEvent > 0 && CurrentEvent == null)
             {
                 _timeUntilNextEvent -= frameTime;
                 return;
@@ -321,7 +322,7 @@ namespace Content.Server.StationEvents
             // playerCount does a lock so we'll just keep the variable here
             if (!ignoreEarliestStart)
             {
-                currentTime = _gameTiming.CurTime;
+                currentTime = _gameTicker.RoundDuration();
             }
             else
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
fixes #5491, makes it so that the time to next event only starts counting down when the current one ends, to account for very long events and to make sure the time between feels correct.