### PR TITLE
Fix item slots spawning entities on startup instead of map init

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -101,7 +101,7 @@ namespace Content.Shared.Containers.ItemSlots
         ///     This doesn't have to mean the slot is somehow physically locked. In the case of the item cabinet, the
         ///     cabinet may simply be closed at the moment and needs to be opened first.
         /// </remarks>
-        [DataField("locked")]
+        [DataField("locked", readOnly: true)]
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Locked = false;
 

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -12,7 +12,6 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Log;
 using Robust.Shared.Player;
-using Robust.Shared.Utility;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -30,7 +29,7 @@ namespace Content.Shared.Containers.ItemSlots
         {
             base.Initialize();
 
-            SubscribeLocalEvent<ItemSlotsComponent, ComponentStartup>(OnStartup);
+            SubscribeLocalEvent<ItemSlotsComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<ItemSlotsComponent, ComponentInit>(Oninitialize);
 
             SubscribeLocalEvent<ItemSlotsComponent, InteractUsingEvent>(OnInteractUsing);
@@ -50,7 +49,7 @@ namespace Content.Shared.Containers.ItemSlots
         /// <summary>
         ///     Spawn in starting items for any item slots that should have one.
         /// </summary>
-        private void OnStartup(EntityUid uid, ItemSlotsComponent itemSlots, ComponentStartup args)
+        private void OnMapInit(EntityUid uid, ItemSlotsComponent itemSlots, MapInitEvent args)
         {
             foreach (var slot in itemSlots.Slots.Values)
             {

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base.yml
@@ -45,3 +45,9 @@
       - !type:PlaySoundBehavior
         sound:
           path: /Audio/Effects/metalbreak.ogg
+  - type: ReagentDispenser
+    beakerSlot:
+      whitelistFailPopup: reagent-dispenser-component-cannot-put-entity-message
+      whitelist:
+        components:
+        - FitsInDispenser

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -9,11 +9,6 @@
     state: industrial-working
   - type: ReagentDispenser
     pack: ChemDispenserStandardInventory
-    beakerSlot:
-      whitelistFailPopup: reagent-dispenser-component-cannot-put-entity-message
-      whitelist:
-        components:
-        - FitsInDispenser
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
   - type: Construction


### PR DESCRIPTION
Fixing my item slots mistake that's causing issues for mappers (e.g. #5437)

Also fix another item slots mistake, where booze dispenser did not have a whitelist