### PR TITLE
Update survival box size to match capacity

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -100,7 +100,7 @@
       - state: box
       - state: writing
   - type: Item
-    size: 15
+    size: 20
   - type: Storage
     capacity: 20
     size: 25


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Survival box has capacity 20 but only takes up 15 space itself. I don't think this is intended behavior.

**Screenshots**
<img src="https://user-images.githubusercontent.com/10750302/143386502-f804dbb8-866b-4bbf-9714-9243abc205eb.png" width="500" />


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Survival boxes are no longer magic
