### PR TITLE
Unfuck the lobby countdown timer

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -154,7 +154,7 @@ namespace Content.Client.Lobby
                 }
                 else
                 {
-                    text = $"{(int) Math.Floor(difference.TotalMinutes / 60)}:{difference.Seconds:D2}";
+                    text = $"{difference.Minutes}:{difference.Seconds:D2}";
                 }
             }
 


### PR DESCRIPTION
how did it get that bad

**Screenshots**
![image](https://user-images.githubusercontent.com/7806367/143490563-0b8b9352-f320-43ec-b72c-e481c9487714.png)

:cl:
- fix: Lobby timer now actually shows minutes.

