### PR TITLE
Fix some BUIs not closing properly

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
+++ b/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
@@ -27,6 +27,13 @@ namespace Content.Client.Access.UI
             _window.OpenCentered();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (!disposing) return;
+            _window?.Dispose();
+        }
+
         protected override void UpdateState(BoundUserInterfaceState state)
         {
             base.UpdateState(state);

--- a/Content.Client/Chemistry/UI/TransferAmountBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/TransferAmountBoundUserInterface.cs
@@ -1,9 +1,7 @@
 using Content.Shared.Chemistry;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
-using Robust.Shared.GameObjects;
 
 namespace Content.Client.Chemistry.UI
 {
@@ -31,6 +29,13 @@ namespace Content.Client.Chemistry.UI
 
         public TransferAmountBoundUserInterface(ClientUserInterfaceComponent owner, object uiKey) : base(owner, uiKey)
         {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (!disposing) return;
+            _window?.Dispose();
         }
     }
 }

--- a/Content.Client/Paper/UI/PaperBoundUserInterface.cs
+++ b/Content.Client/Paper/UI/PaperBoundUserInterface.cs
@@ -46,5 +46,12 @@ namespace Content.Client.Paper.UI
                 }
             }
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (!disposing) return;
+            _window?.Dispose();
+        }
     }
 }

--- a/Content.Client/Research/UI/ResearchClientBoundUserInterface.cs
+++ b/Content.Client/Research/UI/ResearchClientBoundUserInterface.cs
@@ -38,5 +38,12 @@ namespace Content.Client.Research.UI
             if (state is not ResearchClientBoundInterfaceState rState) return;
             _menu?.Populate(rState.ServerCount, rState.ServerNames, rState.ServerIds, rState.SelectedServerId);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (!disposing) return;
+            _menu?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
This just fixes some client side bound user interfaces not properly closing windows.

This is most noticeable with some consoles, like the ID card console. If can open it and then walk away from the console, the BUI is closed but the window never actually closes. If you interact with the console again, a new BUI & window open, and the old window is just non-functional.