### PR TITLE
fix context menu bugs

### DIFF
--- a/Content.Client/Administration/AdminVerbSystem.cs
+++ b/Content.Client/Administration/AdminVerbSystem.cs
@@ -1,10 +1,8 @@
-using Content.Client.Administration.UI.Tabs.AtmosTab;
 using Content.Shared.Verbs;
 using Robust.Client.Console;
 using Robust.Client.ViewVariables;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Map;
 
 namespace Content.Client.Verbs
 {
@@ -33,6 +31,7 @@ namespace Content.Client.Verbs
                 verb.Text = "View Variables";
                 verb.IconTexture = "/Textures/Interface/VerbIcons/vv.svg.192dpi.png";
                 verb.Act = () => _viewVariablesManager.OpenVV(args.Target);
+                verb.ClientExclusive = true; // opening VV window is client-side. Don't ask server to run this verb.
                 args.Verbs.Add(verb);
             }
         }

--- a/Content.Client/ContextMenu/UI/EntityMenuElement.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuElement.cs
@@ -57,7 +57,8 @@ namespace Content.Client.ContextMenu.UI
         /// </summary>
         public void UpdateEntity(IEntity? entity = null)
         {
-            entity ??= Entity;
+            if (Entity != null && !Entity.Deleted)
+                entity ??= Entity;
 
             EntityIcon.Sprite = entity?.GetComponentOrNull<ISpriteComponent>();
 

--- a/Content.Client/ContextMenu/UI/EntityMenuPresenter.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuPresenter.cs
@@ -321,7 +321,7 @@ namespace Content.Client.ContextMenu.UI
         }
 
         /// <summary>
-        ///     Look through a sub-menu and return the first entity.
+        ///     Recursively look through a sub-menu and return the first entity.
         /// </summary>
         private IEntity? GetFirstEntityOrNull(ContextMenuPopup? menu)
         {
@@ -334,8 +334,13 @@ namespace Content.Client.ContextMenu.UI
                     continue;
 
                 if (entityElement.Entity != null)
-                    return entityElement.Entity;
+                {
+                    if (!entityElement.Entity.Deleted)
+                        return entityElement.Entity;
+                    continue;
+                }
 
+                // if the element has no entity, its a group of entities with another attached sub-menu.
                 var entity = GetFirstEntityOrNull(entityElement.SubMenu);
                 if (entity != null)
                     return entity;

--- a/Content.Client/ContextMenu/UI/EntityMenuPresenterGrouping.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuPresenterGrouping.cs
@@ -37,8 +37,14 @@ namespace Content.Client.ContextMenu.UI
                 (a, b) => a.Prototype!.ID == b.Prototype!.ID,
                 (a, b) =>
                 {
-                    var xStates = a.GetComponent<ISpriteComponent>().AllLayers.Where(e => e.Visible).Select(s => s.RsiState.Name);
-                    var yStates = b.GetComponent<ISpriteComponent>().AllLayers.Where(e => e.Visible).Select(s => s.RsiState.Name);
+                    a.TryGetComponent<ISpriteComponent>(out var spriteA);
+                    b.TryGetComponent<ISpriteComponent>(out var spriteB);
+
+                    if (spriteA == null || spriteB == null)
+                        return spriteA == spriteB;
+
+                    var xStates = spriteA.AllLayers.Where(e => e.Visible).Select(s => s.RsiState.Name);
+                    var yStates = spriteB.AllLayers.Where(e => e.Visible).Select(s => s.RsiState.Name);
 
                     return xStates.OrderBy(t => t).SequenceEqual(yStates.OrderBy(t => t));
                 },


### PR DESCRIPTION
this fixes some minor context menu bugs:
- If more than one entity in the menu is deleted, this would sometimes try to get a sprite from a deleted entity
- Some uses of `GetComponent<SpriteComponent>()` that could cause errors when an entity does not have a sprite.
- Fix "View Variables" verb not being set to client-exclusive. Would log a message sever-side about trying to execute unknown verb.
