### PR TITLE
Skip duplicate uids in admin log

### DIFF
--- a/Content.Server/Administration/Logs/AdminLogSystem.Json.cs
+++ b/Content.Server/Administration/Logs/AdminLogSystem.Json.cs
@@ -72,6 +72,8 @@ public partial class AdminLogSystem
                 ? resolvedEntity.Name
                 : null;
 
+            if (entities.Any(e => e.id == (int) uid)) continue;
+
             entities.Add(((int) uid, entityName));
 
             if (_entityManager.TryGetComponent(uid, out ActorComponent? actor))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR 

I tried running a local server/client, and it crashed a little bit after I used an item on myself. I fixed it by preventing ToJson from adding duplicates to the entities, and players list, which ef core fails to save, and crashes on.

**Changelog**

:cl:
- fix: fixed crash when admin log has the same object more then once.
