### PR TITLE
Fix explosions with same source, and target pos

### DIFF
--- a/Content.Server/Explosion/Components/ExplosionLaunchedComponent.cs
+++ b/Content.Server/Explosion/Components/ExplosionLaunchedComponent.cs
@@ -22,8 +22,10 @@ namespace Content.Server.Explosion.Components
 
             var offset = (targetLocation.ToMapPos(Owner.EntityManager) - sourceLocation.ToMapPos(Owner.EntityManager));
 
-            //Don't normalize if the direction is center (0,0)
-            var direction = offset == Vector2.Zero ? offset : offset.Normalized;
+            //Don't throw if the direction is center (0,0)
+            if (offset == Vector2.Zero) return;
+
+            var direction = offset.Normalized;
 
             var throwForce = eventArgs.Severity switch
             {


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If an explosion source, and target had the same position, it would become (NaN, NaN), which would cause TryThrow to crash. This change avoids the code accidentally creating a Vector2(NaN, NaN) by not calling Normalized, when it's a Vector2.Zero. TryThrow knows how to handle Vector2.Zero, so it works.