### PR TITLE
Light Power Cell Standardization

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -23,6 +23,7 @@
     actions:
       - actionType: ToggleLight
   - type: PowerCellSlot
+    startingCellType: PowerCellSmallHigh
 
 - type: entity
   parent: ClothingHeadHatHardhatBase

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -26,6 +26,8 @@
     - type: Appearance
       visuals:
         - type: LanternVisualizer
+    - type: PowerCellSlot
+      startingCellType: PowerCellSmallHigh
 
 - type: entity
   name: extra-bright lantern


### PR DESCRIPTION
Lanterns and hardhats have been upgraded to starting with PowerCellSmallHigh instead of the default of PowerCellSmallStandard.

Partially for standardization of light powercells and partially because having a light last only 2 minutes is annoying.

:cl: Pancake
- tweak: Lanterns and hardhats have been upgraded to starting with Small High-Capacity Power Cells.

