### PR TITLE
Fix the job overflow crash

### DIFF
--- a/Content.Server/GameTicking/GameTicker.JobController.cs
+++ b/Content.Server/GameTicking/GameTicker.JobController.cs
@@ -106,7 +106,7 @@ namespace Content.Server.GameTicking
             return assigned;
         }
 
-        private string PickBestAvailableJob(HumanoidCharacterProfile profile, StationId station)
+        private string? PickBestAvailableJob(HumanoidCharacterProfile profile, StationId station)
         {
             var available = _stationSystem.StationInfo[station].JobList;
 
@@ -148,7 +148,7 @@ namespace Content.Server.GameTicking
             }
 
             var overflows = _stationSystem.StationInfo[station].MapPrototype.OverflowJobs.Clone().ToList();
-            return _robustRandom.Pick(overflows);
+            return overflows.Count != 0 ? _robustRandom.Pick(overflows) : null;
         }
 
         [Conditional("DEBUG")]

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -81,6 +81,15 @@ namespace Content.Server.GameTicking
                 return;
             }
 
+            // Pick best job best on prefs.
+            jobId ??= PickBestAvailableJob(character, station);
+            // If no job available, just bail out.
+            if (jobId is null)
+            {
+                _chatManager.DispatchServerMessage(player, "game-ticker-player-no-jobs-available-when-joining");
+                return;
+            }
+
             PlayerJoinGame(player);
 
             var data = player.ContentData();
@@ -93,9 +102,6 @@ namespace Content.Server.GameTicking
                 CharacterName = character.Name
             };
             newMind.ChangeOwningPlayer(data.UserId);
-
-            // Pick best job best on prefs.
-            jobId ??= PickBestAvailableJob(character, station);
 
             var jobPrototype = _prototypeManager.Index<JobPrototype>(jobId);
             var job = new Job(newMind, jobPrototype);

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -86,7 +86,7 @@ namespace Content.Server.GameTicking
             // If no job available, just bail out.
             if (jobId is null)
             {
-                _chatManager.DispatchServerMessage(player, "game-ticker-player-no-jobs-available-when-joining");
+                _chatManager.DispatchServerMessage(player, Loc.GetString("game-ticker-player-no-jobs-available-when-joining"));
                 return;
             }
 

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -12,6 +12,7 @@ game-ticker-player-join-game-message = Welcome to Space Station 14! If this is y
 game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/color]
                             The current game mode is: [color=white]{$gmTitle}[/color].
                             >[color=yellow]{$desc}[/color]
+game-ticker-player-no-jobs-available-when-joining = When attempting to join to the game, no jobs were available.
 
 # Displayed in chat to admins when a player joins
 player-join-message = Player {$name} joined the server!


### PR DESCRIPTION
Self explanatory, game no longer crashes if it runs out of job slots and there's no overflows.
