### PR TITLE
Block place item ontop in users inventory

### DIFF
--- a/Content.Shared/Placeable/PlaceableSurfaceSystem.cs
+++ b/Content.Shared/Placeable/PlaceableSurfaceSystem.cs
@@ -54,6 +54,9 @@ namespace Content.Shared.Placeable
             if(!args.User.TryGetComponent<SharedHandsComponent>(out var handComponent))
                 return;
 
+            if (!args.ClickLocation.IsValid(args.User.EntityManager))
+                return;
+
             if(!handComponent.TryDropEntity(args.Used, surface.Owner.Transform.Coordinates))
                 return;
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If you have a placeable surface (like pizza box) in one hand, and another item in the other hand, and try to click the other item onto the placeable surface, it gets transformed to somewhere... I never figured out where it went, but it's nowhere good. This makes it so it doesn't try to do anything in the inventory instead.
