### PR TITLE
fix cigar case visuals

### DIFF
--- a/Content.Client/Storage/ClientStorageComponent.cs
+++ b/Content.Client/Storage/ClientStorageComponent.cs
@@ -7,9 +7,7 @@ using Content.Client.Items.Managers;
 using Content.Client.Items.Components;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.DragDrop;
-using Content.Shared.Stacks;
 using Content.Shared.Storage;
-using Content.Shared.Storage.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
@@ -42,14 +40,6 @@ namespace Content.Client.Storage
         private StorageWindow? _window;
 
         public override IReadOnlyList<IEntity> StoredEntities => _storedEntities;
-
-        protected override void Initialize()
-        {
-            base.Initialize();
-
-            // Hide stackVisualizer on start
-            ChangeStorageVisualization(SharedBagState.Close);
-        }
 
         protected override void OnAdd()
         {
@@ -142,36 +132,14 @@ namespace Content.Client.Storage
             if (_window == null) return;
 
             if (_window.IsOpen)
-            {
                 _window.Close();
-                ChangeStorageVisualization(SharedBagState.Close);
-            }
             else
-            {
                 _window.OpenCentered();
-                ChangeStorageVisualization(SharedBagState.Open);
-            }
         }
 
         private void CloseUI()
         {
-            if (_window == null) return;
-
-            _window.Close();
-            ChangeStorageVisualization(SharedBagState.Close);
-
-        }
-
-        private void ChangeStorageVisualization(SharedBagState state)
-        {
-            if (Owner.TryGetComponent<AppearanceComponent>(out var appearanceComponent))
-            {
-                appearanceComponent.SetData(SharedBagOpenVisuals.BagState, state);
-                if (Owner.HasComponent<ItemCounterComponent>())
-                {
-                    appearanceComponent.SetData(StackVisuals.Hide, state == SharedBagState.Close);
-                }
-            }
+            _window?.Close();
         }
 
         /// <summary>

--- a/Content.Server/Storage/Components/ServerStorageComponent.cs
+++ b/Content.Server/Storage/Components/ServerStorageComponent.cs
@@ -361,7 +361,6 @@ namespace Content.Server.Storage.Components
                 SubscribedSessions.Add(session);
             }
 
-
             if (SubscribedSessions.Count == 1)
                 UpdateStorageVisualization();
         }

--- a/Content.Shared/Storage/Components/SharedBagOpenVisuals.cs
+++ b/Content.Shared/Storage/Components/SharedBagOpenVisuals.cs
@@ -13,6 +13,6 @@ namespace Content.Shared.Storage.Components
     public enum SharedBagState : byte
     {
         Open,
-        Close,
+        Closed,
     }
 }


### PR DESCRIPTION
This fixes an issue where the cigars inside a case would be visible despite the case being closed.

The issue was that some appearance data was only set client side, and was overridden by the server. This code is now server side, which also means that if another user opens the case, then the sprite will properly update.

:cl:
- fix: Fixed cigar case visuals. Can no longer see the cigars when case is closed.

