### PR TITLE
Pill canisters added to fills

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -9,3 +9,15 @@
   cost: 1000
   category: Medical
   group: market
+  
+- type: cargoProduct
+  name: "Chemistry Supplies"
+  id: MedicalChemistrySupplies
+  description: Basic chemistry supplies.
+  icon:
+    sprite: Objects/Specific/Chemistry/beaker.rsi
+    state: beaker
+  product: CrateChemistrySupplies
+  cost: 500
+  category: Medical
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
@@ -16,6 +16,25 @@
   - type: Item
   - type: Storage
     capacity: 30
+    
+- type: entity
+  name: pill canister box
+  parent: BoxBase
+  id: BoxPillCanister
+  description: A box full of pill canisters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: PillCanister
+        amount: 6
+  - type: Sprite
+    layers:
+      - state: box
+      - state: pillbox
+
+  - type: Item
+  - type: Storage
+    capacity: 30
 
 - type: entity
   name: sterile box

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -21,6 +21,22 @@
         amount: 2
 
 - type: entity
+  id: CrateChemistrySupplies
+  name: chemistry supplies crate
+  parent: CrateMedical
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxSyringe
+        amount: 1
+      - id: BoxBeaker
+        amount: 1
+      - id: BoxPillCanister
+        amount: 1
+      - id: Dropper
+        amount: 2
+
+- type: entity
   id: CrateMedicalSurgery
   name: surgical supplies crate
   parent: CrateSurgery

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -50,3 +50,5 @@
         prob: 1
       - id: BoxBeaker
         prob: 1
+      - id: BoxPillCanister
+        prob: 1

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -254,6 +254,7 @@
   - type: GalacticMarket
     products:
       - MedicalSupplies
+      - MedicalChemistrySupplies
       - EmergencyExplosive
       - EmergencyFire
       - EmergencyInternals


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pill canisters were added to pill canister boxes, which are found inside chemistry lockers and thew new chemistry supplies crate from cargo.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/60792108/143674477-5862e575-cf2d-4620-a60f-f204331129f2.png)
![image](https://user-images.githubusercontent.com/60792108/143674492-aab86048-646b-403d-8f96-e32578f3b9df.png)
![image](https://user-images.githubusercontent.com/60792108/143674517-fd2f305e-6080-4c9e-be29-ea624a1581ef.png)
![image](https://user-images.githubusercontent.com/60792108/143674545-eeca688f-90d8-4544-9921-56aed5c591b9.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- add: Pill canisters can now be found in a box in chemistry's locker.
- add: Cargo now has access to the chemistry supplies crate, allowing them to replace chemistry's things after they are all stolen or blown up.
