### PR TITLE
Fix some thrust stuff

### DIFF
--- a/Content.Server/Shuttles/EntitySystems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/EntitySystems/ThrusterSystem.cs
@@ -46,7 +46,7 @@ namespace Content.Server.Shuttles.EntitySystems
         {
             base.Initialize();
             SubscribeLocalEvent<ThrusterComponent, ActivateInWorldEvent>(OnActivateThruster);
-            SubscribeLocalEvent<ThrusterComponent, ComponentStartup>(OnThrusterStartup);
+            SubscribeLocalEvent<ThrusterComponent, ComponentInit>(OnThrusterInit);
             SubscribeLocalEvent<ThrusterComponent, ComponentShutdown>(OnThrusterShutdown);
             SubscribeLocalEvent<ThrusterComponent, PowerChangedEvent>(OnPowerChange);
             SubscribeLocalEvent<ThrusterComponent, AnchorStateChangedEvent>(OnAnchorChange);
@@ -188,7 +188,7 @@ namespace Content.Server.Shuttles.EntitySystems
             }
         }
 
-        private void OnThrusterStartup(EntityUid uid, ThrusterComponent component, ComponentStartup args)
+        private void OnThrusterInit(EntityUid uid, ThrusterComponent component, ComponentInit args)
         {
             _ambient.SetAmbience(uid, false);
 


### PR DESCRIPTION
- Angular examine reflects it doesn't need to be exposed
- Rotating should properly turn it off

:cl:
- fix: Gyroscope examine no longer mentions direction which doesn't matter
- fix: Rotating a thruster will now turn it off / on properly
