### PR TITLE
Disable station events while mapping

### DIFF
--- a/Content.Server/GameTicking/Commands/MappingCommand.cs
+++ b/Content.Server/GameTicking/Commands/MappingCommand.cs
@@ -64,6 +64,7 @@ namespace Content.Server.GameTicking.Commands
                     return;
             }
 
+            shell.ExecuteCommand("sudo cvar events.enabled false");
             shell.ExecuteCommand($"addmap {mapId} false");
             shell.ExecuteCommand($"loadbp {mapId} \"{CommandParsing.Escape(mapName)}\" true");
 


### PR DESCRIPTION
## About the PR

Fixes https://github.com/space-wizards/space-station-14/issues/5580 by disabling station events when the mapping command is used.
