### PR TITLE
Change deconstruct verb accessibility

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Guided.cs
+++ b/Content.Server/Construction/ConstructionSystem.Guided.cs
@@ -39,7 +39,8 @@ namespace Content.Server.Construction
         private void AddDeconstructVerb(EntityUid uid, ConstructionComponent component, GetOtherVerbsEvent args)
         {
             if (!args.User.IsInSameOrParentContainer(args.Target) ||
-                _sharedInteractionSystem.InRangeUnobstructed(args.User, args.Target, ignoreInsideBlocker: true))
+                !_sharedInteractionSystem.InRangeUnobstructed(args.User, args.Target, ignoreInsideBlocker: true))
+                return;
 
             if (component.TargetNode == component.DeconstructionNode ||
                 component.Node == component.DeconstructionNode)

--- a/Content.Server/Construction/ConstructionSystem.Guided.cs
+++ b/Content.Server/Construction/ConstructionSystem.Guided.cs
@@ -38,8 +38,7 @@ namespace Content.Server.Construction
 
         private void AddDeconstructVerb(EntityUid uid, ConstructionComponent component, GetOtherVerbsEvent args)
         {
-            if (!args.User.IsInSameOrParentContainer(args.Target) ||
-                !_sharedInteractionSystem.InRangeUnobstructed(args.User, args.Target, ignoreInsideBlocker: true))
+            if (!args.CanAccess)
                 return;
 
             if (component.TargetNode == component.DeconstructionNode ||

--- a/Content.Server/Construction/ConstructionSystem.Guided.cs
+++ b/Content.Server/Construction/ConstructionSystem.Guided.cs
@@ -4,9 +4,12 @@ using Content.Shared.Construction;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Construction.Steps;
 using Content.Shared.Examine;
+using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
+using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 
 namespace Content.Server.Construction
@@ -14,6 +17,8 @@ namespace Content.Server.Construction
     public partial class ConstructionSystem
     {
         private readonly Dictionary<ConstructionPrototype, ConstructionGuide> _guideCache = new();
+
+        [Dependency] private readonly SharedInteractionSystem _sharedInteractionSystem = default!;
 
         private void InitializeGuided()
         {
@@ -33,8 +38,8 @@ namespace Content.Server.Construction
 
         private void AddDeconstructVerb(EntityUid uid, ConstructionComponent component, GetOtherVerbsEvent args)
         {
-            if (!args.CanAccess)
-                return;
+            if (!args.User.IsInSameOrParentContainer(args.Target) ||
+                _sharedInteractionSystem.InRangeUnobstructed(args.User, args.Target, ignoreInsideBlocker: true))
 
             if (component.TargetNode == component.DeconstructionNode ||
                 component.Node == component.DeconstructionNode)

--- a/Content.Server/Construction/ConstructionSystem.Guided.cs
+++ b/Content.Server/Construction/ConstructionSystem.Guided.cs
@@ -4,12 +4,9 @@ using Content.Shared.Construction;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Construction.Steps;
 using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
-using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 
 namespace Content.Server.Construction
@@ -17,8 +14,6 @@ namespace Content.Server.Construction
     public partial class ConstructionSystem
     {
         private readonly Dictionary<ConstructionPrototype, ConstructionGuide> _guideCache = new();
-
-        [Dependency] private readonly SharedInteractionSystem _sharedInteractionSystem = default!;
 
         private void InitializeGuided()
         {

--- a/Content.Shared/Verbs/VerbEvents.cs
+++ b/Content.Shared/Verbs/VerbEvents.cs
@@ -178,7 +178,7 @@ namespace Content.Shared.Verbs
             Target = target;
 
             CanAccess = force || (Target == User) || user.IsInSameOrParentContainer(target) &&
-                EntitySystem.Get<SharedInteractionSystem>().InRangeUnobstructed(user, target);
+                EntitySystem.Get<SharedInteractionSystem>().InRangeUnobstructed(user, target, ignoreInsideBlocker: true);
 
             // A large number of verbs need to check action blockers. Instead of repeatedly having each system individually
             // call ActionBlocker checks, just cache it for the verb request.


### PR DESCRIPTION
Currently you can't use the deconstruct verb on windows because they are blocked by grilles. This just changes the `InRangeUnobstructed` check to fix that.