### PR TITLE
Nerfs the gas leak a bit, turns back on water vapor puddles.

### DIFF
--- a/Content.Server/StationEvents/Events/GasLeak.cs
+++ b/Content.Server/StationEvents/Events/GasLeak.cs
@@ -31,7 +31,7 @@ namespace Content.Server.StationEvents.Events
 
         private static readonly Gas[] LeakableGases = {
             Gas.Plasma,
-            Gas.Tritium,
+            Gas.WaterVapor,
         };
 
         public override int EarliestStart => 10;

--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -23,18 +23,18 @@
   effects:
     - !type:TritiumFireReaction {}
 
-#- type: gasReaction
-#  id: WaterVaporPuddle
-#  priority: 1
-#  maximumTemperature: 373.13 # Boiling point of water.
-#  minimumRequirements: # In this case, same as minimum mole count.
-#    - 0  # oxygen
-#    - 0  # nitrogen
-#    - 0  # carbon dioxide
-#    - 0  # plasma
-#    - 0  # tritium
-#    - 1  # water vapor
-#  effects:
-#    - !type:WaterVaporReaction
-#      gas: 5
-#      reagent: Water
+- type: gasReaction
+  id: WaterVaporPuddle
+  priority: 1
+  maximumTemperature: 373.13 # Boiling point of water.
+  minimumRequirements: # In this case, same as minimum mole count.
+    - 0  # oxygen
+    - 0  # nitrogen
+    - 0  # carbon dioxide
+    - 0  # plasma
+    - 0  # tritium
+    - 1  # water vapor
+  effects:
+    - !type:WaterVaporReaction
+      gas: 5
+      reagent: Water


### PR DESCRIPTION
Now it just has a chance to be annoying instead of deadly.

**Screenshots**
![image](https://user-images.githubusercontent.com/7806367/143719330-2cab0370-0fe0-4d7f-b2d4-6f426bf6a0b5.png)

**Changelog**

:cl:
- tweak: The gas leak event has been nerfed and can no longer produce tritium, but can produce water vapor.
- add: Low temperature water vapor now makes puddles again.
