### PR TITLE
Observing outside the lobby is no longer a thing you can do.

### DIFF
--- a/Content.Server/GameTicking/Commands/JoinGameCommand.cs
+++ b/Content.Server/GameTicking/Commands/JoinGameCommand.cs
@@ -46,7 +46,7 @@ namespace Content.Server.GameTicking.Commands
 
             if (!ticker.PlayersInLobby.ContainsKey(player))
             {
-                shell.WriteError($"{player.Name} not in the lobby.   This incident will be reported.");
+                shell.WriteError($"{player.Name} is not in the lobby.   This incident will be reported.");
                 return;
             }
 

--- a/Content.Server/GameTicking/Commands/ObserveCommand.cs
+++ b/Content.Server/GameTicking/Commands/ObserveCommand.cs
@@ -22,7 +22,10 @@ namespace Content.Server.GameTicking.Commands
             }
 
             var ticker = EntitySystem.Get<GameTicker>();
-            ticker.MakeObserve(player);
+            if (ticker.PlayersInLobby.ContainsKey(player))
+                ticker.MakeObserve(player);
+            else
+                shell.WriteError($"{player.Name} is not in the lobby.   This incident will be reported.");
         }
     }
 }


### PR DESCRIPTION
Fixes a minor bug. You should /ghost, not /observe.