### PR TITLE
Piloting and thruster tuning

### DIFF
--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -204,9 +204,9 @@ namespace Content.Server.Physics.Controllers
 
                         speed /= 10f;
 
-                        if (body.LinearVelocity.LengthSquared < 1f)
+                        if (body.LinearVelocity.LengthSquared < 0.5f)
                         {
-                            speed *= 10f;
+                            speed *= 5f;
                         }
 
                         body.ApplyLinearImpulse(
@@ -226,9 +226,9 @@ namespace Content.Server.Physics.Controllers
                     body.AngularDamping = shuttleSystem.ShuttleMovingAngularDamping;
                     var angularSpeed = shuttle.AngularThrust;
 
-                    if (body.AngularVelocity < 1f)
+                    if (body.AngularVelocity < 0.5f)
                     {
-                        angularSpeed *= 10f;
+                        angularSpeed *= 5f;
                     }
 
                     // Scale rotation by mass just to make rotating larger things a bit more bearable.

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -138,10 +138,9 @@ namespace Content.Server.Physics.Controllers
                 var count = pilots.Count;
                 linearInput /= count;
                 angularInput /= count;
-                var linearLength = linearInput.Length;
 
                 // Handle shuttle movement
-                if (linearLength.Equals(0f))
+                if (linearInput.Length.Equals(0f))
                 {
                     thrusterSystem.DisableLinearThrusters(shuttle);
                     body.LinearDamping = shuttleSystem.ShuttleIdleLinearDamping;
@@ -176,15 +175,36 @@ namespace Content.Server.Physics.Controllers
                             continue;
                         }
 
+                        float length;
+
+                        switch (dir)
+                        {
+                            case DirectionFlag.North:
+                                length = linearInput.Y;
+                                break;
+                            case DirectionFlag.South:
+                                length = -linearInput.Y;
+                                break;
+                            case DirectionFlag.East:
+                                length = linearInput.X;
+                                break;
+                            case DirectionFlag.West:
+                                length = -linearInput.X;
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
+
                         thrusterSystem.EnableLinearThrustDirection(shuttle, dir);
 
                         // TODO: This isn't taking the inputs correctly for length / angle so need to do that.
+                        // Need to get direction as an angle and then use that for rotation; also need to multiply it by linearInput length in that direction
                         var index = (int) Math.Log2((int) dir);
-                        var speed = shuttle.LinearThrusterImpulse[index] * linearLength;
+                        var speed = shuttle.LinearThrusterImpulse[index] * length;
 
                         speed /= 10f;
 
-                        if (body.LinearVelocity.LengthSquared == 0f)
+                        if (body.LinearVelocity.LengthSquared < 1f)
                         {
                             speed *= 10f;
                         }
@@ -206,7 +226,7 @@ namespace Content.Server.Physics.Controllers
                     body.AngularDamping = shuttleSystem.ShuttleMovingAngularDamping;
                     var angularSpeed = shuttle.AngularThrust;
 
-                    if (body.AngularVelocity.Equals(0f))
+                    if (body.AngularVelocity < 1f)
                     {
                         angularSpeed *= 10f;
                     }

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -153,6 +153,7 @@ namespace Content.Server.Physics.Controllers
                     var angle = linearInput.ToWorldAngle();
                     var linearDir = angle.GetDir();
                     var dockFlag = linearDir.AsFlag();
+                    var shuttleNorth = EntityManager.GetComponent<TransformComponent>(body.OwnerUid).WorldRotation.ToWorldVec();
 
                     // Won't just do cardinal directions.
                     foreach (DirectionFlag dir in Enum.GetValues(typeof(DirectionFlag)))
@@ -177,8 +178,8 @@ namespace Content.Server.Physics.Controllers
 
                         thrusterSystem.EnableLinearThrustDirection(shuttle, dir);
 
+                        // TODO: This isn't taking the inputs correctly for length / angle so need to do that.
                         var index = (int) Math.Log2((int) dir);
-
                         var speed = shuttle.LinearThrusterImpulse[index] * linearLength;
 
                         speed /= 10f;
@@ -189,7 +190,7 @@ namespace Content.Server.Physics.Controllers
                         }
 
                         body.ApplyLinearImpulse(
-                            angle.RotateVec(EntityManager.GetComponent<TransformComponent>(body.OwnerUid).WorldRotation.ToWorldVec()) *
+                            angle.RotateVec(shuttleNorth) *
                             speed *
                             frameTime);
                     }

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -169,7 +169,11 @@ namespace Content.Server.Physics.Controllers
                                 continue;
                         }
 
-                        if ((dir & dockFlag) == 0x0) continue;
+                        if ((dir & dockFlag) == 0x0)
+                        {
+                            thrusterSystem.DisableLinearThrustDirection(shuttle, dir);
+                            continue;
+                        }
 
                         thrusterSystem.EnableLinearThrustDirection(shuttle, dir);
 
@@ -177,11 +181,11 @@ namespace Content.Server.Physics.Controllers
 
                         var speed = shuttle.LinearThrusterImpulse[index] * linearLength;
 
-                        speed /= 5f;
+                        speed /= 10f;
 
                         if (body.LinearVelocity.LengthSquared == 0f)
                         {
-                            speed *= 5f;
+                            speed *= 10f;
                         }
 
                         body.ApplyLinearImpulse(

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Shuttles.Components
 
         [ViewVariables]
         [DataField("impulse")]
-        public float Impulse = 500f;
+        public float Impulse = 1500f;
 
         [ViewVariables]
         [DataField("thrusterType")]

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Shuttles.Components
 
         [ViewVariables]
         [DataField("impulse")]
-        public float Impulse = 15f;
+        public float Impulse = 450f;
 
         [ViewVariables]
         [DataField("thrusterType")]

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Shuttles.Components
 
         [ViewVariables]
         [DataField("impulse")]
-        public float Impulse = 5f;
+        public float Impulse = 15f;
 
         [ViewVariables]
         [DataField("thrusterType")]

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Shuttles.Components
 
         [ViewVariables]
         [DataField("impulse")]
-        public float Impulse = 1500f;
+        public float Impulse = 2000f;
 
         [ViewVariables]
         [DataField("thrusterType")]

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Shuttles.Components
 
         [ViewVariables]
         [DataField("impulse")]
-        public float Impulse = 450f;
+        public float Impulse = 500f;
 
         [ViewVariables]
         [DataField("thrusterType")]

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Shuttles.Components
 
         [ViewVariables]
         [DataField("impulse")]
-        public float Impulse = 2000f;
+        public float Impulse = 4500f;
 
         [ViewVariables]
         [DataField("thrusterType")]

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Shuttles.Components
 
         [ViewVariables]
         [DataField("impulse")]
-        public float Impulse = 4500f;
+        public float Impulse = 450f;
 
         [ViewVariables]
         [DataField("thrusterType")]

--- a/Content.Server/Shuttles/EntitySystems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/EntitySystems/ShuttleSystem.cs
@@ -11,6 +11,12 @@ namespace Content.Server.Shuttles.EntitySystems
     {
         private const float TileMassMultiplier = 4f;
 
+        public float ShuttleIdleLinearDamping = 0.2f;
+        public float ShuttleIdleAngularDamping = 0.3f;
+
+        public float ShuttleMovingLinearDamping = 0.05f;
+        public float ShuttleMovingAngularDamping = 0.05f;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -88,8 +94,8 @@ namespace Content.Server.Shuttles.EntitySystems
             component.BodyStatus = BodyStatus.InAir;
             //component.FixedRotation = false; TODO WHEN ROTATING SHUTTLES FIXED.
             component.FixedRotation = false;
-            component.LinearDamping = 0.2f;
-            component.AngularDamping = 0.3f;
+            component.LinearDamping = ShuttleIdleLinearDamping;
+            component.AngularDamping = ShuttleIdleAngularDamping;
         }
 
         private void Disable(PhysicsComponent component)

--- a/Content.Server/Shuttles/EntitySystems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/EntitySystems/ShuttleSystem.cs
@@ -11,8 +11,8 @@ namespace Content.Server.Shuttles.EntitySystems
     {
         private const float TileMassMultiplier = 4f;
 
-        public float ShuttleIdleLinearDamping = 0.2f;
-        public float ShuttleIdleAngularDamping = 0.3f;
+        public float ShuttleIdleLinearDamping = 0.1f;
+        public float ShuttleIdleAngularDamping = 0.2f;
 
         public float ShuttleMovingLinearDamping = 0.05f;
         public float ShuttleMovingAngularDamping = 0.05f;

--- a/Content.Server/Shuttles/EntitySystems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/EntitySystems/ThrusterSystem.cs
@@ -385,46 +385,60 @@ namespace Content.Server.Shuttles.EntitySystems
         /// <summary>
         /// Considers a thrust direction as being active.
         /// </summary>
-        public void EnableThrustDirection(ShuttleComponent component, DirectionFlag direction)
+        public void EnableLinearThrustDirection(ShuttleComponent component, DirectionFlag direction)
         {
             if ((component.ThrustDirections & direction) != 0x0) return;
 
             component.ThrustDirections |= direction;
 
-            if ((direction & (DirectionFlag.East | DirectionFlag.West)) != 0x0)
+            var index = GetFlagIndex(direction);
+
+            foreach (var comp in component.LinearThrusters[index])
             {
-                switch (component.Mode)
-                {
-                    case ShuttleMode.Cruise:
-                        foreach (var comp in component.AngularThrusters)
-                        {
-                            if (!EntityManager.TryGetComponent(comp.OwnerUid, out AppearanceComponent? appearanceComponent))
-                                continue;
+                if (!EntityManager.TryGetComponent(comp.OwnerUid, out AppearanceComponent? appearanceComponent))
+                    continue;
 
-                            comp.Firing = true;
-                            appearanceComponent.SetData(ThrusterVisualState.Thrusting, true);
-                        }
-                        break;
-                    case ShuttleMode.Docking:
-                        var index = GetFlagIndex(direction);
-
-                        foreach (var comp in component.LinearThrusters[index])
-                        {
-                            if (!EntityManager.TryGetComponent(comp.OwnerUid, out AppearanceComponent? appearanceComponent))
-                                continue;
-
-                            comp.Firing = true;
-                            appearanceComponent.SetData(ThrusterVisualState.Thrusting, true);
-                        }
-
-                        break;
-                }
+                comp.Firing = true;
+                appearanceComponent.SetData(ThrusterVisualState.Thrusting, true);
             }
-            else
-            {
-                var index = GetFlagIndex(direction);
+        }
 
-                foreach (var comp in component.LinearThrusters[index])
+        /// <summary>
+        /// Disables a thrust direction.
+        /// </summary>
+        public void DisableLinearThrustDirection(ShuttleComponent component, DirectionFlag direction)
+        {
+            if ((component.ThrustDirections & direction) == 0x0) return;
+
+            component.ThrustDirections &= ~direction;
+
+            var index = GetFlagIndex(direction);
+
+            foreach (var comp in component.LinearThrusters[index])
+            {
+                if (!EntityManager.TryGetComponent(comp.OwnerUid, out AppearanceComponent? appearanceComponent))
+                    continue;
+
+                comp.Firing = false;
+                appearanceComponent.SetData(ThrusterVisualState.Thrusting, false);
+            }
+        }
+
+        public void DisableLinearThrusters(ShuttleComponent component)
+        {
+            foreach (DirectionFlag dir in Enum.GetValues(typeof(DirectionFlag)))
+            {
+                DisableLinearThrustDirection(component, dir);
+            }
+
+            DebugTools.Assert(component.ThrustDirections == DirectionFlag.None);
+        }
+
+        public void SetAngularThrust(ShuttleComponent component, bool on)
+        {
+            if (on)
+            {
+                foreach (var comp in component.AngularThrusters)
                 {
                     if (!EntityManager.TryGetComponent(comp.OwnerUid, out AppearanceComponent? appearanceComponent))
                         continue;
@@ -433,51 +447,9 @@ namespace Content.Server.Shuttles.EntitySystems
                     appearanceComponent.SetData(ThrusterVisualState.Thrusting, true);
                 }
             }
-        }
-
-        /// <summary>
-        /// Disables a thrust direction.
-        /// </summary>
-        public void DisableThrustDirection(ShuttleComponent component, DirectionFlag direction)
-        {
-            if ((component.ThrustDirections & direction) == 0x0) return;
-
-            component.ThrustDirections &= ~direction;
-
-            if ((direction & (DirectionFlag.East | DirectionFlag.West)) != 0x0)
-            {
-                switch (component.Mode)
-                {
-                    case ShuttleMode.Cruise:
-                        foreach (var comp in component.AngularThrusters)
-                        {
-                            if (!EntityManager.TryGetComponent(comp.OwnerUid, out AppearanceComponent? appearanceComponent))
-                                continue;
-
-                            comp.Firing = false;
-                            appearanceComponent.SetData(ThrusterVisualState.Thrusting, false);
-                        }
-                        break;
-                    case ShuttleMode.Docking:
-                        var index = GetFlagIndex(direction);
-
-                        foreach (var comp in component.LinearThrusters[index])
-                        {
-                            if (!EntityManager.TryGetComponent(comp.OwnerUid, out AppearanceComponent? appearanceComponent))
-                                continue;
-
-                            comp.Firing = false;
-                            appearanceComponent.SetData(ThrusterVisualState.Thrusting, false);
-                        }
-
-                        break;
-                }
-            }
             else
             {
-                var index = GetFlagIndex(direction);
-
-                foreach (var comp in component.LinearThrusters[index])
+                foreach (var comp in component.AngularThrusters)
                 {
                     if (!EntityManager.TryGetComponent(comp.OwnerUid, out AppearanceComponent? appearanceComponent))
                         continue;
@@ -486,16 +458,6 @@ namespace Content.Server.Shuttles.EntitySystems
                     appearanceComponent.SetData(ThrusterVisualState.Thrusting, false);
                 }
             }
-        }
-
-        public void DisableAllThrustDirections(ShuttleComponent component)
-        {
-            foreach (DirectionFlag dir in Enum.GetValues(typeof(DirectionFlag)))
-            {
-                DisableThrustDirection(component, dir);
-            }
-
-            DebugTools.Assert(component.ThrustDirections == DirectionFlag.None);
         }
 
         #endregion

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -20,6 +20,7 @@
   - type: ShuttleConsole
   - type: ApcPowerReceiver
     powerLoad: 200
+    needsPower: false
   - type: ExtensionCableReceiver
   - type: PointLight
     radius: 1.5

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -20,7 +20,6 @@
   - type: ShuttleConsole
   - type: ApcPowerReceiver
     powerLoad: 200
-    needsPower: false
   - type: ExtensionCableReceiver
   - type: PointLight
     radius: 1.5

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -26,6 +26,8 @@
     radius: 1.5
     energy: 1.6
     color: "#43ccb5"
+  - type: Rotatable
+    rotateWhileAnchored: true
 
 - type: entity
   parent: ComputerShuttleBase

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -70,7 +70,7 @@
   components:
   - type: Thruster
     thrusterType: Angular
-    impulse: 600
+    impulse: 200
   - type: Sprite
     # Listen I'm not the biggest fan of the sprite but it was the most appropriate thing I could find.
     sprite: Structures/Shuttles/gyroscope.rsi

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -26,6 +26,7 @@
       - type: ThrusterVisualizer
     - type: ApcPowerReceiver
       powerLoad: 1500
+      needsPower: false
     - type: ExtensionCableReceiver
     - type: Damageable
       damageContainer: Inorganic
@@ -47,6 +48,7 @@
   name: thruster
   description: It goes nyooooooom.
   components:
+  - type: Thruster
   - type: Sprite
     sprite: Structures/Shuttles/thruster.rsi
     layers:
@@ -68,7 +70,7 @@
   components:
   - type: Thruster
     thrusterType: Angular
-    impulse: 2
+    impulse: 5
   - type: Sprite
     # Listen I'm not the biggest fan of the sprite but it was the most appropriate thing I could find.
     sprite: Structures/Shuttles/gyroscope.rsi

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -70,7 +70,7 @@
   components:
   - type: Thruster
     thrusterType: Angular
-    impulse: 150
+    impulse: 600
   - type: Sprite
     # Listen I'm not the biggest fan of the sprite but it was the most appropriate thing I could find.
     sprite: Structures/Shuttles/gyroscope.rsi

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -70,7 +70,7 @@
   components:
   - type: Thruster
     thrusterType: Angular
-    impulse: 5
+    impulse: 150
   - type: Sprite
     # Listen I'm not the biggest fan of the sprite but it was the most appropriate thing I could find.
     sprite: Structures/Shuttles/gyroscope.rsi

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -26,7 +26,6 @@
       - type: ThrusterVisualizer
     - type: ApcPowerReceiver
       powerLoad: 1500
-      needsPower: false
     - type: ExtensionCableReceiver
     - type: Damageable
       damageContainer: Inorganic


### PR DESCRIPTION
Averages all pilot inputs before doing shuttle movement once. Also made angular thrust scale based on ship size and re-balanced it a bit so driving a larger ship is more feasible (this was mainly from the dynamic damping change).

:cl:
- tweak: Balance pass on thrusters to make them usable for ships large and small
- tweak: Multiple pilots now supported properly
- fix: Thruster visualizer no longer gets stuck on in some situations
- tweak: Thrusters now work in the direction your console is facing instead of shuttle-North

