### PR TITLE
Shuffle around command perms for trial admin

### DIFF
--- a/Content.Server/Administration/Commands/LoadGameMapCommand.cs
+++ b/Content.Server/Administration/Commands/LoadGameMapCommand.cs
@@ -13,7 +13,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Commands
 {
-    [AdminCommand(AdminFlags.Fun)]
+    [AdminCommand(AdminFlags.Round | AdminFlags.Spawn)]
     public sealed class LoadGameMapCommand : IConsoleCommand
     {
         public string Command => "loadgamemap";

--- a/Content.Server/Administration/Commands/ReadyAll.cs
+++ b/Content.Server/Administration/Commands/ReadyAll.cs
@@ -8,7 +8,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.Administration.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     public class ReadyAll : IConsoleCommand
     {
         public string Command => "readyall";

--- a/Content.Server/Administration/Commands/ShuttleCommands.cs
+++ b/Content.Server/Administration/Commands/ShuttleCommands.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Localization;
 
 namespace Content.Server.Administration.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     public class CallShuttleCommand : IConsoleCommand
     {
         public string Command => "callshuttle";
@@ -36,7 +36,7 @@ namespace Content.Server.Administration.Commands
         }
     }
 
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     public class RecallShuttleCommand : IConsoleCommand
     {
         public string Command => "recallshuttle";

--- a/Content.Server/Administration/Commands/Station/AdjustStationJobCommand.cs
+++ b/Content.Server/Administration/Commands/Station/AdjustStationJobCommand.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Commands.Station;
 
-[AdminCommand(AdminFlags.Spawn)]
+[AdminCommand(AdminFlags.Round)]
 public class AdjustStationJobCommand : IConsoleCommand
 {
     public string Command => "adjstationjob";

--- a/Content.Server/GameTicking/Commands/DelayStartCommand.cs
+++ b/Content.Server/GameTicking/Commands/DelayStartCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     class DelayStartCommand : IConsoleCommand
     {
         public string Command => "delaystart";

--- a/Content.Server/GameTicking/Commands/EndRoundCommand.cs
+++ b/Content.Server/GameTicking/Commands/EndRoundCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     class EndRoundCommand : IConsoleCommand
     {
         public string Command => "endround";

--- a/Content.Server/GameTicking/Commands/ForceMapCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForceMapCommand.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Localization;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     class ForceMapCommand : IConsoleCommand
     {
         public string Command => "forcemap";

--- a/Content.Server/GameTicking/Commands/ForcePresetCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForcePresetCommand.cs
@@ -6,7 +6,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     class ForcePresetCommand : IConsoleCommand
     {
         public string Command => "forcepreset";

--- a/Content.Server/GameTicking/Commands/GoLobbyCommand.cs
+++ b/Content.Server/GameTicking/Commands/GoLobbyCommand.cs
@@ -10,7 +10,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     public class GoLobbyCommand : IConsoleCommand
     {
         public string Command => "golobby";

--- a/Content.Server/GameTicking/Commands/RestartRoundCommand.cs
+++ b/Content.Server/GameTicking/Commands/RestartRoundCommand.cs
@@ -8,7 +8,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     public class RestartRoundCommand : IConsoleCommand
     {
         public string Command => "restartround";
@@ -29,7 +29,7 @@ namespace Content.Server.GameTicking.Commands
         }
     }
 
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     public class RestartRoundNowCommand : IConsoleCommand
     {
         public string Command => "restartroundnow";

--- a/Content.Server/GameTicking/Commands/SetGamePresetCommand.cs
+++ b/Content.Server/GameTicking/Commands/SetGamePresetCommand.cs
@@ -6,7 +6,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     class SetGamePresetCommand : IConsoleCommand
     {
         public string Command => "setgamepreset";

--- a/Content.Server/GameTicking/Commands/StartRoundCommand.cs
+++ b/Content.Server/GameTicking/Commands/StartRoundCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     class StartRoundCommand : IConsoleCommand
     {
         public string Command => "startround";

--- a/Content.Server/GameTicking/Commands/ToggleDisallowLateJoinCommand.cs
+++ b/Content.Server/GameTicking/Commands/ToggleDisallowLateJoinCommand.cs
@@ -8,7 +8,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     class ToggleDisallowLateJoinCommand : IConsoleCommand
     {
         public string Command => "toggledisallowlatejoin";

--- a/Content.Server/StationEvents/StationEventCommand.cs
+++ b/Content.Server/StationEvents/StationEventCommand.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Content.Server.StationEvents
 {
-    [AdminCommand(AdminFlags.Server)]
+    [AdminCommand(AdminFlags.Round)]
     public sealed class StationEventCommand : IConsoleCommand
     {
         public string Command => "events";

--- a/Content.Shared/Administration/AdminFlags.cs
+++ b/Content.Shared/Administration/AdminFlags.cs
@@ -66,6 +66,16 @@ namespace Content.Shared.Administration
         Logs = 1 << 9,
 
         /// <summary>
+        ///     Lets you modify the round (forcemap, loadgamemap, etc)
+        /// </summary>
+        Round = 1 << 10,
+
+        /// <summary>
+        ///     Lets you use BQL queries.
+        /// </summary>
+        Query = 1 << 11,
+
+        /// <summary>
         ///     Dangerous host permissions like scsi.
         /// </summary>
         Host = 1u << 31,

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -50,7 +50,6 @@
   - tp
   - tpto
   - respawn
-  - forall
 
 - Flags: SERVER
   Commands:
@@ -72,3 +71,7 @@
   - saveconfig
   - testlog
   - sudo
+
+- Flags: QUERY
+  Commands:
+  - forall


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR 
Adds +ROUND (something most admins should have) and +QUERY (something most admins should NOT have, it contains BQL)
Standard game admins no longer need +SERVER to manipulate the round, as all round manipulation commands have been put under the +ROUND umbrella.

