### PR TITLE
Don't log empty radiation/explosion damage

### DIFF
--- a/Content.Shared/Damage/Components/DamageableComponent.cs
+++ b/Content.Shared/Damage/Components/DamageableComponent.cs
@@ -98,7 +98,7 @@ namespace Content.Shared.Damage
             var actual = EntitySystem.Get<DamageableSystem>().TryChangeDamage(OwnerUid, damage);
 
             // should logging be disabled during rad storms? a lot of entities are going to be damaged.
-            if (actual != null)
+            if (actual != null && !actual.Empty)
                 EntitySystem.Get<SharedAdminLogSystem>().Add(LogType.Radiation, $"{Owner} took {actual.Total} radiation damage");
         }
 
@@ -123,7 +123,7 @@ namespace Content.Shared.Damage
             var actual = EntitySystem.Get<DamageableSystem>().TryChangeDamage(OwnerUid, damage);
 
             // will logging handle nukes?
-            if (actual != null)
+            if (actual != null && !actual.Empty)
                 EntitySystem.Get<SharedAdminLogSystem>().Add(LogType.Explosion, $"{Owner} took {actual.Total} explosion damage");
         }
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

Prevents logging radiation, and explosion with 0 damage