### PR TITLE
Misc Atmos Improvements

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -37,6 +37,11 @@ namespace Content.Server.Atmos.EntitySystems
 
         public float GetHeatCapacity(GasMixture mixture)
         {
+            if (mixture.Immutable && MathHelper.CloseTo(NumericsHelpers.HorizontalAdd(mixture.Moles), 0f))
+            {
+                return Atmospherics.SpaceHeatCapacity;
+            }
+
             Span<float> tmp = stackalloc float[mixture.Moles.Length];
             NumericsHelpers.Multiply(mixture.Moles, GasSpecificHeats, tmp);
             return MathF.Max(NumericsHelpers.HorizontalAdd(tmp), Atmospherics.MinimumHeatCapacity);
@@ -44,6 +49,11 @@ namespace Content.Server.Atmos.EntitySystems
 
         public float GetHeatCapacityArchived(GasMixture mixture)
         {
+            if (mixture.Immutable && MathHelper.CloseTo(NumericsHelpers.HorizontalAdd(mixture.MolesArchived), 0f))
+            {
+                return Atmospherics.SpaceHeatCapacity;
+            }
+
             Span<float> tmp = stackalloc float[mixture.Moles.Length];
             NumericsHelpers.Multiply(mixture.MolesArchived, GasSpecificHeats, tmp);
             return MathF.Max(NumericsHelpers.HorizontalAdd(tmp), Atmospherics.MinimumHeatCapacity);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -14,6 +14,9 @@ namespace Content.Server.Atmos.EntitySystems
                 return;
             }
 
+            if (tile.ArchivedCycle < fireCount)
+                Archive(tile, fireCount);
+
             tile.CurrentCycle = fireCount;
             var adjacentTileLength = 0;
 
@@ -33,6 +36,7 @@ namespace Content.Server.Atmos.EntitySystems
                 // If the tile is null or has no air, we don't do anything for it.
                 if(enemyTile?.Air == null) continue;
                 if (fireCount <= enemyTile.CurrentCycle) continue;
+                Archive(enemyTile, fireCount);
 
                 var shouldShareAir = false;
 
@@ -105,6 +109,13 @@ namespace Content.Server.Atmos.EntitySystems
 
             if(ExcitedGroups && tile.ExcitedGroup == null && remove)
                 RemoveActiveTile(gridAtmosphere, tile);
+        }
+
+        private void Archive(TileAtmosphere tile, int fireCount)
+        {
+            tile.Air?.Archive();
+            tile.ArchivedCycle = fireCount;
+            tile.TemperatureArchived = tile.Temperature;
         }
 
         private void LastShareCheck(TileAtmosphere tile)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -92,7 +92,7 @@ namespace Content.Server.Atmos.EntitySystems
                     if(tileCount < Atmospherics.MonstermosHardTileLimit)
                         _equalizeTiles[tileCount++] = adj;
 
-                    if (adj.Air.Immutable)
+                    if (adj.Air.Immutable && MonstermosDepressurization)
                     {
                         // Looks like someone opened an airlock to space!
 
@@ -466,6 +466,7 @@ namespace Content.Server.Atmos.EntitySystems
                     otherTile2.PressureDirection = otherTile.MonstermosInfo.CurrentTransferDirection;
                 }
 
+                otherTile.Air!.Temperature = Atmospherics.TCMB;
                 otherTile.Air?.Clear();
                 InvalidateVisuals(otherTile.GridIndex, otherTile.GridIndices);
                 HandleDecompressionFloorRip(mapGrid, otherTile, sum);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -18,11 +18,6 @@ namespace Content.Server.Atmos.EntitySystems
     {
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
 
-        /// <summary>
-        ///     Threshold for logging explosive depressurization.
-        /// </summary>
-        private const float DepressurizationLogThreshold = Atmospherics.MolesCellStandard * 10;
-
         private readonly TileAtmosphereComparer _monstermosComparer = new();
 
         private readonly TileAtmosphere?[] _equalizeTiles = new TileAtmosphere[Atmospherics.MonstermosHardTileLimit];
@@ -467,7 +462,7 @@ namespace Content.Server.Atmos.EntitySystems
                 }
 
                 otherTile.Air!.Temperature = Atmospherics.TCMB;
-                otherTile.Air?.Clear();
+                otherTile.Air.Clear();
                 InvalidateVisuals(otherTile.GridIndex, otherTile.GridIndices);
                 HandleDecompressionFloorRip(mapGrid, otherTile, sum);
             }
@@ -483,7 +478,7 @@ namespace Content.Server.Atmos.EntitySystems
                 gridPhysics.ApplyAngularImpulse(Vector2.Cross(tile.GridIndices - gridPhysics.LocalCenter, direction) * totalMolesRemoved);
             }
 
-            if(totalMolesRemoved > DepressurizationLogThreshold)
+            if(tileCount > 10 && (totalMolesRemoved / tileCount) > 20)
                 _adminLog.Add(LogType.ExplosiveDepressurization, LogImpact.High,
                     $"Explosive depressurization removed {totalMolesRemoved} moles from {tileCount} tiles starting from position {tile.GridIndices:position} on grid ID {tile.GridIndex:grid}");
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -461,8 +461,14 @@ namespace Content.Server.Atmos.EntitySystems
                     otherTile2.PressureDirection = otherTile.MonstermosInfo.CurrentTransferDirection;
                 }
 
-                otherTile.Air!.Temperature = Atmospherics.TCMB;
-                otherTile.Air.Clear();
+
+                // This gas mixture cannot be null, no tile in _depressurizeProgressionOrder can have a null gas mixture
+                otherTile.Air!.Clear();
+
+                // This is a little hacky, but hear me out. It makes sense. We have just vacuumed all of the tile's air
+                // therefore there is no more gas in the tile, therefore the tile should be as cold as space!
+                otherTile.Air.Temperature = Atmospherics.TCMB;
+
                 InvalidateVisuals(otherTile.GridIndex, otherTile.GridIndices);
                 HandleDecompressionFloorRip(mapGrid, otherTile, sum);
             }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -108,14 +108,13 @@ namespace Content.Server.Atmos.EntitySystems
                     tile.Air ??= new GasMixture(volume){Temperature = Atmospherics.T20C};
                 }
 
-                // By removing the active tile, we effectively remove its excited group, if any.
-                RemoveActiveTile(atmosphere, tile);
-
-                // Then we activate the tile again.
+                // We activate the tile.
                 AddActiveTile(atmosphere, tile);
 
-                // TODO ATMOS: Query all the contents of this tile (like walls) and calculate the correct thermal conductivity
-                tile.ThermalConductivity = tile.Tile?.Tile.GetContentTileDefinition().ThermalConductivity ?? 0.5f;
+                // TODO ATMOS: Query all the contents of this tile (like walls) and calculate the correct thermal conductivity and heat capacity
+                var tileDef = tile.Tile?.Tile.GetContentTileDefinition();
+                tile.ThermalConductivity = tileDef?.ThermalConductivity ?? 0.5f;
+                tile.HeatCapacity = tileDef?.HeatCapacity ?? float.PositiveInfinity;
                 InvalidateVisuals(mapGrid.Index, indices);
 
                 for (var i = 0; i < Atmospherics.Directions; i++)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Superconductivity.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Superconductivity.cs
@@ -21,6 +21,9 @@ namespace Content.Server.Atmos.EntitySystems
                 if (adjacent == null || adjacent.ThermalConductivity == 0f)
                     continue;
 
+                if(adjacent.ArchivedCycle < gridAtmosphere.UpdateCounter)
+                    Archive(adjacent, gridAtmosphere.UpdateCounter);
+
                 NeighborConductWithSource(gridAtmosphere, adjacent, tile);
 
                 ConsiderSuperconductivity(gridAtmosphere, adjacent);
@@ -34,6 +37,8 @@ namespace Content.Server.Atmos.EntitySystems
         {
             if(tile.Air == null)
             {
+                if(tile.ArchivedCycle < gridAtmosphere.UpdateCounter)
+                    Archive(tile, gridAtmosphere.UpdateCounter);
                 return AtmosDirection.All;
             }
 
@@ -123,7 +128,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void TemperatureShareMutualSolid(TileAtmosphere tile, TileAtmosphere other, float conductionCoefficient)
         {
-            var deltaTemperature = (tile.Temperature - other.Temperature);
+            var deltaTemperature = (tile.TemperatureArchived - other.TemperatureArchived);
             if (MathF.Abs(deltaTemperature) > Atmospherics.MinimumTemperatureDeltaToConsider
                 && tile.HeatCapacity != 0f && other.HeatCapacity != 0f)
             {
@@ -141,7 +146,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (tile.Temperature > Atmospherics.T0C)
             {
                 // Hardcoded space temperature.
-                var deltaTemperature = (tile.Temperature - Atmospherics.TCMB);
+                var deltaTemperature = (tile.TemperatureArchived - Atmospherics.TCMB);
                 if ((tile.HeatCapacity > 0) && (MathF.Abs(deltaTemperature) > Atmospherics.MinimumTemperatureDeltaToConsider))
                 {
                     var heat = tile.ThermalConductivity * deltaTemperature * (tile.HeatCapacity *

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Superconductivity.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Superconductivity.cs
@@ -61,8 +61,8 @@ namespace Content.Server.Atmos.EntitySystems
                 return false;
 
             if (tile.Air == null || tile.Air.Temperature < (starting
-                ? Atmospherics.MinimumTemperatureStartSuperConduction
-                : Atmospherics.MinimumTemperatureForSuperconduction))
+                    ? Atmospherics.MinimumTemperatureStartSuperConduction
+                    : Atmospherics.MinimumTemperatureForSuperconduction))
                 return false;
 
             return !(GetHeatCapacity(tile.Air) < Atmospherics.MCellWithRatio)

--- a/Content.Server/Atmos/GasMixture.cs
+++ b/Content.Server/Atmos/GasMixture.cs
@@ -26,7 +26,6 @@ namespace Content.Server.Atmos
         [DataField("moles")] [ViewVariables]
         public float[] Moles = new float[Atmospherics.AdjustedNumberOfGases];
 
-        [DataField("molesArchived")] [ViewVariables]
         public float[] MolesArchived = new float[Atmospherics.AdjustedNumberOfGases];
 
         [DataField("temperature")] [ViewVariables]
@@ -73,7 +72,6 @@ namespace Content.Server.Atmos
             }
         }
 
-        [DataField("temperatureArchived")] [ViewVariables]
         public float TemperatureArchived { get; private set; }
 
         [DataField("volume")] [ViewVariables]

--- a/Content.Server/Atmos/GasMixture.cs
+++ b/Content.Server/Atmos/GasMixture.cs
@@ -26,6 +26,9 @@ namespace Content.Server.Atmos
         [DataField("moles")] [ViewVariables]
         public float[] Moles = new float[Atmospherics.AdjustedNumberOfGases];
 
+        [DataField("molesArchived")] [ViewVariables]
+        public float[] MolesArchived = new float[Atmospherics.AdjustedNumberOfGases];
+
         [DataField("temperature")] [ViewVariables]
         private float _temperature = Atmospherics.TCMB;
 
@@ -70,6 +73,9 @@ namespace Content.Server.Atmos
             }
         }
 
+        [DataField("temperatureArchived")] [ViewVariables]
+        public float TemperatureArchived { get; private set; }
+
         [DataField("volume")] [ViewVariables]
         public float Volume { get; set; }
 
@@ -88,6 +94,13 @@ namespace Content.Server.Atmos
         public void MarkImmutable()
         {
             Immutable = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Archive()
+        {
+            Moles.AsSpan().CopyTo(MolesArchived.AsSpan());
+            TemperatureArchived = Temperature;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -240,6 +253,7 @@ namespace Content.Server.Atmos
         {
             // The arrays MUST have a specific length.
             Array.Resize(ref Moles, Atmospherics.AdjustedNumberOfGases);
+            Array.Resize(ref MolesArchived, Atmospherics.AdjustedNumberOfGases);
         }
 
         public override bool Equals(object? obj)
@@ -254,10 +268,12 @@ namespace Content.Server.Atmos
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return Moles.SequenceEqual(other.Moles)
+                   && MolesArchived.SequenceEqual(other.MolesArchived)
                    && _temperature.Equals(other._temperature)
                    && ReactionResults.SequenceEqual(other.ReactionResults)
                    && Immutable == other.Immutable
                    && LastShare.Equals(other.LastShare)
+                   && TemperatureArchived.Equals(other.TemperatureArchived)
                    && Volume.Equals(other.Volume);
         }
 
@@ -268,10 +284,13 @@ namespace Content.Server.Atmos
             for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
             {
                 var moles = Moles[i];
+                var molesArchived = MolesArchived[i];
                 hashCode.Add(moles);
+                hashCode.Add(molesArchived);
             }
 
             hashCode.Add(_temperature);
+            hashCode.Add(TemperatureArchived);
             hashCode.Add(Immutable);
             hashCode.Add(LastShare);
             hashCode.Add(Volume);
@@ -284,9 +303,11 @@ namespace Content.Server.Atmos
             var newMixture = new GasMixture()
             {
                 Moles = (float[])Moles.Clone(),
+                MolesArchived = (float[])MolesArchived.Clone(),
                 _temperature = _temperature,
                 Immutable = Immutable,
                 LastShare = LastShare,
+                TemperatureArchived = TemperatureArchived,
                 Volume = Volume,
             };
             return newMixture;

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -14,10 +14,16 @@ namespace Content.Server.Atmos
     public class TileAtmosphere : IGasMixtureHolder
     {
         [ViewVariables]
+        public int ArchivedCycle;
+
+        [ViewVariables]
         public int CurrentCycle;
 
         [ViewVariables]
         public float Temperature { get; set; } = Atmospherics.T20C;
+
+        [ViewVariables]
+        public float TemperatureArchived { get; set; } = Atmospherics.T20C;
 
         [ViewVariables]
         public TileAtmosphere? PressureSpecificTarget { get; set; }

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -32,7 +32,7 @@ namespace Content.Server.Atmos
         public float PressureDifference { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public float HeatCapacity { get; set; } = 1f;
+        public float HeatCapacity { get; set; } = float.PositiveInfinity;
 
         [ViewVariables]
         public float ThermalConductivity { get; set; } = 0.05f;

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -32,7 +32,7 @@ namespace Content.Server.Atmos
         public float PressureDifference { get; set; }
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public float HeatCapacity { get; set; } = float.PositiveInfinity;
+        public float HeatCapacity { get; set; } = Atmospherics.MinimumHeatCapacity;
 
         [ViewVariables]
         public float ThermalConductivity { get; set; } = 0.05f;

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -138,6 +138,11 @@ namespace Content.Shared.Atmos
         /// </summary>
         public const float MinimumHeatCapacity = 0.0003f;
 
+        /// <summary>
+        ///     For the purposes of making space "colder"
+        /// </summary>
+        public const float SpaceHeatCapacity = 7000f;
+
         #region Excited Groups
 
         /// <summary>

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -38,6 +38,9 @@ namespace Content.Shared.Maps
 
         [DataField("thermalConductivity")] public float ThermalConductivity { get; set; } = 0.05f;
 
+        // Heat capacity is opt-in, not opt-out.
+        [DataField("heatCapacity")] public float HeatCapacity = float.PositiveInfinity;
+
         [DataField("item_drop", customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string ItemDropPrototypeName { get; } = "FloorTileItemSteel";
 

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.ViewVariables;
 using System.Collections.Generic;
+using Content.Shared.Atmos;
 
 namespace Content.Shared.Maps
 {
@@ -39,7 +40,7 @@ namespace Content.Shared.Maps
         [DataField("thermalConductivity")] public float ThermalConductivity { get; set; } = 0.05f;
 
         // Heat capacity is opt-in, not opt-out.
-        [DataField("heatCapacity")] public float HeatCapacity = float.PositiveInfinity;
+        [DataField("heatCapacity")] public float HeatCapacity = Atmospherics.MinimumHeatCapacity;
 
         [DataField("item_drop", customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string ItemDropPrototypeName { get; } = "FloorTileItemSteel";

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -10,6 +10,9 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemDark
+  thermalConductivity: 0.04
+  heatCapacity: 10000
+
 
 - type: tile
   name: floor_elevator_shaft
@@ -22,6 +25,8 @@
   footstep_sounds:
     collection: footstep_floor
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_freezer
@@ -35,6 +40,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemFreezer
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_hydro
@@ -47,6 +54,8 @@
   footstep_sounds:
     collection: footstep_floor
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_green_circuit
@@ -60,6 +69,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemGCircuit
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_blue_circuit
@@ -72,6 +83,8 @@
   footstep_sounds:
     collection: footstep_floor
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_lino
@@ -85,6 +98,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemLino
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_mono
@@ -98,6 +113,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemMono
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_reinforced
@@ -111,6 +128,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemReinforced
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_rock_vault
@@ -123,6 +142,8 @@
   footstep_sounds:
     collection: footstep_floor
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_showroom
@@ -136,6 +157,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemShowroom
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_steel
@@ -149,6 +172,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemSteel
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_steel_dirty
@@ -162,6 +187,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemDirty
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_techmaint
@@ -175,6 +202,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemTechmaint
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_white
@@ -188,6 +217,8 @@
     collection: footstep_floor
   friction: 0.25
   item_drop: FloorTileItemWhite
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_asteroid_sand
@@ -200,6 +231,8 @@
   footstep_sounds:
     collection: footstep_asteroid
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_asteroid_tile
@@ -212,6 +245,8 @@
   footstep_sounds:
     collection: footstep_asteroid
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_asteroid_coarse_sand0
@@ -224,6 +259,8 @@
   footstep_sounds:
     collection: footstep_asteroid
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_asteroid_coarse_sand1
@@ -236,6 +273,8 @@
   footstep_sounds:
     collection: footstep_asteroid
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_asteroid_coarse_sand2
@@ -248,6 +287,8 @@
   footstep_sounds:
     collection: footstep_asteroid
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_asteroid_coarse_sand_dug
@@ -260,6 +301,8 @@
   footstep_sounds:
     collection: footstep_asteroid
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_snow
@@ -272,6 +315,8 @@
   footstep_sounds:
     collection: footstep_snow
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_gold
@@ -285,6 +330,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: FloorTileItemGold
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_silver
@@ -297,6 +344,8 @@
   footstep_sounds:
     collection: footstep_floor
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_glass
@@ -310,6 +359,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: SheetGlass1
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_rglass
@@ -323,6 +374,8 @@
     collection: footstep_floor
   friction: 0.30
   item_drop: SheetRGlass1
+  thermalConductivity: 0.04
+  heatCapacity: 10000
 
 - type: tile
   name: floor_blue
@@ -335,3 +388,5 @@
   footstep_sounds:
     collection: footstep_floor
   friction: 0.30
+  thermalConductivity: 0.04
+  heatCapacity: 10000

--- a/Resources/Prototypes/Tiles/space.yml
+++ b/Resources/Prototypes/Tiles/space.yml
@@ -6,5 +6,5 @@
   is_subfloor: true
   is_space: true
   sturdy: false
-  thermalCapacity: 0.4
+  thermalConductivity: 0.4
   heatCapacity: 700000

--- a/Resources/Prototypes/Tiles/space.yml
+++ b/Resources/Prototypes/Tiles/space.yml
@@ -6,3 +6,5 @@
   is_subfloor: true
   is_space: true
   sturdy: false
+  thermalCapacity: 0.4
+  heatCapacity: 700000


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Brings back atmos archiving
- Tiles can now specify heat capacity
- *Explosive depressurization makes tiles' temperatures be at TCMB, fixes #5605
- Space gas mixtures now have a hardcoded heat capacity to further fix #5605

~~*I need to figure out how to remove monstermos' hacky "set tile temp to TCMB and call it a day", it's bad.~~ This just makes sense imo.

~~NOTE: For some reason, if you disable "monstermos explosive depressurization" but don't enable "excited groups space is all consuming", rooms aren't cooled down when vented. I can't figure it out honestly, and since those settings aren't the default I won't bother fixing it for now.~~

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: The space around you feels colder... Depressurized rooms will now be very, very cold.

