### PR TITLE
Fixes mouse self-eating

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -116,7 +116,8 @@ namespace Content.Server.Nutrition.EntitySystems
             if (!Resolve(uid, ref component))
                 return false;
 
-            if (EntityManager.TryGetComponent<MobStateComponent>(uid, out var mobState) && mobState.IsAlive())
+            if (uid == userUid || //Suppresses self-eating
+                EntityManager.TryGetComponent<MobStateComponent>(uid, out var mobState) && mobState.IsAlive()) // Suppresses eating alive mobs
                 return false;
 
             if (!_solutionContainerSystem.TryGetSolution(uid, component.SolutionName, out var solution))

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Database;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Helpers;
+using Content.Shared.MobState.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
@@ -115,6 +116,9 @@ namespace Content.Server.Nutrition.EntitySystems
             if (!Resolve(uid, ref component))
                 return false;
 
+            if (EntityManager.TryGetComponent<MobStateComponent>(uid, out var mobState) && mobState.IsAlive())
+                return false;
+
             if (!_solutionContainerSystem.TryGetSolution(uid, component.SolutionName, out var solution))
                 return false;
 
@@ -201,16 +205,20 @@ namespace Content.Server.Nutrition.EntitySystems
 
         private void AddEatVerb(EntityUid uid, FoodComponent component, GetInteractionVerbsEvent ev)
         {
-            if (!ev.CanInteract ||
+            if (uid == ev.UserUid ||
+                !ev.CanInteract ||
                 !ev.CanAccess ||
-                !EntityManager.TryGetComponent(ev.User.Uid, out SharedBodyComponent? body) ||
-                !_bodySystem.TryGetComponentsOnMechanisms<StomachComponent>(ev.User.Uid, out var stomachs, body))
+                !EntityManager.TryGetComponent(ev.UserUid, out SharedBodyComponent? body) ||
+                !_bodySystem.TryGetComponentsOnMechanisms<StomachComponent>(ev.UserUid, out var stomachs, body))
+                return;
+
+            if (EntityManager.TryGetComponent<MobStateComponent>(uid, out var mobState) && mobState.IsAlive())
                 return;
 
             Verb verb = new();
             verb.Act = () =>
             {
-                TryUseFood(uid, ev.User.Uid, component);
+                TryUseFood(uid, ev.UserUid, component);
             };
             
             verb.Text = Loc.GetString("food-system-verb-eat");

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -375,8 +375,6 @@
       normal: mouse-0
       crit: dead-0
       dead: splat-0
-# Eek! You can eat them alive for now until someone makes something that detects when
-# a mob is dead or something idk
   - type: Food
   - type: Extractable
     grindableSolutionName: food


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #5618, plus adds IsAlive check for mobs marked as Food (You can still forcefeed someone with alive mouse)
