### PR TITLE
Created a crate for inflatable walls and added to cargo

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
@@ -45,3 +45,15 @@
   cost: 1000
   category: Emergency
   group: market
+
+- type: cargoProduct
+  name: "inflatable wall crate"
+  id: EmergencyInflatablewall
+  description: "Three stacks of inflatable walls for when the stations metal walls don't want to hold atmosphere anymore."
+  icon:
+    sprite: Objects/Misc/inflatable_wall.rsi
+    state: item_wall
+  product: CrateEmergencyInflatablewall
+  cost: 1000
+  category: Emergency
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -73,3 +73,14 @@
         amount: 1
       - id: DrinkShotGlass
         amount: 2
+
+- type: entity
+  id: CrateEmergencyInflatablewall
+  name: inflatable wall crate
+  parent: CrateEngineering
+  components:
+  - type: StorageFill
+    contents:
+      - id: InflatableWallStack
+        amount: 3
+

--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -77,7 +77,7 @@
 - type: entity
   id: CrateEmergencyInflatablewall
   name: inflatable wall crate
-  parent: CrateEngineering
+  parent: CratePlastic
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -259,6 +259,7 @@
       - EmergencyFire
       - EmergencyInternals
       - EmergencyRadiation
+      - EmergencyInflatablewall
       - ArmorySmg
       - ArmoryShotgun
       - SecurityArmor


### PR DESCRIPTION
Adds a crate with 3 stacks of inflatable walls to cargo. Was torn between engineering and emergency so split the diff.

Believe I did this months ago but looks like cargo had a good sort out so bringing it back at the request of discord users.

:cl:
- add: Added inflatable wall crate to cargo under emergency tab.


