### PR TITLE
Adds cable to the autolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -63,6 +63,7 @@
       - MiniHoe
       - Shovel
       - Spade
+      - CableStack
   - type: Appearance
     visuals:
     - type: AutolatheVisualizer

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -36,7 +36,7 @@
 
 - type: latheRecipe
   id: CableStack
-  name: cable coil
+  name: LV cable
   icon: /Textures/Objects/Tools/cable-coils.rsi/coillv-30.png
   result: CableApcStack1
   completetime: 500


### PR DESCRIPTION
Already existed for protolathe but fairly basic item so auto can have - by disord request. 1 Sheet = 1 cable.
Also renamed to be clear on cable type.

Next we need a way to feed cable back into the lathe to break it back down into metal? Or am I misremembering how SS13 worked on that one.

:cl:
- add: Added LV cable to the autolathe.


