### PR TITLE
Change thread.sleep in filtertests to task.delay 

### DIFF
--- a/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Logs;

--- a/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Logs;
@@ -48,7 +47,7 @@ public class FilterTests : ContentIntegrationTest
             sAdminLogSystem.Add(LogType.Unknown, $"{entity:Entity} test log: {commonGuid} {firstGuid}");
         });
 
-        Thread.Sleep(2000);
+        await Task.Delay(2000);
 
         await server.WaitPost(() =>
         {


### PR DESCRIPTION
I totally found this myself and decided to fix it, aha, mhm-hm.
Replaces "Thread.Sleep(2000)" with "await Task.Delay(2000)"