### PR TITLE
Fix tabletop network spam

### DIFF
--- a/Content.Client/Tabletop/TabletopSystem.cs
+++ b/Content.Client/Tabletop/TabletopSystem.cs
@@ -18,6 +18,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Timing;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
 
 namespace Content.Client.Tabletop
@@ -28,6 +29,7 @@ namespace Content.Client.Tabletop
         [Dependency] private readonly IInputManager _inputManager = default!;
         [Dependency] private readonly IUserInterfaceManager _uiManger = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
+        [Dependency] private readonly IGameTiming _gameTiming = default!;
 
         // Time in seconds to wait until sending the location of a dragged entity to the server again
         private const float Delay = 1f / 10; // 10 Hz
@@ -94,7 +96,7 @@ namespace Content.Client.Tabletop
             _timePassed += frameTime;
 
             // Only send new position to server when Delay is reached
-            if (_timePassed >= Delay && _table != null)
+            if (_timePassed >= Delay && _table != null && _gameTiming.IsFirstTimePredicted)
             {
                 RaiseNetworkEvent(new TabletopMoveEvent(_draggedEntity.Value, clampedCoords, _table.Value));
                 _timePassed -= Delay;

--- a/Content.Client/Tabletop/TabletopSystem.cs
+++ b/Content.Client/Tabletop/TabletopSystem.cs
@@ -96,9 +96,10 @@ namespace Content.Client.Tabletop
             _timePassed += frameTime;
 
             // Only send new position to server when Delay is reached
-            if (_timePassed >= Delay && _table != null && _gameTiming.IsFirstTimePredicted)
+            if (_timePassed >= Delay && _table != null)
             {
-                RaiseNetworkEvent(new TabletopMoveEvent(_draggedEntity.Value, clampedCoords, _table.Value));
+                if (_gameTiming.IsFirstTimePredicted)
+                    RaiseNetworkEvent(new TabletopMoveEvent(_draggedEntity.Value, clampedCoords, _table.Value));
                 _timePassed -= Delay;
             }
         }

--- a/Content.Client/Tabletop/TabletopSystem.cs
+++ b/Content.Client/Tabletop/TabletopSystem.cs
@@ -52,6 +52,10 @@ namespace Content.Client.Tabletop
 
         public override void Update(float frameTime)
         {
+            // don't send network messages when doing prediction.
+            if (!_gameTiming.IsFirstTimePredicted)
+                return;
+
             // If there is no player entity, return
             if (_playerManager.LocalPlayer is not { ControlledEntity: { Uid: var playerEntity } }) return;
 
@@ -98,8 +102,7 @@ namespace Content.Client.Tabletop
             // Only send new position to server when Delay is reached
             if (_timePassed >= Delay && _table != null)
             {
-                if (_gameTiming.IsFirstTimePredicted)
-                    RaiseNetworkEvent(new TabletopMoveEvent(_draggedEntity.Value, clampedCoords, _table.Value));
+                RaiseNetworkEvent(new TabletopMoveEvent(_draggedEntity.Value, clampedCoords, _table.Value));
                 _timePassed -= Delay;
             }
         }


### PR DESCRIPTION
This just prevents the tabletop dragging from sending dragging information while doing predictions. Should no longer spam 
`net.ent: Got late MsgEntity!`. This does make the dragging feel less responsive when testing with two clients locally, because it's actually sending messages at 10hz now.