### PR TITLE
check if instrument window is disposed before playing

### DIFF
--- a/Content.Client/Instruments/UI/InstrumentMenu.xaml.cs
+++ b/Content.Client/Instruments/UI/InstrumentMenu.xaml.cs
@@ -79,6 +79,10 @@ namespace Content.Client.Instruments.UI
             var filters = new FileDialogFilters(new FileDialogFilters.Group("mid", "midi"));
             await using var file = await _fileDialogManager.OpenFile(filters);
 
+            // did the instrument menu get closed while waiting for the user to select a file?
+            if (Disposed)
+                return;
+
             // The following checks are only in place to prevent players from playing MIDI songs locally.
             // There are equivalents for these checks on the server.
 


### PR DESCRIPTION
Currently a user can make an instrument play music **locally** despite the instrument menu being closed. You do this by opening the midi file select menu, then closing the instrument menu, then selecting a file. Reported by "Winston Thrasher#3763" on discord.

This PR just makes the awaited function check if the window has been disposed after a file has been selected.
Ideally you'd just close the file selection window when the instrument window is closed, but I'm not sure how to do that. The `FileDialogManager` doesn't seem to have that sort of option?

