### PR TITLE
Make masks & some helmets block eating/drinkling

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -34,6 +34,7 @@ namespace Content.Server.Nutrition.EntitySystems
     [UsedImplicitly]
     public class DrinkSystem : EntitySystem
     {
+        [Dependency] private readonly FoodSystem _foodSystem = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
@@ -262,6 +263,14 @@ namespace Content.Server.Nutrition.EntitySystems
                 return true;
             }
 
+            if (_foodSystem.IsMouthBlocked(userUid, out var blocker))
+            {
+                var name = EntityManager.GetComponent<MetaDataComponent>(blocker.Value).EntityName;
+                _popupSystem.PopupEntity(Loc.GetString("food-system-remove-mask", ("entity", name)),
+                    userUid, Filter.Entities(userUid));
+                return true;
+            }
+
             var transferAmount = FixedPoint2.Min(drink.TransferAmount, drinkSolution.DrainAvailable);
             var drain = _solutionContainerSystem.Drain(uid, drinkSolution, transferAmount);
             var firstStomach = stomachs.FirstOrNull(
@@ -324,6 +333,14 @@ namespace Content.Server.Nutrition.EntitySystems
             {
                 _popupSystem.PopupEntity(Loc.GetString("drink-component-try-use-drink-is-empty",
                     ("entity", drink.Owner.Name)), uid, Filter.Entities(userUid));
+                return true;
+            }
+
+            if (_foodSystem.IsMouthBlocked(targetUid, out var blocker))
+            {
+                var name = EntityManager.GetComponent<MetaDataComponent>(blocker.Value).EntityName;
+                _popupSystem.PopupEntity(Loc.GetString("food-system-remove-mask", ("entity", name)),
+                    userUid, Filter.Entities(userUid));
                 return true;
             }
 

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -456,7 +456,7 @@ namespace Content.Server.Nutrition.EntitySystems
         {
             blockingEntity = null;
 
-            if (!Resolve(uid, ref inventory))
+            if (!Resolve(uid, ref inventory, false))
                 return false;
 
             // check masks

--- a/Resources/Locale/en-US/nutrition/components/food-component.ftl
+++ b/Resources/Locale/en-US/nutrition/components/food-component.ftl
@@ -7,6 +7,8 @@ food-you-need-to-hold-utensil = You need to be holding a {$utensil} to eat that!
 food-nom = Nom
 food-swallow = You swallow the {$food}.
 
+food-system-remove-mask = You need to take off the {$entity} first.
+
 ## System
 
 food-system-you-cannot-eat-any-more = You can't eat any more!

--- a/Resources/Prototypes/Entities/Clothing/Head/base.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base.yml
@@ -41,6 +41,9 @@
         Piercing: 0.95
         Heat: 0.90
         Radiation: 0.25
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -8,6 +8,9 @@
     sprite: Clothing/Head/Helmets/bombsuit.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/bombsuit.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -19,6 +22,9 @@
     sprite: Clothing/Head/Helmets/cosmonaut.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/cosmonaut.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -30,6 +36,9 @@
     sprite: Clothing/Head/Helmets/cult.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/cult.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -70,6 +79,9 @@
     sprite: Clothing/Head/Helmets/light_riot.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/light_riot.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -81,6 +93,9 @@
     sprite: Clothing/Head/Helmets/scaf.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/scaf.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -92,6 +107,9 @@
     sprite: Clothing/Head/Helmets/spaceninja.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/spaceninja.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace # well only partially?
 
 - type: entity
   parent: ClothingHeadBase
@@ -103,6 +121,9 @@
     sprite: Clothing/Head/Helmets/syndicate.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/syndicate.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -114,6 +135,9 @@
     sprite: Clothing/Head/Helmets/templar.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/templar.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -136,3 +160,6 @@
     sprite: Clothing/Head/Helmets/wizardhelm.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/wizardhelm.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -30,6 +30,9 @@
     sprite: Clothing/Head/Misc/chickenhead.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/chickenhead.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -52,6 +55,9 @@
       sprite: Clothing/Head/Misc/pumpkin.rsi
     - type: Clothing
       sprite: Clothing/Head/Misc/pumpkin.rsi
+    - type: Tag
+      tags:
+      - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -74,6 +80,9 @@
     sprite: Clothing/Head/Misc/richard.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/richard.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -85,6 +94,9 @@
     sprite: Clothing/Head/Misc/skubhead.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/skubhead.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -96,6 +108,9 @@
     sprite: Clothing/Head/Misc/xenom.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/xenom.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase
@@ -107,6 +122,9 @@
     sprite: Clothing/Head/Misc/xenos.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/xenos.rsi
+  - type: Tag
+    tags:
+    - ConcealsFace
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -1,5 +1,15 @@
 - type: entity
   parent: ClothingHeadBase
+  id: WeldingMaskBase
+  name: welding mask
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+    - ConcealsFace
+
+- type: entity
+  parent: WeldingMaskBase
   id: ClothingHeadHatWelding
   name: welding mask
   description: A head-mounted face cover designed to protect the wearer completely from space-arc eye.
@@ -10,7 +20,7 @@
     sprite: Clothing/Head/Welding/welding.rsi
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: WeldingMaskBase
   id: ClothingHeadHatWeldingMaskFlame
   name: flame welding mask
   description: A painted welding helmet, this one has flames on it.
@@ -21,7 +31,7 @@
     sprite: Clothing/Head/Welding/flame_welding_mask.rsi
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: WeldingMaskBase
   id: ClothingHeadHatWeldingMaskFlameBlue
   name: blue-flame welding mask
   description: A painted welding helmet, this one has blue flames on it.
@@ -32,7 +42,7 @@
     sprite: Clothing/Head/Welding/blue_flame_welding_mask.rsi
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: WeldingMaskBase
   id: ClothingHeadHatWeldingMaskPainted
   name: painted welding mask
   description: A welding helmet, painted in crimson.

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -239,3 +239,7 @@
 
 - type: Tag
   id: Write
+  
+# for head wear & masks that cover the face.
+- type: Tag
+  id: ConcealsFace


### PR DESCRIPTION
This adds a `IsMouthBlocked()` function to `FoodSystem` that checks whether the user is wearing a mask or a face-covering headwear (hardsuits, welding masks, etc). If they are, it prevents eating and drinking and generates an informative popup.

I'm not sure on what the best way is to distinguish between mouth-covering headwear and generic hats. Given that there is no "headwear" component, and that it makes no sense for generic clothing to have a "covers mouth" field, I just added a new 'ConcealsFace' tag and check if the headwear has that.

:cl:
- tweak: Masks & some headwear now blocks eating & drinking