### PR TITLE
Fixes admin logs and tests to not depend on IEntity caching

### DIFF
--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -161,7 +161,7 @@ public class AddTests : ContentIntegrationTest
         await server.WaitPost(() =>
         {
             var coordinates = GetMainEntityCoordinates(sMaps);
-            var entity = sEntities.SpawnEntity(null, coordinates);
+            var entity = sEntities.SpawnEntity(null, coordinates).Uid;
 
             if (parallel)
             {

--- a/Content.IntegrationTests/Tests/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LungTest.cs
@@ -178,10 +178,14 @@ namespace Content.IntegrationTests.Tests.Body
 
             var increment = 10;
 
+
             for (var tick = 0; tick < 600; tick += increment)
             {
                 await server.WaitRunTicks(increment);
-                Assert.False(respirator.Suffocating, $"Entity {human.Name} is suffocating on tick {tick}");
+                await server.WaitAssertion(() =>
+                {
+                    Assert.False(respirator.Suffocating, $"Entity {human.Name} is suffocating on tick {tick}");
+                });
             }
 
             await server.WaitIdleAsync();

--- a/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
@@ -144,14 +144,13 @@ namespace Content.IntegrationTests.Tests.Doors
             await server.WaitIdleAsync();
 
             // Push the human towards the airlock
-            Assert.That(physBody != null);
-            physBody.LinearVelocity = (0.5f, 0);
+            await server.WaitAssertion(() => Assert.That(physBody != null));
+            await server.WaitPost(() => physBody.LinearVelocity = (0.5f, 0));
 
             for (var i = 0; i < 240; i += 10)
             {
                 // Keep the airlock awake so they collide
-                airlock.GetComponent<IPhysBody>().WakeBody();
-
+                server.Post(() => airlock.GetComponent<IPhysBody>().WakeBody());
 
                 await server.WaitRunTicks(10);
                 await server.WaitIdleAsync();
@@ -164,7 +163,7 @@ namespace Content.IntegrationTests.Tests.Doors
             // Assert.That(physicsDummy.Transform.MapPosition.X, Is.GreaterThan(physicsDummyStartingX));
 
             // Blocked by the airlock
-            Assert.That(Math.Abs(physicsDummy.Transform.MapPosition.X - 1) > 0.01f);
+            await server.WaitAssertion(() => Assert.That(Math.Abs(physicsDummy.Transform.MapPosition.X - 1) > 0.01f));
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
@@ -179,9 +179,6 @@ namespace Content.IntegrationTests.Tests.Fluids
             // Puddle evaporation should have ticked
             await server.WaitAssertion(() =>
             {
-                // Check that the puddle is unpaused
-                Assert.False(puddle.Owner.Paused);
-
                 // Check that puddle has been deleted
                 Assert.True(puddle.Deleted);
             });

--- a/Content.IntegrationTests/Tests/Lobby/CharacterCreationTest.cs
+++ b/Content.IntegrationTests/Tests/Lobby/CharacterCreationTest.cs
@@ -50,9 +50,9 @@ namespace Content.IntegrationTests.Tests.Lobby
                 serverConfig.SetCVar(CCVars.GameDummyTicker, false);
                 serverConfig.SetCVar(CCVars.GameLobbyEnabled, true);
                 serverTicker.RestartRound();
-            });
 
-            Assert.That(serverTicker.RunLevel, Is.EqualTo(GameRunLevel.PreRoundLobby));
+                Assert.That(serverTicker.RunLevel, Is.EqualTo(GameRunLevel.PreRoundLobby));
+            });
 
             // Need to run them in sync to receive the messages.
             await RunTicksSync(client, server, 1);
@@ -68,7 +68,8 @@ namespace Content.IntegrationTests.Tests.Lobby
             {
                 clientPrefManager.SelectCharacter(0);
 
-                var clientCharacters = clientPrefManager.Preferences.Characters;
+                var clientCharacters = clientPrefManager.Preferences?.Characters;
+                Assert.That(clientCharacters, Is.Not.Null);
                 Assert.That(clientCharacters.Count, Is.EqualTo(1));
 
                 Assert.That(clientStateManager.CurrentState, Is.TypeOf<LobbyState>());
@@ -76,8 +77,9 @@ namespace Content.IntegrationTests.Tests.Lobby
                 profile = HumanoidCharacterProfile.Random();
                 clientPrefManager.CreateCharacter(profile);
 
-                clientCharacters = clientPrefManager.Preferences.Characters;
+                clientCharacters = clientPrefManager.Preferences?.Characters;
 
+                Assert.That(clientCharacters, Is.Not.Null);
                 Assert.That(clientCharacters.Count, Is.EqualTo(2));
                 Assert.That(clientCharacters[1].MemberwiseEquals(profile));
             });
@@ -96,7 +98,7 @@ namespace Content.IntegrationTests.Tests.Lobby
             {
                 clientPrefManager.DeleteCharacter(1);
 
-                var clientCharacters = clientPrefManager.Preferences.Characters.Count;
+                var clientCharacters = clientPrefManager.Preferences?.Characters.Count;
                 Assert.That(clientCharacters, Is.EqualTo(1));
             });
 
@@ -116,8 +118,9 @@ namespace Content.IntegrationTests.Tests.Lobby
 
                 clientPrefManager.CreateCharacter(profile);
 
-                var clientCharacters = clientPrefManager.Preferences.Characters;
+                var clientCharacters = clientPrefManager.Preferences?.Characters;
 
+                Assert.That(clientCharacters, Is.Not.Null);
                 Assert.That(clientCharacters.Count, Is.EqualTo(2));
                 Assert.That(clientCharacters[1].MemberwiseEquals(profile));
             });

--- a/Content.IntegrationTests/Tests/Networking/ConnectTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/ConnectTest.cs
@@ -55,10 +55,12 @@ namespace Content.IntegrationTests.Tests.Networking
             var clEntityManager = client.ResolveDependency<IEntityManager>();
             var svEntityManager = server.ResolveDependency<IEntityManager>();
 
-            var lastSvEntity = svEntityManager.GetEntities().Last();
-            var lastClEntity = clEntityManager.GetEntity(lastSvEntity.Uid);
+            var lastSvEntity = svEntityManager.GetEntities().Last().Uid;
+            var lastClEntity = clEntityManager.GetEntity(lastSvEntity).Uid;
 
-            Assert.That(lastClEntity.Transform.Coordinates, Is.EqualTo(lastSvEntity.Transform.Coordinates));
+
+            Assert.That(clEntityManager.GetComponent<TransformComponent>(lastClEntity).Coordinates,
+                Is.EqualTo(svEntityManager.GetComponent<TransformComponent>(lastSvEntity).Coordinates));
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Networking/ConnectTest.cs
+++ b/Content.IntegrationTests/Tests/Networking/ConnectTest.cs
@@ -56,10 +56,8 @@ namespace Content.IntegrationTests.Tests.Networking
             var svEntityManager = server.ResolveDependency<IEntityManager>();
 
             var lastSvEntity = svEntityManager.GetEntities().Last().Uid;
-            var lastClEntity = clEntityManager.GetEntity(lastSvEntity).Uid;
 
-
-            Assert.That(clEntityManager.GetComponent<TransformComponent>(lastClEntity).Coordinates,
+            Assert.That(clEntityManager.GetComponent<TransformComponent>(lastSvEntity).Coordinates,
                 Is.EqualTo(svEntityManager.GetComponent<TransformComponent>(lastSvEntity).Coordinates));
         }
     }

--- a/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadMapTest.cs
@@ -60,21 +60,24 @@ namespace Content.IntegrationTests.Tests
                 mapLoader.LoadMap(new MapId(10), mapPath);
             });
             await server.WaitIdleAsync();
-
+            await server.WaitAssertion(() =>
             {
-                if(!mapManager.TryFindGridAt(new MapId(10), new Vector2(10,10), out var mapGrid))
-                    Assert.Fail();
+                {
+                    if (!mapManager.TryFindGridAt(new MapId(10), new Vector2(10, 10), out var mapGrid))
+                        Assert.Fail();
 
-                Assert.That(mapGrid.WorldPosition, Is.EqualTo(new Vector2(10, 10)));
-                Assert.That(mapGrid.GetTileRef(new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(1, 512)));
-            }
-            {
-                if (!mapManager.TryFindGridAt(new MapId(10), new Vector2(-8, -8), out var mapGrid))
-                    Assert.Fail();
+                    Assert.That(mapGrid.WorldPosition, Is.EqualTo(new Vector2(10, 10)));
 
-                Assert.That(mapGrid.WorldPosition, Is.EqualTo(new Vector2(-8, -8)));
-                Assert.That(mapGrid.GetTileRef(new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(2, 511)));
-            }
+                    Assert.That(mapGrid.GetTileRef(new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(1, 512)));
+                }
+                {
+                    if (!mapManager.TryFindGridAt(new MapId(10), new Vector2(-8, -8), out var mapGrid))
+                        Assert.Fail();
+
+                    Assert.That(mapGrid.WorldPosition, Is.EqualTo(new Vector2(-8, -8)));
+                    Assert.That(mapGrid.GetTileRef(new Vector2i(0, 0)).Tile, Is.EqualTo(new Tile(2, 511)));
+                }
+            });
 
         }
     }

--- a/Content.Server/AI/EntitySystems/AiSystem.cs
+++ b/Content.Server/AI/EntitySystems/AiSystem.cs
@@ -91,13 +91,14 @@ namespace Content.Server.AI.EntitySystems
 
             foreach (var npc in _awakeAi)
             {
-                if (npc.Paused) continue;
-
                 if (npc.Deleted)
                 {
                     toRemove.Add(npc);
                     continue;
                 }
+
+                if (npc.Paused)
+                    continue;
 
                 if (count >= maxUpdates)
                 {

--- a/Content.Server/Administration/Logs/AdminLogSystem.Json.cs
+++ b/Content.Server/Administration/Logs/AdminLogSystem.Json.cs
@@ -68,8 +68,8 @@ public partial class AdminLogSystem
                 continue;
             }
 
-            var entityName = _entityManager.TryGetEntity(uid, out var resolvedEntity)
-                ? resolvedEntity.Name
+            var entityName = _entityManager.TryGetComponent(uid, out MetaDataComponent? metadata)
+                ? metadata.EntityName
                 : null;
 
             if (entities.Any(e => e.id == (int) uid)) continue;

--- a/Content.Server/Administration/Logs/Converters/EntityUidConverter.cs
+++ b/Content.Server/Administration/Logs/Converters/EntityUidConverter.cs
@@ -16,9 +16,9 @@ public class EntityUidConverter : AdminLogConverter<EntityUid>
 
         writer.WriteNumber("id", (int) value);
 
-        if (entities.TryGetEntity(value, out var entity))
+        if (entities.TryGetComponent(value, out MetaDataComponent metaData))
         {
-            writer.WriteString("name", entity.Name);
+            writer.WriteString("name", metaData.EntityName);
         }
 
         if (entities.TryGetComponent(value, out ActorComponent? actor))

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -347,7 +347,7 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 var atmosphere = _currentRunAtmosphere[_currentRunAtmosphereIndex];
 
-                if (atmosphere.Paused || !atmosphere.Simulated || atmosphere.LifeStage >= ComponentLifeStage.Stopping)
+                if (atmosphere.LifeStage >= ComponentLifeStage.Stopping || atmosphere.Paused || !atmosphere.Simulated)
                     continue;
 
                 atmosphere.Timer += frameTime;

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -262,6 +262,9 @@ namespace Content.Server.Disposal.Unit.EntitySystems
 
         private void HandlePowerChange(EntityUid uid, DisposalUnitComponent component, PowerChangedEvent args)
         {
+            if (!component.Running)
+                return;
+
             // TODO: Need to check the other stuff.
             if (!args.Powered)
             {

--- a/Content.Server/Kudzu/SpreaderSystem.cs
+++ b/Content.Server/Kudzu/SpreaderSystem.cs
@@ -35,8 +35,6 @@ public class SpreaderSystem : EntitySystem
 
     private void OnAirtightChanged(AirtightChanged e)
     {
-
-
         UpdateNearbySpreaders(e.Airtight.OwnerUid, e.Airtight);
     }
 

--- a/Content.Server/Kudzu/SpreaderSystem.cs
+++ b/Content.Server/Kudzu/SpreaderSystem.cs
@@ -30,7 +30,14 @@ public class SpreaderSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<SpreaderComponent, ComponentAdd>(SpreaderAddHandler);
-        SubscribeLocalEvent<AirtightChanged>(e => UpdateNearbySpreaders(e.Airtight.OwnerUid, e.Airtight));
+        SubscribeLocalEvent<AirtightChanged>(OnAirtightChanged);
+    }
+
+    private void OnAirtightChanged(AirtightChanged e)
+    {
+
+
+        UpdateNearbySpreaders(e.Airtight.OwnerUid, e.Airtight);
     }
 
     private void SpreaderAddHandler(EntityUid uid, SpreaderComponent component, ComponentAdd args)

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -240,8 +240,11 @@ namespace Content.Server.Light.EntitySystems
             ApcPowerReceiverComponent? powerReceiver = null,
             AppearanceComponent? appearance = null)
         {
-            if (!Resolve(uid, ref light, ref powerReceiver, ref appearance))
+            if (!Resolve(uid, ref light, ref powerReceiver))
                 return;
+
+            // Optional component.
+            Resolve(uid, ref appearance, false);
 
             // check if light has bulb
             var bulbUid = GetBulb(uid, light);

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -5,7 +5,6 @@ using Content.Server.Power.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Physics;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Power.EntitySystems
 {

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Power.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Physics;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Power.EntitySystems
 {


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Required for https://github.com/space-wizards/RobustToolbox/pull/2296, does *not* require a submodule update however.

Fixes various tests and systems to not depend on transform/metadata/entitymanager caching on IEntity.
Admin logs now get `MetaData` component instead of getting `IEntity`, when passed an `EntityUid`.

**IMPORTANT NOTE**: Because now `IEntity` calls `IoC.Resolve<IEntityManager>()` instead of caching it, bulk-adding logs using `Parallel` with `IEntity` is no longer feasible, given `IoC` is thread-local. I think this is not a big deal, given I'm planning on removing `IEntity` entirely soon. Do note, this is a general issue with `Parallel`, not with admin logs specifically.