### PR TITLE
Add Syringe DoAfter

### DIFF
--- a/Content.Server/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Server/Chemistry/Components/InjectorComponent.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Chemistry.Components
         public float Delay = 5;
 
         /// <summary>
-        ///     Is this component currently being used in a DoAfter?
+        /// Is this component currently being used in a DoAfter?
         /// </summary>
         public bool InUse = false;
 
@@ -187,7 +187,7 @@ namespace Content.Server.Chemistry.Components
         }
 
         /// <summary>
-        ///     Send informative pop-up messages and wait for a Do-After to complete.
+        /// Send informative pop-up messages and wait for a Do-After to complete.
         /// </summary>
         public async Task<bool> TryInjectDoAfter(EntityUid user, EntityUid target)
         {

--- a/Content.Server/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Server/Chemistry/Components/InjectorComponent.cs
@@ -234,7 +234,7 @@ namespace Content.Server.Chemistry.Components
                 if (ToggleState == InjectorToggleMode.Inject)
                 {
                     logSys.Add(LogType.ForceFeed,
-                        $"{userEntity} is attempting to injecting a solution into {targetEntity}");
+                        $"{userEntity} is attempting to inject a solution into {targetEntity}");
                     // TODO solution pretty string.
                 }
             }
@@ -246,7 +246,7 @@ namespace Content.Server.Chemistry.Components
                 // and lets log it. TODO solution pretty string.
                 if (ToggleState == InjectorToggleMode.Inject)
                     logSys.Add(LogType.Ingestion,
-                        $"{userEntity} is attempting to injecting themselves with a solution.");
+                        $"{userEntity} is attempting to inject themselves with a solution.");
             }
 
             var status = await EntitySystem.Get<DoAfterSystem>().WaitDoAfter(

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Shared.Database;
+namespace Content.Shared.Database;
 
 // DO NOT CHANGE THE NUMERIC VALUES OF THESE
 public enum LogType
@@ -40,7 +40,8 @@ public enum LogType
     Pickup = 36,
     Drop = 37,
     BulletHit = 38,
-    ForceFeed = 40,
+    ForceFeed = 40, // involuntary
+    Ingestion = 53, // voluntary
     MeleeHit = 41,
     HitScanHit = 42,
     Suicide = 43,

--- a/Resources/Locale/en-US/chemistry/components/injector-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/injector-component.ftl
@@ -17,3 +17,8 @@ injector-component-transfer-success-message = You transfer {$amount}u into {$tar
 injector-component-draw-success-message = You draw {$amount}u from {$target}.
 injector-component-target-already-full-message = {$target} is already full!
 injector-component-target-is-empty-message = {$target} is empty!
+
+## mob-inject doafter messages
+
+injector-component-injecting-user = You start inserting the needle.
+injector-component-injecting-target = {$user} is trying to stick a needle into you!


### PR DESCRIPTION
This adds a do-after for syringes when injecting/drawing from mobs. It will now also create an informative pop-up for the target and add admin logs.

Injecting/drawing from bottles and other non-mob solutions doesn't have a do-after. Maybe it should, but IMO that just makes chemistry a hassle.

:cl:
- tweak Using syringes to inject reagents into mobs now has a delay.

