### PR TITLE
Fix donk pocket boxes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donkpocket.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/donkpocket.yml
@@ -18,6 +18,9 @@
           Quantity: 3
   - type: Item
     size: 1
+  - type: Tag
+    tags:
+    - DonkPocket
 
 # Donkpocket
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -91,6 +91,9 @@
   id: DoorElectronics
 
 - type: Tag
+  id: DonkPocket
+
+- type: Tag
   id: Donut
 
 - type: Tag


### PR DESCRIPTION
Donk boxes had a tag whitelist, but there was no actual tag. This adds the tag.

fixes #5254

:cl:
- fix: Donk pockets now fit into their boxes again.

