### PR TITLE
Make MovementSpeedModifier send the actual modifier in the state

### DIFF
--- a/Content.Shared/Movement/EntitySystems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/EntitySystems/MovementSpeedModifierSystem.cs
@@ -35,6 +35,8 @@ namespace Content.Shared.Movement.EntitySystems
             {
                 BaseWalkSpeed = component.BaseWalkSpeed,
                 BaseSprintSpeed = component.BaseSprintSpeed,
+                WalkSpeedModifier = component.WalkSpeedModifier,
+                SprintSpeedModifier = component.SprintSpeedModifier
             };
         }
 
@@ -43,6 +45,8 @@ namespace Content.Shared.Movement.EntitySystems
             if (args.Current is not MovementSpeedModifierComponentState state) return;
             component.BaseWalkSpeed = state.BaseWalkSpeed;
             component.BaseSprintSpeed = state.BaseSprintSpeed;
+            component.WalkSpeedModifier = state.WalkSpeedModifier;
+            component.SprintSpeedModifier = state.SprintSpeedModifier;
         }
 
         public void RefreshMovementSpeedModifiers(EntityUid uid)
@@ -69,6 +73,8 @@ namespace Content.Shared.Movement.EntitySystems
         {
             public float BaseWalkSpeed;
             public float BaseSprintSpeed;
+            public float WalkSpeedModifier;
+            public float SprintSpeedModifier;
         }
     }
 


### PR DESCRIPTION
Currently `MovementSpeedModifierComponent` is `dirty()`-ed whenever the movement speed modifiers get updated. However it currently only actually sends the base speeds in the component state and not the actual modifier. This PR just makes it also send the actual modifiers to the client.

While this stops clients being stuck with a modifier that differs from the servers, which can happen with kudzu (#5609), it doesn't actually stop whatever causes the discrepancy in the first place.