### PR TITLE
Multiply pushback ratio by 10 for better recovery from being spaced

### DIFF
--- a/Content.Server/Throwing/ThrowHelper.cs
+++ b/Content.Server/Throwing/ThrowHelper.cs
@@ -29,8 +29,8 @@ namespace Content.Server.Throwing
         /// <param name="direction">A vector pointing from the entity to its destination.</param>
         /// <param name="strength">How much the direction vector should be multiplied for velocity.</param>
         /// <param name="user"></param>
-        /// <param name="pushbackRatio">The ratio of impulse applied to the thrower</param>
-        internal static void TryThrow(this IEntity entity, Vector2 direction, float strength = 1.0f, IEntity? user = null, float pushbackRatio = 1.0f)
+        /// <param name="pushbackRatio">The ratio of impulse applied to the thrower - defaults to 10 because otherwise it's not enough to properly recover from getting spaced</param>
+        internal static void TryThrow(this IEntity entity, Vector2 direction, float strength = 1.0f, IEntity? user = null, float pushbackRatio = 10.0f)
         {
             if (entity.Deleted ||
                 strength <= 0f ||


### PR DESCRIPTION
## About the PR

Ok, so some context.
+ Inter-grid transfer absolutely sucks in SS14 right now and there's no good way to fix it (the best thing I can think of is a manual "change direction" button. If you are about to voice criticism of that idea, then you have proven my point as to why this PR is the better solution).
+ Atmospherics remains capable of throwing people into space, it just doesn't tend to throw them through walls anymore.

This in mind, to me, the answer is better recovery from being spaced.

Right now to recover from being spaced, you lose essentially all of your inventory. And if that's not enough you're completely screwed.

This multiplies the pushback ratio by 10 so that a single item should generally be enough to recover from being spaced.

Keep in mind the situations this seriously affects balance-wise have the following causes:
+ Inter-grid transfer bugs
+ Person's connection lagging while spacewalking
+ Explosive decompression (and the docking airlocks are on-touch...)

**Changelog**

:cl:
- tweak: Throw pushback ratio multiplied by 10.

