### PR TITLE
Prevent cigars and some other masks from blocking drinking/eating.

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -460,17 +460,26 @@ namespace Content.Server.Nutrition.EntitySystems
                 return false;
 
             // check masks
+            TagComponent tag;
             if (inventory.TryGetSlotItem(EquipmentSlotDefines.Slots.MASK, out ItemComponent? mask))
             {
-                // For now, lets just assume that any masks always covers the mouth
-                // TODO MASKS if the ability is added to raise/lower masks, this needs to be updated.
-                blockingEntity = mask.OwnerUid;
-                return true;
+                // Masks include things like cigars & clown masks. These are annoying to remove when you just want to
+                // sip a drink. So we use a BlocksMouth tag.
+
+                // TODO MASKS / MASKCOMPONENT.
+                // If the ability is added to raise/lower masks, this needs to be updated to check MaskComponent.Lowered
+                // or something. The BlocksMouth tag can probably also be removed then?
+
+                if (EntityManager.TryGetComponent(mask.OwnerUid, out tag) && tag.HasTag("BlocksMouth"))
+                {
+                    blockingEntity = mask.OwnerUid;
+                    return true;
+                }
             }
 
             // check helmets. Note that not all helmets cover the face.
             if (inventory.TryGetSlotItem(EquipmentSlotDefines.Slots.HEAD, out ItemComponent? head) &&
-                EntityManager.TryGetComponent(head.OwnerUid, out TagComponent tag) &&
+                EntityManager.TryGetComponent(head.OwnerUid, out tag) &&
                 tag.HasTag("ConcealsFace"))
             {
                 blockingEntity = head.OwnerUid;

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -9,6 +9,9 @@
   - type: Clothing
     sprite: Clothing/Mask/gas.rsi
   - type: BreathMask
+  - type: Tag
+    tags: 
+    - BlocksMouth
 
 - type: entity
   parent: ClothingMaskBase
@@ -21,6 +24,9 @@
   - type: Clothing
     sprite: Clothing/Mask/breath.rsi
   - type: BreathMask
+  - type: Tag
+    tags: 
+    - BlocksMouth
 
 - type: entity
   parent: ClothingMaskBase
@@ -69,3 +75,6 @@
   - type: Clothing
     sprite: Clothing/Mask/sterile.rsi
   - type: BreathMask
+  - type: Tag
+    tags: 
+    - BlocksMouth

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -48,3 +48,6 @@
     solution: bucket
   - type: DrainableSolution
     solution: bucket
+  - type: Tag
+    tags:
+    - ConcealsFace

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -6,6 +6,10 @@
 - type: Tag
   id: Bee
 
+# for masks. Unnecessary if something like a mask component  gets added
+- type: Tag
+  id: BlocksMouth 
+
 - type: Tag
   id: Brutepack
 


### PR DESCRIPTION
Currently just done via a "BlocksMouth" tag. If ever mask lowering/raising gets added, this should probably just become a bool in `MaskComponent` or whatever.

:cl:
- fix: Cigars and clown/mime masks no longer block drinking & eating.