### PR TITLE
Add IngestionBlocker component

### DIFF
--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -8,6 +8,7 @@ namespace Content.Client.Entry
             "Anchorable",
             "AmmoBox",
             "Pickaxe",
+            "IngestionBlocker",
             "Interactable",
             "CloningPod",
             "Destructible",

--- a/Content.Server/Nutrition/Components/IngestionBlockerComponent.cs
+++ b/Content.Server/Nutrition/Components/IngestionBlockerComponent.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Analyzers;
+using Robust.Shared.ViewVariables;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Content.Server.Nutrition.EntitySystems;
+
+/// <summary>
+///     Component that denotes a piece of clothing that blocks the mouth or otherwise prevents eating & drinking.
+/// </summary>
+/// <remarks>
+///     In the event that more head-wear & mask functionality is added (like identity systems, or raising/lowering of
+///     masks), then this component might become redundant.
+/// </remarks>
+[RegisterComponent, Friend(typeof(FoodSystem), typeof(DrinkSystem))]
+public class IngestionBlockerComponent : Component
+{
+    public override string Name => "IngestionBlocker";
+
+    /// <summary>
+    ///     Is this component currently blocking consumption.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("enabled")]
+    public bool Enabled { get; set; } = true;
+}

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -263,9 +263,11 @@ namespace Content.Server.Nutrition.EntitySystems
                 return true;
             }
 
-            if (_foodSystem.IsMouthBlocked(userUid, out var blocker))
+            var attempt = new IngestionAttemptEvent();
+            RaiseLocalEvent(userUid, attempt, false);
+            if (attempt.Cancelled && attempt.Blocker != null)
             {
-                var name = EntityManager.GetComponent<MetaDataComponent>(blocker.Value).EntityName;
+                var name = EntityManager.GetComponent<MetaDataComponent>(attempt.Blocker.Value).EntityName;
                 _popupSystem.PopupEntity(Loc.GetString("food-system-remove-mask", ("entity", name)),
                     userUid, Filter.Entities(userUid));
                 return true;
@@ -336,9 +338,11 @@ namespace Content.Server.Nutrition.EntitySystems
                 return true;
             }
 
-            if (_foodSystem.IsMouthBlocked(targetUid, out var blocker))
+            var attempt = new IngestionAttemptEvent();
+            RaiseLocalEvent(targetUid, attempt, false);
+            if (attempt.Cancelled && attempt.Blocker != null)
             {
-                var name = EntityManager.GetComponent<MetaDataComponent>(blocker.Value).EntityName;
+                var name = EntityManager.GetComponent<MetaDataComponent>(attempt.Blocker.Value).EntityName;
                 _popupSystem.PopupEntity(Loc.GetString("food-system-remove-mask", ("entity", name)),
                     userUid, Filter.Entities(userUid));
                 return true;
@@ -423,30 +427,6 @@ namespace Content.Server.Nutrition.EntitySystems
         private void OnForceDrinkCancelled(ForceDrinkCancelledEvent args)
         {
             args.Drink.InUse = false;
-        }
-    }
-
-    public sealed class ForceDrinkEvent : EntityEventArgs
-    {
-        public readonly EntityUid User;
-        public readonly DrinkComponent Drink;
-        public readonly Solution DrinkSolution;
-
-        public ForceDrinkEvent(EntityUid user, DrinkComponent drink, Solution drinkSolution)
-        {
-            User = user;
-            Drink = drink;
-            DrinkSolution = drinkSolution;
-        }
-    }
-
-    public sealed class ForceDrinkCancelledEvent : EntityEventArgs
-    {
-        public readonly DrinkComponent Drink;
-
-        public ForceDrinkCancelledEvent( DrinkComponent drink)
-        {
-            Drink = drink;
         }
     }
 }

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -263,15 +263,8 @@ namespace Content.Server.Nutrition.EntitySystems
                 return true;
             }
 
-            var attempt = new IngestionAttemptEvent();
-            RaiseLocalEvent(userUid, attempt, false);
-            if (attempt.Cancelled && attempt.Blocker != null)
-            {
-                var name = EntityManager.GetComponent<MetaDataComponent>(attempt.Blocker.Value).EntityName;
-                _popupSystem.PopupEntity(Loc.GetString("food-system-remove-mask", ("entity", name)),
-                    userUid, Filter.Entities(userUid));
+            if (_foodSystem.IsMouthBlocked(userUid, userUid))
                 return true;
-            }
 
             var transferAmount = FixedPoint2.Min(drink.TransferAmount, drinkSolution.DrainAvailable);
             var drain = _solutionContainerSystem.Drain(uid, drinkSolution, transferAmount);
@@ -338,15 +331,8 @@ namespace Content.Server.Nutrition.EntitySystems
                 return true;
             }
 
-            var attempt = new IngestionAttemptEvent();
-            RaiseLocalEvent(targetUid, attempt, false);
-            if (attempt.Cancelled && attempt.Blocker != null)
-            {
-                var name = EntityManager.GetComponent<MetaDataComponent>(attempt.Blocker.Value).EntityName;
-                _popupSystem.PopupEntity(Loc.GetString("food-system-remove-mask", ("entity", name)),
-                    userUid, Filter.Entities(userUid));
+            if (_foodSystem.IsMouthBlocked(targetUid, userUid))
                 return true;
-            }
 
             EntityManager.TryGetComponent(userUid, out MetaDataComponent? meta);
             var userName = meta?.EntityName ?? string.Empty;

--- a/Content.Server/Nutrition/IngestionEvents.cs
+++ b/Content.Server/Nutrition/IngestionEvents.cs
@@ -11,7 +11,7 @@ namespace Content.Server.Nutrition;
 public sealed class IngestionAttemptEvent : CancellableEntityEventArgs
 {
     /// <summary>
-    ///     The equipment that is blocking consumption. Should be non-null if the event was canceled.
+    ///     The equipment that is blocking consumption. Should only be non-null if the event was canceled.
     /// </summary>
     public EntityUid? Blocker = null;
 }

--- a/Content.Server/Nutrition/IngestionEvents.cs
+++ b/Content.Server/Nutrition/IngestionEvents.cs
@@ -1,0 +1,79 @@
+using Content.Server.Nutrition.Components;
+using Content.Shared.Chemistry.Components;
+using Robust.Shared.GameObjects;
+using System.Collections.Generic;
+
+namespace Content.Server.Nutrition;
+
+/// <summary>
+///     Raised directed at the consumer when attempting to ingest something.
+/// </summary>
+public sealed class IngestionAttemptEvent : CancellableEntityEventArgs
+{
+    /// <summary>
+    ///     The equipment that is blocking consumption. Should be non-null if the event was canceled.
+    /// </summary>
+    public EntityUid? Blocker = null;
+}
+
+/// <summary>
+///     Raised directed at the food after a successful force-feed do-after.
+/// </summary>
+public sealed class ForceFeedEvent : EntityEventArgs
+{
+    public readonly EntityUid User;
+    public readonly FoodComponent Food;
+    public readonly Solution FoodSolution;
+    public readonly List<UtensilComponent> Utensils;
+
+    public ForceFeedEvent(EntityUid user, FoodComponent food, Solution foodSolution, List<UtensilComponent> utensils)
+    {
+        User = user;
+        Food = food;
+        FoodSolution = foodSolution;
+        Utensils = utensils;
+    }
+}
+
+/// <summary>
+///     Raised directed at the food after a failed force-feed do-after.
+/// </summary>
+public sealed class ForceFeedCancelledEvent : EntityEventArgs
+{
+    public readonly FoodComponent Food;
+
+    public ForceFeedCancelledEvent(FoodComponent food)
+    {
+        Food = food;
+    }
+}
+
+/// <summary>
+///     Raised directed at the drink after a successful force-drink do-after.
+/// </summary>
+public sealed class ForceDrinkEvent : EntityEventArgs
+{
+    public readonly EntityUid User;
+    public readonly DrinkComponent Drink;
+    public readonly Solution DrinkSolution;
+
+    public ForceDrinkEvent(EntityUid user, DrinkComponent drink, Solution drinkSolution)
+    {
+        User = user;
+        Drink = drink;
+        DrinkSolution = drinkSolution;
+    }
+}
+
+/// <summary>
+///     Raised directed at the food after a failed force-dink do-after.
+/// </summary>
+public sealed class ForceDrinkCancelledEvent : EntityEventArgs
+{
+    public readonly DrinkComponent Drink;
+
+    public ForceDrinkCancelledEvent(DrinkComponent drink)
+    {
+        Drink = drink;
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Head/base.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base.yml
@@ -41,9 +41,7 @@
         Piercing: 0.95
         Heat: 0.90
         Radiation: 0.25
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -8,9 +8,7 @@
     sprite: Clothing/Head/Helmets/bombsuit.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/bombsuit.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -22,9 +20,7 @@
     sprite: Clothing/Head/Helmets/cosmonaut.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/cosmonaut.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -36,9 +32,7 @@
     sprite: Clothing/Head/Helmets/cult.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/cult.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -79,9 +73,7 @@
     sprite: Clothing/Head/Helmets/light_riot.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/light_riot.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -93,9 +85,7 @@
     sprite: Clothing/Head/Helmets/scaf.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/scaf.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -107,9 +97,7 @@
     sprite: Clothing/Head/Helmets/spaceninja.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/spaceninja.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace # well only partially?
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -121,9 +109,7 @@
     sprite: Clothing/Head/Helmets/syndicate.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/syndicate.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -135,9 +121,7 @@
     sprite: Clothing/Head/Helmets/templar.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/templar.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -160,6 +144,4 @@
     sprite: Clothing/Head/Helmets/wizardhelm.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/wizardhelm.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -30,9 +30,7 @@
     sprite: Clothing/Head/Misc/chickenhead.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/chickenhead.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -55,9 +53,7 @@
       sprite: Clothing/Head/Misc/pumpkin.rsi
     - type: Clothing
       sprite: Clothing/Head/Misc/pumpkin.rsi
-    - type: Tag
-      tags:
-      - ConcealsFace
+    - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -80,9 +76,7 @@
     sprite: Clothing/Head/Misc/richard.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/richard.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -94,9 +88,7 @@
     sprite: Clothing/Head/Misc/skubhead.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/skubhead.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -108,9 +100,7 @@
     sprite: Clothing/Head/Misc/xenom.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/xenom.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase
@@ -122,9 +112,7 @@
     sprite: Clothing/Head/Misc/xenos.rsi
   - type: Clothing
     sprite: Clothing/Head/Misc/xenos.rsi
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -4,9 +4,7 @@
   name: welding mask
   abstract: true
   components:
-  - type: Tag
-    tags:
-    - ConcealsFace
+  - type: IngestionBlocker
 
 - type: entity
   parent: WeldingMaskBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -9,6 +9,7 @@
   - type: Clothing
     sprite: Clothing/Mask/gas.rsi
   - type: BreathMask
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingMaskBase
@@ -21,6 +22,7 @@
   - type: Clothing
     sprite: Clothing/Mask/breath.rsi
   - type: BreathMask
+  - type: IngestionBlocker
 
 - type: entity
   parent: ClothingMaskBase
@@ -69,3 +71,4 @@
   - type: Clothing
     sprite: Clothing/Mask/sterile.rsi
   - type: BreathMask
+  - type: IngestionBlocker

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -242,7 +242,3 @@
 
 - type: Tag
   id: Write
-  
-# for head wear & masks that cover the face.
-- type: Tag
-  id: ConcealsFace


### PR DESCRIPTION
This PR:
- Adds an `IngestionBlocker` component and `IngestionAttemptEvent`
- Uses these to block drinking & eating, instead of the `ConcealsFace` tag and just assuming all masks block the mouth. 
- Removes the `ConcealsFace` tag as it is no longer used.
- Moves all food & drink events from their respective systems files into `IngestionEvents.cs` and adds some doc strings.

:cl:
- fix: Cigars and clown/mime masks no longer block drinking & eating.