### PR TITLE
Adds InteractUsing to Electrocution

### DIFF
--- a/Content.Server/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Server/Electrocution/Components/ElectrifiedComponent.cs
@@ -26,6 +26,9 @@ namespace Content.Server.Electrocution
         [DataField("onHandInteract")]
         public bool OnHandInteract { get; set; } = true;
 
+        [DataField("onInteractUsing")]
+        public bool OnInteractUsing { get; set; } = true;
+
         [DataField("requirePower")]
         public bool RequirePower { get; } = true;
 

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -75,6 +75,7 @@ namespace Content.Server.Electrocution
             SubscribeLocalEvent<ElectrifiedComponent, StartCollideEvent>(OnElectrifiedStartCollide);
             SubscribeLocalEvent<ElectrifiedComponent, AttackedEvent>(OnElectrifiedAttacked);
             SubscribeLocalEvent<ElectrifiedComponent, InteractHandEvent>(OnElectrifiedHandInteract);
+            SubscribeLocalEvent<ElectrifiedComponent, InteractUsingEvent>(OnElectrifiedInteractUsing);
             SubscribeLocalEvent<RandomInsulationComponent, MapInitEvent>(OnRandomInsulationMapInit);
 
             UpdatesAfter.Add(typeof(PowerNetSystem));
@@ -137,6 +138,14 @@ namespace Content.Server.Electrocution
         private void OnElectrifiedHandInteract(EntityUid uid, ElectrifiedComponent electrified, InteractHandEvent args)
         {
             if (!electrified.OnHandInteract)
+                return;
+
+            TryDoElectrifiedAct(uid, args.User.Uid, electrified);
+        }
+
+        private void OnElectrifiedInteractUsing(EntityUid uid, ElectrifiedComponent electrified, InteractUsingEvent args)
+        {
+            if (!electrified.OnInteractUsing)
                 return;
 
             TryDoElectrifiedAct(uid, args.User.Uid, electrified);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds InteractUsing to Electrocution. Using tools on anything that is electrified should now attempt to electrocute the user.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Tools (along with many other objects) have been stripped of their insulated property. Go get some real insulated gloves!

