### PR TITLE
Fix lung/respirator bug.

### DIFF
--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -50,7 +50,7 @@ public class LungSystem : EntitySystem
         Inhale(uid, lung.CycleDelay);
     }
 
-    public void UpdateLung(EntityUid uid, float frameTime,
+    public void UpdateLung(EntityUid uid,
         LungComponent? lung=null,
         SharedMechanismComponent? mech=null)
     {
@@ -69,8 +69,8 @@ public class LungSystem : EntitySystem
 
         lung.AccumulatedFrametime += lung.Status switch
         {
-            LungStatus.Inhaling => frameTime,
-            LungStatus.Exhaling => -frameTime,
+            LungStatus.Inhaling => 1,
+            LungStatus.Exhaling => -1,
             _ => throw new ArgumentOutOfRangeException()
         };
 

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -36,37 +36,36 @@ namespace Content.Server.Body.Systems
                 if (!EntityManager.TryGetComponent<MobStateComponent>(uid, out var state) ||
                     state.IsDead())
                 {
-                    return;
+                    continue;
                 }
 
                 respirator.AccumulatedFrametime += frameTime;
 
                 if (respirator.AccumulatedFrametime < 1)
                 {
-                    return;
+                    continue;
                 }
 
-                ProcessGases(uid, respirator, frameTime, blood, body);
+                ProcessGases(uid, respirator, blood, body);
 
                 respirator.AccumulatedFrametime -= 1;
 
                 if (SuffocatingPercentage(respirator) > 0)
                 {
                     TakeSuffocationDamage(uid, respirator);
-                    return;
+                    continue;
                 }
 
                 StopSuffocation(uid, respirator);
             }
         }
 
-
-        private Dictionary<Gas, float> NeedsAndDeficit(RespiratorComponent respirator, float frameTime)
+        private Dictionary<Gas, float> NeedsAndDeficit(RespiratorComponent respirator)
         {
             var needs = new Dictionary<Gas, float>(respirator.NeedsGases);
             foreach (var (gas, amount) in respirator.DeficitGases)
             {
-                var newAmount = (needs.GetValueOrDefault(gas) + amount) * frameTime;
+                var newAmount = (needs.GetValueOrDefault(gas) + amount);
                 needs[gas] = newAmount;
             }
 
@@ -130,7 +129,7 @@ namespace Content.Server.Body.Systems
             return respirator.ProducesGases.ToDictionary(pair => pair.Key, pair => GasProducedMultiplier(respirator, pair.Key, usedAverage));
         }
 
-        private void ProcessGases(EntityUid uid, RespiratorComponent respirator, float frameTime,
+        private void ProcessGases(EntityUid uid, RespiratorComponent respirator,
             BloodstreamComponent? bloodstream,
             SharedBodyComponent? body)
         {
@@ -139,12 +138,12 @@ namespace Content.Server.Body.Systems
 
             var lungs = _bodySystem.GetComponentsOnMechanisms<LungComponent>(uid, body).ToArray();
 
-            var needs = NeedsAndDeficit(respirator, frameTime);
+            var needs = NeedsAndDeficit(respirator);
             var used = 0f;
 
             foreach (var (lung, mech) in lungs)
             {
-                _lungSystem.UpdateLung(lung.OwnerUid, frameTime, lung, mech);
+                _lungSystem.UpdateLung(lung.OwnerUid, lung, mech);
             }
 
             foreach (var (gas, amountNeeded) in needs)


### PR DESCRIPTION
This fixes two small lung bugs. It replaces some `return` -> `continue`, which lead to most mobs not being updated properly. Also removes uses of the `frametime` in functions that update once per second.

:cl:
- fix: Fixed some issues preventing mobs from taking proper suffocation damage.