### PR TITLE
Client/DistortionMap: add a shared distortion map overlay

### DIFF
--- a/Content.Client/DistortionMap/DistortionMap.cs
+++ b/Content.Client/DistortionMap/DistortionMap.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Maths;
+
+namespace Content.Client.DistortionMap;
+
+class DistortionMapOverlay : Overlay
+{
+    [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override bool RequestScreenTexture => true;
+
+    private Dictionary<IClydeViewport, DistMapInstance> _maps = new();
+    private ShaderInstance? _shd = default;
+
+    public DistortionMapOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+
+        ZIndex = 99999;
+
+        _shd = _prototypeManager
+            .Index<ShaderPrototype>("Distortion")
+            .Instance()
+            .Duplicate();
+
+        if (_shd is null)
+            throw new Exception("unable to create distortion map shader");
+    }
+
+    public const float MapSizeDivisor = 2.0f;
+
+    public DistMapInstance? CreateMap(IClydeViewport vp, float szDiv = MapSizeDivisor)
+    {
+        var rtfp = new RenderTargetFormatParameters();
+        rtfp.ColorFormat = RenderTargetColorFormat.RG32F;
+
+        var tsp = new TextureSampleParameters();
+        tsp.Filter = true;
+
+        var vs = vp.Size / szDiv;
+        var rt = _clyde.CreateRenderTarget(
+                new Vector2i((int) vs.X, (int) vs.Y),
+                rtfp,
+                tsp
+        );
+
+        if (rt is null)
+            throw new Exception("unable to create distortion map render target");
+
+        var dmi = new DistMapInstance(rt, szDiv) { used = true };
+        _maps[vp] = dmi;
+        return dmi;
+    }
+
+    public bool TryGetMap(IClydeViewport vp, [NotNullWhen(true)] out DistMapInstance? map)
+    {
+        if (_maps.TryGetValue(vp, out var mi))
+        {
+            mi.used = true;
+            map = mi;
+            return true;
+        }
+        map = default;
+        return false;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (!_maps.TryGetValue(args.Viewport, out var map))
+            return;
+
+        if (!map.used)
+            return;
+
+        map.used = false;
+        _shd?.SetParameter("Scr", ScreenTexture!);
+        _shd?.SetParameter("ScrSz", ScreenTexture!.Size);
+        _shd?.SetParameter("Map", map.map.Texture);
+        _shd?.SetParameter("MapSz", map.map.Texture.Size);
+        args.WorldHandle.UseShader(_shd);
+        args.WorldHandle.DrawRect(args.WorldBounds, Color.White);
+    }
+
+    public new void Dispose()
+    {
+        base.Dispose();
+
+        foreach (var v in _maps.Values)
+            v.map.Dispose();
+
+        if (_shd is not null)
+            _shd.Dispose();
+    }
+
+    public class DistMapInstance
+    {
+        public IRenderTexture map;
+
+        public bool used = false;
+        public float szDiv;
+
+        public DistMapInstance(IRenderTexture rt, float div)
+        {
+            map = rt;
+            szDiv = div;
+        }
+    }
+}

--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -3,6 +3,7 @@ using Content.Client.Administration.Managers;
 using Content.Client.Changelog;
 using Content.Client.CharacterInterface;
 using Content.Client.Chat.Managers;
+using Content.Client.DistortionMap;
 using Content.Client.EscapeMenu;
 using Content.Client.Eui;
 using Content.Client.Flash;
@@ -166,6 +167,8 @@ namespace Content.Client.Entry
             ContentContexts.SetupContexts(inputMan.Contexts);
 
             IoCManager.Resolve<IGameHud>().Initialize();
+            IoCManager.Register<DistortionMapOverlay>();
+            IoCManager.BuildGraph();
 
             var overlayMgr = IoCManager.Resolve<IOverlayManager>();
             overlayMgr.AddOverlay(new ParallaxOverlay());
@@ -174,6 +177,7 @@ namespace Content.Client.Entry
             overlayMgr.AddOverlay(new CircleMaskOverlay());
             overlayMgr.AddOverlay(new FlashOverlay());
             overlayMgr.AddOverlay(new RadiationPulseOverlay());
+            overlayMgr.AddOverlay(IoCManager.Resolve<DistortionMapOverlay>());
 
             IoCManager.Resolve<IChatManager>().Initialize();
             IoCManager.Resolve<ISandboxManager>().Initialize();

--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -3,7 +3,6 @@ using Content.Client.Administration.Managers;
 using Content.Client.Changelog;
 using Content.Client.CharacterInterface;
 using Content.Client.Chat.Managers;
-using Content.Client.DistortionMap;
 using Content.Client.EscapeMenu;
 using Content.Client.Eui;
 using Content.Client.Flash;
@@ -167,8 +166,6 @@ namespace Content.Client.Entry
             ContentContexts.SetupContexts(inputMan.Contexts);
 
             IoCManager.Resolve<IGameHud>().Initialize();
-            IoCManager.Register<DistortionMapOverlay>();
-            IoCManager.BuildGraph();
 
             var overlayMgr = IoCManager.Resolve<IOverlayManager>();
             overlayMgr.AddOverlay(new ParallaxOverlay());
@@ -177,7 +174,7 @@ namespace Content.Client.Entry
             overlayMgr.AddOverlay(new CircleMaskOverlay());
             overlayMgr.AddOverlay(new FlashOverlay());
             overlayMgr.AddOverlay(new RadiationPulseOverlay());
-            overlayMgr.AddOverlay(IoCManager.Resolve<DistortionMapOverlay>());
+            overlayMgr.AddOverlay(new DistortionMapOverlay());
 
             IoCManager.Resolve<IChatManager>().Initialize();
             IoCManager.Resolve<ISandboxManager>().Initialize();

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -1,4 +1,9 @@
 - type: shader
+  id: Distortion
+  kind: source
+  path: "/Textures/Shaders/distortion.swsl"
+
+- type: shader
   id: CircleMask
   kind: source
   path: "/Textures/Shaders/circle_mask.swsl"

--- a/Resources/Textures/Shaders/distortion.swsl
+++ b/Resources/Textures/Shaders/distortion.swsl
@@ -1,0 +1,10 @@
+uniform sampler2D Scr;
+uniform highp vec2 ScrSz;
+
+uniform sampler2D Map;
+uniform highp vec2 MapSz;
+
+void fragment() {
+	highp vec2 warp = zTextureSpec(Map, UV.xy).rg;
+	COLOR = zTextureSpec(Scr, UV.xy + warp);
+}


### PR DESCRIPTION
## About the PR

Proof of concept for a shared distortion map, greatly reducing the need for `Overlay`s to request access to `ScreenTexture`.

I generally don't recommend merging this, but ¯\\\_(ベ)\_/¯