### PR TITLE
Fixes flare duration and burn out

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -10,8 +10,8 @@
   - type: ExpendableLight
     spentName: spent flare
     spentDesc: It looks like this flare has burnt out. What a bummer.
-    glowDuration: 150
-    fadeOutDuration: 4
+    glowDuration: 45
+    fadeOutDuration: 15
     iconStateOn: flare_unlit
     iconStateSpent: flare_spent
     turnOnBehaviourID: turn_on
@@ -58,9 +58,9 @@
       - !type:FadeBehaviour # have the radius start small and get larger as it starts to burn
         id: turn_on
         interpolate: Linear
-        maxDuration: 8.0
+        maxDuration: 45.0 #duration of light
         startValue: 1.0
-        endValue: 6.0
+        endValue: 15.0
         property: Radius
       - !type:RandomizeBehaviour # weaker flicker as it fades out
         id: fade_out

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -52,15 +52,15 @@
         minDuration: 0.02
         maxDuration: 0.06
         startValue: 6.0
-        endValue: 9.0
+        endValue: 15.0
         property: Energy
         isLooped: true
       - !type:FadeBehaviour # have the radius start small and get larger as it starts to burn
         id: turn_on
         interpolate: Linear
         maxDuration: 45.0 #duration of light
-        startValue: 1.0
-        endValue: 15.0
+        startValue: 2.5
+        endValue: 10.0
         property: Radius
       - !type:RandomizeBehaviour # weaker flicker as it fades out
         id: fade_out
@@ -74,7 +74,7 @@
       - !type:FadeBehaviour # fade out radius as it burns out
         id: fade_out
         interpolate: Linear
-        maxDuration: 4.0
-        startValue: 6.0
+        maxDuration: 15.0
+        startValue: 8.0
         endValue: 1.0
         property: Radius


### PR DESCRIPTION
Flares currently burn out after about 8 seconds when their duration is set to 150 seconds.

I changed the values around so that the flare burns for 45 seconds now at full brightness, starts at a fairly bright radius as you'd expect when lighting a flare and gradually expands. The flare still burns for a few moments after the flicker stops.

IMO 150 seemed a little OP but can easily be changed but 1 minute with a long 15 second draw down time seems reasonable and tense.

:cl:
- fix: Fixed flares so they now burn longer and burn out slower.

