### PR TITLE
Fix lockers getting stuck on doors

### DIFF
--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -97,6 +97,7 @@ namespace Content.Shared.Pulling
             {
                 var pullerPhysics = puller.Owner.GetComponent<PhysicsComponent>();
                 var pullablePhysics = pullable.Owner.GetComponent<PhysicsComponent>();
+                pullablePhysics.FixedRotation = false;
 
                 // State startup
                 puller.Pulling = pullable.Owner;


### PR DESCRIPTION
## About the PR

I was trying to find a way to stop things getting stuck when your going through doors.
This seems to work, and pulling lockers through doors feels way better. I don't know if this is alright, or if it has any long term effects on pulled items. I can't find a problem with it from playing in any case. I'm hoping this will inspire a solution, if this isn't good.

**Changelog**
:cl:
- fix: Pulled items get stuck less

