### PR TITLE
Give all service doors proper access

### DIFF
--- a/Resources/Maps/packedstation.yml
+++ b/Resources/Maps/packedstation.yml
@@ -12667,6 +12667,8 @@ entities:
       mass: 12
       restitution: 0.1
     type: Fixtures
+  - chunkCollection: {}
+    type: DecalGrid
 - uid: 1
   type: Grille
   components:
@@ -13984,9 +13986,9 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 196
-  type: AirlockMaint
+  type: AirlockJanitorLocked
   components:
-  - pos: 5.5,-7.5
+  - pos: 4.5,-2.5
     parent: 0
     type: Transform
   - containers:
@@ -13994,9 +13996,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 197
-  type: Airlock
+  type: AirlockMaintJanitorLocked
   components:
-  - pos: 4.5,-2.5
+  - pos: 5.5,-7.5
     parent: 0
     type: Transform
   - containers:
@@ -20813,9 +20815,9 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1181
-  type: AirlockMaintBarLocked
+  type: AirlockTheatreLocked
   components:
-  - pos: 26.5,9.5
+  - pos: 26.5,4.5
     parent: 0
     type: Transform
   - containers:
@@ -20823,9 +20825,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1182
-  type: AirlockTheatreLocked
+  type: AirlockMaintTheatreLocked
   components:
-  - pos: 26.5,4.5
+  - pos: 26.5,9.5
     parent: 0
     type: Transform
   - containers:
@@ -21055,9 +21057,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 1214
-  type: Airlock
+  type: AirlockMaintChapelLocked
   components:
-  - pos: 33.5,6.5
+  - pos: 29.5,9.5
     parent: 0
     type: Transform
   - containers:
@@ -21065,9 +21067,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1215
-  type: AirlockMaintLocked
+  type: AirlockChapelLocked
   components:
-  - pos: 29.5,9.5
+  - pos: 33.5,6.5
     parent: 0
     type: Transform
   - containers:
@@ -23469,7 +23471,7 @@ entities:
   - startingCharge: 12000
     type: Battery
 - uid: 1592
-  type: AirlockServiceGlassLocked
+  type: AirlockKitchenGlassLocked
   components:
   - pos: 34.5,-8.5
     parent: 0
@@ -23479,7 +23481,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1593
-  type: AirlockServiceGlassLocked
+  type: AirlockKitchenGlassLocked
   components:
   - pos: 33.5,-8.5
     parent: 0
@@ -23816,7 +23818,7 @@ entities:
     supplyRampPosition: 14.450751
     type: PowerNetworkBattery
 - uid: 1637
-  type: AirlockMaintBarLocked
+  type: AirlockMaintKitchenLocked
   components:
   - pos: 40.5,-12.5
     parent: 0
@@ -23910,7 +23912,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1648
-  type: AirlockFreezerLocked
+  type: AirlockFreezerKitchenHydroLocked
   components:
   - pos: 40.5,-9.5
     parent: 0
@@ -24138,7 +24140,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1679
-  type: AirlockGlass
+  type: AirlockHydroGlassLocked
   components:
   - pos: 41.5,-2.5
     parent: 0
@@ -24160,7 +24162,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1682
-  type: Windoor
+  type: WindoorHydroponicsLocked
   components:
   - pos: 44.5,-2.5
     parent: 0
@@ -24492,7 +24494,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1719
-  type: AirlockMaintLocked
+  type: AirlockMaintHydroLocked
   components:
   - pos: 41.5,-11.5
     parent: 0
@@ -64922,6 +64924,12 @@ entities:
       board: !type:Container
         ents: []
     type: ContainerContainer
+- uid: 6815
+  type: WindoorHydroponicsLocked
+  components:
+  - pos: 43.5,-2.5
+    parent: 0
+    type: Transform
 - uid: 6825
   type: CableApcExtension
   components:
@@ -67811,20 +67819,6 @@ entities:
   type: DisposalPipe
   components:
   - pos: 36.5,-3.5
-    parent: 0
-    type: Transform
-  - visible: False
-    type: Sprite
-  - canCollide: False
-    type: Physics
-  - containers:
-      DisposalTransit: !type:Container
-        ents: []
-    type: ContainerContainer
-- uid: 7124
-  type: DisposalPipe
-  components:
-  - pos: 36.5,-4.5
     parent: 0
     type: Transform
   - visible: False
@@ -111096,12 +111090,6 @@ entities:
   components:
   - rot: 3.141592653589793 rad
     pos: 47.5,12.5
-    parent: 0
-    type: Transform
-- uid: 11453
-  type: Windoor
-  components:
-  - pos: 43.5,-2.5
     parent: 0
     type: Transform
 - uid: 11454

--- a/Resources/Maps/packedstation.yml
+++ b/Resources/Maps/packedstation.yml
@@ -67829,6 +67829,20 @@ entities:
       DisposalTransit: !type:Container
         ents: []
     type: ContainerContainer
+- uid: 7124
+  type: DisposalPipe
+  components:
+  - pos: 36.5,-4.5
+    parent: 0
+    type: Transform
+  - visible: False
+    type: Sprite
+  - canCollide: False
+    type: Physics
+  - containers:
+      DisposalTransit: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 7125
   type: DisposalPipe
   components:

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -5636,12 +5636,9 @@ entities:
     parent: 853
     type: Transform
 - uid: 522
-  type: Airlock
+  type: AirlockHydroGlassLocked
   components:
-  - name: Hydroponics
-    type: MetaData
-  - rot: 4.371139006309477E-08 rad
-    pos: -16.5,2.5
+  - pos: -16.5,2.5
     parent: 853
     type: Transform
   - containers:
@@ -5649,10 +5646,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 523
-  type: AirlockMaintCommonLocked
+  type: AirlockMaintHydroLocked
   components:
-  - rot: 4.371139006309477E-08 rad
-    pos: -16.5,-3.5
+  - pos: -16.5,-3.5
     parent: 853
     type: Transform
   - containers:
@@ -5660,10 +5656,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 524
-  type: AirlockMaintCommonLocked
+  type: AirlockMaintTheatreLocked
   components:
-  - rot: 4.371139006309477E-08 rad
-    pos: -14.5,-4.5
+  - pos: -16.5,-7.5
     parent: 853
     type: Transform
   - containers:
@@ -6166,10 +6161,9 @@ entities:
     parent: 853
     type: Transform
 - uid: 584
-  type: AirlockMaintCommonLocked
+  type: AirlockMaintJanitorLocked
   components:
-  - rot: 4.371139006309477E-08 rad
-    pos: -16.5,-7.5
+  - pos: -20.5,11.5
     parent: 853
     type: Transform
   - containers:
@@ -6341,10 +6335,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 600
-  type: AirlockMaintCommonLocked
+  type: AirlockKitchenLocked
   components:
-  - rot: 4.371139006309477E-08 rad
-    pos: -20.5,11.5
+  - pos: -12.5,-2.5
     parent: 853
     type: Transform
   - containers:
@@ -6444,12 +6437,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 610
-  type: AirlockServiceGlassLocked
+  type: AirlockJanitorLocked
   components:
-  - name: Kitchen
-    type: MetaData
-  - rot: 4.371139006309477E-08 rad
-    pos: -10.5,-1.5
+  - pos: -22.5,9.5
     parent: 853
     type: Transform
   - containers:
@@ -6510,17 +6500,11 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 616
-  type: Airlock
+  type: AirlockMaintBarLocked
   components:
-  - name: Custodial Closet
-    type: MetaData
-  - rot: 4.371139006309477E-08 rad
-    pos: -22.5,9.5
+  - pos: -12.5,-8.5
     parent: 853
     type: Transform
-  - access:
-    - - Janitor
-    type: AccessReader
   - containers:
       board: !type:Container
         ents: []
@@ -8432,9 +8416,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 821
-  type: AirlockMaintBarLocked
+  type: AirlockMaintKitchenLocked
   components:
-  - pos: -8.5,-6.5
+  - pos: -14.5,-4.5
     parent: 853
     type: Transform
   - containers:
@@ -15791,6 +15775,8 @@ entities:
       mass: 16
       restitution: 0.1
     type: Fixtures
+  - chunkCollection: {}
+    type: DecalGrid
 - uid: 854
   type: Catwalk
   components:
@@ -26740,12 +26726,9 @@ entities:
     parent: 853
     type: Transform
 - uid: 2293
-  type: AirlockServiceLocked
+  type: AirlockBarLocked
   components:
-  - name: Freezer
-    type: MetaData
-  - rot: 4.371139006309477E-08 rad
-    pos: -12.5,-2.5
+  - pos: -8.5,-6.5
     parent: 853
     type: Transform
   - containers:
@@ -36057,6 +36040,16 @@ entities:
     type: Sprite
   - canCollide: False
     type: Physics
+- uid: 3244
+  type: AirlockKitchenGlassLocked
+  components:
+  - pos: -10.5,-1.5
+    parent: 853
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 3245
   type: CableApcExtension
   components:
@@ -50933,16 +50926,6 @@ entities:
     pos: 4.5,-30.5
     parent: 853
     type: Transform
-- uid: 4881
-  type: AirlockMaintBarLocked
-  components:
-  - pos: -12.5,-8.5
-    parent: 853
-    type: Transform
-  - containers:
-      board: !type:Container
-        ents: []
-    type: ContainerContainer
 - uid: 4882
   type: WeldingFuelTankFull
   components:

--- a/Resources/Prototypes/AccessLevels/service.yml
+++ b/Resources/Prototypes/AccessLevels/service.yml
@@ -1,11 +1,11 @@
 - type: accessLevel
   id: Bar
 
-#- type: accessLevel
-#  id: Kitchen
+- type: accessLevel
+  id: Kitchen
 
-#- type: accessLevel
-#  id: Hydroponics
+- type: accessLevel
+  id: Hydroponics
 
 - type: accessLevel
   id: Service
@@ -15,3 +15,6 @@
 
 - type: accessLevel
   id: Theatre
+
+- type: accessLevel
+  id: Chapel

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -69,7 +69,7 @@
   suffix: Service, Locked
   components:
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Kitchen"]]
 
 - type: entity
   parent: AirlockFreezer
@@ -224,6 +224,14 @@
   components:
   - type: AccessReader
     access: [["Bar"]]
+
+- type: entity
+  parent: AirlockGlass
+  id: AirlockKitchenGlassLocked
+  suffix: Kitchen, Locked
+  components:
+  - type: AccessReader
+    access: [["Kitchen"]]
 
 - type: entity
   parent: AirlockGlass

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -14,6 +14,46 @@
   components:
   - type: AccessReader
     access: [["Theatre"]]
+    
+- type: entity
+  parent: Airlock
+  id: AirlockChapelLocked
+  suffix: Chapel, Locked
+  components:
+  - type: AccessReader
+    access: [["Chapel"]]
+    
+- type: entity
+  parent: Airlock
+  id: AirlockJanitorLocked
+  suffix: Janitor, Locked
+  components:
+  - type: AccessReader
+    access: [["Janitor"]]
+
+- type: entity
+  parent: Airlock
+  id: AirlockKitchenLocked
+  suffix: Kitchen, Locked
+  components:
+  - type: AccessReader
+    access: [["Kitchen"]]
+    
+- type: entity
+  parent: Airlock
+  id: AirlockBarLocked
+  suffix: Bar, Locked
+  components:
+  - type: AccessReader
+    access: [["Bar"]]
+    
+- type: entity
+  parent: Airlock
+  id: AirlockHydroponicsLocked
+  suffix: Hydroponics, Locked
+  components:
+  - type: AccessReader
+    access: [["Hydroponics"]]
 
 - type: entity
   parent: AirlockExternal
@@ -30,6 +70,15 @@
   components:
   - type: AccessReader
     access: [["Service"]]
+
+- type: entity
+  parent: AirlockFreezer
+  id: AirlockFreezerKitchenHydroLocked
+  suffix: Kitchen/Hydroponics, Locked
+  components:
+  - type: AccessReader
+    access: [["Kitchen"], ["Hydroponics"]]
+
 
 - type: entity
   parent: AirlockEngineering
@@ -177,6 +226,22 @@
     access: [["Bar"]]
 
 - type: entity
+  parent: AirlockGlass
+  id: AirlockHydroGlassLocked
+  suffix: Hydroponics, Locked
+  components:
+  - type: AccessReader
+    access: [["Hydroponics"]]
+
+- type: entity
+  parent: AirlockGlass
+  id: AirlockChapelGlassLocked
+  suffix: Chapel, Locked
+  components:
+  - type: AccessReader
+    access: [["Chapel"]]
+
+- type: entity
   parent: AirlockEngineeringGlass
   id: AirlockEngineeringGlassLocked
   suffix: Glass, Locked
@@ -232,7 +297,7 @@
   - type: AccessReader
     access: [["Security"]]
 
-# Maintenance Hatchs
+# Maintenance Hatches
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintLocked
@@ -280,6 +345,46 @@
   components:
   - type: AccessReader
     access: [["Bar"]]
+
+- type: entity
+  parent: AirlockMaint
+  id: AirlockMaintChapelLocked
+  suffix: Chapel, Locked
+  components:
+  - type: AccessReader
+    access: [["Chapel"]]
+
+- type: entity
+  parent: AirlockMaint
+  id: AirlockMaintHydroLocked
+  suffix: Hydroponics, Locked
+  components:
+  - type: AccessReader
+    access: [["Hydroponics"]]
+
+- type: entity
+  parent: AirlockMaint
+  id: AirlockMaintJanitorLocked
+  suffix: Janitor, Locked
+  components:
+  - type: AccessReader
+    access: [["Janitor"]]
+
+- type: entity
+  parent: AirlockMaint
+  id: AirlockMaintTheatreLocked
+  suffix: Theatre, Locked
+  components:
+  - type: AccessReader
+    access: [["Theatre"]]
+    
+- type: entity
+  parent: AirlockMaint
+  id: AirlockMaintKitchenLocked
+  suffix: Kitchen, Locked
+  components:
+  - type: AccessReader
+    access: [["Kitchen"]]
 
 - type: entity
   parent: AirlockMaint

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -20,6 +20,15 @@
   - type: AccessReader
     access: [["Bar"]]
 
+# Botany Windoor
+- type: entity
+  parent: Windoor
+  id: WindoorHydroponicsLocked
+  suffix: Hydroponics, Locked
+  components:
+  - type: AccessReader
+    access: [["Hydroponics"]]
+
 # Chemistry windoor
 - type: entity
   parent: WindoorSecure
@@ -27,7 +36,7 @@
   suffix: Medical, Locked
   components:
   - type: AccessReader
-    access: [["Medical"]]
+    access: [["Chemistry"]]
 
 # Science windoor
 - type: entity

--- a/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
@@ -9,6 +9,7 @@
   access:
   - Service
   - Maintenance
+  - Hydroponics
 
 - type: startingGear
   id: BotanistGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -7,8 +7,9 @@
   icon: "Chaplain"
   supervisors: "the head of personnel"
   access:
-#  - Chapel
+  - Chapel
   - Maintenance
+
 - type: startingGear
   id: ChaplainGear
   equipment:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -9,6 +9,7 @@
   access:
   - Service
   - Maintenance
+  - Kitchen
 
 - type: startingGear
   id: ChefGear

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -36,6 +36,9 @@
   - Theatre
   - Bar
   - Chemistry
+  - Kitchen
+  - Chapel
+  - Hydroponics
   
 - type: startingGear
   id: CaptainGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -18,6 +18,9 @@
   - Maintenance
   - Janitor
   - Theatre
+  - Kitchen
+  - Chapel
+  - Hydroponics
   # I mean they'll give themselves the rest of the access levels *anyways*.
 
 - type: startingGear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR updates every door belonging to the service department to have proper access. No more assistants walking into botany and digging up all the plants or clown trashing the janitor's office.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Airlock access to rooms under the service department has been updated to include only those who need it.

