### PR TITLE
Status effects fix. Refresh the status effect cooldown.

### DIFF
--- a/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
+++ b/Content.IntegrationTests/Tests/InventoryHelpersTest.cs
@@ -73,7 +73,7 @@ namespace Content.IntegrationTests.Tests
                 Assert.That(inventory.TryGetSlotItem(Slots.INNERCLOTHING, out ItemComponent uniform));
                 Assert.That(uniform.Owner.Prototype != null && uniform.Owner.Prototype.ID == "InventoryJumpsuitJanitorDummy");
 
-                EntitySystem.Get<StunSystem>().TryStun(human.Uid, TimeSpan.FromSeconds(1f));
+                EntitySystem.Get<StunSystem>().TryStun(human.Uid, TimeSpan.FromSeconds(1f), true);
 
                 // Since the mob is stunned, they can't equip this.
                 Assert.That(inventory.SpawnItemInSlot(Slots.IDCARD, "InventoryIDCardDummy", true), Is.False);

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -180,7 +180,7 @@ namespace Content.Server.Atmos.EntitySystems
             flammable.Resisting = true;
 
             flammable.Owner.PopupMessage(Loc.GetString("flammable-component-resist-message"));
-            _stunSystem.TryParalyze(uid, TimeSpan.FromSeconds(2f), alerts: alerts);
+            _stunSystem.TryParalyze(uid, TimeSpan.FromSeconds(2f), true, alerts: alerts);
 
             // TODO FLAMMABLE: Make this not use TimerComponent...
             flammable.Owner.SpawnTimer(2000, () =>

--- a/Content.Server/Chemistry/ReagentEffects/Electrocute.cs
+++ b/Content.Server/Chemistry/ReagentEffects/Electrocute.cs
@@ -15,12 +15,17 @@ public class Electrocute : ReagentEffect
 
     [DataField("electrocuteDamageScale")] public int ElectrocuteDamageScale = 5;
 
+    /// <remarks>
+    ///     true - refresh electrocute time,  false - accumulate electrocute time
+    /// </remarks>
+    [DataField("refresh")] public bool Refresh = true;
+
     public override bool ShouldLog => true;
 
     public override void Effect(ReagentEffectArgs args)
     {
         EntitySystem.Get<ElectrocutionSystem>().TryDoElectrocution(args.SolutionEntity, null,
-            Math.Max((args.Quantity * ElectrocuteDamageScale).Int(), 1), TimeSpan.FromSeconds(ElectrocuteTime));
+            Math.Max((args.Quantity * ElectrocuteDamageScale).Int(), 1), TimeSpan.FromSeconds(ElectrocuteTime), Refresh);
 
         args.Source?.RemoveReagent(args.Reagent.ID, args.Quantity);
     }

--- a/Content.Server/Chemistry/ReagentEffects/StatusEffects/GenericStatusEffect.cs
+++ b/Content.Server/Chemistry/ReagentEffects/StatusEffects/GenericStatusEffect.cs
@@ -30,6 +30,12 @@ namespace Content.Server.Chemistry.ReagentEffects.StatusEffects
         [DataField("time")]
         public float Time = 2.0f;
 
+        /// <remarks>
+        ///     true - refresh status effect time,  false - accumulate status effect time
+        /// </remarks>
+        [DataField("refresh")]
+        public bool Refresh = true;
+
         /// <summary>
         ///     Should this effect add the status effect, remove time from it, or set its cooldown?
         /// </summary>
@@ -41,7 +47,7 @@ namespace Content.Server.Chemistry.ReagentEffects.StatusEffects
             var statusSys = args.EntityManager.EntitySysManager.GetEntitySystem<StatusEffectsSystem>();
             if (Type == StatusEffectMetabolismType.Add && Component != String.Empty)
             {
-                statusSys.TryAddStatusEffect(args.SolutionEntity, Key, TimeSpan.FromSeconds(Time), Component);
+                statusSys.TryAddStatusEffect(args.SolutionEntity, Key, TimeSpan.FromSeconds(Time), Refresh, Component);
             }
             else if (Type == StatusEffectMetabolismType.Remove)
             {

--- a/Content.Server/Chemistry/ReagentEffects/StatusEffects/Jitter.cs
+++ b/Content.Server/Chemistry/ReagentEffects/StatusEffects/Jitter.cs
@@ -23,10 +23,16 @@ namespace Content.Server.Chemistry.ReagentEffects.StatusEffects
         [DataField("time")]
         public float Time = 2.0f;
 
+        /// <remarks>
+        ///     true - refresh jitter time,  false - accumulate jitter time
+        /// </remarks>
+        [DataField("refresh")]
+        public bool Refresh = true;
+
         public override void Effect(ReagentEffectArgs args)
         {
             args.EntityManager.EntitySysManager.GetEntitySystem<SharedJitteringSystem>()
-                .DoJitter(args.SolutionEntity, TimeSpan.FromSeconds(Time), Amplitude, Frequency);
+                .DoJitter(args.SolutionEntity, TimeSpan.FromSeconds(Time), Refresh, Amplitude, Frequency);
         }
     }
 }

--- a/Content.Server/Conveyor/ConveyorSystem.cs
+++ b/Content.Server/Conveyor/ConveyorSystem.cs
@@ -61,7 +61,7 @@ namespace Content.Server.Conveyor
                 signal != TwoWayLeverSignal.Middle)
             {
                 args.Cancel();
-                _stunSystem.TryParalyze(uid, TimeSpan.FromSeconds(2f));
+                _stunSystem.TryParalyze(uid, TimeSpan.FromSeconds(2f), true);
                 component.Owner.PopupMessage(args.Attemptee, Loc.GetString("conveyor-component-failed-link"));
             }
         }

--- a/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
@@ -51,7 +51,7 @@ namespace Content.Server.Damage.Systems
             component.LastHit = _gameTiming.CurTime;
 
             if (_robustRandom.Prob(component.StunChance))
-                _stunSystem.TryStun(uid, TimeSpan.FromSeconds(component.StunSeconds));
+                _stunSystem.TryStun(uid, TimeSpan.FromSeconds(component.StunSeconds), true);
 
             var damageScale = (speed / component.MinimumSpeed) * component.Factor;
 

--- a/Content.Server/Doors/Components/ServerDoorComponent.cs
+++ b/Content.Server/Doors/Components/ServerDoorComponent.cs
@@ -585,7 +585,7 @@ namespace Content.Server.Doors.Components
                 if (e.Owner.HasComponent<DamageableComponent>())
                     EntitySystem.Get<DamageableSystem>().TryChangeDamage(e.Owner.Uid, CrushDamage);
 
-                EntitySystem.Get<StunSystem>().TryParalyze(e.Owner.Uid, TimeSpan.FromSeconds(DoorStunTime));
+                EntitySystem.Get<StunSystem>().TryParalyze(e.Owner.Uid, TimeSpan.FromSeconds(DoorStunTime), true);
             }
 
             // If we hit someone, open up after stun (opens right when stun ends)

--- a/Content.Server/Electrocution/ElectrocuteCommand.cs
+++ b/Content.Server/Electrocution/ElectrocuteCommand.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Electrocution
             }
 
             entityManager.EntitySysManager.GetEntitySystem<ElectrocutionSystem>()
-                .TryDoElectrocution(uid, null, damage, TimeSpan.FromSeconds(seconds));
+                .TryDoElectrocution(uid, null, damage, TimeSpan.FromSeconds(seconds), true);
         }
     }
 }

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -131,7 +131,7 @@ namespace Content.Server.Flash
                 flashable.Dirty();
             }
 
-            _stunSystem.TrySlowdown(target, TimeSpan.FromSeconds(flashDuration/1000f),
+            _stunSystem.TrySlowdown(target, TimeSpan.FromSeconds(flashDuration/1000f), true,
                 slowTo, slowTo);
 
             if (displayPopup && user != null && target != user)

--- a/Content.Server/Instruments/InstrumentSystem.cs
+++ b/Content.Server/Instruments/InstrumentSystem.cs
@@ -158,7 +158,7 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
 
                 if (mob != null)
                 {
-                    _stunSystem.TryParalyze(mob.Uid, TimeSpan.FromSeconds(1));
+                    _stunSystem.TryParalyze(mob.Uid, TimeSpan.FromSeconds(1), true);
 
                     instrument.Owner.PopupMessage(mob, "instrument-component-finger-cramps-max-message");
                 }

--- a/Content.Server/PneumaticCannon/PneumaticCannonSystem.cs
+++ b/Content.Server/PneumaticCannon/PneumaticCannonSystem.cs
@@ -247,7 +247,7 @@ namespace Content.Server.PneumaticCannon
             if(data.User.TryGetComponent<StatusEffectsComponent>(out var status)
                && comp.Power == PneumaticCannonPower.High)
             {
-                _stun.TryParalyze(data.User.Uid, TimeSpan.FromSeconds(comp.HighPowerStunTime), status);
+                _stun.TryParalyze(data.User.Uid, TimeSpan.FromSeconds(comp.HighPowerStunTime), true, status);
                 data.User.PopupMessage(Loc.GetString("pneumatic-cannon-component-power-stun",
                     ("cannon", comp.Owner)));
             }

--- a/Content.Server/Speech/EntitySystems/StutteringSystem.cs
+++ b/Content.Server/Speech/EntitySystems/StutteringSystem.cs
@@ -28,13 +28,13 @@ namespace Content.Server.Speech.EntitySystems
             SubscribeLocalEvent<StutteringAccentComponent, AccentGetEvent>(OnAccent);
         }
 
-        public override void DoStutter(EntityUid uid, TimeSpan time, StatusEffectsComponent? status = null, SharedAlertsComponent? alerts = null)
+        public override void DoStutter(EntityUid uid, TimeSpan time, bool refresh, StatusEffectsComponent? status = null, SharedAlertsComponent? alerts = null)
         {
             if (!Resolve(uid, ref status, false))
                 return;
 
             if (!_statusEffectsSystem.HasStatusEffect(uid, StutterKey, status))
-                _statusEffectsSystem.TryAddStatusEffect<StutteringAccentComponent>(uid, StutterKey, time, status, alerts);
+                _statusEffectsSystem.TryAddStatusEffect<StutteringAccentComponent>(uid, StutterKey, time, refresh, status, alerts);
             else
                 _statusEffectsSystem.TryAddTime(uid, StutterKey, time, status);
         }

--- a/Content.Server/Stunnable/StunOnCollideSystem.cs
+++ b/Content.Server/Stunnable/StunOnCollideSystem.cs
@@ -37,12 +37,12 @@ namespace Content.Server.Stunnable
                 // Let the actual methods log errors for these.
                 Resolve(otherUid, ref alerts, ref standingState, ref appearance, false);
 
-                _stunSystem.TryStun(otherUid, TimeSpan.FromSeconds(component.StunAmount), status, alerts);
+                _stunSystem.TryStun(otherUid, TimeSpan.FromSeconds(component.StunAmount), true, status, alerts);
 
-                _stunSystem.TryKnockdown(otherUid, TimeSpan.FromSeconds(component.KnockdownAmount),
+                _stunSystem.TryKnockdown(otherUid, TimeSpan.FromSeconds(component.KnockdownAmount), true,
                     status, alerts);
 
-                _stunSystem.TrySlowdown(otherUid, TimeSpan.FromSeconds(component.SlowdownAmount),
+                _stunSystem.TrySlowdown(otherUid, TimeSpan.FromSeconds(component.SlowdownAmount), true,
                     component.WalkSpeedMultiplier, component.RunSpeedMultiplier, status, alerts);
             }
         }

--- a/Content.Server/Stunnable/StunSystem.cs
+++ b/Content.Server/Stunnable/StunSystem.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Stunnable
             if (args.Handled || !_random.Prob(args.PushProbability))
                 return;
 
-            if (!TryParalyze(uid, TimeSpan.FromSeconds(4f), status))
+            if (!TryParalyze(uid, TimeSpan.FromSeconds(4f), true, status))
                 return;
 
             var source = args.Source;

--- a/Content.Server/Stunnable/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/StunbatonSystem.cs
@@ -129,21 +129,21 @@ namespace Content.Server.Stunnable
             if (!EntityManager.HasComponent<SlowedDownComponent>(entity.Uid))
             {
                 if (_robustRandom.Prob(comp.ParalyzeChanceNoSlowdown))
-                    _stunSystem.TryParalyze(entity.Uid, TimeSpan.FromSeconds(comp.ParalyzeTime), status);
+                    _stunSystem.TryParalyze(entity.Uid, TimeSpan.FromSeconds(comp.ParalyzeTime), true, status);
                 else
-                    _stunSystem.TrySlowdown(entity.Uid, TimeSpan.FromSeconds(comp.SlowdownTime), 0.5f, 0.5f, status);
+                    _stunSystem.TrySlowdown(entity.Uid, TimeSpan.FromSeconds(comp.SlowdownTime), true,  0.5f, 0.5f, status);
             }
             else
             {
                 if (_robustRandom.Prob(comp.ParalyzeChanceWithSlowdown))
-                    _stunSystem.TryParalyze(entity.Uid, TimeSpan.FromSeconds(comp.ParalyzeTime), status);
+                    _stunSystem.TryParalyze(entity.Uid, TimeSpan.FromSeconds(comp.ParalyzeTime), true, status);
                 else
-                    _stunSystem.TrySlowdown(entity.Uid, TimeSpan.FromSeconds(comp.SlowdownTime), 0.5f, 0.5f, status);
+                    _stunSystem.TrySlowdown(entity.Uid, TimeSpan.FromSeconds(comp.SlowdownTime), true,  0.5f, 0.5f, status);
             }
 
             var slowdownTime = TimeSpan.FromSeconds(comp.SlowdownTime);
-            _jitterSystem.DoJitter(entity.Uid, slowdownTime, status:status);
-            _stutteringSystem.DoStutter(entity.Uid, slowdownTime, status);
+            _jitterSystem.DoJitter(entity.Uid, slowdownTime, true, status:status);
+            _stutteringSystem.DoStutter(entity.Uid, slowdownTime, true, status);
 
             if (!comp.Owner.TryGetComponent<PowerCellSlotComponent>(out var slot) || slot.Cell == null || !(slot.Cell.CurrentCharge < comp.EnergyPerUse))
                 return;

--- a/Content.Server/Weapon/Ranged/ServerRangedWeaponComponent.cs
+++ b/Content.Server/Weapon/Ranged/ServerRangedWeaponComponent.cs
@@ -174,7 +174,7 @@ namespace Content.Server.Weapon.Ranged
             {
                 //Wound them
                 EntitySystem.Get<DamageableSystem>().TryChangeDamage(user.Uid, ClumsyDamage);
-                EntitySystem.Get<StunSystem>().TryParalyze(user.Uid, TimeSpan.FromSeconds(3f));
+                EntitySystem.Get<StunSystem>().TryParalyze(user.Uid, TimeSpan.FromSeconds(3f), true);
 
                 // Apply salt to the wound ("Honk!")
                 SoundSystem.Play(

--- a/Content.Shared/Jittering/SharedJitteringSystem.cs
+++ b/Content.Shared/Jittering/SharedJitteringSystem.cs
@@ -53,12 +53,13 @@ namespace Content.Shared.Jittering
         /// </remarks>
         /// <param name="uid">Entity in question.</param>
         /// <param name="time">For how much time to apply the effect.</param>
+        /// <param name="refresh">The status effect cooldown should be refreshed (true) or accumulated (false).</param>
         /// <param name="amplitude">Jitteriness of the animation. See <see cref="MaxAmplitude"/> and <see cref="MinAmplitude"/>.</param>
         /// <param name="frequency">Frequency for jittering. See <see cref="MaxFrequency"/> and <see cref="MinFrequency"/>.</param>
         /// <param name="forceValueChange">Whether to change any existing jitter value even if they're greater than the ones we're setting.</param>
         /// <param name="status">The status effects component to modify.</param>
         /// <param name="alerts">The alerts component.</param>
-        public void DoJitter(EntityUid uid, TimeSpan time, float amplitude = 10f, float frequency = 4f, bool forceValueChange = false,
+        public void DoJitter(EntityUid uid, TimeSpan time, bool refresh, float amplitude = 10f, float frequency = 4f, bool forceValueChange = false,
             StatusEffectsComponent? status = null,
             SharedAlertsComponent? alerts = null)
         {
@@ -68,7 +69,7 @@ namespace Content.Shared.Jittering
             amplitude = Math.Clamp(amplitude, MinAmplitude, MaxAmplitude);
             frequency = Math.Clamp(frequency, MinFrequency, MaxFrequency);
 
-            if (StatusEffects.TryAddStatusEffect<JitteringComponent>(uid, "Jitter", time, status, alerts))
+            if (StatusEffects.TryAddStatusEffect<JitteringComponent>(uid, "Jitter", time, refresh, status, alerts))
             {
                 var jittering = EntityManager.GetComponent<JitteringComponent>(uid);
 

--- a/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
@@ -68,7 +68,7 @@ namespace Content.Shared.Nutrition.EntitySystems
 
             CreamedEntity(uid, creamPied, args);
 
-            _stunSystem.TryParalyze(uid, TimeSpan.FromSeconds(creamPie.ParalyzeTime));
+            _stunSystem.TryParalyze(uid, TimeSpan.FromSeconds(creamPie.ParalyzeTime), true);
         }
 
         protected virtual void CreamedEntity(EntityUid uid, CreamPiedComponent creamPied, ThrowHitByEvent args) {}

--- a/Content.Shared/Slippery/SharedSlipperySystem.cs
+++ b/Content.Shared/Slippery/SharedSlipperySystem.cs
@@ -64,7 +64,7 @@ namespace Content.Shared.Slippery
             if (!component.Slippery
                 || component.Owner.IsInContainer()
                 || component.Slipped.Contains(uid)
-                || !_statusEffectsSystem.CanApplyEffect(uid, "Stun"))
+                || !_statusEffectsSystem.CanApplyEffect(uid, "Stun")) //Should be KnockedDown instead?
             {
                 return false;
             }
@@ -95,11 +95,17 @@ namespace Content.Shared.Slippery
 
             otherBody.LinearVelocity *= component.LaunchForwardsMultiplier;
 
-            _stunSystem.TryParalyze(otherBody.OwnerUid, TimeSpan.FromSeconds(5));
+            bool playSound = !_statusEffectsSystem.HasStatusEffect(otherBody.OwnerUid, "KnockedDown");
+
+            _stunSystem.TryParalyze(otherBody.OwnerUid, TimeSpan.FromSeconds(component.ParalyzeTime), true);
             component.Slipped.Add(otherBody.OwnerUid);
             component.Dirty();
 
-            PlaySound(component);
+            //Preventing from playing the slip sound when you are already knocked down.
+            if(playSound)
+            {
+                PlaySound(component);
+            }
 
             _adminLog.Add(LogType.Slip, LogImpact.Low, $"{component.Owner} slipped on collision with {otherBody.Owner}");
 

--- a/Content.Shared/Slippery/SlipperyComponent.cs
+++ b/Content.Shared/Slippery/SlipperyComponent.cs
@@ -18,7 +18,7 @@ namespace Content.Shared.Slippery
     {
         public override string Name => "Slippery";
 
-        private float _paralyzeTime = 3f;
+        private float _paralyzeTime = 5f;
         private float _intersectPercentage = 0.3f;
         private float _requiredSlipSpeed = 5f;
         private float _launchForwardsMultiplier = 1f;

--- a/Content.Shared/Speech/EntitySystems/SharedStutteringSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/SharedStutteringSystem.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Speech.EntitySystems
     public abstract class SharedStutteringSystem : EntitySystem
     {
         // For code in shared... I imagine we ain't getting accent prediction anytime soon so let's not bother.
-        public virtual void DoStutter(EntityUid uid, TimeSpan time, StatusEffectsComponent? status = null, SharedAlertsComponent? alerts = null)
+        public virtual void DoStutter(EntityUid uid, TimeSpan time, bool refresh, StatusEffectsComponent? status = null, SharedAlertsComponent? alerts = null)
         {
         }
     }

--- a/Content.Shared/StatusEffect/StatusEffectsComponent.cs
+++ b/Content.Shared/StatusEffect/StatusEffectsComponent.cs
@@ -39,15 +39,23 @@ namespace Content.Shared.StatusEffect
         public (TimeSpan, TimeSpan) Cooldown;
 
         /// <summary>
+        ///     Specifies whether to refresh or accumulate the cooldown of the status effect.
+        ///     true - refresh time, false - accumulate time.
+        /// </summary>
+        [ViewVariables]
+        public bool CooldownRefresh = true;
+
+        /// <summary>
         ///     The name of the relevant component that
         ///     was added alongside the effect, if any.
         /// </summary>
         [ViewVariables]
         public string? RelevantComponent;
 
-        public StatusEffectState((TimeSpan, TimeSpan) cooldown, string? relevantComponent=null)
+        public StatusEffectState((TimeSpan, TimeSpan) cooldown, bool refresh, string? relevantComponent=null)
         {
             Cooldown = cooldown;
+            CooldownRefresh = refresh;
             RelevantComponent = relevantComponent;
         }
     }

--- a/Content.Shared/StatusEffect/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffect/StatusEffectsSystem.cs
@@ -169,7 +169,7 @@ namespace Content.Shared.StatusEffect
             if (HasStatusEffect(uid, key, status))
             {
                 status.ActiveEffects[key].CooldownRefresh = refresh;
-                if(status.ActiveEffects[key].CooldownRefresh)
+                if(refresh)
                 {
                     //Making sure we don't reset a longer cooldown by applying a shorter one.
                     if((status.ActiveEffects[key].Cooldown.Item2 - _gameTiming.CurTime) < time)

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -118,7 +118,7 @@ namespace Content.Shared.Stunnable
         /// <summary>
         ///     Stuns the entity, disallowing it from doing many interactions temporarily.
         /// </summary>
-        public bool TryStun(EntityUid uid, TimeSpan time,
+        public bool TryStun(EntityUid uid, TimeSpan time, bool refresh,
             StatusEffectsComponent? status = null,
             SharedAlertsComponent? alerts = null)
         {
@@ -130,13 +130,13 @@ namespace Content.Shared.Stunnable
 
             Resolve(uid, ref alerts, false);
 
-            return _statusEffectSystem.TryAddStatusEffect<StunnedComponent>(uid, "Stun", time, alerts: alerts);
+            return _statusEffectSystem.TryAddStatusEffect<StunnedComponent>(uid, "Stun", time, refresh, alerts: alerts);
         }
 
         /// <summary>
         ///     Knocks down the entity, making it fall to the ground.
         /// </summary>
-        public bool TryKnockdown(EntityUid uid, TimeSpan time,
+        public bool TryKnockdown(EntityUid uid, TimeSpan time, bool refresh,
             StatusEffectsComponent? status = null,
             SharedAlertsComponent? alerts = null)
         {
@@ -148,13 +148,13 @@ namespace Content.Shared.Stunnable
 
             Resolve(uid, ref alerts, false);
 
-            return _statusEffectSystem.TryAddStatusEffect<KnockedDownComponent>(uid, "KnockedDown", time, alerts: alerts);
+            return _statusEffectSystem.TryAddStatusEffect<KnockedDownComponent>(uid, "KnockedDown", time, refresh, alerts: alerts);
         }
 
         /// <summary>
         ///     Applies knockdown and stun to the entity temporarily.
         /// </summary>
-        public bool TryParalyze(EntityUid uid, TimeSpan time,
+        public bool TryParalyze(EntityUid uid, TimeSpan time, bool refresh,
             StatusEffectsComponent? status = null,
             SharedAlertsComponent? alerts = null)
         {
@@ -164,13 +164,13 @@ namespace Content.Shared.Stunnable
             // Optional component.
             Resolve(uid, ref alerts, false);
 
-            return TryKnockdown(uid, time, status, alerts) && TryStun(uid, time, status, alerts);
+            return TryKnockdown(uid, time, refresh, status, alerts) && TryStun(uid, time, refresh, status, alerts);
         }
 
         /// <summary>
         ///     Slows down the mob's walking/running speed temporarily
         /// </summary>
-        public bool TrySlowdown(EntityUid uid, TimeSpan time,
+        public bool TrySlowdown(EntityUid uid, TimeSpan time, bool refresh,
             float walkSpeedMultiplier = 1f, float runSpeedMultiplier = 1f,
             StatusEffectsComponent? status = null,
             SharedAlertsComponent? alerts = null)
@@ -184,7 +184,7 @@ namespace Content.Shared.Stunnable
             if (time <= TimeSpan.Zero)
                 return false;
 
-            if (_statusEffectSystem.TryAddStatusEffect<SlowedDownComponent>(uid, "SlowedDown", time, status, alerts))
+            if (_statusEffectSystem.TryAddStatusEffect<SlowedDownComponent>(uid, "SlowedDown", time, refresh, status, alerts))
             {
                 var slowed = EntityManager.GetComponent<SlowedDownComponent>(uid);
                 // Doesn't make much sense to have the "TrySlowdown" method speed up entities now does it?


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #5607

Currently, status effects accumulates cooldown time each time they are applied to entity.

I made it so that the cooldown time can be refreshed. Thus, now you need to provide a refresh flag along with the cooldown time when you want to try to apply the status effect and don't want it to accumulate.

I leave the accumulation part just in case. Not sure where this can be applied.

Key changes are in `Content.Shared/StatusEffect/StatusEffectsSystem.cs `

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed the status effects cooldown time accumulation. (Major clown nerf).


