### PR TITLE
Show rules on first connection

### DIFF
--- a/Content.Client/Changelog/ChangelogManager.cs
+++ b/Content.Client/Changelog/ChangelogManager.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Content.Shared.CCVar;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
@@ -18,9 +19,6 @@ namespace Content.Client.Changelog
 {
     public sealed class ChangelogManager
     {
-        // If you fork SS14, change this to have the changelog "last seen" date stored separately.
-        public const string ForkId = "Wizards";
-
         [Dependency] private readonly IResourceManager _resource = default!;
         [Dependency] private readonly ISerializationManager _serialization = default!;
 
@@ -43,7 +41,7 @@ namespace Content.Client.Changelog
             NewChangelogEntries = false;
             NewChangelogEntriesChanged?.Invoke();
 
-            using var file = _resource.UserData.Create(new ResourcePath($"/changelog_last_seen_{ForkId}"));
+            using var file = _resource.UserData.Create(new ResourcePath($"/changelog_last_seen_{CCVars.ServerId}"));
             using var sw = new StreamWriter(file);
 
             sw.Write(MaxId.ToString());
@@ -61,7 +59,7 @@ namespace Content.Client.Changelog
 
             MaxId = changelog.Max(c => c.Id);
 
-            var path = new ResourcePath($"/changelog_last_seen_{ForkId}");
+            var path = new ResourcePath($"/changelog_last_seen_{CCVars.ServerId}");
             if (_resource.UserData.Exists(path))
             {
                 LastReadId = int.Parse(_resource.UserData.ReadAllText(path));

--- a/Content.Client/Changelog/ChangelogManager.cs
+++ b/Content.Client/Changelog/ChangelogManager.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
@@ -21,6 +22,7 @@ namespace Content.Client.Changelog
     {
         [Dependency] private readonly IResourceManager _resource = default!;
         [Dependency] private readonly ISerializationManager _serialization = default!;
+        [Dependency] private readonly IConfigurationManager _configManager = default!;
 
         public bool NewChangelogEntries { get; private set; }
         public int LastReadId { get; private set; }
@@ -41,7 +43,7 @@ namespace Content.Client.Changelog
             NewChangelogEntries = false;
             NewChangelogEntriesChanged?.Invoke();
 
-            using var file = _resource.UserData.Create(new ResourcePath($"/changelog_last_seen_{CCVars.ServerId}"));
+            using var file = _resource.UserData.Create(new ResourcePath($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}"));
             using var sw = new StreamWriter(file);
 
             sw.Write(MaxId.ToString());
@@ -59,7 +61,7 @@ namespace Content.Client.Changelog
 
             MaxId = changelog.Max(c => c.Id);
 
-            var path = new ResourcePath($"/changelog_last_seen_{CCVars.ServerId}");
+            var path = new ResourcePath($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}");
             if (_resource.UserData.Exists(path))
             {
                 LastReadId = int.Parse(_resource.UserData.ReadAllText(path));

--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -7,6 +7,7 @@ using Content.Client.EscapeMenu;
 using Content.Client.Eui;
 using Content.Client.Flash;
 using Content.Client.HUD;
+using Content.Client.Info;
 using Content.Client.Input;
 using Content.Client.IoC;
 using Content.Client.Launcher;
@@ -112,6 +113,7 @@ namespace Content.Client.Entry
             IoCManager.Resolve<IStylesheetManager>().Initialize();
             IoCManager.Resolve<IScreenshotHook>().Initialize();
             IoCManager.Resolve<ChangelogManager>().Initialize();
+            IoCManager.Resolve<RulesManager>().Initialize();
             IoCManager.Resolve<ViewportManager>().Initialize();
 
             IoCManager.InjectDependencies(this);

--- a/Content.Client/HUD/GameHud.cs
+++ b/Content.Client/HUD/GameHud.cs
@@ -303,6 +303,8 @@ namespace Content.Client.HUD
 
             _infoWindow = new InfoWindow();
 
+            IoCManager.Resolve<RulesManager>().OpenRulesWindow += OpenInfoWindow;
+
             _infoWindow.OnClose += () => _buttonInfo.Pressed = false;
 
             _inputManager.SetInputCommand(ContentKeyFunctions.OpenInfo,
@@ -426,6 +428,12 @@ namespace Content.Client.HUD
             LC.SetMarginTop(VoteContainer, 100);
             LC.SetGrowHorizontal(VoteContainer, LC.GrowDirection.End);
             LC.SetGrowVertical(VoteContainer, LC.GrowDirection.End);
+        }
+
+        private void OpenInfoWindow()
+        {
+            _infoWindow.OpenCentered();
+            _buttonInfo.Pressed = true;
         }
 
         private void ButtonInfoOnOnToggled()

--- a/Content.Client/HUD/GameHud.cs
+++ b/Content.Client/HUD/GameHud.cs
@@ -104,7 +104,7 @@ namespace Content.Client.HUD
         private TopButton _buttonActionsMenu = default!;
         private TopButton _buttonAdminMenu = default!;
         private TopButton _buttonSandboxMenu = default!;
-        private InfoWindow _infoWindow = default!;
+        private RulesAndInfoWindow _rulesAndInfoWindow = default!;
         private TargetingDoll _targetingDoll = default!;
         private BoxContainer _combatPanelContainer = default!;
         private BoxContainer _topNotificationContainer = default!;
@@ -301,11 +301,11 @@ namespace Content.Client.HUD
 
             _buttonInfo.OnToggled += a => ButtonInfoOnOnToggled();
 
-            _infoWindow = new InfoWindow();
+            _rulesAndInfoWindow = new RulesAndInfoWindow();
 
-            IoCManager.Resolve<RulesManager>().OpenRulesWindow += OpenInfoWindow;
+            IoCManager.Resolve<RulesManager>().OpenRulesAndInfoWindow += OpenRulesAndInfoWindow;
 
-            _infoWindow.OnClose += () => _buttonInfo.Pressed = false;
+            _rulesAndInfoWindow.OnClose += () => _buttonInfo.Pressed = false;
 
             _inputManager.SetInputCommand(ContentKeyFunctions.OpenInfo,
                 InputCmdHandler.FromDelegate(s => ButtonInfoOnOnToggled()));
@@ -430,31 +430,31 @@ namespace Content.Client.HUD
             LC.SetGrowVertical(VoteContainer, LC.GrowDirection.End);
         }
 
-        private void OpenInfoWindow()
+        private void OpenRulesAndInfoWindow()
         {
-            _infoWindow.OpenCentered();
+            _rulesAndInfoWindow.OpenCentered();
             _buttonInfo.Pressed = true;
         }
 
         private void ButtonInfoOnOnToggled()
         {
             _buttonInfo.StyleClasses.Remove(TopButton.StyleClassRedTopButton);
-            if (_infoWindow.IsOpen)
+            if (_rulesAndInfoWindow.IsOpen)
             {
-                if (!_infoWindow.IsAtFront())
+                if (!_rulesAndInfoWindow.IsAtFront())
                 {
-                    _infoWindow.MoveToFront();
+                    _rulesAndInfoWindow.MoveToFront();
                     _buttonInfo.Pressed = true;
                 }
                 else
                 {
-                    _infoWindow.Close();
+                    _rulesAndInfoWindow.Close();
                     _buttonInfo.Pressed = false;
                 }
             }
             else
             {
-                _infoWindow.OpenCentered();
+                _rulesAndInfoWindow.OpenCentered();
                 _buttonInfo.Pressed = true;
             }
         }

--- a/Content.Client/Info/InfoWindow.cs
+++ b/Content.Client/Info/InfoWindow.cs
@@ -17,6 +17,7 @@ namespace Content.Client.Info
 {
     public sealed class InfoWindow : SS14Window
     {
+        [Dependency] private readonly RulesManager _rulesManager = default!;
         [Dependency] private readonly IResourceCache _resourceManager = default!;
 
         private OptionsMenu optionsMenu;
@@ -161,6 +162,13 @@ namespace Content.Client.Info
 
             controlsButton.OnPressed += _ =>
                 optionsMenu.OpenCentered();
+        }
+
+        protected override void Opened()
+        {
+            base.Opened();
+
+            _rulesManager.SaveLastReadTime();
         }
 
         private static IEnumerable<string> Lines(TextReader reader)

--- a/Content.Client/Info/RulesAndInfoWindow.cs
+++ b/Content.Client/Info/RulesAndInfoWindow.cs
@@ -15,14 +15,14 @@ using static Robust.Client.UserInterface.Controls.BoxContainer;
 
 namespace Content.Client.Info
 {
-    public sealed class InfoWindow : SS14Window
+    public sealed class RulesAndInfoWindow : SS14Window
     {
         [Dependency] private readonly RulesManager _rulesManager = default!;
         [Dependency] private readonly IResourceCache _resourceManager = default!;
 
         private OptionsMenu optionsMenu;
 
-        public InfoWindow()
+        public RulesAndInfoWindow()
         {
             IoCManager.InjectDependencies(this);
 

--- a/Content.Client/Info/RulesManager.cs
+++ b/Content.Client/Info/RulesManager.cs
@@ -11,18 +11,6 @@ namespace Content.Client.Info;
 public sealed class RulesManager
 {
     [Dependency] private readonly IClientNetManager _clientNetManager = default!;
-/*
- * Rules unread should be per server to show that the rules are different.
- * Save server id
- * Save the last read date
- *
- * Last read date is used for comparing against rules change date sent from server
- * Last read date is used for reopening the rules after some time as a reminder (2 months?)
- *
- * Add delay before allowing the player to close.
- * Require scrolling to the bottom to close.
- * Make the close button an `I Agree` button.
- */
 
     // If you fork SS14, change this to have the rules "last seen" date stored separately.
     public const string ForkId = "Wizards";
@@ -31,8 +19,11 @@ public sealed class RulesManager
 
     public event Action? OpenRulesWindow;
 
-    public void Startup()
+    private void OnConnectStateChanged(ClientConnectionState state)
     {
+        if (state != ClientConnectionState.Connected)
+            return;
+
         var path = new ResourcePath($"/rules_last_seen_{ForkId}");
         var lastReadTime = DateTime.UnixEpoch;
         if (_resource.UserData.Exists(path))
@@ -45,13 +36,6 @@ public sealed class RulesManager
         if (showRules)
             OpenRulesWindow?.Invoke();
     }
-
-    private void OnConnectStateChanged(ClientConnectionState state)
-    {
-        if (state == ClientConnectionState.Connected)
-            Startup();
-    }
-
 
     /// <summary>
     ///     Ran when the user opens ("read") the rules, stores the new ID to disk.

--- a/Content.Client/Info/RulesManager.cs
+++ b/Content.Client/Info/RulesManager.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using Content.Client.HUD;
+using Content.Shared.CCVar;
 using Robust.Shared.ContentPack;
 using Robust.Shared.IoC;
 using Robust.Shared.Network;
@@ -11,10 +13,6 @@ namespace Content.Client.Info;
 public sealed class RulesManager
 {
     [Dependency] private readonly IClientNetManager _clientNetManager = default!;
-
-    // If you fork SS14, change this to have the rules "last seen" date stored separately.
-    public const string ForkId = "Wizards";
-
     [Dependency] private readonly IResourceManager _resource = default!;
 
     public event Action? OpenRulesWindow;
@@ -24,7 +22,7 @@ public sealed class RulesManager
         if (state != ClientConnectionState.Connected)
             return;
 
-        var path = new ResourcePath($"/rules_last_seen_{ForkId}");
+        var path = new ResourcePath($"/rules_last_seen_{CCVars.ServerId}");
         var lastReadTime = DateTime.UnixEpoch;
         if (_resource.UserData.Exists(path))
         {

--- a/Content.Client/Info/RulesManager.cs
+++ b/Content.Client/Info/RulesManager.cs
@@ -15,7 +15,7 @@ public sealed class RulesManager
     [Dependency] private readonly IClientNetManager _clientNetManager = default!;
     [Dependency] private readonly IResourceManager _resource = default!;
 
-    public event Action? OpenRulesWindow;
+    public event Action? OpenRulesAndInfoWindow;
 
     private void OnConnectStateChanged(ClientConnectionState state)
     {
@@ -32,7 +32,7 @@ public sealed class RulesManager
         var showRules = lastReadTime < DateTime.UtcNow - TimeSpan.FromDays(60);
 
         if (showRules)
-            OpenRulesWindow?.Invoke();
+            OpenRulesAndInfoWindow?.Invoke();
     }
 
     /// <summary>

--- a/Content.Client/Info/RulesManager.cs
+++ b/Content.Client/Info/RulesManager.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using Robust.Shared.ContentPack;
+using Robust.Shared.IoC;
+using Robust.Shared.Network;
+using Robust.Shared.Utility;
+
+namespace Content.Client.Info;
+
+public sealed class RulesManager
+{
+    [Dependency] private readonly IClientNetManager _clientNetManager = default!;
+/*
+ * Rules unread should be per server to show that the rules are different.
+ * Save server id
+ * Save the last read date
+ *
+ * Last read date is used for comparing against rules change date sent from server
+ * Last read date is used for reopening the rules after some time as a reminder (2 months?)
+ *
+ * Add delay before allowing the player to close.
+ * Require scrolling to the bottom to close.
+ * Make the close button an `I Agree` button.
+ */
+
+    // If you fork SS14, change this to have the rules "last seen" date stored separately.
+    public const string ForkId = "Wizards";
+
+    [Dependency] private readonly IResourceManager _resource = default!;
+
+    public event Action? OpenRulesWindow;
+
+    public void Startup()
+    {
+        var path = new ResourcePath($"/rules_last_seen_{ForkId}");
+        var lastReadTime = DateTime.UnixEpoch;
+        if (_resource.UserData.Exists(path))
+        {
+            lastReadTime = DateTime.Parse(_resource.UserData.ReadAllText(path), null, DateTimeStyles.AssumeUniversal);
+        }
+
+        var showRules = lastReadTime < DateTime.UtcNow - TimeSpan.FromDays(60);
+
+        if (showRules)
+            OpenRulesWindow?.Invoke();
+    }
+
+    private void OnConnectStateChanged(ClientConnectionState state)
+    {
+        if (state == ClientConnectionState.Connected)
+            Startup();
+    }
+
+
+    /// <summary>
+    ///     Ran when the user opens ("read") the rules, stores the new ID to disk.
+    /// </summary>
+    public void SaveLastReadTime()
+    {
+        using var file = _resource.UserData.Create(new ResourcePath($"/rules_last_seen_{ForkId}"));
+        using var sw = new StreamWriter(file);
+
+        sw.Write(DateTime.UtcNow.ToUniversalTime());
+    }
+
+    public void Initialize()
+    {
+        _clientNetManager.ClientConnectStateChanged += OnConnectStateChanged;
+    }
+}

--- a/Content.Client/Info/RulesManager.cs
+++ b/Content.Client/Info/RulesManager.cs
@@ -40,7 +40,7 @@ public sealed class RulesManager
     /// </summary>
     public void SaveLastReadTime()
     {
-        using var file = _resource.UserData.Create(new ResourcePath($"/rules_last_seen_{ForkId}"));
+        using var file = _resource.UserData.Create(new ResourcePath($"/rules_last_seen_{CCVars.ServerId}"));
         using var sw = new StreamWriter(file);
 
         sw.Write(DateTime.UtcNow.ToUniversalTime());

--- a/Content.Client/Info/ServerInfo.cs
+++ b/Content.Client/Info/ServerInfo.cs
@@ -32,7 +32,7 @@ namespace Content.Client.Info
             var uriOpener = IoCManager.Resolve<IUriOpener>();
 
             var rulesButton = new Button() { Text = Loc.GetString("server-info-rules-button") };
-            rulesButton.OnPressed += args => new InfoWindow().Open();
+            rulesButton.OnPressed += args => new RulesAndInfoWindow().Open();
 
             var discordButton = new Button {Text = Loc.GetString("server-info-discord-button") };
             discordButton.OnPressed += args => uriOpener.OpenUri(UILinks.Discord);

--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -5,6 +5,7 @@ using Content.Client.Clickable;
 using Content.Client.EscapeMenu;
 using Content.Client.Eui;
 using Content.Client.HUD;
+using Content.Client.Info;
 using Content.Client.Items.Managers;
 using Content.Client.Module;
 using Content.Client.Parallax.Managers;
@@ -44,6 +45,7 @@ namespace Content.Client.IoC
             IoCManager.Register<EuiManager, EuiManager>();
             IoCManager.Register<IVoteManager, VoteManager>();
             IoCManager.Register<ChangelogManager, ChangelogManager>();
+            IoCManager.Register<RulesManager, RulesManager>();
             IoCManager.Register<ViewportManager, ViewportManager>();
         }
     }

--- a/Content.Client/Preferences/UI/CharacterSetupGui.xaml.cs
+++ b/Content.Client/Preferences/UI/CharacterSetupGui.xaml.cs
@@ -69,7 +69,7 @@ namespace Content.Client.Preferences.UI
 
             UpdateUI();
 
-            RulesButton.OnPressed += _ => new InfoWindow().Open();
+            RulesButton.OnPressed += _ => new RulesAndInfoWindow().Open();
             preferencesManager.OnServerDataLoaded += UpdateUI;
         }
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.CCVar
         ///     Change this to have the changelog and rules "last seen" date stored separately.
         /// </summary>
         public static readonly CVarDef<string> ServerId =
-            CVarDef.Create("server.id", "Wizards");
+            CVarDef.Create("server.id", "unknown");
 
         /*
          * Ambience

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -8,6 +8,16 @@ namespace Content.Shared.CCVar
     public sealed class CCVars : CVars
     {
         /*
+         * Server
+         */
+
+        /// <summary>
+        ///     Change this to have the changelog and rules "last seen" date stored separately.
+        /// </summary>
+        public static readonly CVarDef<string> ServerId =
+            CVarDef.Create("server.id", "Wizards");
+
+        /*
          * Ambience
          */
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.CCVar
         ///     Change this to have the changelog and rules "last seen" date stored separately.
         /// </summary>
         public static readonly CVarDef<string> ServerId =
-            CVarDef.Create("server.id", "unknown");
+            CVarDef.Create("server.id", "unknown_server_id");
 
         /*
          * Ambience


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the rules popup on the first connection to the server.

When the client connects to a server it checks for the `rules_last_seen_{CCVar.ServerId}` file. If the file doesn't exist or the stored timestamp is older than 60 days, it opens the rules window.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Rules now pop up on the first connection to the server
