### PR TITLE
Fix food & do-after bugs

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -1,6 +1,8 @@
-﻿using Content.Server.Chemistry.Components;
+using Content.Server.Chemistry.Components;
+using Content.Shared.Hands;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
+using System;
 
 namespace Content.Server.Chemistry.EntitySystems
 {
@@ -12,6 +14,16 @@ namespace Content.Server.Chemistry.EntitySystems
             base.Initialize();
 
             SubscribeLocalEvent<InjectorComponent, SolutionChangedEvent>(OnSolutionChange);
+            SubscribeLocalEvent<InjectorComponent, HandDeselectedEvent>(OnInjectorDeselected);
+        }
+
+        private void OnInjectorDeselected(EntityUid uid, InjectorComponent component, HandDeselectedEvent args)
+        {
+            if (component.CancelToken != null)
+            {
+                component.CancelToken.Cancel();
+                component.CancelToken = null;
+            }
         }
 
         private void OnSolutionChange(EntityUid uid, InjectorComponent component, SolutionChangedEvent args)

--- a/Content.Server/DoAfter/DoAfterSystem.cs
+++ b/Content.Server/DoAfter/DoAfterSystem.cs
@@ -12,8 +12,8 @@ namespace Content.Server.DoAfter
     public sealed class DoAfterSystem : EntitySystem
     {
         // We cache these lists as to not allocate them every update tick...
-        private readonly List<DoAfter> _cancelled = new();
-        private readonly List<DoAfter> _finished = new();
+        private readonly Queue<DoAfter> _cancelled = new();
+        private readonly Queue<DoAfter> _finished = new();
 
         public override void Initialize()
         {
@@ -52,17 +52,17 @@ namespace Content.Server.DoAfter
                         case DoAfterStatus.Running:
                             break;
                         case DoAfterStatus.Cancelled:
-                            _cancelled.Add(doAfter);
+                            _cancelled.Enqueue(doAfter);
                             break;
                         case DoAfterStatus.Finished:
-                            _finished.Add(doAfter);
+                            _finished.Enqueue(doAfter);
                             break;
                         default:
                             throw new ArgumentOutOfRangeException();
                     }
                 }
 
-                foreach (var doAfter in _cancelled)
+                while (_cancelled.TryDequeue(out var doAfter))
                 {
                     comp.Cancelled(doAfter);
 
@@ -76,7 +76,7 @@ namespace Content.Server.DoAfter
                         RaiseLocalEvent(doAfter.EventArgs.BroadcastCancelledEvent);
                 }
 
-                foreach (var doAfter in _finished)
+                while (_finished.TryDequeue(out var doAfter))
                 {
                     comp.Finished(doAfter);
 
@@ -89,10 +89,6 @@ namespace Content.Server.DoAfter
                     if(doAfter.EventArgs.BroadcastFinishedEvent != null)
                         RaiseLocalEvent(doAfter.EventArgs.BroadcastFinishedEvent);
                 }
-
-                // Clean the shared lists at the end, ensuring they'll be clean for the next time we need them.
-                _cancelled.Clear();
-                _finished.Clear();
             }
         }
 

--- a/Content.Server/Nutrition/Components/DrinkComponent.cs
+++ b/Content.Server/Nutrition/Components/DrinkComponent.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Sound;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
@@ -7,6 +6,7 @@ using Robust.Shared.ViewVariables;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Analyzers;
+using System.Threading;
 
 namespace Content.Server.Nutrition.Components
 {
@@ -50,8 +50,9 @@ namespace Content.Server.Nutrition.Components
         public float ForceFeedDelay = 3;
 
         /// <summary>
-        ///     If true, this drink has some DoAfter active (someone is being force fed).
+        ///     Token for interrupting a do-after action (e.g., force feeding). If not null, implies component is
+        ///     currently "in use".
         /// </summary>
-        public bool InUse = false;
+        public CancellationTokenSource? CancelToken;
     }
 }

--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.FixedPoint;
@@ -55,9 +56,10 @@ namespace Content.Server.Nutrition.Components
         public float ForceFeedDelay = 3;
 
         /// <summary>
-        ///     If true, this food has some DoAfter active (someone is being force fed).
+        ///     Token for interrupting a do-after action (e.g., force feeding). If not null, implies component is
+        ///     currently "in use".
         /// </summary>
-        public bool InUse = false;
+        public CancellationTokenSource? CancelToken;
 
         [ViewVariables]
         public int UsesRemaining

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -235,6 +235,9 @@ namespace Content.Server.Nutrition.EntitySystems
 
         private void AddEatVerb(EntityUid uid, FoodComponent component, GetInteractionVerbsEvent ev)
         {
+            if (component.CancelToken != null)
+                return;
+
             if (uid == ev.UserUid ||
                 !ev.CanInteract ||
                 !ev.CanAccess ||


### PR DESCRIPTION
This fixes a couple of food & drink bugs. Credit to Tomtoot/Tali#6532 on discord for information. The bugs are:
- Force-feeding was supposed to disallow do-after stacking, but was missing the required check. 
- Force feeding/drinking wouldn't be cancelled if the item was dropped, thrown, or consumed/deleted.
- Force feeding/drinking didn't check if the food/drink had been deleted upon Do-After completion

These bugs together meant that you could start force-feeding someone something, and then eat the food yourself. The do-after would then try to use a deleted entity and raise an error. Do-afters also have an issue where if an error occurs while executing completed do-afters, those do-afters are not removed from the list of completed do afters, and the server will repeatedly attempt to complete that do-after indefinitely. Because force-feeding generated popup-messages and sounds before encountering the error, this lead to the users being spammed with messages & sound.

So this PR:
- Fixes the food do-after stacking & checks if the entity was deleted before eating
- The food, drink and injector components had their in-use bools replaced with a nullable cancellation token.
- Cancels the do-afters when the active hand is switched away from the item currently being used to force feed/drink/inject.
- Makes do-afters use a `Queue` & `while (tryDequeue)` instead of a `List`+`foreach`+`list.Clear()` 

:cl:
- fixed: Fixed a force-feeding bug that would sometimes spam clients with popup-messages and audio.

