### PR TITLE
Disconnect closed pipes

### DIFF
--- a/Content.Server/NodeContainer/Nodes/PipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PipeNode.cs
@@ -132,6 +132,7 @@ namespace Content.Server.NodeContainer.Nodes
 
         public override IEnumerable<Node> GetReachableNodes()
         {
+            if (!ConnectionsEnabled) yield break;
             for (var i = 0; i < PipeDirectionHelpers.AllPipeDirections; i++)
             {
                 var pipeDir = (PipeDirection) (1 << i);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

This makes a node unreachable, if connections are not enabled. This fixes the manual valve. Previous behavior seems to be always on. This is trading a bigger bug for a smaller bug though. While it now physically works, it visually acts a little odd. I don't know enough to correct it, and it doesn't look like it would be easy.

Fixes #5714

**Changelog**
:cl:
- fix: gas valves can stop gas now

