### PR TITLE
Advertisements: SecTech only has 4 advert strings, not 9.

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Advertisements/sectech.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Advertisements/sectech.yml
@@ -5,8 +5,3 @@
     - advertisement-sectech-2
     - advertisement-sectech-3
     - advertisement-sectech-4
-    - advertisement-sectech-5
-    - advertisement-sectech-6
-    - advertisement-sectech-7
-    - advertisement-sectech-8
-    - advertisement-sectech-9


### PR DESCRIPTION
## About the PR
See also: [Resources/Locale/en-US/advertisements/vending/sectech.ftl](https://github.com/space-wizards/space-station-14/blob/bd8acc5b6b1fe5ea4d6a95e869d00b04409258f7/Resources/Locale/en-US/advertisements/vending/sectech.ftl#L1-L4)