### PR TITLE
Cleanup matches on shutdown

### DIFF
--- a/Content.Server/Light/EntitySystems/MatchstickSystem.cs
+++ b/Content.Server/Light/EntitySystems/MatchstickSystem.cs
@@ -24,6 +24,12 @@ namespace Content.Server.Light.EntitySystems
             base.Initialize();
             SubscribeLocalEvent<MatchstickComponent, InteractUsingEvent>(OnInteractUsing);
             SubscribeLocalEvent<MatchstickComponent, IsHotEvent>(OnIsHotEvent);
+            SubscribeLocalEvent<MatchstickComponent, ComponentShutdown>(OnShutdown);
+        }
+
+        private void OnShutdown(EntityUid uid, MatchstickComponent component, ComponentShutdown args)
+        {
+            _litMatches.Remove(component);
         }
 
         public override void Update(float frameTime)
@@ -31,7 +37,7 @@ namespace Content.Server.Light.EntitySystems
             base.Update(frameTime);
             foreach (var match in _litMatches)
             {
-                if (match.CurrentState != SmokableState.Lit)
+                if (match.CurrentState != SmokableState.Lit || match.Paused || match.Deleted)
                     continue;
 
                 _atmosphereSystem.HotspotExpose(match.Owner.Transform.Coordinates, 400, 50, true);


### PR DESCRIPTION
Noticed some logs about transform missing on grafana so I assumed the matches were deleted and still getting iterated
