### PR TITLE
Emergency kit & clothing tweaks

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -95,6 +95,7 @@
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
       - id: EpinephrineMedipen
+      - id: Flare
   - type: Sprite
     layers:
       - state: box

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -96,6 +96,7 @@
       - id: EmergencyOxygenTankFilled
       - id: EpinephrineMedipen
       - id: Flare
+      - id: FoodSnackChocolate
   - type: Sprite
     layers:
       - state: box

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -104,8 +104,8 @@
   - type: Item
     size: 20
   - type: Storage
-    capacity: 20
-    size: 25
+    capacity: 30
+    size: 30
 
 - type: entity
   name: box of hugs

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -12,7 +12,9 @@
         amount: 2
       - id: FoodSnackChocolate
       - id: FlashlightLantern
-        amount: 2
+        amount: 1
+      - id: FlashlightLantern
+        prob: 0.5
       - id: HarmonicaInstrument
         prob: 0.15
         orGroup: HarmonicaOrChocolate

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -32,6 +32,8 @@
           prob: 0.6
         - id: ClothingOuterSuitFire
           prob: 0.75
+        - id: ClothingMaskGas
+          prob: 0.75
 
 - type: entity
   id: ClosetMaintenanceFilledRandom

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -31,8 +31,6 @@
     lowPressureMultiplier: 25
   - type: TemperatureProtection
     coefficient: 0.1
-  - type: Clothing
-    sprite: Clothing/OuterClothing/Suits/fire.rsi
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -26,6 +26,18 @@
     sprite: Clothing/OuterClothing/Suits/emergency.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/emergency.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.85
+    lowPressureMultiplier: 25
+  - type: TemperatureProtection
+    coefficient: 0.1
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Suits/fire.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Slash: 0.95
+        Heat: 0.85
 
 - type: entity
   parent: ClothingOuterBase
@@ -39,7 +51,7 @@
     highPressureMultiplier: 0.85
     lowPressureMultiplier: 25
   - type: TemperatureProtection
-    coefficient: 0.001
+    coefficient: 0.01
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/fire.rsi
   - type: Armor


### PR DESCRIPTION
Changelog is comprehensive. Reduced heat resistance slightly of fire suit as it was super OP and added some resistances to the emergency suit as it had non.

Also added a flare to the survival box now that they work and a chocolate bar (like rations have).

And finally, changed emergency toolboxes from 2 flashlights to 1 + chance of another one. 2 seemed too OP considering they spawn in lockers. Good lighting should be a premium in an emergency and flares should be more common than flashlights.
Also added gas mask probability spawn to fire lockers.

Will work on fire fighter helmets next that are like a very basic hardsuit not meant for space as well as softsuits.

:cl:
- tweak: Improved stats of emergency suit and reduced heat resistance of fire suit
- tweak: Changed spawn probabilities in fire closets and emergency toolboxes. Added flare to survival box.

