### PR TITLE
Makes secure crates harder to break into

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -16,6 +16,18 @@
     Slash: 0.5
     Piercing: 0.7
     Shock: 1.2
+    
+- type: damageModifierSet
+  id: StrongMetallic
+  coefficients:
+    Blunt: 0.7
+    Slash: 0.5
+    Piercing: 0.7
+    Shock: 1.2
+  flatReductions:
+    Blunt: 16
+    Slash: 16
+    Piercing: 10
 
 - type: damageModifierSet
   id: Inflatable

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base.yml
@@ -61,3 +61,71 @@
       whitelist:
         components:
         - Paper
+
+
+- type: entity
+  id: CrateBaseSecure
+  parent: BaseStructureDynamic
+  abstract: true
+  name: crate
+  description: A large container for items.
+  components:
+  - type: Transform
+    noRot: true
+  - type: Sprite
+    noRot: true
+    netsync: false
+    sprite: Structures/Storage/Crates/generic.rsi
+    layers:
+    - state: crate
+    - state: crate_door
+      map: ["enum.StorageVisualLayers.Door"]
+    - state: welded
+      visible: false
+      map: ["enum.StorageVisualLayers.Welded"]
+  - type: InteractionOutline
+  - type: Physics
+  - type: Fixtures
+    fixtures:
+    - shape:
+        !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.29"
+      mass: 25
+      mask:
+      - Impassable
+      - VaultImpassable
+      - SmallImpassable
+      layer:
+      - Opaque
+      - MobImpassable
+      - SmallImpassable
+  - type: EntityStorage
+    Capacity: 500
+    CanWeldShut: true
+  - type: PlaceableSurface
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: StrongMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: Appearance
+    visuals:
+    - type: StorageVisualizer
+      state_open: crate_open
+      state_closed: crate_door
+  - type: PaperLabel
+    labelSlot:
+      insertVerbText: Attach Label
+      ejectVerbText: Remove Label
+      whitelist:
+        components:
+        - Paper
+  - type: Construction
+    graph: CrateSecure
+    node: cratesecure

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -291,7 +291,7 @@
 - type: entity
   id: CrateSecgear
   name: secgear crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
     access: [["Security"]]
@@ -316,14 +316,11 @@
     - type: StorageVisualizer
       state_open: secgearcrate_open
       state_closed: secgearcrate_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
 
 - type: entity
   id: CrateEngineeringSecure
   name: secure engineering crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
     access: [["Engineering"]]
@@ -348,14 +345,11 @@
     - type: StorageVisualizer
       state_open: engicratesecure_open
       state_closed: engicratesecure_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
 
 - type: entity
   id: CrateMedicalSecure
   name: secure medical crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
     access: [["Medical"]]
@@ -380,14 +374,11 @@
     - type: StorageVisualizer
       state_open: medicalcratesecure_open
       state_closed: medicalcratesecure_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
 
 - type: entity
   id: CratePrivateSecure
   name: private crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
   - type: Lock
@@ -411,14 +402,11 @@
     - type: StorageVisualizer
       state_open: privatecrate_open
       state_closed: privatecrate_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
 
 - type: entity
   id: CrateScienceSecure
   name: secure science crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
     access: [["Research"]]
@@ -443,14 +431,11 @@
     - type: StorageVisualizer
       state_open: scicratesecure_open
       state_closed: scicratesecure_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
     
 - type: entity
   id: CratePlasma
   name: plasma crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
     access: [["Engineering"]]
@@ -475,14 +460,11 @@
     - type: StorageVisualizer
       state_open: plasmacrate_open
       state_closed: plasmacrate_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
 
 - type: entity
   id: CrateSecure
   name: secure crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
   - type: Lock
@@ -506,14 +488,11 @@
     - type: StorageVisualizer
       state_open: securecrate_open
       state_closed: securecrate_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
 
 - type: entity
   id: CrateHydroSecure
   name: secure hydroponics crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
     access: [["Service"]]
@@ -538,14 +517,11 @@
     - type: StorageVisualizer
       state_open: hydrocratesecure_open
       state_closed: hydrocratesecure_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
     
 - type: entity
   id: CrateWeaponSecure
   name: secure weapon crate
-  parent: CrateGeneric
+  parent: CrateBaseSecure
   components:
   - type: AccessReader
     access: [["Security"]]
@@ -567,9 +543,6 @@
     - type: StorageVisualizer
       state_open: weaponcrate_open
       state_closed: weaponcrate_door
-  - type: Construction
-    graph: CrateSecure
-    node: cratesecure
 
 - type: entity
   id: CrateLivestock


### PR DESCRIPTION
Made a metallic damage type that can't be damaged below a rather high threshold (read: nearly impossible to break without high end weapons like captains sabre or guns / laser weapons). This means far less cargonia.

:cl:
- tweak: Sad day for Cargonia. All secure crates have been buffed so your basic tools won't break them anymore,


