### PR TITLE
ViewVariables: Add admin flag to *VIEW* variables

### DIFF
--- a/Content.Client/Administration/AdminVerbSystem.cs
+++ b/Content.Client/Administration/AdminVerbSystem.cs
@@ -24,7 +24,7 @@ namespace Content.Client.Verbs
             // Currently this is only the ViewVariables verb, but more admin-UI related verbs can be added here.
 
             // View variables verbs
-            if (_clientConGroupController.CanViewVar())
+            if (_clientConGroupController.CanViewVar(false))
             {
                 Verb verb = new();
                 verb.Category = VerbCategory.Debug;

--- a/Content.Client/Administration/Managers/ClientAdminManager.cs
+++ b/Content.Client/Administration/Managers/ClientAdminManager.cs
@@ -36,9 +36,9 @@ namespace Content.Client.Administration.Managers
             return _availableCommands.Contains(cmdName);
         }
 
-        public bool CanViewVar()
+        public bool CanViewVar(bool write)
         {
-            return CanCommand("vv");
+            return (!write && CanCommand("vv")) || HasFlag(AdminFlags.VarEdit);
         }
 
         public bool CanAdminPlace()

--- a/Content.Client/Administration/Managers/IClientAdminManager.cs
+++ b/Content.Client/Administration/Managers/IClientAdminManager.cs
@@ -34,7 +34,7 @@ namespace Content.Client.Administration.Managers
         /// <summary>
         ///     Check if the local player can open the VV menu.
         /// </summary>
-        bool CanViewVar();
+        bool CanViewVar(bool write);
 
         /// <summary>
         ///     Check if the local player can spawn stuff in with the entity/tile spawn panel.

--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -441,9 +441,9 @@ namespace Content.Server.Administration.Managers
             return (attribs.Length != 0, attribs);
         }
 
-        public bool CanViewVar(IPlayerSession session)
+        public bool CanViewVar(IPlayerSession session, bool write)
         {
-            return CanCommand(session, "vv");
+            return (!write && CanCommand(session, "vv")) || (GetAdminData(session)?.HasFlag(AdminFlags.VarEdit) ?? false);
         }
 
         public bool CanAdminPlace(IPlayerSession session)

--- a/Content.Shared/Administration/AdminFlags.cs
+++ b/Content.Shared/Administration/AdminFlags.cs
@@ -81,6 +81,12 @@ namespace Content.Shared.Administration
         Adminhelp = 1 << 12,
 
         /// <summary>
+        ///     Lets you *VIEW* variables, not change them.
+        ///     <seealso cref="VarEdit"/> conveys both.
+        /// </summary>
+        VarView = 1 << 13,
+
+        /// <summary>
         ///     Dangerous host permissions like scsi.
         /// </summary>
         Host = 1u << 31,


### PR DESCRIPTION
## About the PR
Mostly to let koders debug without having to give them permission to do anything ~~fun~~ destructive.

Requires space-wizards/RobustToolbox#2323