### PR TITLE
Remove SmallImpassable collision mask from booze and soda dispensers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -9,5 +9,18 @@
     sprite: Structures/dispensers.rsi
     drawdepth: SmallObjects
     state: booze
+  - type: Fixtures
+    fixtures:
+    - shape:
+        !type:PhysShapeAabb
+          bounds: "-0.4,-0.3,0.4,0.3"
+      mass: 25
+      mask:
+        - Impassable
+        - VaultImpassable
+      layer:
+        - Opaque
+        - MobImpassable
+        - SmallImpassable
   - type: ReagentDispenser
     pack: BoozeDispenserInventory

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -9,5 +9,18 @@
     sprite: Structures/dispensers.rsi
     drawdepth: SmallObjects
     state: soda
+  - type: Fixtures
+    fixtures:
+    - shape:
+        !type:PhysShapeAabb
+          bounds: "-0.4,-0.3,0.4,0.3"
+      mass: 25
+      mask:
+        - Impassable
+        - VaultImpassable
+      layer:
+        - Opaque
+        - MobImpassable
+        - SmallImpassable
   - type: ReagentDispenser
     pack: SodaDispenserInventory


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #5074
The SmallImpassable collision mask inherited from ReagentDispenserBase prevented booze and soda dispensers from moving onto tables.

<!-- **Screenshots** -->
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed booze and soda dispensers colliding with tables.

