### PR TITLE
Fix entityUid nullability for handcuffs and morgues

### DIFF
--- a/Content.Server/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Server/Cuffs/Components/CuffableComponent.cs
@@ -252,15 +252,17 @@ namespace Content.Server.Cuffs.Components
                 SoundSystem.Play(Filter.Pvs(Owner), cuff.EndUncuffSound.GetSound(), Owner);
 
                 Container.ForceRemove(cuffsToRemove.Value);
-                _entMan.GetComponent<TransformComponent>(cuffsToRemove.Value).AttachToGridOrMap();
-                _entMan.GetComponent<TransformComponent>(cuffsToRemove.Value).WorldPosition = _entMan.GetComponent<TransformComponent>(Owner).WorldPosition;
+                var transform = _entMan.GetComponent<TransformComponent>(cuffsToRemove.Value);
+                transform.AttachToGridOrMap();
+                transform.WorldPosition = _entMan.GetComponent<TransformComponent>(Owner).WorldPosition;
 
                 if (cuff.BreakOnRemove)
                 {
                     cuff.Broken = true;
 
-                    _entMan.GetComponent<MetaDataComponent>(cuffsToRemove.Value).EntityName = cuff.BrokenName;
-                    _entMan.GetComponent<MetaDataComponent>(cuffsToRemove.Value).EntityDescription = cuff.BrokenDesc;
+                    var meta = _entMan.GetComponent<MetaDataComponent>(cuffsToRemove.Value);
+                    meta.EntityName = cuff.BrokenName;
+                    meta.EntityDescription = cuff.BrokenDesc;
 
                     if (_entMan.TryGetComponent<SpriteComponent?>(cuffsToRemove, out var sprite) && cuff.BrokenState != null)
                     {

--- a/Content.Server/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Server/Cuffs/Components/CuffableComponent.cs
@@ -177,7 +177,7 @@ namespace Content.Server.Cuffs.Components
         /// </summary>
         /// <param name="user">The cuffed entity</param>
         /// <param name="cuffsToRemove">Optional param for the handcuff entity to remove from the cuffed entity. If null, uses the most recently added handcuff entity.</param>
-        public async void TryUncuff(EntityUid user, EntityUid cuffsToRemove = default)
+        public async void TryUncuff(EntityUid user, EntityUid? cuffsToRemove = null)
         {
             if (_uncuffing) return;
 
@@ -194,7 +194,7 @@ namespace Content.Server.Cuffs.Components
             }
             else
             {
-                if (!Container.ContainedEntities.Contains(cuffsToRemove))
+                if (!Container.ContainedEntities.Contains(cuffsToRemove.Value))
                 {
                     Logger.Warning("A user is trying to remove handcuffs that aren't in the owner's container. This should never happen!");
                 }
@@ -217,13 +217,6 @@ namespace Content.Server.Cuffs.Components
             if (!isOwner && !user.InRangeUnobstructed(Owner))
             {
                 user.PopupMessage(Loc.GetString("cuffable-component-cannot-remove-cuffs-too-far-message"));
-                return;
-            }
-
-            // TODO: Why are we even doing this check?
-            if (!cuffsToRemove.InRangeUnobstructed(Owner))
-            {
-                Logger.Warning("Handcuffs being removed from player are obstructed or too far away! This should not happen!");
                 return;
             }
 
@@ -258,16 +251,16 @@ namespace Content.Server.Cuffs.Components
             {
                 SoundSystem.Play(Filter.Pvs(Owner), cuff.EndUncuffSound.GetSound(), Owner);
 
-                Container.ForceRemove(cuffsToRemove);
-                _entMan.GetComponent<TransformComponent>(cuffsToRemove).AttachToGridOrMap();
-                _entMan.GetComponent<TransformComponent>(cuffsToRemove).WorldPosition = _entMan.GetComponent<TransformComponent>(Owner).WorldPosition;
+                Container.ForceRemove(cuffsToRemove.Value);
+                _entMan.GetComponent<TransformComponent>(cuffsToRemove.Value).AttachToGridOrMap();
+                _entMan.GetComponent<TransformComponent>(cuffsToRemove.Value).WorldPosition = _entMan.GetComponent<TransformComponent>(Owner).WorldPosition;
 
                 if (cuff.BreakOnRemove)
                 {
                     cuff.Broken = true;
 
-                    _entMan.GetComponent<MetaDataComponent>(cuffsToRemove).EntityName = cuff.BrokenName;
-                    _entMan.GetComponent<MetaDataComponent>(cuffsToRemove).EntityDescription = cuff.BrokenDesc;
+                    _entMan.GetComponent<MetaDataComponent>(cuffsToRemove.Value).EntityName = cuff.BrokenName;
+                    _entMan.GetComponent<MetaDataComponent>(cuffsToRemove.Value).EntityDescription = cuff.BrokenDesc;
 
                     if (_entMan.TryGetComponent<SpriteComponent?>(cuffsToRemove, out var sprite) && cuff.BrokenState != null)
                     {

--- a/Content.Server/Morgue/Components/MorgueEntityStorageComponent.cs
+++ b/Content.Server/Morgue/Components/MorgueEntityStorageComponent.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Morgue.Components
         private string? _trayPrototypeId;
 
         [ViewVariables]
-        private EntityUid _tray;
+        private EntityUid? _tray;
 
         [ViewVariables]
         public ContainerSlot? TrayContainer { get; private set; }
@@ -67,7 +67,7 @@ namespace Content.Server.Morgue.Components
         public override Vector2 ContentsDumpPosition()
         {
             if (_tray != null)
-                return _entMan.GetComponent<TransformComponent>(_tray).WorldPosition;
+                return _entMan.GetComponent<TransformComponent>(_tray.Value).WorldPosition;
             return base.ContentsDumpPosition();
         }
 
@@ -103,15 +103,15 @@ namespace Content.Server.Morgue.Components
             if (_tray == null)
             {
                 _tray = _entMan.SpawnEntity(_trayPrototypeId, _entMan.GetComponent<TransformComponent>(Owner).Coordinates);
-                var trayComp = _tray.EnsureComponent<MorgueTrayComponent>();
+                var trayComp = _tray.Value.EnsureComponent<MorgueTrayComponent>();
                 trayComp.Morgue = Owner;
             }
             else
             {
-                TrayContainer?.Remove(_tray);
+                TrayContainer?.Remove(_tray.Value);
             }
 
-            _entMan.GetComponent<TransformComponent>(_tray).Coordinates = new EntityCoordinates(Owner, 0, -1);
+            _entMan.GetComponent<TransformComponent>(_tray.Value).Coordinates = new EntityCoordinates(Owner, 0, -1);
 
             base.OpenStorage();
         }
@@ -143,7 +143,7 @@ namespace Content.Server.Morgue.Components
 
             if (_tray != null)
             {
-                TrayContainer?.Insert(_tray);
+                TrayContainer?.Insert(_tray.Value);
             }
         }
 
@@ -155,7 +155,7 @@ namespace Content.Server.Morgue.Components
             }
 
             var entityLookup = IoCManager.Resolve<IEntityLookup>();
-            foreach (var entity in entityLookup.GetEntitiesIntersecting(_tray, flags: LookupFlags.None))
+            foreach (var entity in entityLookup.GetEntitiesIntersecting(_tray.Value, flags: LookupFlags.None))
             {
                 yield return entity;
             }


### PR DESCRIPTION
Currently when trying to break out of handcuffs it uses some fallback entity if the provided `EntityUid` is null. During the great `IEntity` purge the default function argument was set to `default` instead of using a nullable `EntityUid`.  So currently you generally can't uncuff yourself. This just fixes that by making the `EntityUid` nullable.

There is a similar bug with morgues. Given that both are very small fixes, I've just combined them here.

:cl:
- fix: Fixed a bug preventing people from breaking out of handcuffs.
- fix: fixed not being able to open morgues.

