### PR TITLE
Add anchored checks to GetReachableNodes() for power device nodes

### DIFF
--- a/Content.Server/Power/Nodes/CableDeviceNode.cs
+++ b/Content.Server/Power/Nodes/CableDeviceNode.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Content.Server.NodeContainer.Nodes;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -15,6 +15,9 @@ namespace Content.Server.Power.Nodes
     {
         public override IEnumerable<Node> GetReachableNodes()
         {
+            if (!Anchored)
+                yield break;
+
             var entMan = IoCManager.Resolve<IEntityManager>();
 
             // If we're in an invalid grid, such as grid 0, we cannot connect to anything.

--- a/Content.Server/Power/Nodes/CableTerminalNode.cs
+++ b/Content.Server/Power/Nodes/CableTerminalNode.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Content.Server.NodeContainer.Nodes;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -12,6 +12,9 @@ namespace Content.Server.Power.Nodes
     {
         public override IEnumerable<Node> GetReachableNodes()
         {
+            if (!Anchored)
+                yield break;
+
             if (IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(Owner).GridID == GridId.Invalid)
                 yield break; // No funny nodes in spess.
 

--- a/Content.Server/Power/Nodes/CableTerminalPortNode.cs
+++ b/Content.Server/Power/Nodes/CableTerminalPortNode.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Content.Server.NodeContainer.Nodes;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -12,6 +12,9 @@ namespace Content.Server.Power.Nodes
     {
         public override IEnumerable<Node> GetReachableNodes()
         {
+            if (!Anchored)
+                yield break;
+
             if (IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(Owner).GridID == GridId.Invalid)
                 yield break; // No funny nodes in spess.
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #5116
Checks if node is anchored before finding reachable nodes in CableDeviceNode, CableTerminalNode, and CableTerminalPortNode. 
This matches with when and how CableNode checks if anchored.

<!--**Screenshots**
 If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed power devices remaining connected to the network after unwrenching