### PR TITLE
Fix openahelp and quit command perms

### DIFF
--- a/Content.Client/Administration/Managers/ClientAdminManager.cs
+++ b/Content.Client/Administration/Managers/ClientAdminManager.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Content.Shared.Administration;
 using Robust.Client.Console;
+using Robust.Shared.Console;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Network;
+using Robust.Shared.Reflection;
 
 namespace Content.Client.Administration.Managers
 {
@@ -61,6 +64,15 @@ namespace Content.Client.Administration.Managers
         private void UpdateMessageRx(MsgUpdateAdminStatus message)
         {
             _availableCommands.Clear();
+            var host = IoCManager.Resolve<IClientConsoleHost>();
+
+            // Anything marked as Any we'll just add even if the server doesn't know about it.
+            foreach (var (command, instance) in host.RegisteredCommands)
+            {
+                if (Attribute.GetCustomAttribute(instance.GetType(), typeof(AnyCommandAttribute)) == null) continue;
+                _availableCommands.Add(command);
+            }
+
             _availableCommands.UnionWith(message.AvailableCommands);
             Logger.DebugS("admin", $"Have {message.AvailableCommands.Length} commands available");
 

--- a/Content.Client/Commands/OpenAHelpCommand.cs
+++ b/Content.Client/Commands/OpenAHelpCommand.cs
@@ -1,5 +1,6 @@
 using System;
  using Content.Client.Administration;
+using Content.Shared.Administration;
 using Robust.Client.Console;
 using Robust.Client.GameObjects;
 using Robust.Shared.Console;
@@ -10,6 +11,7 @@ using Robust.Shared.IoC;
 
 namespace Content.Client.Commands
 {
+    [AnyCommand]
     public class OpenAHelpCommand : IConsoleCommand
     {
         public string Command => "openahelp";

--- a/Content.Server/Administration/Commands/ReAdminCommand.cs
+++ b/Content.Server/Administration/Commands/ReAdminCommand.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration.Managers;
+using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;

--- a/Content.Server/Chat/Commands/MeCommand.cs
+++ b/Content.Server/Chat/Commands/MeCommand.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration;
 using Content.Server.Chat.Managers;
 using Content.Server.Players;
+using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;

--- a/Content.Server/Chat/Commands/OOCCommand.cs
+++ b/Content.Server/Chat/Commands/OOCCommand.cs
@@ -1,5 +1,6 @@
 using Content.Server.Administration;
 using Content.Server.Chat.Managers;
+using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;

--- a/Content.Server/Chat/Commands/SayCommand.cs
+++ b/Content.Server/Chat/Commands/SayCommand.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration;
 using Content.Server.Chat.Managers;
 using Content.Server.Ghost.Components;
 using Content.Server.Players;
+using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;

--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -8,6 +8,7 @@ using Content.Server.Hands.Components;
 using Content.Server.Items;
 using Content.Server.Players;
 using Content.Server.Popups;
+using Content.Shared.Administration;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Database;

--- a/Content.Server/GameTicking/Commands/JoinGameCommand.cs
+++ b/Content.Server/GameTicking/Commands/JoinGameCommand.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Content.Server.Administration;
 using Content.Server.Roles;
 using Content.Server.Station;
+using Content.Shared.Administration;
 using Content.Shared.Roles;
 using Content.Shared.Station;
 using Robust.Server.Player;

--- a/Content.Server/GameTicking/Commands/ObserveCommand.cs
+++ b/Content.Server/GameTicking/Commands/ObserveCommand.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration;
+using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.GameObjects;

--- a/Content.Server/GameTicking/Commands/ToggleReadyCommand.cs
+++ b/Content.Server/GameTicking/Commands/ToggleReadyCommand.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration;
+using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.GameObjects;

--- a/Content.Server/Ghost/Ghost.cs
+++ b/Content.Server/Ghost/Ghost.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration;
 using Content.Server.GameTicking;
 using Content.Server.Players;
+using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.GameObjects;

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Ghost.Components;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Ghost.Roles.UI;
 using Content.Server.Players;
+using Content.Shared.Administration;
 using Content.Shared.GameTicking;
 using Content.Shared.Ghost;
 using Content.Shared.Ghost.Roles;

--- a/Content.Server/Utility/Commands/EchoCommand.cs
+++ b/Content.Server/Utility/Commands/EchoCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.Administration;
+using Content.Shared.Administration;
 using Robust.Shared.Console;
 using Robust.Shared.Localization;
 

--- a/Content.Shared/Administration/AnyCommandAttribute.cs
+++ b/Content.Shared/Administration/AnyCommandAttribute.cs
@@ -2,12 +2,11 @@
 using JetBrains.Annotations;
 using Robust.Shared.Console;
 
-namespace Content.Server.Administration
+namespace Content.Shared.Administration
 {
     /// <summary>
     ///     Specifies that a command can be executed by any player.
     /// </summary>
-    /// <seealso cref="AdminCommandAttribute"/>
     [AttributeUsage(AttributeTargets.Class)]
     [BaseTypeRequired(typeof(IConsoleCommand))]
     [MeansImplicitUse]

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -3,6 +3,7 @@
   - disconnect
   - help
   - list
+  - quit
 
 - Flags: VAREDIT
   Commands:


### PR DESCRIPTION
I moved AnyCommand to shared and made it so anything marked as that client-side is added to the available commands. quit just needed adding to the engine perms.

:cl:
- fix: Fix AHelp and Quit command permissions
