### PR TITLE
Fix collision of broken grille

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -85,6 +85,7 @@
       graph: grille
       node: grilleBroken
       deconstructionTarget: start
+    - type: Fixtures # overwrite BaseStructure parent.
     - type: Damageable
       damageContainer: Inorganic
       damageModifierSet: FlimsyMetallic


### PR DESCRIPTION
#5676 removed the fixture definition for broken grilles which unintentionally just made it inherit the base-structure fixtures. 

This just gives it an empty fixture, but maybe it should just not inherit from `BaseStructure` in the first place.

:cl:
- fix: The collision for broken grilles have been fixed, you can now walk through them again.

