### PR TITLE
Add more pretty strings to logs

### DIFF
--- a/Content.Server/Actions/Actions/DisarmAction.cs
+++ b/Content.Server/Actions/Actions/DisarmAction.cs
@@ -97,7 +97,7 @@ namespace Content.Server.Actions.Actions
 
             entMan.EventBus.RaiseLocalEvent(args.Target, eventArgs);
 
-            EntitySystem.Get<AdminLogSystem>().Add(LogType.DisarmedAction, LogImpact.Low, $"{entMan.ToPrettyString(args.Performer):performer} used disarm on {entMan.ToPrettyString(args.Target):target}");
+            EntitySystem.Get<AdminLogSystem>().Add(LogType.DisarmedAction, LogImpact.Low, $"{entMan.ToPrettyString(args.Performer):user} used disarm on {entMan.ToPrettyString(args.Target):target}");
 
             // Check if the event has been handled, and if so, do nothing else!
             if (eventArgs.Handled)

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (!barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = true;
-                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner)} started taking low pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):Entity} started taking low pressure damage");
                         }
 
                         if (status == null) break;
@@ -139,7 +139,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (!barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = true;
-                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner)} started taking high pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):Entity} started taking high pressure damage");
                         }
 
                         if (status == null) break;
@@ -158,7 +158,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = false;
-                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner)} stopped taking pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):Entity} stopped taking pressure damage");
                         }
                         status?.ClearAlertCategory(AlertCategory.Pressure);
                         break;

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (!barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = true;
-                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):Entity} started taking low pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):entity} started taking low pressure damage");
                         }
 
                         if (status == null) break;
@@ -139,7 +139,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (!barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = true;
-                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):Entity} started taking high pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):entity} started taking high pressure damage");
                         }
 
                         if (status == null) break;
@@ -158,7 +158,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = false;
-                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):Entity} stopped taking pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner):entity} stopped taking pressure damage");
                         }
                         status?.ClearAlertCategory(AlertCategory.Pressure);
                         break;

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (!barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = true;
-                            _logSystem.Add(LogType.Barotrauma, $"{barotrauma.Owner} started taking low pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner)} started taking low pressure damage");
                         }
 
                         if (status == null) break;
@@ -139,7 +139,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (!barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = true;
-                            _logSystem.Add(LogType.Barotrauma, $"{barotrauma.Owner} started taking high pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner)} started taking high pressure damage");
                         }
 
                         if (status == null) break;
@@ -158,7 +158,7 @@ namespace Content.Server.Atmos.EntitySystems
                         if (barotrauma.TakingDamage)
                         {
                             barotrauma.TakingDamage = false;
-                            _logSystem.Add(LogType.Barotrauma, $"{barotrauma.Owner} stopped taking pressure damage");
+                            _logSystem.Add(LogType.Barotrauma, $"{ToPrettyString(barotrauma.Owner)} stopped taking pressure damage");
                         }
                         status?.ClearAlertCategory(AlertCategory.Pressure);
                         break;

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -143,7 +143,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!flammable.OnFire)
                 return;
 
-            _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner)} stopped being on fire damage");
+            _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner):Entity} stopped being on fire damage");
             flammable.OnFire = false;
             flammable.FireStacks = 0;
 
@@ -159,7 +159,7 @@ namespace Content.Server.Atmos.EntitySystems
 
             if (flammable.FireStacks > 0 && !flammable.OnFire)
             {
-                _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner)} is on fire");
+                _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner):Entity} is on fire");
                 flammable.OnFire = true;
             }
 

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -143,7 +143,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!flammable.OnFire)
                 return;
 
-            _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner):Entity} stopped being on fire damage");
+            _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner):entity} stopped being on fire damage");
             flammable.OnFire = false;
             flammable.FireStacks = 0;
 
@@ -159,7 +159,7 @@ namespace Content.Server.Atmos.EntitySystems
 
             if (flammable.FireStacks > 0 && !flammable.OnFire)
             {
-                _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner):Entity} is on fire");
+                _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner):entity} is on fire");
                 flammable.OnFire = true;
             }
 

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -143,7 +143,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!flammable.OnFire)
                 return;
 
-            _logSystem.Add(LogType.Flammable, $"{flammable.Owner} stopped being on fire damage");
+            _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner)} stopped being on fire damage");
             flammable.OnFire = false;
             flammable.FireStacks = 0;
 
@@ -159,7 +159,7 @@ namespace Content.Server.Atmos.EntitySystems
 
             if (flammable.FireStacks > 0 && !flammable.OnFire)
             {
-                _logSystem.Add(LogType.Flammable, $"{flammable.Owner} is on fire");
+                _logSystem.Add(LogType.Flammable, $"{ToPrettyString(flammable.Owner)} is on fire");
                 flammable.OnFire = true;
             }
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -63,7 +63,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (environment is not null)
                 _atmosphereSystem.Merge(environment, canister.Air);
 
-            _adminLogSystem.Add(LogType.CanisterPurged, LogImpact.Medium, $"Canister {ToPrettyString(uid)} purged its contents of {canister.Air} into the environment.");
+            _adminLogSystem.Add(LogType.CanisterPurged, LogImpact.Medium, $"Canister {ToPrettyString(uid):canister} purged its contents of {canister.Air:gas} into the environment.");
             canister.Air.Clear();
         }
 
@@ -130,7 +130,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (container.ContainedEntities.Count == 0)
                 return;
 
-            _adminLogSystem.Add(LogType.CanisterTankEjected, LogImpact.Medium, $"Player {ToPrettyString(args.Session.AttachedEntity.GetValueOrDefault()):player} ejected tank {container.ContainedEntities[0]:tank} from {uid}");
+            _adminLogSystem.Add(LogType.CanisterTankEjected, LogImpact.Medium, $"Player {ToPrettyString(args.Session.AttachedEntity.GetValueOrDefault()):player} ejected tank {ToPrettyString(container.ContainedEntities[0]):tank} from {ToPrettyString(uid):canister}");
             container.Remove(container.ContainedEntities[0]);
         }
 
@@ -141,7 +141,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             var pressure = Math.Clamp(args.Pressure, canister.MinReleasePressure, canister.MaxReleasePressure);
 
-            _adminLogSystem.Add(LogType.CanisterPressure, LogImpact.Medium, $"{ToPrettyString(args.Session.AttachedEntity.GetValueOrDefault()):player} set the release pressure on {uid} to {args.Pressure}");
+            _adminLogSystem.Add(LogType.CanisterPressure, LogImpact.Medium, $"{ToPrettyString(args.Session.AttachedEntity.GetValueOrDefault()):player} set the release pressure on {ToPrettyString(uid):canister} to {args.Pressure}");
 
             canister.ReleasePressure = pressure;
             DirtyUI(uid, canister);
@@ -157,7 +157,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 && containerManager.TryGetContainer(canister.ContainerName, out var container))
                 impact = container.ContainedEntities.Count != 0 ? LogImpact.Medium : LogImpact.High;
 
-            _adminLogSystem.Add(LogType.CanisterValve, impact, $"{ToPrettyString(args.Session.AttachedEntity.GetValueOrDefault()):player} set the valve on {uid} to {args.Valve:valveState}");
+            _adminLogSystem.Add(LogType.CanisterValve, impact, $"{ToPrettyString(args.Session.AttachedEntity.GetValueOrDefault()):player} set the valve on {ToPrettyString(uid):canister} to {args.Valve:valveState}");
 
             canister.ReleaseValve = args.Valve;
             DirtyUI(uid, canister);
@@ -278,7 +278,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (!hands.Drop(args.Used, container))
                 return;
 
-            _adminLogSystem.Add(LogType.CanisterTankInserted, LogImpact.Medium, $"Player {ToPrettyString(args.User):player} inserted tank {container.ContainedEntities[0]} into {canister}");
+            _adminLogSystem.Add(LogType.CanisterTankInserted, LogImpact.Medium, $"Player {ToPrettyString(args.User):player} inserted tank {ToPrettyString(container.ContainedEntities[0]):tank} into {ToPrettyString(canister):canister}");
 
             args.Handled = true;
         }

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -165,7 +165,7 @@ namespace Content.Server.Body.Systems
                         {
                             var entity = args.SolutionEntity;
                             _logSystem.Add(LogType.ReagentEffect, effect.LogImpact,
-                                $"Metabolism effect {effect.GetType().Name} of reagent {args.Reagent.Name:reagent} applied on entity {entity} at {Transform(entity).Coordinates}");
+                                $"Metabolism effect {effect.GetType().Name:effect} of reagent {args.Reagent.Name:reagent} applied on entity {entity} at {Transform(entity).Coordinates:coordinates}");
                         }
 
                         effect.Effect(args);

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Server.Administration.Logs;
@@ -198,7 +198,7 @@ namespace Content.Server.Body.Systems
         private void TakeSuffocationDamage(EntityUid uid, RespiratorComponent respirator)
         {
             if (!respirator.Suffocating)
-                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid):Entity} started suffocating");
+                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid):entity} started suffocating");
 
             respirator.Suffocating = true;
 
@@ -213,7 +213,7 @@ namespace Content.Server.Body.Systems
         private void StopSuffocation(EntityUid uid, RespiratorComponent respirator)
         {
             if (respirator.Suffocating)
-                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid):Entity} stopped suffocating");
+                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid):entity} stopped suffocating");
 
             respirator.Suffocating = false;
 

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -198,7 +198,7 @@ namespace Content.Server.Body.Systems
         private void TakeSuffocationDamage(EntityUid uid, RespiratorComponent respirator)
         {
             if (!respirator.Suffocating)
-                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid)} started suffocating");
+                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid):Entity} started suffocating");
 
             respirator.Suffocating = true;
 
@@ -213,7 +213,7 @@ namespace Content.Server.Body.Systems
         private void StopSuffocation(EntityUid uid, RespiratorComponent respirator)
         {
             if (respirator.Suffocating)
-                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid)} stopped suffocating");
+                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid):Entity} stopped suffocating");
 
             respirator.Suffocating = false;
 

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -198,7 +198,7 @@ namespace Content.Server.Body.Systems
         private void TakeSuffocationDamage(EntityUid uid, RespiratorComponent respirator)
         {
             if (!respirator.Suffocating)
-                _logSys.Add(LogType.Asphyxiation, $"{uid:Entity} started suffocating");
+                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid)} started suffocating");
 
             respirator.Suffocating = true;
 
@@ -213,7 +213,7 @@ namespace Content.Server.Body.Systems
         private void StopSuffocation(EntityUid uid, RespiratorComponent respirator)
         {
             if (respirator.Suffocating)
-                _logSys.Add(LogType.Asphyxiation, $"{uid:Entity} stopped suffocating");
+                _logSys.Add(LogType.Asphyxiation, $"{ToPrettyString(uid)} stopped suffocating");
 
             respirator.Suffocating = false;
 

--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -69,7 +69,7 @@ namespace Content.Server.Chat.Commands
                 return;
             }
 
-            if (player.Status != SessionStatus.InGame)
+            if (player.Status != SessionStatus.InGame || player.AttachedEntity == null)
                 return;
 
             var chat = IoCManager.Resolve<IChatManager>();
@@ -85,7 +85,8 @@ namespace Content.Server.Chat.Commands
             //TODO: needs to check if the mob is actually alive
             //TODO: maybe set a suicided flag to prevent resurrection?
 
-            EntitySystem.Get<AdminLogSystem>().Add(LogType.Suicide, $"{player.AttachedEntity} is committing suicide");
+            EntitySystem.Get<AdminLogSystem>().Add(LogType.Suicide,
+                $"{_entities.ToPrettyString(player.AttachedEntity.Value):player} is committing suicide");
 
             // Held item suicide
             var handsComponent = _entities.GetComponent<HandsComponent>(owner);

--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -86,7 +86,7 @@ namespace Content.Server.Chat.Commands
             //TODO: maybe set a suicided flag to prevent resurrection?
 
             EntitySystem.Get<AdminLogSystem>().Add(LogType.Suicide,
-                $"{_entities.ToPrettyString(player.AttachedEntity.Value):Player} is committing suicide");
+                $"{_entities.ToPrettyString(player.AttachedEntity.Value):player} is committing suicide");
 
             // Held item suicide
             var handsComponent = _entities.GetComponent<HandsComponent>(owner);

--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -86,7 +86,7 @@ namespace Content.Server.Chat.Commands
             //TODO: maybe set a suicided flag to prevent resurrection?
 
             EntitySystem.Get<AdminLogSystem>().Add(LogType.Suicide,
-                $"{_entities.ToPrettyString(player.AttachedEntity.Value):player} is committing suicide");
+                $"{_entities.ToPrettyString(player.AttachedEntity.Value):Player} is committing suicide");
 
             // Held item suicide
             var handsComponent = _entities.GetComponent<HandsComponent>(owner);

--- a/Content.Server/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Server/Chemistry/Components/InjectorComponent.cs
@@ -209,6 +209,9 @@ namespace Content.Server.Chemistry.Components
             // Create a pop-up for the user
             popupSys.PopupEntity(Loc.GetString("injector-component-injecting-user"), target, Filter.Entities(user));
 
+            if (!EntitySystem.Get<SolutionContainerSystem>().TryGetSolution(Owner, SolutionName, out var solution))
+                return false;
+
             // Get entity for logging. Log with EntityUids when?
             var logSys = EntitySystem.Get<AdminLogSystem>();
 
@@ -238,7 +241,7 @@ namespace Content.Server.Chemistry.Components
                 if (ToggleState == InjectorToggleMode.Inject)
                 {
                     logSys.Add(LogType.ForceFeed,
-                        $"{_entities.ToPrettyString(user)} is attempting to inject a solution into {_entities.ToPrettyString(target)}");
+                        $"{_entities.ToPrettyString(user):user} is attempting to inject {_entities.ToPrettyString(target):target} with a solution {SolutionContainerSystem.ToPrettyString(solution):solution}");
                     // TODO solution pretty string.
                 }
             }
@@ -249,7 +252,7 @@ namespace Content.Server.Chemistry.Components
 
                 if (ToggleState == InjectorToggleMode.Inject)
                     logSys.Add(LogType.Ingestion,
-                        $"{_entities.ToPrettyString(user)} is attempting to inject themselves with a solution.");
+                        $"{_entities.ToPrettyString(user)} is attempting to inject themselves with a solution {SolutionContainerSystem.ToPrettyString(solution):solution}.");
                     //TODO solution pretty string.
             }
 

--- a/Content.Server/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Server/Chemistry/Components/InjectorComponent.cs
@@ -252,7 +252,7 @@ namespace Content.Server.Chemistry.Components
 
                 if (ToggleState == InjectorToggleMode.Inject)
                     logSys.Add(LogType.Ingestion,
-                        $"{_entities.ToPrettyString(user)} is attempting to inject themselves with a solution {SolutionContainerSystem.ToPrettyString(solution):solution}.");
+                        $"{_entities.ToPrettyString(user):user} is attempting to inject themselves with a solution {SolutionContainerSystem.ToPrettyString(solution):solution}.");
                     //TODO solution pretty string.
             }
 

--- a/Content.Server/Chemistry/EntitySystems/ChemicalReactionSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemicalReactionSystem.cs
@@ -18,7 +18,7 @@ namespace Content.Server.Chemistry.EntitySystems
             var coordinates = Transform(Owner).Coordinates;
 
             _logSystem.Add(LogType.ChemicalReaction, reaction.Impact,
-                $"Chemical reaction {reaction.ID} occurred with strength {unitReactions:strength} on entity {ToPrettyString(Owner)} at {coordinates}");
+                $"Chemical reaction {reaction.ID:reaction} occurred with strength {unitReactions:strength} on entity {ToPrettyString(Owner):metabolizer} at {coordinates}");
 
             SoundSystem.Play(Filter.Pvs(Owner, entityManager:EntityManager), reaction.Sound.GetSound(), Owner);
         }

--- a/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.Capabilities.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.Capabilities.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Content.Server.Chemistry.Components.SolutionManager;
 using Content.Server.Database;
@@ -134,7 +134,7 @@ namespace Content.Server.Chemistry.EntitySystems
         public static string ToPrettyString(Solution solution)
         {
             var sb = new StringBuilder();
-            sb.Append("Solution content: [");
+            sb.Append("[");
             var first = true;
             foreach (var (id, quantity) in solution.Contents)
             {

--- a/Content.Server/Crayon/CrayonComponent.cs
+++ b/Content.Server/Crayon/CrayonComponent.cs
@@ -135,7 +135,7 @@ namespace Content.Server.Crayon
             // Decrease "Ammo"
             Charges--;
             Dirty();
-            EntitySystem.Get<AdminLogSystem>().Add(LogType.CrayonDraw, $"{_entMan.ToPrettyString(eventArgs.User):player} drew a {_color:color} {SelectedState}");
+            EntitySystem.Get<AdminLogSystem>().Add(LogType.CrayonDraw, $"{_entMan.ToPrettyString(eventArgs.User):User} drew a {_color:Color} {SelectedState}");
             return true;
         }
 

--- a/Content.Server/Crayon/CrayonComponent.cs
+++ b/Content.Server/Crayon/CrayonComponent.cs
@@ -135,7 +135,7 @@ namespace Content.Server.Crayon
             // Decrease "Ammo"
             Charges--;
             Dirty();
-            EntitySystem.Get<AdminLogSystem>().Add(LogType.CrayonDraw, $"{_entMan.ToPrettyString(eventArgs.User):User} drew a {_color:Color} {SelectedState}");
+            EntitySystem.Get<AdminLogSystem>().Add(LogType.CrayonDraw, LogImpact.Low, $"{_entMan.ToPrettyString(eventArgs.User):user} drew a {_color:color} {SelectedState}");
             return true;
         }
 

--- a/Content.Server/Crayon/CrayonComponent.cs
+++ b/Content.Server/Crayon/CrayonComponent.cs
@@ -135,7 +135,7 @@ namespace Content.Server.Crayon
             // Decrease "Ammo"
             Charges--;
             Dirty();
-            EntitySystem.Get<AdminLogSystem>().Add(LogType.CrayonDraw, $"{eventArgs.User:player} drew a {_color:color} {SelectedState}");
+            EntitySystem.Get<AdminLogSystem>().Add(LogType.CrayonDraw, $"{_entMan.ToPrettyString(eventArgs.User):player} drew a {_color:color} {SelectedState}");
             return true;
         }
 

--- a/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Damage.Systems
             var dmg = _damageableSystem.TryChangeDamage(uid, component.Damage * damageScale);
 
             if (dmg != null)
-                _logSystem.Add(LogType.Damaged, $"{ToPrettyString(component.Owner):Entity} took {dmg.Total:Damage} damage from a high speed collision");
+                _logSystem.Add(LogType.Damaged, $"{ToPrettyString(component.Owner):entity} took {dmg.Total:damage} damage from a high speed collision");
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Damage.Systems
             var dmg = _damageableSystem.TryChangeDamage(uid, component.Damage * damageScale);
 
             if (dmg != null)
-                _logSystem.Add(LogType.Damaged, $"{ToPrettyString(component.Owner)} took {dmg.Total} damage from a high speed collision");
+                _logSystem.Add(LogType.Damaged, $"{ToPrettyString(component.Owner):Entity} took {dmg.Total:Damage} damage from a high speed collision");
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Damage.Systems
             var dmg = _damageableSystem.TryChangeDamage(uid, component.Damage * damageScale);
 
             if (dmg != null)
-                _logSystem.Add(LogType.Damaged, $"{component.Owner} took {dmg.Total} damage from a high speed collision");
+                _logSystem.Add(LogType.Damaged, $"{ToPrettyString(component.Owner)} took {dmg.Total} damage from a high speed collision");
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOnLandSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnLandSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Damage.Systems
             if (dmg == null)
                 return;
 
-            _logSystem.Add(LogType.Landed, $"{ToPrettyString(component.Owner)} received {dmg.Total} damage from landing");
+            _logSystem.Add(LogType.Landed, $"{ToPrettyString(component.Owner):Entity} received {dmg.Total:Damage} damage from landing");
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOnLandSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnLandSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Damage.Systems
             if (dmg == null)
                 return;
 
-            _logSystem.Add(LogType.Landed, $"{component.Owner} received {dmg.Total} damage from landing");
+            _logSystem.Add(LogType.Landed, $"{ToPrettyString(component.Owner)} received {dmg.Total} damage from landing");
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOnLandSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnLandSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Damage.Systems
             if (dmg == null)
                 return;
 
-            _logSystem.Add(LogType.Landed, $"{ToPrettyString(component.Owner):Entity} received {dmg.Total:Damage} damage from landing");
+            _logSystem.Add(LogType.Landed, $"{ToPrettyString(component.Owner):entity} received {dmg.Total:damage} damage from landing");
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Damage.Systems
 
                 if (dmg != null)
                     _logSystem.Add(LogType.Damaged,
-                        $"{ToPrettyString(args.User):user} used {ToPrettyString(args.Used):used} as a welder to deal {dmg.Total} damage to {ToPrettyString(args.Target):target}");
+                        $"{ToPrettyString(args.User):User} used {ToPrettyString(args.Used):Used} as a welder to deal {dmg.Total:Damage} damage to {ToPrettyString(args.Target):Target}");
 
                 args.Handled = true;
             }
@@ -47,7 +47,7 @@ namespace Content.Server.Damage.Systems
 
                 if (dmg != null)
                     _logSystem.Add(LogType.Damaged,
-                        $"{ToPrettyString(args.User):user} used {ToPrettyString(args.Used):used} as a tool to deal {dmg.Total} damage to {ToPrettyString(args.Target):target}");
+                        $"{ToPrettyString(args.User):User} used {ToPrettyString(args.Used):Used} as a tool to deal {dmg.Total:Damage} damage to {ToPrettyString(args.Target):Target}");
 
                 args.Handled = true;
             }

--- a/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Damage.Systems
 
                 if (dmg != null)
                     _logSystem.Add(LogType.Damaged,
-                        $"{ToPrettyString(args.User):User} used {ToPrettyString(args.Used):Used} as a welder to deal {dmg.Total:Damage} damage to {ToPrettyString(args.Target):Target}");
+                        $"{ToPrettyString(args.User):user} used {ToPrettyString(args.Used):used} as a welder to deal {dmg.Total:damage} damage to {ToPrettyString(args.Target):target}");
 
                 args.Handled = true;
             }
@@ -47,7 +47,7 @@ namespace Content.Server.Damage.Systems
 
                 if (dmg != null)
                     _logSystem.Add(LogType.Damaged,
-                        $"{ToPrettyString(args.User):User} used {ToPrettyString(args.Used):Used} as a tool to deal {dmg.Total:Damage} damage to {ToPrettyString(args.Target):Target}");
+                        $"{ToPrettyString(args.User):user} used {ToPrettyString(args.Used):used} as a tool to deal {dmg.Total:damage} damage to {ToPrettyString(args.Target):target}");
 
                 args.Handled = true;
             }

--- a/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnToolInteractSystem.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Damage.Systems
 
                 if (dmg != null)
                     _logSystem.Add(LogType.Damaged,
-                        $"{args.User} used {args.Used} as a welder to deal {dmg.Total} damage to {args.Target}");
+                        $"{ToPrettyString(args.User):user} used {ToPrettyString(args.Used):used} as a welder to deal {dmg.Total} damage to {ToPrettyString(args.Target):target}");
 
                 args.Handled = true;
             }
@@ -47,7 +47,7 @@ namespace Content.Server.Damage.Systems
 
                 if (dmg != null)
                     _logSystem.Add(LogType.Damaged,
-                        $"{args.User} used {args.Used} as a tool to deal {dmg.Total} damage to {args.Target}");
+                        $"{ToPrettyString(args.User):user} used {ToPrettyString(args.Used):used} as a tool to deal {dmg.Total} damage to {ToPrettyString(args.Target):target}");
 
                 args.Handled = true;
             }

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Damage.Systems
         {
             var dmg = _damageableSystem.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances);
             if (dmg != null)
-                _logSystem.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):Target} received {dmg.Total:Damage} damage from collision");
+                _logSystem.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total:damage} damage from collision");
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Damage.Systems
         {
             var dmg = _damageableSystem.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances);
             if (dmg != null)
-                _logSystem.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total} damage from collision");
+                _logSystem.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):Target} received {dmg.Total:Damage} damage from collision");
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Damage.Systems
         {
             var dmg = _damageableSystem.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances);
             if (dmg != null)
-                _logSystem.Add(LogType.ThrowHit, $"{args.Target} received {dmg.Total} damage from collision");
+                _logSystem.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total} damage from collision");
         }
     }
 }

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Server.Electrocution
                     var actual = _damageableSystem.TryChangeDamage(finished.Electrocuting, damage);
                     if (actual != null)
                         _logSystem.Add(LogType.Electrocution,
-                            $"{ToPrettyString(finished.Owner):Entity} received {actual.Total:Damage} powered electrocution damage");
+                            $"{ToPrettyString(finished.Owner):entity} received {actual.Total:damage} powered electrocution damage");
                 }
 
                 EntityManager.DeleteEntity(uid);
@@ -357,7 +357,7 @@ namespace Content.Server.Electrocution
 
                 if (actual != null)
                     _logSystem.Add(LogType.Electrocution,
-                        $"{ToPrettyString(statusEffects.Owner):Entity} received {actual.Total:Damage} powered electrocution damage");
+                        $"{ToPrettyString(statusEffects.Owner):entity} received {actual.Total:damage} powered electrocution damage");
             }
 
             _stutteringSystem.DoStutter(uid, time * StutteringTimeMultiplier, refresh, statusEffects, alerts);

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Server.Electrocution
                     var actual = _damageableSystem.TryChangeDamage(finished.Electrocuting, damage);
                     if (actual != null)
                         _logSystem.Add(LogType.Electrocution,
-                            $"{finished.Owner} took {actual.Total} powered electrocution damage");
+                            $"{ToPrettyString(finished.Owner)} received {actual.Total} powered electrocution damage");
                 }
 
                 EntityManager.DeleteEntity(uid);
@@ -357,7 +357,7 @@ namespace Content.Server.Electrocution
 
                 if (actual != null)
                     _logSystem.Add(LogType.Electrocution,
-                        $"{statusEffects.Owner} took {actual.Total} powered electrocution damage");
+                        $"{ToPrettyString(statusEffects.Owner)} received {actual.Total} powered electrocution damage");
             }
 
             _stutteringSystem.DoStutter(uid, time * StutteringTimeMultiplier, refresh, statusEffects, alerts);

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Server.Electrocution
                     var actual = _damageableSystem.TryChangeDamage(finished.Electrocuting, damage);
                     if (actual != null)
                         _logSystem.Add(LogType.Electrocution,
-                            $"{ToPrettyString(finished.Owner)} received {actual.Total} powered electrocution damage");
+                            $"{ToPrettyString(finished.Owner):Entity} received {actual.Total:Damage} powered electrocution damage");
                 }
 
                 EntityManager.DeleteEntity(uid);
@@ -357,7 +357,7 @@ namespace Content.Server.Electrocution
 
                 if (actual != null)
                     _logSystem.Add(LogType.Electrocution,
-                        $"{ToPrettyString(statusEffects.Owner)} received {actual.Total} powered electrocution damage");
+                        $"{ToPrettyString(statusEffects.Owner):Entity} received {actual.Total:Damage} powered electrocution damage");
             }
 
             _stutteringSystem.DoStutter(uid, time * StutteringTimeMultiplier, refresh, statusEffects, alerts);

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -343,20 +343,20 @@ namespace Content.Server.Explosion.EntitySystems
             }
 
             // logging
-            var text = $"{epicenter} with range {devastationRange}/{heavyImpactRange}/{lightImpactRange}/{flashRange}";
+            var range = $"{devastationRange}/{heavyImpactRange}/{lightImpactRange}/{flashRange}";
             if (entity == null || !entity.Value.IsValid())
             {
-                _logSystem.Add(LogType.Explosion, LogImpact.High, $"Explosion spawned at {text}");
+                _logSystem.Add(LogType.Explosion, LogImpact.High, $"Explosion spawned at {epicenter:coordinates} with range {range}");
             }
             else if (user == null || !user.Value.IsValid())
             {
                 _logSystem.Add(LogType.Explosion, LogImpact.High,
-                    $"{ToPrettyString(entity.Value)} exploded at {text}");
+                    $"{ToPrettyString(entity.Value):entity} exploded at {epicenter:coordinates} with range {range}");
             }
             else
             {
                 _logSystem.Add(LogType.Explosion, LogImpact.High,
-                    $"{ToPrettyString(user.Value)} caused {ToPrettyString(entity.Value)} to explode at {text}");
+                    $"{ToPrettyString(user.Value):user} caused {ToPrettyString(entity.Value):entity} to explode at {epicenter:coordinates} with range {range}");
             }
 
             var maxRange = MathHelper.Max(devastationRange, heavyImpactRange, lightImpactRange, 0);

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -65,7 +65,7 @@ public class SpillableSystem : EntitySystem
         if (args.User != null)
         {
             _logSystem.Add(LogType.Landed,
-                $"{EntityManager.ToPrettyString(uid)} spilled {SolutionContainerSystem.ToPrettyString(solution)} on landing");
+                $"{ToPrettyString(uid)} spilled a solution {SolutionContainerSystem.ToPrettyString(solution)} on landing");
         }
 
         var drainedSolution = _solutionContainerSystem.Drain(uid, solution, solution.DrainAvailable);

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -65,7 +65,7 @@ public class SpillableSystem : EntitySystem
         if (args.User != null)
         {
             _logSystem.Add(LogType.Landed,
-                $"{ToPrettyString(uid)} spilled a solution {SolutionContainerSystem.ToPrettyString(solution)} on landing");
+                $"{ToPrettyString(uid):Entity} spilled a solution {SolutionContainerSystem.ToPrettyString(solution):Solution} on landing");
         }
 
         var drainedSolution = _solutionContainerSystem.Drain(uid, solution, solution.DrainAvailable);

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -65,7 +65,7 @@ public class SpillableSystem : EntitySystem
         if (args.User != null)
         {
             _logSystem.Add(LogType.Landed,
-                $"{ToPrettyString(uid):Entity} spilled a solution {SolutionContainerSystem.ToPrettyString(solution):Solution} on landing");
+                $"{ToPrettyString(uid):entity} spilled a solution {SolutionContainerSystem.ToPrettyString(solution):solution} on landing");
         }
 
         var drainedSolution = _solutionContainerSystem.Drain(uid, solution, solution.DrainAvailable);

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -138,9 +138,9 @@ namespace Content.Server.GameTicking
             _stationSystem.TryAssignJobToStation(station, jobPrototype);
 
             if (lateJoin)
-                _adminLogSystem.Add(LogType.LateJoin, LogImpact.Medium, $"Player {player.Name} late joined as {character.Name:characterName} on station {_stationSystem.StationInfo[station].Name:stationName} with {ToPrettyString(mob)} as a {job.Name:jobName}.");
+                _adminLogSystem.Add(LogType.LateJoin, LogImpact.Medium, $"Player {player.Name} late joined as {character.Name:characterName} on station {_stationSystem.StationInfo[station].Name:stationName} with {ToPrettyString(mob):entity} as a {job.Name:jobName}.");
             else
-                _adminLogSystem.Add(LogType.RoundStartJoin, LogImpact.Medium, $"Player {player.Name} joined as {character.Name:characterName} on station {_stationSystem.StationInfo[station].Name:stationName} with {ToPrettyString(mob)} as a {job.Name:jobName}.");
+                _adminLogSystem.Add(LogType.RoundStartJoin, LogImpact.Medium, $"Player {player.Name} joined as {character.Name:characterName} on station {_stationSystem.StationInfo[station].Name:stationName} with {ToPrettyString(mob):entity} as a {job.Name:jobName}.");
 
             Preset?.OnSpawnPlayerCompleted(player, mob, lateJoin);
         }

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -523,7 +523,7 @@ namespace Content.Server.Interaction
                 var ev = new WideAttackEvent(user, user, coordinates);
                 RaiseLocalEvent(user, ev, false);
                 if (ev.Handled)
-                    _adminLogSystem.Add(LogType.AttackUnarmedWide, $"{ToPrettyString(user):user} wide attacked at {coordinates}");
+                    _adminLogSystem.Add(LogType.AttackUnarmedWide, $"{ToPrettyString(user):User} wide attacked at {coordinates:Coordinates}");
             }
             else
             {

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -523,7 +523,7 @@ namespace Content.Server.Interaction
                 var ev = new WideAttackEvent(user, user, coordinates);
                 RaiseLocalEvent(user, ev, false);
                 if (ev.Handled)
-                    _adminLogSystem.Add(LogType.AttackUnarmedWide, $"{user} wide attacked at {coordinates}");
+                    _adminLogSystem.Add(LogType.AttackUnarmedWide, $"{ToPrettyString(user):user} wide attacked at {coordinates}");
             }
             else
             {

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -394,7 +394,7 @@ namespace Content.Server.Interaction
             // all interactions should only happen when in range / unobstructed, so no range check is needed
             var message = new InteractHandEvent(user, target);
             RaiseLocalEvent(target, message);
-            _adminLogSystem.Add(LogType.InteractHand, LogImpact.Low, $"{ToPrettyString(user)} interacted with {ToPrettyString(target)}");
+            _adminLogSystem.Add(LogType.InteractHand, LogImpact.Low, $"{ToPrettyString(user):user} interacted with {ToPrettyString(target):target}");
             if (message.Handled)
                 return;
 
@@ -482,7 +482,7 @@ namespace Content.Server.Interaction
 
                         if (ev.Handled)
                         {
-                            _adminLogSystem.Add(LogType.AttackArmedWide, LogImpact.Medium, $"{ToPrettyString(user)} wide attacked with {ToPrettyString(item)} at {coordinates}");
+                            _adminLogSystem.Add(LogType.AttackArmedWide, LogImpact.Medium, $"{ToPrettyString(user):user} wide attacked with {ToPrettyString(item):used} at {coordinates}");
                             return;
                         }
                     }
@@ -496,12 +496,12 @@ namespace Content.Server.Interaction
                             if (targetUid != default)
                             {
                                 _adminLogSystem.Add(LogType.AttackArmedClick, LogImpact.Medium,
-                                    $"{ToPrettyString(user)} attacked {ToPrettyString(targetUid)} with {ToPrettyString(item)} at {coordinates}");
+                                    $"{ToPrettyString(user):user} attacked {ToPrettyString(targetUid):target} with {ToPrettyString(item):used} at {coordinates}");
                             }
                             else
                             {
                                 _adminLogSystem.Add(LogType.AttackArmedClick, LogImpact.Medium,
-                                    $"{ToPrettyString(user)} attacked with {ToPrettyString(item)} at {coordinates}");
+                                    $"{ToPrettyString(user):user} attacked with {ToPrettyString(item):used} at {coordinates}");
                             }
 
                             return;
@@ -523,7 +523,7 @@ namespace Content.Server.Interaction
                 var ev = new WideAttackEvent(user, user, coordinates);
                 RaiseLocalEvent(user, ev, false);
                 if (ev.Handled)
-                    _adminLogSystem.Add(LogType.AttackUnarmedWide, $"{ToPrettyString(user):User} wide attacked at {coordinates:Coordinates}");
+                    _adminLogSystem.Add(LogType.AttackUnarmedWide, $"{ToPrettyString(user):user} wide attacked at {coordinates}");
             }
             else
             {
@@ -534,12 +534,12 @@ namespace Content.Server.Interaction
                     if (targetUid != default)
                     {
                         _adminLogSystem.Add(LogType.AttackUnarmedClick, LogImpact.Medium,
-                            $"{ToPrettyString(user)} attacked {ToPrettyString(targetUid)} at {coordinates}");
+                            $"{ToPrettyString(user):user} attacked {ToPrettyString(targetUid):target} at {coordinates}");
                     }
                     else
                     {
                         _adminLogSystem.Add(LogType.AttackUnarmedClick, LogImpact.Medium,
-                            $"{ToPrettyString(user)} attacked at {coordinates}");
+                            $"{ToPrettyString(user):user} attacked at {coordinates}");
                     }
                 }
             }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -119,7 +119,7 @@ namespace Content.Server.Light.EntitySystems
 
                     if (damage != null)
                         _logSystem.Add(LogType.Damaged,
-                            $"{ToPrettyString(args.User):user} burned their hand on {ToPrettyString(args.Target):target} and received {damage.Total} damage");
+                            $"{ToPrettyString(args.User):User} burned their hand on {ToPrettyString(args.Target):Entity} and received {damage.Total:Damage} damage");
 
                     SoundSystem.Play(Filter.Pvs(uid), light.BurnHandSound.GetSound(), uid);
 

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -119,7 +119,7 @@ namespace Content.Server.Light.EntitySystems
 
                     if (damage != null)
                         _logSystem.Add(LogType.Damaged,
-                            $"{ToPrettyString(args.User):User} burned their hand on {ToPrettyString(args.Target):Entity} and received {damage.Total:Damage} damage");
+                            $"{ToPrettyString(args.User):user} burned their hand on {ToPrettyString(args.Target):target} and received {damage.Total:damage} damage");
 
                     SoundSystem.Play(Filter.Pvs(uid), light.BurnHandSound.GetSound(), uid);
 

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -119,7 +119,7 @@ namespace Content.Server.Light.EntitySystems
 
                     if (damage != null)
                         _logSystem.Add(LogType.Damaged,
-                            $"{args.User} burned their hand on {args.Target} and received {damage.Total} damage");
+                            $"{ToPrettyString(args.User):user} burned their hand on {ToPrettyString(args.Target):target} and received {damage.Total} damage");
 
                     SoundSystem.Play(Filter.Pvs(uid), light.BurnHandSound.GetSound(), uid);
 

--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -73,9 +73,9 @@ namespace Content.Server.Medical.Components
                 return true;
 
             if (eventArgs.Target != eventArgs.User)
-                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):User} healed {_entMan.ToPrettyString(eventArgs.Target.Value):Target} for {healed.Total:Damage} damage");
+                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):user} healed {_entMan.ToPrettyString(eventArgs.Target.Value):target} for {healed.Total:damage} damage");
             else
-                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):User} healed themselves for {healed.Total:Damage} damage");
+                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):user} healed themselves for {healed.Total:damage} damage");
 
             return true;
         }

--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -73,9 +73,9 @@ namespace Content.Server.Medical.Components
                 return true;
 
             if (eventArgs.Target != eventArgs.User)
-                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{eventArgs.User} healed {eventArgs.Target} for {healed.Total} damage");
+                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):user} healed {_entMan.ToPrettyString(eventArgs.Target.Value):target} for {healed.Total} damage");
             else
-                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{eventArgs.User} healed themselves for {healed.Total} damage");
+                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):user} healed themselves for {healed.Total} damage");
 
             return true;
         }

--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -73,9 +73,9 @@ namespace Content.Server.Medical.Components
                 return true;
 
             if (eventArgs.Target != eventArgs.User)
-                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):user} healed {_entMan.ToPrettyString(eventArgs.Target.Value):target} for {healed.Total} damage");
+                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):User} healed {_entMan.ToPrettyString(eventArgs.Target.Value):Target} for {healed.Total:Damage} damage");
             else
-                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):user} healed themselves for {healed.Total} damage");
+                EntitySystem.Get<AdminLogSystem>().Add(LogType.Healed, $"{_entMan.ToPrettyString(eventArgs.User):User} healed themselves for {healed.Total:Damage} damage");
 
             return true;
         }

--- a/Content.Server/Nutrition/Components/HungerComponent.cs
+++ b/Content.Server/Nutrition/Components/HungerComponent.cs
@@ -208,9 +208,9 @@ namespace Content.Server.Nutrition.Components
             if (calculatedHungerThreshold != _currentHungerThreshold)
             {
                 if (_currentHungerThreshold == HungerThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{Owner} has stopped starving");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner)} has stopped starving");
                 else if (calculatedHungerThreshold == HungerThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{Owner} has started starving");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner)} has started starving");
 
                 _currentHungerThreshold = calculatedHungerThreshold;
                 HungerThresholdEffect();

--- a/Content.Server/Nutrition/Components/HungerComponent.cs
+++ b/Content.Server/Nutrition/Components/HungerComponent.cs
@@ -208,9 +208,9 @@ namespace Content.Server.Nutrition.Components
             if (calculatedHungerThreshold != _currentHungerThreshold)
             {
                 if (_currentHungerThreshold == HungerThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner)} has stopped starving");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner):Entity} has stopped starving");
                 else if (calculatedHungerThreshold == HungerThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner)} has started starving");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner):Entity} has started starving");
 
                 _currentHungerThreshold = calculatedHungerThreshold;
                 HungerThresholdEffect();

--- a/Content.Server/Nutrition/Components/HungerComponent.cs
+++ b/Content.Server/Nutrition/Components/HungerComponent.cs
@@ -208,9 +208,9 @@ namespace Content.Server.Nutrition.Components
             if (calculatedHungerThreshold != _currentHungerThreshold)
             {
                 if (_currentHungerThreshold == HungerThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner):Entity} has stopped starving");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner):entity} has stopped starving");
                 else if (calculatedHungerThreshold == HungerThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner):Entity} has started starving");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Hunger, $"{_entMan.ToPrettyString(Owner):entity} has started starving");
 
                 _currentHungerThreshold = calculatedHungerThreshold;
                 HungerThresholdEffect();

--- a/Content.Server/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Server/Nutrition/Components/ThirstComponent.cs
@@ -205,9 +205,9 @@ namespace Content.Server.Nutrition.Components
             if (calculatedThirstThreshold != _currentThirstThreshold)
             {
                 if (_currentThirstThreshold == ThirstThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{Owner} has stopped taking dehydration damage");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner)} has stopped taking dehydration damage");
                 else if (calculatedThirstThreshold == ThirstThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{Owner} has started taking dehydration damage");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner)} has started taking dehydration damage");
 
                 _currentThirstThreshold = calculatedThirstThreshold;
                 ThirstThresholdEffect();

--- a/Content.Server/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Server/Nutrition/Components/ThirstComponent.cs
@@ -205,9 +205,9 @@ namespace Content.Server.Nutrition.Components
             if (calculatedThirstThreshold != _currentThirstThreshold)
             {
                 if (_currentThirstThreshold == ThirstThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner)} has stopped taking dehydration damage");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner):Entity} has stopped taking dehydration damage");
                 else if (calculatedThirstThreshold == ThirstThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner)} has started taking dehydration damage");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner):Entity} has started taking dehydration damage");
 
                 _currentThirstThreshold = calculatedThirstThreshold;
                 ThirstThresholdEffect();

--- a/Content.Server/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Server/Nutrition/Components/ThirstComponent.cs
@@ -205,9 +205,9 @@ namespace Content.Server.Nutrition.Components
             if (calculatedThirstThreshold != _currentThirstThreshold)
             {
                 if (_currentThirstThreshold == ThirstThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner):Entity} has stopped taking dehydration damage");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner):entity} has stopped taking dehydration damage");
                 else if (calculatedThirstThreshold == ThirstThreshold.Dead)
-                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner):Entity} has started taking dehydration damage");
+                    EntitySystem.Get<AdminLogSystem>().Add(LogType.Thirst, $"{_entMan.ToPrettyString(Owner):entity} has started taking dehydration damage");
 
                 _currentThirstThreshold = calculatedThirstThreshold;
                 ThirstThresholdEffect();

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -380,7 +380,7 @@ namespace Content.Server.Nutrition.EntitySystems
             });
 
             // logging
-            _logSystem.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(userUid)} is forcing {ToPrettyString(targetUid)} to drink {ToPrettyString(uid)} {SolutionContainerSystem.ToPrettyString(drinkSolution):solution}");
+            _logSystem.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(userUid):user} is forcing {ToPrettyString(targetUid):target} to drink {ToPrettyString(uid):drink} {SolutionContainerSystem.ToPrettyString(drinkSolution):solution}");
 
             return true;
         }

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -380,7 +380,7 @@ namespace Content.Server.Nutrition.EntitySystems
             });
 
             // logging
-            _logSystem.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(userUid)} is forcing {ToPrettyString(targetUid)} to drink {ToPrettyString(uid)}");
+            _logSystem.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(userUid)} is forcing {ToPrettyString(targetUid)} to drink {ToPrettyString(uid)} {SolutionContainerSystem.ToPrettyString(drinkSolution):solution}");
 
             return true;
         }

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -325,7 +325,7 @@ namespace Content.Server.Nutrition.EntitySystems
             });
 
             // logging
-            _logSystem.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(user)} is forcing {ToPrettyString(target)} to eat {ToPrettyString(uid)}");
+            _logSystem.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(user)} is forcing {ToPrettyString(target)} to eat {ToPrettyString(uid)} {SolutionContainerSystem.ToPrettyString(foodSolution):solution}");
 
             return true;
         }
@@ -415,9 +415,9 @@ namespace Content.Server.Nutrition.EntitySystems
 
             // logging
             if (user == null)
-                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(uid):food} was thrown into the mouth of {ToPrettyString(target):target}");
+                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(uid):food} {SolutionContainerSystem.ToPrettyString(foodSolution):solution} was thrown into the mouth of {ToPrettyString(target):target}");
             else
-                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(user.Value):user} threw {ToPrettyString(uid):food} into the mouth of {ToPrettyString(target):target}");
+                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(user.Value):user} threw {ToPrettyString(uid):food} {SolutionContainerSystem.ToPrettyString(foodSolution):solution} into the mouth of {ToPrettyString(target):target}");
 
             var filter = user == null ? Filter.Entities(target) : Filter.Entities(target, user.Value);
             _popupSystem.PopupEntity(Loc.GetString(food.EatMessage), target, filter);

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -415,9 +415,9 @@ namespace Content.Server.Nutrition.EntitySystems
 
             // logging
             if (user == null)
-                _logSystem.Add(LogType.ForceFeed, $"{uid} was thrown into the mouth of {target}");
+                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(uid):food} was thrown into the mouth of {ToPrettyString(target):target}");
             else
-                _logSystem.Add(LogType.ForceFeed, $"{user} threw {uid} into the mouth of {target}");
+                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(user.Value):user} threw {ToPrettyString(uid):food} into the mouth of {ToPrettyString(target):target}");
 
             var filter = user == null ? Filter.Entities(target) : Filter.Entities(target, user.Value);
             _popupSystem.PopupEntity(Loc.GetString(food.EatMessage), target, filter);

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -415,9 +415,9 @@ namespace Content.Server.Nutrition.EntitySystems
 
             // logging
             if (user == null)
-                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(uid):food} {SolutionContainerSystem.ToPrettyString(foodSolution):solution} was thrown into the mouth of {ToPrettyString(target):target}");
+                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(uid):Food} {SolutionContainerSystem.ToPrettyString(foodSolution):Solution} was thrown into the mouth of {ToPrettyString(target):Target}");
             else
-                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(user.Value):user} threw {ToPrettyString(uid):food} {SolutionContainerSystem.ToPrettyString(foodSolution):solution} into the mouth of {ToPrettyString(target):target}");
+                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(user.Value):User} threw {ToPrettyString(uid):Food} {SolutionContainerSystem.ToPrettyString(foodSolution):Solution} into the mouth of {ToPrettyString(target):Target}");
 
             var filter = user == null ? Filter.Entities(target) : Filter.Entities(target, user.Value);
             _popupSystem.PopupEntity(Loc.GetString(food.EatMessage), target, filter);

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -325,7 +325,7 @@ namespace Content.Server.Nutrition.EntitySystems
             });
 
             // logging
-            _logSystem.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(user)} is forcing {ToPrettyString(target)} to eat {ToPrettyString(uid)} {SolutionContainerSystem.ToPrettyString(foodSolution):solution}");
+            _logSystem.Add(LogType.ForceFeed, LogImpact.Medium, $"{ToPrettyString(user):user} is forcing {ToPrettyString(target):target} to eat {ToPrettyString(uid):food} {SolutionContainerSystem.ToPrettyString(foodSolution):solution}");
 
             return true;
         }
@@ -415,9 +415,9 @@ namespace Content.Server.Nutrition.EntitySystems
 
             // logging
             if (user == null)
-                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(uid):Food} {SolutionContainerSystem.ToPrettyString(foodSolution):Solution} was thrown into the mouth of {ToPrettyString(target):Target}");
+                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(uid):food} {SolutionContainerSystem.ToPrettyString(foodSolution):solution} was thrown into the mouth of {ToPrettyString(target):target}");
             else
-                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(user.Value):User} threw {ToPrettyString(uid):Food} {SolutionContainerSystem.ToPrettyString(foodSolution):Solution} into the mouth of {ToPrettyString(target):Target}");
+                _logSystem.Add(LogType.ForceFeed, $"{ToPrettyString(user.Value):user} threw {ToPrettyString(uid):food} {SolutionContainerSystem.ToPrettyString(foodSolution):solution} into the mouth of {ToPrettyString(target):target}");
 
             var filter = user == null ? Filter.Entities(target) : Filter.Entities(target, user.Value);
             _popupSystem.PopupEntity(Loc.GetString(food.EatMessage), target, filter);

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -58,7 +58,7 @@ namespace Content.Server.Projectiles
 
                 if (dmg is not null && EntityManager.EntityExists(component.Shooter))
                     _adminLogSystem.Add(LogType.BulletHit, LogImpact.Low,
-                        $"Projectile {ToPrettyString(component.Owner)} shot by {ToPrettyString(component.Shooter):shooter} hit {ToPrettyString(otherEntity)} and dealt {dmg.Total} damage");
+                        $"Projectile {ToPrettyString(component.Owner):projectile} shot by {ToPrettyString(component.Shooter):user} hit {ToPrettyString(otherEntity):target} and dealt {dmg.Total:damage} damage");
             }
 
             // Damaging it can delete it

--- a/Content.Server/Repairable/RepairableSystem.cs
+++ b/Content.Server/Repairable/RepairableSystem.cs
@@ -36,7 +36,7 @@ namespace Content.Server.Repairable
 
             // Repair all damage
             _damageableSystem.SetAllDamage(damageable, 0);
-            _logSystem.Add(LogType.Healed, $"{args.User} repaired ${uid} back to full health");
+            _logSystem.Add(LogType.Healed, $"{ToPrettyString(args.User):user} repaired ${ToPrettyString(uid):entity} back to full health");
 
             component.Owner.PopupMessage(args.User,
                 Loc.GetString("comp-repairable-repair",

--- a/Content.Server/Repairable/RepairableSystem.cs
+++ b/Content.Server/Repairable/RepairableSystem.cs
@@ -36,7 +36,7 @@ namespace Content.Server.Repairable
 
             // Repair all damage
             _damageableSystem.SetAllDamage(damageable, 0);
-            _logSystem.Add(LogType.Healed, $"{ToPrettyString(args.User):user} repaired ${ToPrettyString(uid):entity} back to full health");
+            _logSystem.Add(LogType.Healed, $"{ToPrettyString(args.User):User} repaired ${ToPrettyString(uid):Entity} back to full health");
 
             component.Owner.PopupMessage(args.User,
                 Loc.GetString("comp-repairable-repair",

--- a/Content.Server/Repairable/RepairableSystem.cs
+++ b/Content.Server/Repairable/RepairableSystem.cs
@@ -36,7 +36,7 @@ namespace Content.Server.Repairable
 
             // Repair all damage
             _damageableSystem.SetAllDamage(damageable, 0);
-            _logSystem.Add(LogType.Healed, $"{ToPrettyString(args.User):User} repaired ${ToPrettyString(uid):Entity} back to full health");
+            _logSystem.Add(LogType.Healed, $"{ToPrettyString(args.User):user} repaired ${ToPrettyString(uid):target} back to full health");
 
             component.Owner.PopupMessage(args.User,
                 Loc.GetString("comp-repairable-repair",

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -95,7 +95,7 @@ namespace Content.Server.RoundEnd
 
             if (requester != null)
             {
-                _adminLog.Add(LogType.ShuttleCalled, LogImpact.High, $"Shuttle called by {ToPrettyString(requester.Value)}");
+                _adminLog.Add(LogType.ShuttleCalled, LogImpact.High, $"Shuttle called by {ToPrettyString(requester.Value):user}");
             }
             else
             {
@@ -128,7 +128,7 @@ namespace Content.Server.RoundEnd
 
             if (requester != null)
             {
-                _adminLog.Add(LogType.ShuttleRecalled, LogImpact.High, $"Shuttle recalled by {ToPrettyString(requester.Value)}");
+                _adminLog.Add(LogType.ShuttleRecalled, LogImpact.High, $"Shuttle recalled by {ToPrettyString(requester.Value):user}");
             }
             else
             {

--- a/Content.Server/Stunnable/StunSystem.cs
+++ b/Content.Server/Stunnable/StunSystem.cs
@@ -53,7 +53,7 @@ namespace Content.Server.Stunnable
                 }
             }
 
-            _adminLogSystem.Add(LogType.DisarmedKnockdown, LogImpact.Medium, $"{ToPrettyString(args.Source):performer} knocked down {ToPrettyString(args.Target):target}");
+            _adminLogSystem.Add(LogType.DisarmedKnockdown, LogImpact.Medium, $"{ToPrettyString(args.Source):user} knocked down {ToPrettyString(args.Target):target}");
 
             args.Handled = true;
         }

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -166,7 +166,7 @@ namespace Content.Server.Temperature.Systems
             {
                 if (!temperature.TakingDamage)
                 {
-                    _logSystem.Add(LogType.Temperature, $"{temperature.Owner} started taking high temperature damage");
+                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner)} started taking high temperature damage");
                     temperature.TakingDamage = true;
                 }
 
@@ -178,7 +178,7 @@ namespace Content.Server.Temperature.Systems
             {
                 if (!temperature.TakingDamage)
                 {
-                    _logSystem.Add(LogType.Temperature, $"{temperature.Owner} started taking low temperature damage");
+                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner)} started taking low temperature damage");
                     temperature.TakingDamage = true;
                 }
 
@@ -189,7 +189,7 @@ namespace Content.Server.Temperature.Systems
             }
             else if (temperature.TakingDamage)
             {
-                _logSystem.Add(LogType.Temperature, $"{temperature.Owner} stopped taking temperature damage");
+                _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner)} stopped taking temperature damage");
                 temperature.TakingDamage = false;
             }
         }

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -166,7 +166,7 @@ namespace Content.Server.Temperature.Systems
             {
                 if (!temperature.TakingDamage)
                 {
-                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):Entity} started taking high temperature damage");
+                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):entity} started taking high temperature damage");
                     temperature.TakingDamage = true;
                 }
 
@@ -178,7 +178,7 @@ namespace Content.Server.Temperature.Systems
             {
                 if (!temperature.TakingDamage)
                 {
-                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):Entity} started taking low temperature damage");
+                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):entity} started taking low temperature damage");
                     temperature.TakingDamage = true;
                 }
 
@@ -189,7 +189,7 @@ namespace Content.Server.Temperature.Systems
             }
             else if (temperature.TakingDamage)
             {
-                _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):Entity} stopped taking temperature damage");
+                _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):entity} stopped taking temperature damage");
                 temperature.TakingDamage = false;
             }
         }

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -166,7 +166,7 @@ namespace Content.Server.Temperature.Systems
             {
                 if (!temperature.TakingDamage)
                 {
-                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner)} started taking high temperature damage");
+                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):Entity} started taking high temperature damage");
                     temperature.TakingDamage = true;
                 }
 
@@ -178,7 +178,7 @@ namespace Content.Server.Temperature.Systems
             {
                 if (!temperature.TakingDamage)
                 {
-                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner)} started taking low temperature damage");
+                    _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):Entity} started taking low temperature damage");
                     temperature.TakingDamage = true;
                 }
 
@@ -189,7 +189,7 @@ namespace Content.Server.Temperature.Systems
             }
             else if (temperature.TakingDamage)
             {
-                _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner)} stopped taking temperature damage");
+                _logSystem.Add(LogType.Temperature, $"{ToPrettyString(temperature.Owner):Entity} stopped taking temperature damage");
                 temperature.TakingDamage = false;
             }
         }

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -101,10 +101,10 @@ namespace Content.Server.Weapon.Melee
                     {
                         if (args.Used == args.User)
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(args.Target):target} using their hands and dealt {damageResult.Total} damage");
+                                $"{ToPrettyString(args.User):User} melee attacked {ToPrettyString(args.Target):Target} using their hands and dealt {damageResult.Total:Damage} damage");
                         else
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(args.Target):target} using {ToPrettyString(args.Used):used} and dealt {damageResult.Total} damage");
+                                $"{ToPrettyString(args.User):User} melee attacked {ToPrettyString(args.Target):Target} using {ToPrettyString(args.Used):Used} and dealt {damageResult.Total:Damage} damage");
                     }
 
                     SoundSystem.Play(Filter.Pvs(owner), comp.HitSound.GetSound(), target);
@@ -179,10 +179,10 @@ namespace Content.Server.Weapon.Melee
                     {
                         if (args.Used == args.User)
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(entity):target} using their hands and dealt {damageResult.Total} damage");
+                                $"{ToPrettyString(args.User):User} melee attacked {ToPrettyString(entity):Target} using their hands and dealt {damageResult.Total:Damage} damage");
                         else
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(entity):target} using {ToPrettyString(args.Used):used} and dealt {damageResult.Total} damage");
+                                $"{ToPrettyString(args.User):User} melee attacked {ToPrettyString(entity):Target} using {ToPrettyString(args.Used):used} and dealt {damageResult.Total:Damage} damage");
                     }
                 }
             }

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -101,10 +101,10 @@ namespace Content.Server.Weapon.Melee
                     {
                         if (args.Used == args.User)
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{ToPrettyString(args.User):User} melee attacked {ToPrettyString(args.Target):Target} using their hands and dealt {damageResult.Total:Damage} damage");
+                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(args.Target):target} using their hands and dealt {damageResult.Total:damage} damage");
                         else
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{ToPrettyString(args.User):User} melee attacked {ToPrettyString(args.Target):Target} using {ToPrettyString(args.Used):Used} and dealt {damageResult.Total:Damage} damage");
+                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(args.Target):target} using {ToPrettyString(args.Used):used} and dealt {damageResult.Total:damage} damage");
                     }
 
                     SoundSystem.Play(Filter.Pvs(owner), comp.HitSound.GetSound(), target);
@@ -179,10 +179,10 @@ namespace Content.Server.Weapon.Melee
                     {
                         if (args.Used == args.User)
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{ToPrettyString(args.User):User} melee attacked {ToPrettyString(entity):Target} using their hands and dealt {damageResult.Total:Damage} damage");
+                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(entity):target} using their hands and dealt {damageResult.Total:damage} damage");
                         else
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{ToPrettyString(args.User):User} melee attacked {ToPrettyString(entity):Target} using {ToPrettyString(args.Used):used} and dealt {damageResult.Total:Damage} damage");
+                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(entity):target} using {ToPrettyString(args.Used):used} and dealt {damageResult.Total:damage} damage");
                     }
                 }
             }

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -101,10 +101,10 @@ namespace Content.Server.Weapon.Melee
                     {
                         if (args.Used == args.User)
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{args.User} melee attacked {args.TargetEntity} using their hands and dealt {damageResult.Total} damage");
+                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(args.Target):target} using their hands and dealt {damageResult.Total} damage");
                         else
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{args.User} melee attacked {args.TargetEntity} using {args.Used} and dealt {damageResult.Total} damage");
+                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(args.Target):target} using {ToPrettyString(args.Used):used} and dealt {damageResult.Total} damage");
                     }
 
                     SoundSystem.Play(Filter.Pvs(owner), comp.HitSound.GetSound(), target);
@@ -179,10 +179,10 @@ namespace Content.Server.Weapon.Melee
                     {
                         if (args.Used == args.User)
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{args.User} melee attacked {entity} using their hands and dealt {damageResult.Total} damage");
+                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(entity):target} using their hands and dealt {damageResult.Total} damage");
                         else
                             _logSystem.Add(LogType.MeleeHit,
-                                $"{args.User} melee attacked {entity} using {args.Used} and dealt {damageResult.Total} damage");
+                                $"{ToPrettyString(args.User):user} melee attacked {ToPrettyString(entity):target} using {ToPrettyString(args.Used):used} and dealt {damageResult.Total} damage");
                     }
                 }
             }

--- a/Content.Server/Weapon/Ranged/Barrels/Components/ServerRangedBarrelComponent.cs
+++ b/Content.Server/Weapon/Ranged/Barrels/Components/ServerRangedBarrelComponent.cs
@@ -399,7 +399,7 @@ namespace Content.Server.Weapon.Ranged.Barrels.Components
                 var dmg = EntitySystem.Get<DamageableSystem>().TryChangeDamage(result.HitEntity, hitscan.Damage);
                 if (dmg != null)
                     EntitySystem.Get<AdminLogSystem>().Add(LogType.HitScanHit,
-                        $"{shooter} hit {result.HitEntity} using {hitscan.Owner} and dealt {dmg.Total} damage");
+                        $"{_entities.ToPrettyString(shooter):user} hit {_entities.ToPrettyString(result.HitEntity):target} using {_entities.ToPrettyString(hitscan.Owner):used} and dealt {dmg.Total} damage");
             }
             else
             {

--- a/Content.Server/Weapon/Ranged/Barrels/Components/ServerRangedBarrelComponent.cs
+++ b/Content.Server/Weapon/Ranged/Barrels/Components/ServerRangedBarrelComponent.cs
@@ -399,7 +399,7 @@ namespace Content.Server.Weapon.Ranged.Barrels.Components
                 var dmg = EntitySystem.Get<DamageableSystem>().TryChangeDamage(result.HitEntity, hitscan.Damage);
                 if (dmg != null)
                     EntitySystem.Get<AdminLogSystem>().Add(LogType.HitScanHit,
-                        $"{_entities.ToPrettyString(shooter):user} hit {_entities.ToPrettyString(result.HitEntity):target} using {_entities.ToPrettyString(hitscan.Owner):used} and dealt {dmg.Total} damage");
+                        $"{_entities.ToPrettyString(shooter):User} hit {_entities.ToPrettyString(result.HitEntity):Target} using {_entities.ToPrettyString(hitscan.Owner):Used} and dealt {dmg.Total:Damage} damage");
             }
             else
             {

--- a/Content.Server/Weapon/Ranged/Barrels/Components/ServerRangedBarrelComponent.cs
+++ b/Content.Server/Weapon/Ranged/Barrels/Components/ServerRangedBarrelComponent.cs
@@ -399,7 +399,7 @@ namespace Content.Server.Weapon.Ranged.Barrels.Components
                 var dmg = EntitySystem.Get<DamageableSystem>().TryChangeDamage(result.HitEntity, hitscan.Damage);
                 if (dmg != null)
                     EntitySystem.Get<AdminLogSystem>().Add(LogType.HitScanHit,
-                        $"{_entities.ToPrettyString(shooter):User} hit {_entities.ToPrettyString(result.HitEntity):Target} using {_entities.ToPrettyString(hitscan.Owner):Used} and dealt {dmg.Total:Damage} damage");
+                        $"{_entities.ToPrettyString(shooter):user} hit {_entities.ToPrettyString(result.HitEntity):target} using {_entities.ToPrettyString(hitscan.Owner):used} and dealt {dmg.Total:damage} damage");
             }
             else
             {

--- a/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
@@ -190,7 +190,7 @@ namespace Content.Shared.Chemistry.Reaction
                 {
                     var entity = args.SolutionEntity;
                     _logSystem.Add(LogType.ReagentEffect, effect.LogImpact,
-                        $"Reaction effect {effect.GetType().Name} of reaction ${reaction.ID:reaction} applied on entity {ToPrettyString(entity)} at {Transform(entity).Coordinates}");
+                        $"Reaction effect {effect.GetType().Name:effect} of reaction ${reaction.ID:reaction} applied on entity {ToPrettyString(entity):entity} at {Transform(entity).Coordinates:coordinates}");
                 }
 
                 effect.Effect(args);

--- a/Content.Shared/Chemistry/ReactiveSystem.cs
+++ b/Content.Shared/Chemistry/ReactiveSystem.cs
@@ -66,7 +66,7 @@ namespace Content.Shared.Chemistry
                         {
                             var entity = args.SolutionEntity;
                             _logSystem.Add(LogType.ReagentEffect, effect.LogImpact,
-                                $"Reactive effect {effect.GetType().Name} of reagent {reagent.ID:reagent} with method {method} applied on entity {ToPrettyString(entity)} at {Transform(entity).Coordinates}");
+                                $"Reactive effect {effect.GetType().Name:effect} of reagent {reagent.ID:reagent} with method {method} applied on entity {ToPrettyString(entity):entity} at {Transform(entity).Coordinates:coordinates}");
                         }
 
                         effect.Effect(args);
@@ -94,7 +94,7 @@ namespace Content.Shared.Chemistry
                         {
                             var entity = args.SolutionEntity;
                             _logSystem.Add(LogType.ReagentEffect, effect.LogImpact,
-                                $"Reactive effect {effect.GetType().Name} of {ToPrettyString(entity)} using reagent {reagent.ID} with method {method} at {Transform(entity).Coordinates}");
+                                $"Reactive effect {effect.GetType().Name:effect} of {ToPrettyString(entity):entity} using reagent {reagent.ID:reagent} with method {method} at {Transform(entity).Coordinates:coordinates}");
                         }
 
                         effect.Effect(args);

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Body.Prototypes;
@@ -123,7 +123,7 @@ namespace Content.Shared.Chemistry.Reagent
                 {
                     var entity = args.SolutionEntity;
                     EntitySystem.Get<SharedAdminLogSystem>().Add(LogType.ReagentEffect, plantMetabolizable.LogImpact,
-                        $"Plant metabolism effect {plantMetabolizable.GetType().Name:effect} of reagent {ID} applied on entity {entMan.ToPrettyString(entity)} at {entMan.GetComponent<TransformComponent>(entity).Coordinates}");
+                        $"Plant metabolism effect {plantMetabolizable.GetType().Name:effect} of reagent {ID:reagent} applied on entity {entMan.ToPrettyString(entity):entity} at {entMan.GetComponent<TransformComponent>(entity).Coordinates:coordinates}");
                     plantMetabolizable.Effect(args);
                 }
             }

--- a/Content.Shared/Hands/Components/SharedHandsComponent.cs
+++ b/Content.Shared/Hands/Components/SharedHandsComponent.cs
@@ -673,7 +673,7 @@ namespace Content.Shared.Hands.Components
 
             HandlePickupAnimation(entity);
             PutEntityIntoHand(hand, entity);
-            EntitySystem.Get<SharedAdminLogSystem>().Add(LogType.Pickup, LogImpact.Low, $"{_entMan.ToPrettyString(Owner)} picked up {_entMan.ToPrettyString(entity)}");
+            EntitySystem.Get<SharedAdminLogSystem>().Add(LogType.Pickup, LogImpact.Low, $"{_entMan.ToPrettyString(Owner):user} picked up {_entMan.ToPrettyString(entity):entity}");
             return true;
         }
 

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -468,7 +468,7 @@ namespace Content.Shared.Interaction
             RaiseLocalEvent(used, activateMsg);
             if (activateMsg.Handled)
             {
-                _adminLogSystem.Add(LogType.InteractActivate, LogImpact.Low, $"{ToPrettyString(user)} activated {ToPrettyString(used)}");
+                _adminLogSystem.Add(LogType.InteractActivate, LogImpact.Low, $"{ToPrettyString(user):user} activated {ToPrettyString(used):used}");
                 return;
             }
 
@@ -477,7 +477,7 @@ namespace Content.Shared.Interaction
 
             var activateEventArgs = new ActivateEventArgs(user, used);
             activateComp.Activate(activateEventArgs);
-            _adminLogSystem.Add(LogType.InteractActivate, LogImpact.Low, $"{ToPrettyString(user)} activated {ToPrettyString(used)}"); // No way to check success.
+            _adminLogSystem.Add(LogType.InteractActivate, LogImpact.Low, $"{ToPrettyString(user):user} activated {ToPrettyString(used):used}"); // No way to check success.
         }
         #endregion
 
@@ -556,7 +556,7 @@ namespace Content.Shared.Interaction
             RaiseLocalEvent(thrown, throwMsg);
             if (throwMsg.Handled)
             {
-                _adminLogSystem.Add(LogType.Throw, LogImpact.Low,$"{ToPrettyString(user)} threw {ToPrettyString(thrown)}");
+                _adminLogSystem.Add(LogType.Throw, LogImpact.Low,$"{ToPrettyString(user):user} threw {ToPrettyString(thrown):entity}");
                 return;
             }
 
@@ -568,7 +568,7 @@ namespace Content.Shared.Interaction
             {
                 comp.Thrown(args);
             }
-            _adminLogSystem.Add(LogType.Throw, LogImpact.Low,$"{ToPrettyString(user)} threw {ToPrettyString(thrown)}");
+            _adminLogSystem.Add(LogType.Throw, LogImpact.Low,$"{ToPrettyString(user):user} threw {ToPrettyString(thrown):entity}");
         }
         #endregion
 
@@ -677,7 +677,7 @@ namespace Content.Shared.Interaction
             RaiseLocalEvent(item, dropMsg);
             if (dropMsg.Handled)
             {
-                _adminLogSystem.Add(LogType.Drop, LogImpact.Low, $"{ToPrettyString(user)} dropped {ToPrettyString(item)}");
+                _adminLogSystem.Add(LogType.Drop, LogImpact.Low, $"{ToPrettyString(user):user} dropped {ToPrettyString(item):entity}");
                 return;
             }
 
@@ -690,7 +690,7 @@ namespace Content.Shared.Interaction
             {
                 comp.Dropped(new DroppedEventArgs(user));
             }
-            _adminLogSystem.Add(LogType.Drop, LogImpact.Low, $"{ToPrettyString(user)} dropped {ToPrettyString(item)}");
+            _adminLogSystem.Add(LogType.Drop, LogImpact.Low, $"{ToPrettyString(user):user} dropped {ToPrettyString(item):entity}");
         }
         #endregion
 

--- a/Content.Shared/Slippery/SharedSlipperySystem.cs
+++ b/Content.Shared/Slippery/SharedSlipperySystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.Administration.Logs;
@@ -106,7 +106,7 @@ namespace Content.Shared.Slippery
                 PlaySound(component);
             }
 
-            _adminLog.Add(LogType.Slip, LogImpact.Low, $"{ToPrettyString(otherBody.Owner)} slipped on collision with {ToPrettyString(component.Owner)}");
+            _adminLog.Add(LogType.Slip, LogImpact.Low, $"{ToPrettyString(otherBody.Owner):mob} slipped on collision with {ToPrettyString(component.Owner):entity}");
 
             return true;
         }

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -128,7 +128,7 @@ namespace Content.Shared.Throwing
 
             // Assume it's uninteresting if it has no thrower. For now anyway.
             if (thrownItem.Thrower is not null)
-                _adminLogSystem.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(landing)} thrown by {ToPrettyString(thrownItem.Thrower.Value):thrower} landed.");
+                _adminLogSystem.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(landing):entity} thrown by {ToPrettyString(thrownItem.Thrower.Value):thrower} landed.");
 
             var landMsg = new LandEvent {User = thrownItem.Thrower};
             RaiseLocalEvent(landing, landMsg, false);

--- a/Content.Shared/Verbs/SharedVerbSystem.cs
+++ b/Content.Shared/Verbs/SharedVerbSystem.cs
@@ -130,19 +130,22 @@ namespace Content.Shared.Verbs
             if (usedUid != default)
                 EntityManager.EntityExists(usedUid);
 
-            // then prepare the basic log message body
             var verbText = $"{verb.Category?.Text} {verb.Text}".Trim();
-            var logText = forced
-                ? $"was forced to execute the '{verbText}' verb targeting " // let's not frame people, eh?
-                : $"executed '{verbText}' verb targeting ";
 
-            // then log with entity information
-            if (used != null)
+            // lets not frame people, eh?
+            var executionText = forced ? "was forced to execute" : "executed";
+
+            if (used == null)
+            {
                 _logSystem.Add(LogType.Verb, verb.Impact,
-                       $"{ToPrettyString(user)} {logText} {ToPrettyString(target)} while holding {ToPrettyString(used.Value)}");
+                        $"{ToPrettyString(user):user} {executionText} the [{verbText:verb}] verb targeting {ToPrettyString(target):target}");
+            }
             else
+            {
                 _logSystem.Add(LogType.Verb, verb.Impact,
-                       $"{ToPrettyString(user)} {logText} {ToPrettyString(target)}");
+                       $"{ToPrettyString(user):user} {executionText} the [{verbText:verb}] verb targeting {ToPrettyString(target):target} while holding {ToPrettyString(used.Value):held}");
+            }
+                
         }
     }
 }


### PR DESCRIPTION
This PR
- makes more (all?) admin logs use `EntityUid` pretty strings. 
- Adds format strings where needed.
- Adds the some solution-pretty-strings to force feeding/drinking/injecting logs, so they now actually describe what reagents were forced into someone.