### PR TITLE
Buffed crate resistance further and secure lockers

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -16,7 +16,8 @@
     Slash: 0.5
     Piercing: 0.7
     Shock: 1.2
-    
+
+# Like metallic but very strong to resist most all basic tools and weapons.
 - type: damageModifierSet
   id: StrongMetallic
   coefficients:
@@ -27,7 +28,7 @@
   flatReductions:
     Blunt: 16
     Slash: 16
-    Piercing: 10
+    Piercing: 16
 
 - type: damageModifierSet
   id: Inflatable

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -29,6 +29,8 @@
     Blunt: 16
     Slash: 16
     Piercing: 16
+    Shock: 10
+    Heat: 10
 
 - type: damageModifierSet
   id: Inflatable

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base.yml
@@ -23,7 +23,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 150
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -35,3 +35,12 @@
           SheetSteel1:
             min: 1
             max: 2
+
+- type: entity
+  id: LockerBaseSecure
+  parent: LockerBase
+  abstract: true
+  components:
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: StrongMetallic

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -32,7 +32,7 @@
 # Command
 - type: entity
   id: LockerCaptain
-  parent: LockerBase
+  parent: LockerBaseSecure
   name: captain's locker
   components:
   - type: Appearance
@@ -44,7 +44,7 @@
 
 - type: entity
   id: LockerHeadOfPersonnel
-  parent: LockerBase
+  parent: LockerBaseSecure
   name: head of personnel's locker
   components:
   - type: Appearance
@@ -57,7 +57,7 @@
 # CE
 - type: entity
   id: LockerChiefEngineer
-  parent: LockerBase
+  parent: LockerBaseSecure
   name: chief engineer's locker
   components:
   - type: Appearance
@@ -191,7 +191,7 @@
 # CMO
 - type: entity
   id: LockerChiefMedicalOfficer
-  parent: LockerBase
+  parent: LockerBaseSecure
   name: chief medical officer's locker
   components:
   - type: Appearance
@@ -202,7 +202,6 @@
     access: [ [ "Medical", "Command" ] ]
 
 # Science
-
 - type: entity
   id: LockerResearchDirector
   parent: LockerBase
@@ -230,7 +229,7 @@
 # HoS
 - type: entity
   id: LockerHeadOfSecurity
-  parent: LockerBase
+  parent: LockerBaseSecure
   name: head of security's locker
   components:
   - type: Appearance
@@ -243,7 +242,7 @@
 # Warden
 - type: entity
   id: LockerWarden
-  parent: LockerBase
+  parent: LockerBaseSecure
   name: warden's locker
   components:
   - type: Appearance
@@ -256,7 +255,7 @@
 # Security Officer
 - type: entity
   id: LockerSecurity
-  parent: LockerBase
+  parent: LockerBaseSecure
   name: security officer's locker
   components:
   - type: Appearance
@@ -277,11 +276,10 @@
     access: [["Service"]] # TODO access [["Detective"]]
 
 # Syndicate
-
 - type: entity
   id: LockerSyndicatePersonal
   name: armory closet
-  parent: LockerBase
+  parent: LockerBaseSecure
   description: It's a personal storage unit for operative gear.
   components:
   - type: Appearance


### PR DESCRIPTION
I name this masterpeice F*#k Cargonia.

Secure crates now can't be smashed with a pickaxe.
Applied same modifier to heads of staff and security secure lockers so traitors need to work a little harder to break into them now.

**Long story:**
Buffed the damageset modifier I used for the securecratebase further so that pickaxes and hatchets can no longer get in (silly me) so now some of the only things that can break a crate are swords and guns (but not the barkeeps shotgun). Weapon balance may need looked at in future but not now.

This is in response to cargo building an AME and cloner every single round effectively ruining the round for all other departments making them useless. This obviously won't cure stupidity when the captain rushes cargo but it's a slow down mechanism.

Also made a new lockerbase specific for secure lockers for heads and security so that people can't spam tools on them now to get an RCD or captains ID. Makes traitors have to think harder or go loud to get their objectives which currently isn't a bad thing. Reduced locker health to compensate.


:cl:
- tweak: Cargonia didn't learn. Crates are now buffed harder so no more cargo AME or laser crates.
- tweak: Buffed some secure lockers too.

