### PR TITLE
Added some missing engine command permissions.

### DIFF
--- a/Content.Client/Administration/Managers/ClientAdminManager.cs
+++ b/Content.Client/Administration/Managers/ClientAdminManager.cs
@@ -38,7 +38,7 @@ namespace Content.Client.Administration.Managers
 
         public bool CanViewVar()
         {
-            return _adminData?.CanViewVar() ?? false;
+            return CanCommand("vv");
         }
 
         public bool CanAdminPlace()

--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -443,7 +443,7 @@ namespace Content.Server.Administration.Managers
 
         public bool CanViewVar(IPlayerSession session)
         {
-            return GetAdminData(session)?.CanViewVar() ?? false;
+            return CanCommand(session, "vv");
         }
 
         public bool CanAdminPlace(IPlayerSession session)

--- a/Content.Shared/Administration/AdminData.cs
+++ b/Content.Shared/Administration/AdminData.cs
@@ -33,14 +33,6 @@ namespace Content.Shared.Administration
         }
 
         /// <summary>
-        ///     Check if this admin can open the VV menu.
-        /// </summary>
-        public bool CanViewVar()
-        {
-            return HasFlag(AdminFlags.VarEdit);
-        }
-
-        /// <summary>
         ///     Check if this admin can spawn stuff in with the entity/tile spawn panel.
         /// </summary>
         public bool CanAdminPlace()

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -4,12 +4,15 @@
   - help
   - list
   - quit
+  - cvar
+  - devwindow
 
 - Flags: VAREDIT
   Commands:
   - addcomp
   - rmcomp
   - vv
+  - scale
 
 - Flags: DEBUG
   Commands:
@@ -30,6 +33,10 @@
   - toggleshadows
   - testbed
   - vv
+  - szr_stats
+  - addview
+  - removeview
+
 
 - Flags: MAPPING
   Commands:
@@ -74,6 +81,8 @@
   - saveconfig
   - testlog
   - sudo
+  - scsi
+  - lsasm
 
 - Flags: QUERY
   Commands:

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -17,6 +17,14 @@
   - setclipboard
   - getclipboard
   - gcf
+  - net_graph
+  - net_watchent
+  - net_draw_interp
+  - devwindow
+  - fill
+  - dumpentities
+  - getcomponentregistration
+  - fuck
 
 - Flags: VAREDIT
   Commands:
@@ -55,10 +63,6 @@
   - addview
   - removeview
   - hwid
-  - fill
-  - dumpentities
-  - getcomponentregistration
-  - fuck
   - showpos
   - showray
   - showchunkbb
@@ -82,10 +86,6 @@
   - showvelocities
   - tilelookup
   - net_entityreport
-  - net_graph
-  - net_watchent
-  - net_draw_interp
-  - devwindow
   - scene
 
 

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -4,13 +4,19 @@
   - help
   - list
   - quit
+  - hardquit
   - cvar
-  - devwindow
+  - svbind
+  - bind
+  - exec # macro moment
+  - clear
 
 - Flags: VAREDIT
   Commands:
   - addcomp
+  - addcompc
   - rmcomp
+  - rmcompc
   - vv
   - scale
 
@@ -26,16 +32,60 @@
   - netaudit
   - querymappaused
   - physics
+  - showislands
   - showtime
+  - showspritebb
+  - cldbglyr
   - togglefov
   - togglehardfov
   - togglelight
+  - togglelightbuf
   - toggleshadows
   - testbed
+  - lightbb
   - vv
   - szr_stats
   - addview
   - removeview
+  - hwid
+  - fill
+  - dumpentities
+  - getcomponentregistration
+  - monitor
+  - fuck
+  - showpos
+  - showray
+  - showchunkbb
+  - entfo
+  - sggcell
+  - ldrsc
+  - rldrsc
+  - rldshader
+  - rldloc
+  - guidump
+  - uitest
+  - setclipboard
+  - getclipboard
+  - chunkinfo
+  - keyinfo
+  - showanchored
+  - dmetamem
+  - launchauth
+  - lsmonitor
+  - monitorinfo
+  - setmonitor
+  - watch
+  - sendgarbage
+  - setinputcontext
+  - showvelocities
+  - tilelookup
+  - net_entityreport
+  - net_graph
+  - net_watchent
+  - net_draw_interp
+  - vram
+  - devwindow
+  - scene
 
 
 - Flags: MAPPING
@@ -51,6 +101,7 @@
   - savebp
   - savemap
   - tpgrid
+  - gridtc
 
 - Flags: ADMIN
   Commands:
@@ -72,16 +123,19 @@
 - Flags: SPAWN
   Commands:
   - spawn
+  - cspawn
 
 - Flags: HOST
   Commands:
   - gc_mode
   - gc
+  - gcf
   - loglevel
   - saveconfig
   - testlog
   - sudo
   - scsi
+  - csi
   - lsasm
 
 - Flags: QUERY

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -10,6 +10,13 @@
   - bind
   - exec # macro moment
   - clear
+  - vram
+  - monitor
+  - setmonitor
+  - keyinfo
+  - setclipboard
+  - getclipboard
+  - gcf
 
 - Flags: VAREDIT
   Commands:
@@ -51,7 +58,6 @@
   - fill
   - dumpentities
   - getcomponentregistration
-  - monitor
   - fuck
   - showpos
   - showray
@@ -64,16 +70,12 @@
   - rldloc
   - guidump
   - uitest
-  - setclipboard
-  - getclipboard
   - chunkinfo
-  - keyinfo
   - showanchored
   - dmetamem
   - launchauth
   - lsmonitor
   - monitorinfo
-  - setmonitor
   - watch
   - sendgarbage
   - setinputcontext
@@ -83,7 +85,6 @@
   - net_graph
   - net_watchent
   - net_draw_interp
-  - vram
   - devwindow
   - scene
 
@@ -129,7 +130,6 @@
   Commands:
   - gc_mode
   - gc
-  - gcf
   - loglevel
   - saveconfig
   - testlog


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Also CanViewVar is determined by whether you can execute the "vv" command or not.
Something to note is that content client-side commands cannot have permissions right now... This should probably be addressed somehow, but out of scope for now-- (see #5783)