### PR TITLE
Adds T-ray spawn chance to lockers, toolboxes and to youtool vendor

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -34,8 +34,8 @@
       - id: Wirecutter
       - id: CableApcStack
       - id: CableMVStack
-	  - id: trayScanner
-	    prob: 0.9
+      - id: trayScanner
+        prob: 0.9
       - id: ClothingHandsGlovesColorYellow
         prob: 0.05
         orGroup: GlovesOrWires

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -34,6 +34,8 @@
       - id: Wirecutter
       - id: CableApcStack
       - id: CableMVStack
+	  - id: trayScanner
+	    prob: 0.9
       - id: ClothingHandsGlovesColorYellow
         prob: 0.05
         orGroup: GlovesOrWires

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -21,6 +21,8 @@
         prob: 0.7
       - id: Multitool
         prob: 0.2
+      - id: trayScanner
+        prob: 0.7      
       - id: ClothingBeltUtility
         prob: 0.2
       - id: ClothingHandsGlovesColorYellow

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: YouToolInventory
   name: YouTool
   animationDuration: 1.1
@@ -10,4 +10,5 @@
     Wirecutter: 5
     Wrench: 5
     Screwdriver: 5
+    trayScanner: 5
     ClothingHandsGlovesColorYellowBudget: 5


### PR DESCRIPTION
Title is explanatory. Did not add to utility belt spawn on purpose since it will be in lockers, vendors and toolboxes and not every engineer will use it.

:cl:
- add: T-Ray Scanner can now be obtained from Youtool! As well as some engineering toolboxes and lockers.

