### PR TITLE
Fix disposal pipe visibility in entity menu

### DIFF
--- a/Content.Client/SubFloor/SubFloorShowLayerVisualizer.cs
+++ b/Content.Client/SubFloor/SubFloorShowLayerVisualizer.cs
@@ -17,22 +17,23 @@ namespace Content.Client.SubFloor
             if (!entities.TryGetComponent(component.Owner, out SpriteComponent? sprite))
                 return;
 
-            if (component.TryGetData(SubFloorVisuals.SubFloor, out bool subfloor))
+            if (!component.TryGetData(SubFloorVisuals.SubFloor, out bool subfloor))
+                return;
+
+            foreach (var layer in sprite.AllLayers)
             {
-                sprite.Visible = true;
-
-                // Due to the way this visualizer works, you might want to specify it before any other
-                // visualizer that hides/shows layers depending on certain conditions, such as PipeConnectorVisualizer.
-                foreach (var layer in sprite.AllLayers)
-                {
-                    layer.Visible = subfloor;
-                }
-
-                if (sprite.LayerMapTryGet(Layers.FirstLayer, out var firstLayer))
-                {
-                    sprite.LayerSetVisible(firstLayer, true);
-                }
+                layer.Visible = subfloor;
             }
+
+            if (!sprite.LayerMapTryGet(Layers.FirstLayer, out var firstLayer))
+            {
+                sprite.Visible = subfloor;
+                return;
+            }
+
+            // show the top part of the sprite. E.g. the grille-part of a vent, but not the connecting pipes.
+            sprite.LayerSetVisible(firstLayer, true);
+            sprite.Visible = true;
         }
 
         public enum Layers : byte


### PR DESCRIPTION
Currently you can see disposal pipes in the entity menu, despite them being invisible. 

The actual issue is that the `SubFloorShowLayerVisualizer` can mark a sprite as visible, despite each individual layer being invisible. This just changes it so that if no layers are visible, the sprite is not marked as visible.

Alternatively, I could have made the entity menu check if at least one layer of every visible sprite is actually visible, but I feel like if that isn't the case a sprite shouldn't be marked as visible in the first place.