### PR TITLE
Added AME shielding deconstruction

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -150,3 +150,6 @@
   - type: Appearance
     visuals:
     - type: AMEVisualizer
+  - type: Construction
+    graph: ame_shielding
+    node: ame_shielding 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -151,5 +151,5 @@
     visuals:
     - type: AMEVisualizer
   - type: Construction
-    graph: ame_shielding
-    node: ame_shielding 
+    graph: ameShielding
+    node: ameShielding

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
@@ -3,11 +3,6 @@
   start: start
   graph:
     - node: start
-      edges:
-        - to: ameShielding
-          steps:
-            - prototype: AMEPart
-              doAfter: 2
 
     - node: ameShielding
       entity: AMEShielding

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
@@ -7,7 +7,6 @@
         - to: ame_shielding
           steps:
             - prototype: AMEPart
-              amount: 1
               doAfter: 2
 
     - node: ame_shielding

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
@@ -6,7 +6,7 @@
       edges:
         - to: ame_shielding
           steps:
-            - material: AMEPart
+            - prototype: AMEPart
               amount: 1
               doAfter: 2
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
@@ -1,0 +1,24 @@
+- type: constructionGraph
+  id: ame_shielding
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: ame_shielding
+          steps:
+            - material: AMEPart
+              amount: 1
+              doAfter: 2
+
+    - node: ame_shielding
+      entity: AMEShielding
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: AMEPart
+              amount: 1
+            - !type:DeleteEntity
+          steps:
+            - tool: Welding
+              doAfter: 3

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
@@ -1,15 +1,15 @@
 - type: constructionGraph
-  id: ame_shielding
+  id: ameShielding
   start: start
   graph:
     - node: start
       edges:
-        - to: ame_shielding
+        - to: ameShielding
           steps:
             - prototype: AMEPart
               doAfter: 2
 
-    - node: ame_shielding
+    - node: ameShielding
       entity: AMEShielding
       edges:
         - to: start

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -46,21 +46,6 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
 
-- type: construction
-  name: AME shielding
-  id: AMEShielding
-  graph: ameShielding
-  startNode: start
-  targetNode: ameShielding
-  category: Utilities
-  description: "Shielding for the antimatter engine"
-  icon:
-    sprite: Structures/Power/Generation/ame.rsi
-    state: shield_0
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-
 
 #DISPOSALS
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -46,6 +46,21 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
 
+- type: construction
+  name: AME shielding
+  id: AMEShielding
+  graph: ame_shielding
+  startNode: start
+  targetNode: ame_shielding
+  category: Utilities
+  description: "Shielding for the antimatter engine"
+  icon:
+    sprite: Structures/Power/Generation/ame.rsi
+    state: shield_0
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+
 
 #DISPOSALS
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -49,9 +49,9 @@
 - type: construction
   name: AME shielding
   id: AMEShielding
-  graph: ame_shielding
+  graph: ameShielding
   startNode: start
-  targetNode: ame_shielding
+  targetNode: ameShielding
   category: Utilities
   description: "Shielding for the antimatter engine"
   icon:


### PR DESCRIPTION
As title suggests. Players have been having issues placing AME in the wrong spot and can't break it down so made it so they can weld it back down to a part.

:cl:
- tweak: Antimatter Engine Shielding can now be deconstructed with a welder.

