### PR TITLE
Gives the singularity some weight

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -18,6 +18,7 @@
         !type:PhysShapeCircle
           radius: 0.5
       restitution: 0.9
+      mass: 99999
       mask:
       - AllMask
       layer:


### PR DESCRIPTION
Turns out that with a mass of 0 it can be sent flying into the abyss from merely contacting a loose tile.
:cl:
- tweak: The singularity is no longer weightless.

