### PR TITLE
Door naming error + more windoor accesses

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -119,6 +119,14 @@
   components:
   - type: AccessReader
     access: [["Research"]]
+    
+- type: entity
+  parent: AirlockScience
+  id: AirlockMedicalScienceLocked
+  suffix: Medical/Science, Locked
+  components:
+  - type: AccessReader
+    access: [["Research"], ["Medical"]]
 
 - type: entity
   parent: AirlockCommand
@@ -252,7 +260,7 @@
 - type: entity
   parent: AirlockEngineeringGlass
   id: AirlockEngineeringGlassLocked
-  suffix: Glass, Locked
+  suffix: Engineering, Locked
   components:
   - type: AccessReader
     access: [["Engineering"]]
@@ -421,7 +429,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintRnDLocked
-  suffix: RnD, Locked
+  suffix: Science, Locked
   components:
   - type: AccessReader
     access: [["Research"]]
@@ -429,7 +437,7 @@
 - type: entity
   parent: AirlockMaint
   id: AirlockMaintRnDMedLocked
-  suffix: Med/RnD, Locked
+  suffix: Medical/Science, Locked
   components:
   - type: AccessReader
     access: [["Research"], ["Medical"]]

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -73,3 +73,27 @@
   components:
   - type: AccessReader
     access: [["Security"]]
+    
+- type: entity
+  parent: WindoorSecure
+  id: WindoorEngineeringLocked
+  suffix: Engineering, Locked
+  components:
+  - type: AccessReader
+    access: [["Engineering"]]
+    
+- type: entity
+  parent: WindoorSecure
+  id: WindoorChapelLocked
+  suffix: Chapel, Locked
+  components:
+  - type: AccessReader
+    access: [["Chapel"]]
+    
+- type: entity
+  parent: WindoorSecure
+  id: WindoorJanitorLocked
+  suffix: Janitor, Locked
+  components:
+  - type: AccessReader
+    access: [["Janitor"]]


### PR DESCRIPTION
Naming error with engineering glass airlock fixed.

Naming consistency fixed with sci/med maintenance hatches which were Med/RND whereas all other doors are science not RND.

Added windoors for chapel, engineer and janitory. 

- Engineer is for things like glass closets and storages you can see in e.g. board storage racks as well as for securing substations without taking up a whole tile.
- Chapel is for things like spectators being able to see a cremator or glass storage for things like coffins when added.
- Janitor is similar to engineer, having cleaning closets and storages that are visible but not obstructive.

Did not think it necessary to add a chef windoor since the kitchen is naturally open air and should serve directly onto a non secured table. Can add though if people think it necessary.