### PR TITLE
Fix cold damage crash on simplespacemobbase

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -66,6 +66,9 @@
     heatDamageThreshold: 360
     coldDamageThreshold: 260
     currentTemperature: 310.15
+    coldDamage:
+      types:
+        Cold : 1 #per second, scales with temperature & other constants
     specificHeat: 42
     heatDamage:
       types:


### PR DESCRIPTION
## About the PR
Fixes a crash that happens when a space carp is spawned, because cold damage was not set
