### PR TITLE
Small changes for crit mobs to be able to gasp and dead mobs to show dead on examine

### DIFF
--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -47,7 +47,7 @@ public class LungSystem : EntitySystem
             _popupSystem.PopupEntity(Loc.GetString("lung-behavior-gasp"), uid, Filter.Pvs(uid));
         }
 
-        if (!EntityManager.GetComponent<MobStateComponent>(uid).IsCritical())
+        if (EntityManager.TryGetComponent((uid), out MobStateComponent? mobState) && !mobState.IsCritical())
         {
             Inhale(uid, lung.CycleDelay);
         }

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -38,7 +38,7 @@ public class LungSystem : EntitySystem
         LungComponent? lung=null,
         SharedMechanismComponent? mech=null)
     {
-        if (!Resolve(uid, ref lung))
+        if (!Resolve(uid, ref lung, ref mech))
             return;
 
         if (_gameTiming.CurTime >= lung.LastGaspPopupTime + lung.GaspPopupCooldown)
@@ -47,10 +47,10 @@ public class LungSystem : EntitySystem
             _popupSystem.PopupEntity(Loc.GetString("lung-behavior-gasp"), uid, Filter.Pvs(uid));
         }
 
-        if (EntityManager.TryGetComponent((uid), out MobStateComponent? mobState) && !mobState.IsCritical())
-        {
-            Inhale(uid, lung.CycleDelay);
-        }
+        if (mech.Body != null && TryComp((mech.Body).Owner, out MobStateComponent? mobState) && !mobState.IsAlive())
+            return;
+
+        Inhale(uid, lung.CycleDelay);
     }
 
     public void UpdateLung(EntityUid uid,

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -47,7 +47,10 @@ public class LungSystem : EntitySystem
             _popupSystem.PopupEntity(Loc.GetString("lung-behavior-gasp"), uid, Filter.Pvs(uid));
         }
 
-        Inhale(uid, lung.CycleDelay);
+        if (!EntityManager.GetComponent<MobStateComponent>(uid).IsCritical())
+        {
+            Inhale(uid, lung.CycleDelay);
+        }
     }
 
     public void UpdateLung(EntityUid uid,

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -153,13 +153,10 @@ namespace Content.Server.Body.Systems
 
                 if (bloodstreamAmount < amountNeeded)
                 {
-                    if (!EntityManager.GetComponent<MobStateComponent>(uid).IsCritical())
+                    // Panic inhale
+                    foreach (var (lung, mech) in lungs)
                     {
-                        // Panic inhale
-                        foreach (var (lung, mech) in lungs)
-                        {
-                            _lungSystem.Gasp((lung).Owner, lung, mech);
-                        }
+                        _lungSystem.Gasp((lung).Owner, lung, mech);
                     }
 
                     bloodstreamAmount = bloodstream.Air.GetMoles(gas);

--- a/Content.Server/Mind/Components/MindComponent.cs
+++ b/Content.Server/Mind/Components/MindComponent.cs
@@ -137,18 +137,22 @@ namespace Content.Server.Mind.Components
                 _entMan.TryGetComponent<MobStateComponent?>(Owner, out var state) &&
                 state.IsDead();
 
-            if (!HasMind)
+            if (dead)
+            {
+                var noSessionText = $"[color=yellow]{Loc.GetString("mind-component-no-mind-and-dead-text", ("ent", Owner))}[/color]";
+                var hasSessionText = $"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", Owner))}[/color]";
+
+                message.AddMarkup(Mind?.Session == null ? noSessionText : hasSessionText);
+            }
+            else if (!HasMind)
             {
                 var aliveText =
                     $"[color=purple]{Loc.GetString("comp-mind-examined-catatonic", ("ent", Owner))}[/color]";
-                var deadText = $"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", Owner))}[/color]";
 
-                message.AddMarkup(dead ? deadText : aliveText);
+                message.AddMarkup(aliveText);
             }
             else if (Mind?.Session == null)
             {
-                if (dead) return;
-
                 var text =
                     $"[color=yellow]{Loc.GetString("comp-mind-examined-ssd", ("ent", Owner))}[/color]";
 

--- a/Content.Server/Mind/Components/MindComponent.cs
+++ b/Content.Server/Mind/Components/MindComponent.cs
@@ -149,17 +149,11 @@ namespace Content.Server.Mind.Components
             }
             else if (!HasMind)
             {
-                var aliveText =
-                    $"[color=purple]{Loc.GetString("comp-mind-examined-catatonic", ("ent", Owner))}[/color]";
-
-                message.AddMarkup(aliveText);
+                message.AddMarkup($"[color=purple]{Loc.GetString("comp-mind-examined-catatonic", ("ent", Owner))}[/color]");
             }
             else if (Mind?.Session == null)
             {
-                var text =
-                    $"[color=yellow]{Loc.GetString("comp-mind-examined-ssd", ("ent", Owner))}[/color]";
-
-                message.AddMarkup(text);
+                message.AddMarkup($"[color=yellow]{Loc.GetString("comp-mind-examined-ssd", ("ent", Owner))}[/color]");
             }
         }
     }

--- a/Content.Server/Mind/Components/MindComponent.cs
+++ b/Content.Server/Mind/Components/MindComponent.cs
@@ -139,10 +139,13 @@ namespace Content.Server.Mind.Components
 
             if (dead)
             {
-                var noSessionText = $"[color=yellow]{Loc.GetString("mind-component-no-mind-and-dead-text", ("ent", Owner))}[/color]";
-                var hasSessionText = $"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", Owner))}[/color]";
-
-                message.AddMarkup(Mind?.Session == null ? noSessionText : hasSessionText);
+                if (Mind?.Session == null) {
+                    // Player has no session attached and dead
+                    message.AddMarkup($"[color=yellow]{Loc.GetString("mind-component-no-mind-and-dead-text", ("ent", Owner))}[/color]");
+                } else {
+                    // Player is dead with session
+                    message.AddMarkup($"[color=red]{Loc.GetString("comp-mind-examined-dead", ("ent", Owner))}[/color]");
+                }
             }
             else if (!HasMind)
             {

--- a/Resources/Locale/en-US/mind/components/mind-component.ftl
+++ b/Resources/Locale/en-US/mind/components/mind-component.ftl
@@ -7,5 +7,5 @@ comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } 
 
 
 mind-component-no-mind-and-alive-text = {$owner} is totally catatonic. The stresses of life in deep-space must have been too much for them. Any recovery is unlikely.
-mind-component-no-mind-and-dead-text = {$owner}'s soul has departed.
+mind-component-no-mind-and-dead-text = {$owner}'s soul has departed and has moved on. Any recovery is unlikely.
 mind-component-mind-and-no-session-text = {$owner} has a blank, absent-minded stare and appears completely unresponsive to anything. {$owner} may snap out of it soon.

--- a/Resources/Locale/en-US/mind/components/mind-component.ftl
+++ b/Resources/Locale/en-US/mind/components/mind-component.ftl
@@ -7,5 +7,5 @@ comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } 
 
 
 mind-component-no-mind-and-alive-text = {$owner} is totally catatonic. The stresses of life in deep-space must have been too much for them. Any recovery is unlikely.
-mind-component-no-mind-and-dead-text = {$owner}'s soul has departed and has moved on. Any recovery is unlikely.
+mind-component-no-mind-and-dead-text = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and has moved on. Any recovery is unlikely.
 mind-component-mind-and-no-session-text = {$owner} has a blank, absent-minded stare and appears completely unresponsive to anything. {$owner} may snap out of it soon.

--- a/Resources/Locale/en-US/mind/components/mind-component.ftl
+++ b/Resources/Locale/en-US/mind/components/mind-component.ftl
@@ -6,6 +6,6 @@ comp-mind-examined-dead = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed.
 comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } a blank, absent-minded stare and appears completely unresponsive to anything. { CAPITALIZE(SUBJECT($ent)) } may snap out of it soon.
 
 
-mind-component-no-mind-and-alive-text = {$owner} is totally catatonic. The stresses of life in deep-space must have been too much for them. Any recovery is unlikely.
-mind-component-no-mind-and-dead-text = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and has moved on. Any recovery is unlikely.
-mind-component-mind-and-no-session-text = {$owner} has a blank, absent-minded stare and appears completely unresponsive to anything. {$owner} may snap out of it soon.
+mind-component-no-mind-and-alive-text = { CAPITALIZE(POSS-ADJ($ent)) } is totally catatonic. The stresses of life in deep-space must have been too much for them. Any recovery is unlikely.
+mind-component-no-mind-and-dead-text = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. Any recovery is unlikely.
+mind-component-mind-and-no-session-text = { CAPITALIZE(POSS-ADJ($ent)) } { CONJUGATE-HAVE($ent) } a blank, absent-minded stare and appears completely unresponsive to anything. { CAPITALIZE(POSS-ADJ($ent)) } may snap out of it soon.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is a small tweak to both examining and gasping to better show mobs that are actually dead vs in critical state.

Mobs in critical state will now gasp but will not inhale to replenish blood oxygen state.
All dead examined mobs now show "Soul has departed" instead of only ones where someone has ghosted
Dead session ended mobs now show "{$owner}'s soul has departed and has moved on. Any recovery is unlikely."


**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

someone dead with no connected session
![image](https://user-images.githubusercontent.com/47410468/146663417-e821d646-ee55-4521-b5af-a9f863b82ba9.png)

still alive still gasping
![image](https://user-images.githubusercontent.com/47410468/146663458-8983b049-ea1e-481e-826e-e9d8525bcc7f.png)

Soul still in body, still shows death
![image](https://user-images.githubusercontent.com/47410468/146663524-1bc73117-a638-47ce-afad-87c5aba58c63.png)

monkey gasp:
![image](https://user-images.githubusercontent.com/47410468/146663573-c1d5e899-1a01-4b21-9502-9598ea388fb7.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Mobs in crit state now gasp
- add: Examined humans will now tell if they are dead or not regardless if the body is still being occupied by a ghost.

