### PR TITLE
Fix botany watering 

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantAdjustNutrition.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantAdjustNutrition.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
     {
         public override void Effect(ReagentEffectArgs args)
         {
-            if (!CanMetabolize(args.SolutionEntity, out var plantHolderComp, args.EntityManager))
+            if (!CanMetabolize(args.SolutionEntity, out var plantHolderComp, args.EntityManager, mustHaveAlivePlant: false))
                 return;
 
             plantHolderComp.AdjustNutrient(Amount);

--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantAdjustWater.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantAdjustWater.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
     {
         public override void Effect(ReagentEffectArgs args)
         {
-            if (!CanMetabolize(args.SolutionEntity, out var plantHolderComp, args.EntityManager))
+            if (!CanMetabolize(args.SolutionEntity, out var plantHolderComp, args.EntityManager, mustHaveAlivePlant: false))
                 return;
 
             plantHolderComp.AdjustWater(Amount);


### PR DESCRIPTION
sets mustHaveAlivePlant: false for nutrition & water reagent effects.

:cl:
- fix: You can once again refill botany trays without requiring a plant to be present.

