### PR TITLE
Hide Jobs

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -324,6 +324,8 @@ namespace Content.Client.Preferences.UI
 
             foreach (var job in prototypeManager.EnumeratePrototypes<JobPrototype>().OrderBy(j => j.Name))
             {
+                if(!job.SetPreference) { continue; }
+
                 foreach (var department in job.Departments)
                 {
                     if (!_jobCategories.TryGetValue(department, out var category))

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -35,6 +35,9 @@ namespace Content.Shared.Roles
         [DataField("requireAdminNotify")]
         public bool RequireAdminNotify { get; } = false;
 
+        [DataField("setPreference")]
+        public bool SetPreference { get; } = true;
+
         [DataField("canBeAntag")]
         public bool CanBeAntag { get; } = true;
 

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -1,6 +1,7 @@
 - type: job
   id: CentralCommandOffical
   name: "centcom official"
+  setPreference: false
   startingGear: CentcomGear
   departments:
     - Command


### PR DESCRIPTION
Job prototypes now include a flag so jobs can be hidden from the job preferences list.
SetPreference name is taken from AntagPrototype.

Hides CentCom Official as no map currently implements it.