### PR TITLE
Custom transfer amount to hydroponic trays

### DIFF
--- a/Content.Server/Botany/Components/PlantHolderComponent.cs
+++ b/Content.Server/Botany/Components/PlantHolderComponent.cs
@@ -733,7 +733,6 @@ namespace Content.Server.Botany.Components
             {
                 var amount = FixedPoint2.New(1);
 
-                var sprayed = true;
                 var targetEntity = Owner;
                 var solutionEntity = usingItem;
 
@@ -751,8 +750,7 @@ namespace Content.Server.Botany.Components
                     return true;
                 }
 
-                user.PopupMessageCursor(Loc.GetString(
-                    sprayed ? "plant-holder-component-spray-message" : "plant-holder-component-transfer-message",
+                user.PopupMessageCursor(Loc.GetString("plant-holder-component-spray-message",
                     ("owner", Owner),
                     ("amount", split.TotalVolume)));
 

--- a/Content.Server/Botany/Components/PlantHolderComponent.cs
+++ b/Content.Server/Botany/Components/PlantHolderComponent.cs
@@ -729,33 +729,18 @@ namespace Content.Server.Botany.Components
 
             var solutionSystem = EntitySystem.Get<SolutionContainerSystem>();
             if (solutionSystem.TryGetDrainableSolution(usingItem, out var solution)
-                && solutionSystem.TryGetSolution(Owner, SoilSolutionName, out var targetSolution))
+                && solutionSystem.TryGetSolution(Owner, SoilSolutionName, out var targetSolution) && _entMan.TryGetComponent(usingItem, out SprayComponent? spray))
             {
-                var amount = FixedPoint2.New(5);
+                var amount = FixedPoint2.New(1);
 
-                var maxamount = FixedPoint2.New(50);
-                var minamount = FixedPoint2.New(5);
-
-                var sprayed = false;
+                var sprayed = true;
                 var targetEntity = Owner;
                 var solutionEntity = usingItem;
 
-                if (_entMan.TryGetComponent(usingItem, out SolutionTransferComponent transfer))
-                {
-                    
-                    amount = FixedPoint2.Clamp(transfer.TransferAmount, minamount, maxamount);
-                }
-
-                if (_entMan.TryGetComponent(usingItem, out SprayComponent? spray))
-                {
-                    sprayed = true;
-                    amount = FixedPoint2.New(1);
-
-                    SoundSystem.Play(Filter.Pvs(usingItem), spray.SpraySound.GetSound(), usingItem,
-                        AudioHelpers.WithVariation(0.125f));
-                }
-
-                amount = FixedPoint2.Min(amount, FixedPoint2.Min(solution.DrainAvailable, targetSolution.AvailableVolume));
+                
+                SoundSystem.Play(Filter.Pvs(usingItem), spray.SpraySound.GetSound(), usingItem,
+                AudioHelpers.WithVariation(0.125f));
+                
 
                 var split = solutionSystem.Drain(solutionEntity, solution, amount);
 

--- a/Content.Server/Chemistry/Components/SolutionManager/RefillableSolutionComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionManager/RefillableSolutionComponent.cs
@@ -25,17 +25,9 @@ namespace Content.Server.Chemistry.Components.SolutionManager
         /// <summary>
         /// The maximum amount that can be transferred to the solution at once
         /// </summary>
-        [DataField("maxrefill")]
+        [DataField("maxRefill")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public FixedPoint2 MaxRefill { get; set; } = FixedPoint2.New(0);
-
-        /// <summary>
-        /// Does this item have a max refill set?
-        /// </summary>
-        [DataField("cappedfill")]
-        [ViewVariables(VVAccess.ReadWrite)]
-        public bool CappedFill { get; set; } = false;
-
+        public FixedPoint2? MaxRefill { get; set; } = null;
 
 
     }

--- a/Content.Server/Chemistry/Components/SolutionManager/RefillableSolutionComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionManager/RefillableSolutionComponent.cs
@@ -1,6 +1,7 @@
-﻿using Robust.Shared.GameObjects;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.ViewVariables;
+using Content.Shared.FixedPoint;
 
 namespace Content.Server.Chemistry.Components.SolutionManager
 {
@@ -20,6 +21,22 @@ namespace Content.Server.Chemistry.Components.SolutionManager
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("solution")]
         public string Solution { get; set; } = "default";
+
+        /// <summary>
+        /// The maximum amount that can be transferred to the solution at once
+        /// </summary>
+        [DataField("maxrefill")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public FixedPoint2 MaxRefill { get; set; } = FixedPoint2.New(0);
+
+        /// <summary>
+        /// Does this item have a max refill set?
+        /// </summary>
+        [DataField("cappedfill")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool CappedFill { get; set; } = false;
+
+
 
     }
 }

--- a/Content.Server/Chemistry/Components/SolutionTransferComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionTransferComponent.cs
@@ -136,9 +136,9 @@ namespace Content.Server.Chemistry.Components
             {
                 var tankTransferAmount = tank.TransferAmount;
 
-                if (_entities.TryGetComponent(Owner, out RefillableSolutionComponent? refill) && refill.CappedFill == true)
+                if (_entities.TryGetComponent(Owner, out RefillableSolutionComponent? refill) && refill.MaxRefill != null)
                 {
-                    tankTransferAmount = FixedPoint2.Min(tankTransferAmount, refill.MaxRefill);
+                    tankTransferAmount = FixedPoint2.Min(tankTransferAmount, (FixedPoint2) refill.MaxRefill);
                 }
 
                 var transferred = DoTransfer(eventArgs.User, target, targetDrain, Owner, ownerRefill, tankTransferAmount);
@@ -160,9 +160,9 @@ namespace Content.Server.Chemistry.Components
             {
                 var transferAmount = TransferAmount;
 
-                if (_entities.TryGetComponent(target, out RefillableSolutionComponent? refill) && refill.CappedFill == true)
+                if (_entities.TryGetComponent(target, out RefillableSolutionComponent? refill) && refill.MaxRefill != null)
                 {
-                    transferAmount = FixedPoint2.Min(transferAmount, refill.MaxRefill);
+                    transferAmount = FixedPoint2.Min(transferAmount, (FixedPoint2) refill.MaxRefill);
                 }
 
                 var transferred = DoTransfer(eventArgs.User, Owner, ownerDrain, target, targetRefill, transferAmount);

--- a/Resources/Prototypes/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/Entities/Structures/soil.yml
@@ -47,6 +47,8 @@
         maxVol: 200
   - type: RefillableSolution
     solution: soil
+    maxrefill: 50
+    cappedfill: true
   - type: Transform
     anchored: true
   - type: Reactive

--- a/Resources/Prototypes/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/Entities/Structures/soil.yml
@@ -47,8 +47,7 @@
         maxVol: 200
   - type: RefillableSolution
     solution: soil
-    maxrefill: 50
-    cappedfill: true
+    maxRefill: 50
   - type: Transform
     anchored: true
   - type: Reactive


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Set transfer amount to hydroponic trays <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

<img width="965" alt="transfer" src="https://user-images.githubusercontent.com/22404812/146675258-d0759aa7-354e-4525-a8d8-37d2392bb4a9.PNG">

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- Can fill hydroponic trays with the transfer amount set on container (bucket) instead of base 5 per click (within 5-50 units capped by how much solution is left/room in tray)

Open to feedback since this is my first PR and it might change botany a bit 


