### PR TITLE
Add messages on cloner eject fail

### DIFF
--- a/Content.Server/Cloning/Components/CloningPodComponent.cs
+++ b/Content.Server/Cloning/Components/CloningPodComponent.cs
@@ -160,6 +160,16 @@ namespace Content.Server.Cloning.Components
                     break;
 
                 case UiButton.Eject:
+                    if (BodyContainer.ContainedEntity == null)
+                    {
+                        obj.Session.AttachedEntity.Value.PopupMessageCursor(Loc.GetString("cloning-pod-component-msg-empty"));
+                        return;
+                    }
+                    if (CloningProgress < CloningTime)
+                    {
+                        obj.Session.AttachedEntity.Value.PopupMessageCursor(Loc.GetString("cloning-pod-component-msg-incomplete"));
+                        return;
+                    }
                     Eject();
                     break;
 

--- a/Resources/Locale/en-US/cloning/components/cloning-pod-component.ftl
+++ b/Resources/Locale/en-US/cloning/components/cloning-pod-component.ftl
@@ -15,4 +15,6 @@ cloning-pod-component-msg-bad-selection = ERROR: Entry Removed During Selection 
 cloning-pod-component-msg-already-cloning = ERROR: Pod Network Conflict
 cloning-pod-component-msg-already-alive = ERROR: Metaphysical Conflict
 cloning-pod-component-msg-user-offline = ERROR: Metaphysical Disturbance
+cloning-pod-component-msg-incomplete = ERROR: Cloning in progress
+cloning-pod-component-msg-empty = ERROR: The pod is empty
 


### PR DESCRIPTION
## About the PR
When you hit the eject button on the cloner, it will now try to tell you why it can't do it. This is both a quality of life improvement, and should help narrow down why this issue #5844 is happening, if it happens again.


**Changelog**
:cl:
- add: cloner now tells you why it can't eject

