### PR TITLE
Optimise air + cable shutdowns for grid deletion

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnAirtightShutdown(EntityUid uid, AirtightComponent airtight, ComponentShutdown args)
         {
-            var xform = EntityManager.GetComponent<TransformComponent>(uid);
+            var xform = Transform(uid);
 
             // If the grid is deleting no point updating atmos.
             if (_mapManager.TryGetGrid(xform.GridID, out var grid))

--- a/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
@@ -92,7 +92,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!Resolve(airtight.Owner, ref xform)) return;
 
             airtight.AirBlocked = airblocked;
-            UpdatePosition(airtight);
+            UpdatePosition(airtight, xform);
             RaiseLocalEvent(airtight.Owner, new AirtightChanged(airtight));
         }
 

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -88,14 +88,15 @@ namespace Content.Server.Power.EntitySystems
 
         private IEnumerable<ExtensionCableReceiverComponent> FindAvailableReceivers(EntityUid owner, float range)
         {
-            var nearbyEntities = _lookup.GetEntitiesInRange(owner, range);
-
             var xform = Transform(owner);
             var coordinates = xform.Coordinates;
 
+            var nearbyEntities = _lookup.GetEntitiesInRange(coordinates, range);
+
             foreach (var entity in nearbyEntities)
             {
-                if (EntityManager.TryGetComponent<ExtensionCableReceiverComponent>(entity, out var receiver) &&
+                if (entity != owner &&
+                    EntityManager.TryGetComponent<ExtensionCableReceiverComponent>(entity, out var receiver) &&
                     receiver.Connectable &&
                     receiver.Provider == null &&
                     Transform(entity).Coordinates.TryDistance(EntityManager, coordinates, out var distance) &&

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -53,7 +53,7 @@ namespace Content.Server.Power.EntitySystems
 
         private void OnProviderShutdown(EntityUid uid, ExtensionCableProviderComponent provider, ComponentShutdown args)
         {
-            var xform = EntityManager.GetComponent<TransformComponent>(uid);
+            var xform = Transform(uid);
 
             // If grid deleting no need to update power.
             if (_mapManager.TryGetGrid(xform.GridID, out var grid))


### PR DESCRIPTION
Took up ~1/4 of grid deletion time

@Zumorica on the airtight

Makes regular deletions slightly slower (having to check TryGetGrid) but given the large savings on grid deletion that seemed to be more important.