### PR TITLE
Make CharacterWindow bigger to accomodate traitor objectives

### DIFF
--- a/Content.Client/CharacterInterface/CharacterInterfaceComponent.cs
+++ b/Content.Client/CharacterInterface/CharacterInterfaceComponent.cs
@@ -41,7 +41,11 @@ namespace Content.Client.CharacterInterface
                 {
                     Orientation = LayoutOrientation.Vertical
                 };
-                Contents.AddChild(contentsVBox);
+
+                var mainScrollContainer = new ScrollContainer { };
+                mainScrollContainer.AddChild(contentsVBox);
+
+                Contents.AddChild(mainScrollContainer);
 
                 windowComponents.Sort((a, b) => ((int) a.Priority).CompareTo((int) b.Priority));
                 foreach (var element in windowComponents)

--- a/Content.Client/CharacterInterface/CharacterInterfaceSystem.cs
+++ b/Content.Client/CharacterInterface/CharacterInterfaceSystem.cs
@@ -48,8 +48,11 @@ namespace Content.Client.CharacterInterface
             if (comp.UIComponents.Count == 0)
                 return;
 
-            comp.Window = new CharacterInterfaceComponent.CharacterWindow(comp.UIComponents);
-            comp.Window.MinSize = (545, 400);
+            comp.Window = new CharacterInterfaceComponent.CharacterWindow(comp.UIComponents)
+            {
+                MinSize = (545, 400)
+            };
+            
             comp.Window.OnClose += () => _gameHud.CharacterButtonDown = false;
         }
 

--- a/Content.Client/CharacterInterface/CharacterInterfaceSystem.cs
+++ b/Content.Client/CharacterInterface/CharacterInterfaceSystem.cs
@@ -50,7 +50,7 @@ namespace Content.Client.CharacterInterface
 
             comp.Window = new CharacterInterfaceComponent.CharacterWindow(comp.UIComponents)
             {
-                MinSize = (545, 400)
+                SetSize = (545, 400)
             };
             
             comp.Window.OnClose += () => _gameHud.CharacterButtonDown = false;

--- a/Content.Client/CharacterInterface/CharacterInterfaceSystem.cs
+++ b/Content.Client/CharacterInterface/CharacterInterfaceSystem.cs
@@ -49,6 +49,7 @@ namespace Content.Client.CharacterInterface
                 return;
 
             comp.Window = new CharacterInterfaceComponent.CharacterWindow(comp.UIComponents);
+            comp.Window.MinSize = (545, 400);
             comp.Window.OnClose += () => _gameHud.CharacterButtonDown = false;
         }
 


### PR DESCRIPTION
## About the PR
Name's pretty descriptive!
I tried to do it dinamically so only windows with objectives would get resized, but sadly, that is way beyond my current expertise, so set sizes it is!
Fixes #5056
[FOR REAL THIS TIME MOM, I PROMISE.]

A huge kudos to @ShadowCommander 's patience in guiding me through the steps.
A cookie to the man!
**Screenshots**

![1](https://user-images.githubusercontent.com/52474532/146842199-2f4a0207-a04d-40f3-988d-717fa02c489e.PNG)
![2](https://user-images.githubusercontent.com/52474532/146842201-fa0e934d-7caa-49f7-9c4e-5da7997f654f.jpg)
![3](https://user-images.githubusercontent.com/52474532/146842202-292feaae-a3ec-465f-91bb-80caeee65d98.jpg)

**Changelog**


:cl:
fix: Increased CharacterWindow size to accomodate objectives!

