### PR TITLE
Improve airlock power ui

### DIFF
--- a/Content.Server/Doors/Components/AirlockComponent.cs
+++ b/Content.Server/Doors/Components/AirlockComponent.cs
@@ -158,16 +158,35 @@ namespace Content.Server.Doors.Components
                 return;
             }
 
-            var powerLight = new StatusLightData(Color.Yellow, StatusLightState.On, "POWR");
-            if (PowerWiresPulsed)
+            StatusLightData powerLight;
+            if(WiresComponent != null)
             {
-                powerLight = new StatusLightData(Color.Yellow, StatusLightState.BlinkingFast, "POWR");
+                var mainPowerCut = WiresComponent.IsWireCut(Wires.MainPower);
+                var backupPowerCut = WiresComponent.IsWireCut(Wires.BackupPower);
+                var statusLightState = PowerWiresPulsed ? StatusLightState.BlinkingFast : StatusLightState.On;
+                if (mainPowerCut && backupPowerCut)
+                {
+                    powerLight = new StatusLightData(Color.Yellow, StatusLightState.Off, "POWR");
+                }
+                else if(mainPowerCut != backupPowerCut)
+                {
+                    powerLight = new StatusLightData(Color.Yellow, statusLightState, "POWR");
+                }
+                else
+                {
+                    powerLight = new StatusLightData(Color.Red, statusLightState, "POWR");
+                }
             }
-            else if (WiresComponent != null &&
-                     WiresComponent.IsWireCut(Wires.MainPower) &&
-                     WiresComponent.IsWireCut(Wires.BackupPower))
+            else
             {
-                powerLight = new StatusLightData(Color.Red, StatusLightState.On, "POWR");
+                if (PowerWiresPulsed)
+                {
+                    powerLight = new StatusLightData(Color.Yellow, StatusLightState.BlinkingFast, "POWR");
+                }
+                else
+                {
+                    powerLight = new StatusLightData(Color.Yellow, StatusLightState.On, "POWR");
+                }
             }
 
             var boltStatus =
@@ -219,7 +238,7 @@ namespace Content.Server.Doors.Components
             }
 
             ReceiverComponent.PowerDisabled =
-                WiresComponent.IsWireCut(Wires.MainPower) ||
+                WiresComponent.IsWireCut(Wires.MainPower) &&
                 WiresComponent.IsWireCut(Wires.BackupPower);
         }
 

--- a/Content.Server/Doors/Components/AirlockComponent.cs
+++ b/Content.Server/Doors/Components/AirlockComponent.cs
@@ -153,46 +153,29 @@ namespace Content.Server.Doors.Components
 
         public void UpdateWiresStatus()
         {
-            if (DoorComponent == null)
-            {
-                return;
-            }
+            if (WiresComponent == null) return;
 
+            var mainPowerCut = WiresComponent.IsWireCut(Wires.MainPower);
+            var backupPowerCut = WiresComponent.IsWireCut(Wires.BackupPower);
+            var statusLightState = PowerWiresPulsed ? StatusLightState.BlinkingFast : StatusLightState.On;
             StatusLightData powerLight;
-            if(WiresComponent != null)
+            if (mainPowerCut && backupPowerCut)
             {
-                var mainPowerCut = WiresComponent.IsWireCut(Wires.MainPower);
-                var backupPowerCut = WiresComponent.IsWireCut(Wires.BackupPower);
-                var statusLightState = PowerWiresPulsed ? StatusLightState.BlinkingFast : StatusLightState.On;
-                if (mainPowerCut && backupPowerCut)
-                {
-                    powerLight = new StatusLightData(Color.Yellow, StatusLightState.Off, "POWR");
-                }
-                else if(mainPowerCut != backupPowerCut)
-                {
-                    powerLight = new StatusLightData(Color.Yellow, statusLightState, "POWR");
-                }
-                else
-                {
-                    powerLight = new StatusLightData(Color.Red, statusLightState, "POWR");
-                }
+                powerLight = new StatusLightData(Color.DarkGoldenrod, StatusLightState.Off, "POWER");
+            }
+            else if (mainPowerCut != backupPowerCut)
+            {
+                powerLight = new StatusLightData(Color.Gold, statusLightState, "POWER");
             }
             else
             {
-                if (PowerWiresPulsed)
-                {
-                    powerLight = new StatusLightData(Color.Yellow, StatusLightState.BlinkingFast, "POWR");
-                }
-                else
-                {
-                    powerLight = new StatusLightData(Color.Yellow, StatusLightState.On, "POWR");
-                }
+                powerLight = new StatusLightData(Color.Yellow, statusLightState, "POWER");
             }
 
             var boltStatus =
                 new StatusLightData(Color.Red, BoltsDown ? StatusLightState.On : StatusLightState.Off, "BOLT");
             var boltLightsStatus = new StatusLightData(Color.Lime,
-                _boltLightsWirePulsed ? StatusLightState.On : StatusLightState.Off, "BLTL");
+                _boltLightsWirePulsed ? StatusLightState.On : StatusLightState.Off, "BOLT LED");
 
             var ev = new DoorGetCloseTimeModifierEvent();
             IoCManager.Resolve<IEntityManager>().EventBus.RaiseLocalEvent(Owner, ev, false);
@@ -204,17 +187,13 @@ namespace Content.Server.Doors.Components
                                                     "TIME");
 
             var safetyStatus =
-                new StatusLightData(Color.Red, Safety ? StatusLightState.On : StatusLightState.Off, "SAFE");
+                new StatusLightData(Color.Red, Safety ? StatusLightState.On : StatusLightState.Off, "SAFETY");
 
-            if (WiresComponent == null)
-            {
-                return;
-            }
 
             WiresComponent.SetStatus(AirlockWireStatus.PowerIndicator, powerLight);
             WiresComponent.SetStatus(AirlockWireStatus.BoltIndicator, boltStatus);
             WiresComponent.SetStatus(AirlockWireStatus.BoltLightIndicator, boltLightsStatus);
-            WiresComponent.SetStatus(AirlockWireStatus.AIControlIndicator, new StatusLightData(Color.Purple, StatusLightState.BlinkingSlow, "AICT"));
+            WiresComponent.SetStatus(AirlockWireStatus.AIControlIndicator, new StatusLightData(Color.Purple, StatusLightState.BlinkingSlow, "AI CTRL"));
             WiresComponent.SetStatus(AirlockWireStatus.TimingIndicator, timingStatus);
             WiresComponent.SetStatus(AirlockWireStatus.SafetyIndicator, safetyStatus);
         }


### PR DESCRIPTION
## About the PR
See Changelog

**Changelog**
:cl:
- add: It is now possible to tell when airlock power wires are partially cut
- tweak: Airlock text is a little bit clearer
- fix: Airlock now only loses power when both backup, and main power wires are cut

