### PR TITLE
Add AntagPrototype to TraitorRole and Fix traitors choice logic

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorDeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorDeathMatchRuleSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.Inventory;
 using Content.Shared.MobState.Components;
 using Content.Shared.PDA;
+using Content.Shared.Roles;
 using Content.Shared.Traitor.Uplink;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
@@ -52,6 +53,8 @@ public class TraitorDeathMatchRuleSystem : GameRuleSystem
 
     private readonly Dictionary<UplinkAccount, string> _allOriginalNames = new();
 
+    private const string TraitorPrototypeID = "Traitor";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -77,7 +80,8 @@ public class TraitorDeathMatchRuleSystem : GameRuleSystem
             return;
         }
 
-        var traitorRole = new TraitorRole(mind);
+        var antagPrototype = _prototypeManager.Index<AntagPrototype>(TraitorPrototypeID);
+        var traitorRole = new TraitorRole(mind, antagPrototype);
         mind.AddRole(traitorRole);
 
         // Delete anything that may contain "dangerous" role-specific items.

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -120,7 +120,7 @@ public class TraitorRuleSystem : GameRuleSystem
         for (var i = 0; i < numTraitors; i++)
         {
             IPlayerSession traitor;
-            if(prefList.Count < numTraitors)
+            if(prefList.Count == 0)
             {
                 if (list.Count == 0)
                 {

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -10,6 +10,7 @@ using Content.Server.Traitor.Uplink;
 using Content.Server.Traitor.Uplink.Account;
 using Content.Shared.CCVar;
 using Content.Shared.Dataset;
+using Content.Shared.Roles;
 using Content.Shared.Sound;
 using Content.Shared.Traitor.Uplink;
 using Robust.Server.Player;
@@ -38,6 +39,8 @@ public class TraitorRuleSystem : GameRuleSystem
 
     private readonly SoundSpecifier _addedSound = new SoundPathSpecifier("/Audio/Misc/tatoralert.ogg");
     private readonly List<TraitorRole> _traitors = new ();
+
+    private const string TraitorPrototypeID = "Traitor";
 
     public override void Initialize()
     {
@@ -105,7 +108,7 @@ public class TraitorRuleSystem : GameRuleSystem
                 continue;
             }
             var profile = ev.Profiles[player.UserId];
-            if (profile.AntagPreferences.Contains("Traitor"))
+            if (profile.AntagPreferences.Contains(TraitorPrototypeID))
             {
                 prefList.Add(player);
             }
@@ -153,7 +156,8 @@ public class TraitorRuleSystem : GameRuleSystem
                     .AddUplink(mind.OwnedEntity!.Value, uplinkAccount))
                 continue;
 
-            var traitorRole = new TraitorRole(mind);
+            var antagPrototype = _prototypeManager.Index<AntagPrototype>(TraitorPrototypeID);
+            var traitorRole = new TraitorRole(mind, antagPrototype);
             mind.AddRole(traitorRole);
             _traitors.Add(traitorRole);
         }

--- a/Content.Server/Traitor/TraitorRole.cs
+++ b/Content.Server/Traitor/TraitorRole.cs
@@ -1,5 +1,6 @@
 using Content.Server.Chat.Managers;
 using Content.Server.Roles;
+using Content.Shared.Roles;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 
@@ -7,12 +8,17 @@ namespace Content.Server.Traitor
 {
     public class TraitorRole : Role
     {
-        public TraitorRole(Mind.Mind mind) : base(mind)
+        public AntagPrototype Prototype { get; }
+
+        public TraitorRole(Mind.Mind mind, AntagPrototype antagPrototype) : base(mind)
         {
+            Prototype = antagPrototype;
+            Name = antagPrototype.Name;
+            Antagonist = antagPrototype.Antagonist;
         }
 
-        public override string Name => Loc.GetString("traitor-role-name");
-        public override bool Antagonist => true;
+        public override string Name { get; }
+        public override bool Antagonist { get; }
 
         public void GreetTraitor(string[] codewords)
         {

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -39,6 +39,5 @@ traitor-death-match-end-round-description-entry = {$originalName}'s PDA, with {$
 ## TraitorRole
 
 # TraitorRole
-traitor-role-name = Syndicate Agent
 traitor-role-greeting = Hello Agent
 traitor-role-codewords = Your codewords are: {$codewords}

--- a/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_innocent.yml
+++ b/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_innocent.yml
@@ -1,6 +1,6 @@
 - type: antag
   id: SuspicionInnocent
-  name: "innocent"
+  name: "Innocent"
   antagonist: false
   setPreference: false
   objective: "Discover and eliminate all traitors."

--- a/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_traitor.yml
@@ -1,6 +1,6 @@
 - type: antag
   id: SuspicionTraitor
-  name: "suspect"
+  name: "Suspect"
   antagonist: true
   setPreference: true
   objective: "Kill the innocents."

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -1,6 +1,6 @@
 - type: antag
   id: Traitor
-  name: "traitor"
+  name: "Syndicate Agent"
   antagonist: true
   setPreference: true
   objective: "Complete your objectives without being caught."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
~~Now in character perfomance exist `traitor` checkbox but used it for `Suspicion` game mode and often players do not understand why they were given role of a traitor, although they have this setting turned off. It happen because only `Suspicion` roles use `AntagPrototype` according to which antag list is built in preferences.~~

Ok, while im doing this, code already has been refactored. Now exist `AntagPrototype` and this PR apply it for `TraitorRole` same as in Suspicion mode. Aslo change names for antag roles to more pretty (because remove traitor name from locale file).
Also make role candidate searching as in `Suspicion` mode because now if available 2 traitor candidates only 1 will be taken but other will be chosen randomly which is not correct.

After last refactor I don't really know if this need, but i think at least traitor selection fix necessary (I can move it separately).

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/14136326/147043123-9ef8596c-65d3-41d6-977b-ebd66b08ea7f.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Changed antag names in preferences
- fix: Does not choose a random traitor if there are available candidates

