### PR TITLE
Light bulb brightness (and other settings) change clientside PointLights

### DIFF
--- a/Content.Server/Light/Components/LightBulbComponent.cs
+++ b/Content.Server/Light/Components/LightBulbComponent.cs
@@ -29,6 +29,15 @@ namespace Content.Server.Light.Components
         [DataField("BurningTemperature")]
         public int BurningTemperature = 1400;
 
+        [DataField("lightEnergy")]
+        public float lightEnergy = 0.8F;
+
+        [DataField("lightRadius")]
+        public float lightRadius = 10;
+
+        [DataField("lightSoftness")]
+        public float lightSoftness = 1;
+
         [DataField("PowerUse")]
         public int PowerUse = 40;
 

--- a/Content.Server/Light/Components/LightBulbComponent.cs
+++ b/Content.Server/Light/Components/LightBulbComponent.cs
@@ -30,7 +30,7 @@ namespace Content.Server.Light.Components
         public int BurningTemperature = 1400;
 
         [DataField("lightEnergy")]
-        public float lightEnergy = 0.8F;
+        public float lightEnergy = 0.8f;
 
         [DataField("lightRadius")]
         public float lightRadius = 10;

--- a/Content.Server/Light/Components/PoweredLightComponent.cs
+++ b/Content.Server/Light/Components/PoweredLightComponent.cs
@@ -28,6 +28,9 @@ namespace Content.Server.Light.Components
         [DataField("hasLampOnSpawn")]
         public bool HasLampOnSpawn = true;
 
+        [DataField("particularLampOnSpawn")]
+        public string? ParticularLampOnSpawn = null;
+
         [DataField("bulb")]
         public LightBulbType BulbType;
 

--- a/Content.Server/Light/Components/PoweredLightComponent.cs
+++ b/Content.Server/Light/Components/PoweredLightComponent.cs
@@ -7,6 +7,8 @@ using Robust.Shared.Analyzers;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Prototypes;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Server.Light.Components
@@ -25,11 +27,8 @@ namespace Content.Server.Light.Components
         [DataField("turnOnSound")]
         public SoundSpecifier TurnOnSound = new SoundPathSpecifier("/Audio/Machines/light_tube_on.ogg");
 
-        [DataField("hasLampOnSpawn")]
-        public bool HasLampOnSpawn = true;
-
-        [DataField("particularLampOnSpawn")]
-        public string? ParticularLampOnSpawn = null;
+        [DataField("hasLampOnSpawn", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+        public string? HasLampOnSpawn = null;
 
         [DataField("bulb")]
         public LightBulbType BulbType;

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -66,13 +66,20 @@ namespace Content.Server.Light.EntitySystems
         {
             if (light.HasLampOnSpawn)
             {
-                var prototype = light.BulbType switch
+                var prototype = "";
+                if(light.ParticularLampOnSpawn == null)
                 {
-                    LightBulbType.Bulb => "LightBulb",
-                    LightBulbType.Tube => "LightTube",
-                    _ => throw new ArgumentOutOfRangeException()
-                };
-
+                    prototype = light.BulbType switch
+                    {
+                        LightBulbType.Bulb => "LightBulb",
+                        LightBulbType.Tube => "LightTube",
+                        _ => throw new ArgumentOutOfRangeException()
+                    };
+                }
+                else
+                {
+                    prototype = light.ParticularLampOnSpawn;
+                }
                 var entity = EntityManager.SpawnEntity(prototype, EntityManager.GetComponent<TransformComponent>(light.Owner).Coordinates);
                 light.LightBulbContainer.Insert(entity);
             }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -64,11 +64,9 @@ namespace Content.Server.Light.EntitySystems
 
         private void OnMapInit(EntityUid uid, PoweredLightComponent light, MapInitEvent args)
         {
-
-            var prototype = "";
             if (light.HasLampOnSpawn != null)
             {
-                var entity = EntityManager.SpawnEntity(prototype, EntityManager.GetComponent<TransformComponent>(light.Owner).Coordinates);
+                var entity = EntityManager.SpawnEntity(light.HasLampOnSpawn, EntityManager.GetComponent<TransformComponent>(light.Owner).Coordinates);
                 light.LightBulbContainer.Insert(entity);
             }
             // need this to update visualizers

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -64,26 +64,13 @@ namespace Content.Server.Light.EntitySystems
 
         private void OnMapInit(EntityUid uid, PoweredLightComponent light, MapInitEvent args)
         {
-            if (light.HasLampOnSpawn)
+
+            var prototype = "";
+            if (light.HasLampOnSpawn != null)
             {
-                var prototype = "";
-                if(light.ParticularLampOnSpawn == null)
-                {
-                    prototype = light.BulbType switch
-                    {
-                        LightBulbType.Bulb => "LightBulb",
-                        LightBulbType.Tube => "LightTube",
-                        _ => throw new ArgumentOutOfRangeException()
-                    };
-                }
-                else
-                {
-                    prototype = light.ParticularLampOnSpawn;
-                }
                 var entity = EntityManager.SpawnEntity(prototype, EntityManager.GetComponent<TransformComponent>(light.Owner).Coordinates);
                 light.LightBulbContainer.Insert(entity);
             }
-
             // need this to update visualizers
             UpdateLight(uid, light);
         }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -158,7 +158,6 @@ namespace Content.Server.Light.EntitySystems
                 return false;
 
             UpdateLight(uid, light);
-
             return true;
         }
 
@@ -260,7 +259,7 @@ namespace Content.Server.Light.EntitySystems
                     case LightBulbState.Normal:
                         if (powerReceiver.Powered && light.On)
                         {
-                            SetLight(uid, true, lightBulb.Color, light);
+                            SetLight(uid, true, lightBulb.Color, light, lightBulb.lightRadius, lightBulb.lightEnergy, lightBulb.lightSoftness);
                             appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.On);
                             var time = _gameTiming.CurTime;
                             if (time > light.LastThunk + ThunkDelay)
@@ -363,7 +362,7 @@ namespace Content.Server.Light.EntitySystems
             SetState(uid, enabled, component);
         }
 
-        private void SetLight(EntityUid uid, bool value, Color? color = null, PoweredLightComponent? light = null)
+        private void SetLight(EntityUid uid, bool value, Color? color = null, PoweredLightComponent? light = null, float? radius = null, float? energy = null, float? softness=null)
         {
             if (!Resolve(uid, ref light))
                 return;
@@ -377,6 +376,12 @@ namespace Content.Server.Light.EntitySystems
 
                 if (color != null)
                     pointLight.Color = color.Value;
+                if (radius != null)
+                    pointLight.Radius = (float) radius;
+                if (energy != null)
+                    pointLight.Energy = (float) energy;
+                if (softness != null)
+                    pointLight.Softness = (float) softness;
             }
         }
 

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -60,6 +60,9 @@
   - type: LightBulb
     bulb: Bulb
     color: "#FFD1A3" # 4000K color temp
+    lightEnergy: 1.0
+    lightRadius: 6
+    lightSoftness: 1.1
   - type: Sprite
     sprite: Objects/Power/light_bulb.rsi
     state: normal
@@ -73,6 +76,9 @@
   - type: LightBulb
     bulb: Tube
     color: "#FFE4CE" # 5000K color temp
+    lightEnergy: 0.8
+    lightRadius: 10
+    lightSoftness: 1
   - type: Sprite
     sprite:  Objects/Power/light_tube.rsi
     state: normal
@@ -85,6 +91,9 @@
   - type: LightBulb
     bulb: Tube
     color: "#EEEEFF"
+    lightEnergy: 4
+    lightRadius: 10
+    lightSoftness: 0.9
     BurningTemperature: 350
     PowerUse: 9
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -108,7 +108,7 @@
   parent: Poweredlight
   components:
   - type: PoweredLight
-    hasLampOnSpawn: "LedLightTube"
+    hasLampOnSpawn: LedLightTube
     damage:
       types:
         Heat: 20

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -61,19 +61,18 @@
 
 - type: entity
   name: light
-  description: "A powered wall light emitting... light."
-  id: Poweredlight
-  suffix: Powered
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  id: PoweredlightEmpty
+  suffix: Empty, Powered
   parent: WallLight
   components:
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/light_tube.rsi
-    state: off
+    state: empty
   - type: PointLight
     enabled: false
   - type: PoweredLight
     bulb: Tube
-    hasLampOnSpawn: LightTube
     damage:
       types:
         Heat: 20
@@ -89,22 +88,22 @@
         path: "/Audio/Machines/light_tube_on.ogg"
 
 - type: entity
-  id: PoweredlightEmpty
-  description: "A wall light. It's empty."
-  suffix: Empty, Powered
-  parent: Poweredlight
+  id: Poweredlight
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Powered
+  parent: PoweredlightEmpty
   components:
   - type: Sprite
-    state: empty
+    state: off
   - type: PoweredLight
-    hasLampOnSpawn: null
+    hasLampOnSpawn: LightTube
     damage:
       types:
         Heat: 20
 
 - type: entity
   id: PoweredlightLED
-  description: "A powered wall light emitting... light."
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   suffix: LED tube, Powered
   parent: Poweredlight
   components:
@@ -156,14 +155,14 @@
 
 - type: entity
   name: small light
-  description: "A powered wall light emitting... light."
-  id: PoweredSmallLight
-  suffix: Powered
+  description: "A light fixture. Draws power and produces light when equipped with a light bulb."
+  id: PoweredSmallLightEmpty
+  suffix: Empty, Powered
   parent: SmallLight
   components:
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/light_small.rsi
-    state: off
+    state: empty
   - type: PointLight
     enabled: false
     offset: "0, -0.5"
@@ -176,7 +175,6 @@
       layer: [ Passable ]
   - type: PoweredLight
     bulb: Bulb
-    hasLampOnSpawn: "LightBulb"
     damage:
       types:
         Heat: 20
@@ -190,14 +188,14 @@
     - type: PoweredLightVisualizer
 
 - type: entity
-  id: PoweredSmallLightEmpty
-  suffix: Empty, Powered
-  parent: PoweredSmallLight
+  id: PoweredSmallLight
+  suffix: Powered
+  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
-    state: empty
+    state: off
   - type: PoweredLight
-    hasLampOnSpawn: null
+    hasLampOnSpawn: "LightBulb"
     damage:
       types:
         Heat: 20

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -73,6 +73,7 @@
     enabled: false
   - type: PoweredLight
     bulb: Tube
+    hasLampOnSpawn: LightTube
     damage:
       types:
         Heat: 20

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -96,7 +96,7 @@
   - type: Sprite
     state: empty
   - type: PoweredLight
-    hasLampOnSpawn: False
+    hasLampOnSpawn: null
     damage:
       types:
         Heat: 20
@@ -108,8 +108,7 @@
   parent: Poweredlight
   components:
   - type: PoweredLight
-    hasLampOnSpawn: True
-    particularLampOnSpawn: "LedLightTube"
+    hasLampOnSpawn: "LedLightTube"
     damage:
       types:
         Heat: 20
@@ -176,6 +175,7 @@
       layer: [ Passable ]
   - type: PoweredLight
     bulb: Bulb
+    hasLampOnSpawn: "LightBulb"
     damage:
       types:
         Heat: 20
@@ -196,7 +196,7 @@
   - type: Sprite
     state: empty
   - type: PoweredLight
-    hasLampOnSpawn: False
+    hasLampOnSpawn: null
     damage:
       types:
         Heat: 20

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -102,6 +102,19 @@
         Heat: 20
 
 - type: entity
+  id: PoweredlightLED
+  description: "A powered wall light emitting... light."
+  suffix: LED tube, Powered
+  parent: Poweredlight
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: True
+    particularLampOnSpawn: "LedLightTube"
+    damage:
+      types:
+        Heat: 20
+
+- type: entity
   name: small light
   description: "An unpowered light."
   id: SmallLight

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -195,7 +195,7 @@
   - type: Sprite
     state: off
   - type: PoweredLight
-    hasLampOnSpawn: "LightBulb"
+    hasLampOnSpawn: LightBulb
     damage:
       types:
         Heat: 20


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes the implementation of PoweredLights to allow more of the PointLight's values to be defined per-bulb instead of per-fixture, and for those values to replicate from server to client. Additionally, it changes these values for the LED bulb to demonstrate the difference. A version of the wall light spawning with an LED bulb is provided so that mappers and admin/sandbox spawning can take advantage of these brighter light sources.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
A light fixture using our standard fluorescent bulb, updated to the new system:
![fluorescent1](https://user-images.githubusercontent.com/12946202/147177902-13c1431f-5946-40c2-a01a-574753f2856d.png)
The same fixture with its bulb replaced with a brighter LED equivalent.
![LED1](https://user-images.githubusercontent.com/12946202/147177926-cbac008a-20ee-48d8-8dd8-9715cb78dea4.png)
Radius has been left at the default 10 on the brighter bulb, and would be inadvisable to increase further for PVS/pop-in reasons, but is available for bulbs to specify, such as the 6 radius on incandescent light bulbs (formerly on the small fixtures accepting incandescent bulbs).

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Made LED tubes increase the brightness of lights they're installed in
- add: Provided an admin/sandbox/map-spawnable light fixture that starts out with an LED tube, for brighter-lit areas.

Requires https://github.com/space-wizards/RobustToolbox/pull/2367