### PR TITLE
[ADD] Hypospray to CMO lockers and to traitor objectives

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -138,6 +138,8 @@
         prob: 1
       - id: ClothingOuterHardsuitMedical
         prob: 1
+      - id: Hypospray
+        prob: 1
 
 - type: entity
   id: LockerResearchDirectorFilled

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -40,3 +40,15 @@
         - StayAliveCondition
   conditions:
     - !type:DieCondition {}
+
+- type: objective
+  id: CMOHyposprayStealObjective
+  issuer: syndicate
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+  conditions:
+    - !type:StealCondition
+      prototype: Hypospray


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is a really small PR to add the Hypospray to the CMO's locker and to also add it as a traitor objective.

I was considering adding more steal traitor goals on top of this but couldn't think of any that are significant.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![Capture1](https://user-images.githubusercontent.com/47410468/147187247-73e8e39e-de2e-4e90-b226-e74ead531df5.PNG)
![Capture2](https://user-images.githubusercontent.com/47410468/147187259-29ef53a3-731f-49b5-96de-029b4cd5ec8e.PNG)
![Capture3](https://user-images.githubusercontent.com/47410468/147187267-020c6a38-5ea6-46a4-a96f-dc8f38cff623.PNG)


Steal captain ID and fail hypospray
![image](https://user-images.githubusercontent.com/47410468/147187530-352b9e22-cf3e-4265-bfe6-c2c17af3ae38.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Hypospray to CMO lockers and also traitor goals.

