### PR TITLE
Move Eye Lerping to content and fix/improve it a bunch.

### DIFF
--- a/Content.Client/Eye/EyeLerpingSystem.cs
+++ b/Content.Client/Eye/EyeLerpingSystem.cs
@@ -1,0 +1,123 @@
+using System;
+using Content.Shared.Movement.Components;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Physics;
+using Robust.Client.Player;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Maths;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Eye;
+
+public class EyeLerpingSystem : EntitySystem
+{
+    [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    private Angle? _lastGridAngle;
+    private Angle? _lerpTo;
+    private Angle _lerpStartRotation;
+    private float _accumulator;
+
+    // How fast the camera rotates in radians / s
+    private const float CameraRotateSpeed = MathF.PI;
+
+    // Safety override
+    private const float LerpTimeMax = 1.5f;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        UpdatesAfter.Add(typeof(TransformSystem));
+        UpdatesAfter.Add(typeof(PhysicsSystem));
+        UpdatesBefore.Add(typeof(EyeUpdateSystem));
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        if (!_gameTiming.IsFirstTimePredicted)
+            return;
+
+        var currentEye = _eyeManager.CurrentEye;
+
+        if (_playerManager.LocalPlayer?.ControlledEntity is not {} mob || Deleted(mob))
+            return;
+
+        // We can't lerp if the mob can't move!
+        if (!TryComp(mob, out IMoverComponent? mover))
+            return;
+
+        var moverLastGridAngle = mover.LastGridAngle;
+
+        // Let's not turn the camera into a washing machine when the game starts.
+        if (_lastGridAngle == null)
+        {
+            _lastGridAngle = moverLastGridAngle;
+            currentEye.Rotation = -moverLastGridAngle;
+            return;
+        }
+
+        // Check if the last lerp grid angle we have is not the same as the last mover grid angle...
+        if (!_lastGridAngle.Value.EqualsApprox(moverLastGridAngle))
+        {
+            // And now, we start lerping.
+            _lerpTo = moverLastGridAngle;
+            _lastGridAngle = moverLastGridAngle;
+            _lerpStartRotation = currentEye.Rotation;
+            _accumulator = 0f;
+        }
+
+        if (_lerpTo != null)
+        {
+            _accumulator += frameTime;
+
+            var lerpRot = -_lerpTo.Value.FlipPositive().Reduced();
+            var startRot = _lerpStartRotation.FlipPositive().Reduced();
+
+            var changeNeeded = Angle.ShortestDistance(startRot, lerpRot);
+
+            if (changeNeeded.EqualsApprox(Angle.Zero))
+            {
+                // Nothing to do here!
+                CleanupLerp();
+                return;
+            }
+
+            // Get how much the camera should have moved by now. Make it faster depending on the change needed.
+            var changeRot = (CameraRotateSpeed * Math.Max(1f, Math.Abs(changeNeeded) * 0.75f)) * _accumulator * Math.Sign(changeNeeded);
+
+            // How close is this from reaching the end?
+            var percentage = (float)Math.Abs(changeRot / changeNeeded);
+
+            currentEye.Rotation = Angle.Lerp(startRot, lerpRot, percentage);
+
+            // Either we have overshot, or we have taken way too long on this, emergency reset time
+            if (percentage >= 1.0f || _accumulator >= LerpTimeMax)
+            {
+                CleanupLerp();
+            }
+
+            void CleanupLerp()
+            {
+                currentEye.Rotation = -_lerpTo.Value;
+                _lerpStartRotation = currentEye.Rotation;
+                _lerpTo = null;
+                _accumulator = 0f;
+            }
+        }
+        else
+        {
+            // This makes it so rotating the camera manually is impossible...
+            // However, it is needed. Why? Because of a funny (hilarious, even) race condition involving
+            // ghosting, this system listening for attached mob changes, and the eye rotation being reset after our
+            // changes back to zero because of an EyeComponent state coming from the server being applied.
+            // At some point we'll need to come up with a solution for that. But for now, I just want to fix this.
+            currentEye.Rotation = -moverLastGridAngle;
+        }
+    }
+}

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -5,6 +5,7 @@ using Content.Shared.Pulling.Components;
 using Robust.Client.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Map;
 using Robust.Shared.Physics;
 
 namespace Content.Client.Physics.Controllers
@@ -19,10 +20,14 @@ namespace Content.Client.Physics.Controllers
 
             if (_playerManager.LocalPlayer?.ControlledEntity is not {Valid: true} player ||
                 !EntityManager.TryGetComponent(player, out IMoverComponent? mover) ||
-                !EntityManager.TryGetComponent(player, out PhysicsComponent? body))
+                !EntityManager.TryGetComponent(player, out PhysicsComponent? body) ||
+                !EntityManager.TryGetComponent(player, out TransformComponent? xform))
             {
                 return;
             }
+
+            if (xform.GridID != GridId.Invalid)
+                mover.LastGridAngle = GetParentGridAngle(xform, mover);
 
             // Essentially we only want to set our mob to predicted so every other entity we just interpolate
             // (i.e. only see what the server has sent us).

--- a/Content.Shared/Movement/Components/SharedPlayerInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/SharedPlayerInputMoverComponent.cs
@@ -50,6 +50,7 @@ namespace Content.Shared.Movement.Components
 
         private MoveButtons _heldMoveButtons = MoveButtons.None;
 
+        [ViewVariables]
         public Angle LastGridAngle { get; set; } = new(0);
 
         public float CurrentWalkSpeed => _movementSpeed?.CurrentWalkSpeed ?? MovementSpeedModifierComponent.DefaultBaseWalkSpeed;


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Improves cross-grid camera lerping massively. It is now based on movement direction.
~~Depends on https://github.com/space-wizards/RobustToolbox/pull/2371~~ Requires a submodule update.

**Screenshots**
![Peek 25-12-2021 14-31](https://user-images.githubusercontent.com/6766154/147386432-bd1950f4-acbe-40b4-8076-c77355016a7e.gif)
![Peek 25-12-2021 14-26](https://user-images.githubusercontent.com/6766154/147386450-bacc2e3b-100d-4caf-b99a-8d1674ff1b7d.gif)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed camera rotation when going across grids.

