### PR TITLE
Cardboard box, weight changes, bureaucracy crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -45,3 +45,15 @@
   cost: 1000
   category: Service
   group: market
+
+- type: cargoProduct
+  name: "bureaucracy crate"
+  id: ServiceBureaucracy
+  description: "Several stacks of paper and a few pens, what more can you ask for."
+  icon:
+    sprite: Objects/Misc/bureaucracy.rsi
+    state: pen
+  product: CrateServiceBureaucracy
+  cost: 500
+  category: Service
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -54,6 +54,6 @@
     sprite: Objects/Misc/bureaucracy.rsi
     state: pen
   product: CrateServiceBureaucracy
-  cost: 500
+  cost: 1000
   category: Service
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -1,6 +1,22 @@
 - type: entity
-  name: lightbulb box
+  name: cardboard box
   parent: BoxBase
+  id: BoxCardboard
+  description: A cardboard box for storing things.
+  components:
+  - type: Sprite
+    layers:
+      - state: box
+      - state: writing
+  - type: Item
+    size: 20
+  - type: Storage
+    capacity: 20
+    size: 20
+
+- type: entity
+  name: lightbulb box
+  parent: BoxCardboard
   id: BoxLightbulb
   description: This box is shaped on the inside so that only light tubes and bulbs fit.
   components:
@@ -13,10 +29,13 @@
       - state: box
       - state: light
   - type: Item
+    size: 60
+  - type: Storage
+    capacity: 60
 
 - type: entity
   name: lighttube box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxLighttube
   description: This box is shaped on the inside so that only light tubes and bulbs fit.
   components:
@@ -29,10 +48,13 @@
       - state: box
       - state: lighttube
   - type: Item
+    size: 60
+  - type: Storage
+    capacity: 60
 
 - type: entity
   name: mixed lights box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxLightMixed
   description: This box is shaped on the inside so that only light tubes and bulbs fit.
   components:
@@ -47,28 +69,32 @@
       - state: box
       - state: lightmixed
   - type: Item
+    size: 60
+  - type: Storage
+    capacity: 60
 
 - type: entity
   name: pda box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxPDA
   description: A box of spare PDA microcomputers.
   components:
   - type: StorageFill
     contents:
       - id: AssistantPDA
-        amount: 3
+        amount: 6
   - type: Sprite
     layers:
       - state: box
       - state: pda
   - type: Item
+    size: 60
   - type: Storage
-    capacity: 30
+    capacity: 60
 
 - type: entity
   name: meson box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxMesonScanners
   description: A box of spare meson goggles.
   components:
@@ -80,13 +106,10 @@
     layers:
       - state: box
       - state: meson
-  - type: Item
-  - type: Storage
-    capacity: 20
 
 - type: entity
   name: survival box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxSurvival
   description: It's box with basic internals inside.
   components:
@@ -97,19 +120,13 @@
       - id: EpinephrineMedipen
       - id: Flare
       - id: FoodSnackChocolate
-  - type: Sprite
-    layers:
-      - state: box
-      - state: writing
-  - type: Item
-    size: 20
   - type: Storage
     capacity: 30
     size: 30
 
 - type: entity
   name: box of hugs
-  parent: BoxSurvival
+  parent: BoxCardboard
   id: BoxHug
   description: A special box for sensitive people.
   components:
@@ -119,3 +136,10 @@
       - state: heart
   - type: Item
     HeldPrefix: hug
+  - type: StorageFill
+    contents:
+      - id: Brutepack
+        amount: 5
+  - type: Storage
+    capacity: 30
+    size: 30

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -139,7 +139,7 @@
   - type: StorageFill
     contents:
       - id: Brutepack
-        amount: 5
+        amount: 6
   - type: Storage
     capacity: 30
     size: 30

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -7,7 +7,6 @@
   - type: Sprite
     layers:
       - state: box
-      - state: writing
   - type: Item
     size: 20
   - type: Storage
@@ -28,10 +27,11 @@
     layers:
       - state: box
       - state: light
-  - type: Item
-    size: 60
   - type: Storage
     capacity: 60
+    whitelist:
+      components:
+      - LightBulb
 
 - type: entity
   name: lighttube box
@@ -47,10 +47,11 @@
     layers:
       - state: box
       - state: lighttube
-  - type: Item
-    size: 60
   - type: Storage
     capacity: 60
+    whitelist:
+      components:
+      - LightBulb
 
 - type: entity
   name: mixed lights box
@@ -68,10 +69,11 @@
     layers:
       - state: box
       - state: lightmixed
-  - type: Item
-    size: 60
   - type: Storage
     capacity: 60
+    whitelist:
+      components:
+      - LightBulb
 
 - type: entity
   name: pda box
@@ -87,10 +89,11 @@
     layers:
       - state: box
       - state: pda
-  - type: Item
-    size: 60
   - type: Storage
     capacity: 60
+    whitelist:
+      components:
+      - PDA
 
 - type: entity
   name: meson box

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -123,6 +123,10 @@
       - id: EpinephrineMedipen
       - id: Flare
       - id: FoodSnackChocolate
+  - type: Sprite
+    layers:
+      - state: box
+      - state: writing
   - type: Storage
     capacity: 30
     size: 30

--- a/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: syringe box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxSyringe
   description: A box full of syringes.
   components:
@@ -12,14 +12,14 @@
     layers:
       - state: box
       - state: syringe
-
   - type: Item
+    size: 30
   - type: Storage
     capacity: 30
-    
+
 - type: entity
   name: pill canister box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxPillCanister
   description: A box full of pill canisters.
   components:
@@ -31,14 +31,14 @@
     layers:
       - state: box
       - state: pillbox
-
   - type: Item
+    size: 30
   - type: Storage
     capacity: 30
 
 - type: entity
   name: sterile box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxSterile
   description: This box contains sterile medical masks.
   components:
@@ -51,13 +51,9 @@
       - state: box
       - state: sterile
 
-  - type: Item
-  - type: Storage
-    capacity: 20
-
 - type: entity
   name: latex box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxLatex
   description: Contains sterile latex gloves.
   components:
@@ -69,7 +65,3 @@
     layers:
       - state: box
       - state: latex
-
-  - type: Item
-  - type: Storage
-    capacity: 20

--- a/Resources/Prototypes/Catalog/Fills/Boxes/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/science.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: beaker box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxBeaker
   description: A box full of beakers.
   components:
@@ -14,7 +14,7 @@
     layers:
       - state: box
       - state: beaker
-
   - type: Item
+    size: 30
   - type: Storage
     capacity: 30

--- a/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: handcuff box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxHandcuff
   description: A box full of handcuffs.
   components:
@@ -13,13 +13,9 @@
       - state: box_security
       - state: handcuff
 
-  - type: Item
-  - type: Storage
-    capacity: 20
-
 - type: entity
   name: flashbang box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxFlashbang
   description: 'WARNING: These devices are extremely dangerous and can cause blindness or deafness in repeated use.'
   components:
@@ -32,13 +28,9 @@
       - state: box_security
       - state: flashbang
 
-  - type: Item
-  - type: Storage
-    capacity: 20
-
 - type: entity
   name: sechud box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxSechud
   description: A box of security glasses.
   components:
@@ -51,13 +43,9 @@
       - state: box_security
       - state: sechud
 
-  - type: Item
-  - type: Storage
-    capacity: 20
-
 - type: entity
   name: ziptie box
-  parent: BoxBase
+  parent: BoxCardboard
   id: BoxZiptie
   description: A box full of zipties.
   components:
@@ -69,7 +57,3 @@
     layers:
       - state: box_security
       - state: ziptie
-
-  - type: Item
-  - type: Storage
-    capacity: 20

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -74,3 +74,16 @@
     - id: GroundTobacco
       amount: 4
     - id: Matchbox
+
+- type: entity
+  id: CrateServiceBureaucracy
+  name: bureaucracy crate
+  description: Several stacks of paper and a few pens, what more can you ask for.
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+    - id: Paper
+      amount: 15
+    - id: Pen
+      amount: 2

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -19,7 +19,7 @@
   - type: Item
     sprite: Objects/Consumable/Food/snacks.rsi
     HeldPrefix: packet
-
+    size: 3
 # Snacks
 
 # "Snacks" means food in a packet. Down the line this stuff can have multiple

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cartons.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CigCartonGreen
-  parent: BoxBase
+  parent: BoxCardboard
   name: Spessman's Smokes carton
   description: "A carton containing 6 packets of Spessman's Smokes."
   components:
@@ -12,6 +12,7 @@
     capacity: 36
   - type: Item
     sprite: Objects/Consumable/Smokeables/Cigarettes/Cartons/green.rsi
+    size: 36
   - type: StorageFill
     contents:
       - id: CigPackGreen

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -206,7 +206,7 @@
     - CrayonPurple
 
 - type: entity
-  parent: BaseItem
+  parent: BoxCardboard
   id: CrayonBox
   name: crayon box
   description: "It's a box of crayons."

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -219,7 +219,7 @@
     capacity: 7
   - type: Item
     sprite: Objects/Fun/crayons.rsi
-    size: 9999
+    size: 7
     HeldPrefix: box
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseItem
+  parent: BoxCardboard
   name: monkey cube box
   id: MonkeyCubeBox
   description: Drymate brand monkey cubes. Just add water!

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -23,6 +23,8 @@
           # This default isn't actually explicitly used right now.
           enum.PaperStatus.Blank: paper
           enum.PaperStatus.Written: paper_words
+  - type: Item
+    size: 1
 
 - type: entity
   parent: Paper
@@ -62,3 +64,4 @@
   - type: Item
     sprite: Objects/Misc/bureaucracy.rsi
     HeldPrefix: pen
+    size: 2

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -26,6 +26,7 @@
     state: blue-icon-3
   - type: Item
     sprite: Objects/Specific/Janitorial/trashbag.rsi
+    HeldPrefix: blue
     size: 125
   - type: Storage
     capacity: 125

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -19,21 +19,12 @@
 - type: entity
   name: trash bag
   id: TrashBagBlue
-  parent: BaseItem
+  parent: TrashBag
   components:
   - type: Sprite
-    sprite: Objects/Specific/Janitorial/trashbag.rsi
     state: blue-icon-3
   - type: Item
-    sprite: Objects/Specific/Janitorial/trashbag.rsi
     HeldPrefix: blue
-    size: 125
-  - type: Storage
-    capacity: 125
-    quickInsert: true
-    areaInsert: true
-    storageSoundCollection:
-      collection: trashBagRustle
 
 - type: entity
   name: spell of all-consuming cleanliness

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -6,6 +6,9 @@
   - type: Sprite
     sprite: Objects/Specific/Janitorial/trashbag.rsi
     state: icon-3
+  - type: Item
+    sprite: Objects/Specific/Janitorial/trashbag.rsi
+    size: 125
   - type: Storage
     capacity: 125
     quickInsert: true
@@ -21,6 +24,9 @@
   - type: Sprite
     sprite: Objects/Specific/Janitorial/trashbag.rsi
     state: blue-icon-3
+  - type: Item
+    sprite: Objects/Specific/Janitorial/trashbag.rsi
+    size: 125
   - type: Storage
     capacity: 125
     quickInsert: true

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -6,8 +6,6 @@
   - type: Sprite
     sprite: Objects/Specific/Janitorial/trashbag.rsi
     state: icon-3
-  - type: Item
-    sprite: Objects/Specific/Janitorial/trashbag.rsi
   - type: Storage
     capacity: 125
     quickInsert: true
@@ -23,9 +21,6 @@
   - type: Sprite
     sprite: Objects/Specific/Janitorial/trashbag.rsi
     state: blue-icon-3
-  - type: Item
-    sprite: Objects/Specific/Janitorial/trashbag.rsi
-    HeldPrefix: blue
   - type: Storage
     capacity: 125
     quickInsert: true

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -282,6 +282,7 @@
       - ServiceSmokeables
       - ServiceCustomSmokable
       - SalvageEquipment
+      - ServiceBureaucracy
       - EngineeringCableLv
       - EngineeringCableMv
       - EngineeringCableHv


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is a PR that does a few things that are small, if something needs to be separated to a separate PR or if I've overstepped please let me know:

ADD: basic cardboard box to base other cardboard boxes off of and allow them to be added to other storage.
CHANGE: boxes with high capacity to be whitelisted for their own specialized type, exceptions being the survival box for now.
CHANGE: weight of some smaller items:
   paper: 5 -> 1
   pen:  5 -> 2
   snacks: 5 -> 3
ADD: bureaucracy crate which contains some paper and pens
CHANGE: garbage bags to weigh their proper size
CHANGE: number of PDAs in PDA box to 6 to be more in line with ss13 value, box is whitelist only
ADD: bruise packs to the box of hugs

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
All boxes:
![image](https://user-images.githubusercontent.com/47410468/147400725-3e572981-8608-4f48-ba83-74cb9616f2d4.png)

still have content:
![image](https://user-images.githubusercontent.com/47410468/147400765-4e7b4d35-5ff5-422e-b9e1-aba78e6938e9.png)

cannot insert random items into lightbulb box:
![image](https://user-images.githubusercontent.com/47410468/147400787-c1cca5fe-f5fb-47c1-bdef-5ac6aad075a9.png)

boxes now fit into backpacks:
![image](https://user-images.githubusercontent.com/47410468/147400805-356e44e2-9097-42a9-9981-b2fccc539898.png)

trashbags do not fit into pockets:
![image](https://user-images.githubusercontent.com/47410468/147400812-28122be3-52a7-46f9-8c95-a5dab070f097.png)

bureaucracy crate
![image](https://user-images.githubusercontent.com/47410468/147400832-0376348f-cb28-4c4f-a3b9-8e8439074690.png)

has what it says and new weight:
![image](https://user-images.githubusercontent.com/47410468/147400865-7b73cdf2-2e66-471a-a6e7-fd737f96b89a.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: added a bureaucracy crate for when the mime reaches the end of his pages
- change: size of boxes so they can fit inside backpacks, changed garbage bags so they don't
- add: bruise packs to the clown's box of hugs
- change: size of pen and papers to not take up so much space
- add: 3 more PDAs to the Head of Personal's spare PDA box
