### PR TITLE
Makes beanbag shells stun

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -26,6 +26,8 @@
       types:
         Blunt: 10
   - type: StunOnCollide
+    stunAmount: 5
+    knockdownAmount: 3
 
 - type: entity
   id: PelletShotgun


### PR DESCRIPTION
Very simple fix. Previously beanbag rounds had a stun element but didn't actually do anything. Simply added a 3 second time to the stun so not as good as tasers but knocks you down if it hits you.

:cl:
- fix: Beanbag rounds now stun people.

