### PR TITLE
Fix Salvage Crate not being in the computer.

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_salvage.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_salvage.yml
@@ -6,6 +6,6 @@
     sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
     state: icon
   product: CrateSalvageEquipment
-  cost: 5000
+  cost: 8000
   category: Salvage
   group: market

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -281,6 +281,7 @@
       - ServiceLightsReplacement
       - ServiceSmokeables
       - ServiceCustomSmokable
+      - SalvageEquipment
       - EngineeringCableLv
       - EngineeringCableMv
       - EngineeringCableHv


### PR DESCRIPTION
Forgot to add the crate to the computers.yml!

:cl: Pancake
- tweak: Salvage Equipment crates can be purchased from the cargo computer.

