### PR TITLE
Containers with access readers have properly restrictive access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -109,7 +109,7 @@
       broken: true
     - type: WiresVisualizer
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Bar"]]
 
 - type: entity
   parent: VendingMachine
@@ -138,7 +138,7 @@
       broken: true
     - type: WiresVisualizer
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Bar"]]
 
 - type: entity
   parent: VendingMachine
@@ -469,7 +469,7 @@
       broken: true
     - type: WiresVisualizer
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Hydroponics"]]
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -538,7 +538,7 @@
       broken: true
     - type: WiresVisualizer
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Hydroponics"]]
   - type: PointLight
     radius: 1.5
     energy: 1.6

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -65,7 +65,7 @@
     - type: StorageVisualizer
       state: ce
   - type: AccessReader
-    access: [ [ "Engineering", "Command" ] ]
+    access: [ [ "ChiefEngineer" ] ]
 
 # Electrical supplies
 - type: entity
@@ -132,7 +132,7 @@
     - type: StorageVisualizer
       state: freezer
   - type: AccessReader
-    access: [ [ "Service" ] ]
+    access: [ [ "Kitchen" ] ]
 
 # Botanist
 - type: entity
@@ -145,7 +145,7 @@
     - type: StorageVisualizer
       state: hydro
   - type: AccessReader
-    access: [ [ "Service" ] ]
+    access: [ [ "Hydroponics" ] ]
 
 # Medicine
 - type: entity
@@ -199,7 +199,7 @@
     - type: StorageVisualizer
       state: cmo
   - type: AccessReader
-    access: [ [ "Medical", "Command" ] ]
+    access: [ [ "ChiefMedicalOfficer" ] ]
 
 # Science
 - type: entity
@@ -212,7 +212,7 @@
     - type: StorageVisualizer
       state: rd
   - type: AccessReader
-    access: [ [ "Research", "Command" ] ]
+    access: [ [ "ResearchDirector" ] ]
 
 - type: entity
   id: LockerScientist
@@ -237,7 +237,7 @@
     - type: StorageVisualizer
       state: hos
   - type: AccessReader
-    access: [["Security", "Command"]]
+    access: [["HeadOfSecurity"]]
 
 # Warden
 - type: entity
@@ -273,7 +273,7 @@
   description: Usually cold and empty... like your heart.
   components:
   - type: AccessReader
-    access: [["Service"]] # TODO access [["Detective"]]
+    access: [["Security"]] # TODO access [["Detective"]]
 
 # Syndicate
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -495,7 +495,7 @@
   parent: CrateBaseSecure
   components:
   - type: AccessReader
-    access: [["Service"]]
+    access: [["Hydroponics"]]
   - type: Lock
   - type: Sprite
     sprite: Structures/Storage/Crates/hydro_secure.rsi
@@ -524,7 +524,7 @@
   parent: CrateBaseSecure
   components:
   - type: AccessReader
-    access: [["Security"]]
+    access: [["Armory"]]
   - type: Lock
   - type: Sprite
     sprite: Structures/Storage/Crates/weapon.rsi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Several containers had access that was too permissive, so I changed them to be properly restricted.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Containers with access readers have been reconfigured to ensure they have the proper restrictions. Botanists are the major winners here.

