### PR TITLE
Adds a lobby final countdown.

### DIFF
--- a/Content.Server/GameTicking/GameTicker.CVars.cs
+++ b/Content.Server/GameTicking/GameTicker.CVars.cs
@@ -16,6 +16,9 @@ namespace Content.Server.GameTicking
         public TimeSpan LobbyDuration { get; private set; } = TimeSpan.Zero;
 
         [ViewVariables]
+        public TimeSpan LobbyFinalCountdownDuration { get; private set; } = TimeSpan.Zero;
+
+        [ViewVariables]
         public bool DisallowLateJoin { get; private set; } = false;
 
         [ViewVariables]
@@ -32,6 +35,8 @@ namespace Content.Server.GameTicking
             _configurationManager.OnValueChanged(CCVars.GameLobbyEnabled, value => LobbyEnabled = value, true);
             _configurationManager.OnValueChanged(CCVars.GameDummyTicker, value => DummyTicker = value, true);
             _configurationManager.OnValueChanged(CCVars.GameLobbyDuration, value => LobbyDuration = TimeSpan.FromSeconds(value), true);
+            _configurationManager.OnValueChanged(CCVars.GameLobbyFinalCountdownDuration,
+                value => LobbyFinalCountdownDuration = TimeSpan.FromSeconds(value), true);
             _configurationManager.OnValueChanged(CCVars.GameDisallowLateJoins,
                 value => { DisallowLateJoin = value; UpdateLateJoinStatus(); UpdateJobsAvailable(); }, true);
             _configurationManager.OnValueChanged(CCVars.StationOffset, value => StationOffset = value, true);

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -20,9 +20,6 @@ namespace Content.Server.GameTicking
         private TimeSpan _roundStartTime;
 
         [ViewVariables]
-        private readonly TimeSpan _finalCountdownTime = new TimeSpan(0, 0, 10);
-
-        [ViewVariables]
         private TimeSpan _pauseTime;
 
         [ViewVariables]
@@ -144,9 +141,9 @@ namespace Content.Server.GameTicking
             {
                 if (!_playersInLobby.ContainsValue(LobbyPlayerStatus.NotReady))
                 {
-                    if ((_roundStartTime - _gameTiming.CurTime) > _finalCountdownTime)
+                    if ((_roundStartTime - _gameTiming.CurTime) > LobbyFinalCountdownDuration)
                     {
-                        _roundStartTime = _gameTiming.CurTime + _finalCountdownTime;
+                        _roundStartTime = _gameTiming.CurTime + LobbyFinalCountdownDuration;
                     }
                 }
 

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -20,6 +20,9 @@ namespace Content.Server.GameTicking
         private TimeSpan _roundStartTime;
 
         [ViewVariables]
+        private readonly TimeSpan _finalCountdownTime = new TimeSpan(0, 0, 10);
+
+        [ViewVariables]
         private TimeSpan _pauseTime;
 
         [ViewVariables]
@@ -135,6 +138,20 @@ namespace Content.Server.GameTicking
             _playersInLobby[player] = ready ? LobbyPlayerStatus.Ready : LobbyPlayerStatus.NotReady;
             RaiseNetworkEvent(GetStatusMsg(player), player.ConnectedClient);
             RaiseNetworkEvent(GetStatusSingle(player, status));
+
+            //The final countdown conditions checkup.
+            if (!Paused)
+            {
+                if (!_playersInLobby.ContainsValue(LobbyPlayerStatus.NotReady))
+                {
+                    if ((_roundStartTime - _gameTiming.CurTime) > _finalCountdownTime)
+                    {
+                        _roundStartTime = _gameTiming.CurTime + _finalCountdownTime;
+                    }
+                }
+
+                RaiseNetworkEvent(new TickerLobbyCountdownEvent(_roundStartTime, Paused));
+            }
         }
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -76,6 +76,12 @@ namespace Content.Shared.CCVar
             GameLobbyDuration = CVarDef.Create("game.lobbyduration", 150, CVar.ARCHIVE);
 
         /// <summary>
+        ///     Controls the duration of the final countdown timer in lobby when all players are ready. In seconds.
+        /// </summary>
+        public static readonly CVarDef<int>
+            GameLobbyFinalCountdownDuration = CVarDef.Create("game.lobbyfinalcountdownduration", 10, CVar.ARCHIVE);
+
+        /// <summary>
         ///     Controls if players can latejoin at all.
         /// </summary>
         public static readonly CVarDef<bool>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Setting a round start time to 10 seconds (default value) when all players in the lobby pressed the "Ready Up" button.

The final countdown duration can be changed by using cvar.

https://user-images.githubusercontent.com/91910481/147684742-ea1a4be2-e0a5-420e-9515-2a3856069aab.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added a final countdown in the lobby when all players are ready. 
