### PR TITLE
Reregister ghost role when player ghosts while alive

### DIFF
--- a/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
@@ -56,7 +56,7 @@ namespace Content.Server.Ghost.Roles.Components
         }
 
         [ViewVariables(VVAccess.ReadOnly)]
-        public bool Taken { get; protected set; }
+        public bool Taken { get; set; }
 
         [ViewVariables]
         public uint Identifier { get; set; }

--- a/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
@@ -61,6 +61,13 @@ namespace Content.Server.Ghost.Roles.Components
         [ViewVariables]
         public uint Identifier { get; set; }
 
+        /// <summary>
+        /// Reregisters the ghost role when the current player ghosts.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("reregister")]
+        public bool ReregisterOnGhost { get; set; } = true;
+
         protected override void Initialize()
         {
             base.Initialize();

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -204,6 +204,8 @@ namespace Content.Server.Ghost.Roles
 
         private void OnMindRemoved(EntityUid uid, GhostRoleComponent component, MindRemovedMessage args)
         {
+            if (!component.ReregisterOnGhost)
+                return;
             component.Taken = false;
             RegisterGhostRole(component);
         }

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.EUI;
 using Content.Server.Ghost.Components;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Ghost.Roles.UI;
+using Content.Server.Mind.Components;
 using Content.Server.Players;
 using Content.Shared.Administration;
 using Content.Shared.GameTicking;
@@ -42,6 +43,7 @@ namespace Content.Server.Ghost.Roles
 
             SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
+            SubscribeLocalEvent<GhostRoleComponent, MindRemovedMessage>(OnMindRemoved);
 
             _playerManager.PlayerStatusChanged += PlayerStatusChanged;
         }
@@ -198,6 +200,12 @@ namespace Content.Server.Ghost.Roles
             if (!_openUis.ContainsKey(message.Player)) return;
             if (EntityManager.HasComponent<GhostComponent>(message.Entity)) return;
             CloseEui(message.Player);
+        }
+
+        private void OnMindRemoved(EntityUid uid, GhostRoleComponent component, MindRemovedMessage args)
+        {
+            component.Taken = false;
+            RegisterGhostRole(component);
         }
 
         public void Reset(RoundRestartCleanupEvent ev)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If a player ghosts while the ghost role is still alive, this puts the ghost role back into the list.