### PR TITLE
Fixed issue with beaker not displaying liquid content after grind

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -318,7 +318,6 @@ namespace Content.Server.Kitchen.EntitySystems
                                 component.HeldBeaker.MaxVolume) continue;
                             solution.ScaleSolution(juiceEvent.Scalar);
                             _solutionsSystem.TryAddSolution(beakerEntity.Value, component.HeldBeaker, solution);
-                            _solutionsSystem.RemoveAllSolution(beakerEntity.Value, solution);
                             EntityManager.DeleteEntity(item);
                         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #5957 - Beaker not displaying contents visually after grinding

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
**Before:**
https://user-images.githubusercontent.com/1194692/147797992-41b788c1-f53c-4118-ad31-48dc66f947f7.mp4



**After:**
https://user-images.githubusercontent.com/1194692/147798001-f8abd840-4219-42fc-88a2-1c813d17c67c.mp4



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: MeltedPixel
- Fix: Fixed issue where beaker contents visually did not show after being ground in the grinder.

