### PR TITLE
A number of Packed fixes.

### DIFF
--- a/Resources/Maps/packedstation.yml
+++ b/Resources/Maps/packedstation.yml
@@ -81411,6 +81411,16 @@ entities:
   - pos: 51.5,-26.5
     parent: 0
     type: Transform
+- uid: 7951
+  type: ComputerCrewMonitoring
+  components:
+  - pos: 31.5,48.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 7952
   type: ReinforcedPlasmaWindow
   components:
@@ -114602,6 +114612,26 @@ entities:
   - pos: 30.5,-23.5
     parent: 0
     type: Transform
+- uid: 11177
+  type: ComputerCrewMonitoring
+  components:
+  - pos: 44.5,2.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 11178
+  type: ComputerCrewMonitoring
+  components:
+  - pos: 54.5,-11.5
+    parent: 0
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 11179
   type: SmgWt550
   components:
@@ -117630,6 +117660,14 @@ entities:
   - containers:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
+- uid: 11562
+  type: Basketball
+  components:
+  - pos: 30.518913,4.5333457
+    parent: 0
+    type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 11563
   type: CableTerminal
   components:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

This PR adds some requested features to Packed, including more lights (fixes #5871 ) and some non-lethal gear (including tasers and zipties) to Security in order to curb wanton gun violence. Salvage now starts with two hardsuit crates. The secret areas that used to have the Gough carvings have been re-stocked as well.

Edit: Here's a complete list of changes:

- Poster spawners were added to some locations that were bare walls in Canon Packed.
- The doors in Toxins that were previously all-access have been fixed.
- The shower room now has a door that leads to the hallway (how the hell did I miss that?)
- Rollerbeds were added to Medbay to match Canon Packed.
- Security now starts with a number of tasers and a box of zipties.
- Salvage now starts with two hardsuit crates.
- Secret areas have been restocked.
- Removes the plasma on Packedstation entirely.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/7907891/147417866-51602808-380e-4c23-87b0-336984378a35.png)

![image](https://user-images.githubusercontent.com/7907891/147417876-53a71f95-79ef-4987-bd34-e8f60809f1c5.png)

![image](https://user-images.githubusercontent.com/7907891/147417891-4fd357ff-cb51-4eb7-8afb-7e049dd20964.png)

![image](https://user-images.githubusercontent.com/7907891/147417896-1297a530-01e5-4fe8-8bf6-e7ee9df26770.png)
Changelog
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Packed Station is now significantly brighter.
- tweak: Cargo on Packed Station now has two starting hardsuit crates.
- tweak: In response to rampant gun violence, Security on Packed Station now has some new non-lethal gear.
- add: Some of the secret areas on Packed Station have been re-stocked.
- remove: Packed Station's plasma canisters have been replaced with Nanotrasen-brand Safety Plasma.