### PR TITLE
Fix inventory UI not showing entities

### DIFF
--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -86,20 +86,23 @@ namespace Content.Client.Inventory
 
         private void OnDidUnequip(EntityUid uid, ClientInventoryComponent component, DidUnequipEvent args)
         {
-            UpdateComponentUISlot(component, args.Slot, null);
+            UpdateComponentUISlot(uid, component, args.Slot, null);
         }
 
         private void OnDidEquip(EntityUid uid, ClientInventoryComponent component, DidEquipEvent args)
         {
-            UpdateComponentUISlot(component, args.Slot, args.Equipment);
+            UpdateComponentUISlot(uid, component, args.Slot, args.Equipment);
         }
 
-        private void UpdateComponentUISlot(ClientInventoryComponent component, string slot, EntityUid? entity)
+        private void UpdateComponentUISlot(EntityUid uid, ClientInventoryComponent? component, string slot, EntityUid? item)
         {
+            if (!Resolve(uid, ref component))
+                return;
+
             if (!component.SlotButtons.TryGetValue(slot, out var buttons))
                 return;
 
-            UpdateUISlot(buttons, entity);
+            UpdateUISlot(buttons, item);
         }
 
         private void UpdateUISlot(List<ItemSlotButton> buttons, EntityUid? entity)

--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -94,7 +94,7 @@ namespace Content.Client.Inventory
             UpdateComponentUISlot(uid, component, args.Slot, args.Equipment);
         }
 
-        private void UpdateComponentUISlot(EntityUid uid, ClientInventoryComponent? component, string slot, EntityUid? item)
+        private void UpdateComponentUISlot(EntityUid uid, string slot, EntityUid? item, ClientInventoryComponent? component = null)
         {
             if (!Resolve(uid, ref component))
                 return;

--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -86,12 +86,12 @@ namespace Content.Client.Inventory
 
         private void OnDidUnequip(EntityUid uid, ClientInventoryComponent component, DidUnequipEvent args)
         {
-            UpdateComponentUISlot(uid, component, args.Slot, null);
+            UpdateComponentUISlot(uid, args.Slot, null, component);
         }
 
         private void OnDidEquip(EntityUid uid, ClientInventoryComponent component, DidEquipEvent args)
         {
-            UpdateComponentUISlot(uid, component, args.Slot, args.Equipment);
+            UpdateComponentUISlot(uid, args.Slot, args.Equipment, component);
         }
 
         private void UpdateComponentUISlot(EntityUid uid, string slot, EntityUid? item, ClientInventoryComponent? component = null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #5978 

Inventory UI was not fetching stored items when first initialized.
This was more noticeable when PVS was off. The stored entities and the human mob got received at the same time which usually called the inventory update functions before the buttons were initialized and thus not showing the entities contained.