### PR TITLE
Prevent equipping HandVirtualItems

### DIFF
--- a/Content.Client/Hands/Systems/HandVirtualItemSystem.cs
+++ b/Content.Client/Hands/Systems/HandVirtualItemSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Client.Items;
+using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
@@ -6,7 +7,7 @@ using Robust.Shared.GameObjects;
 namespace Content.Client.Hands.Systems
 {
     [UsedImplicitly]
-    public sealed class HandVirtualItemSystem : EntitySystem
+    public sealed class HandVirtualItemSystem : SharedHandVirtualItemSystem
     {
         public override void Initialize()
         {

--- a/Content.Server/Hands/Systems/HandVirtualItemSystem.cs
+++ b/Content.Server/Hands/Systems/HandVirtualItemSystem.cs
@@ -8,7 +8,7 @@ using Robust.Shared.GameObjects;
 namespace Content.Server.Hands.Systems
 {
     [UsedImplicitly]
-    public sealed class HandVirtualItemSystem : EntitySystem
+    public sealed class HandVirtualItemSystem : SharedHandVirtualItemSystem
     {
         public override void Initialize()
         {

--- a/Content.Shared/Hands/SharedHandVirtualItemSystem.cs
+++ b/Content.Shared/Hands/SharedHandVirtualItemSystem.cs
@@ -1,0 +1,20 @@
+﻿using Content.Shared.Hands.Components;
+using Content.Shared.Inventory.Events;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.Hands;
+
+public abstract class SharedHandVirtualItemSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HandVirtualItemComponent, BeingEquippedAttemptEvent>(OnBeingEquippedAttempt);
+    }
+
+    private void OnBeingEquippedAttempt(EntityUid uid, HandVirtualItemComponent component, BeingEquippedAttemptEvent args)
+    {
+        args.Cancel();
+    }
+}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Prevents hands virtual entities from being equipped in the inventory.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- remove: Removed the ability to stuff the held part of a pulled entity in your pocket.