### PR TITLE
Fix player tab opening multiple VV when closed by the X and reopened

### DIFF
--- a/Content.Client/Administration/AdminSystem.Menu.cs
+++ b/Content.Client/Administration/AdminSystem.Menu.cs
@@ -94,7 +94,12 @@ namespace Content.Client.Administration
 
         public void Open()
         {
-            _window ??= new AdminMenuWindow();
+            if (_window == null)
+            {
+                _window = new AdminMenuWindow();
+                _window.OnClose += Close;
+            }
+
             _window.PlayerTabControl.OnEntryPressed += PlayerTabEntryPressed;
             _window.OpenCentered();
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Player tab was missing an unsubscribe when the window was closed using the X button.