### PR TITLE
Changes tile crafting recipe to make four floor tiles per unit of material used.

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/tiles.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/tiles.yml
@@ -5,6 +5,9 @@
     - node: start
       edges:
         - to: steeltile
+          completed:
+            - !type:SetStackCount
+              amount: 4
           steps:
             - material: Steel
               amount: 1
@@ -18,8 +21,12 @@
     - node: start
       edges:
         - to: woodtile
+          completed:
+            - !type:SetStackCount
+              amount: 4
           steps:
             # Needs StackType ID
             - material: WoodPlank
+              amount: 1
     - node: woodtile
       entity: FloorTileItemWood

--- a/Resources/Prototypes/Recipes/Crafting/tiles.yml
+++ b/Resources/Prototypes/Recipes/Crafting/tiles.yml
@@ -7,7 +7,7 @@
   startNode: start
   targetNode: steeltile
   category: Tiles
-  description: "A steel station tile."
+  description: "Four steel station tiles."
   icon: Objects/Tiles/tile.rsi/steel.png
   objectType: Item
 
@@ -18,7 +18,7 @@
   startNode: start
   targetNode: woodtile
   category: Tiles
-  description: "A piece of wooden station flooring."
+  description: "Four pieces of wooden station flooring."
   icon: Objects/Tiles/tile.rsi/wood.png
   objectType: Item
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the crafting recipe of tiles from producing one tile per unit of material to four tiles per unit, bringing crafting in line to SS13 (i.e. /[tg/station](https://tgstation13.org/wiki/Guide_to_construction#Floor_Tiles)) and seriously cutting down on resources needed for floor repair or replacement. Changes are based on the scripting used for metal rod crafting. I've also changed the recipe's description to reflect the amount of tiles produced.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Floor tile crafting now produces four floor tiles instead of one.


