### PR TITLE
Sync station rotation with a spawned salvage rotation

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -215,7 +215,7 @@ namespace Content.Server.Salvage
             {
                 coords = new EntityCoordinates(smc.Owner, smc.Offset).ToMap(EntityManager);
                 var grid = tsc.GridID;
-                if (grid != GridId.Invalid && _mapManager.TryGetGrid(grid, out var magnetGrid))
+                if (_mapManager.TryGetGrid(grid, out var magnetGrid))
                 {
                     angle = magnetGrid.WorldRotation;
                 }

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -215,10 +215,9 @@ namespace Content.Server.Salvage
             {
                 coords = new EntityCoordinates(smc.Owner, smc.Offset).ToMap(EntityManager);
                 var grid = tsc.GridID;
-                if (grid != GridId.Invalid)
+                if (grid != GridId.Invalid && _mapManager.TryGetGrid(grid, out var magnetGrid))
                 {
-                    // Has a valid grid - synchronize angle so that salvage doesn't have to deal with cross-grid manipulation issues
-                    angle = tsc.WorldRotation;
+                    angle = magnetGrid.WorldRotation;
                 }
                 return true;
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before this PR salvage spawns with 180 degrees rotation. It's annoying.
Now salvage spawns with the same rotation as station.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Spawned salvage now synced with a station rotation.

