### PR TITLE
Add content to radiation closets and medicine lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -106,5 +106,7 @@
         amount: 2
       - id: ClothingOuterSuitRad
         amount: 2
+      - id: ClothingEyesGlassesMeson
+        amount: 2
 
   

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -98,7 +98,7 @@
   id: ClosetRadiationSuitFilled
   parent: ClosetRadiationSuit
   suffix: Filled
-  description: "More comfortable then radiation poisioning."
+  description: "More comfortable than radiation poisioning."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -98,7 +98,7 @@
   id: ClosetRadiationSuitFilled
   parent: ClosetRadiationSuit
   suffix: Filled
-  description: "More comfortable then radiation poisioning"
+  description: "More comfortable then radiation poisioning."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -98,3 +98,13 @@
   id: ClosetRadiationSuitFilled
   parent: ClosetRadiationSuit
   suffix: Filled
+  description: "More comfortable then radiation poisioning"
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingHeadHatHoodRad
+        amount: 2
+      - id: ClothingOuterSuitRad
+        amount: 2
+
+  

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -98,7 +98,6 @@
   id: ClosetRadiationSuitFilled
   parent: ClosetRadiationSuit
   suffix: Filled
-  description: "More comfortable than radiation poisioning."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -2,6 +2,19 @@
   id: LockerMedicineFilled
   suffix: Filled
   parent: LockerMedicine
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxPillCanister
+        amount: 1
+      - id: BoxSyringe
+        amount: 1
+      - id: EpinephrineChemistryBottle
+        amount: 3
+      - id: Brutepack
+        amount: 2
+      - id: Ointment
+        amount: 2
 
 - type: entity
   id: LockerMedicalFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -2,7 +2,6 @@
   id: LockerMedicineFilled
   suffix: Filled
   parent: LockerMedicine
-  description: "Ze healing leaves little time for ze hurting."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -2,6 +2,7 @@
   id: LockerMedicineFilled
   suffix: Filled
   parent: LockerMedicine
+  description: "Ze healing leaves little time for ze hurting."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
@@ -17,7 +17,7 @@
   id: ClosetRadiationSuit
   name: radiation suit closet
   parent: ClosetBase
-  description: It's a storage unit for rad-protective suits.
+  description: "More comfortable than radiation poisioning."
   components:
   - type: Appearance
     visuals:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The currently implemented versions of filled radiation closets and medicine lockers are empty. I've changed this, adding rad suits to the radiation closet and some medical supplies to the medicine lockers, as well as giving catchy descriptions to both. This should hopefully result in less engineers dying from the singularity and provide a source of medicine to doctors when the NanoMeds aren't working.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Radiation closets and medicine lockers now come with supplies inside.


