### PR TITLE
Events/PowerGridCheck: Stagger the shutdown/reboot

### DIFF
--- a/Content.Server/StationEvents/Events/PowerGridCheck.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheck.cs
@@ -144,12 +144,15 @@ namespace Content.Server.StationEvents.Events
             {
                 // The (rough) goal for how long each stage should take to shut down
                 var tgt = SHUTOFF_TARGET_MS / _powerStages.Count;
-                // Half the target
-                var htgt = (int) (0.5f * tgt);
 
                 // The actual next time will be fudged ±50% of the target.
-                var nt = _random.Next(tgt - htgt, tgt + htgt);
-                Timer.Spawn(nt, () => DoShutoff(tier+1));
+                Timer.Spawn(
+                    _random.Next(
+                        tgt - (int)(0.5f * tgt),
+                        tgt + (int)(0.5f * tgt)
+                    ),
+                    () => DoShutoff(tier + 1)
+                );
             }
         }
 
@@ -172,10 +175,14 @@ namespace Content.Server.StationEvents.Events
             {
                 // Same as the DoShutoff version.
                 var tgt = REBOOT_TARGET_MS / _powerStages.Count;
-                var htgt = (int) (0.5f * tgt);
 
-                var nt = _random.Next(tgt - htgt, tgt + htgt);
-                Timer.Spawn(nt, () => DoReboot(tier-1));
+                Timer.Spawn(
+                    _random.Next(
+                        tgt - (int)(0.5f * tgt),
+                        tgt + (int)(0.5f * tgt)
+                    ),
+                    () => DoReboot(tier - 1)
+                );
             }
         }
 

--- a/Content.Server/StationEvents/Events/PowerGridCheck.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheck.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Content.Server.Power.Components;
+using Content.Server.NodeContainer;
+using Content.Server.NodeContainer.NodeGroups;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
 using Robust.Shared.GameObjects;
@@ -28,7 +31,10 @@ namespace Content.Server.StationEvents.Events
 
         private CancellationTokenSource? _announceCancelToken;
 
-        private readonly List<EntityUid> _powered = new();
+        private readonly List<HashSet<NodeContainerComponent>> _powerStages = new();
+
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
 
         public override void Announce()
         {
@@ -36,32 +42,146 @@ namespace Content.Server.StationEvents.Events
             EndAfter = IoCManager.Resolve<IRobustRandom>().Next(60, 120);
         }
 
+        private const int SHUTOFF_TARGET_MS = 8000;
+        private const int REBOOT_TARGET_MS = 4000;
+
+        private static bool IsAcceptableNode(NodeGroupID i) => i is NodeGroupID.HVPower or NodeGroupID.MVPower or NodeGroupID.Apc;
+
         public override void Startup()
         {
-            var entityManager = IoCManager.Resolve<IEntityManager>();
+            // Everything we've ever seen. Used to avoid loops.
+            var seen = new HashSet<NodeContainerComponent>();
+            // Current sources. Not like electrical current, just the ones we're using right now.
+            var curr = new HashSet<NodeContainerComponent>();
+            // Current children, i.e. the next curr
+            var next = new HashSet<NodeContainerComponent>();
 
-            foreach (var component in entityManager.EntityQuery<ApcPowerReceiverComponent>(true))
+            // First we get the seed units
+            foreach (var (ngComp, pSupComp) in _entityManager.EntityQuery<NodeContainerComponent, PowerSupplierComponent>(true))
             {
-                component.PowerDisabled = true;
-                _powered.Add(component.Owner);
+                // We start with the HV networks
+                if (ngComp.Nodes.Values.Any(n => n.NodeGroupID == NodeGroupID.HVPower))
+                {
+                    curr.Add(ngComp);
+                }
             }
+
+            // Break 'em in to tiers
+            while (curr.Count > 0)
+            {
+                foreach (var cncc in curr)
+                {
+                    // Seen 'em? Skip em.
+                    if (!seen.Add(cncc))
+                        continue;
+
+                    // No breaking atmos nets, pls
+                    foreach (var n in cncc.Nodes.Values.Where(nn => IsAcceptableNode(nn.NodeGroupID)))
+                    {
+                        foreach (var rn in n.ReachableNodes)
+                        {
+                            // WHY DO WE HAVE TO PUT THIS SO MANY LAYERS DOWN
+                            // FUCK
+                            if (_entityManager.TryGetComponent<NodeContainerComponent>(rn.Owner, out var ncc))
+                                next.Add(ncc);
+                        }
+                    }
+                }
+
+                _powerStages.Add(curr);
+                curr = next;
+                next = new();
+            }
+
+            if (next.Count > 0)
+                _powerStages.Add(next);
+
+            DoShutoff(0);
 
             base.Startup();
         }
 
+        private void Toggle(EntityUid owner, bool off)
+        {
+            if (_entityManager.Deleted(owner))
+                return;
+
+            // We try to be as component-agnostic as possible here, so we try everything.
+
+            if (_entityManager.TryGetComponent<PowerSupplierComponent>(owner, out var psc))
+                psc.Enabled = !off;
+
+            // Nothing to shut off?
+            /*
+            if (_entityManager.TryGetComponent<PowerConsumerComponent>(pns.Owner, out var pcc))
+                pcc.
+            */
+
+            if (_entityManager.TryGetComponent<PowerNetworkBatteryComponent>(owner, out var pnbc))
+                pnbc.Enabled = !off;
+
+            // Nothing to shut off here either, I guess
+            /*
+            if (_entityManager.TryGetComponent<ApcPowerProviderComponent>(pns.Owner, out var appc))
+                appc.
+            */
+
+            if (_entityManager.TryGetComponent<ApcPowerReceiverComponent>(owner, out var aprc))
+                aprc.PowerDisabled = off;
+        }
+
+        private void DoShutoff(int tier, bool fast = false)
+        {
+            if (tier >= _powerStages.Count)
+                return;
+
+            foreach (var pns in _powerStages[tier])
+                Toggle(pns.Owner, true);
+
+            if (fast)
+                DoShutoff(tier+1);
+            else
+            {
+                // The (rough) goal for how long each stage should take to shut down
+                var tgt = SHUTOFF_TARGET_MS / _powerStages.Count;
+                // Half the target
+                var htgt = (int) (0.5f * tgt);
+
+                // The actual next time will be fudged ±50% of the target.
+                var nt = _random.Next(tgt - htgt, tgt + htgt);
+                Timer.Spawn(nt, () => DoShutoff(tier+1));
+            }
+        }
+
+        // NOTE: Fast is provided in case we ever add a way to abort an event.
+        // It's mostly relevant for this, but I added it to DoShutoff too just for good measure.
+        private void DoReboot(int tier, bool fast = false)
+        {
+            if (tier < 0)
+            {
+                _powerStages.Clear();
+                return;
+            }
+
+            foreach (var pns in _powerStages[tier])
+                Toggle(pns.Owner, false);
+
+            if (fast)
+                DoReboot(tier - 1);
+            else
+            {
+                // Same as the DoShutoff version.
+                var tgt = REBOOT_TARGET_MS / _powerStages.Count;
+                var htgt = (int) (0.5f * tgt);
+
+                var nt = _random.Next(tgt - htgt, tgt + htgt);
+                Timer.Spawn(nt, () => DoReboot(tier-1));
+            }
+        }
+
         public override void Shutdown()
         {
-            var entMan = IoCManager.Resolve<IEntityManager>();
-
-            foreach (var entity in _powered)
-            {
-                if (entMan.Deleted(entity)) continue;
-
-                if (entMan.TryGetComponent(entity, out ApcPowerReceiverComponent? powerReceiverComponent))
-                {
-                    powerReceiverComponent.PowerDisabled = false;
-                }
-            }
+            DoReboot(_powerStages.Count - 1);
 
             // Can't use the default EndAudio
             _announceCancelToken?.Cancel();
@@ -70,7 +190,6 @@ namespace Content.Server.StationEvents.Events
             {
                 SoundSystem.Play(Filter.Broadcast(), "/Audio/Announcements/power_on.ogg");
             }, _announceCancelToken.Token);
-            _powered.Clear();
 
             base.Shutdown();
         }


### PR DESCRIPTION
## About the PR
See #3900

It starts with power generators and works down the "tree" to find every device connected, disabling each along the way. The event's shutdown does the inverse, working from the bottom up.

The (approximate) duration of each is tweakable via `SHUTOFF_TARGET_MS` and `REBOOT_TARGET_MS`. The current values thereof are just spitballed and are open for bikeshedding.

Frankly, I'd like them both to be longer (to show off the effect), but the timing needs to consider gameplay impact.

The original attempt used a fixed time per power tier. Apparently Saltern has about ~190 tiers, which made the shutdown last longer than the event was supposed to last, leading to the current proportional approach.

**Screenshots**
too lazy to record a video
so no

**Changelog**
N/A