### PR TITLE
Adds filled versions of coloured wardrobes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_colors.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_colors.yml
@@ -59,13 +59,13 @@
         prob: 0.25
       - id: ClothingUniformJumpskirtColorDarkBlue
         prob: 0.25
-      - id: ClothingUniformJumpsuitColorDarkTeal
+      - id: ClothingUniformJumpsuitColorTeal
         prob: 0.25
-      - id: ClothingUniformJumpskirtColorDarkTeal
+      - id: ClothingUniformJumpskirtColorTeal
         prob: 0.25
-      - id: ClothingUniformJumpsuitColorDarkPurple
+      - id: ClothingUniformJumpsuitColorPurple
         prob: 0.25
-      - id: ClothingUniformJumpskirtColorDarkPurple
+      - id: ClothingUniformJumpskirtColorPurple
         prob: 0.25
       - id: ClothingShoesColorBlack
         amount: 1

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_colors.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_colors.yml
@@ -2,7 +2,6 @@
   id: WardrobeGreyFilled
   suffix: Filled
   parent: WardrobeGrey
-  description: "A wardrobe packed with a tide of grey clothing."
   components:
   - type: StorageFill
     contents:
@@ -23,7 +22,6 @@
   id: WardrobeMixedFilled
   suffix: Filled
   parent: WardrobeMixed
-  description: "A wardrobe packed with a mix of colorful clothing."
   components:
   - type: StorageFill
     contents:
@@ -82,7 +80,6 @@
   id: WardrobeYellowFilled
   suffix: Filled
   parent: WardrobeYellow
-  description: "A wardrobe packed with stylish yellow clothing."
   components:
   - type: StorageFill
     contents:
@@ -100,7 +97,6 @@
   id: WardrobeWhiteFilled
   suffix: Filled
   parent: WardrobeWhite
-  description: "A wardrobe packed with stylish white clothing."
   components:
   - type: StorageFill
     contents:
@@ -117,7 +113,6 @@
   id: WardrobeBlueFilled
   suffix: Filled
   parent: WardrobeBlue
-  description: "A wardrobe packed with stylish blue clothing."
   components:
   - type: StorageFill
     contents:
@@ -132,7 +127,6 @@
   id: WardrobePinkFilled
   suffix: Filled
   parent: WardrobePink
-  description: "A wardrobe packed with fabulous pink clothing."
   components:
   - type: StorageFill
     contents:
@@ -147,7 +141,6 @@
   id: WardrobeBlackFilled
   suffix: Filled
   parent: WardrobeBlack
-  description: "A wardrobe packed with stylish black clothing."
   components:
   - type: StorageFill
     contents:
@@ -166,7 +159,6 @@
   id: WardrobeGreenFilled
   suffix: Filled
   parent: WardrobeGreen
-  description: "A wardrobe packed with stylish green clothing."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_colors.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_colors.yml
@@ -1,39 +1,181 @@
-#- type: entity
-#  id: WardrobeGreyFilled
-#  suffix: Filled
-#  parent: WardrobeGrey
+- type: entity
+  id: WardrobeGreyFilled
+  suffix: Filled
+  parent: WardrobeGrey
+  description: "A wardrobe packed with a tide of grey clothing."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingUniformJumpsuitColorGrey
+        amount: 2
+      - id: ClothingUniformJumpskirtColorGrey
+        amount: 2
+      - id: ClothingShoesColorBlack
+        amount: 3
+      - id: ClothingHeadHatGreysoft
+        amount: 1
+      - id: ClothingBackpackDuffel
+        prob: 0.5
+      - id: ClothingOuterCoatBomber
+        prob: 0.3
 
-#- type: entity
-#  id: WardrobeMixedFilled
-#  suffix: Filled
-#  parent: WardrobeMixed
+- type: entity
+  id: WardrobeMixedFilled
+  suffix: Filled
+  parent: WardrobeMixed
+  description: "A wardrobe packed with a mix of colorful clothing."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingUniformJumpsuitColorWhite
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorWhite
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorBlue
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorBlue
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorYellow
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorYellow
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorGreen
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorGreen
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorOrange
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorOrange
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorPink
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorPink
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorRed
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorRed
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorDarkBlue
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorDarkBlue
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorDarkTeal
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorDarkTeal
+        prob: 0.25
+      - id: ClothingUniformJumpsuitColorDarkPurple
+        prob: 0.25
+      - id: ClothingUniformJumpskirtColorDarkPirple
+        prob: 0.25
+      - id: ClothingShoesColorBlack
+        amount: 1
+      - id: ClothingShoesColorBrown
+        amount: 1
+      - id: ClothingShoesColorWhite
+        amount: 1
+      - id: ClothingOuterCoatBomber
+        prob: 0.4
+      - id: ClothingOuterCoatGentle
+        prob: 0.3
 
-#- type: entity
-#  id: WardrobeYellowFilled
-#  suffix: Filled
-#  parent: WardrobeYellow
+- type: entity
+  id: WardrobeYellowFilled
+  suffix: Filled
+  parent: WardrobeYellow
+  description: "A wardrobe packed with stylish yellow clothing."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingUniformJumpsuitColorYellow
+        amount: 1
+      - id: ClothingUniformJumpskirtColorYellow
+        amount: 1
+      - id: ClothingShoesColorOrange
+        amount: 2
+      - id: HatBandGold
+        amount: 1
+
 
 - type: entity
   id: WardrobeWhiteFilled
   suffix: Filled
   parent: WardrobeWhite
+  description: "A wardrobe packed with stylish white clothing."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingUniformJumpsuitColorWhite
+        amount: 1
+      - id: ClothingUniformJumpskirtColorWhite
+        amount: 1
+      - id: ClothingShoesColorWhite
+        amount: 2
+      - id: ClothingHeadHatMimesoft
+        amount: 1
 
-#- type: entity
-#  id: WardrobeBlueFilled
-#  suffix: Filled
-#  parent: WardrobeBlue
+- type: entity
+  id: WardrobeBlueFilled
+  suffix: Filled
+  parent: WardrobeBlue
+  description: "A wardrobe packed with stylish blue clothing."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingUniformJumpsuitColorBlue
+        amount: 1
+      - id: ClothingUniformJumpskirtColorBlue
+        amount: 1
+      - id: ClothingShoesColorBrown
+        amount: 2
 
-#- type: entity
-#  id: WardrobePinkFilled
-#  suffix: Filled
-#  parent: WardrobePink
+- type: entity
+  id: WardrobePinkFilled
+  suffix: Filled
+  parent: WardrobePink
+  description: "A wardrobe packed with fabulous pink clothing."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingUniformJumpsuitColorPink
+        amount: 1
+      - id: ClothingUniformJumpskirtColorPink
+        amount: 1
+      - id: ClothingShoesColorBrown
+        amount: 2
 
-#- type: entity
-#  id: WardrobeBlackFilled
-#  suffix: Filled
-#  parent: WardrobeBlack
+- type: entity
+  id: WardrobeBlackFilled
+  suffix: Filled
+  parent: WardrobeBlack
+  description: "A wardrobe packed with stylish black clothing."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingUniformJumpsuitColorBlack
+        amount: 1
+      - id: ClothingUniformJumpskirtColorBlack
+        amount: 1
+      - id: ClothingShoesColorBlack
+        amount: 2
+      - id: HatBandBlack
+        amount: 1
+      - id: HatBandSkull
+        prob: 0.4
 
-#- type: entity
-#  id: WardrobeGreenFilled
-#  suffix: Filled
-#  parent: WardrobeGreen
+- type: entity
+  id: WardrobeGreenFilled
+  suffix: Filled
+  parent: WardrobeGreen
+  description: "A wardrobe packed with stylish green clothing."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingUniformJumpsuitColorGreen
+        amount: 1
+      - id: ClothingUniformJumpskirtColorGreen
+        amount: 1
+      - id: ClothingShoesColorBlack
+        amount: 2
+      - id: HatBandGreen
+        amount: 1
+

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_colors.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_colors.yml
@@ -65,7 +65,7 @@
         prob: 0.25
       - id: ClothingUniformJumpsuitColorDarkPurple
         prob: 0.25
-      - id: ClothingUniformJumpskirtColorDarkPirple
+      - id: ClothingUniformJumpskirtColorDarkPurple
         prob: 0.25
       - id: ClothingShoesColorBlack
         amount: 1

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/wardrobe.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/wardrobe.yml
@@ -12,6 +12,7 @@
   id: WardrobeBlue
   parent: WardrobeBase
   name: blue wardrobe
+  description: "A wardrobe packed with stylish blue clothing."
   components:
   - type: Appearance
     visuals:
@@ -25,6 +26,7 @@
   id: WardrobePink
   parent: WardrobeBase
   name: pink wardrobe
+  description: "A wardrobe packed with fabulous pink clothing."
   components:
   - type: Appearance
     visuals:
@@ -38,6 +40,7 @@
   id: WardrobeBlack
   parent: WardrobeBase
   name: black wardrobe
+  description: "A wardrobe packed with stylish black clothing."
   components:
   - type: Appearance
     visuals:
@@ -51,6 +54,7 @@
   id: WardrobeGreen
   parent: WardrobeBase
   name: green wardrobe
+  description: "A wardrobe packed with stylish green clothing."
   components:
   - type: Appearance
     visuals:
@@ -77,6 +81,7 @@
   id: WardrobeYellow
   parent: WardrobeBase
   name: yellow wardrobe
+  description: "A wardrobe packed with stylish yellow clothing."
   components:
   - type: Appearance
     visuals:
@@ -90,6 +95,7 @@
   id: WardrobeWhite
   parent: WardrobeBase
   name: white wardrobe
+  description: "A wardrobe packed with stylish white clothing."
   components:
   - type: Appearance
     visuals:
@@ -103,6 +109,7 @@
   id: WardrobeGrey
   parent: WardrobeBase
   name: grey wardrobe
+  description: "A wardrobe packed with a tide of grey clothing."
   components:
   - type: Appearance
     visuals:
@@ -116,6 +123,7 @@
   id: WardrobeMixed
   parent: WardrobeBase
   name: mixed wardrobe
+  description: "A wardrobe packed with a mix of colorful clothing."
   components:
   - type: Appearance
     visuals:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds filled versions of the coloured wardrobes, now crew-members can redress after they lose their body in a horrific chemistry 'accident'. Mapmakers should update their maps to use the filled version of these wardrobes so that the jumpsuits are actually available. 

Based on the contents of wardrobes in [/tg/station](https://github.com/tgstation/tgstation/blob/d894b00cd55ccc2afae9db4cd5fd296e4deb0761/code/game/objects/structures/crates_lockers/closets/wardrobe.dm), however I have lowered the amount of clothes in each closet to reflect the lower average player count and to avoid any potential performance issues (along the lines of #5778), so there should only be about 5 items in each closet.

**Screenshots**
![Screenshot from 2022-01-03 20-28-18](https://user-images.githubusercontent.com/96937466/147916552-1ba42852-92aa-4b95-a8f8-ae0cb8bb5253.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Spare jumpsuits and jumpskirts are now available in the form of various colour themed wardrobes. Collect them all!