### PR TITLE
Fire & Air Alarm Electronics now constructable

### DIFF
--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -227,6 +227,8 @@
     - FireExtinguisher
     - AutolatheMachineCircuitboard
     - ProtolatheMachineCircuitboard
+    - AirAlarmElectronics
+    - FireAlarmElectronics
 
 - type: technology
   name: material sheet printing

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/atmos_alarms.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/atmos_alarms.yml
@@ -8,7 +8,7 @@
     - AirAlarmElectronics
   - type: Sprite
     sprite: Objects/Misc/module.rsi
-    state: door_electronics
+    state: airalarm_electronics
 
 - type: entity
   id: FireAlarmElectronics

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -168,14 +168,16 @@
       - ShellShotgun
       - CartridgeLRifle
       - CartridgeMagnum
-      - FirelockElectronics
       - MicroManipulatorStockPart
       - ScanningModuleStockPart
       - MicroLaserStockPart
       - MatterBinStockPart
       - CapacitorStockPart
+      - FirelockElectronics
       - DoorElectronics
       - APCElectronics
+      - AirAlarmElectronics
+      - FireAlarmElectronics
       - CloningPodMachineCircuitboard
       - MedicalScannerMachineCircuitboard
       - ChemMasterMachineCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -24,6 +24,24 @@
   materials:
      Steel: 50
      Glass: 50
+     
+- type: latheRecipe
+  id: AirAlarmElectronics
+  icon: Objects/Misc/module.rsi/airalarm_electronics.png
+  result: AirAlarmElectronics
+  completetime: 500
+  materials:
+     Steel: 50
+     Glass: 50
+
+- type: latheRecipe
+  id: FireAlarmElectronics
+  icon: Objects/Misc/module.rsi/door_electronics.png
+  result: FireAlarmElectronics
+  completetime: 500
+  materials:
+     Steel: 50
+     Glass: 50
 
 - type: latheRecipe
   id: CloningPodMachineCircuitboard


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds alarm electronics recipes to the lathe (and also makes the air alarm electronics use the unused sprite we also had specifically for them).

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![alarmelectronics](https://user-images.githubusercontent.com/60792108/147979032-eea8a74e-09ed-4bbc-9a82-e2d156cfcc81.png)
![air alarm working](https://user-images.githubusercontent.com/60792108/147979043-919d3557-61f4-42c8-a539-0e7d567b2a70.png)
![fire alarm built](https://user-images.githubusercontent.com/60792108/147979050-eafccaab-83bb-4e7d-a241-26ac036489de.png)
![fire alarm "works"](https://user-images.githubusercontent.com/60792108/147979056-caa6ef70-aaaa-4908-8f16-97dc29e1ff51.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- add: Fire and Air Alarm Electronics can now be printed in the lathe after unlocking Industrial Engineering.

