### PR TITLE
Follow verb for ghosts

### DIFF
--- a/Content.Shared/Follower/Components/FollowedComponent.cs
+++ b/Content.Shared/Follower/Components/FollowedComponent.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.Follower.Components;
+
+/// <summary>
+///     Attached to entities that are currently being followed by a ghost.
+/// </summary>
+[RegisterComponent, ComponentProtoName("Followed"), Friend(typeof(FollowerSystem))]
+public class FollowedComponent : Component
+{
+    public HashSet<EntityUid> Following = new();
+}

--- a/Content.Shared/Follower/Components/FollowerComponent.cs
+++ b/Content.Shared/Follower/Components/FollowerComponent.cs
@@ -1,7 +1,7 @@
 ﻿using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 
-namespace Content.Shared.Follower;
+namespace Content.Shared.Follower.Components;
 
 [RegisterComponent, ComponentProtoName("Follower")]
 [Friend(typeof(FollowerSystem))]

--- a/Content.Shared/Follower/FollowerComponent.cs
+++ b/Content.Shared/Follower/FollowerComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.Follower;
+
+[RegisterComponent, ComponentProtoName("Follower")]
+[Friend(typeof(FollowerSystem))]
+public class FollowerComponent : Component
+{
+    public EntityUid Following;
+}

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -24,7 +24,6 @@ public class FollowerSystem : EntitySystem
 
         foreach (var follower in EntityManager.EntityQuery<FollowerComponent>())
         {
-            Logger.Debug($"Entity {follower} on {follower.Following}");
             var xform = Transform(follower.Owner);
             var targetXform = Transform(follower.Following);
             xform.Coordinates = targetXform.Coordinates;

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Verbs;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 using Robust.Shared.Log;
+using Robust.Shared.Maths;
 
 namespace Content.Shared.Follower;
 

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -83,6 +83,8 @@ public class FollowerSystem : EntitySystem
             return;
 
         followed.Following.Remove(uid);
+        if (followed.Following.Count == 0)
+            RemComp<FollowedComponent>(target);
         RemComp<FollowerComponent>(uid);
         Transform(uid).AttachToGridOrMap();
     }

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -18,18 +18,6 @@ public class FollowerSystem : EntitySystem
         SubscribeLocalEvent<FollowerComponent, RelayMoveInputEvent>(OnFollowerMove);
     }
 
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        foreach (var follower in EntityManager.EntityQuery<FollowerComponent>())
-        {
-            var xform = Transform(follower.Owner);
-            var targetXform = Transform(follower.Following);
-            xform.Coordinates = targetXform.Coordinates;
-        }
-    }
-
     private void OnGetAlternativeVerbs(GetAlternativeVerbsEvent ev)
     {
         if (!HasComp<SharedGhostComponent>(ev.User))
@@ -42,6 +30,9 @@ public class FollowerSystem : EntitySystem
             {
                 var follower = EnsureComp<FollowerComponent>(ev.User);
                 follower.Following = ev.Target;
+                var xform = Transform(ev.User);
+                xform.Coordinates = Transform(ev.Target).Coordinates;
+                xform.AttachParent(ev.Target);
             }),
             Impact = LogImpact.Low,
             Text = Loc.GetString("verb-follow-text"),
@@ -54,5 +45,6 @@ public class FollowerSystem : EntitySystem
     private void OnFollowerMove(EntityUid uid, FollowerComponent component, RelayMoveInputEvent args)
     {
         RemComp<FollowerComponent>(uid);
+        Transform(uid).AttachToGridOrMap();
     }
 }

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -31,8 +31,8 @@ public class FollowerSystem : EntitySystem
                 var follower = EnsureComp<FollowerComponent>(ev.User);
                 follower.Following = ev.Target;
                 var xform = Transform(ev.User);
-                xform.Coordinates = Transform(ev.Target).Coordinates;
                 xform.AttachParent(ev.Target);
+                xform.LocalPosition = Vector2.Zero;
             }),
             Impact = LogImpact.Low,
             Text = Loc.GetString("verb-follow-text"),

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -1,0 +1,59 @@
+﻿using Content.Shared.Database;
+using Content.Shared.Ghost;
+using Content.Shared.Movement.EntitySystems;
+using Content.Shared.Verbs;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.Log;
+
+namespace Content.Shared.Follower;
+
+public class FollowerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GetAlternativeVerbsEvent>(OnGetAlternativeVerbs);
+        SubscribeLocalEvent<FollowerComponent, RelayMoveInputEvent>(OnFollowerMove);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        foreach (var follower in EntityManager.EntityQuery<FollowerComponent>())
+        {
+            Logger.Debug($"Entity {follower} on {follower.Following}");
+            var xform = Transform(follower.Owner);
+            var targetXform = Transform(follower.Following);
+            xform.Coordinates = targetXform.Coordinates;
+        }
+    }
+
+    private void OnGetAlternativeVerbs(GetAlternativeVerbsEvent ev)
+    {
+        if (!HasComp<SharedGhostComponent>(ev.User))
+            return;
+
+        var verb = new Verb
+        {
+            Priority = 10,
+            Act = (() =>
+            {
+                var follower = EnsureComp<FollowerComponent>(ev.User);
+                follower.Following = ev.Target;
+            }),
+            Impact = LogImpact.Low,
+            Text = Loc.GetString("verb-follow-text"),
+            IconTexture = "/Textures/Interface/VerbIcons/open.svg.192dpi.png",
+        };
+
+        ev.Verbs.Add(verb);
+    }
+
+    private void OnFollowerMove(EntityUid uid, FollowerComponent component, RelayMoveInputEvent args)
+    {
+        RemComp<FollowerComponent>(uid);
+    }
+}

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -42,7 +42,7 @@ public class FollowerSystem : EntitySystem
 
     private void OnFollowerMove(EntityUid uid, FollowerComponent component, RelayMoveInputEvent args)
     {
-        StopFollowingEntity(uid);
+        StopFollowingEntity(uid, component.Following);
     }
 
     // Since we parent our observer to the followed entity, we need to detach

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -42,9 +42,6 @@ public class FollowerSystem : EntitySystem
 
     private void OnFollowerMove(EntityUid uid, FollowerComponent component, RelayMoveInputEvent args)
     {
-        RemComp<FollowerComponent>(uid);
-        Transform(uid).AttachToGridOrMap();
-
         StopFollowingEntity(uid);
     }
 
@@ -76,11 +73,16 @@ public class FollowerSystem : EntitySystem
     /// <summary>
     ///     Forces an entity to stop following another entity, if it is doing so.
     /// </summary>
-    public void StopFollowingEntity(EntityUid uid)
+    public void StopFollowingEntity(EntityUid uid, EntityUid target,
+        FollowedComponent? followed=null)
     {
+        if (!Resolve(target, ref followed))
+            return;
+
         if (!HasComp<FollowerComponent>(uid))
             return;
 
+        followed.Following.Remove(uid);
         RemComp<FollowerComponent>(uid);
         Transform(uid).AttachToGridOrMap();
     }
@@ -96,7 +98,7 @@ public class FollowerSystem : EntitySystem
 
         foreach (var player in followed.Following)
         {
-            StopFollowingEntity(player);
+            StopFollowingEntity(player, uid, followed);
         }
     }
 }

--- a/Resources/Locale/en-US/follower/follow-verb.ftl
+++ b/Resources/Locale/en-US/follower/follow-verb.ftl
@@ -1,0 +1,1 @@
+﻿verb-follow-text = Follow


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Pretty simple. Predicted, adds component on follow, sets their position to the followed entity every tick, removes component on move input.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/19853115/147980926-959dbcf9-c4b2-4e53-b109-4b7b8b072b2f.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Ghosts can now automatically follow entities by using a right click Follow verb.
