### PR TITLE
Added difficulty overrides for several traitor objectives

### DIFF
--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -45,6 +45,7 @@
 - type: objective
   id: CMOHyposprayStealObjective
   issuer: syndicate
+  difficultyOverride: 2.25
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -57,6 +58,7 @@
 - type: objective
   id: RDHardsuitStealObjective
   issuer: syndicate
+  difficultyOverride: 2.5
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -93,6 +95,7 @@
 - type: objective
   id: MagbootsStealObjective #Replace this with CE magboots when we get those
   issuer: syndicate
+  difficultyOverride: 1.5
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -105,6 +108,7 @@
 - type: objective
   id: HOSHardsuitHelmStealObjective
   issuer: syndicate
+  difficultyOverride: 2.5
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I adjusted the difficulties of some of the steal objectives that are particularly easier or harder than the average

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: The Syndicate now considers certain steal targets to be easier or harder than others.
