### PR TITLE
HeightComparer is a little faster

### DIFF
--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -13,10 +13,9 @@ namespace Content.Server.Power.Pow3r
 
             public int Compare(Network? x, Network? y)
             {
-                if (ReferenceEquals(x, y)) return 0;
-                if (ReferenceEquals(null, y)) return 1;
-                if (ReferenceEquals(null, x)) return -1;
-                return x.Height.CompareTo(y.Height);
+                if (x!.Height == y!.Height) return 0;
+                if (x!.Height > y!.Height) return 1;
+                return -1;
             }
         }
 

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -7,11 +7,11 @@ namespace Content.Server.Power.Pow3r
 {
     public sealed class BatteryRampPegSolver : IPowerSolver
     {
-        private sealed class HeightComparer : IComparer<Network>
+        private sealed class HeightComparer : Comparer<Network>
         {
             public static HeightComparer Instance { get; } = new();
 
-            public int Compare(Network? x, Network? y)
+            public override int Compare(Network? x, Network? y)
             {
                 if (x!.Height == y!.Height) return 0;
                 if (x!.Height > y!.Height) return 1;


### PR DESCRIPTION
## About the PR
This gets called a lot, so making it faster helps.
It never gets any nulls, so we don't check for that now.
The heights being equal seems common, so it is up front.