### PR TITLE
Quick fixes (firefightercrate fill and rollerbed size)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -35,7 +35,7 @@
         amount: 2
       - id: ClothingOuterSuitFire
         amount: 2
-      - id: RedOxygenTank
+      - id: RedOxygenTankFilled
         amount: 2
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
@@ -7,7 +7,7 @@
     - type: Transform
       noRot: true
     - type: Item
-      size: 5
+      size: 25
     - type: Sprite
       sprite: Structures/Furniture/rollerbeds.rsi
       netsync: false


### PR DESCRIPTION
Fixed the tanks in firefighter crates to actually be filled with air.
Increased the size of rollerbeds from 5 to 25 so they should no longer fit inside of storage like backpacks (when backpack size limit is corrected or smthn).

As usual with a bunch of my tweak PRs I don't think it justifies a changelog, since it's tiny minor bugs people won't have realised. Peace.
