### PR TITLE
Fix use delay

### DIFF
--- a/Content.Shared/Timing/UseDelayComponent.cs
+++ b/Content.Shared/Timing/UseDelayComponent.cs
@@ -46,12 +46,9 @@ namespace Content.Shared.Timing
 
             _lastUseTime = IoCManager.Resolve<IGameTiming>().CurTime;
 
-            if (IoCManager.Resolve<IEntityManager>().TryGetComponent(Owner, out ItemCooldownComponent? cooldown))
-            {
-                cooldown.CooldownStart = _lastUseTime;
-                cooldown.CooldownEnd = _lastUseTime + TimeSpan.FromSeconds(Delay);
-            }
-
+            var cooldown = IoCManager.Resolve<IEntityManager>().EnsureComponent<ItemCooldownComponent>(Owner);
+            cooldown.CooldownStart = _lastUseTime;
+            cooldown.CooldownEnd = _lastUseTime + TimeSpan.FromSeconds(Delay);
         }
 
         public void Cancel()


### PR DESCRIPTION
Currently when an entity with a use delay is interacted with, the delay / cooldown starts regardless of whether the user was actually able to perform any interaction. This PR just makes it so that the delay only starts if an interaction took place.

This caused issues after #5951, where in some instances no interactions could occur at all due to self-blocking. I.e., use-in-hand defaults to activate-interactions if no interaction occurred. But a use-interaction will trigger the cooldown, regardless of whether an interaction happened, which then blocks the activate-interaction. This caused issues with hand labellers which have a 2-second cooldown.

Also replaces a `TryGetComponent` with an `EnsureComponent`, to make sure that items with delays actually have visual feedback in the hands gui.

:cl:
- fix: Fixed a bug preventing hand-labellers from being used.

