### PR TITLE
Fixes #6041. Multi-steps in construction graph visible in examine menu.

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Guided.cs
+++ b/Content.Server/Construction/ConstructionSystem.Guided.cs
@@ -95,7 +95,9 @@ namespace Content.Server.Construction
                     preventStepExamine |= condition.DoExamine(args);
                 }
 
-                if (preventStepExamine) return;
+                if (!preventStepExamine && component.StepIndex < edge.Steps.Count)
+                    edge.Steps[component.StepIndex].DoExamine(args);
+                return;
             }
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

See #6041. This is my first PR, so it would be great to get another set of eyes on this, specifically someone who knows the construction system better than me.
> #6041: When deconstructing certain tiles, only the first step is shown in the guided construction helper

**Changelog**

:cl: weaver
- fix: All disassembly steps are now visible in the 'Examine' menu when complex tiles are deconstructed (like reinforced windows and walls)

