### PR TITLE
Make smoking cool again.

### DIFF
--- a/Content.Client/Smoking/BurnStateVisualizer.cs
+++ b/Content.Client/Smoking/BurnStateVisualizer.cs
@@ -1,16 +1,18 @@
-﻿using Content.Client.Clothing;
 using Content.Shared.Smoking;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Client.Smoking
 {
     [UsedImplicitly]
-    public class BurnStateVisualizer : AppearanceVisualizer
+    public sealed class BurnStateVisualizer : AppearanceVisualizer, ISerializationHooks
     {
+        [Dependency] private readonly IEntityManager _entMan = default!;
+
         [DataField("burntIcon")]
         private string _burntIcon = "burnt-icon";
         [DataField("litIcon")]
@@ -18,49 +20,29 @@ namespace Content.Client.Smoking
         [DataField("unlitIcon")]
         private string _unlitIcon = "icon";
 
-        [DataField("burntPrefix")]
-        private string _burntPrefix = "unlit";
-        [DataField("litPrefix")]
-        private string _litPrefix = "lit";
-        [DataField("unlitPrefix")]
-        private string _unlitPrefix = "unlit";
+        void ISerializationHooks.AfterDeserialization()
+        {
+            IoCManager.InjectDependencies(this);
+        }
 
         public override void OnChangeData(AppearanceComponent component)
         {
             base.OnChangeData(component);
 
-            if (component.TryGetData<SmokableState>(SmokingVisuals.Smoking, out var smoking))
-            {
-                SetState(component, smoking);
-            }
-        }
+            if (!_entMan.TryGetComponent(component.Owner, out SpriteComponent? sprite))
+                return;
 
-        private void SetState(AppearanceComponent component, SmokableState burnState)
-        {
-            var entities = IoCManager.Resolve<IEntityManager>();
-            var clothing = entities.GetComponentOrNull<ClothingComponent>(component.Owner);
+            if (!component.TryGetData<SmokableState>(SmokingVisuals.Smoking, out var burnState))
+                return;
 
-            if (entities.TryGetComponent(component.Owner, out ISpriteComponent sprite))
+            var state = burnState switch
             {
-                switch (burnState)
-                {
-                    case SmokableState.Lit:
-                        if (clothing != null)
-                            clothing.EquippedPrefix = _litPrefix;
-                        sprite.LayerSetState(0, _litIcon);
-                        break;
-                    case SmokableState.Burnt:
-                        if (clothing != null)
-                            clothing.EquippedPrefix = _burntPrefix;
-                        sprite.LayerSetState(0, _burntIcon);
-                        break;
-                    case SmokableState.Unlit:
-                        if (clothing != null)
-                            clothing.EquippedPrefix = _unlitPrefix;
-                        sprite.LayerSetState(0, _unlitIcon);
-                        break;
-                }
-            }
+                SmokableState.Lit => _litIcon,
+                SmokableState.Burnt => _burntIcon,
+                _ => _unlitIcon
+            };
+
+            sprite.LayerSetState(0, state);
         }
     }
 }

--- a/Content.Server/Nutrition/Components/SmokableComponent.cs
+++ b/Content.Server/Nutrition/Components/SmokableComponent.cs
@@ -24,5 +24,13 @@ namespace Content.Server.Nutrition.Components
 
         [DataField("state")]
         public SmokableState State { get; set; } = SmokableState.Unlit;
+
+        // clothing prefixes
+        [DataField("burntPrefix")]
+        public string BurntPrefix = "unlit";
+        [DataField("litPrefix")]
+        public string LitPrefix = "lit";
+        [DataField("unlitPrefix")]
+        public string UnlitPrefix = "unlit";
     }
 }

--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Chemistry.EntitySystems;
+using Content.Server.Clothing.Components;
 using Content.Server.Nutrition.Components;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Reagent;
@@ -38,13 +39,21 @@ namespace Content.Server.Nutrition.EntitySystems
             InitializeCigars();
         }
 
-        public void SetSmokableState(EntityUid uid, SmokableState state, SmokableComponent? smokable = null, AppearanceComponent? appearance = null)
+        public void SetSmokableState(EntityUid uid, SmokableState state, SmokableComponent? smokable = null,
+            AppearanceComponent? appearance = null, ClothingComponent? clothing = null)
         {
-            if (!Resolve(uid, ref smokable, ref appearance))
+            if (!Resolve(uid, ref smokable, ref appearance, ref clothing))
                 return;
 
             smokable.State = state;
             appearance.SetData(SmokingVisuals.Smoking, state);
+
+            clothing.EquippedPrefix = state switch
+            {
+                SmokableState.Lit => smokable.LitPrefix,
+                SmokableState.Burnt => smokable.BurntPrefix,
+                _ => smokable.UnlitPrefix
+            };
 
             if (state == SmokableState.Lit)
                 _active.Add(uid);


### PR DESCRIPTION
Fixes smoking visuals not working properly. Main change is just moving the setting of the clothing prefix to server side code. It was only being set client-side and was being overridden by the server-side clothing state somewhere along the way.

:cl:
- fix: Smoking is cool again (fixed animation/sprite).

