### PR TITLE
Makes magboots grant gravity.

### DIFF
--- a/Content.Client/Clothing/MagbootsComponent.cs
+++ b/Content.Client/Clothing/MagbootsComponent.cs
@@ -4,6 +4,7 @@ using Robust.Shared.GameObjects;
 namespace Content.Client.Clothing
 {
     [RegisterComponent]
+    [ComponentReference(typeof(SharedMagbootsComponent))]
     public sealed class MagbootsComponent : SharedMagbootsComponent
     {
         public override bool On { get; set; }

--- a/Content.Server/Clothing/Components/MagbootsComponent.cs
+++ b/Content.Server/Clothing/Components/MagbootsComponent.cs
@@ -17,6 +17,7 @@ namespace Content.Server.Clothing.Components
 {
     [RegisterComponent]
     [ComponentReference(typeof(IActivate))]
+    [ComponentReference(typeof(SharedMagbootsComponent))]
     public sealed class MagbootsComponent : SharedMagbootsComponent, IActivate
     {
         [ComponentDependency] private SharedItemComponent? _item = null;

--- a/Content.Shared/Movement/Components/MovementIgnoreGravityComponent.cs
+++ b/Content.Shared/Movement/Components/MovementIgnoreGravityComponent.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Clothing;
 using Content.Shared.Gravity;
+using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Map;
@@ -36,6 +38,13 @@ namespace Content.Shared.Movement.Components
 
             mapManager ??= IoCManager.Resolve<IMapManager>();
             var grid = mapManager.GetGrid(gridId);
+            var invSys = EntitySystem.Get<InventorySystem>();
+
+            if (invSys.TryGetSlotEntity(entity, "shoes", out var ent))
+            {
+                if (entityManager.TryGetComponent<SharedMagbootsComponent>(ent, out var boots) && boots.On)
+                    return false;
+            }
 
             if (!entityManager.GetComponent<GravityComponent>(grid.GridEntityId).Enabled)
             {


### PR DESCRIPTION
Ported from Outer Rim 14 as a patch, original commit history not present.

:cl:
- add: Magboots now allow you to ignore a lack of gravity, as they should.