### PR TITLE
Interrupt do-afters when the user gets incapacitated.

### DIFF
--- a/Content.Server/DoAfter/DoAfter.cs
+++ b/Content.Server/DoAfter/DoAfter.cs
@@ -26,8 +26,6 @@ namespace Content.Server.DoAfter
 
         public EntityCoordinates TargetGrid { get; }
 
-        public bool TookDamage { get; set; }
-
         public DoAfterStatus Status => AsTask.IsCompletedSuccessfully ? AsTask.Result : DoAfterStatus.Running;
 
         // NeedHand
@@ -60,6 +58,12 @@ namespace Content.Server.DoAfter
 
             Tcs = new TaskCompletionSource<DoAfterStatus>();
             AsTask = Tcs.Task;
+        }
+
+        public void Cancel()
+        {
+            if (Status == DoAfterStatus.Running)
+                Tcs.SetResult(DoAfterStatus.Cancelled);
         }
 
         public void Run(float frameTime, IEntityManager entityManager)
@@ -120,11 +124,6 @@ namespace Content.Server.DoAfter
 
             if (EventArgs.BreakOnTargetMove && !entityManager.GetComponent<TransformComponent>(EventArgs.Target!.Value).Coordinates.InRange(
                 entityManager, TargetGrid, EventArgs.MovementThreshold))
-            {
-                return true;
-            }
-
-            if (EventArgs.BreakOnDamage && TookDamage)
             {
                 return true;
             }

--- a/Content.Server/DoAfter/DoAfterSystem.cs
+++ b/Content.Server/DoAfter/DoAfterSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Server.DoAfter
 
         private void HandleStateChanged(EntityUid uid, DoAfterComponent component, MobStateChangedEvent args)
         {
-            if (component.DoAfters.Count == 0 || !args.CurrentMobState.IsIncapacitated())
+            if (!args.CurrentMobState.IsIncapacitated())
                 return;
 
             foreach (var doAfter in component.DoAfters)
@@ -36,10 +36,8 @@ namespace Content.Server.DoAfter
 
         public void HandleDamage(EntityUid _, DoAfterComponent component, DamageChangedEvent args)
         {
-            if (component.DoAfters.Count == 0 || !args.InterruptsDoAfters || args.DamageIncreased)
-            {
+            if (!args.InterruptsDoAfters || !args.DamageIncreased)
                 return;
-            }
 
             foreach (var doAfter in component.DoAfters)
             {

--- a/Content.Server/DoAfter/DoAfterSystem.cs
+++ b/Content.Server/DoAfter/DoAfterSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Content.Shared.Damage;
+using Content.Shared.MobState;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 
@@ -19,11 +20,23 @@ namespace Content.Server.DoAfter
         {
             base.Initialize();
             SubscribeLocalEvent<DoAfterComponent, DamageChangedEvent>(HandleDamage);
+            SubscribeLocalEvent<DoAfterComponent, MobStateChangedEvent>(HandleStateChanged);
+        }
+
+        private void HandleStateChanged(EntityUid uid, DoAfterComponent component, MobStateChangedEvent args)
+        {
+            if (component.DoAfters.Count == 0 || !args.CurrentMobState.IsIncapacitated())
+                return;
+
+            foreach (var doAfter in component.DoAfters)
+            {
+                doAfter.Cancel();
+            }
         }
 
         public void HandleDamage(EntityUid _, DoAfterComponent component, DamageChangedEvent args)
         {
-            if (component.DoAfters.Count == 0 || !args.InterruptsDoAfters)
+            if (component.DoAfters.Count == 0 || !args.InterruptsDoAfters || args.DamageIncreased)
             {
                 return;
             }
@@ -32,7 +45,7 @@ namespace Content.Server.DoAfter
             {
                 if (doAfter.EventArgs.BreakOnDamage)
                 {
-                    doAfter.TookDamage = true;
+                    doAfter.Cancel();
                 }
             }
         }


### PR DESCRIPTION
Currently a user can die from non-interrupting damage (e.g. asphyxiation), but the do-afters don't get interrupted. This fixes that. Also stops healing from interrupting do-afters.