### PR TITLE
Fix outer clothing

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -5,7 +5,7 @@
   components:
   - type: Clothing
     Slots:
-    - outerclothing
+    - outerClothing
   - type: Sprite
     state: icon
 

--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -16,7 +16,7 @@
   equipment:
     head: ClothingHeadHatTophat
     jumpsuit: ClothingUniformJumpsuitBartender
-    outerclothing: ClothingOuterVestKevlar
+    outerClothing: ClothingOuterVestKevlar
     back: ClothingBackpackFilled
     shoes: ClothingShoesColorBlack
     id: BartenderPDA

--- a/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
@@ -19,7 +19,7 @@
     shoes: ClothingShoesColorBrown
     id: BotanistPDA
     ears: ClothingHeadsetService
-    outerclothing: ClothingOuterApronBotanist
+    outerClothing: ClothingOuterApronBotanist
   innerclothingskirt: ClothingUniformJumpskirtHydroponics
   satchel: ClothingBackpackSatchelHydroponicsFilled
   duffelbag: ClothingBackpackDuffelFilled

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -20,7 +20,7 @@
     shoes: ClothingShoesColorBlack
     id: ChefPDA
     ears: ClothingHeadsetService
-    outerclothing: ClothingOuterApronChef
+    outerClothing: ClothingOuterApronChef
   innerclothingskirt: ClothingUniformJumpskirtChef
   satchel: ClothingBackpackSatchelFilled
   duffelbag: ClothingBackpackDuffelFilled

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -49,7 +49,7 @@
     head: ClothingHeadHatCaptain
     eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesCaptain
-    outerclothing: ClothingOuterHardsuitCap
+    outerClothing: ClothingOuterHardsuitCap
     id: CaptainPDA
     ears: ClothingHeadsetAltCommand
   innerclothingskirt: ClothingUniformJumpskirtCaptain

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -19,7 +19,7 @@
     head: ClothingHeadHatCentcom
     eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesColorBlack
-    outerclothing: ClothingOuterVestKevlar
+    outerClothing: ClothingOuterVestKevlar
     id: CentcomPDA
     ears: ClothingHeadsetAltCommand
     pocket1: Paper

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -18,7 +18,7 @@
     jumpsuit: ClothingUniformJumpsuitEngineering
     back: ClothingBackpackEngineeringFilled
     shoes: ClothingShoesBootsWork
-    outerclothing: ClothingOuterVestHazard
+    outerClothing: ClothingOuterVestHazard
     id: EngineerPDA
     belt: ClothingBeltUtilityFilled
     ears: ClothingHeadsetEngineering

--- a/Resources/Prototypes/Roles/Jobs/Fun/cult_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/cult_startinggear.yml
@@ -6,7 +6,7 @@
     backpack: ClothingBackpackFilled
     head: ClothingHeadHelmetCult
     neck: BedsheetCult
-    outerclothing: ClothingOuterArmorCult
+    outerClothing: ClothingOuterArmorCult
     shoes: ClothingShoesCult
     idcard: AssistantPDA
     ears: ClothingHeadsetService
@@ -20,7 +20,7 @@
     innerclothing: ClothingUniformJumpsuitColorBlack
     backpack: ClothingBackpackFilled
     head: ClothingHeadHatHoodCulthood
-    outerclothing: ClothingOuterRobesCult
+    outerClothing: ClothingOuterRobesCult
     shoes: ClothingShoesColorRed
     idcard: AssistantPDA
     ears: ClothingHeadsetService

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -6,7 +6,7 @@
     backpack: ClothingBackpackFilled
     head: ClothingHeadHelmetIHSVoidHelm
     gloves: ClothingHandsGlovesIhscombat
-    outerclothing: IHSVoidsuit
+    outerClothing: IHSVoidsuit
     shoes: ClothingShoesBootsJack
     idcard: AssistantPDA
     ears: ClothingHeadsetService

--- a/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
@@ -5,7 +5,7 @@
     innerclothing: ClothingUniformJumpsuitColorDarkBlue
     backpack: ClothingBackpackFilled
     head: ClothingHeadHatWizard
-    outerclothing: ClothingOuterWizard
+    outerClothing: ClothingOuterWizard
     shoes: ClothingShoesWizard
     idcard: AssistantPDA
     ears: ClothingHeadsetService
@@ -19,7 +19,7 @@
     innerclothing: ClothingUniformJumpsuitColorRed
     backpack: ClothingBackpackFilled
     head: ClothingHeadHatRedwizard
-    outerclothing: ClothingOuterWizardRed
+    outerClothing: ClothingOuterWizardRed
     shoes: ClothingShoesWizard
     idcard: AssistantPDA
     ears: ClothingHeadsetService
@@ -33,7 +33,7 @@
     innerclothing: ClothingUniformJumpsuitColorPurple
     backpack: ClothingBackpackFilled
     head: ClothingHeadHatVioletwizard
-    outerclothing: ClothingOuterWizardViolet
+    outerClothing: ClothingOuterWizardViolet
     shoes: ClothingShoesWizard
     idcard: AssistantPDA
     ears: ClothingHeadsetService
@@ -47,7 +47,7 @@
     innerclothing: ClothingUniformJumpsuitColorPurple
     backpack: ClothingBackpackFilled
     head: ClothingHeadHelmetHardsuitWizard
-    outerclothing: ClothingOuterHardsuitWizard
+    outerClothing: ClothingOuterHardsuitWizard
     shoes: ClothingShoesWizard
     idcard: AssistantPDA
     ears: ClothingHeadsetService

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -17,7 +17,7 @@
     jumpsuit: ClothingUniformJumpsuitChemistry
     back: ClothingBackpackChemistryFilled
     shoes: ClothingShoesColorWhite
-    outerclothing: ClothingOuterCoatLabChem
+    outerClothing: ClothingOuterCoatLabChem
     id: ChemistryPDA
     ears: ClothingHeadsetMedical
     belt: ClothingBeltMedical

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -25,7 +25,7 @@
     jumpsuit: ClothingUniformJumpsuitCMO
     back: ClothingBackpackMedicalFilled
     shoes: ClothingShoesColorBrown
-    outerclothing: ClothingOuterCoatLabCmo
+    outerClothing: ClothingOuterCoatLabCmo
     id: CMOPDA
     ears: ClothingHeadsetAltMedical
     belt: ClothingBeltMedicalFilled

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -16,7 +16,7 @@
     jumpsuit: ClothingUniformJumpsuitMedicalDoctor
     back: ClothingBackpackMedicalFilled
     shoes: ClothingShoesColorWhite
-    outerclothing: ClothingOuterCoatLab
+    outerClothing: ClothingOuterCoatLab
     id: MedicalPDA
     ears: ClothingHeadsetMedical
     belt: ClothingBeltMedicalFilled

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -22,7 +22,7 @@
     jumpsuit: ClothingUniformJumpsuitResearchDirector
     back: ClothingBackpackScienceFilled
     shoes: ClothingShoesColorBrown
-    outerclothing: ClothingOuterCoatLab
+    outerClothing: ClothingOuterCoatLab
     id: RnDPDA
     ears: ClothingHeadsetScience
   innerclothingskirt: ClothingUniformJumpskirtResearchDirector

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -16,7 +16,7 @@
     jumpsuit: ClothingUniformJumpsuitScientist
     back: ClothingBackpackScienceFilled
     shoes: ClothingShoesColorWhite
-    outerclothing: ClothingOuterCoatLab
+    outerClothing: ClothingOuterCoatLab
     id: SciencePDA
     ears: ClothingHeadsetScience
   innerclothingskirt: ClothingUniformJumpskirtScientist

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -25,7 +25,7 @@
     jumpsuit: ClothingUniformJumpsuitHoS
     back: ClothingBackpackSecurityFilled
     shoes: ClothingShoesBootsJack
-    outerclothing: ClothingOuterCoatHoSTrench
+    outerClothing: ClothingOuterCoatHoSTrench
     eyes: ClothingEyesGlassesSecurity
     head: ClothingHeadHatBeretHoS
     id: HoSPDA

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -20,7 +20,7 @@
     shoes: ClothingShoesBootsJack
     eyes: ClothingEyesGlassesSecurity
     head: ClothingHeadHelmetHelmetOld
-    outerclothing: ClothingOuterVestKevlar
+    outerClothing: ClothingOuterVestKevlar
     id: SecurityPDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltSecurityFilled

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -21,7 +21,7 @@
     back: ClothingBackpackSecurityFilled
     shoes: ClothingShoesBootsJack
     eyes: ClothingEyesGlassesSecurity
-    outerclothing: ClothingOuterCoatWarden
+    outerClothing: ClothingOuterCoatWarden
     id: WardenPDA
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltSecurityFilled


### PR DESCRIPTION
C# code uses camelCase for `outerClothing`, while some yaml files used all lower case. This was causing players to spawn in without outer clothing equipped. This just updates all the yaml files to use camel case.

:cl:
- fix: Station staff should once again spawn with their "outer clothing" (lab coats, vests, etc) equipped.
