### PR TITLE
Added toxin damage to ingesting welder fuel

### DIFF
--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -139,6 +139,15 @@
   meltingPoint: -80.7
   tileReactions:
   - !type:FlammableTileReaction {}
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 1
+      - !type:FlammableReaction
+        multiplier: 0.4
 
 - type: reagent
   id: Fluorosurfactant


### PR DESCRIPTION
Self explanatory

50u of welder fuel now crits you after about a minute of ingesting.

:cl:
- fix: Drinking welder fuel now does toxin damage. Tasty.

