### PR TITLE
Renames walls and rods to improve consistency

### DIFF
--- a/Content.Server/RCD/Systems/RCDSystem.cs
+++ b/Content.Server/RCD/Systems/RCDSystem.cs
@@ -127,7 +127,7 @@ namespace Content.Server.RCD.Systems
                 //Walls are a special behaviour, and require us to build a new object with a transform rather than setting a grid tile,
                 // thus we early return to avoid the tile set code.
                 case RcdMode.Walls:
-                    var ent = EntityManager.SpawnEntity("WallSolid", mapGrid.GridTileToLocal(snapPos));
+                    var ent = EntityManager.SpawnEntity("WallSteel", mapGrid.GridTileToLocal(snapPos));
                     EntityManager.GetComponent<TransformComponent>(ent).LocalRotation = Angle.Zero; // Walls always need to point south.
                     break;
                 case RcdMode.Airlock:

--- a/Resources/Maps/Salvage/medium-1.yml
+++ b/Resources/Maps/Salvage/medium-1.yml
@@ -639,37 +639,37 @@ entities:
       - 0
     type: GridAtmosphere
 - uid: 1
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-5.5
     parent: 0
     type: Transform
 - uid: 2
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-6.5
     parent: 0
     type: Transform
 - uid: 3
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,-6.5
     parent: 0
     type: Transform
 - uid: 4
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,-6.5
     parent: 0
     type: Transform
 - uid: 5
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,-6.5
     parent: 0
     type: Transform
 - uid: 6
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-1.5
     parent: 0
@@ -681,73 +681,73 @@ entities:
     parent: 0
     type: Transform
 - uid: 8
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-1.5
     parent: 0
     type: Transform
 - uid: 9
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-2.5
     parent: 0
     type: Transform
 - uid: 10
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-3.5
     parent: 0
     type: Transform
 - uid: 11
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-4.5
     parent: 0
     type: Transform
 - uid: 12
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,-1.5
     parent: 0
     type: Transform
 - uid: 13
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,-1.5
     parent: 0
     type: Transform
 - uid: 14
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,-0.5
     parent: 0
     type: Transform
 - uid: 15
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,0.5
     parent: 0
     type: Transform
 - uid: 16
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,1.5
     parent: 0
     type: Transform
 - uid: 17
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,1.5
     parent: 0
     type: Transform
 - uid: 18
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,2.5
     parent: 0
     type: Transform
 - uid: 19
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,2.5
     parent: 0
@@ -759,103 +759,103 @@ entities:
     parent: 0
     type: Transform
 - uid: 21
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,2.5
     parent: 0
     type: Transform
 - uid: 22
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,2.5
     parent: 0
     type: Transform
 - uid: 23
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,2.5
     parent: 0
     type: Transform
 - uid: 24
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,1.5
     parent: 0
     type: Transform
 - uid: 25
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,0.5
     parent: 0
     type: Transform
 - uid: 26
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-0.5
     parent: 0
     type: Transform
 - uid: 27
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-1.5
     parent: 0
     type: Transform
 - uid: 28
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-1.5
     parent: 0
     type: Transform
 - uid: 29
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-3.5
     parent: 0
     type: Transform
 - uid: 30
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-3.5
     parent: 0
     type: Transform
 - uid: 31
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-3.5
     parent: 0
     type: Transform
 - uid: 32
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-3.5
     parent: 0
     type: Transform
 - uid: 33
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-3.5
     parent: 0
     type: Transform
 - uid: 34
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-2.5
     parent: 0
     type: Transform
 - uid: 35
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-1.5
     parent: 0
     type: Transform
 - uid: 36
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-0.5
     parent: 0
     type: Transform
 - uid: 37
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,0.5
     parent: 0
@@ -897,121 +897,121 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 42
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,4.5
     parent: 0
     type: Transform
 - uid: 43
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,5.5
     parent: 0
     type: Transform
 - uid: 44
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,5.5
     parent: 0
     type: Transform
 - uid: 45
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,5.5
     parent: 0
     type: Transform
 - uid: 46
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,5.5
     parent: 0
     type: Transform
 - uid: 47
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,5.5
     parent: 0
     type: Transform
 - uid: 48
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,5.5
     parent: 0
     type: Transform
 - uid: 49
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,5.5
     parent: 0
     type: Transform
 - uid: 50
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,4.5
     parent: 0
     type: Transform
 - uid: 51
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,3.5
     parent: 0
     type: Transform
 - uid: 52
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,3.5
     parent: 0
     type: Transform
 - uid: 53
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,1.5
     parent: 0
     type: Transform
 - uid: 54
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -5.5,1.5
     parent: 0
     type: Transform
 - uid: 55
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -6.5,1.5
     parent: 0
     type: Transform
 - uid: 56
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -6.5,2.5
     parent: 0
     type: Transform
 - uid: 57
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -6.5,3.5
     parent: 0
     type: Transform
 - uid: 58
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,4.5
     parent: 0
     type: Transform
 - uid: 59
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,4.5
     parent: 0
     type: Transform
 - uid: 60
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -5.5,3.5
     parent: 0
     type: Transform
 - uid: 61
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -5.5,4.5
     parent: 0

--- a/Resources/Maps/Salvage/medium-ruined-emergency-shuttle.yml
+++ b/Resources/Maps/Salvage/medium-ruined-emergency-shuttle.yml
@@ -570,7 +570,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-1.5
     parent: 0
@@ -582,7 +582,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 5
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,4.5
     parent: 0
@@ -595,7 +595,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 7
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-5.5
     parent: 0
@@ -624,7 +624,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 11
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,2.5
     parent: 0
@@ -636,7 +636,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 13
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,4.5
     parent: 0
@@ -648,7 +648,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 15
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,4.5
     parent: 0
@@ -672,31 +672,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 19
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-3.5
     parent: 0
     type: Transform
 - uid: 20
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-3.5
     parent: 0
     type: Transform
 - uid: 21
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,4.5
     parent: 0
     type: Transform
 - uid: 22
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,6.5
     parent: 0
     type: Transform
 - uid: 23
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,-3.5
     parent: 0
@@ -709,49 +709,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 25
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,-3.5
     parent: 0
     type: Transform
 - uid: 26
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-7.5
     parent: 0
     type: Transform
 - uid: 27
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-5.5
     parent: 0
     type: Transform
 - uid: 28
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-3.5
     parent: 0
     type: Transform
 - uid: 29
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-1.5
     parent: 0
     type: Transform
 - uid: 30
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-2.5
     parent: 0
     type: Transform
 - uid: 31
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,2.5
     parent: 0
     type: Transform
 - uid: 32
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,3.5
     parent: 0
@@ -857,7 +857,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 44
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,4.5
     parent: 0
@@ -869,13 +869,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 46
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-4.5
     parent: 0
     type: Transform
 - uid: 47
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-3.5
     parent: 0
@@ -915,7 +915,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 53
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,4.5
     parent: 0
@@ -927,7 +927,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 55
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-6.5
     parent: 0

--- a/Resources/Maps/Salvage/medium-silent-orchestra.yml
+++ b/Resources/Maps/Salvage/medium-silent-orchestra.yml
@@ -684,145 +684,145 @@ entities:
   - sleepTime: 0.0666664
     type: Physics
 - uid: 16
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,2.5
     parent: 0
     type: Transform
 - uid: 17
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,1.5
     parent: 0
     type: Transform
 - uid: 18
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,0.5
     parent: 0
     type: Transform
 - uid: 19
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,-0.5
     parent: 0
     type: Transform
 - uid: 20
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,-1.5
     parent: 0
     type: Transform
 - uid: 21
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,-2.5
     parent: 0
     type: Transform
 - uid: 22
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,-3.5
     parent: 0
     type: Transform
 - uid: 23
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,-4.5
     parent: 0
     type: Transform
 - uid: 24
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,-5.5
     parent: 0
     type: Transform
 - uid: 25
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,-6.5
     parent: 0
     type: Transform
 - uid: 26
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,3.5
     parent: 0
     type: Transform
 - uid: 27
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,4.5
     parent: 0
     type: Transform
 - uid: 28
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,5.5
     parent: 0
     type: Transform
 - uid: 29
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,6.5
     parent: 0
     type: Transform
 - uid: 30
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -6.5,6.5
     parent: 0
     type: Transform
 - uid: 31
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -5.5,6.5
     parent: 0
     type: Transform
 - uid: 32
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,6.5
     parent: 0
     type: Transform
 - uid: 33
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,6.5
     parent: 0
     type: Transform
 - uid: 34
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,6.5
     parent: 0
     type: Transform
 - uid: 35
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,6.5
     parent: 0
     type: Transform
 - uid: 36
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,6.5
     parent: 0
     type: Transform
 - uid: 37
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,6.5
     parent: 0
     type: Transform
 - uid: 38
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,6.5
     parent: 0
     type: Transform
 - uid: 39
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,6.5
     parent: 0
@@ -1016,7 +1016,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 62
-  type: PartRodMetal1
+  type: PartRodSteel1
   components:
   - pos: 0.22723055,-0.8676058
     parent: 0

--- a/Resources/Maps/Salvage/medium-vault-1.yml
+++ b/Resources/Maps/Salvage/medium-vault-1.yml
@@ -764,91 +764,91 @@ entities:
   - chunkCollection: {}
     type: DecalGrid
 - uid: 1
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,5.5
     parent: 0
     type: Transform
 - uid: 2
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,2.5
     parent: 0
     type: Transform
 - uid: 3
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,2.5
     parent: 0
     type: Transform
 - uid: 4
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,2.5
     parent: 0
     type: Transform
 - uid: 5
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,2.5
     parent: 0
     type: Transform
 - uid: 6
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-3.5
     parent: 0
     type: Transform
 - uid: 7
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-2.5
     parent: 0
     type: Transform
 - uid: 8
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-1.5
     parent: 0
     type: Transform
 - uid: 9
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-0.5
     parent: 0
     type: Transform
 - uid: 10
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,0.5
     parent: 0
     type: Transform
 - uid: 11
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,2.5
     parent: 0
     type: Transform
 - uid: 12
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,2.5
     parent: 0
     type: Transform
 - uid: 13
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,3.5
     parent: 0
     type: Transform
 - uid: 14
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,3.5
     parent: 0
     type: Transform
 - uid: 15
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,4.5
     parent: 0
@@ -867,79 +867,79 @@ entities:
       PaperLabel: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 17
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-1.5
     parent: 0
     type: Transform
 - uid: 18
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-2.5
     parent: 0
     type: Transform
 - uid: 19
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-5.5
     parent: 0
     type: Transform
 - uid: 20
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-5.5
     parent: 0
     type: Transform
 - uid: 21
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-0.5
     parent: 0
     type: Transform
 - uid: 22
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,1.5
     parent: 0
     type: Transform
 - uid: 23
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-4.5
     parent: 0
     type: Transform
 - uid: 24
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,5.5
     parent: 0
     type: Transform
 - uid: 25
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-3.5
     parent: 0
     type: Transform
 - uid: 26
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-6.5
     parent: 0
     type: Transform
 - uid: 27
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-6.5
     parent: 0
     type: Transform
 - uid: 28
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-0.5
     parent: 0
     type: Transform
 - uid: 29
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-1.5
     parent: 0
@@ -951,115 +951,115 @@ entities:
     parent: 0
     type: Transform
 - uid: 31
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-4.5
     parent: 0
     type: Transform
 - uid: 32
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-6.5
     parent: 0
     type: Transform
 - uid: 33
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-2.5
     parent: 0
     type: Transform
 - uid: 34
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-1.5
     parent: 0
     type: Transform
 - uid: 35
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-3.5
     parent: 0
     type: Transform
 - uid: 36
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,5.5
     parent: 0
     type: Transform
 - uid: 37
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,1.5
     parent: 0
     type: Transform
 - uid: 38
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-6.5
     parent: 0
     type: Transform
 - uid: 39
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,5.5
     parent: 0
     type: Transform
 - uid: 40
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,4.5
     parent: 0
     type: Transform
 - uid: 41
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,2.5
     parent: 0
     type: Transform
 - uid: 42
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-0.5
     parent: 0
     type: Transform
 - uid: 43
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,-0.5
     parent: 0
     type: Transform
 - uid: 44
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,0.5
     parent: 0
     type: Transform
 - uid: 45
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,1.5
     parent: 0
     type: Transform
 - uid: 46
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-3.5
     parent: 0
     type: Transform
 - uid: 47
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-4.5
     parent: 0
     type: Transform
 - uid: 48
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,5.5
     parent: 0
     type: Transform
 - uid: 49
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,5.5
     parent: 0
@@ -1161,103 +1161,103 @@ entities:
     parent: 0
     type: Transform
 - uid: 66
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-6.5
     parent: 0
     type: Transform
 - uid: 67
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-1.5
     parent: 0
     type: Transform
 - uid: 68
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-5.5
     parent: 0
     type: Transform
 - uid: 69
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-5.5
     parent: 0
     type: Transform
 - uid: 70
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-5.5
     parent: 0
     type: Transform
 - uid: 71
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-0.5
     parent: 0
     type: Transform
 - uid: 72
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-6.5
     parent: 0
     type: Transform
 - uid: 73
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-2.5
     parent: 0
     type: Transform
 - uid: 74
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-1.5
     parent: 0
     type: Transform
 - uid: 75
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-0.5
     parent: 0
     type: Transform
 - uid: 76
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-4.5
     parent: 0
     type: Transform
 - uid: 77
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-5.5
     parent: 0
     type: Transform
 - uid: 78
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-5.5
     parent: 0
     type: Transform
 - uid: 79
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-4.5
     parent: 0
     type: Transform
 - uid: 80
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-3.5
     parent: 0
     type: Transform
 - uid: 81
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-2.5
     parent: 0
     type: Transform
 - uid: 82
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-1.5
     parent: 0
@@ -1273,19 +1273,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 84
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,5.5
     parent: 0
     type: Transform
 - uid: 85
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-5.5
     parent: 0
     type: Transform
 - uid: 86
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,1.5
     parent: 0
@@ -1309,13 +1309,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 90
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,5.5
     parent: 0
     type: Transform
 - uid: 91
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,2.5
     parent: 0

--- a/Resources/Maps/Salvage/small-1.yml
+++ b/Resources/Maps/Salvage/small-1.yml
@@ -197,13 +197,13 @@ entities:
       path: /Audio/Effects/alert.ogg
     type: Gravity
 - uid: 1
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,1.5
     parent: 0
     type: Transform
 - uid: 2
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,1.5
     parent: 0

--- a/Resources/Maps/Salvage/small-2.yml
+++ b/Resources/Maps/Salvage/small-2.yml
@@ -314,19 +314,19 @@ entities:
       path: /Audio/Effects/alert.ogg
     type: Gravity
 - uid: 1
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,1.5
     parent: 0
     type: Transform
 - uid: 2
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,1.5
     parent: 0
     type: Transform
 - uid: 3
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,1.5
     parent: 0
@@ -344,19 +344,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 5
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,1.5
     parent: 0
     type: Transform
 - uid: 6
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,1.5
     parent: 0
     type: Transform
 - uid: 7
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,1.5
     parent: 0
@@ -392,7 +392,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 13
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-2.5
     parent: 0

--- a/Resources/Maps/Salvage/small-3.yml
+++ b/Resources/Maps/Salvage/small-3.yml
@@ -400,7 +400,7 @@ entities:
   - chunkCollection: {}
     type: DecalGrid
 - uid: 1
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-2.5
     parent: 0
@@ -454,13 +454,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 6
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-2.5
     parent: 0
     type: Transform
 - uid: 7
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,-2.5
     parent: 0

--- a/Resources/Maps/Salvage/small-4.yml
+++ b/Resources/Maps/Salvage/small-4.yml
@@ -435,7 +435,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 9
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,-3.5
     parent: 0
@@ -451,7 +451,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 11
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-3.5
     parent: 0
@@ -556,7 +556,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 25
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,-1.5
     parent: 0
@@ -848,7 +848,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 55
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-3.5
     parent: 0

--- a/Resources/Maps/Salvage/small-ai-survey-drone.yml
+++ b/Resources/Maps/Salvage/small-ai-survey-drone.yml
@@ -358,7 +358,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-3.5
     parent: 0
@@ -429,7 +429,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 11
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-2.5
     parent: 0
@@ -441,13 +441,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 13
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-1.5
     parent: 0
     type: Transform
 - uid: 14
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-0.5
     parent: 0
@@ -459,25 +459,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 16
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,0.5
     parent: 0
     type: Transform
 - uid: 17
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,1.5
     parent: 0
     type: Transform
 - uid: 18
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,1.5
     parent: 0
     type: Transform
 - uid: 19
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,2.5
     parent: 0
@@ -503,61 +503,61 @@ entities:
     parent: 0
     type: Transform
 - uid: 23
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,2.5
     parent: 0
     type: Transform
 - uid: 24
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,1.5
     parent: 0
     type: Transform
 - uid: 25
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,1.5
     parent: 0
     type: Transform
 - uid: 26
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,0.5
     parent: 0
     type: Transform
 - uid: 27
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-0.5
     parent: 0
     type: Transform
 - uid: 28
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-0.5
     parent: 0
     type: Transform
 - uid: 29
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-1.5
     parent: 0
     type: Transform
 - uid: 30
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-2.5
     parent: 0
     type: Transform
 - uid: 31
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-2.5
     parent: 0
     type: Transform
 - uid: 32
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-3.5
     parent: 0

--- a/Resources/Maps/Test/Breathing/3by3-20oxy-80nit.yml
+++ b/Resources/Maps/Test/Breathing/3by3-20oxy-80nit.yml
@@ -86,49 +86,49 @@ entities:
     bodyType: Dynamic
     type: Physics
 - uid: 1
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,1.5
     parent: 0
     type: Transform
 - uid: 2
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,1.5
     parent: 0
     type: Transform
 - uid: 3
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,1.5
     parent: 0
     type: Transform
 - uid: 4
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,0.5
     parent: 0
     type: Transform
 - uid: 5
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-0.5
     parent: 0
     type: Transform
 - uid: 6
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-0.5
     parent: 0
     type: Transform
 - uid: 7
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-0.5
     parent: 0
     type: Transform
 - uid: 8
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,0.5
     parent: 0

--- a/Resources/Maps/Test/singularity.yml
+++ b/Resources/Maps/Test/singularity.yml
@@ -1579,7 +1579,7 @@ entities:
     pos: 0.5,10.5
     type: Transform
 - uid: 190
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 3.5,17.5
@@ -1615,145 +1615,145 @@ entities:
     pos: 2.5,13.5
     type: Transform
 - uid: 196
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 4.5,17.5
     type: Transform
 - uid: 197
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 5.5,17.5
     type: Transform
 - uid: 198
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 6.5,17.5
     type: Transform
 - uid: 199
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,17.5
     type: Transform
 - uid: 200
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,16.5
     type: Transform
 - uid: 201
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,15.5
     type: Transform
 - uid: 202
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,14.5
     type: Transform
 - uid: 203
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,13.5
     type: Transform
 - uid: 204
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,12.5
     type: Transform
 - uid: 205
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,11.5
     type: Transform
 - uid: 206
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,10.5
     type: Transform
 - uid: 207
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 7.5,9.5
     type: Transform
 - uid: 208
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 1.5,17.5
     type: Transform
 - uid: 209
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 2.5,17.5
     type: Transform
 - uid: 210
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,9.5
     type: Transform
 - uid: 211
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,10.5
     type: Transform
 - uid: 212
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,11.5
     type: Transform
 - uid: 213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,12.5
     type: Transform
 - uid: 214
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,13.5
     type: Transform
 - uid: 215
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,14.5
     type: Transform
 - uid: 216
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,15.5
     type: Transform
 - uid: 217
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,16.5
     type: Transform
 - uid: 218
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: -0.5,17.5
     type: Transform
 - uid: 219
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - parent: 0
     pos: 0.5,17.5

--- a/Resources/Maps/dart.yml
+++ b/Resources/Maps/dart.yml
@@ -651,13 +651,13 @@ entities:
       - 0
     type: GridAtmosphere
 - uid: 5
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-8.5
     parent: 4
     type: Transform
 - uid: 6
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-7.5
     parent: 4
@@ -669,31 +669,31 @@ entities:
     parent: 4
     type: Transform
 - uid: 8
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-5.5
     parent: 4
     type: Transform
 - uid: 9
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-4.5
     parent: 4
     type: Transform
 - uid: 10
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-3.5
     parent: 4
     type: Transform
 - uid: 11
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-2.5
     parent: 4
     type: Transform
 - uid: 12
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-1.5
     parent: 4
@@ -707,7 +707,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 14
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,0.5
     parent: 4
@@ -719,25 +719,25 @@ entities:
     parent: 4
     type: Transform
 - uid: 16
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,2.5
     parent: 4
     type: Transform
 - uid: 17
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,3.5
     parent: 4
     type: Transform
 - uid: 18
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,3.5
     parent: 4
     type: Transform
 - uid: 19
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,4.5
     parent: 4
@@ -755,25 +755,25 @@ entities:
     parent: 4
     type: Transform
 - uid: 22
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,4.5
     parent: 4
     type: Transform
 - uid: 23
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,3.5
     parent: 4
     type: Transform
 - uid: 24
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,3.5
     parent: 4
     type: Transform
 - uid: 25
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,2.5
     parent: 4
@@ -785,43 +785,43 @@ entities:
     parent: 4
     type: Transform
 - uid: 27
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,0.5
     parent: 4
     type: Transform
 - uid: 28
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,0.5
     parent: 4
     type: Transform
 - uid: 29
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-1.5
     parent: 4
     type: Transform
 - uid: 30
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-2.5
     parent: 4
     type: Transform
 - uid: 31
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-3.5
     parent: 4
     type: Transform
 - uid: 32
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-4.5
     parent: 4
     type: Transform
 - uid: 33
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-5.5
     parent: 4
@@ -833,31 +833,31 @@ entities:
     parent: 4
     type: Transform
 - uid: 35
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-7.5
     parent: 4
     type: Transform
 - uid: 36
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-8.5
     parent: 4
     type: Transform
 - uid: 37
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-8.5
     parent: 4
     type: Transform
 - uid: 38
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-9.5
     parent: 4
     type: Transform
 - uid: 39
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 4.5,-12.5
@@ -880,103 +880,103 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 42
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-9.5
     parent: 4
     type: Transform
 - uid: 43
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-8.5
     parent: 4
     type: Transform
 - uid: 44
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-4.5
     parent: 4
     type: Transform
 - uid: 45
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-4.5
     parent: 4
     type: Transform
 - uid: 46
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-4.5
     parent: 4
     type: Transform
 - uid: 47
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-4.5
     parent: 4
     type: Transform
 - uid: 48
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-3.5
     parent: 4
     type: Transform
 - uid: 49
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-2.5
     parent: 4
     type: Transform
 - uid: 50
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-2.5
     parent: 4
     type: Transform
 - uid: 51
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-1.5
     parent: 4
     type: Transform
 - uid: 52
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,0.5
     parent: 4
     type: Transform
 - uid: 53
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,0.5
     parent: 4
     type: Transform
 - uid: 54
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,0.5
     parent: 4
     type: Transform
 - uid: 55
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,0.5
     parent: 4
     type: Transform
 - uid: 56
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,2.5
     parent: 4
     type: Transform
 - uid: 57
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,3.5
     parent: 4
     type: Transform
 - uid: 58
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,3.5
     parent: 4
@@ -1102,13 +1102,13 @@ entities:
     parent: 4
     type: Transform
 - uid: 79
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,0.5
     parent: 4
     type: Transform
 - uid: 80
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-3.5
     parent: 4
@@ -1331,7 +1331,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 107
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 4.5,-13.5
@@ -1912,7 +1912,7 @@ entities:
       cellslot_cell_container: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 185
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-0.5
     parent: 4
@@ -2125,7 +2125,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 209
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 3.5,-13.5
@@ -2400,7 +2400,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,0.5
     parent: 4
@@ -2436,13 +2436,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 241
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-2.5
     parent: 4
     type: Transform
 - uid: 242
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 4.5,-10.5
@@ -2457,7 +2457,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 244
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 2.5,-13.5
@@ -2730,7 +2730,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 272
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-3.5
     parent: 4
@@ -2776,14 +2776,14 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 277
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 4.5,-11.5
     parent: 4
     type: Transform
 - uid: 278
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 1.5,-13.5
@@ -2998,28 +2998,28 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 300
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 0.5,-13.5
     parent: 4
     type: Transform
 - uid: 301
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 0.5,-11.5
     parent: 4
     type: Transform
 - uid: 302
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 0.5,-10.5
     parent: 4
     type: Transform
 - uid: 303
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 3.141592653589793 rad
     pos: 0.5,-12.5
@@ -3210,7 +3210,7 @@ entities:
   - color: '#03FCF0FF'
     type: AtmosPipeColor
 - uid: 319
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-0.5
     parent: 4
@@ -3254,7 +3254,7 @@ entities:
   - color: '#03FCF0FF'
     type: AtmosPipeColor
 - uid: 323
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-3.5
     parent: 4

--- a/Resources/Maps/knightship.yml
+++ b/Resources/Maps/knightship.yml
@@ -1149,19 +1149,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 11
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-11.5
     parent: 0
     type: Transform
 - uid: 12
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-9.5
     parent: 0
     type: Transform
 - uid: 13
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-7.5
     parent: 0
@@ -1227,49 +1227,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 24
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-12.5
     parent: 0
     type: Transform
 - uid: 25
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-10.5
     parent: 0
     type: Transform
 - uid: 26
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-8.5
     parent: 0
     type: Transform
 - uid: 27
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,2.5
     parent: 0
     type: Transform
 - uid: 28
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,2.5
     parent: 0
     type: Transform
 - uid: 29
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,2.5
     parent: 0
     type: Transform
 - uid: 30
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-6.5
     parent: 0
     type: Transform
 - uid: 31
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-13.5
     parent: 0
@@ -1292,55 +1292,55 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 34
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,2.5
     parent: 0
     type: Transform
 - uid: 35
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,0.5
     parent: 0
     type: Transform
 - uid: 36
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,0.5
     parent: 0
     type: Transform
 - uid: 37
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,0.5
     parent: 0
     type: Transform
 - uid: 38
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-13.5
     parent: 0
     type: Transform
 - uid: 39
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-14.5
     parent: 0
     type: Transform
 - uid: 40
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-14.5
     parent: 0
     type: Transform
 - uid: 41
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-14.5
     parent: 0
     type: Transform
 - uid: 42
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-14.5
     parent: 0
@@ -1354,7 +1354,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 44
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-14.5
     parent: 0
@@ -1403,37 +1403,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 50
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-8.5
     parent: 0
     type: Transform
 - uid: 51
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-9.5
     parent: 0
     type: Transform
 - uid: 52
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-10.5
     parent: 0
     type: Transform
 - uid: 53
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-11.5
     parent: 0
     type: Transform
 - uid: 54
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-12.5
     parent: 0
     type: Transform
 - uid: 55
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-13.5
     parent: 0
@@ -1447,115 +1447,115 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 57
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-7.5
     parent: 0
     type: Transform
 - uid: 58
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-6.5
     parent: 0
     type: Transform
 - uid: 59
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-5.5
     parent: 0
     type: Transform
 - uid: 60
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-4.5
     parent: 0
     type: Transform
 - uid: 61
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-3.5
     parent: 0
     type: Transform
 - uid: 62
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-2.5
     parent: 0
     type: Transform
 - uid: 63
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-1.5
     parent: 0
     type: Transform
 - uid: 64
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-0.5
     parent: 0
     type: Transform
 - uid: 65
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-5.5
     parent: 0
     type: Transform
 - uid: 66
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-4.5
     parent: 0
     type: Transform
 - uid: 67
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-3.5
     parent: 0
     type: Transform
 - uid: 68
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-2.5
     parent: 0
     type: Transform
 - uid: 69
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-1.5
     parent: 0
     type: Transform
 - uid: 70
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-0.5
     parent: 0
     type: Transform
 - uid: 71
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,0.5
     parent: 0
     type: Transform
 - uid: 72
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,1.5
     parent: 0
     type: Transform
 - uid: 73
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,2.5
     parent: 0
     type: Transform
 - uid: 74
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,2.5
     parent: 0
     type: Transform
 - uid: 75
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,2.5
     parent: 0
@@ -1603,7 +1603,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 83
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,3.5
     parent: 0
@@ -1657,7 +1657,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 92
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-10.5
     parent: 0
@@ -1681,7 +1681,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 95
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-9.5
     parent: 0
@@ -1699,7 +1699,7 @@ entities:
   - radius: 2.5
     type: PointLight
 - uid: 97
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-9.5
     parent: 0
@@ -1723,31 +1723,31 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 100
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-12.5
     parent: 0
     type: Transform
 - uid: 101
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-8.5
     parent: 0
     type: Transform
 - uid: 102
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-9.5
     parent: 0
     type: Transform
 - uid: 103
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-10.5
     parent: 0
     type: Transform
 - uid: 104
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-11.5
     parent: 0
@@ -1792,7 +1792,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 110
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-9.5
     parent: 0
@@ -1874,79 +1874,79 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 118
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-6.5
     parent: 0
     type: Transform
 - uid: 119
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-5.5
     parent: 0
     type: Transform
 - uid: 120
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-4.5
     parent: 0
     type: Transform
 - uid: 121
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-3.5
     parent: 0
     type: Transform
 - uid: 122
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -3.5,-3.5
     parent: 0
     type: Transform
 - uid: 123
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -2.5,-3.5
     parent: 0
     type: Transform
 - uid: 124
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,-3.5
     parent: 0
     type: Transform
 - uid: 125
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-3.5
     parent: 0
     type: Transform
 - uid: 126
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,0.5
     parent: 0
     type: Transform
 - uid: 127
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -1.5,0.5
     parent: 0
     type: Transform
 - uid: 128
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,0.5
     parent: 0
     type: Transform
 - uid: 129
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-0.5
     parent: 0
     type: Transform
 - uid: 130
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-1.5
     parent: 0
@@ -2571,7 +2571,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 202
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,3.5
     parent: 0
@@ -2607,13 +2607,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 207
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,3.5
     parent: 0
     type: Transform
 - uid: 208
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,3.5
     parent: 0
@@ -2686,7 +2686,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 218
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-4.5
     parent: 0
@@ -2704,13 +2704,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 220
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,-4.5
     parent: 0
     type: Transform
 - uid: 221
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-4.5
     parent: 0
@@ -2840,7 +2840,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 238
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-8.5
     parent: 0
@@ -2870,13 +2870,13 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 242
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-9.5
     parent: 0
     type: Transform
 - uid: 243
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-10.5
     parent: 0
@@ -2914,7 +2914,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 248
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-9.5
     parent: 0
@@ -2971,7 +2971,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 255
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-7.5
     parent: 0
@@ -3010,7 +3010,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 260
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,0.5
     parent: 0
@@ -3022,7 +3022,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 262
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-0.5
     parent: 0
@@ -3036,7 +3036,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 264
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,0.5
     parent: 0
@@ -3054,7 +3054,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 266
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,0.5
     parent: 0
@@ -3071,7 +3071,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 268
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,2.5
     parent: 0
@@ -3338,13 +3338,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 299
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-2.5
     parent: 0
     type: Transform
 - uid: 300
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-2.5
     parent: 0
@@ -3362,19 +3362,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 303
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,0.5
     parent: 0
     type: Transform
 - uid: 304
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-2.5
     parent: 0
     type: Transform
 - uid: 305
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-2.5
     parent: 0
@@ -3439,25 +3439,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 312
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-1.5
     parent: 0
     type: Transform
 - uid: 313
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-1.5
     parent: 0
     type: Transform
 - uid: 314
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,0.5
     parent: 0
     type: Transform
 - uid: 315
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-1.5
     parent: 0
@@ -3517,13 +3517,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 322
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-5.5
     parent: 0
     type: Transform
 - uid: 323
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-5.5
     parent: 0
@@ -3541,19 +3541,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 325
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-5.5
     parent: 0
     type: Transform
 - uid: 326
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-5.5
     parent: 0
     type: Transform
 - uid: 327
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-3.5
     parent: 0
@@ -3689,13 +3689,13 @@ entities:
         reagents: []
     type: SolutionContainerManager
 - uid: 339
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-3.5
     parent: 0
     type: Transform
 - uid: 340
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-3.5
     parent: 0
@@ -5155,55 +5155,55 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 500
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-14.5
     parent: 0
     type: Transform
 - uid: 501
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-14.5
     parent: 0
     type: Transform
 - uid: 502
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-14.5
     parent: 0
     type: Transform
 - uid: 503
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-14.5
     parent: 0
     type: Transform
 - uid: 504
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-14.5
     parent: 0
     type: Transform
 - uid: 505
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-14.5
     parent: 0
     type: Transform
 - uid: 506
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-14.5
     parent: 0
     type: Transform
 - uid: 507
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-14.5
     parent: 0
     type: Transform
 - uid: 508
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-14.5
     parent: 0
@@ -5467,7 +5467,7 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 539
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,-14.5
     parent: 0
@@ -5498,7 +5498,7 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 543
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-14.5
     parent: 0
@@ -5574,7 +5574,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 552
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-16.5
     parent: 0

--- a/Resources/Maps/packedstation.yml
+++ b/Resources/Maps/packedstation.yml
@@ -17142,31 +17142,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 13
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,1.5
     parent: 0
     type: Transform
 - uid: 14
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,1.5
     parent: 0
     type: Transform
 - uid: 15
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,1.5
     parent: 0
     type: Transform
 - uid: 16
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,1.5
     parent: 0
     type: Transform
 - uid: 17
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,1.5
     parent: 0
@@ -17376,25 +17376,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 52
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -20.5,-5.5
     parent: 0
     type: Transform
 - uid: 53
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,-5.5
     parent: 0
     type: Transform
 - uid: 54
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,-5.5
     parent: 0
     type: Transform
 - uid: 55
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -10.5,-5.5
     parent: 0
@@ -17496,73 +17496,73 @@ entities:
     parent: 0
     type: Transform
 - uid: 72
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -7.5,-10.5
     parent: 0
     type: Transform
 - uid: 73
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-10.5
     parent: 0
     type: Transform
 - uid: 74
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,-10.5
     parent: 0
     type: Transform
 - uid: 75
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,2.5
     parent: 0
     type: Transform
 - uid: 76
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-6.5
     parent: 0
     type: Transform
 - uid: 77
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-6.5
     parent: 0
     type: Transform
 - uid: 78
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-6.5
     parent: 0
     type: Transform
 - uid: 79
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-6.5
     parent: 0
     type: Transform
 - uid: 80
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-6.5
     parent: 0
     type: Transform
 - uid: 81
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-5.5
     parent: 0
     type: Transform
 - uid: 82
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-3.5
     parent: 0
     type: Transform
 - uid: 83
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-2.5
     parent: 0
@@ -17578,19 +17578,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 85
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-3.5
     parent: 0
     type: Transform
 - uid: 86
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-5.5
     parent: 0
     type: Transform
 - uid: 87
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-6.5
     parent: 0
@@ -17896,55 +17896,55 @@ entities:
     parent: 0
     type: Transform
 - uid: 127
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-13.5
     parent: 0
     type: Transform
 - uid: 128
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,-13.5
     parent: 0
     type: Transform
 - uid: 129
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-13.5
     parent: 0
     type: Transform
 - uid: 130
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-12.5
     parent: 0
     type: Transform
 - uid: 131
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-11.5
     parent: 0
     type: Transform
 - uid: 132
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-9.5
     parent: 0
     type: Transform
 - uid: 133
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-8.5
     parent: 0
     type: Transform
 - uid: 134
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-8.5
     parent: 0
     type: Transform
 - uid: 135
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-7.5
     parent: 0
@@ -18190,109 +18190,109 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 167
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-3.5
     parent: 0
     type: Transform
 - uid: 168
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-4.5
     parent: 0
     type: Transform
 - uid: 169
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-5.5
     parent: 0
     type: Transform
 - uid: 170
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-6.5
     parent: 0
     type: Transform
 - uid: 171
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-7.5
     parent: 0
     type: Transform
 - uid: 172
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-7.5
     parent: 0
     type: Transform
 - uid: 173
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-7.5
     parent: 0
     type: Transform
 - uid: 174
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-7.5
     parent: 0
     type: Transform
 - uid: 175
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-2.5
     parent: 0
     type: Transform
 - uid: 176
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-2.5
     parent: 0
     type: Transform
 - uid: 177
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-2.5
     parent: 0
     type: Transform
 - uid: 178
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-2.5
     parent: 0
     type: Transform
 - uid: 179
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-3.5
     parent: 0
     type: Transform
 - uid: 180
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-4.5
     parent: 0
     type: Transform
 - uid: 181
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-5.5
     parent: 0
     type: Transform
 - uid: 182
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-6.5
     parent: 0
     type: Transform
 - uid: 183
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-7.5
     parent: 0
     type: Transform
 - uid: 184
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-2.5
     parent: 0
@@ -18440,103 +18440,103 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 201
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-8.5
     parent: 0
     type: Transform
 - uid: 202
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-9.5
     parent: 0
     type: Transform
 - uid: 203
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-10.5
     parent: 0
     type: Transform
 - uid: 204
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-10.5
     parent: 0
     type: Transform
 - uid: 205
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-10.5
     parent: 0
     type: Transform
 - uid: 206
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-10.5
     parent: 0
     type: Transform
 - uid: 207
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-10.5
     parent: 0
     type: Transform
 - uid: 208
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-10.5
     parent: 0
     type: Transform
 - uid: 209
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-12.5
     parent: 0
     type: Transform
 - uid: 210
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-13.5
     parent: 0
     type: Transform
 - uid: 211
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-14.5
     parent: 0
     type: Transform
 - uid: 212
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-16.5
     parent: 0
     type: Transform
 - uid: 213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-17.5
     parent: 0
     type: Transform
 - uid: 214
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-14.5
     parent: 0
     type: Transform
 - uid: 215
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-15.5
     parent: 0
     type: Transform
 - uid: 216
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-16.5
     parent: 0
     type: Transform
 - uid: 217
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-17.5
     parent: 0
@@ -18604,97 +18604,97 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 227
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-2.5
     parent: 0
     type: Transform
 - uid: 228
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-3.5
     parent: 0
     type: Transform
 - uid: 229
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-4.5
     parent: 0
     type: Transform
 - uid: 230
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-4.5
     parent: 0
     type: Transform
 - uid: 231
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-4.5
     parent: 0
     type: Transform
 - uid: 232
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-4.5
     parent: 0
     type: Transform
 - uid: 233
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-5.5
     parent: 0
     type: Transform
 - uid: 234
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-6.5
     parent: 0
     type: Transform
 - uid: 235
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-7.5
     parent: 0
     type: Transform
 - uid: 236
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-8.5
     parent: 0
     type: Transform
 - uid: 237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-9.5
     parent: 0
     type: Transform
 - uid: 238
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-9.5
     parent: 0
     type: Transform
 - uid: 239
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-9.5
     parent: 0
     type: Transform
 - uid: 240
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-9.5
     parent: 0
     type: Transform
 - uid: 241
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-10.5
     parent: 0
     type: Transform
 - uid: 242
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-10.5
     parent: 0
@@ -18932,31 +18932,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 276
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,6.5
     parent: 0
     type: Transform
 - uid: 277
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,8.5
     parent: 0
     type: Transform
 - uid: 278
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,12.5
     parent: 0
     type: Transform
 - uid: 279
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,1.5
     parent: 0
     type: Transform
 - uid: 280
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,1.5
     parent: 0
@@ -19034,109 +19034,109 @@ entities:
     parent: 0
     type: Transform
 - uid: 293
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,8.5
     parent: 0
     type: Transform
 - uid: 294
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,4.5
     parent: 0
     type: Transform
 - uid: 295
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,3.5
     parent: 0
     type: Transform
 - uid: 296
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,2.5
     parent: 0
     type: Transform
 - uid: 297
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,2.5
     parent: 0
     type: Transform
 - uid: 298
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,2.5
     parent: 0
     type: Transform
 - uid: 299
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,2.5
     parent: 0
     type: Transform
 - uid: 300
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,2.5
     parent: 0
     type: Transform
 - uid: 301
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,2.5
     parent: 0
     type: Transform
 - uid: 302
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,2.5
     parent: 0
     type: Transform
 - uid: 303
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,2.5
     parent: 0
     type: Transform
 - uid: 304
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,3.5
     parent: 0
     type: Transform
 - uid: 305
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,4.5
     parent: 0
     type: Transform
 - uid: 306
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,6.5
     parent: 0
     type: Transform
 - uid: 307
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,6.5
     parent: 0
     type: Transform
 - uid: 308
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,7.5
     parent: 0
     type: Transform
 - uid: 309
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,8.5
     parent: 0
     type: Transform
 - uid: 310
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,8.5
     parent: 0
@@ -19566,7 +19566,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 365
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,13.5
     parent: 0
@@ -19726,19 +19726,19 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 390
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,13.5
     parent: 0
     type: Transform
 - uid: 391
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,12.5
     parent: 0
     type: Transform
 - uid: 392
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,11.5
     parent: 0
@@ -19879,13 +19879,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 409
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,16.5
     parent: 0
     type: Transform
 - uid: 410
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,17.5
     parent: 0
@@ -19903,55 +19903,55 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 412
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,19.5
     parent: 0
     type: Transform
 - uid: 413
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,20.5
     parent: 0
     type: Transform
 - uid: 414
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,20.5
     parent: 0
     type: Transform
 - uid: 415
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,16.5
     parent: 0
     type: Transform
 - uid: 416
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,16.5
     parent: 0
     type: Transform
 - uid: 417
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,15.5
     parent: 0
     type: Transform
 - uid: 418
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,15.5
     parent: 0
     type: Transform
 - uid: 419
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,16.5
     parent: 0
     type: Transform
 - uid: 420
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,20.5
     parent: 0
@@ -20039,25 +20039,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 433
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,16.5
     parent: 0
     type: Transform
 - uid: 434
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,16.5
     parent: 0
     type: Transform
 - uid: 435
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,15.5
     parent: 0
     type: Transform
 - uid: 436
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,14.5
     parent: 0
@@ -20161,19 +20161,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 452
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,21.5
     parent: 0
     type: Transform
 - uid: 453
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,20.5
     parent: 0
     type: Transform
 - uid: 454
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,19.5
     parent: 0
@@ -20205,7 +20205,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 458
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,17.5
     parent: 0
@@ -20239,7 +20239,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 462
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,18.5
     parent: 0
@@ -20301,79 +20301,79 @@ entities:
     parent: 0
     type: Transform
 - uid: 469
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,14.5
     parent: 0
     type: Transform
 - uid: 470
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,14.5
     parent: 0
     type: Transform
 - uid: 471
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,14.5
     parent: 0
     type: Transform
 - uid: 472
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,14.5
     parent: 0
     type: Transform
 - uid: 473
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,14.5
     parent: 0
     type: Transform
 - uid: 474
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,14.5
     parent: 0
     type: Transform
 - uid: 475
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,13.5
     parent: 0
     type: Transform
 - uid: 476
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,12.5
     parent: 0
     type: Transform
 - uid: 477
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,11.5
     parent: 0
     type: Transform
 - uid: 478
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,11.5
     parent: 0
     type: Transform
 - uid: 479
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,11.5
     parent: 0
     type: Transform
 - uid: 480
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,11.5
     parent: 0
     type: Transform
 - uid: 481
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,11.5
     parent: 0
@@ -20456,67 +20456,67 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 491
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-17.5
     parent: 0
     type: Transform
 - uid: 492
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-16.5
     parent: 0
     type: Transform
 - uid: 493
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-14.5
     parent: 0
     type: Transform
 - uid: 494
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-11.5
     parent: 0
     type: Transform
 - uid: 495
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-12.5
     parent: 0
     type: Transform
 - uid: 496
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-12.5
     parent: 0
     type: Transform
 - uid: 497
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-13.5
     parent: 0
     type: Transform
 - uid: 498
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-13.5
     parent: 0
     type: Transform
 - uid: 499
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-14.5
     parent: 0
     type: Transform
 - uid: 500
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,-14.5
     parent: 0
     type: Transform
 - uid: 501
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-14.5
     parent: 0
@@ -20572,133 +20572,133 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 507
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-6.5
     parent: 0
     type: Transform
 - uid: 508
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-11.5
     parent: 0
     type: Transform
 - uid: 509
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-10.5
     parent: 0
     type: Transform
 - uid: 510
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-12.5
     parent: 0
     type: Transform
 - uid: 511
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-12.5
     parent: 0
     type: Transform
 - uid: 512
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-6.5
     parent: 0
     type: Transform
 - uid: 513
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-6.5
     parent: 0
     type: Transform
 - uid: 514
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-6.5
     parent: 0
     type: Transform
 - uid: 515
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-6.5
     parent: 0
     type: Transform
 - uid: 516
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-6.5
     parent: 0
     type: Transform
 - uid: 517
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-6.5
     parent: 0
     type: Transform
 - uid: 518
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-5.5
     parent: 0
     type: Transform
 - uid: 519
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-4.5
     parent: 0
     type: Transform
 - uid: 520
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-3.5
     parent: 0
     type: Transform
 - uid: 521
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-2.5
     parent: 0
     type: Transform
 - uid: 522
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-1.5
     parent: 0
     type: Transform
 - uid: 523
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-1.5
     parent: 0
     type: Transform
 - uid: 524
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-1.5
     parent: 0
     type: Transform
 - uid: 525
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-1.5
     parent: 0
     type: Transform
 - uid: 526
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-1.5
     parent: 0
     type: Transform
 - uid: 527
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-2.5
     parent: 0
     type: Transform
 - uid: 528
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-2.5
     parent: 0
@@ -20716,25 +20716,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 531
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-7.5
     parent: 0
     type: Transform
 - uid: 532
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-8.5
     parent: 0
     type: Transform
 - uid: 533
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-9.5
     parent: 0
     type: Transform
 - uid: 534
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-10.5
     parent: 0
@@ -20750,115 +20750,115 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 536
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-2.5
     parent: 0
     type: Transform
 - uid: 537
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-3.5
     parent: 0
     type: Transform
 - uid: 538
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-3.5
     parent: 0
     type: Transform
 - uid: 539
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-1.5
     parent: 0
     type: Transform
 - uid: 540
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-1.5
     parent: 0
     type: Transform
 - uid: 541
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-4.5
     parent: 0
     type: Transform
 - uid: 542
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-5.5
     parent: 0
     type: Transform
 - uid: 543
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-6.5
     parent: 0
     type: Transform
 - uid: 544
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-6.5
     parent: 0
     type: Transform
 - uid: 545
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-7.5
     parent: 0
     type: Transform
 - uid: 546
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-8.5
     parent: 0
     type: Transform
 - uid: 547
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-8.5
     parent: 0
     type: Transform
 - uid: 548
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,-8.5
     parent: 0
     type: Transform
 - uid: 549
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-8.5
     parent: 0
     type: Transform
 - uid: 550
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-8.5
     parent: 0
     type: Transform
 - uid: 551
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-9.5
     parent: 0
     type: Transform
 - uid: 552
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-10.5
     parent: 0
     type: Transform
 - uid: 553
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-11.5
     parent: 0
     type: Transform
 - uid: 554
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-12.5
     parent: 0
@@ -20872,7 +20872,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 556
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-13.5
     parent: 0
@@ -20886,37 +20886,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 558
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-13.5
     parent: 0
     type: Transform
 - uid: 559
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-13.5
     parent: 0
     type: Transform
 - uid: 560
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-13.5
     parent: 0
     type: Transform
 - uid: 561
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-13.5
     parent: 0
     type: Transform
 - uid: 562
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-13.5
     parent: 0
     type: Transform
 - uid: 563
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-13.5
     parent: 0
@@ -20954,19 +20954,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 568
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,2.5
     parent: 0
     type: Transform
 - uid: 569
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,2.5
     parent: 0
     type: Transform
 - uid: 570
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,2.5
     parent: 0
@@ -21492,271 +21492,271 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 637
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-14.5
     parent: 0
     type: Transform
 - uid: 638
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-15.5
     parent: 0
     type: Transform
 - uid: 639
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-14.5
     parent: 0
     type: Transform
 - uid: 640
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-14.5
     parent: 0
     type: Transform
 - uid: 641
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-14.5
     parent: 0
     type: Transform
 - uid: 642
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-14.5
     parent: 0
     type: Transform
 - uid: 643
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-14.5
     parent: 0
     type: Transform
 - uid: 644
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-14.5
     parent: 0
     type: Transform
 - uid: 645
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-15.5
     parent: 0
     type: Transform
 - uid: 646
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-16.5
     parent: 0
     type: Transform
 - uid: 647
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-17.5
     parent: 0
     type: Transform
 - uid: 648
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-18.5
     parent: 0
     type: Transform
 - uid: 649
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-19.5
     parent: 0
     type: Transform
 - uid: 650
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-20.5
     parent: 0
     type: Transform
 - uid: 651
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-15.5
     parent: 0
     type: Transform
 - uid: 652
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-16.5
     parent: 0
     type: Transform
 - uid: 653
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-17.5
     parent: 0
     type: Transform
 - uid: 654
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-18.5
     parent: 0
     type: Transform
 - uid: 655
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-19.5
     parent: 0
     type: Transform
 - uid: 656
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-20.5
     parent: 0
     type: Transform
 - uid: 657
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-15.5
     parent: 0
     type: Transform
 - uid: 658
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-15.5
     parent: 0
     type: Transform
 - uid: 659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-15.5
     parent: 0
     type: Transform
 - uid: 660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-20.5
     parent: 0
     type: Transform
 - uid: 661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-20.5
     parent: 0
     type: Transform
 - uid: 662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-20.5
     parent: 0
     type: Transform
 - uid: 663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-20.5
     parent: 0
     type: Transform
 - uid: 664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-20.5
     parent: 0
     type: Transform
 - uid: 665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-20.5
     parent: 0
     type: Transform
 - uid: 666
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-20.5
     parent: 0
     type: Transform
 - uid: 667
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-20.5
     parent: 0
     type: Transform
 - uid: 668
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-20.5
     parent: 0
     type: Transform
 - uid: 669
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-20.5
     parent: 0
     type: Transform
 - uid: 670
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-19.5
     parent: 0
     type: Transform
 - uid: 671
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-19.5
     parent: 0
     type: Transform
 - uid: 672
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-19.5
     parent: 0
     type: Transform
 - uid: 673
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-19.5
     parent: 0
     type: Transform
 - uid: 674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-19.5
     parent: 0
     type: Transform
 - uid: 675
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-19.5
     parent: 0
     type: Transform
 - uid: 676
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-19.5
     parent: 0
     type: Transform
 - uid: 677
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-19.5
     parent: 0
     type: Transform
 - uid: 678
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-18.5
     parent: 0
     type: Transform
 - uid: 679
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-16.5
     parent: 0
     type: Transform
 - uid: 680
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-15.5
     parent: 0
     type: Transform
 - uid: 681
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-14.5
     parent: 0
@@ -21969,55 +21969,55 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 711
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-17.5
     parent: 0
     type: Transform
 - uid: 712
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-17.5
     parent: 0
     type: Transform
 - uid: 713
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-17.5
     parent: 0
     type: Transform
 - uid: 714
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-18.5
     parent: 0
     type: Transform
 - uid: 715
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-19.5
     parent: 0
     type: Transform
 - uid: 716
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-20.5
     parent: 0
     type: Transform
 - uid: 717
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-21.5
     parent: 0
     type: Transform
 - uid: 718
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-21.5
     parent: 0
     type: Transform
 - uid: 719
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-22.5
     parent: 0
@@ -22065,7 +22065,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 727
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-28.5
     parent: 0
@@ -22077,193 +22077,193 @@ entities:
     parent: 0
     type: Transform
 - uid: 729
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-22.5
     parent: 0
     type: Transform
 - uid: 730
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-23.5
     parent: 0
     type: Transform
 - uid: 731
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-24.5
     parent: 0
     type: Transform
 - uid: 732
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-25.5
     parent: 0
     type: Transform
 - uid: 733
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-24.5
     parent: 0
     type: Transform
 - uid: 734
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-24.5
     parent: 0
     type: Transform
 - uid: 735
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-24.5
     parent: 0
     type: Transform
 - uid: 736
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-25.5
     parent: 0
     type: Transform
 - uid: 737
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-25.5
     parent: 0
     type: Transform
 - uid: 738
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-26.5
     parent: 0
     type: Transform
 - uid: 739
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-27.5
     parent: 0
     type: Transform
 - uid: 740
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-28.5
     parent: 0
     type: Transform
 - uid: 741
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-29.5
     parent: 0
     type: Transform
 - uid: 742
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-30.5
     parent: 0
     type: Transform
 - uid: 743
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-31.5
     parent: 0
     type: Transform
 - uid: 744
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-32.5
     parent: 0
     type: Transform
 - uid: 745
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-32.5
     parent: 0
     type: Transform
 - uid: 746
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-32.5
     parent: 0
     type: Transform
 - uid: 747
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-32.5
     parent: 0
     type: Transform
 - uid: 748
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-32.5
     parent: 0
     type: Transform
 - uid: 749
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-32.5
     parent: 0
     type: Transform
 - uid: 750
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-32.5
     parent: 0
     type: Transform
 - uid: 751
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-32.5
     parent: 0
     type: Transform
 - uid: 752
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-32.5
     parent: 0
     type: Transform
 - uid: 753
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-28.5
     parent: 0
     type: Transform
 - uid: 754
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-29.5
     parent: 0
     type: Transform
 - uid: 755
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-29.5
     parent: 0
     type: Transform
 - uid: 756
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-29.5
     parent: 0
     type: Transform
 - uid: 757
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-29.5
     parent: 0
     type: Transform
 - uid: 758
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-29.5
     parent: 0
     type: Transform
 - uid: 759
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-30.5
     parent: 0
     type: Transform
 - uid: 760
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-31.5
     parent: 0
@@ -22357,133 +22357,133 @@ entities:
     parent: 0
     type: Transform
 - uid: 775
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-22.5
     parent: 0
     type: Transform
 - uid: 776
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-22.5
     parent: 0
     type: Transform
 - uid: 777
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-22.5
     parent: 0
     type: Transform
 - uid: 778
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-22.5
     parent: 0
     type: Transform
 - uid: 779
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-22.5
     parent: 0
     type: Transform
 - uid: 780
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-22.5
     parent: 0
     type: Transform
 - uid: 781
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-22.5
     parent: 0
     type: Transform
 - uid: 782
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-22.5
     parent: 0
     type: Transform
 - uid: 783
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-22.5
     parent: 0
     type: Transform
 - uid: 784
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-22.5
     parent: 0
     type: Transform
 - uid: 785
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-22.5
     parent: 0
     type: Transform
 - uid: 786
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-23.5
     parent: 0
     type: Transform
 - uid: 787
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-24.5
     parent: 0
     type: Transform
 - uid: 788
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-25.5
     parent: 0
     type: Transform
 - uid: 789
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-25.5
     parent: 0
     type: Transform
 - uid: 790
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-26.5
     parent: 0
     type: Transform
 - uid: 791
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-27.5
     parent: 0
     type: Transform
 - uid: 792
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-29.5
     parent: 0
     type: Transform
 - uid: 793
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-29.5
     parent: 0
     type: Transform
 - uid: 794
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-29.5
     parent: 0
     type: Transform
 - uid: 795
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,-29.5
     parent: 0
     type: Transform
 - uid: 796
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,-29.5
     parent: 0
@@ -22812,61 +22812,61 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 838
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-30.5
     parent: 0
     type: Transform
 - uid: 839
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,-30.5
     parent: 0
     type: Transform
 - uid: 840
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 26.5,-30.5
     parent: 0
     type: Transform
 - uid: 841
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-30.5
     parent: 0
     type: Transform
 - uid: 842
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,-30.5
     parent: 0
     type: Transform
 - uid: 843
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-29.5
     parent: 0
     type: Transform
 - uid: 844
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-29.5
     parent: 0
     type: Transform
 - uid: 845
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-25.5
     parent: 0
     type: Transform
 - uid: 846
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-26.5
     parent: 0
     type: Transform
 - uid: 847
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-27.5
     parent: 0
@@ -23034,67 +23034,67 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 865
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-31.5
     parent: 0
     type: Transform
 - uid: 866
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,-33.5
     parent: 0
     type: Transform
 - uid: 867
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-33.5
     parent: 0
     type: Transform
 - uid: 868
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,-33.5
     parent: 0
     type: Transform
 - uid: 869
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-33.5
     parent: 0
     type: Transform
 - uid: 870
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-33.5
     parent: 0
     type: Transform
 - uid: 871
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-33.5
     parent: 0
     type: Transform
 - uid: 872
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-31.5
     parent: 0
     type: Transform
 - uid: 873
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-29.5
     parent: 0
     type: Transform
 - uid: 874
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-29.5
     parent: 0
     type: Transform
 - uid: 875
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-29.5
     parent: 0
@@ -23196,25 +23196,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 892
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-34.5
     parent: 0
     type: Transform
 - uid: 893
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-33.5
     parent: 0
     type: Transform
 - uid: 894
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-34.5
     parent: 0
     type: Transform
 - uid: 895
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-33.5
     parent: 0
@@ -23370,7 +23370,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 912
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: 25.588993,-31.402525
     parent: 0
@@ -23581,37 +23581,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 937
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-33.5
     parent: 0
     type: Transform
 - uid: 938
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-34.5
     parent: 0
     type: Transform
 - uid: 939
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-35.5
     parent: 0
     type: Transform
 - uid: 940
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-36.5
     parent: 0
     type: Transform
 - uid: 941
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-37.5
     parent: 0
     type: Transform
 - uid: 942
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-37.5
     parent: 0
@@ -23811,61 +23811,61 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 971
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-37.5
     parent: 0
     type: Transform
 - uid: 972
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-37.5
     parent: 0
     type: Transform
 - uid: 973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-37.5
     parent: 0
     type: Transform
 - uid: 974
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-37.5
     parent: 0
     type: Transform
 - uid: 975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-38.5
     parent: 0
     type: Transform
 - uid: 976
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-39.5
     parent: 0
     type: Transform
 - uid: 977
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-40.5
     parent: 0
     type: Transform
 - uid: 978
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-37.5
     parent: 0
     type: Transform
 - uid: 979
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-40.5
     parent: 0
     type: Transform
 - uid: 980
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-40.5
     parent: 0
@@ -24265,19 +24265,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1043
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-43.5
     parent: 0
     type: Transform
 - uid: 1044
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-43.5
     parent: 0
     type: Transform
 - uid: 1045
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-42.5
     parent: 0
@@ -24353,55 +24353,55 @@ entities:
     parent: 0
     type: Transform
 - uid: 1055
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,-37.5
     parent: 0
     type: Transform
 - uid: 1056
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,-37.5
     parent: 0
     type: Transform
 - uid: 1057
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-38.5
     parent: 0
     type: Transform
 - uid: 1058
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-39.5
     parent: 0
     type: Transform
 - uid: 1059
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-40.5
     parent: 0
     type: Transform
 - uid: 1060
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-41.5
     parent: 0
     type: Transform
 - uid: 1061
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-42.5
     parent: 0
     type: Transform
 - uid: 1062
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-43.5
     parent: 0
     type: Transform
 - uid: 1063
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,-37.5
     parent: 0
@@ -24462,73 +24462,73 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1071
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,17.5
     parent: 0
     type: Transform
 - uid: 1072
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,16.5
     parent: 0
     type: Transform
 - uid: 1073
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,15.5
     parent: 0
     type: Transform
 - uid: 1074
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,19.5
     parent: 0
     type: Transform
 - uid: 1075
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,18.5
     parent: 0
     type: Transform
 - uid: 1076
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,17.5
     parent: 0
     type: Transform
 - uid: 1077
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,16.5
     parent: 0
     type: Transform
 - uid: 1078
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,20.5
     parent: 0
     type: Transform
 - uid: 1079
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,20.5
     parent: 0
     type: Transform
 - uid: 1080
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,20.5
     parent: 0
     type: Transform
 - uid: 1081
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,19.5
     parent: 0
     type: Transform
 - uid: 1082
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,19.5
     parent: 0
@@ -24554,91 +24554,91 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1085
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,17.5
     parent: 0
     type: Transform
 - uid: 1086
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,17.5
     parent: 0
     type: Transform
 - uid: 1087
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,17.5
     parent: 0
     type: Transform
 - uid: 1088
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,14.5
     parent: 0
     type: Transform
 - uid: 1089
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,12.5
     parent: 0
     type: Transform
 - uid: 1090
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,11.5
     parent: 0
     type: Transform
 - uid: 1091
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,11.5
     parent: 0
     type: Transform
 - uid: 1092
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,11.5
     parent: 0
     type: Transform
 - uid: 1093
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,11.5
     parent: 0
     type: Transform
 - uid: 1094
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,16.5
     parent: 0
     type: Transform
 - uid: 1095
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,17.5
     parent: 0
     type: Transform
 - uid: 1096
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,17.5
     parent: 0
     type: Transform
 - uid: 1097
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,17.5
     parent: 0
     type: Transform
 - uid: 1098
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,16.5
     parent: 0
     type: Transform
 - uid: 1099
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,16.5
     parent: 0
@@ -24694,109 +24694,109 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1105
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,11.5
     parent: 0
     type: Transform
 - uid: 1106
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,11.5
     parent: 0
     type: Transform
 - uid: 1107
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,10.5
     parent: 0
     type: Transform
 - uid: 1108
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,9.5
     parent: 0
     type: Transform
 - uid: 1109
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,8.5
     parent: 0
     type: Transform
 - uid: 1110
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,5.5
     parent: 0
     type: Transform
 - uid: 1111
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,4.5
     parent: 0
     type: Transform
 - uid: 1112
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,4.5
     parent: 0
     type: Transform
 - uid: 1113
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,4.5
     parent: 0
     type: Transform
 - uid: 1114
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,4.5
     parent: 0
     type: Transform
 - uid: 1115
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,4.5
     parent: 0
     type: Transform
 - uid: 1116
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,4.5
     parent: 0
     type: Transform
 - uid: 1117
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,5.5
     parent: 0
     type: Transform
 - uid: 1118
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,6.5
     parent: 0
     type: Transform
 - uid: 1119
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,7.5
     parent: 0
     type: Transform
 - uid: 1120
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,8.5
     parent: 0
     type: Transform
 - uid: 1121
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,7.5
     parent: 0
     type: Transform
 - uid: 1122
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,8.5
     parent: 0
@@ -24929,175 +24929,175 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1137
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,2.5
     parent: 0
     type: Transform
 - uid: 1138
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,2.5
     parent: 0
     type: Transform
 - uid: 1139
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,2.5
     parent: 0
     type: Transform
 - uid: 1140
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,2.5
     parent: 0
     type: Transform
 - uid: 1141
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,2.5
     parent: 0
     type: Transform
 - uid: 1142
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,2.5
     parent: 0
     type: Transform
 - uid: 1143
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,11.5
     parent: 0
     type: Transform
 - uid: 1144
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,11.5
     parent: 0
     type: Transform
 - uid: 1145
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,11.5
     parent: 0
     type: Transform
 - uid: 1146
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,11.5
     parent: 0
     type: Transform
 - uid: 1147
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,9.5
     parent: 0
     type: Transform
 - uid: 1148
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,8.5
     parent: 0
     type: Transform
 - uid: 1149
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,7.5
     parent: 0
     type: Transform
 - uid: 1150
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,6.5
     parent: 0
     type: Transform
 - uid: 1151
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,5.5
     parent: 0
     type: Transform
 - uid: 1152
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,4.5
     parent: 0
     type: Transform
 - uid: 1153
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,3.5
     parent: 0
     type: Transform
 - uid: 1154
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,9.5
     parent: 0
     type: Transform
 - uid: 1155
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,9.5
     parent: 0
     type: Transform
 - uid: 1156
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,9.5
     parent: 0
     type: Transform
 - uid: 1157
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,8.5
     parent: 0
     type: Transform
 - uid: 1158
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,7.5
     parent: 0
     type: Transform
 - uid: 1159
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,6.5
     parent: 0
     type: Transform
 - uid: 1160
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,5.5
     parent: 0
     type: Transform
 - uid: 1161
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,4.5
     parent: 0
     type: Transform
 - uid: 1162
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,4.5
     parent: 0
     type: Transform
 - uid: 1163
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,3.5
     parent: 0
     type: Transform
 - uid: 1164
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,2.5
     parent: 0
     type: Transform
 - uid: 1165
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,4.5
     parent: 0
@@ -25281,49 +25281,49 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1187
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,5.5
     parent: 0
     type: Transform
 - uid: 1188
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,5.5
     parent: 0
     type: Transform
 - uid: 1189
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,5.5
     parent: 0
     type: Transform
 - uid: 1190
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,5.5
     parent: 0
     type: Transform
 - uid: 1191
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,5.5
     parent: 0
     type: Transform
 - uid: 1192
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,4.5
     parent: 0
     type: Transform
 - uid: 1193
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,3.5
     parent: 0
     type: Transform
 - uid: 1194
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,2.5
     parent: 0
@@ -25417,49 +25417,49 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1206
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,9.5
     parent: 0
     type: Transform
 - uid: 1207
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,10.5
     parent: 0
     type: Transform
 - uid: 1208
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,10.5
     parent: 0
     type: Transform
 - uid: 1209
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,10.5
     parent: 0
     type: Transform
 - uid: 1210
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,10.5
     parent: 0
     type: Transform
 - uid: 1211
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,9.5
     parent: 0
     type: Transform
 - uid: 1212
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,8.5
     parent: 0
     type: Transform
 - uid: 1213
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,7.5
     parent: 0
@@ -25516,49 +25516,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 1219
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,11.5
     parent: 0
     type: Transform
 - uid: 1220
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,11.5
     parent: 0
     type: Transform
 - uid: 1221
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,12.5
     parent: 0
     type: Transform
 - uid: 1222
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,12.5
     parent: 0
     type: Transform
 - uid: 1223
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,12.5
     parent: 0
     type: Transform
 - uid: 1224
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,12.5
     parent: 0
     type: Transform
 - uid: 1225
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,12.5
     parent: 0
     type: Transform
 - uid: 1226
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,12.5
     parent: 0
@@ -25588,43 +25588,43 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1230
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-37.5
     parent: 0
     type: Transform
 - uid: 1231
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-37.5
     parent: 0
     type: Transform
 - uid: 1232
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-37.5
     parent: 0
     type: Transform
 - uid: 1233
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-37.5
     parent: 0
     type: Transform
 - uid: 1234
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-37.5
     parent: 0
     type: Transform
 - uid: 1235
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,-37.5
     parent: 0
     type: Transform
 - uid: 1236
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-37.5
     parent: 0
@@ -25672,7 +25672,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1244
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-51.5
     parent: 0
@@ -25684,19 +25684,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 1246
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-55.5
     parent: 0
     type: Transform
 - uid: 1247
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-54.5
     parent: 0
     type: Transform
 - uid: 1248
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-53.5
     parent: 0
@@ -25810,7 +25810,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1267
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,-58.5
     parent: 0
@@ -25834,13 +25834,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 1271
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,-58.5
     parent: 0
     type: Transform
 - uid: 1272
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-58.5
     parent: 0
@@ -25858,7 +25858,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1275
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-31.5
     parent: 0
@@ -25894,301 +25894,301 @@ entities:
     parent: 0
     type: Transform
 - uid: 1280
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-52.5
     parent: 0
     type: Transform
 - uid: 1281
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-43.5
     parent: 0
     type: Transform
 - uid: 1282
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-43.5
     parent: 0
     type: Transform
 - uid: 1283
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-43.5
     parent: 0
     type: Transform
 - uid: 1284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-44.5
     parent: 0
     type: Transform
 - uid: 1285
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-45.5
     parent: 0
     type: Transform
 - uid: 1286
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-46.5
     parent: 0
     type: Transform
 - uid: 1287
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-47.5
     parent: 0
     type: Transform
 - uid: 1288
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-48.5
     parent: 0
     type: Transform
 - uid: 1289
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-49.5
     parent: 0
     type: Transform
 - uid: 1290
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-50.5
     parent: 0
     type: Transform
 - uid: 1291
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-51.5
     parent: 0
     type: Transform
 - uid: 1292
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-52.5
     parent: 0
     type: Transform
 - uid: 1293
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-53.5
     parent: 0
     type: Transform
 - uid: 1294
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-54.5
     parent: 0
     type: Transform
 - uid: 1295
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-55.5
     parent: 0
     type: Transform
 - uid: 1296
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-57.5
     parent: 0
     type: Transform
 - uid: 1297
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-25.5
     parent: 0
     type: Transform
 - uid: 1298
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-57.5
     parent: 0
     type: Transform
 - uid: 1299
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-56.5
     parent: 0
     type: Transform
 - uid: 1300
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-43.5
     parent: 0
     type: Transform
 - uid: 1301
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-44.5
     parent: 0
     type: Transform
 - uid: 1302
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-45.5
     parent: 0
     type: Transform
 - uid: 1303
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-45.5
     parent: 0
     type: Transform
 - uid: 1304
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-46.5
     parent: 0
     type: Transform
 - uid: 1305
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-47.5
     parent: 0
     type: Transform
 - uid: 1306
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-48.5
     parent: 0
     type: Transform
 - uid: 1307
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-49.5
     parent: 0
     type: Transform
 - uid: 1308
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-47.5
     parent: 0
     type: Transform
 - uid: 1309
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-48.5
     parent: 0
     type: Transform
 - uid: 1310
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-49.5
     parent: 0
     type: Transform
 - uid: 1311
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-50.5
     parent: 0
     type: Transform
 - uid: 1312
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-51.5
     parent: 0
     type: Transform
 - uid: 1313
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-52.5
     parent: 0
     type: Transform
 - uid: 1314
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-50.5
     parent: 0
     type: Transform
 - uid: 1315
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-51.5
     parent: 0
     type: Transform
 - uid: 1316
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-52.5
     parent: 0
     type: Transform
 - uid: 1317
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-54.5
     parent: 0
     type: Transform
 - uid: 1318
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-53.5
     parent: 0
     type: Transform
 - uid: 1319
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-55.5
     parent: 0
     type: Transform
 - uid: 1320
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-55.5
     parent: 0
     type: Transform
 - uid: 1321
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-59.5
     parent: 0
     type: Transform
 - uid: 1322
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-33.5
     parent: 0
     type: Transform
 - uid: 1323
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-33.5
     parent: 0
     type: Transform
 - uid: 1324
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-33.5
     parent: 0
     type: Transform
 - uid: 1325
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-33.5
     parent: 0
     type: Transform
 - uid: 1326
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-31.5
     parent: 0
     type: Transform
 - uid: 1327
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-31.5
     parent: 0
     type: Transform
 - uid: 1328
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-33.5
     parent: 0
     type: Transform
 - uid: 1329
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-29.5
     parent: 0
@@ -26242,133 +26242,133 @@ entities:
     parent: 0
     type: Transform
 - uid: 1338
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-22.5
     parent: 0
     type: Transform
 - uid: 1339
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-22.5
     parent: 0
     type: Transform
 - uid: 1340
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-22.5
     parent: 0
     type: Transform
 - uid: 1341
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-22.5
     parent: 0
     type: Transform
 - uid: 1342
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-22.5
     parent: 0
     type: Transform
 - uid: 1343
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-23.5
     parent: 0
     type: Transform
 - uid: 1344
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-24.5
     parent: 0
     type: Transform
 - uid: 1345
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-25.5
     parent: 0
     type: Transform
 - uid: 1346
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-26.5
     parent: 0
     type: Transform
 - uid: 1347
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-27.5
     parent: 0
     type: Transform
 - uid: 1348
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-33.5
     parent: 0
     type: Transform
 - uid: 1349
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-33.5
     parent: 0
     type: Transform
 - uid: 1350
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-33.5
     parent: 0
     type: Transform
 - uid: 1351
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-33.5
     parent: 0
     type: Transform
 - uid: 1352
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-33.5
     parent: 0
     type: Transform
 - uid: 1353
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-32.5
     parent: 0
     type: Transform
 - uid: 1354
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-32.5
     parent: 0
     type: Transform
 - uid: 1355
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-32.5
     parent: 0
     type: Transform
 - uid: 1356
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-31.5
     parent: 0
     type: Transform
 - uid: 1357
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-30.5
     parent: 0
     type: Transform
 - uid: 1358
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-27.5
     parent: 0
     type: Transform
 - uid: 1359
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-27.5
     parent: 0
@@ -26442,55 +26442,55 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1370
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-34.5
     parent: 0
     type: Transform
 - uid: 1371
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-35.5
     parent: 0
     type: Transform
 - uid: 1372
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-36.5
     parent: 0
     type: Transform
 - uid: 1373
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-37.5
     parent: 0
     type: Transform
 - uid: 1374
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-37.5
     parent: 0
     type: Transform
 - uid: 1375
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-37.5
     parent: 0
     type: Transform
 - uid: 1376
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-37.5
     parent: 0
     type: Transform
 - uid: 1377
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-37.5
     parent: 0
     type: Transform
 - uid: 1378
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-37.5
     parent: 0
@@ -27283,19 +27283,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1504
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-1.5
     parent: 0
     type: Transform
 - uid: 1505
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-8.5
     parent: 0
     type: Transform
 - uid: 1506
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-8.5
     parent: 0
@@ -27312,109 +27312,109 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 1508
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,-8.5
     parent: 0
     type: Transform
 - uid: 1509
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-8.5
     parent: 0
     type: Transform
 - uid: 1510
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,-8.5
     parent: 0
     type: Transform
 - uid: 1511
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-8.5
     parent: 0
     type: Transform
 - uid: 1512
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-8.5
     parent: 0
     type: Transform
 - uid: 1513
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,-8.5
     parent: 0
     type: Transform
 - uid: 1514
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-7.5
     parent: 0
     type: Transform
 - uid: 1515
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-6.5
     parent: 0
     type: Transform
 - uid: 1516
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-5.5
     parent: 0
     type: Transform
 - uid: 1517
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-4.5
     parent: 0
     type: Transform
 - uid: 1518
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-3.5
     parent: 0
     type: Transform
 - uid: 1519
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-2.5
     parent: 0
     type: Transform
 - uid: 1520
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-1.5
     parent: 0
     type: Transform
 - uid: 1521
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,-1.5
     parent: 0
     type: Transform
 - uid: 1522
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,-1.5
     parent: 0
     type: Transform
 - uid: 1523
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-1.5
     parent: 0
     type: Transform
 - uid: 1524
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-1.5
     parent: 0
     type: Transform
 - uid: 1525
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-2.5
     parent: 0
@@ -27930,121 +27930,121 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1597
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-9.5
     parent: 0
     type: Transform
 - uid: 1598
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-10.5
     parent: 0
     type: Transform
 - uid: 1599
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-12.5
     parent: 0
     type: Transform
 - uid: 1600
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-12.5
     parent: 0
     type: Transform
 - uid: 1601
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-13.5
     parent: 0
     type: Transform
 - uid: 1602
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-13.5
     parent: 0
     type: Transform
 - uid: 1603
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-13.5
     parent: 0
     type: Transform
 - uid: 1604
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,-13.5
     parent: 0
     type: Transform
 - uid: 1605
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-13.5
     parent: 0
     type: Transform
 - uid: 1606
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-12.5
     parent: 0
     type: Transform
 - uid: 1607
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-11.5
     parent: 0
     type: Transform
 - uid: 1608
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-10.5
     parent: 0
     type: Transform
 - uid: 1609
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-13.5
     parent: 0
     type: Transform
 - uid: 1610
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-13.5
     parent: 0
     type: Transform
 - uid: 1611
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,-13.5
     parent: 0
     type: Transform
 - uid: 1612
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-13.5
     parent: 0
     type: Transform
 - uid: 1613
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-13.5
     parent: 0
     type: Transform
 - uid: 1614
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,-13.5
     parent: 0
     type: Transform
 - uid: 1615
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-11.5
     parent: 0
     type: Transform
 - uid: 1616
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-10.5
     parent: 0
@@ -28069,7 +28069,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1619
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-13.5
     parent: 0
@@ -28424,97 +28424,97 @@ entities:
     parent: 0
     type: Transform
 - uid: 1659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-2.5
     parent: 0
     type: Transform
 - uid: 1660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-3.5
     parent: 0
     type: Transform
 - uid: 1661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-4.5
     parent: 0
     type: Transform
 - uid: 1662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-5.5
     parent: 0
     type: Transform
 - uid: 1663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-6.5
     parent: 0
     type: Transform
 - uid: 1664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-7.5
     parent: 0
     type: Transform
 - uid: 1665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-8.5
     parent: 0
     type: Transform
 - uid: 1666
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-10.5
     parent: 0
     type: Transform
 - uid: 1667
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-11.5
     parent: 0
     type: Transform
 - uid: 1668
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 47.5,-11.5
     parent: 0
     type: Transform
 - uid: 1669
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 46.5,-11.5
     parent: 0
     type: Transform
 - uid: 1670
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 45.5,-11.5
     parent: 0
     type: Transform
 - uid: 1671
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,-11.5
     parent: 0
     type: Transform
 - uid: 1672
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,-11.5
     parent: 0
     type: Transform
 - uid: 1673
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 42.5,-11.5
     parent: 0
     type: Transform
 - uid: 1674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-9.5
     parent: 0
@@ -28916,67 +28916,67 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1721
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-13.5
     parent: 0
     type: Transform
 - uid: 1722
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-13.5
     parent: 0
     type: Transform
 - uid: 1723
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-13.5
     parent: 0
     type: Transform
 - uid: 1724
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-13.5
     parent: 0
     type: Transform
 - uid: 1725
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-13.5
     parent: 0
     type: Transform
 - uid: 1726
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-13.5
     parent: 0
     type: Transform
 - uid: 1727
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-17.5
     parent: 0
     type: Transform
 - uid: 1728
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-17.5
     parent: 0
     type: Transform
 - uid: 1729
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-17.5
     parent: 0
     type: Transform
 - uid: 1730
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-17.5
     parent: 0
     type: Transform
 - uid: 1731
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-17.5
     parent: 0
@@ -29018,7 +29018,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1738
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-17.5
     parent: 0
@@ -29058,61 +29058,61 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 1742
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-17.5
     parent: 0
     type: Transform
 - uid: 1743
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-18.5
     parent: 0
     type: Transform
 - uid: 1744
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-18.5
     parent: 0
     type: Transform
 - uid: 1745
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-18.5
     parent: 0
     type: Transform
 - uid: 1746
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,-18.5
     parent: 0
     type: Transform
 - uid: 1747
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-18.5
     parent: 0
     type: Transform
 - uid: 1748
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-18.5
     parent: 0
     type: Transform
 - uid: 1749
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-17.5
     parent: 0
     type: Transform
 - uid: 1750
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-15.5
     parent: 0
     type: Transform
 - uid: 1751
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-14.5
     parent: 0
@@ -29130,25 +29130,25 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 1753
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,-18.5
     parent: 0
     type: Transform
 - uid: 1754
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-18.5
     parent: 0
     type: Transform
 - uid: 1755
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-18.5
     parent: 0
     type: Transform
 - uid: 1756
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,-18.5
     parent: 0
@@ -29673,13 +29673,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1824
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-19.5
     parent: 0
     type: Transform
 - uid: 1825
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-20.5
     parent: 0
@@ -29803,13 +29803,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1839
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-21.5
     parent: 0
     type: Transform
 - uid: 1840
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-21.5
     parent: 0
@@ -29825,37 +29825,37 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1842
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-19.5
     parent: 0
     type: Transform
 - uid: 1843
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-19.5
     parent: 0
     type: Transform
 - uid: 1844
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-19.5
     parent: 0
     type: Transform
 - uid: 1845
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-19.5
     parent: 0
     type: Transform
 - uid: 1846
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-19.5
     parent: 0
     type: Transform
 - uid: 1847
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,-19.5
     parent: 0
@@ -29879,7 +29879,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1850
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-25.5
     parent: 0
@@ -30131,49 +30131,49 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1889
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-37.5
     parent: 0
     type: Transform
 - uid: 1890
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-37.5
     parent: 0
     type: Transform
 - uid: 1891
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-37.5
     parent: 0
     type: Transform
 - uid: 1892
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-23.5
     parent: 0
     type: Transform
 - uid: 1893
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-36.5
     parent: 0
     type: Transform
 - uid: 1894
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-35.5
     parent: 0
     type: Transform
 - uid: 1895
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-25.5
     parent: 0
     type: Transform
 - uid: 1896
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-25.5
     parent: 0
@@ -30185,43 +30185,43 @@ entities:
     parent: 0
     type: Transform
 - uid: 1898
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-25.5
     parent: 0
     type: Transform
 - uid: 1899
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-29.5
     parent: 0
     type: Transform
 - uid: 1900
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-30.5
     parent: 0
     type: Transform
 - uid: 1901
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-31.5
     parent: 0
     type: Transform
 - uid: 1902
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-29.5
     parent: 0
     type: Transform
 - uid: 1903
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-23.5
     parent: 0
     type: Transform
 - uid: 1904
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-31.5
     parent: 0
@@ -30233,103 +30233,103 @@ entities:
     parent: 0
     type: Transform
 - uid: 1906
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-25.5
     parent: 0
     type: Transform
 - uid: 1907
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-25.5
     parent: 0
     type: Transform
 - uid: 1908
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-22.5
     parent: 0
     type: Transform
 - uid: 1909
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-31.5
     parent: 0
     type: Transform
 - uid: 1910
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-25.5
     parent: 0
     type: Transform
 - uid: 1911
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-29.5
     parent: 0
     type: Transform
 - uid: 1912
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-21.5
     parent: 0
     type: Transform
 - uid: 1913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-29.5
     parent: 0
     type: Transform
 - uid: 1914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-21.5
     parent: 0
     type: Transform
 - uid: 1915
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-23.5
     parent: 0
     type: Transform
 - uid: 1916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-26.5
     parent: 0
     type: Transform
 - uid: 1917
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-29.5
     parent: 0
     type: Transform
 - uid: 1918
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-27.5
     parent: 0
     type: Transform
 - uid: 1919
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-28.5
     parent: 0
     type: Transform
 - uid: 1920
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-24.5
     parent: 0
     type: Transform
 - uid: 1921
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-23.5
     parent: 0
     type: Transform
 - uid: 1922
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-23.5
     parent: 0
@@ -30413,7 +30413,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1936
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-38.5
     parent: 0
@@ -30509,19 +30509,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 1952
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-31.5
     parent: 0
     type: Transform
 - uid: 1953
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-21.5
     parent: 0
     type: Transform
 - uid: 1954
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-23.5
     parent: 0
@@ -30535,25 +30535,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1956
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-27.5
     parent: 0
     type: Transform
 - uid: 1957
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-33.5
     parent: 0
     type: Transform
 - uid: 1958
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-33.5
     parent: 0
     type: Transform
 - uid: 1959
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-33.5
     parent: 0
@@ -30571,13 +30571,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 1962
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-31.5
     parent: 0
     type: Transform
 - uid: 1963
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-33.5
     parent: 0
@@ -30601,7 +30601,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1966
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-31.5
     parent: 0
@@ -30638,109 +30638,109 @@ entities:
     parent: 0
     type: Transform
 - uid: 1971
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-14.5
     parent: 0
     type: Transform
 - uid: 1972
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-15.5
     parent: 0
     type: Transform
 - uid: 1973
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-16.5
     parent: 0
     type: Transform
 - uid: 1974
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-17.5
     parent: 0
     type: Transform
 - uid: 1975
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,-17.5
     parent: 0
     type: Transform
 - uid: 1976
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,-17.5
     parent: 0
     type: Transform
 - uid: 1977
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,-16.5
     parent: 0
     type: Transform
 - uid: 1978
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,-15.5
     parent: 0
     type: Transform
 - uid: 1979
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,-14.5
     parent: 0
     type: Transform
 - uid: 1980
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,-14.5
     parent: 0
     type: Transform
 - uid: 1981
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-19.5
     parent: 0
     type: Transform
 - uid: 1982
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,-19.5
     parent: 0
     type: Transform
 - uid: 1983
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-19.5
     parent: 0
     type: Transform
 - uid: 1984
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-19.5
     parent: 0
     type: Transform
 - uid: 1985
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-19.5
     parent: 0
     type: Transform
 - uid: 1986
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-19.5
     parent: 0
     type: Transform
 - uid: 1987
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-19.5
     parent: 0
     type: Transform
 - uid: 1988
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-19.5
     parent: 0
@@ -30782,109 +30782,109 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1994
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,-18.5
     parent: 0
     type: Transform
 - uid: 1995
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,-16.5
     parent: 0
     type: Transform
 - uid: 1996
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,-16.5
     parent: 0
     type: Transform
 - uid: 1997
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,-16.5
     parent: 0
     type: Transform
 - uid: 1998
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-15.5
     parent: 0
     type: Transform
 - uid: 1999
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-14.5
     parent: 0
     type: Transform
 - uid: 2000
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-13.5
     parent: 0
     type: Transform
 - uid: 2001
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,-15.5
     parent: 0
     type: Transform
 - uid: 2002
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-14.5
     parent: 0
     type: Transform
 - uid: 2003
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-13.5
     parent: 0
     type: Transform
 - uid: 2004
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,-16.5
     parent: 0
     type: Transform
 - uid: 2005
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-16.5
     parent: 0
     type: Transform
 - uid: 2006
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-12.5
     parent: 0
     type: Transform
 - uid: 2007
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,-12.5
     parent: 0
     type: Transform
 - uid: 2008
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-12.5
     parent: 0
     type: Transform
 - uid: 2009
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-12.5
     parent: 0
     type: Transform
 - uid: 2010
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-12.5
     parent: 0
     type: Transform
 - uid: 2011
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-12.5
     parent: 0
@@ -30900,43 +30900,43 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2013
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,19.5
     parent: 0
     type: Transform
 - uid: 2014
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,19.5
     parent: 0
     type: Transform
 - uid: 2015
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,19.5
     parent: 0
     type: Transform
 - uid: 2016
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,19.5
     parent: 0
     type: Transform
 - uid: 2017
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,19.5
     parent: 0
     type: Transform
 - uid: 2018
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,19.5
     parent: 0
     type: Transform
 - uid: 2019
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,19.5
     parent: 0
@@ -31036,145 +31036,145 @@ entities:
     parent: 0
     type: Transform
 - uid: 2033
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,29.5
     parent: 0
     type: Transform
 - uid: 2034
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,30.5
     parent: 0
     type: Transform
 - uid: 2035
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,31.5
     parent: 0
     type: Transform
 - uid: 2036
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,32.5
     parent: 0
     type: Transform
 - uid: 2037
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,33.5
     parent: 0
     type: Transform
 - uid: 2038
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,33.5
     parent: 0
     type: Transform
 - uid: 2039
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,33.5
     parent: 0
     type: Transform
 - uid: 2040
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,33.5
     parent: 0
     type: Transform
 - uid: 2041
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,33.5
     parent: 0
     type: Transform
 - uid: 2042
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,33.5
     parent: 0
     type: Transform
 - uid: 2043
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,32.5
     parent: 0
     type: Transform
 - uid: 2044
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,31.5
     parent: 0
     type: Transform
 - uid: 2045
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,30.5
     parent: 0
     type: Transform
 - uid: 2046
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,29.5
     parent: 0
     type: Transform
 - uid: 2047
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,29.5
     parent: 0
     type: Transform
 - uid: 2048
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,29.5
     parent: 0
     type: Transform
 - uid: 2049
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,32.5
     parent: 0
     type: Transform
 - uid: 2050
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,32.5
     parent: 0
     type: Transform
 - uid: 2051
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,32.5
     parent: 0
     type: Transform
 - uid: 2052
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,32.5
     parent: 0
     type: Transform
 - uid: 2053
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,31.5
     parent: 0
     type: Transform
 - uid: 2054
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,29.5
     parent: 0
     type: Transform
 - uid: 2055
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,30.5
     parent: 0
     type: Transform
 - uid: 2056
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,27.5
     parent: 0
@@ -31242,37 +31242,37 @@ entities:
   - fixtures: []
     type: Fixtures
 - uid: 2066
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,23.5
     parent: 0
     type: Transform
 - uid: 2067
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,24.5
     parent: 0
     type: Transform
 - uid: 2068
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,25.5
     parent: 0
     type: Transform
 - uid: 2069
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,26.5
     parent: 0
     type: Transform
 - uid: 2070
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,26.5
     parent: 0
     type: Transform
 - uid: 2071
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,26.5
     parent: 0
@@ -31609,133 +31609,133 @@ entities:
     parent: 0
     type: Transform
 - uid: 2115
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,25.5
     parent: 0
     type: Transform
 - uid: 2116
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,25.5
     parent: 0
     type: Transform
 - uid: 2117
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,25.5
     parent: 0
     type: Transform
 - uid: 2118
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,25.5
     parent: 0
     type: Transform
 - uid: 2119
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,25.5
     parent: 0
     type: Transform
 - uid: 2120
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,26.5
     parent: 0
     type: Transform
 - uid: 2121
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,26.5
     parent: 0
     type: Transform
 - uid: 2122
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,26.5
     parent: 0
     type: Transform
 - uid: 2123
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,26.5
     parent: 0
     type: Transform
 - uid: 2124
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,28.5
     parent: 0
     type: Transform
 - uid: 2125
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,28.5
     parent: 0
     type: Transform
 - uid: 2126
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,28.5
     parent: 0
     type: Transform
 - uid: 2127
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,28.5
     parent: 0
     type: Transform
 - uid: 2128
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,28.5
     parent: 0
     type: Transform
 - uid: 2129
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,28.5
     parent: 0
     type: Transform
 - uid: 2130
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,28.5
     parent: 0
     type: Transform
 - uid: 2131
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,28.5
     parent: 0
     type: Transform
 - uid: 2132
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,28.5
     parent: 0
     type: Transform
 - uid: 2133
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,29.5
     parent: 0
     type: Transform
 - uid: 2134
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,30.5
     parent: 0
     type: Transform
 - uid: 2135
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,31.5
     parent: 0
     type: Transform
 - uid: 2136
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,32.5
     parent: 0
@@ -32183,49 +32183,49 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2191
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,19.5
     parent: 0
     type: Transform
 - uid: 2192
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,19.5
     parent: 0
     type: Transform
 - uid: 2193
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,19.5
     parent: 0
     type: Transform
 - uid: 2194
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,18.5
     parent: 0
     type: Transform
 - uid: 2195
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,17.5
     parent: 0
     type: Transform
 - uid: 2196
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,16.5
     parent: 0
     type: Transform
 - uid: 2197
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,16.5
     parent: 0
     type: Transform
 - uid: 2198
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,16.5
     parent: 0
@@ -32345,277 +32345,277 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2212
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,16.5
     parent: 0
     type: Transform
 - uid: 2213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,16.5
     parent: 0
     type: Transform
 - uid: 2214
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,16.5
     parent: 0
     type: Transform
 - uid: 2215
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,16.5
     parent: 0
     type: Transform
 - uid: 2216
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,16.5
     parent: 0
     type: Transform
 - uid: 2217
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,16.5
     parent: 0
     type: Transform
 - uid: 2218
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,19.5
     parent: 0
     type: Transform
 - uid: 2219
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,22.5
     parent: 0
     type: Transform
 - uid: 2220
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,26.5
     parent: 0
     type: Transform
 - uid: 2221
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,27.5
     parent: 0
     type: Transform
 - uid: 2222
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,27.5
     parent: 0
     type: Transform
 - uid: 2223
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,27.5
     parent: 0
     type: Transform
 - uid: 2224
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,27.5
     parent: 0
     type: Transform
 - uid: 2225
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,28.5
     parent: 0
     type: Transform
 - uid: 2226
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,29.5
     parent: 0
     type: Transform
 - uid: 2227
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,30.5
     parent: 0
     type: Transform
 - uid: 2228
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,31.5
     parent: 0
     type: Transform
 - uid: 2229
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,31.5
     parent: 0
     type: Transform
 - uid: 2230
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,31.5
     parent: 0
     type: Transform
 - uid: 2231
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,31.5
     parent: 0
     type: Transform
 - uid: 2232
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,31.5
     parent: 0
     type: Transform
 - uid: 2233
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,31.5
     parent: 0
     type: Transform
 - uid: 2234
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,31.5
     parent: 0
     type: Transform
 - uid: 2235
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,32.5
     parent: 0
     type: Transform
 - uid: 2236
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,32.5
     parent: 0
     type: Transform
 - uid: 2237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,32.5
     parent: 0
     type: Transform
 - uid: 2238
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,32.5
     parent: 0
     type: Transform
 - uid: 2239
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,31.5
     parent: 0
     type: Transform
 - uid: 2240
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,33.5
     parent: 0
     type: Transform
 - uid: 2241
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,34.5
     parent: 0
     type: Transform
 - uid: 2242
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,35.5
     parent: 0
     type: Transform
 - uid: 2243
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,36.5
     parent: 0
     type: Transform
 - uid: 2244
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,36.5
     parent: 0
     type: Transform
 - uid: 2245
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,37.5
     parent: 0
     type: Transform
 - uid: 2246
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,37.5
     parent: 0
     type: Transform
 - uid: 2247
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,37.5
     parent: 0
     type: Transform
 - uid: 2248
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,37.5
     parent: 0
     type: Transform
 - uid: 2249
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,37.5
     parent: 0
     type: Transform
 - uid: 2250
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,36.5
     parent: 0
     type: Transform
 - uid: 2251
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,38.5
     parent: 0
     type: Transform
 - uid: 2252
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,38.5
     parent: 0
     type: Transform
 - uid: 2253
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,38.5
     parent: 0
     type: Transform
 - uid: 2254
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,37.5
     parent: 0
     type: Transform
 - uid: 2255
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,36.5
     parent: 0
     type: Transform
 - uid: 2256
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,35.5
     parent: 0
     type: Transform
 - uid: 2257
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,34.5
     parent: 0
@@ -32669,37 +32669,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 2266
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,22.5
     parent: 0
     type: Transform
 - uid: 2267
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,22.5
     parent: 0
     type: Transform
 - uid: 2268
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,22.5
     parent: 0
     type: Transform
 - uid: 2269
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,19.5
     parent: 0
     type: Transform
 - uid: 2270
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,19.5
     parent: 0
     type: Transform
 - uid: 2271
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,19.5
     parent: 0
@@ -32779,85 +32779,85 @@ entities:
     parent: 0
     type: Transform
 - uid: 2282
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,29.5
     parent: 0
     type: Transform
 - uid: 2283
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,29.5
     parent: 0
     type: Transform
 - uid: 2284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,29.5
     parent: 0
     type: Transform
 - uid: 2285
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,29.5
     parent: 0
     type: Transform
 - uid: 2286
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,29.5
     parent: 0
     type: Transform
 - uid: 2287
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,29.5
     parent: 0
     type: Transform
 - uid: 2288
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,29.5
     parent: 0
     type: Transform
 - uid: 2289
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,29.5
     parent: 0
     type: Transform
 - uid: 2290
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,29.5
     parent: 0
     type: Transform
 - uid: 2291
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,29.5
     parent: 0
     type: Transform
 - uid: 2292
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,30.5
     parent: 0
     type: Transform
 - uid: 2293
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,31.5
     parent: 0
     type: Transform
 - uid: 2294
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,32.5
     parent: 0
     type: Transform
 - uid: 2295
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,33.5
     parent: 0
@@ -32869,25 +32869,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 2297
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,30.5
     parent: 0
     type: Transform
 - uid: 2298
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,38.5
     parent: 0
     type: Transform
 - uid: 2299
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,38.5
     parent: 0
     type: Transform
 - uid: 2300
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,37.5
     parent: 0
@@ -33310,31 +33310,31 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2349
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,25.5
     parent: 0
     type: Transform
 - uid: 2350
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,28.5
     parent: 0
     type: Transform
 - uid: 2351
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,27.5
     parent: 0
     type: Transform
 - uid: 2352
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,26.5
     parent: 0
     type: Transform
 - uid: 2353
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,25.5
     parent: 0
@@ -33346,109 +33346,109 @@ entities:
     parent: 0
     type: Transform
 - uid: 2355
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,27.5
     parent: 0
     type: Transform
 - uid: 2356
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,26.5
     parent: 0
     type: Transform
 - uid: 2357
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,26.5
     parent: 0
     type: Transform
 - uid: 2358
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,26.5
     parent: 0
     type: Transform
 - uid: 2359
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,26.5
     parent: 0
     type: Transform
 - uid: 2360
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,25.5
     parent: 0
     type: Transform
 - uid: 2361
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,24.5
     parent: 0
     type: Transform
 - uid: 2362
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,23.5
     parent: 0
     type: Transform
 - uid: 2363
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,22.5
     parent: 0
     type: Transform
 - uid: 2364
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,21.5
     parent: 0
     type: Transform
 - uid: 2365
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,21.5
     parent: 0
     type: Transform
 - uid: 2366
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,21.5
     parent: 0
     type: Transform
 - uid: 2367
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,21.5
     parent: 0
     type: Transform
 - uid: 2368
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,21.5
     parent: 0
     type: Transform
 - uid: 2369
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,21.5
     parent: 0
     type: Transform
 - uid: 2370
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,21.5
     parent: 0
     type: Transform
 - uid: 2371
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,20.5
     parent: 0
     type: Transform
 - uid: 2372
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,19.5
     parent: 0
@@ -33508,13 +33508,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 2382
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,20.5
     parent: 0
     type: Transform
 - uid: 2383
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,20.5
     parent: 0
@@ -34158,79 +34158,79 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2465
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,17.5
     parent: 0
     type: Transform
 - uid: 2466
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,16.5
     parent: 0
     type: Transform
 - uid: 2467
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,16.5
     parent: 0
     type: Transform
 - uid: 2468
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,16.5
     parent: 0
     type: Transform
 - uid: 2469
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,16.5
     parent: 0
     type: Transform
 - uid: 2470
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,16.5
     parent: 0
     type: Transform
 - uid: 2471
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,16.5
     parent: 0
     type: Transform
 - uid: 2472
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,16.5
     parent: 0
     type: Transform
 - uid: 2473
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,20.5
     parent: 0
     type: Transform
 - uid: 2474
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,19.5
     parent: 0
     type: Transform
 - uid: 2475
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,18.5
     parent: 0
     type: Transform
 - uid: 2476
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,17.5
     parent: 0
     type: Transform
 - uid: 2477
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,16.5
     parent: 0
@@ -34566,97 +34566,97 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2518
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,10.5
     parent: 0
     type: Transform
 - uid: 2519
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,10.5
     parent: 0
     type: Transform
 - uid: 2520
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,4.5
     parent: 0
     type: Transform
 - uid: 2521
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,3.5
     parent: 0
     type: Transform
 - uid: 2522
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,10.5
     parent: 0
     type: Transform
 - uid: 2523
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,10.5
     parent: 0
     type: Transform
 - uid: 2524
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,10.5
     parent: 0
     type: Transform
 - uid: 2525
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,2.5
     parent: 0
     type: Transform
 - uid: 2526
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,2.5
     parent: 0
     type: Transform
 - uid: 2527
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,2.5
     parent: 0
     type: Transform
 - uid: 2528
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,2.5
     parent: 0
     type: Transform
 - uid: 2529
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,2.5
     parent: 0
     type: Transform
 - uid: 2530
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,2.5
     parent: 0
     type: Transform
 - uid: 2531
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,3.5
     parent: 0
     type: Transform
 - uid: 2532
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,4.5
     parent: 0
     type: Transform
 - uid: 2533
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,4.5
     parent: 0
@@ -34935,19 +34935,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2569
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,12.5
     parent: 0
     type: Transform
 - uid: 2570
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,12.5
     parent: 0
     type: Transform
 - uid: 2571
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,12.5
     parent: 0
@@ -34983,19 +34983,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2575
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,12.5
     parent: 0
     type: Transform
 - uid: 2576
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,12.5
     parent: 0
     type: Transform
 - uid: 2577
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,12.5
     parent: 0
@@ -35059,271 +35059,271 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2584
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,33.5
     parent: 0
     type: Transform
 - uid: 2585
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,33.5
     parent: 0
     type: Transform
 - uid: 2586
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,33.5
     parent: 0
     type: Transform
 - uid: 2587
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,33.5
     parent: 0
     type: Transform
 - uid: 2588
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,33.5
     parent: 0
     type: Transform
 - uid: 2589
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,33.5
     parent: 0
     type: Transform
 - uid: 2590
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,34.5
     parent: 0
     type: Transform
 - uid: 2591
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,34.5
     parent: 0
     type: Transform
 - uid: 2592
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,35.5
     parent: 0
     type: Transform
 - uid: 2593
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,37.5
     parent: 0
     type: Transform
 - uid: 2594
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,35.5
     parent: 0
     type: Transform
 - uid: 2595
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,36.5
     parent: 0
     type: Transform
 - uid: 2596
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,37.5
     parent: 0
     type: Transform
 - uid: 2597
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,38.5
     parent: 0
     type: Transform
 - uid: 2598
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,38.5
     parent: 0
     type: Transform
 - uid: 2599
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,38.5
     parent: 0
     type: Transform
 - uid: 2600
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,38.5
     parent: 0
     type: Transform
 - uid: 2601
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,38.5
     parent: 0
     type: Transform
 - uid: 2602
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,39.5
     parent: 0
     type: Transform
 - uid: 2603
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,40.5
     parent: 0
     type: Transform
 - uid: 2604
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,41.5
     parent: 0
     type: Transform
 - uid: 2605
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,42.5
     parent: 0
     type: Transform
 - uid: 2606
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,43.5
     parent: 0
     type: Transform
 - uid: 2607
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,43.5
     parent: 0
     type: Transform
 - uid: 2608
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,43.5
     parent: 0
     type: Transform
 - uid: 2609
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,44.5
     parent: 0
     type: Transform
 - uid: 2610
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,44.5
     parent: 0
     type: Transform
 - uid: 2611
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,44.5
     parent: 0
     type: Transform
 - uid: 2612
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,44.5
     parent: 0
     type: Transform
 - uid: 2613
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,43.5
     parent: 0
     type: Transform
 - uid: 2614
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,42.5
     parent: 0
     type: Transform
 - uid: 2615
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,41.5
     parent: 0
     type: Transform
 - uid: 2616
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,44.5
     parent: 0
     type: Transform
 - uid: 2617
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,44.5
     parent: 0
     type: Transform
 - uid: 2618
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,44.5
     parent: 0
     type: Transform
 - uid: 2619
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,43.5
     parent: 0
     type: Transform
 - uid: 2620
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,42.5
     parent: 0
     type: Transform
 - uid: 2621
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,41.5
     parent: 0
     type: Transform
 - uid: 2622
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,40.5
     parent: 0
     type: Transform
 - uid: 2623
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,39.5
     parent: 0
     type: Transform
 - uid: 2624
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,39.5
     parent: 0
     type: Transform
 - uid: 2625
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,39.5
     parent: 0
     type: Transform
 - uid: 2626
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,39.5
     parent: 0
     type: Transform
 - uid: 2627
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,39.5
     parent: 0
     type: Transform
 - uid: 2628
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,38.5
     parent: 0
@@ -35451,139 +35451,139 @@ entities:
     parent: 0
     type: Transform
 - uid: 2648
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,43.5
     parent: 0
     type: Transform
 - uid: 2649
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,42.5
     parent: 0
     type: Transform
 - uid: 2650
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,42.5
     parent: 0
     type: Transform
 - uid: 2651
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,43.5
     parent: 0
     type: Transform
 - uid: 2652
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,43.5
     parent: 0
     type: Transform
 - uid: 2653
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,43.5
     parent: 0
     type: Transform
 - uid: 2654
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,42.5
     parent: 0
     type: Transform
 - uid: 2655
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,42.5
     parent: 0
     type: Transform
 - uid: 2656
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,41.5
     parent: 0
     type: Transform
 - uid: 2657
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,40.5
     parent: 0
     type: Transform
 - uid: 2658
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,39.5
     parent: 0
     type: Transform
 - uid: 2659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,38.5
     parent: 0
     type: Transform
 - uid: 2660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,38.5
     parent: 0
     type: Transform
 - uid: 2661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,38.5
     parent: 0
     type: Transform
 - uid: 2662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,38.5
     parent: 0
     type: Transform
 - uid: 2663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,39.5
     parent: 0
     type: Transform
 - uid: 2664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,40.5
     parent: 0
     type: Transform
 - uid: 2665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,41.5
     parent: 0
     type: Transform
 - uid: 2666
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,38.5
     parent: 0
     type: Transform
 - uid: 2667
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,39.5
     parent: 0
     type: Transform
 - uid: 2668
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,40.5
     parent: 0
     type: Transform
 - uid: 2669
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,42.5
     parent: 0
     type: Transform
 - uid: 2670
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,43.5
     parent: 0
@@ -35607,55 +35607,55 @@ entities:
     parent: 0
     type: Transform
 - uid: 2674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,42.5
     parent: 0
     type: Transform
 - uid: 2675
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,41.5
     parent: 0
     type: Transform
 - uid: 2676
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,40.5
     parent: 0
     type: Transform
 - uid: 2677
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,39.5
     parent: 0
     type: Transform
 - uid: 2678
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,38.5
     parent: 0
     type: Transform
 - uid: 2679
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,37.5
     parent: 0
     type: Transform
 - uid: 2680
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,35.5
     parent: 0
     type: Transform
 - uid: 2681
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,34.5
     parent: 0
     type: Transform
 - uid: 2682
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,35.5
     parent: 0
@@ -35669,25 +35669,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2684
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,36.5
     parent: 0
     type: Transform
 - uid: 2685
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,34.5
     parent: 0
     type: Transform
 - uid: 2686
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,37.5
     parent: 0
     type: Transform
 - uid: 2687
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,34.5
     parent: 0
@@ -35715,49 +35715,49 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2690
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,34.5
     parent: 0
     type: Transform
 - uid: 2691
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,34.5
     parent: 0
     type: Transform
 - uid: 2692
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,34.5
     parent: 0
     type: Transform
 - uid: 2693
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,34.5
     parent: 0
     type: Transform
 - uid: 2694
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,34.5
     parent: 0
     type: Transform
 - uid: 2695
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,34.5
     parent: 0
     type: Transform
 - uid: 2696
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,34.5
     parent: 0
     type: Transform
 - uid: 2697
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,33.5
     parent: 0
@@ -36238,13 +36238,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 2760
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,35.5
     parent: 0
     type: Transform
 - uid: 2761
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,34.5
     parent: 0
@@ -36719,37 +36719,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 2822
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,49.5
     parent: 0
     type: Transform
 - uid: 2823
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,48.5
     parent: 0
     type: Transform
 - uid: 2824
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,47.5
     parent: 0
     type: Transform
 - uid: 2825
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,47.5
     parent: 0
     type: Transform
 - uid: 2826
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,47.5
     parent: 0
     type: Transform
 - uid: 2827
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,47.5
     parent: 0
@@ -36779,43 +36779,43 @@ entities:
     parent: 0
     type: Transform
 - uid: 2832
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,46.5
     parent: 0
     type: Transform
 - uid: 2833
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,47.5
     parent: 0
     type: Transform
 - uid: 2834
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,47.5
     parent: 0
     type: Transform
 - uid: 2835
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,47.5
     parent: 0
     type: Transform
 - uid: 2836
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,47.5
     parent: 0
     type: Transform
 - uid: 2837
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,48.5
     parent: 0
     type: Transform
 - uid: 2838
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,49.5
     parent: 0
@@ -37036,67 +37036,67 @@ entities:
     parent: 0
     type: Transform
 - uid: 2870
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-12.5
     parent: 0
     type: Transform
 - uid: 2871
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-11.5
     parent: 0
     type: Transform
 - uid: 2872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-10.5
     parent: 0
     type: Transform
 - uid: 2873
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-9.5
     parent: 0
     type: Transform
 - uid: 2874
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-8.5
     parent: 0
     type: Transform
 - uid: 2875
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-8.5
     parent: 0
     type: Transform
 - uid: 2876
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-8.5
     parent: 0
     type: Transform
 - uid: 2877
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-8.5
     parent: 0
     type: Transform
 - uid: 2878
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-9.5
     parent: 0
     type: Transform
 - uid: 2879
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-10.5
     parent: 0
     type: Transform
 - uid: 2880
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-11.5
     parent: 0
@@ -37156,61 +37156,61 @@ entities:
     parent: 0
     type: Transform
 - uid: 2890
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,-12.5
     parent: 0
     type: Transform
 - uid: 2891
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,-13.5
     parent: 0
     type: Transform
 - uid: 2892
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,-14.5
     parent: 0
     type: Transform
 - uid: 2893
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 65.5,-12.5
     parent: 0
     type: Transform
 - uid: 2894
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 66.5,-12.5
     parent: 0
     type: Transform
 - uid: 2895
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,-12.5
     parent: 0
     type: Transform
 - uid: 2896
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-12.5
     parent: 0
     type: Transform
 - uid: 2897
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-13.5
     parent: 0
     type: Transform
 - uid: 2898
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-14.5
     parent: 0
     type: Transform
 - uid: 2899
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-15.5
     parent: 0
@@ -37246,31 +37246,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 2905
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-17.5
     parent: 0
     type: Transform
 - uid: 2906
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-18.5
     parent: 0
     type: Transform
 - uid: 2907
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,-18.5
     parent: 0
     type: Transform
 - uid: 2908
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-18.5
     parent: 0
     type: Transform
 - uid: 2909
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 61.5,-18.5
     parent: 0
@@ -37336,7 +37336,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 2918
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: 65.52396,-13.395477
     parent: 0
@@ -37344,7 +37344,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2919
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: 65.85208,-13.442352
     parent: 0
@@ -37549,229 +37549,229 @@ entities:
       ReagentDispenser-beaker: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 2945
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-3.5
     parent: 0
     type: Transform
 - uid: 2946
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-4.5
     parent: 0
     type: Transform
 - uid: 2947
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-2.5
     parent: 0
     type: Transform
 - uid: 2948
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-1.5
     parent: 0
     type: Transform
 - uid: 2949
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-0.5
     parent: 0
     type: Transform
 - uid: 2950
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-0.5
     parent: 0
     type: Transform
 - uid: 2951
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 66.5,-0.5
     parent: 0
     type: Transform
 - uid: 2952
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,-0.5
     parent: 0
     type: Transform
 - uid: 2953
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-0.5
     parent: 0
     type: Transform
 - uid: 2954
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-1.5
     parent: 0
     type: Transform
 - uid: 2955
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-2.5
     parent: 0
     type: Transform
 - uid: 2956
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-3.5
     parent: 0
     type: Transform
 - uid: 2957
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-4.5
     parent: 0
     type: Transform
 - uid: 2958
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-5.5
     parent: 0
     type: Transform
 - uid: 2959
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-6.5
     parent: 0
     type: Transform
 - uid: 2960
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-7.5
     parent: 0
     type: Transform
 - uid: 2961
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,-7.5
     parent: 0
     type: Transform
 - uid: 2962
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-8.5
     parent: 0
     type: Transform
 - uid: 2963
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 65.5,-7.5
     parent: 0
     type: Transform
 - uid: 2964
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-8.5
     parent: 0
     type: Transform
 - uid: 2965
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-7.5
     parent: 0
     type: Transform
 - uid: 2966
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-6.5
     parent: 0
     type: Transform
 - uid: 2967
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-7.5
     parent: 0
     type: Transform
 - uid: 2968
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-9.5
     parent: 0
     type: Transform
 - uid: 2969
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-10.5
     parent: 0
     type: Transform
 - uid: 2970
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-11.5
     parent: 0
     type: Transform
 - uid: 2971
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-10.5
     parent: 0
     type: Transform
 - uid: 2972
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-11.5
     parent: 0
     type: Transform
 - uid: 2973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-3.5
     parent: 0
     type: Transform
 - uid: 2974
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-2.5
     parent: 0
     type: Transform
 - uid: 2975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-2.5
     parent: 0
     type: Transform
 - uid: 2976
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-8.5
     parent: 0
     type: Transform
 - uid: 2977
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,-9.5
     parent: 0
     type: Transform
 - uid: 2978
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-9.5
     parent: 0
     type: Transform
 - uid: 2979
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-9.5
     parent: 0
     type: Transform
 - uid: 2980
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,-7.5
     parent: 0
     type: Transform
 - uid: 2981
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,-2.5
     parent: 0
     type: Transform
 - uid: 2982
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-2.5
     parent: 0
@@ -37827,103 +37827,103 @@ entities:
     parent: 0
     type: Transform
 - uid: 2991
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,1.5
     parent: 0
     type: Transform
 - uid: 2992
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,2.5
     parent: 0
     type: Transform
 - uid: 2993
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,5.5
     parent: 0
     type: Transform
 - uid: 2994
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 47.5,5.5
     parent: 0
     type: Transform
 - uid: 2995
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 46.5,5.5
     parent: 0
     type: Transform
 - uid: 2996
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 45.5,5.5
     parent: 0
     type: Transform
 - uid: 2997
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,5.5
     parent: 0
     type: Transform
 - uid: 2998
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,5.5
     parent: 0
     type: Transform
 - uid: 2999
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,6.5
     parent: 0
     type: Transform
 - uid: 3000
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,4.5
     parent: 0
     type: Transform
 - uid: 3001
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,3.5
     parent: 0
     type: Transform
 - uid: 3002
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,2.5
     parent: 0
     type: Transform
 - uid: 3003
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,5.5
     parent: 0
     type: Transform
 - uid: 3004
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,5.5
     parent: 0
     type: Transform
 - uid: 3005
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,5.5
     parent: 0
     type: Transform
 - uid: 3006
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 51.5,5.5
     parent: 0
     type: Transform
 - uid: 3007
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,1.5
     parent: 0
@@ -37983,103 +37983,103 @@ entities:
     parent: 0
     type: Transform
 - uid: 3017
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,5.5
     parent: 0
     type: Transform
 - uid: 3018
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,5.5
     parent: 0
     type: Transform
 - uid: 3019
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,4.5
     parent: 0
     type: Transform
 - uid: 3020
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 55.5,4.5
     parent: 0
     type: Transform
 - uid: 3021
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,5.5
     parent: 0
     type: Transform
 - uid: 3022
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,4.5
     parent: 0
     type: Transform
 - uid: 3023
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,4.5
     parent: 0
     type: Transform
 - uid: 3024
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 59.5,5.5
     parent: 0
     type: Transform
 - uid: 3025
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 60.5,5.5
     parent: 0
     type: Transform
 - uid: 3026
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 61.5,5.5
     parent: 0
     type: Transform
 - uid: 3027
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 62.5,5.5
     parent: 0
     type: Transform
 - uid: 3028
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,5.5
     parent: 0
     type: Transform
 - uid: 3029
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,5.5
     parent: 0
     type: Transform
 - uid: 3030
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 65.5,5.5
     parent: 0
     type: Transform
 - uid: 3031
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 66.5,5.5
     parent: 0
     type: Transform
 - uid: 3032
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,5.5
     parent: 0
     type: Transform
 - uid: 3033
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,6.5
     parent: 0
@@ -38145,139 +38145,139 @@ entities:
     parent: 0
     type: Transform
 - uid: 3044
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,12.5
     parent: 0
     type: Transform
 - uid: 3045
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,11.5
     parent: 0
     type: Transform
 - uid: 3046
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,10.5
     parent: 0
     type: Transform
 - uid: 3047
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,9.5
     parent: 0
     type: Transform
 - uid: 3048
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,8.5
     parent: 0
     type: Transform
 - uid: 3049
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,8.5
     parent: 0
     type: Transform
 - uid: 3050
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,8.5
     parent: 0
     type: Transform
 - uid: 3051
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,8.5
     parent: 0
     type: Transform
 - uid: 3052
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,8.5
     parent: 0
     type: Transform
 - uid: 3053
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,8.5
     parent: 0
     type: Transform
 - uid: 3054
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,7.5
     parent: 0
     type: Transform
 - uid: 3055
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,7.5
     parent: 0
     type: Transform
 - uid: 3056
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,7.5
     parent: 0
     type: Transform
 - uid: 3057
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,7.5
     parent: 0
     type: Transform
 - uid: 3058
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,7.5
     parent: 0
     type: Transform
 - uid: 3059
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,7.5
     parent: 0
     type: Transform
 - uid: 3060
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,7.5
     parent: 0
     type: Transform
 - uid: 3061
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,7.5
     parent: 0
     type: Transform
 - uid: 3062
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,8.5
     parent: 0
     type: Transform
 - uid: 3063
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,9.5
     parent: 0
     type: Transform
 - uid: 3064
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,10.5
     parent: 0
     type: Transform
 - uid: 3065
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,11.5
     parent: 0
     type: Transform
 - uid: 3066
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,12.5
     parent: 0
@@ -38295,121 +38295,121 @@ entities:
     parent: 0
     type: Transform
 - uid: 3069
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,13.5
     parent: 0
     type: Transform
 - uid: 3070
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,12.5
     parent: 0
     type: Transform
 - uid: 3071
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,15.5
     parent: 0
     type: Transform
 - uid: 3072
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,16.5
     parent: 0
     type: Transform
 - uid: 3073
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 46.5,20.5
     parent: 0
     type: Transform
 - uid: 3074
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,20.5
     parent: 0
     type: Transform
 - uid: 3075
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,16.5
     parent: 0
     type: Transform
 - uid: 3076
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,16.5
     parent: 0
     type: Transform
 - uid: 3077
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 51.5,16.5
     parent: 0
     type: Transform
 - uid: 3078
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,16.5
     parent: 0
     type: Transform
 - uid: 3079
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,15.5
     parent: 0
     type: Transform
 - uid: 3080
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,13.5
     parent: 0
     type: Transform
 - uid: 3081
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,12.5
     parent: 0
     type: Transform
 - uid: 3082
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 51.5,12.5
     parent: 0
     type: Transform
 - uid: 3083
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,12.5
     parent: 0
     type: Transform
 - uid: 3084
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,12.5
     parent: 0
     type: Transform
 - uid: 3085
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,39.5
     parent: 0
     type: Transform
 - uid: 3086
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,40.5
     parent: 0
     type: Transform
 - uid: 3087
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,40.5
     parent: 0
     type: Transform
 - uid: 3088
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,39.5
     parent: 0
@@ -38439,91 +38439,91 @@ entities:
     parent: 0
     type: Transform
 - uid: 3093
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,43.5
     parent: 0
     type: Transform
 - uid: 3094
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,43.5
     parent: 0
     type: Transform
 - uid: 3095
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,43.5
     parent: 0
     type: Transform
 - uid: 3096
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,43.5
     parent: 0
     type: Transform
 - uid: 3097
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,44.5
     parent: 0
     type: Transform
 - uid: 3098
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,45.5
     parent: 0
     type: Transform
 - uid: 3099
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,46.5
     parent: 0
     type: Transform
 - uid: 3100
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,47.5
     parent: 0
     type: Transform
 - uid: 3101
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,45.5
     parent: 0
     type: Transform
 - uid: 3102
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,44.5
     parent: 0
     type: Transform
 - uid: 3103
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,43.5
     parent: 0
     type: Transform
 - uid: 3104
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,43.5
     parent: 0
     type: Transform
 - uid: 3105
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,42.5
     parent: 0
     type: Transform
 - uid: 3106
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,41.5
     parent: 0
     type: Transform
 - uid: 3107
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,40.5
     parent: 0
@@ -38763,7 +38763,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3147
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,45.5
     parent: 0
@@ -38889,325 +38889,325 @@ entities:
     parent: 0
     type: Transform
 - uid: 3168
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,36.5
     parent: 0
     type: Transform
 - uid: 3169
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,34.5
     parent: 0
     type: Transform
 - uid: 3170
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,35.5
     parent: 0
     type: Transform
 - uid: 3171
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,33.5
     parent: 0
     type: Transform
 - uid: 3172
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,32.5
     parent: 0
     type: Transform
 - uid: 3173
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,31.5
     parent: 0
     type: Transform
 - uid: 3174
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,30.5
     parent: 0
     type: Transform
 - uid: 3175
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,29.5
     parent: 0
     type: Transform
 - uid: 3176
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,28.5
     parent: 0
     type: Transform
 - uid: 3177
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,28.5
     parent: 0
     type: Transform
 - uid: 3178
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,28.5
     parent: 0
     type: Transform
 - uid: 3179
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,28.5
     parent: 0
     type: Transform
 - uid: 3180
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,28.5
     parent: 0
     type: Transform
 - uid: 3181
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,29.5
     parent: 0
     type: Transform
 - uid: 3182
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,30.5
     parent: 0
     type: Transform
 - uid: 3183
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,31.5
     parent: 0
     type: Transform
 - uid: 3184
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,32.5
     parent: 0
     type: Transform
 - uid: 3185
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,33.5
     parent: 0
     type: Transform
 - uid: 3186
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,34.5
     parent: 0
     type: Transform
 - uid: 3187
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,35.5
     parent: 0
     type: Transform
 - uid: 3188
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,36.5
     parent: 0
     type: Transform
 - uid: 3189
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,37.5
     parent: 0
     type: Transform
 - uid: 3190
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,38.5
     parent: 0
     type: Transform
 - uid: 3191
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,37.5
     parent: 0
     type: Transform
 - uid: 3192
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,38.5
     parent: 0
     type: Transform
 - uid: 3193
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,39.5
     parent: 0
     type: Transform
 - uid: 3194
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,39.5
     parent: 0
     type: Transform
 - uid: 3195
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,38.5
     parent: 0
     type: Transform
 - uid: 3196
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,39.5
     parent: 0
     type: Transform
 - uid: 3197
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,40.5
     parent: 0
     type: Transform
 - uid: 3198
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,40.5
     parent: 0
     type: Transform
 - uid: 3199
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,39.5
     parent: 0
     type: Transform
 - uid: 3200
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,39.5
     parent: 0
     type: Transform
 - uid: 3201
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,40.5
     parent: 0
     type: Transform
 - uid: 3202
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,40.5
     parent: 0
     type: Transform
 - uid: 3203
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,39.5
     parent: 0
     type: Transform
 - uid: 3204
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,39.5
     parent: 0
     type: Transform
 - uid: 3205
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,40.5
     parent: 0
     type: Transform
 - uid: 3206
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,39.5
     parent: 0
     type: Transform
 - uid: 3207
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,39.5
     parent: 0
     type: Transform
 - uid: 3208
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,38.5
     parent: 0
     type: Transform
 - uid: 3209
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,38.5
     parent: 0
     type: Transform
 - uid: 3210
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,37.5
     parent: 0
     type: Transform
 - uid: 3211
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,38.5
     parent: 0
     type: Transform
 - uid: 3212
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,37.5
     parent: 0
     type: Transform
 - uid: 3213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,35.5
     parent: 0
     type: Transform
 - uid: 3214
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,34.5
     parent: 0
     type: Transform
 - uid: 3215
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,36.5
     parent: 0
     type: Transform
 - uid: 3216
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,33.5
     parent: 0
     type: Transform
 - uid: 3217
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,32.5
     parent: 0
     type: Transform
 - uid: 3218
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,31.5
     parent: 0
     type: Transform
 - uid: 3219
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,30.5
     parent: 0
     type: Transform
 - uid: 3220
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,29.5
     parent: 0
     type: Transform
 - uid: 3221
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,28.5
     parent: 0
@@ -39223,7 +39223,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3223
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,29.5
     parent: 0
@@ -39239,37 +39239,37 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3225
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,36.5
     parent: 0
     type: Transform
 - uid: 3226
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,37.5
     parent: 0
     type: Transform
 - uid: 3227
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,37.5
     parent: 0
     type: Transform
 - uid: 3228
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 55.5,37.5
     parent: 0
     type: Transform
 - uid: 3229
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 55.5,35.5
     parent: 0
     type: Transform
 - uid: 3230
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,35.5
     parent: 0
@@ -39311,49 +39311,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 3237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,32.5
     parent: 0
     type: Transform
 - uid: 3238
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,32.5
     parent: 0
     type: Transform
 - uid: 3239
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,32.5
     parent: 0
     type: Transform
 - uid: 3240
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,32.5
     parent: 0
     type: Transform
 - uid: 3241
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,32.5
     parent: 0
     type: Transform
 - uid: 3242
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,32.5
     parent: 0
     type: Transform
 - uid: 3243
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,32.5
     parent: 0
     type: Transform
 - uid: 3244
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,32.5
     parent: 0
@@ -39545,55 +39545,55 @@ entities:
     parent: 0
     type: Transform
 - uid: 3276
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,28.5
     parent: 0
     type: Transform
 - uid: 3277
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,28.5
     parent: 0
     type: Transform
 - uid: 3278
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,28.5
     parent: 0
     type: Transform
 - uid: 3279
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,28.5
     parent: 0
     type: Transform
 - uid: 3280
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,28.5
     parent: 0
     type: Transform
 - uid: 3281
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,28.5
     parent: 0
     type: Transform
 - uid: 3282
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,28.5
     parent: 0
     type: Transform
 - uid: 3283
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,28.5
     parent: 0
     type: Transform
 - uid: 3284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,29.5
     parent: 0
@@ -39609,7 +39609,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3286
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,45.5
     parent: 0
@@ -39621,109 +39621,109 @@ entities:
     parent: 0
     type: Transform
 - uid: 3288
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,45.5
     parent: 0
     type: Transform
 - uid: 3289
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,45.5
     parent: 0
     type: Transform
 - uid: 3290
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,45.5
     parent: 0
     type: Transform
 - uid: 3291
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,44.5
     parent: 0
     type: Transform
 - uid: 3292
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,43.5
     parent: 0
     type: Transform
 - uid: 3293
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,30.5
     parent: 0
     type: Transform
 - uid: 3294
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,31.5
     parent: 0
     type: Transform
 - uid: 3295
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,32.5
     parent: 0
     type: Transform
 - uid: 3296
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,33.5
     parent: 0
     type: Transform
 - uid: 3297
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,34.5
     parent: 0
     type: Transform
 - uid: 3298
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,35.5
     parent: 0
     type: Transform
 - uid: 3299
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,36.5
     parent: 0
     type: Transform
 - uid: 3300
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,37.5
     parent: 0
     type: Transform
 - uid: 3301
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,38.5
     parent: 0
     type: Transform
 - uid: 3302
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,39.5
     parent: 0
     type: Transform
 - uid: 3303
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,40.5
     parent: 0
     type: Transform
 - uid: 3304
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,41.5
     parent: 0
     type: Transform
 - uid: 3305
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,42.5
     parent: 0
@@ -39915,13 +39915,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3337
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,49.5
     parent: 0
     type: Transform
 - uid: 3338
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,49.5
     parent: 0
@@ -39933,13 +39933,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3340
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,50.5
     parent: 0
     type: Transform
 - uid: 3341
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,50.5
     parent: 0
@@ -39951,13 +39951,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3343
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,51.5
     parent: 0
     type: Transform
 - uid: 3344
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,51.5
     parent: 0
@@ -40137,73 +40137,73 @@ entities:
     parent: 0
     type: Transform
 - uid: 3374
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,47.5
     parent: 0
     type: Transform
 - uid: 3375
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,47.5
     parent: 0
     type: Transform
 - uid: 3376
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,47.5
     parent: 0
     type: Transform
 - uid: 3377
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,47.5
     parent: 0
     type: Transform
 - uid: 3378
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,46.5
     parent: 0
     type: Transform
 - uid: 3379
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,45.5
     parent: 0
     type: Transform
 - uid: 3380
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,44.5
     parent: 0
     type: Transform
 - uid: 3381
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,43.5
     parent: 0
     type: Transform
 - uid: 3382
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,41.5
     parent: 0
     type: Transform
 - uid: 3383
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,41.5
     parent: 0
     type: Transform
 - uid: 3384
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,41.5
     parent: 0
     type: Transform
 - uid: 3385
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,42.5
     parent: 0
@@ -40245,97 +40245,97 @@ entities:
     parent: 0
     type: Transform
 - uid: 3392
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,43.5
     parent: 0
     type: Transform
 - uid: 3393
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,43.5
     parent: 0
     type: Transform
 - uid: 3394
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,43.5
     parent: 0
     type: Transform
 - uid: 3395
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,35.5
     parent: 0
     type: Transform
 - uid: 3396
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,35.5
     parent: 0
     type: Transform
 - uid: 3397
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,36.5
     parent: 0
     type: Transform
 - uid: 3398
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,38.5
     parent: 0
     type: Transform
 - uid: 3399
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,37.5
     parent: 0
     type: Transform
 - uid: 3400
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,39.5
     parent: 0
     type: Transform
 - uid: 3401
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,40.5
     parent: 0
     type: Transform
 - uid: 3402
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,40.5
     parent: 0
     type: Transform
 - uid: 3403
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,41.5
     parent: 0
     type: Transform
 - uid: 3404
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,41.5
     parent: 0
     type: Transform
 - uid: 3405
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,35.5
     parent: 0
     type: Transform
 - uid: 3406
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,35.5
     parent: 0
     type: Transform
 - uid: 3407
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,35.5
     parent: 0
@@ -40351,13 +40351,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3409
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,37.5
     parent: 0
     type: Transform
 - uid: 3410
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,38.5
     parent: 0
@@ -40405,7 +40405,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3418
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 66.5,45.5
     parent: 0
@@ -40549,187 +40549,187 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3436
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,31.5
     parent: 0
     type: Transform
 - uid: 3437
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,30.5
     parent: 0
     type: Transform
 - uid: 3438
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,30.5
     parent: 0
     type: Transform
 - uid: 3439
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,22.5
     parent: 0
     type: Transform
 - uid: 3440
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,22.5
     parent: 0
     type: Transform
 - uid: 3441
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,22.5
     parent: 0
     type: Transform
 - uid: 3442
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,21.5
     parent: 0
     type: Transform
 - uid: 3443
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,20.5
     parent: 0
     type: Transform
 - uid: 3444
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,19.5
     parent: 0
     type: Transform
 - uid: 3445
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,19.5
     parent: 0
     type: Transform
 - uid: 3446
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,19.5
     parent: 0
     type: Transform
 - uid: 3447
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,19.5
     parent: 0
     type: Transform
 - uid: 3448
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,19.5
     parent: 0
     type: Transform
 - uid: 3449
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,19.5
     parent: 0
     type: Transform
 - uid: 3450
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,20.5
     parent: 0
     type: Transform
 - uid: 3451
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,21.5
     parent: 0
     type: Transform
 - uid: 3452
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,22.5
     parent: 0
     type: Transform
 - uid: 3453
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,22.5
     parent: 0
     type: Transform
 - uid: 3454
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,23.5
     parent: 0
     type: Transform
 - uid: 3455
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,24.5
     parent: 0
     type: Transform
 - uid: 3456
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,24.5
     parent: 0
     type: Transform
 - uid: 3457
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,24.5
     parent: 0
     type: Transform
 - uid: 3458
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,24.5
     parent: 0
     type: Transform
 - uid: 3459
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,24.5
     parent: 0
     type: Transform
 - uid: 3460
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,24.5
     parent: 0
     type: Transform
 - uid: 3461
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,25.5
     parent: 0
     type: Transform
 - uid: 3462
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,26.5
     parent: 0
     type: Transform
 - uid: 3463
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,27.5
     parent: 0
     type: Transform
 - uid: 3464
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,29.5
     parent: 0
     type: Transform
 - uid: 3465
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,33.5
     parent: 0
     type: Transform
 - uid: 3466
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,34.5
     parent: 0
@@ -40773,43 +40773,43 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3471
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,28.5
     parent: 0
     type: Transform
 - uid: 3472
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,27.5
     parent: 0
     type: Transform
 - uid: 3473
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,26.5
     parent: 0
     type: Transform
 - uid: 3474
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,25.5
     parent: 0
     type: Transform
 - uid: 3475
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,27.5
     parent: 0
     type: Transform
 - uid: 3476
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,26.5
     parent: 0
     type: Transform
 - uid: 3477
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,25.5
     parent: 0
@@ -40851,85 +40851,85 @@ entities:
     parent: 0
     type: Transform
 - uid: 3484
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,22.5
     parent: 0
     type: Transform
 - uid: 3485
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,21.5
     parent: 0
     type: Transform
 - uid: 3486
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,21.5
     parent: 0
     type: Transform
 - uid: 3487
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,21.5
     parent: 0
     type: Transform
 - uid: 3488
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,21.5
     parent: 0
     type: Transform
 - uid: 3489
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,21.5
     parent: 0
     type: Transform
 - uid: 3490
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,22.5
     parent: 0
     type: Transform
 - uid: 3491
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,23.5
     parent: 0
     type: Transform
 - uid: 3492
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,20.5
     parent: 0
     type: Transform
 - uid: 3493
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,19.5
     parent: 0
     type: Transform
 - uid: 3494
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,18.5
     parent: 0
     type: Transform
 - uid: 3495
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,17.5
     parent: 0
     type: Transform
 - uid: 3496
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,26.5
     parent: 0
     type: Transform
 - uid: 3497
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,26.5
     parent: 0
@@ -40965,25 +40965,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 3503
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,26.5
     parent: 0
     type: Transform
 - uid: 3504
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,26.5
     parent: 0
     type: Transform
 - uid: 3505
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,22.5
     parent: 0
     type: Transform
 - uid: 3506
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,22.5
     parent: 0
@@ -40999,19 +40999,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3508
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,23.5
     parent: 0
     type: Transform
 - uid: 3509
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,25.5
     parent: 0
     type: Transform
 - uid: 3510
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,26.5
     parent: 0
@@ -41033,13 +41033,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3513
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,22.5
     parent: 0
     type: Transform
 - uid: 3514
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,22.5
     parent: 0
@@ -41051,7 +41051,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3516
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,27.5
     parent: 0
@@ -41075,7 +41075,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3520
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,26.5
     parent: 0
@@ -41117,37 +41117,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 3527
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,22.5
     parent: 0
     type: Transform
 - uid: 3528
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,23.5
     parent: 0
     type: Transform
 - uid: 3529
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,24.5
     parent: 0
     type: Transform
 - uid: 3530
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,25.5
     parent: 0
     type: Transform
 - uid: 3531
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,26.5
     parent: 0
     type: Transform
 - uid: 3532
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,26.5
     parent: 0
@@ -41176,37 +41176,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 3536
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,21.5
     parent: 0
     type: Transform
 - uid: 3537
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,22.5
     parent: 0
     type: Transform
 - uid: 3538
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,21.5
     parent: 0
     type: Transform
 - uid: 3539
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,21.5
     parent: 0
     type: Transform
 - uid: 3540
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,21.5
     parent: 0
     type: Transform
 - uid: 3541
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,21.5
     parent: 0
@@ -41230,37 +41230,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 3545
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,16.5
     parent: 0
     type: Transform
 - uid: 3546
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,16.5
     parent: 0
     type: Transform
 - uid: 3547
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 55.5,16.5
     parent: 0
     type: Transform
 - uid: 3548
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,16.5
     parent: 0
     type: Transform
 - uid: 3549
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,16.5
     parent: 0
     type: Transform
 - uid: 3550
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,16.5
     parent: 0
@@ -41308,43 +41308,43 @@ entities:
     parent: 0
     type: Transform
 - uid: 3558
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 74.5,19.5
     parent: 0
     type: Transform
 - uid: 3559
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,19.5
     parent: 0
     type: Transform
 - uid: 3560
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,18.5
     parent: 0
     type: Transform
 - uid: 3561
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,14.5
     parent: 0
     type: Transform
 - uid: 3562
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,13.5
     parent: 0
     type: Transform
 - uid: 3563
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,13.5
     parent: 0
     type: Transform
 - uid: 3564
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 81.5,13.5
     parent: 0
@@ -41364,13 +41364,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3567
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-5.5
     parent: 0
     type: Transform
 - uid: 3568
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-4.5
     parent: 0
@@ -41382,19 +41382,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3570
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-3.5
     parent: 0
     type: Transform
 - uid: 3571
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-2.5
     parent: 0
     type: Transform
 - uid: 3572
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-1.5
     parent: 0
@@ -41410,13 +41410,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3574
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 88.5,-1.5
     parent: 0
     type: Transform
 - uid: 3575
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,2.5
     parent: 0
@@ -41430,85 +41430,85 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3577
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-1.5
     parent: 0
     type: Transform
 - uid: 3578
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-0.5
     parent: 0
     type: Transform
 - uid: 3579
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,6.5
     parent: 0
     type: Transform
 - uid: 3580
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,6.5
     parent: 0
     type: Transform
 - uid: 3581
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,2.5
     parent: 0
     type: Transform
 - uid: 3582
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,2.5
     parent: 0
     type: Transform
 - uid: 3583
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,2.5
     parent: 0
     type: Transform
 - uid: 3584
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,3.5
     parent: 0
     type: Transform
 - uid: 3585
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,5.5
     parent: 0
     type: Transform
 - uid: 3586
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,6.5
     parent: 0
     type: Transform
 - uid: 3587
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,6.5
     parent: 0
     type: Transform
 - uid: 3588
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 89.5,6.5
     parent: 0
     type: Transform
 - uid: 3589
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,10.5
     parent: 0
     type: Transform
 - uid: 3590
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,9.5
     parent: 0
@@ -41520,115 +41520,115 @@ entities:
     parent: 0
     type: Transform
 - uid: 3592
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,3.5
     parent: 0
     type: Transform
 - uid: 3593
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 78.5,11.5
     parent: 0
     type: Transform
 - uid: 3594
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 77.5,11.5
     parent: 0
     type: Transform
 - uid: 3595
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,8.5
     parent: 0
     type: Transform
 - uid: 3596
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,7.5
     parent: 0
     type: Transform
 - uid: 3597
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,9.5
     parent: 0
     type: Transform
 - uid: 3598
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,9.5
     parent: 0
     type: Transform
 - uid: 3599
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 74.5,9.5
     parent: 0
     type: Transform
 - uid: 3600
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,9.5
     parent: 0
     type: Transform
 - uid: 3601
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,9.5
     parent: 0
     type: Transform
 - uid: 3602
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 71.5,9.5
     parent: 0
     type: Transform
 - uid: 3603
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 83.5,9.5
     parent: 0
     type: Transform
 - uid: 3604
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,12.5
     parent: 0
     type: Transform
 - uid: 3605
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,11.5
     parent: 0
     type: Transform
 - uid: 3606
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,9.5
     parent: 0
     type: Transform
 - uid: 3607
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,6.5
     parent: 0
     type: Transform
 - uid: 3608
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,11.5
     parent: 0
     type: Transform
 - uid: 3609
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,11.5
     parent: 0
     type: Transform
 - uid: 3610
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 89.5,2.5
     parent: 0
@@ -41640,19 +41640,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3612
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,13.5
     parent: 0
     type: Transform
 - uid: 3613
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,13.5
     parent: 0
     type: Transform
 - uid: 3614
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,13.5
     parent: 0
@@ -41690,61 +41690,61 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3619
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,7.5
     parent: 0
     type: Transform
 - uid: 3620
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,2.5
     parent: 0
     type: Transform
 - uid: 3621
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 83.5,6.5
     parent: 0
     type: Transform
 - uid: 3622
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,13.5
     parent: 0
     type: Transform
 - uid: 3623
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,12.5
     parent: 0
     type: Transform
 - uid: 3624
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,11.5
     parent: 0
     type: Transform
 - uid: 3625
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,10.5
     parent: 0
     type: Transform
 - uid: 3626
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,9.5
     parent: 0
     type: Transform
 - uid: 3627
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,9.5
     parent: 0
     type: Transform
 - uid: 3628
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,8.5
     parent: 0
@@ -41756,19 +41756,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3630
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,13.5
     parent: 0
     type: Transform
 - uid: 3631
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,13.5
     parent: 0
     type: Transform
 - uid: 3632
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 84.5,9.5
     parent: 0
@@ -41798,25 +41798,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 3637
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,3.5
     parent: 0
     type: Transform
 - uid: 3638
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,3.5
     parent: 0
     type: Transform
 - uid: 3639
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,7.5
     parent: 0
     type: Transform
 - uid: 3640
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,7.5
     parent: 0
@@ -41864,163 +41864,163 @@ entities:
     parent: 0
     type: Transform
 - uid: 3648
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,3.5
     parent: 0
     type: Transform
 - uid: 3649
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,2.5
     parent: 0
     type: Transform
 - uid: 3650
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,1.5
     parent: 0
     type: Transform
 - uid: 3651
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,0.5
     parent: 0
     type: Transform
 - uid: 3652
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,-1.5
     parent: 0
     type: Transform
 - uid: 3653
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,-0.5
     parent: 0
     type: Transform
 - uid: 3654
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,-2.5
     parent: 0
     type: Transform
 - uid: 3655
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-2.5
     parent: 0
     type: Transform
 - uid: 3656
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-8.5
     parent: 0
     type: Transform
 - uid: 3657
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,12.5
     parent: 0
     type: Transform
 - uid: 3658
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,12.5
     parent: 0
     type: Transform
 - uid: 3659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,12.5
     parent: 0
     type: Transform
 - uid: 3660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,12.5
     parent: 0
     type: Transform
 - uid: 3661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,13.5
     parent: 0
     type: Transform
 - uid: 3662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,14.5
     parent: 0
     type: Transform
 - uid: 3663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,15.5
     parent: 0
     type: Transform
 - uid: 3664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,16.5
     parent: 0
     type: Transform
 - uid: 3665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,17.5
     parent: 0
     type: Transform
 - uid: 3666
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,17.5
     parent: 0
     type: Transform
 - uid: 3667
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,17.5
     parent: 0
     type: Transform
 - uid: 3668
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,17.5
     parent: 0
     type: Transform
 - uid: 3669
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,17.5
     parent: 0
     type: Transform
 - uid: 3670
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,12.5
     parent: 0
     type: Transform
 - uid: 3671
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 67.5,12.5
     parent: 0
     type: Transform
 - uid: 3672
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 67.5,17.5
     parent: 0
     type: Transform
 - uid: 3673
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 66.5,17.5
     parent: 0
     type: Transform
 - uid: 3674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,17.5
     parent: 0
@@ -42038,139 +42038,139 @@ entities:
     parent: 0
     type: Transform
 - uid: 3677
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 65.5,13.5
     parent: 0
     type: Transform
 - uid: 3678
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 66.5,12.5
     parent: 0
     type: Transform
 - uid: 3679
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,12.5
     parent: 0
     type: Transform
 - uid: 3680
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,17.5
     parent: 0
     type: Transform
 - uid: 3681
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,17.5
     parent: 0
     type: Transform
 - uid: 3682
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,17.5
     parent: 0
     type: Transform
 - uid: 3683
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,7.5
     parent: 0
     type: Transform
 - uid: 3684
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,7.5
     parent: 0
     type: Transform
 - uid: 3685
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,8.5
     parent: 0
     type: Transform
 - uid: 3686
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,9.5
     parent: 0
     type: Transform
 - uid: 3687
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,10.5
     parent: 0
     type: Transform
 - uid: 3688
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,11.5
     parent: 0
     type: Transform
 - uid: 3689
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 59.5,12.5
     parent: 0
     type: Transform
 - uid: 3690
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,12.5
     parent: 0
     type: Transform
 - uid: 3691
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,11.5
     parent: 0
     type: Transform
 - uid: 3692
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,10.5
     parent: 0
     type: Transform
 - uid: 3693
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,9.5
     parent: 0
     type: Transform
 - uid: 3694
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,8.5
     parent: 0
     type: Transform
 - uid: 3695
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,7.5
     parent: 0
     type: Transform
 - uid: 3696
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,7.5
     parent: 0
     type: Transform
 - uid: 3697
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,7.5
     parent: 0
     type: Transform
 - uid: 3698
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,7.5
     parent: 0
     type: Transform
 - uid: 3699
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,7.5
     parent: 0
@@ -42194,19 +42194,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3703
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,8.5
     parent: 0
     type: Transform
 - uid: 3704
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,9.5
     parent: 0
     type: Transform
 - uid: 3705
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,4.5
     parent: 0
@@ -42252,7 +42252,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3712
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,3.5
     parent: 0
@@ -42282,61 +42282,61 @@ entities:
     parent: 0
     type: Transform
 - uid: 3717
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,3.5
     parent: 0
     type: Transform
 - uid: 3718
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 77.5,3.5
     parent: 0
     type: Transform
 - uid: 3719
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,3.5
     parent: 0
     type: Transform
 - uid: 3720
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,6.5
     parent: 0
     type: Transform
 - uid: 3721
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,4.5
     parent: 0
     type: Transform
 - uid: 3722
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,5.5
     parent: 0
     type: Transform
 - uid: 3723
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,6.5
     parent: 0
     type: Transform
 - uid: 3724
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,8.5
     parent: 0
     type: Transform
 - uid: 3725
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,7.5
     parent: 0
     type: Transform
 - uid: 3726
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,10.5
     parent: 0
@@ -42380,67 +42380,67 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3732
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-7.5
     parent: 0
     type: Transform
 - uid: 3733
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-8.5
     parent: 0
     type: Transform
 - uid: 3734
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-9.5
     parent: 0
     type: Transform
 - uid: 3735
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-10.5
     parent: 0
     type: Transform
 - uid: 3736
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-11.5
     parent: 0
     type: Transform
 - uid: 3737
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-11.5
     parent: 0
     type: Transform
 - uid: 3738
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 89.5,-11.5
     parent: 0
     type: Transform
 - uid: 3739
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-11.5
     parent: 0
     type: Transform
 - uid: 3740
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-9.5
     parent: 0
     type: Transform
 - uid: 3741
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-8.5
     parent: 0
     type: Transform
 - uid: 3742
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-7.5
     parent: 0
@@ -42474,85 +42474,85 @@ entities:
       PaperLabel: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 3745
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-3.5
     parent: 0
     type: Transform
 - uid: 3746
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-4.5
     parent: 0
     type: Transform
 - uid: 3747
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-7.5
     parent: 0
     type: Transform
 - uid: 3748
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-5.5
     parent: 0
     type: Transform
 - uid: 3749
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-6.5
     parent: 0
     type: Transform
 - uid: 3750
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-6.5
     parent: 0
     type: Transform
 - uid: 3751
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,-6.5
     parent: 0
     type: Transform
 - uid: 3752
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,-4.5
     parent: 0
     type: Transform
 - uid: 3753
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,-5.5
     parent: 0
     type: Transform
 - uid: 3754
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 84.5,-4.5
     parent: 0
     type: Transform
 - uid: 3755
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 86.5,-1.5
     parent: 0
     type: Transform
 - uid: 3756
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 86.5,-0.5
     parent: 0
     type: Transform
 - uid: 3757
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 86.5,0.5
     parent: 0
     type: Transform
 - uid: 3758
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,0.5
     parent: 0
@@ -42568,187 +42568,187 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3760
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-7.5
     parent: 0
     type: Transform
 - uid: 3761
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-8.5
     parent: 0
     type: Transform
 - uid: 3762
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-9.5
     parent: 0
     type: Transform
 - uid: 3763
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-10.5
     parent: 0
     type: Transform
 - uid: 3764
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-11.5
     parent: 0
     type: Transform
 - uid: 3765
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,-12.5
     parent: 0
     type: Transform
 - uid: 3766
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,-13.5
     parent: 0
     type: Transform
 - uid: 3767
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 81.5,0.5
     parent: 0
     type: Transform
 - uid: 3768
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 80.5,0.5
     parent: 0
     type: Transform
 - uid: 3769
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,0.5
     parent: 0
     type: Transform
 - uid: 3770
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,-0.5
     parent: 0
     type: Transform
 - uid: 3771
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,-1.5
     parent: 0
     type: Transform
 - uid: 3772
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,-2.5
     parent: 0
     type: Transform
 - uid: 3773
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,-2.5
     parent: 0
     type: Transform
 - uid: 3774
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,-8.5
     parent: 0
     type: Transform
 - uid: 3775
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,-9.5
     parent: 0
     type: Transform
 - uid: 3776
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 77.5,-9.5
     parent: 0
     type: Transform
 - uid: 3777
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-9.5
     parent: 0
     type: Transform
 - uid: 3778
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-9.5
     parent: 0
     type: Transform
 - uid: 3779
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-8.5
     parent: 0
     type: Transform
 - uid: 3780
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-7.5
     parent: 0
     type: Transform
 - uid: 3781
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-6.5
     parent: 0
     type: Transform
 - uid: 3782
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-5.5
     parent: 0
     type: Transform
 - uid: 3783
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-4.5
     parent: 0
     type: Transform
 - uid: 3784
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-3.5
     parent: 0
     type: Transform
 - uid: 3785
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-2.5
     parent: 0
     type: Transform
 - uid: 3786
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-2.5
     parent: 0
     type: Transform
 - uid: 3787
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-1.5
     parent: 0
     type: Transform
 - uid: 3788
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-0.5
     parent: 0
     type: Transform
 - uid: 3789
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,0.5
     parent: 0
     type: Transform
 - uid: 3790
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,0.5
     parent: 0
@@ -42778,187 +42778,187 @@ entities:
     parent: 0
     type: Transform
 - uid: 3795
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,0.5
     parent: 0
     type: Transform
 - uid: 3796
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 74.5,0.5
     parent: 0
     type: Transform
 - uid: 3797
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,0.5
     parent: 0
     type: Transform
 - uid: 3798
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 74.5,-4.5
     parent: 0
     type: Transform
 - uid: 3799
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 71.5,0.5
     parent: 0
     type: Transform
 - uid: 3800
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,0.5
     parent: 0
     type: Transform
 - uid: 3801
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,-0.5
     parent: 0
     type: Transform
 - uid: 3802
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,-0.5
     parent: 0
     type: Transform
 - uid: 3803
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-4.5
     parent: 0
     type: Transform
 - uid: 3804
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-4.5
     parent: 0
     type: Transform
 - uid: 3805
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,-4.5
     parent: 0
     type: Transform
 - uid: 3806
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,-4.5
     parent: 0
     type: Transform
 - uid: 3807
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 74.5,-7.5
     parent: 0
     type: Transform
 - uid: 3808
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-7.5
     parent: 0
     type: Transform
 - uid: 3809
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,-6.5
     parent: 0
     type: Transform
 - uid: 3810
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,-5.5
     parent: 0
     type: Transform
 - uid: 3811
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-8.5
     parent: 0
     type: Transform
 - uid: 3812
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-9.5
     parent: 0
     type: Transform
 - uid: 3813
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-10.5
     parent: 0
     type: Transform
 - uid: 3814
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-11.5
     parent: 0
     type: Transform
 - uid: 3815
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 74.5,-11.5
     parent: 0
     type: Transform
 - uid: 3816
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-11.5
     parent: 0
     type: Transform
 - uid: 3817
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 77.5,-11.5
     parent: 0
     type: Transform
 - uid: 3818
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-11.5
     parent: 0
     type: Transform
 - uid: 3819
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,-11.5
     parent: 0
     type: Transform
 - uid: 3820
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,-11.5
     parent: 0
     type: Transform
 - uid: 3821
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 80.5,-11.5
     parent: 0
     type: Transform
 - uid: 3822
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 81.5,-11.5
     parent: 0
     type: Transform
 - uid: 3823
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,-11.5
     parent: 0
     type: Transform
 - uid: 3824
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-11.5
     parent: 0
     type: Transform
 - uid: 3825
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,-11.5
     parent: 0
@@ -42994,163 +42994,163 @@ entities:
     parent: 0
     type: Transform
 - uid: 3831
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 78.5,-12.5
     parent: 0
     type: Transform
 - uid: 3832
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 78.5,-13.5
     parent: 0
     type: Transform
 - uid: 3833
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 78.5,-14.5
     parent: 0
     type: Transform
 - uid: 3834
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 77.5,-14.5
     parent: 0
     type: Transform
 - uid: 3835
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,-14.5
     parent: 0
     type: Transform
 - uid: 3836
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,-14.5
     parent: 0
     type: Transform
 - uid: 3837
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,-13.5
     parent: 0
     type: Transform
 - uid: 3838
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,-12.5
     parent: 0
     type: Transform
 - uid: 3839
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,-14.5
     parent: 0
     type: Transform
 - uid: 3840
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-14.5
     parent: 0
     type: Transform
 - uid: 3841
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-13.5
     parent: 0
     type: Transform
 - uid: 3842
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-12.5
     parent: 0
     type: Transform
 - uid: 3843
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-11.5
     parent: 0
     type: Transform
 - uid: 3844
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,-14.5
     parent: 0
     type: Transform
 - uid: 3845
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,-14.5
     parent: 0
     type: Transform
 - uid: 3846
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 84.5,-13.5
     parent: 0
     type: Transform
 - uid: 3847
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 84.5,-14.5
     parent: 0
     type: Transform
 - uid: 3848
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 83.5,-14.5
     parent: 0
     type: Transform
 - uid: 3849
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 81.5,-14.5
     parent: 0
     type: Transform
 - uid: 3850
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 80.5,-14.5
     parent: 0
     type: Transform
 - uid: 3851
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,-14.5
     parent: 0
     type: Transform
 - uid: 3852
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-12.5
     parent: 0
     type: Transform
 - uid: 3853
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-13.5
     parent: 0
     type: Transform
 - uid: 3854
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 89.5,-13.5
     parent: 0
     type: Transform
 - uid: 3855
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 88.5,-13.5
     parent: 0
     type: Transform
 - uid: 3856
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 88.5,-12.5
     parent: 0
     type: Transform
 - uid: 3857
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 87.5,-13.5
     parent: 0
@@ -43164,43 +43164,43 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3859
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,-20.5
     parent: 0
     type: Transform
 - uid: 3860
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,-20.5
     parent: 0
     type: Transform
 - uid: 3861
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,-20.5
     parent: 0
     type: Transform
 - uid: 3862
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 67.5,-20.5
     parent: 0
     type: Transform
 - uid: 3863
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-20.5
     parent: 0
     type: Transform
 - uid: 3864
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,-20.5
     parent: 0
     type: Transform
 - uid: 3865
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 66.5,-20.5
     parent: 0
@@ -43214,13 +43214,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3867
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,-20.5
     parent: 0
     type: Transform
 - uid: 3868
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-19.5
     parent: 0
@@ -43234,25 +43234,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3870
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,-20.5
     parent: 0
     type: Transform
 - uid: 3871
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,-19.5
     parent: 0
     type: Transform
 - uid: 3872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,-18.5
     parent: 0
     type: Transform
 - uid: 3873
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,-17.5
     parent: 0
@@ -43426,37 +43426,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 3902
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-14.5
     parent: 0
     type: Transform
 - uid: 3903
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-15.5
     parent: 0
     type: Transform
 - uid: 3904
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-16.5
     parent: 0
     type: Transform
 - uid: 3905
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-17.5
     parent: 0
     type: Transform
 - uid: 3906
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-17.5
     parent: 0
     type: Transform
 - uid: 3907
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-18.5
     parent: 0
@@ -43472,19 +43472,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3909
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-21.5
     parent: 0
     type: Transform
 - uid: 3910
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-22.5
     parent: 0
     type: Transform
 - uid: 3911
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-22.5
     parent: 0
@@ -43496,13 +43496,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-22.5
     parent: 0
     type: Transform
 - uid: 3914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-22.5
     parent: 0
@@ -43520,49 +43520,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 3917
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 93.5,-21.5
     parent: 0
     type: Transform
 - uid: 3918
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-21.5
     parent: 0
     type: Transform
 - uid: 3919
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 89.5,-22.5
     parent: 0
     type: Transform
 - uid: 3920
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-19.5
     parent: 0
     type: Transform
 - uid: 3921
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-19.5
     parent: 0
     type: Transform
 - uid: 3922
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 92.5,-18.5
     parent: 0
     type: Transform
 - uid: 3923
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-18.5
     parent: 0
     type: Transform
 - uid: 3924
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-17.5
     parent: 0
@@ -43830,19 +43830,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3968
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-21.5
     parent: 0
     type: Transform
 - uid: 3969
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-31.5
     parent: 0
     type: Transform
 - uid: 3970
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-21.5
     parent: 0
@@ -43860,7 +43860,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-21.5
     parent: 0
@@ -43872,7 +43872,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-27.5
     parent: 0
@@ -43932,7 +43932,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3985
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-30.5
     parent: 0
@@ -43962,7 +43962,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3990
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-31.5
     parent: 0
@@ -43980,19 +43980,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3993
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-33.5
     parent: 0
     type: Transform
 - uid: 3994
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-33.5
     parent: 0
     type: Transform
 - uid: 3995
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-58.5
     parent: 0
@@ -44004,13 +44004,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3997
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-31.5
     parent: 0
     type: Transform
 - uid: 3998
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-31.5
     parent: 0
@@ -44098,49 +44098,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 4012
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-59.5
     parent: 0
     type: Transform
 - uid: 4013
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-59.5
     parent: 0
     type: Transform
 - uid: 4014
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-59.5
     parent: 0
     type: Transform
 - uid: 4015
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-56.5
     parent: 0
     type: Transform
 - uid: 4016
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-59.5
     parent: 0
     type: Transform
 - uid: 4017
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-59.5
     parent: 0
     type: Transform
 - uid: 4018
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-59.5
     parent: 0
     type: Transform
 - uid: 4019
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-59.5
     parent: 0
@@ -44973,19 +44973,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4112
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-13.5
     parent: 0
     type: Transform
 - uid: 4113
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-12.5
     parent: 0
     type: Transform
 - uid: 4114
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-12.5
     parent: 0
@@ -45141,7 +45141,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4133
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,-8.5
     parent: 0
@@ -45157,7 +45157,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4135
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-13.5
     parent: 0
@@ -45179,7 +45179,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4138
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-2.5
     parent: 0
@@ -51137,7 +51137,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4766
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,27.5
     parent: 0
@@ -52436,7 +52436,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4908
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,35.5
     parent: 0
@@ -56716,7 +56716,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 5387
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,12.5
     parent: 0
@@ -57046,13 +57046,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5424
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,18.5
     parent: 0
     type: Transform
 - uid: 5425
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,19.5
     parent: 0
@@ -57066,7 +57066,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5427
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,20.5
     parent: 0
@@ -57380,19 +57380,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5464
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 71.5,38.5
     parent: 0
     type: Transform
 - uid: 5465
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,38.5
     parent: 0
     type: Transform
 - uid: 5466
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,38.5
     parent: 0
@@ -57666,37 +57666,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5500
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,34.5
     parent: 0
     type: Transform
 - uid: 5501
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,30.5
     parent: 0
     type: Transform
 - uid: 5502
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,26.5
     parent: 0
     type: Transform
 - uid: 5503
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,26.5
     parent: 0
     type: Transform
 - uid: 5504
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,26.5
     parent: 0
     type: Transform
 - uid: 5505
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,26.5
     parent: 0
@@ -59635,13 +59635,13 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 5747
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-10.5
     parent: 0
     type: Transform
 - uid: 5748
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-11.5
     parent: 0
@@ -63273,25 +63273,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 6145
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-41.5
     parent: 0
     type: Transform
 - uid: 6146
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-40.5
     parent: 0
     type: Transform
 - uid: 6147
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-40.5
     parent: 0
     type: Transform
 - uid: 6148
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-40.5
     parent: 0
@@ -63381,13 +63381,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 6163
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-41.5
     parent: 0
     type: Transform
 - uid: 6164
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-43.5
     parent: 0
@@ -63883,13 +63883,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 6221
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,-12.5
     parent: 0
     type: Transform
 - uid: 6222
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,-12.5
     parent: 0
@@ -63983,25 +63983,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 6234
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,-20.5
     parent: 0
     type: Transform
 - uid: 6235
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,-20.5
     parent: 0
     type: Transform
 - uid: 6236
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,-20.5
     parent: 0
     type: Transform
 - uid: 6237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-20.5
     parent: 0
@@ -69265,25 +69265,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 6808
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-20.5
     parent: 0
     type: Transform
 - uid: 6809
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-20.5
     parent: 0
     type: Transform
 - uid: 6810
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,-20.5
     parent: 0
     type: Transform
 - uid: 6811
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,-20.5
     parent: 0
@@ -75202,7 +75202,7 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 7322
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-27.5
     parent: 0
@@ -75261,61 +75261,61 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 7328
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-27.5
     parent: 0
     type: Transform
 - uid: 7329
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-29.5
     parent: 0
     type: Transform
 - uid: 7330
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-27.5
     parent: 0
     type: Transform
 - uid: 7331
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-39.5
     parent: 0
     type: Transform
 - uid: 7332
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-39.5
     parent: 0
     type: Transform
 - uid: 7333
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-39.5
     parent: 0
     type: Transform
 - uid: 7334
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-39.5
     parent: 0
     type: Transform
 - uid: 7335
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-39.5
     parent: 0
     type: Transform
 - uid: 7336
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-39.5
     parent: 0
     type: Transform
 - uid: 7337
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-39.5
     parent: 0
@@ -75426,19 +75426,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 7347
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,-39.5
     parent: 0
     type: Transform
 - uid: 7348
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-39.5
     parent: 0
     type: Transform
 - uid: 7349
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,-33.5
     parent: 0
@@ -81140,151 +81140,151 @@ entities:
     parent: 0
     type: Transform
 - uid: 7911
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,-48.5
     parent: 0
     type: Transform
 - uid: 7912
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,-48.5
     parent: 0
     type: Transform
 - uid: 7913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,-48.5
     parent: 0
     type: Transform
 - uid: 7914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,-48.5
     parent: 0
     type: Transform
 - uid: 7915
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-48.5
     parent: 0
     type: Transform
 - uid: 7916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-48.5
     parent: 0
     type: Transform
 - uid: 7917
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-47.5
     parent: 0
     type: Transform
 - uid: 7918
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-47.5
     parent: 0
     type: Transform
 - uid: 7919
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-47.5
     parent: 0
     type: Transform
 - uid: 7920
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-47.5
     parent: 0
     type: Transform
 - uid: 7921
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-47.5
     parent: 0
     type: Transform
 - uid: 7922
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-47.5
     parent: 0
     type: Transform
 - uid: 7923
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-47.5
     parent: 0
     type: Transform
 - uid: 7924
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-47.5
     parent: 0
     type: Transform
 - uid: 7925
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-46.5
     parent: 0
     type: Transform
 - uid: 7926
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-42.5
     parent: 0
     type: Transform
 - uid: 7927
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-41.5
     parent: 0
     type: Transform
 - uid: 7928
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-41.5
     parent: 0
     type: Transform
 - uid: 7929
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-41.5
     parent: 0
     type: Transform
 - uid: 7930
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-41.5
     parent: 0
     type: Transform
 - uid: 7931
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-41.5
     parent: 0
     type: Transform
 - uid: 7932
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-41.5
     parent: 0
     type: Transform
 - uid: 7933
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-41.5
     parent: 0
     type: Transform
 - uid: 7934
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-41.5
     parent: 0
     type: Transform
 - uid: 7935
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-40.5
     parent: 0
@@ -81446,7 +81446,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 7956
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-31.5
     parent: 0
@@ -81470,7 +81470,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 7960
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-30.5
     parent: 0
@@ -81482,19 +81482,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 7962
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-26.5
     parent: 0
     type: Transform
 - uid: 7963
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-25.5
     parent: 0
     type: Transform
 - uid: 7964
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-25.5
     parent: 0
@@ -81506,7 +81506,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 7966
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-25.5
     parent: 0
@@ -81524,19 +81524,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 7969
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-25.5
     parent: 0
     type: Transform
 - uid: 7970
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-26.5
     parent: 0
     type: Transform
 - uid: 7971
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-25.5
     parent: 0
@@ -82445,7 +82445,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8068
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-27.5
     parent: 0
@@ -82461,25 +82461,25 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 8070
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-29.5
     parent: 0
     type: Transform
 - uid: 8071
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-29.5
     parent: 0
     type: Transform
 - uid: 8072
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-29.5
     parent: 0
     type: Transform
 - uid: 8073
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-29.5
     parent: 0
@@ -82497,7 +82497,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8076
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-27.5
     parent: 0
@@ -88939,7 +88939,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8758
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 93.5,-18.5
     parent: 0
@@ -88957,13 +88957,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 8761
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 94.5,-18.5
     parent: 0
     type: Transform
 - uid: 8762
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 94.5,-21.5
     parent: 0
@@ -88975,7 +88975,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8764
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 92.5,-21.5
     parent: 0
@@ -89177,7 +89177,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8796
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-10.5
     parent: 0
@@ -89193,37 +89193,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 8798
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 99.5,-18.5
     parent: 0
     type: Transform
 - uid: 8799
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 99.5,-21.5
     parent: 0
     type: Transform
 - uid: 8800
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 100.5,-18.5
     parent: 0
     type: Transform
 - uid: 8801
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-18.5
     parent: 0
     type: Transform
 - uid: 8802
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 100.5,-21.5
     parent: 0
     type: Transform
 - uid: 8803
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-21.5
     parent: 0
@@ -89246,43 +89246,43 @@ entities:
     parent: 0
     type: Transform
 - uid: 8806
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-17.5
     parent: 0
     type: Transform
 - uid: 8807
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-16.5
     parent: 0
     type: Transform
 - uid: 8808
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-15.5
     parent: 0
     type: Transform
 - uid: 8809
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-14.5
     parent: 0
     type: Transform
 - uid: 8810
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-13.5
     parent: 0
     type: Transform
 - uid: 8811
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-12.5
     parent: 0
     type: Transform
 - uid: 8812
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-11.5
     parent: 0
@@ -89306,7 +89306,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8816
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-9.5
     parent: 0
@@ -89325,19 +89325,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 8818
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-11.5
     parent: 0
     type: Transform
 - uid: 8819
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 103.5,-11.5
     parent: 0
     type: Transform
 - uid: 8820
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 102.5,-11.5
     parent: 0
@@ -89401,19 +89401,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 8830
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 102.5,-21.5
     parent: 0
     type: Transform
 - uid: 8831
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 103.5,-21.5
     parent: 0
     type: Transform
 - uid: 8832
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-21.5
     parent: 0
@@ -89481,7 +89481,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8843
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 104.5,-20.5
     parent: 0
@@ -89521,37 +89521,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 8849
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-25.5
     parent: 0
     type: Transform
 - uid: 8850
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-24.5
     parent: 0
     type: Transform
 - uid: 8851
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-23.5
     parent: 0
     type: Transform
 - uid: 8852
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-22.5
     parent: 0
     type: Transform
 - uid: 8853
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-21.5
     parent: 0
     type: Transform
 - uid: 8854
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-20.5
     parent: 0
@@ -89676,31 +89676,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 8870
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 104.5,-13.5
     parent: 0
     type: Transform
 - uid: 8871
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 103.5,-13.5
     parent: 0
     type: Transform
 - uid: 8872
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 103.5,-14.5
     parent: 0
     type: Transform
 - uid: 8873
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 104.5,-14.5
     parent: 0
     type: Transform
 - uid: 8874
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 102.5,-14.5
     parent: 0
@@ -89960,37 +89960,37 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 8903
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-10.5
     parent: 0
     type: Transform
 - uid: 8904
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-9.5
     parent: 0
     type: Transform
 - uid: 8905
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-11.5
     parent: 0
     type: Transform
 - uid: 8906
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-12.5
     parent: 0
     type: Transform
 - uid: 8907
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-13.5
     parent: 0
     type: Transform
 - uid: 8908
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-14.5
     parent: 0
@@ -90020,25 +90020,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 8913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 109.5,-20.5
     parent: 0
     type: Transform
 - uid: 8914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 110.5,-20.5
     parent: 0
     type: Transform
 - uid: 8915
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 113.5,-20.5
     parent: 0
     type: Transform
 - uid: 8916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 116.5,-20.5
     parent: 0
@@ -90068,31 +90068,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 8921
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 109.5,-19.5
     parent: 0
     type: Transform
 - uid: 8922
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 109.5,-18.5
     parent: 0
     type: Transform
 - uid: 8923
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 109.5,-14.5
     parent: 0
     type: Transform
 - uid: 8924
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 109.5,-15.5
     parent: 0
     type: Transform
 - uid: 8925
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 109.5,-16.5
     parent: 0
@@ -90421,19 +90421,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 8973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 110.5,-14.5
     parent: 0
     type: Transform
 - uid: 8974
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 113.5,-14.5
     parent: 0
     type: Transform
 - uid: 8975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 116.5,-14.5
     parent: 0
@@ -90546,7 +90546,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8993
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 116.5,-17.5
     parent: 0
@@ -93025,31 +93025,31 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 9255
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-13.5
     parent: 0
     type: Transform
 - uid: 9256
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-14.5
     parent: 0
     type: Transform
 - uid: 9257
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-15.5
     parent: 0
     type: Transform
 - uid: 9258
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-17.5
     parent: 0
     type: Transform
 - uid: 9259
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,-18.5
     parent: 0
@@ -98045,7 +98045,7 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 9673
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,13.5
     parent: 0
@@ -111557,37 +111557,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 10783
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-19.5
     parent: 0
     type: Transform
 - uid: 10784
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,-19.5
     parent: 0
     type: Transform
 - uid: 10785
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,-19.5
     parent: 0
     type: Transform
 - uid: 10786
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,-21.5
     parent: 0
     type: Transform
 - uid: 10787
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-21.5
     parent: 0
     type: Transform
 - uid: 10788
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,-21.5
     parent: 0
@@ -112018,7 +112018,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 10850
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 89.5,-17.5
     parent: 0
@@ -112543,7 +112543,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 10916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,-59.5
     parent: 0
@@ -114521,7 +114521,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 11164
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: 54.520523,-14.325092
     parent: 0
@@ -115434,7 +115434,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 11279
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-8.5
     parent: 0
@@ -116553,19 +116553,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 11437
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,5.5
     parent: 0
     type: Transform
 - uid: 11438
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,4.5
     parent: 0
     type: Transform
 - uid: 11439
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,3.5
     parent: 0
@@ -119218,13 +119218,13 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 11862
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-24.5
     parent: 0
     type: Transform
 - uid: 11863
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-23.5
     parent: 0
@@ -119240,7 +119240,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 11865
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-22.5
     parent: 0
@@ -119266,7 +119266,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 11868
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-22.5
     parent: 0
@@ -119301,67 +119301,67 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 11872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-21.5
     parent: 0
     type: Transform
 - uid: 11873
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-21.5
     parent: 0
     type: Transform
 - uid: 11874
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-21.5
     parent: 0
     type: Transform
 - uid: 11875
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-21.5
     parent: 0
     type: Transform
 - uid: 11876
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-21.5
     parent: 0
     type: Transform
 - uid: 11877
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-21.5
     parent: 0
     type: Transform
 - uid: 11878
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,-21.5
     parent: 0
     type: Transform
 - uid: 11879
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,-21.5
     parent: 0
     type: Transform
 - uid: 11880
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,-21.5
     parent: 0
     type: Transform
 - uid: 11881
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,-21.5
     parent: 0
     type: Transform
 - uid: 11882
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-21.5
     parent: 0
@@ -119377,7 +119377,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 11884
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-22.5
     parent: 0
@@ -119504,25 +119504,25 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 11898
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-24.5
     parent: 0
     type: Transform
 - uid: 11899
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-23.5
     parent: 0
     type: Transform
 - uid: 11900
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-22.5
     parent: 0
     type: Transform
 - uid: 11901
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-25.5
     parent: 0

--- a/Resources/Maps/packedstationxmas.yml
+++ b/Resources/Maps/packedstationxmas.yml
@@ -17142,31 +17142,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 13
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,1.5
     parent: 0
     type: Transform
 - uid: 14
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,1.5
     parent: 0
     type: Transform
 - uid: 15
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,1.5
     parent: 0
     type: Transform
 - uid: 16
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,1.5
     parent: 0
     type: Transform
 - uid: 17
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,1.5
     parent: 0
@@ -17376,25 +17376,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 52
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -20.5,-5.5
     parent: 0
     type: Transform
 - uid: 53
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,-5.5
     parent: 0
     type: Transform
 - uid: 54
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,-5.5
     parent: 0
     type: Transform
 - uid: 55
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -10.5,-5.5
     parent: 0
@@ -17496,73 +17496,73 @@ entities:
     parent: 0
     type: Transform
 - uid: 72
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -7.5,-10.5
     parent: 0
     type: Transform
 - uid: 73
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-10.5
     parent: 0
     type: Transform
 - uid: 74
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,-10.5
     parent: 0
     type: Transform
 - uid: 75
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,2.5
     parent: 0
     type: Transform
 - uid: 76
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-6.5
     parent: 0
     type: Transform
 - uid: 77
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-6.5
     parent: 0
     type: Transform
 - uid: 78
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-6.5
     parent: 0
     type: Transform
 - uid: 79
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-6.5
     parent: 0
     type: Transform
 - uid: 80
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-6.5
     parent: 0
     type: Transform
 - uid: 81
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-5.5
     parent: 0
     type: Transform
 - uid: 82
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-3.5
     parent: 0
     type: Transform
 - uid: 83
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-2.5
     parent: 0
@@ -17578,19 +17578,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 85
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-3.5
     parent: 0
     type: Transform
 - uid: 86
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-5.5
     parent: 0
     type: Transform
 - uid: 87
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-6.5
     parent: 0
@@ -17896,55 +17896,55 @@ entities:
     parent: 0
     type: Transform
 - uid: 127
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-13.5
     parent: 0
     type: Transform
 - uid: 128
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,-13.5
     parent: 0
     type: Transform
 - uid: 129
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-13.5
     parent: 0
     type: Transform
 - uid: 130
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-12.5
     parent: 0
     type: Transform
 - uid: 131
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-11.5
     parent: 0
     type: Transform
 - uid: 132
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-9.5
     parent: 0
     type: Transform
 - uid: 133
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -0.5,-8.5
     parent: 0
     type: Transform
 - uid: 134
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-8.5
     parent: 0
     type: Transform
 - uid: 135
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,-7.5
     parent: 0
@@ -18190,109 +18190,109 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 167
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-3.5
     parent: 0
     type: Transform
 - uid: 168
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-4.5
     parent: 0
     type: Transform
 - uid: 169
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-5.5
     parent: 0
     type: Transform
 - uid: 170
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-6.5
     parent: 0
     type: Transform
 - uid: 171
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-7.5
     parent: 0
     type: Transform
 - uid: 172
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-7.5
     parent: 0
     type: Transform
 - uid: 173
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-7.5
     parent: 0
     type: Transform
 - uid: 174
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-7.5
     parent: 0
     type: Transform
 - uid: 175
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-2.5
     parent: 0
     type: Transform
 - uid: 176
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-2.5
     parent: 0
     type: Transform
 - uid: 177
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-2.5
     parent: 0
     type: Transform
 - uid: 178
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-2.5
     parent: 0
     type: Transform
 - uid: 179
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-3.5
     parent: 0
     type: Transform
 - uid: 180
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-4.5
     parent: 0
     type: Transform
 - uid: 181
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-5.5
     parent: 0
     type: Transform
 - uid: 182
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-6.5
     parent: 0
     type: Transform
 - uid: 183
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-7.5
     parent: 0
     type: Transform
 - uid: 184
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-2.5
     parent: 0
@@ -18440,103 +18440,103 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 201
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-8.5
     parent: 0
     type: Transform
 - uid: 202
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-9.5
     parent: 0
     type: Transform
 - uid: 203
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-10.5
     parent: 0
     type: Transform
 - uid: 204
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-10.5
     parent: 0
     type: Transform
 - uid: 205
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-10.5
     parent: 0
     type: Transform
 - uid: 206
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-10.5
     parent: 0
     type: Transform
 - uid: 207
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-10.5
     parent: 0
     type: Transform
 - uid: 208
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-10.5
     parent: 0
     type: Transform
 - uid: 209
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-12.5
     parent: 0
     type: Transform
 - uid: 210
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-13.5
     parent: 0
     type: Transform
 - uid: 211
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-14.5
     parent: 0
     type: Transform
 - uid: 212
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-16.5
     parent: 0
     type: Transform
 - uid: 213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-17.5
     parent: 0
     type: Transform
 - uid: 214
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-14.5
     parent: 0
     type: Transform
 - uid: 215
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-15.5
     parent: 0
     type: Transform
 - uid: 216
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-16.5
     parent: 0
     type: Transform
 - uid: 217
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-17.5
     parent: 0
@@ -18604,97 +18604,97 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 227
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-2.5
     parent: 0
     type: Transform
 - uid: 228
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-3.5
     parent: 0
     type: Transform
 - uid: 229
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-4.5
     parent: 0
     type: Transform
 - uid: 230
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-4.5
     parent: 0
     type: Transform
 - uid: 231
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-4.5
     parent: 0
     type: Transform
 - uid: 232
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-4.5
     parent: 0
     type: Transform
 - uid: 233
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-5.5
     parent: 0
     type: Transform
 - uid: 234
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-6.5
     parent: 0
     type: Transform
 - uid: 235
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-7.5
     parent: 0
     type: Transform
 - uid: 236
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-8.5
     parent: 0
     type: Transform
 - uid: 237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-9.5
     parent: 0
     type: Transform
 - uid: 238
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-9.5
     parent: 0
     type: Transform
 - uid: 239
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-9.5
     parent: 0
     type: Transform
 - uid: 240
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-9.5
     parent: 0
     type: Transform
 - uid: 241
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-10.5
     parent: 0
     type: Transform
 - uid: 242
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-10.5
     parent: 0
@@ -18932,31 +18932,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 276
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,6.5
     parent: 0
     type: Transform
 - uid: 277
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,8.5
     parent: 0
     type: Transform
 - uid: 278
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,12.5
     parent: 0
     type: Transform
 - uid: 279
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,1.5
     parent: 0
     type: Transform
 - uid: 280
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,1.5
     parent: 0
@@ -19034,109 +19034,109 @@ entities:
     parent: 0
     type: Transform
 - uid: 293
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,8.5
     parent: 0
     type: Transform
 - uid: 294
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,4.5
     parent: 0
     type: Transform
 - uid: 295
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,3.5
     parent: 0
     type: Transform
 - uid: 296
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,2.5
     parent: 0
     type: Transform
 - uid: 297
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,2.5
     parent: 0
     type: Transform
 - uid: 298
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,2.5
     parent: 0
     type: Transform
 - uid: 299
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,2.5
     parent: 0
     type: Transform
 - uid: 300
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,2.5
     parent: 0
     type: Transform
 - uid: 301
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,2.5
     parent: 0
     type: Transform
 - uid: 302
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,2.5
     parent: 0
     type: Transform
 - uid: 303
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,2.5
     parent: 0
     type: Transform
 - uid: 304
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,3.5
     parent: 0
     type: Transform
 - uid: 305
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,4.5
     parent: 0
     type: Transform
 - uid: 306
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,6.5
     parent: 0
     type: Transform
 - uid: 307
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,6.5
     parent: 0
     type: Transform
 - uid: 308
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,7.5
     parent: 0
     type: Transform
 - uid: 309
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,8.5
     parent: 0
     type: Transform
 - uid: 310
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,8.5
     parent: 0
@@ -19566,7 +19566,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 365
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,13.5
     parent: 0
@@ -19726,19 +19726,19 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 390
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,13.5
     parent: 0
     type: Transform
 - uid: 391
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,12.5
     parent: 0
     type: Transform
 - uid: 392
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,11.5
     parent: 0
@@ -19879,13 +19879,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 409
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,16.5
     parent: 0
     type: Transform
 - uid: 410
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,17.5
     parent: 0
@@ -19903,55 +19903,55 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 412
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,19.5
     parent: 0
     type: Transform
 - uid: 413
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,20.5
     parent: 0
     type: Transform
 - uid: 414
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,20.5
     parent: 0
     type: Transform
 - uid: 415
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,16.5
     parent: 0
     type: Transform
 - uid: 416
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,16.5
     parent: 0
     type: Transform
 - uid: 417
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,15.5
     parent: 0
     type: Transform
 - uid: 418
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,15.5
     parent: 0
     type: Transform
 - uid: 419
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,16.5
     parent: 0
     type: Transform
 - uid: 420
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,20.5
     parent: 0
@@ -20039,25 +20039,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 433
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,16.5
     parent: 0
     type: Transform
 - uid: 434
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,16.5
     parent: 0
     type: Transform
 - uid: 435
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,15.5
     parent: 0
     type: Transform
 - uid: 436
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,14.5
     parent: 0
@@ -20161,19 +20161,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 452
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,21.5
     parent: 0
     type: Transform
 - uid: 453
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,20.5
     parent: 0
     type: Transform
 - uid: 454
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,19.5
     parent: 0
@@ -20205,7 +20205,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 458
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,17.5
     parent: 0
@@ -20239,7 +20239,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 462
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,18.5
     parent: 0
@@ -20301,79 +20301,79 @@ entities:
     parent: 0
     type: Transform
 - uid: 469
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,14.5
     parent: 0
     type: Transform
 - uid: 470
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,14.5
     parent: 0
     type: Transform
 - uid: 471
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,14.5
     parent: 0
     type: Transform
 - uid: 472
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,14.5
     parent: 0
     type: Transform
 - uid: 473
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,14.5
     parent: 0
     type: Transform
 - uid: 474
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,14.5
     parent: 0
     type: Transform
 - uid: 475
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,13.5
     parent: 0
     type: Transform
 - uid: 476
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,12.5
     parent: 0
     type: Transform
 - uid: 477
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,11.5
     parent: 0
     type: Transform
 - uid: 478
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,11.5
     parent: 0
     type: Transform
 - uid: 479
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,11.5
     parent: 0
     type: Transform
 - uid: 480
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,11.5
     parent: 0
     type: Transform
 - uid: 481
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,11.5
     parent: 0
@@ -20456,67 +20456,67 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 491
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-17.5
     parent: 0
     type: Transform
 - uid: 492
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-16.5
     parent: 0
     type: Transform
 - uid: 493
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-14.5
     parent: 0
     type: Transform
 - uid: 494
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-11.5
     parent: 0
     type: Transform
 - uid: 495
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-12.5
     parent: 0
     type: Transform
 - uid: 496
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-12.5
     parent: 0
     type: Transform
 - uid: 497
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-13.5
     parent: 0
     type: Transform
 - uid: 498
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-13.5
     parent: 0
     type: Transform
 - uid: 499
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-14.5
     parent: 0
     type: Transform
 - uid: 500
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,-14.5
     parent: 0
     type: Transform
 - uid: 501
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-14.5
     parent: 0
@@ -20572,133 +20572,133 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 507
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-6.5
     parent: 0
     type: Transform
 - uid: 508
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-11.5
     parent: 0
     type: Transform
 - uid: 509
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-10.5
     parent: 0
     type: Transform
 - uid: 510
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-12.5
     parent: 0
     type: Transform
 - uid: 511
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-12.5
     parent: 0
     type: Transform
 - uid: 512
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-6.5
     parent: 0
     type: Transform
 - uid: 513
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-6.5
     parent: 0
     type: Transform
 - uid: 514
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-6.5
     parent: 0
     type: Transform
 - uid: 515
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-6.5
     parent: 0
     type: Transform
 - uid: 516
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-6.5
     parent: 0
     type: Transform
 - uid: 517
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-6.5
     parent: 0
     type: Transform
 - uid: 518
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-5.5
     parent: 0
     type: Transform
 - uid: 519
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-4.5
     parent: 0
     type: Transform
 - uid: 520
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-3.5
     parent: 0
     type: Transform
 - uid: 521
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-2.5
     parent: 0
     type: Transform
 - uid: 522
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-1.5
     parent: 0
     type: Transform
 - uid: 523
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-1.5
     parent: 0
     type: Transform
 - uid: 524
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-1.5
     parent: 0
     type: Transform
 - uid: 525
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-1.5
     parent: 0
     type: Transform
 - uid: 526
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-1.5
     parent: 0
     type: Transform
 - uid: 527
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-2.5
     parent: 0
     type: Transform
 - uid: 528
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-2.5
     parent: 0
@@ -20716,25 +20716,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 531
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-7.5
     parent: 0
     type: Transform
 - uid: 532
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-8.5
     parent: 0
     type: Transform
 - uid: 533
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-9.5
     parent: 0
     type: Transform
 - uid: 534
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-10.5
     parent: 0
@@ -20750,115 +20750,115 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 536
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-2.5
     parent: 0
     type: Transform
 - uid: 537
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-3.5
     parent: 0
     type: Transform
 - uid: 538
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-3.5
     parent: 0
     type: Transform
 - uid: 539
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-1.5
     parent: 0
     type: Transform
 - uid: 540
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-1.5
     parent: 0
     type: Transform
 - uid: 541
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-4.5
     parent: 0
     type: Transform
 - uid: 542
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-5.5
     parent: 0
     type: Transform
 - uid: 543
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-6.5
     parent: 0
     type: Transform
 - uid: 544
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-6.5
     parent: 0
     type: Transform
 - uid: 545
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-7.5
     parent: 0
     type: Transform
 - uid: 546
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-8.5
     parent: 0
     type: Transform
 - uid: 547
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-8.5
     parent: 0
     type: Transform
 - uid: 548
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,-8.5
     parent: 0
     type: Transform
 - uid: 549
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-8.5
     parent: 0
     type: Transform
 - uid: 550
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-8.5
     parent: 0
     type: Transform
 - uid: 551
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-9.5
     parent: 0
     type: Transform
 - uid: 552
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-10.5
     parent: 0
     type: Transform
 - uid: 553
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-11.5
     parent: 0
     type: Transform
 - uid: 554
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-12.5
     parent: 0
@@ -20872,7 +20872,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 556
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-13.5
     parent: 0
@@ -20886,37 +20886,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 558
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-13.5
     parent: 0
     type: Transform
 - uid: 559
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-13.5
     parent: 0
     type: Transform
 - uid: 560
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-13.5
     parent: 0
     type: Transform
 - uid: 561
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-13.5
     parent: 0
     type: Transform
 - uid: 562
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-13.5
     parent: 0
     type: Transform
 - uid: 563
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-13.5
     parent: 0
@@ -20954,19 +20954,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 568
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,2.5
     parent: 0
     type: Transform
 - uid: 569
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,2.5
     parent: 0
     type: Transform
 - uid: 570
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,2.5
     parent: 0
@@ -21492,271 +21492,271 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 637
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-14.5
     parent: 0
     type: Transform
 - uid: 638
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-15.5
     parent: 0
     type: Transform
 - uid: 639
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-14.5
     parent: 0
     type: Transform
 - uid: 640
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-14.5
     parent: 0
     type: Transform
 - uid: 641
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-14.5
     parent: 0
     type: Transform
 - uid: 642
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-14.5
     parent: 0
     type: Transform
 - uid: 643
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-14.5
     parent: 0
     type: Transform
 - uid: 644
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-14.5
     parent: 0
     type: Transform
 - uid: 645
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-15.5
     parent: 0
     type: Transform
 - uid: 646
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-16.5
     parent: 0
     type: Transform
 - uid: 647
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-17.5
     parent: 0
     type: Transform
 - uid: 648
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-18.5
     parent: 0
     type: Transform
 - uid: 649
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-19.5
     parent: 0
     type: Transform
 - uid: 650
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-20.5
     parent: 0
     type: Transform
 - uid: 651
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-15.5
     parent: 0
     type: Transform
 - uid: 652
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-16.5
     parent: 0
     type: Transform
 - uid: 653
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-17.5
     parent: 0
     type: Transform
 - uid: 654
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-18.5
     parent: 0
     type: Transform
 - uid: 655
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-19.5
     parent: 0
     type: Transform
 - uid: 656
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-20.5
     parent: 0
     type: Transform
 - uid: 657
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-15.5
     parent: 0
     type: Transform
 - uid: 658
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-15.5
     parent: 0
     type: Transform
 - uid: 659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-15.5
     parent: 0
     type: Transform
 - uid: 660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-20.5
     parent: 0
     type: Transform
 - uid: 661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-20.5
     parent: 0
     type: Transform
 - uid: 662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-20.5
     parent: 0
     type: Transform
 - uid: 663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-20.5
     parent: 0
     type: Transform
 - uid: 664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-20.5
     parent: 0
     type: Transform
 - uid: 665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-20.5
     parent: 0
     type: Transform
 - uid: 666
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-20.5
     parent: 0
     type: Transform
 - uid: 667
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-20.5
     parent: 0
     type: Transform
 - uid: 668
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-20.5
     parent: 0
     type: Transform
 - uid: 669
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-20.5
     parent: 0
     type: Transform
 - uid: 670
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-19.5
     parent: 0
     type: Transform
 - uid: 671
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-19.5
     parent: 0
     type: Transform
 - uid: 672
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-19.5
     parent: 0
     type: Transform
 - uid: 673
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-19.5
     parent: 0
     type: Transform
 - uid: 674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-19.5
     parent: 0
     type: Transform
 - uid: 675
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-19.5
     parent: 0
     type: Transform
 - uid: 676
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-19.5
     parent: 0
     type: Transform
 - uid: 677
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-19.5
     parent: 0
     type: Transform
 - uid: 678
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-18.5
     parent: 0
     type: Transform
 - uid: 679
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-16.5
     parent: 0
     type: Transform
 - uid: 680
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-15.5
     parent: 0
     type: Transform
 - uid: 681
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-14.5
     parent: 0
@@ -21969,55 +21969,55 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 711
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-17.5
     parent: 0
     type: Transform
 - uid: 712
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-17.5
     parent: 0
     type: Transform
 - uid: 713
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-17.5
     parent: 0
     type: Transform
 - uid: 714
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-18.5
     parent: 0
     type: Transform
 - uid: 715
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-19.5
     parent: 0
     type: Transform
 - uid: 716
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-20.5
     parent: 0
     type: Transform
 - uid: 717
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-21.5
     parent: 0
     type: Transform
 - uid: 718
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-21.5
     parent: 0
     type: Transform
 - uid: 719
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-22.5
     parent: 0
@@ -22065,7 +22065,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 727
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-28.5
     parent: 0
@@ -22077,193 +22077,193 @@ entities:
     parent: 0
     type: Transform
 - uid: 729
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-22.5
     parent: 0
     type: Transform
 - uid: 730
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-23.5
     parent: 0
     type: Transform
 - uid: 731
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-24.5
     parent: 0
     type: Transform
 - uid: 732
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-25.5
     parent: 0
     type: Transform
 - uid: 733
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-24.5
     parent: 0
     type: Transform
 - uid: 734
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-24.5
     parent: 0
     type: Transform
 - uid: 735
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-24.5
     parent: 0
     type: Transform
 - uid: 736
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-25.5
     parent: 0
     type: Transform
 - uid: 737
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-25.5
     parent: 0
     type: Transform
 - uid: 738
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-26.5
     parent: 0
     type: Transform
 - uid: 739
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-27.5
     parent: 0
     type: Transform
 - uid: 740
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-28.5
     parent: 0
     type: Transform
 - uid: 741
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-29.5
     parent: 0
     type: Transform
 - uid: 742
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-30.5
     parent: 0
     type: Transform
 - uid: 743
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-31.5
     parent: 0
     type: Transform
 - uid: 744
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-32.5
     parent: 0
     type: Transform
 - uid: 745
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-32.5
     parent: 0
     type: Transform
 - uid: 746
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-32.5
     parent: 0
     type: Transform
 - uid: 747
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-32.5
     parent: 0
     type: Transform
 - uid: 748
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-32.5
     parent: 0
     type: Transform
 - uid: 749
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-32.5
     parent: 0
     type: Transform
 - uid: 750
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-32.5
     parent: 0
     type: Transform
 - uid: 751
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-32.5
     parent: 0
     type: Transform
 - uid: 752
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-32.5
     parent: 0
     type: Transform
 - uid: 753
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-28.5
     parent: 0
     type: Transform
 - uid: 754
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-29.5
     parent: 0
     type: Transform
 - uid: 755
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-29.5
     parent: 0
     type: Transform
 - uid: 756
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-29.5
     parent: 0
     type: Transform
 - uid: 757
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-29.5
     parent: 0
     type: Transform
 - uid: 758
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-29.5
     parent: 0
     type: Transform
 - uid: 759
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-30.5
     parent: 0
     type: Transform
 - uid: 760
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-31.5
     parent: 0
@@ -22357,133 +22357,133 @@ entities:
     parent: 0
     type: Transform
 - uid: 775
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-22.5
     parent: 0
     type: Transform
 - uid: 776
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-22.5
     parent: 0
     type: Transform
 - uid: 777
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-22.5
     parent: 0
     type: Transform
 - uid: 778
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-22.5
     parent: 0
     type: Transform
 - uid: 779
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-22.5
     parent: 0
     type: Transform
 - uid: 780
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-22.5
     parent: 0
     type: Transform
 - uid: 781
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-22.5
     parent: 0
     type: Transform
 - uid: 782
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-22.5
     parent: 0
     type: Transform
 - uid: 783
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-22.5
     parent: 0
     type: Transform
 - uid: 784
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-22.5
     parent: 0
     type: Transform
 - uid: 785
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-22.5
     parent: 0
     type: Transform
 - uid: 786
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-23.5
     parent: 0
     type: Transform
 - uid: 787
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-24.5
     parent: 0
     type: Transform
 - uid: 788
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-25.5
     parent: 0
     type: Transform
 - uid: 789
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-25.5
     parent: 0
     type: Transform
 - uid: 790
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-26.5
     parent: 0
     type: Transform
 - uid: 791
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-27.5
     parent: 0
     type: Transform
 - uid: 792
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-29.5
     parent: 0
     type: Transform
 - uid: 793
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-29.5
     parent: 0
     type: Transform
 - uid: 794
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,-29.5
     parent: 0
     type: Transform
 - uid: 795
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,-29.5
     parent: 0
     type: Transform
 - uid: 796
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,-29.5
     parent: 0
@@ -22812,61 +22812,61 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 838
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,-30.5
     parent: 0
     type: Transform
 - uid: 839
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,-30.5
     parent: 0
     type: Transform
 - uid: 840
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 26.5,-30.5
     parent: 0
     type: Transform
 - uid: 841
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-30.5
     parent: 0
     type: Transform
 - uid: 842
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,-30.5
     parent: 0
     type: Transform
 - uid: 843
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-29.5
     parent: 0
     type: Transform
 - uid: 844
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-29.5
     parent: 0
     type: Transform
 - uid: 845
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-25.5
     parent: 0
     type: Transform
 - uid: 846
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-26.5
     parent: 0
     type: Transform
 - uid: 847
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-27.5
     parent: 0
@@ -23034,67 +23034,67 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 865
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-31.5
     parent: 0
     type: Transform
 - uid: 866
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,-33.5
     parent: 0
     type: Transform
 - uid: 867
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-33.5
     parent: 0
     type: Transform
 - uid: 868
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,-33.5
     parent: 0
     type: Transform
 - uid: 869
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-33.5
     parent: 0
     type: Transform
 - uid: 870
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-33.5
     parent: 0
     type: Transform
 - uid: 871
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-33.5
     parent: 0
     type: Transform
 - uid: 872
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-31.5
     parent: 0
     type: Transform
 - uid: 873
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-29.5
     parent: 0
     type: Transform
 - uid: 874
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-29.5
     parent: 0
     type: Transform
 - uid: 875
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-29.5
     parent: 0
@@ -23196,25 +23196,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 892
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-34.5
     parent: 0
     type: Transform
 - uid: 893
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-33.5
     parent: 0
     type: Transform
 - uid: 894
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-34.5
     parent: 0
     type: Transform
 - uid: 895
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-33.5
     parent: 0
@@ -23370,7 +23370,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 912
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: 25.588993,-31.402525
     parent: 0
@@ -23581,37 +23581,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 937
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-33.5
     parent: 0
     type: Transform
 - uid: 938
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-34.5
     parent: 0
     type: Transform
 - uid: 939
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-35.5
     parent: 0
     type: Transform
 - uid: 940
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-36.5
     parent: 0
     type: Transform
 - uid: 941
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-37.5
     parent: 0
     type: Transform
 - uid: 942
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-37.5
     parent: 0
@@ -23811,61 +23811,61 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 971
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-37.5
     parent: 0
     type: Transform
 - uid: 972
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-37.5
     parent: 0
     type: Transform
 - uid: 973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-37.5
     parent: 0
     type: Transform
 - uid: 974
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-37.5
     parent: 0
     type: Transform
 - uid: 975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-38.5
     parent: 0
     type: Transform
 - uid: 976
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-39.5
     parent: 0
     type: Transform
 - uid: 977
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-40.5
     parent: 0
     type: Transform
 - uid: 978
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-37.5
     parent: 0
     type: Transform
 - uid: 979
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-40.5
     parent: 0
     type: Transform
 - uid: 980
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-40.5
     parent: 0
@@ -24265,19 +24265,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1043
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-43.5
     parent: 0
     type: Transform
 - uid: 1044
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-43.5
     parent: 0
     type: Transform
 - uid: 1045
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-42.5
     parent: 0
@@ -24353,55 +24353,55 @@ entities:
     parent: 0
     type: Transform
 - uid: 1055
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,-37.5
     parent: 0
     type: Transform
 - uid: 1056
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,-37.5
     parent: 0
     type: Transform
 - uid: 1057
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-38.5
     parent: 0
     type: Transform
 - uid: 1058
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-39.5
     parent: 0
     type: Transform
 - uid: 1059
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-40.5
     parent: 0
     type: Transform
 - uid: 1060
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-41.5
     parent: 0
     type: Transform
 - uid: 1061
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-42.5
     parent: 0
     type: Transform
 - uid: 1062
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-43.5
     parent: 0
     type: Transform
 - uid: 1063
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,-37.5
     parent: 0
@@ -24462,73 +24462,73 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1071
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,17.5
     parent: 0
     type: Transform
 - uid: 1072
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,16.5
     parent: 0
     type: Transform
 - uid: 1073
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,15.5
     parent: 0
     type: Transform
 - uid: 1074
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,19.5
     parent: 0
     type: Transform
 - uid: 1075
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,18.5
     parent: 0
     type: Transform
 - uid: 1076
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,17.5
     parent: 0
     type: Transform
 - uid: 1077
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,16.5
     parent: 0
     type: Transform
 - uid: 1078
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,20.5
     parent: 0
     type: Transform
 - uid: 1079
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,20.5
     parent: 0
     type: Transform
 - uid: 1080
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,20.5
     parent: 0
     type: Transform
 - uid: 1081
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,19.5
     parent: 0
     type: Transform
 - uid: 1082
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,19.5
     parent: 0
@@ -24554,97 +24554,97 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1085
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,17.5
     parent: 0
     type: Transform
 - uid: 1086
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,17.5
     parent: 0
     type: Transform
 - uid: 1087
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,17.5
     parent: 0
     type: Transform
 - uid: 1088
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,14.5
     parent: 0
     type: Transform
 - uid: 1089
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,12.5
     parent: 0
     type: Transform
 - uid: 1090
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,11.5
     parent: 0
     type: Transform
 - uid: 1091
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,11.5
     parent: 0
     type: Transform
 - uid: 1092
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,11.5
     parent: 0
     type: Transform
 - uid: 1093
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,11.5
     parent: 0
     type: Transform
 - uid: 1094
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,16.5
     parent: 0
     type: Transform
 - uid: 1095
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,17.5
     parent: 0
     type: Transform
 - uid: 1096
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,17.5
     parent: 0
     type: Transform
 - uid: 1097
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,17.5
     parent: 0
     type: Transform
 - uid: 1098
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,16.5
     parent: 0
     type: Transform
 - uid: 1099
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,16.5
     parent: 0
     type: Transform
 - uid: 1100
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,16.5
     parent: 0
@@ -24690,109 +24690,109 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1105
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,11.5
     parent: 0
     type: Transform
 - uid: 1106
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,11.5
     parent: 0
     type: Transform
 - uid: 1107
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,10.5
     parent: 0
     type: Transform
 - uid: 1108
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,9.5
     parent: 0
     type: Transform
 - uid: 1109
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,8.5
     parent: 0
     type: Transform
 - uid: 1110
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,5.5
     parent: 0
     type: Transform
 - uid: 1111
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,4.5
     parent: 0
     type: Transform
 - uid: 1112
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,4.5
     parent: 0
     type: Transform
 - uid: 1113
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,4.5
     parent: 0
     type: Transform
 - uid: 1114
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,4.5
     parent: 0
     type: Transform
 - uid: 1115
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,4.5
     parent: 0
     type: Transform
 - uid: 1116
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,4.5
     parent: 0
     type: Transform
 - uid: 1117
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,5.5
     parent: 0
     type: Transform
 - uid: 1118
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,6.5
     parent: 0
     type: Transform
 - uid: 1119
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,7.5
     parent: 0
     type: Transform
 - uid: 1120
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,8.5
     parent: 0
     type: Transform
 - uid: 1121
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,7.5
     parent: 0
     type: Transform
 - uid: 1122
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,8.5
     parent: 0
@@ -24925,175 +24925,175 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1137
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,2.5
     parent: 0
     type: Transform
 - uid: 1138
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,2.5
     parent: 0
     type: Transform
 - uid: 1139
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,2.5
     parent: 0
     type: Transform
 - uid: 1140
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,2.5
     parent: 0
     type: Transform
 - uid: 1141
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,2.5
     parent: 0
     type: Transform
 - uid: 1142
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,2.5
     parent: 0
     type: Transform
 - uid: 1143
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,11.5
     parent: 0
     type: Transform
 - uid: 1144
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,11.5
     parent: 0
     type: Transform
 - uid: 1145
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,11.5
     parent: 0
     type: Transform
 - uid: 1146
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,11.5
     parent: 0
     type: Transform
 - uid: 1147
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,9.5
     parent: 0
     type: Transform
 - uid: 1148
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,8.5
     parent: 0
     type: Transform
 - uid: 1149
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,7.5
     parent: 0
     type: Transform
 - uid: 1150
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,6.5
     parent: 0
     type: Transform
 - uid: 1151
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,5.5
     parent: 0
     type: Transform
 - uid: 1152
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,4.5
     parent: 0
     type: Transform
 - uid: 1153
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,3.5
     parent: 0
     type: Transform
 - uid: 1154
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,9.5
     parent: 0
     type: Transform
 - uid: 1155
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,9.5
     parent: 0
     type: Transform
 - uid: 1156
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,9.5
     parent: 0
     type: Transform
 - uid: 1157
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,8.5
     parent: 0
     type: Transform
 - uid: 1158
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,7.5
     parent: 0
     type: Transform
 - uid: 1159
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,6.5
     parent: 0
     type: Transform
 - uid: 1160
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,5.5
     parent: 0
     type: Transform
 - uid: 1161
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,4.5
     parent: 0
     type: Transform
 - uid: 1162
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,4.5
     parent: 0
     type: Transform
 - uid: 1163
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,3.5
     parent: 0
     type: Transform
 - uid: 1164
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,2.5
     parent: 0
     type: Transform
 - uid: 1165
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,4.5
     parent: 0
@@ -25278,49 +25278,49 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1187
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,5.5
     parent: 0
     type: Transform
 - uid: 1188
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,5.5
     parent: 0
     type: Transform
 - uid: 1189
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,5.5
     parent: 0
     type: Transform
 - uid: 1190
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,5.5
     parent: 0
     type: Transform
 - uid: 1191
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,5.5
     parent: 0
     type: Transform
 - uid: 1192
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,4.5
     parent: 0
     type: Transform
 - uid: 1193
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,3.5
     parent: 0
     type: Transform
 - uid: 1194
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,2.5
     parent: 0
@@ -25414,49 +25414,49 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1206
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,9.5
     parent: 0
     type: Transform
 - uid: 1207
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,10.5
     parent: 0
     type: Transform
 - uid: 1208
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,10.5
     parent: 0
     type: Transform
 - uid: 1209
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,10.5
     parent: 0
     type: Transform
 - uid: 1210
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,10.5
     parent: 0
     type: Transform
 - uid: 1211
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,9.5
     parent: 0
     type: Transform
 - uid: 1212
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,8.5
     parent: 0
     type: Transform
 - uid: 1213
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,7.5
     parent: 0
@@ -25513,49 +25513,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 1219
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,11.5
     parent: 0
     type: Transform
 - uid: 1220
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,11.5
     parent: 0
     type: Transform
 - uid: 1221
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,12.5
     parent: 0
     type: Transform
 - uid: 1222
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,12.5
     parent: 0
     type: Transform
 - uid: 1223
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,12.5
     parent: 0
     type: Transform
 - uid: 1224
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,12.5
     parent: 0
     type: Transform
 - uid: 1225
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,12.5
     parent: 0
     type: Transform
 - uid: 1226
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,12.5
     parent: 0
@@ -25585,43 +25585,43 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1230
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-37.5
     parent: 0
     type: Transform
 - uid: 1231
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-37.5
     parent: 0
     type: Transform
 - uid: 1232
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-37.5
     parent: 0
     type: Transform
 - uid: 1233
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-37.5
     parent: 0
     type: Transform
 - uid: 1234
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-37.5
     parent: 0
     type: Transform
 - uid: 1235
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,-37.5
     parent: 0
     type: Transform
 - uid: 1236
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-37.5
     parent: 0
@@ -25669,7 +25669,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1244
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-51.5
     parent: 0
@@ -25681,19 +25681,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 1246
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-55.5
     parent: 0
     type: Transform
 - uid: 1247
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-54.5
     parent: 0
     type: Transform
 - uid: 1248
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-53.5
     parent: 0
@@ -25807,7 +25807,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1267
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,-58.5
     parent: 0
@@ -25831,13 +25831,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 1271
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,-58.5
     parent: 0
     type: Transform
 - uid: 1272
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-58.5
     parent: 0
@@ -25855,7 +25855,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1275
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-31.5
     parent: 0
@@ -25891,301 +25891,301 @@ entities:
     parent: 0
     type: Transform
 - uid: 1280
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-52.5
     parent: 0
     type: Transform
 - uid: 1281
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-43.5
     parent: 0
     type: Transform
 - uid: 1282
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-43.5
     parent: 0
     type: Transform
 - uid: 1283
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-43.5
     parent: 0
     type: Transform
 - uid: 1284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-44.5
     parent: 0
     type: Transform
 - uid: 1285
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-45.5
     parent: 0
     type: Transform
 - uid: 1286
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-46.5
     parent: 0
     type: Transform
 - uid: 1287
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-47.5
     parent: 0
     type: Transform
 - uid: 1288
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-48.5
     parent: 0
     type: Transform
 - uid: 1289
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-49.5
     parent: 0
     type: Transform
 - uid: 1290
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-50.5
     parent: 0
     type: Transform
 - uid: 1291
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-51.5
     parent: 0
     type: Transform
 - uid: 1292
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-52.5
     parent: 0
     type: Transform
 - uid: 1293
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-53.5
     parent: 0
     type: Transform
 - uid: 1294
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-54.5
     parent: 0
     type: Transform
 - uid: 1295
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-55.5
     parent: 0
     type: Transform
 - uid: 1296
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-57.5
     parent: 0
     type: Transform
 - uid: 1297
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-25.5
     parent: 0
     type: Transform
 - uid: 1298
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-57.5
     parent: 0
     type: Transform
 - uid: 1299
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-56.5
     parent: 0
     type: Transform
 - uid: 1300
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-43.5
     parent: 0
     type: Transform
 - uid: 1301
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-44.5
     parent: 0
     type: Transform
 - uid: 1302
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-45.5
     parent: 0
     type: Transform
 - uid: 1303
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-45.5
     parent: 0
     type: Transform
 - uid: 1304
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-46.5
     parent: 0
     type: Transform
 - uid: 1305
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-47.5
     parent: 0
     type: Transform
 - uid: 1306
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-48.5
     parent: 0
     type: Transform
 - uid: 1307
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-49.5
     parent: 0
     type: Transform
 - uid: 1308
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-47.5
     parent: 0
     type: Transform
 - uid: 1309
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-48.5
     parent: 0
     type: Transform
 - uid: 1310
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-49.5
     parent: 0
     type: Transform
 - uid: 1311
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-50.5
     parent: 0
     type: Transform
 - uid: 1312
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-51.5
     parent: 0
     type: Transform
 - uid: 1313
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-52.5
     parent: 0
     type: Transform
 - uid: 1314
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-50.5
     parent: 0
     type: Transform
 - uid: 1315
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-51.5
     parent: 0
     type: Transform
 - uid: 1316
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-52.5
     parent: 0
     type: Transform
 - uid: 1317
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-54.5
     parent: 0
     type: Transform
 - uid: 1318
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-53.5
     parent: 0
     type: Transform
 - uid: 1319
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-55.5
     parent: 0
     type: Transform
 - uid: 1320
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-55.5
     parent: 0
     type: Transform
 - uid: 1321
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-59.5
     parent: 0
     type: Transform
 - uid: 1322
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-33.5
     parent: 0
     type: Transform
 - uid: 1323
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-33.5
     parent: 0
     type: Transform
 - uid: 1324
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-33.5
     parent: 0
     type: Transform
 - uid: 1325
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-33.5
     parent: 0
     type: Transform
 - uid: 1326
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-31.5
     parent: 0
     type: Transform
 - uid: 1327
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-31.5
     parent: 0
     type: Transform
 - uid: 1328
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-33.5
     parent: 0
     type: Transform
 - uid: 1329
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-29.5
     parent: 0
@@ -26239,133 +26239,133 @@ entities:
     parent: 0
     type: Transform
 - uid: 1338
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-22.5
     parent: 0
     type: Transform
 - uid: 1339
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-22.5
     parent: 0
     type: Transform
 - uid: 1340
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-22.5
     parent: 0
     type: Transform
 - uid: 1341
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-22.5
     parent: 0
     type: Transform
 - uid: 1342
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-22.5
     parent: 0
     type: Transform
 - uid: 1343
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-23.5
     parent: 0
     type: Transform
 - uid: 1344
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-24.5
     parent: 0
     type: Transform
 - uid: 1345
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-25.5
     parent: 0
     type: Transform
 - uid: 1346
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-26.5
     parent: 0
     type: Transform
 - uid: 1347
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-27.5
     parent: 0
     type: Transform
 - uid: 1348
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-33.5
     parent: 0
     type: Transform
 - uid: 1349
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,-33.5
     parent: 0
     type: Transform
 - uid: 1350
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,-33.5
     parent: 0
     type: Transform
 - uid: 1351
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-33.5
     parent: 0
     type: Transform
 - uid: 1352
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-33.5
     parent: 0
     type: Transform
 - uid: 1353
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-32.5
     parent: 0
     type: Transform
 - uid: 1354
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-32.5
     parent: 0
     type: Transform
 - uid: 1355
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-32.5
     parent: 0
     type: Transform
 - uid: 1356
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-31.5
     parent: 0
     type: Transform
 - uid: 1357
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-30.5
     parent: 0
     type: Transform
 - uid: 1358
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-27.5
     parent: 0
     type: Transform
 - uid: 1359
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-27.5
     parent: 0
@@ -26439,55 +26439,55 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1370
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-34.5
     parent: 0
     type: Transform
 - uid: 1371
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-35.5
     parent: 0
     type: Transform
 - uid: 1372
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-36.5
     parent: 0
     type: Transform
 - uid: 1373
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-37.5
     parent: 0
     type: Transform
 - uid: 1374
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-37.5
     parent: 0
     type: Transform
 - uid: 1375
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-37.5
     parent: 0
     type: Transform
 - uid: 1376
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-37.5
     parent: 0
     type: Transform
 - uid: 1377
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-37.5
     parent: 0
     type: Transform
 - uid: 1378
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-37.5
     parent: 0
@@ -27280,19 +27280,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1504
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-1.5
     parent: 0
     type: Transform
 - uid: 1505
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-8.5
     parent: 0
     type: Transform
 - uid: 1506
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-8.5
     parent: 0
@@ -27309,109 +27309,109 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 1508
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,-8.5
     parent: 0
     type: Transform
 - uid: 1509
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-8.5
     parent: 0
     type: Transform
 - uid: 1510
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,-8.5
     parent: 0
     type: Transform
 - uid: 1511
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-8.5
     parent: 0
     type: Transform
 - uid: 1512
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-8.5
     parent: 0
     type: Transform
 - uid: 1513
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,-8.5
     parent: 0
     type: Transform
 - uid: 1514
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-7.5
     parent: 0
     type: Transform
 - uid: 1515
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-6.5
     parent: 0
     type: Transform
 - uid: 1516
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-5.5
     parent: 0
     type: Transform
 - uid: 1517
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-4.5
     parent: 0
     type: Transform
 - uid: 1518
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-3.5
     parent: 0
     type: Transform
 - uid: 1519
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-2.5
     parent: 0
     type: Transform
 - uid: 1520
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-1.5
     parent: 0
     type: Transform
 - uid: 1521
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,-1.5
     parent: 0
     type: Transform
 - uid: 1522
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,-1.5
     parent: 0
     type: Transform
 - uid: 1523
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-1.5
     parent: 0
     type: Transform
 - uid: 1524
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-1.5
     parent: 0
     type: Transform
 - uid: 1525
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-2.5
     parent: 0
@@ -27927,121 +27927,121 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1597
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-9.5
     parent: 0
     type: Transform
 - uid: 1598
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-10.5
     parent: 0
     type: Transform
 - uid: 1599
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-12.5
     parent: 0
     type: Transform
 - uid: 1600
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-12.5
     parent: 0
     type: Transform
 - uid: 1601
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-13.5
     parent: 0
     type: Transform
 - uid: 1602
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-13.5
     parent: 0
     type: Transform
 - uid: 1603
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-13.5
     parent: 0
     type: Transform
 - uid: 1604
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,-13.5
     parent: 0
     type: Transform
 - uid: 1605
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-13.5
     parent: 0
     type: Transform
 - uid: 1606
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-12.5
     parent: 0
     type: Transform
 - uid: 1607
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-11.5
     parent: 0
     type: Transform
 - uid: 1608
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 32.5,-10.5
     parent: 0
     type: Transform
 - uid: 1609
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-13.5
     parent: 0
     type: Transform
 - uid: 1610
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-13.5
     parent: 0
     type: Transform
 - uid: 1611
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,-13.5
     parent: 0
     type: Transform
 - uid: 1612
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-13.5
     parent: 0
     type: Transform
 - uid: 1613
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-13.5
     parent: 0
     type: Transform
 - uid: 1614
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,-13.5
     parent: 0
     type: Transform
 - uid: 1615
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-11.5
     parent: 0
     type: Transform
 - uid: 1616
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 40.5,-10.5
     parent: 0
@@ -28066,7 +28066,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1619
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-13.5
     parent: 0
@@ -28421,97 +28421,97 @@ entities:
     parent: 0
     type: Transform
 - uid: 1659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-2.5
     parent: 0
     type: Transform
 - uid: 1660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-3.5
     parent: 0
     type: Transform
 - uid: 1661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-4.5
     parent: 0
     type: Transform
 - uid: 1662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-5.5
     parent: 0
     type: Transform
 - uid: 1663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-6.5
     parent: 0
     type: Transform
 - uid: 1664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-7.5
     parent: 0
     type: Transform
 - uid: 1665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-8.5
     parent: 0
     type: Transform
 - uid: 1666
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-10.5
     parent: 0
     type: Transform
 - uid: 1667
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-11.5
     parent: 0
     type: Transform
 - uid: 1668
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 47.5,-11.5
     parent: 0
     type: Transform
 - uid: 1669
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 46.5,-11.5
     parent: 0
     type: Transform
 - uid: 1670
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 45.5,-11.5
     parent: 0
     type: Transform
 - uid: 1671
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,-11.5
     parent: 0
     type: Transform
 - uid: 1672
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,-11.5
     parent: 0
     type: Transform
 - uid: 1673
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 42.5,-11.5
     parent: 0
     type: Transform
 - uid: 1674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-9.5
     parent: 0
@@ -28913,67 +28913,67 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1721
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-13.5
     parent: 0
     type: Transform
 - uid: 1722
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-13.5
     parent: 0
     type: Transform
 - uid: 1723
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-13.5
     parent: 0
     type: Transform
 - uid: 1724
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-13.5
     parent: 0
     type: Transform
 - uid: 1725
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-13.5
     parent: 0
     type: Transform
 - uid: 1726
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-13.5
     parent: 0
     type: Transform
 - uid: 1727
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-17.5
     parent: 0
     type: Transform
 - uid: 1728
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-17.5
     parent: 0
     type: Transform
 - uid: 1729
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-17.5
     parent: 0
     type: Transform
 - uid: 1730
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-17.5
     parent: 0
     type: Transform
 - uid: 1731
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-17.5
     parent: 0
@@ -29015,7 +29015,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1738
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-17.5
     parent: 0
@@ -29055,61 +29055,61 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 1742
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-17.5
     parent: 0
     type: Transform
 - uid: 1743
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,-18.5
     parent: 0
     type: Transform
 - uid: 1744
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-18.5
     parent: 0
     type: Transform
 - uid: 1745
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-18.5
     parent: 0
     type: Transform
 - uid: 1746
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,-18.5
     parent: 0
     type: Transform
 - uid: 1747
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,-18.5
     parent: 0
     type: Transform
 - uid: 1748
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-18.5
     parent: 0
     type: Transform
 - uid: 1749
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-17.5
     parent: 0
     type: Transform
 - uid: 1750
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-15.5
     parent: 0
     type: Transform
 - uid: 1751
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,-14.5
     parent: 0
@@ -29127,25 +29127,25 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 1753
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,-18.5
     parent: 0
     type: Transform
 - uid: 1754
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,-18.5
     parent: 0
     type: Transform
 - uid: 1755
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-18.5
     parent: 0
     type: Transform
 - uid: 1756
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,-18.5
     parent: 0
@@ -29670,13 +29670,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1824
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-19.5
     parent: 0
     type: Transform
 - uid: 1825
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,-20.5
     parent: 0
@@ -29800,13 +29800,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1839
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-21.5
     parent: 0
     type: Transform
 - uid: 1840
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-21.5
     parent: 0
@@ -29822,37 +29822,37 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1842
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-19.5
     parent: 0
     type: Transform
 - uid: 1843
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-19.5
     parent: 0
     type: Transform
 - uid: 1844
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-19.5
     parent: 0
     type: Transform
 - uid: 1845
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-19.5
     parent: 0
     type: Transform
 - uid: 1846
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-19.5
     parent: 0
     type: Transform
 - uid: 1847
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,-19.5
     parent: 0
@@ -29876,7 +29876,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1850
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-25.5
     parent: 0
@@ -30128,49 +30128,49 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1889
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-37.5
     parent: 0
     type: Transform
 - uid: 1890
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-37.5
     parent: 0
     type: Transform
 - uid: 1891
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-37.5
     parent: 0
     type: Transform
 - uid: 1892
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-23.5
     parent: 0
     type: Transform
 - uid: 1893
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-36.5
     parent: 0
     type: Transform
 - uid: 1894
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,-35.5
     parent: 0
     type: Transform
 - uid: 1895
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-25.5
     parent: 0
     type: Transform
 - uid: 1896
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-25.5
     parent: 0
@@ -30182,43 +30182,43 @@ entities:
     parent: 0
     type: Transform
 - uid: 1898
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-25.5
     parent: 0
     type: Transform
 - uid: 1899
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-29.5
     parent: 0
     type: Transform
 - uid: 1900
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-30.5
     parent: 0
     type: Transform
 - uid: 1901
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-31.5
     parent: 0
     type: Transform
 - uid: 1902
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-29.5
     parent: 0
     type: Transform
 - uid: 1903
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-23.5
     parent: 0
     type: Transform
 - uid: 1904
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-31.5
     parent: 0
@@ -30230,103 +30230,103 @@ entities:
     parent: 0
     type: Transform
 - uid: 1906
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-25.5
     parent: 0
     type: Transform
 - uid: 1907
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-25.5
     parent: 0
     type: Transform
 - uid: 1908
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-22.5
     parent: 0
     type: Transform
 - uid: 1909
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-31.5
     parent: 0
     type: Transform
 - uid: 1910
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-25.5
     parent: 0
     type: Transform
 - uid: 1911
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-29.5
     parent: 0
     type: Transform
 - uid: 1912
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-21.5
     parent: 0
     type: Transform
 - uid: 1913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-29.5
     parent: 0
     type: Transform
 - uid: 1914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-21.5
     parent: 0
     type: Transform
 - uid: 1915
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-23.5
     parent: 0
     type: Transform
 - uid: 1916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-26.5
     parent: 0
     type: Transform
 - uid: 1917
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-29.5
     parent: 0
     type: Transform
 - uid: 1918
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-27.5
     parent: 0
     type: Transform
 - uid: 1919
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-28.5
     parent: 0
     type: Transform
 - uid: 1920
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-24.5
     parent: 0
     type: Transform
 - uid: 1921
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-23.5
     parent: 0
     type: Transform
 - uid: 1922
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-23.5
     parent: 0
@@ -30410,7 +30410,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 1936
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-38.5
     parent: 0
@@ -30506,19 +30506,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 1952
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-31.5
     parent: 0
     type: Transform
 - uid: 1953
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-21.5
     parent: 0
     type: Transform
 - uid: 1954
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-23.5
     parent: 0
@@ -30532,25 +30532,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1956
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-27.5
     parent: 0
     type: Transform
 - uid: 1957
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-33.5
     parent: 0
     type: Transform
 - uid: 1958
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-33.5
     parent: 0
     type: Transform
 - uid: 1959
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-33.5
     parent: 0
@@ -30568,13 +30568,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 1962
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-31.5
     parent: 0
     type: Transform
 - uid: 1963
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-33.5
     parent: 0
@@ -30598,7 +30598,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1966
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-31.5
     parent: 0
@@ -30635,109 +30635,109 @@ entities:
     parent: 0
     type: Transform
 - uid: 1971
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-14.5
     parent: 0
     type: Transform
 - uid: 1972
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-15.5
     parent: 0
     type: Transform
 - uid: 1973
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-16.5
     parent: 0
     type: Transform
 - uid: 1974
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,-17.5
     parent: 0
     type: Transform
 - uid: 1975
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,-17.5
     parent: 0
     type: Transform
 - uid: 1976
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,-17.5
     parent: 0
     type: Transform
 - uid: 1977
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,-16.5
     parent: 0
     type: Transform
 - uid: 1978
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,-15.5
     parent: 0
     type: Transform
 - uid: 1979
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,-14.5
     parent: 0
     type: Transform
 - uid: 1980
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,-14.5
     parent: 0
     type: Transform
 - uid: 1981
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,-19.5
     parent: 0
     type: Transform
 - uid: 1982
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,-19.5
     parent: 0
     type: Transform
 - uid: 1983
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-19.5
     parent: 0
     type: Transform
 - uid: 1984
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-19.5
     parent: 0
     type: Transform
 - uid: 1985
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-19.5
     parent: 0
     type: Transform
 - uid: 1986
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-19.5
     parent: 0
     type: Transform
 - uid: 1987
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-19.5
     parent: 0
     type: Transform
 - uid: 1988
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-19.5
     parent: 0
@@ -30779,109 +30779,109 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1994
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,-18.5
     parent: 0
     type: Transform
 - uid: 1995
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,-16.5
     parent: 0
     type: Transform
 - uid: 1996
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,-16.5
     parent: 0
     type: Transform
 - uid: 1997
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,-16.5
     parent: 0
     type: Transform
 - uid: 1998
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-15.5
     parent: 0
     type: Transform
 - uid: 1999
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-14.5
     parent: 0
     type: Transform
 - uid: 2000
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-13.5
     parent: 0
     type: Transform
 - uid: 2001
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,-15.5
     parent: 0
     type: Transform
 - uid: 2002
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-14.5
     parent: 0
     type: Transform
 - uid: 2003
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-13.5
     parent: 0
     type: Transform
 - uid: 2004
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,-16.5
     parent: 0
     type: Transform
 - uid: 2005
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-16.5
     parent: 0
     type: Transform
 - uid: 2006
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-12.5
     parent: 0
     type: Transform
 - uid: 2007
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,-12.5
     parent: 0
     type: Transform
 - uid: 2008
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-12.5
     parent: 0
     type: Transform
 - uid: 2009
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-12.5
     parent: 0
     type: Transform
 - uid: 2010
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-12.5
     parent: 0
     type: Transform
 - uid: 2011
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-12.5
     parent: 0
@@ -30897,43 +30897,43 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2013
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,19.5
     parent: 0
     type: Transform
 - uid: 2014
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,19.5
     parent: 0
     type: Transform
 - uid: 2015
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,19.5
     parent: 0
     type: Transform
 - uid: 2016
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,19.5
     parent: 0
     type: Transform
 - uid: 2017
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,19.5
     parent: 0
     type: Transform
 - uid: 2018
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,19.5
     parent: 0
     type: Transform
 - uid: 2019
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,19.5
     parent: 0
@@ -31033,145 +31033,145 @@ entities:
     parent: 0
     type: Transform
 - uid: 2033
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,29.5
     parent: 0
     type: Transform
 - uid: 2034
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,30.5
     parent: 0
     type: Transform
 - uid: 2035
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,31.5
     parent: 0
     type: Transform
 - uid: 2036
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,32.5
     parent: 0
     type: Transform
 - uid: 2037
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,33.5
     parent: 0
     type: Transform
 - uid: 2038
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,33.5
     parent: 0
     type: Transform
 - uid: 2039
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,33.5
     parent: 0
     type: Transform
 - uid: 2040
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,33.5
     parent: 0
     type: Transform
 - uid: 2041
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,33.5
     parent: 0
     type: Transform
 - uid: 2042
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,33.5
     parent: 0
     type: Transform
 - uid: 2043
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,32.5
     parent: 0
     type: Transform
 - uid: 2044
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,31.5
     parent: 0
     type: Transform
 - uid: 2045
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,30.5
     parent: 0
     type: Transform
 - uid: 2046
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,29.5
     parent: 0
     type: Transform
 - uid: 2047
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,29.5
     parent: 0
     type: Transform
 - uid: 2048
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,29.5
     parent: 0
     type: Transform
 - uid: 2049
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,32.5
     parent: 0
     type: Transform
 - uid: 2050
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,32.5
     parent: 0
     type: Transform
 - uid: 2051
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,32.5
     parent: 0
     type: Transform
 - uid: 2052
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,32.5
     parent: 0
     type: Transform
 - uid: 2053
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,31.5
     parent: 0
     type: Transform
 - uid: 2054
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,29.5
     parent: 0
     type: Transform
 - uid: 2055
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,30.5
     parent: 0
     type: Transform
 - uid: 2056
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,27.5
     parent: 0
@@ -31239,37 +31239,37 @@ entities:
   - fixtures: []
     type: Fixtures
 - uid: 2066
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,23.5
     parent: 0
     type: Transform
 - uid: 2067
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,24.5
     parent: 0
     type: Transform
 - uid: 2068
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,25.5
     parent: 0
     type: Transform
 - uid: 2069
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,26.5
     parent: 0
     type: Transform
 - uid: 2070
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,26.5
     parent: 0
     type: Transform
 - uid: 2071
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,26.5
     parent: 0
@@ -31606,133 +31606,133 @@ entities:
     parent: 0
     type: Transform
 - uid: 2115
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,25.5
     parent: 0
     type: Transform
 - uid: 2116
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,25.5
     parent: 0
     type: Transform
 - uid: 2117
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,25.5
     parent: 0
     type: Transform
 - uid: 2118
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,25.5
     parent: 0
     type: Transform
 - uid: 2119
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,25.5
     parent: 0
     type: Transform
 - uid: 2120
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,26.5
     parent: 0
     type: Transform
 - uid: 2121
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,26.5
     parent: 0
     type: Transform
 - uid: 2122
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,26.5
     parent: 0
     type: Transform
 - uid: 2123
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,26.5
     parent: 0
     type: Transform
 - uid: 2124
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,28.5
     parent: 0
     type: Transform
 - uid: 2125
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,28.5
     parent: 0
     type: Transform
 - uid: 2126
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,28.5
     parent: 0
     type: Transform
 - uid: 2127
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,28.5
     parent: 0
     type: Transform
 - uid: 2128
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,28.5
     parent: 0
     type: Transform
 - uid: 2129
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,28.5
     parent: 0
     type: Transform
 - uid: 2130
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,28.5
     parent: 0
     type: Transform
 - uid: 2131
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,28.5
     parent: 0
     type: Transform
 - uid: 2132
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,28.5
     parent: 0
     type: Transform
 - uid: 2133
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,29.5
     parent: 0
     type: Transform
 - uid: 2134
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,30.5
     parent: 0
     type: Transform
 - uid: 2135
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,31.5
     parent: 0
     type: Transform
 - uid: 2136
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,32.5
     parent: 0
@@ -32180,49 +32180,49 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2191
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,19.5
     parent: 0
     type: Transform
 - uid: 2192
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,19.5
     parent: 0
     type: Transform
 - uid: 2193
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,19.5
     parent: 0
     type: Transform
 - uid: 2194
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,18.5
     parent: 0
     type: Transform
 - uid: 2195
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,17.5
     parent: 0
     type: Transform
 - uid: 2196
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 23.5,16.5
     parent: 0
     type: Transform
 - uid: 2197
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,16.5
     parent: 0
     type: Transform
 - uid: 2198
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 24.5,16.5
     parent: 0
@@ -32342,277 +32342,277 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2212
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,16.5
     parent: 0
     type: Transform
 - uid: 2213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,16.5
     parent: 0
     type: Transform
 - uid: 2214
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,16.5
     parent: 0
     type: Transform
 - uid: 2215
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,16.5
     parent: 0
     type: Transform
 - uid: 2216
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,16.5
     parent: 0
     type: Transform
 - uid: 2217
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,16.5
     parent: 0
     type: Transform
 - uid: 2218
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,19.5
     parent: 0
     type: Transform
 - uid: 2219
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,22.5
     parent: 0
     type: Transform
 - uid: 2220
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,26.5
     parent: 0
     type: Transform
 - uid: 2221
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,27.5
     parent: 0
     type: Transform
 - uid: 2222
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,27.5
     parent: 0
     type: Transform
 - uid: 2223
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,27.5
     parent: 0
     type: Transform
 - uid: 2224
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,27.5
     parent: 0
     type: Transform
 - uid: 2225
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,28.5
     parent: 0
     type: Transform
 - uid: 2226
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,29.5
     parent: 0
     type: Transform
 - uid: 2227
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,30.5
     parent: 0
     type: Transform
 - uid: 2228
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,31.5
     parent: 0
     type: Transform
 - uid: 2229
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,31.5
     parent: 0
     type: Transform
 - uid: 2230
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,31.5
     parent: 0
     type: Transform
 - uid: 2231
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,31.5
     parent: 0
     type: Transform
 - uid: 2232
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,31.5
     parent: 0
     type: Transform
 - uid: 2233
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,31.5
     parent: 0
     type: Transform
 - uid: 2234
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,31.5
     parent: 0
     type: Transform
 - uid: 2235
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,32.5
     parent: 0
     type: Transform
 - uid: 2236
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,32.5
     parent: 0
     type: Transform
 - uid: 2237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,32.5
     parent: 0
     type: Transform
 - uid: 2238
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,32.5
     parent: 0
     type: Transform
 - uid: 2239
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,31.5
     parent: 0
     type: Transform
 - uid: 2240
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,33.5
     parent: 0
     type: Transform
 - uid: 2241
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,34.5
     parent: 0
     type: Transform
 - uid: 2242
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,35.5
     parent: 0
     type: Transform
 - uid: 2243
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,36.5
     parent: 0
     type: Transform
 - uid: 2244
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,36.5
     parent: 0
     type: Transform
 - uid: 2245
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,37.5
     parent: 0
     type: Transform
 - uid: 2246
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,37.5
     parent: 0
     type: Transform
 - uid: 2247
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,37.5
     parent: 0
     type: Transform
 - uid: 2248
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,37.5
     parent: 0
     type: Transform
 - uid: 2249
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,37.5
     parent: 0
     type: Transform
 - uid: 2250
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,36.5
     parent: 0
     type: Transform
 - uid: 2251
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,38.5
     parent: 0
     type: Transform
 - uid: 2252
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,38.5
     parent: 0
     type: Transform
 - uid: 2253
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,38.5
     parent: 0
     type: Transform
 - uid: 2254
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,37.5
     parent: 0
     type: Transform
 - uid: 2255
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,36.5
     parent: 0
     type: Transform
 - uid: 2256
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,35.5
     parent: 0
     type: Transform
 - uid: 2257
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,34.5
     parent: 0
@@ -32666,37 +32666,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 2266
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,22.5
     parent: 0
     type: Transform
 - uid: 2267
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,22.5
     parent: 0
     type: Transform
 - uid: 2268
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,22.5
     parent: 0
     type: Transform
 - uid: 2269
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 29.5,19.5
     parent: 0
     type: Transform
 - uid: 2270
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,19.5
     parent: 0
     type: Transform
 - uid: 2271
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 31.5,19.5
     parent: 0
@@ -32776,85 +32776,85 @@ entities:
     parent: 0
     type: Transform
 - uid: 2282
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,29.5
     parent: 0
     type: Transform
 - uid: 2283
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,29.5
     parent: 0
     type: Transform
 - uid: 2284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,29.5
     parent: 0
     type: Transform
 - uid: 2285
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,29.5
     parent: 0
     type: Transform
 - uid: 2286
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,29.5
     parent: 0
     type: Transform
 - uid: 2287
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,29.5
     parent: 0
     type: Transform
 - uid: 2288
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,29.5
     parent: 0
     type: Transform
 - uid: 2289
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,29.5
     parent: 0
     type: Transform
 - uid: 2290
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,29.5
     parent: 0
     type: Transform
 - uid: 2291
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,29.5
     parent: 0
     type: Transform
 - uid: 2292
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,30.5
     parent: 0
     type: Transform
 - uid: 2293
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,31.5
     parent: 0
     type: Transform
 - uid: 2294
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,32.5
     parent: 0
     type: Transform
 - uid: 2295
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,33.5
     parent: 0
@@ -32866,25 +32866,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 2297
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,30.5
     parent: 0
     type: Transform
 - uid: 2298
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,38.5
     parent: 0
     type: Transform
 - uid: 2299
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,38.5
     parent: 0
     type: Transform
 - uid: 2300
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,37.5
     parent: 0
@@ -33307,31 +33307,31 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2349
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,25.5
     parent: 0
     type: Transform
 - uid: 2350
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,28.5
     parent: 0
     type: Transform
 - uid: 2351
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,27.5
     parent: 0
     type: Transform
 - uid: 2352
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,26.5
     parent: 0
     type: Transform
 - uid: 2353
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,25.5
     parent: 0
@@ -33343,109 +33343,109 @@ entities:
     parent: 0
     type: Transform
 - uid: 2355
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,27.5
     parent: 0
     type: Transform
 - uid: 2356
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,26.5
     parent: 0
     type: Transform
 - uid: 2357
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,26.5
     parent: 0
     type: Transform
 - uid: 2358
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,26.5
     parent: 0
     type: Transform
 - uid: 2359
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,26.5
     parent: 0
     type: Transform
 - uid: 2360
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,25.5
     parent: 0
     type: Transform
 - uid: 2361
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,24.5
     parent: 0
     type: Transform
 - uid: 2362
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,23.5
     parent: 0
     type: Transform
 - uid: 2363
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,22.5
     parent: 0
     type: Transform
 - uid: 2364
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,21.5
     parent: 0
     type: Transform
 - uid: 2365
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,21.5
     parent: 0
     type: Transform
 - uid: 2366
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,21.5
     parent: 0
     type: Transform
 - uid: 2367
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,21.5
     parent: 0
     type: Transform
 - uid: 2368
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,21.5
     parent: 0
     type: Transform
 - uid: 2369
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,21.5
     parent: 0
     type: Transform
 - uid: 2370
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,21.5
     parent: 0
     type: Transform
 - uid: 2371
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,20.5
     parent: 0
     type: Transform
 - uid: 2372
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,19.5
     parent: 0
@@ -33505,13 +33505,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 2382
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,20.5
     parent: 0
     type: Transform
 - uid: 2383
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,20.5
     parent: 0
@@ -34155,79 +34155,79 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2465
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,17.5
     parent: 0
     type: Transform
 - uid: 2466
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,16.5
     parent: 0
     type: Transform
 - uid: 2467
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,16.5
     parent: 0
     type: Transform
 - uid: 2468
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,16.5
     parent: 0
     type: Transform
 - uid: 2469
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,16.5
     parent: 0
     type: Transform
 - uid: 2470
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,16.5
     parent: 0
     type: Transform
 - uid: 2471
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,16.5
     parent: 0
     type: Transform
 - uid: 2472
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,16.5
     parent: 0
     type: Transform
 - uid: 2473
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,20.5
     parent: 0
     type: Transform
 - uid: 2474
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,19.5
     parent: 0
     type: Transform
 - uid: 2475
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,18.5
     parent: 0
     type: Transform
 - uid: 2476
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,17.5
     parent: 0
     type: Transform
 - uid: 2477
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,16.5
     parent: 0
@@ -34562,97 +34562,97 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2518
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,10.5
     parent: 0
     type: Transform
 - uid: 2519
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,10.5
     parent: 0
     type: Transform
 - uid: 2520
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,4.5
     parent: 0
     type: Transform
 - uid: 2521
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,3.5
     parent: 0
     type: Transform
 - uid: 2522
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,10.5
     parent: 0
     type: Transform
 - uid: 2523
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,10.5
     parent: 0
     type: Transform
 - uid: 2524
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,10.5
     parent: 0
     type: Transform
 - uid: 2525
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,2.5
     parent: 0
     type: Transform
 - uid: 2526
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,2.5
     parent: 0
     type: Transform
 - uid: 2527
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,2.5
     parent: 0
     type: Transform
 - uid: 2528
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,2.5
     parent: 0
     type: Transform
 - uid: 2529
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,2.5
     parent: 0
     type: Transform
 - uid: 2530
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,2.5
     parent: 0
     type: Transform
 - uid: 2531
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,3.5
     parent: 0
     type: Transform
 - uid: 2532
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,4.5
     parent: 0
     type: Transform
 - uid: 2533
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,4.5
     parent: 0
@@ -34931,19 +34931,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2569
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,12.5
     parent: 0
     type: Transform
 - uid: 2570
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 38.5,12.5
     parent: 0
     type: Transform
 - uid: 2571
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 37.5,12.5
     parent: 0
@@ -34979,19 +34979,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2575
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 36.5,12.5
     parent: 0
     type: Transform
 - uid: 2576
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 35.5,12.5
     parent: 0
     type: Transform
 - uid: 2577
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 34.5,12.5
     parent: 0
@@ -35055,271 +35055,271 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2584
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 28.5,33.5
     parent: 0
     type: Transform
 - uid: 2585
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,33.5
     parent: 0
     type: Transform
 - uid: 2586
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,33.5
     parent: 0
     type: Transform
 - uid: 2587
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,33.5
     parent: 0
     type: Transform
 - uid: 2588
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,33.5
     parent: 0
     type: Transform
 - uid: 2589
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,33.5
     parent: 0
     type: Transform
 - uid: 2590
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,34.5
     parent: 0
     type: Transform
 - uid: 2591
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,34.5
     parent: 0
     type: Transform
 - uid: 2592
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,35.5
     parent: 0
     type: Transform
 - uid: 2593
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,37.5
     parent: 0
     type: Transform
 - uid: 2594
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,35.5
     parent: 0
     type: Transform
 - uid: 2595
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,36.5
     parent: 0
     type: Transform
 - uid: 2596
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,37.5
     parent: 0
     type: Transform
 - uid: 2597
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,38.5
     parent: 0
     type: Transform
 - uid: 2598
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,38.5
     parent: 0
     type: Transform
 - uid: 2599
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,38.5
     parent: 0
     type: Transform
 - uid: 2600
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,38.5
     parent: 0
     type: Transform
 - uid: 2601
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,38.5
     parent: 0
     type: Transform
 - uid: 2602
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,39.5
     parent: 0
     type: Transform
 - uid: 2603
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,40.5
     parent: 0
     type: Transform
 - uid: 2604
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,41.5
     parent: 0
     type: Transform
 - uid: 2605
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,42.5
     parent: 0
     type: Transform
 - uid: 2606
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,43.5
     parent: 0
     type: Transform
 - uid: 2607
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,43.5
     parent: 0
     type: Transform
 - uid: 2608
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,43.5
     parent: 0
     type: Transform
 - uid: 2609
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,44.5
     parent: 0
     type: Transform
 - uid: 2610
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,44.5
     parent: 0
     type: Transform
 - uid: 2611
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,44.5
     parent: 0
     type: Transform
 - uid: 2612
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,44.5
     parent: 0
     type: Transform
 - uid: 2613
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,43.5
     parent: 0
     type: Transform
 - uid: 2614
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,42.5
     parent: 0
     type: Transform
 - uid: 2615
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,41.5
     parent: 0
     type: Transform
 - uid: 2616
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,44.5
     parent: 0
     type: Transform
 - uid: 2617
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,44.5
     parent: 0
     type: Transform
 - uid: 2618
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,44.5
     parent: 0
     type: Transform
 - uid: 2619
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,43.5
     parent: 0
     type: Transform
 - uid: 2620
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,42.5
     parent: 0
     type: Transform
 - uid: 2621
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,41.5
     parent: 0
     type: Transform
 - uid: 2622
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,40.5
     parent: 0
     type: Transform
 - uid: 2623
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,39.5
     parent: 0
     type: Transform
 - uid: 2624
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,39.5
     parent: 0
     type: Transform
 - uid: 2625
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,39.5
     parent: 0
     type: Transform
 - uid: 2626
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,39.5
     parent: 0
     type: Transform
 - uid: 2627
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,39.5
     parent: 0
     type: Transform
 - uid: 2628
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,38.5
     parent: 0
@@ -35447,139 +35447,139 @@ entities:
     parent: 0
     type: Transform
 - uid: 2648
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,43.5
     parent: 0
     type: Transform
 - uid: 2649
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,42.5
     parent: 0
     type: Transform
 - uid: 2650
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,42.5
     parent: 0
     type: Transform
 - uid: 2651
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,43.5
     parent: 0
     type: Transform
 - uid: 2652
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,43.5
     parent: 0
     type: Transform
 - uid: 2653
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,43.5
     parent: 0
     type: Transform
 - uid: 2654
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,42.5
     parent: 0
     type: Transform
 - uid: 2655
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,42.5
     parent: 0
     type: Transform
 - uid: 2656
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,41.5
     parent: 0
     type: Transform
 - uid: 2657
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,40.5
     parent: 0
     type: Transform
 - uid: 2658
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,39.5
     parent: 0
     type: Transform
 - uid: 2659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,38.5
     parent: 0
     type: Transform
 - uid: 2660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,38.5
     parent: 0
     type: Transform
 - uid: 2661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,38.5
     parent: 0
     type: Transform
 - uid: 2662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,38.5
     parent: 0
     type: Transform
 - uid: 2663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,39.5
     parent: 0
     type: Transform
 - uid: 2664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,40.5
     parent: 0
     type: Transform
 - uid: 2665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,41.5
     parent: 0
     type: Transform
 - uid: 2666
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,38.5
     parent: 0
     type: Transform
 - uid: 2667
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,39.5
     parent: 0
     type: Transform
 - uid: 2668
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,40.5
     parent: 0
     type: Transform
 - uid: 2669
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,42.5
     parent: 0
     type: Transform
 - uid: 2670
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,43.5
     parent: 0
@@ -35603,55 +35603,55 @@ entities:
     parent: 0
     type: Transform
 - uid: 2674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,42.5
     parent: 0
     type: Transform
 - uid: 2675
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,41.5
     parent: 0
     type: Transform
 - uid: 2676
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,40.5
     parent: 0
     type: Transform
 - uid: 2677
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,39.5
     parent: 0
     type: Transform
 - uid: 2678
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,38.5
     parent: 0
     type: Transform
 - uid: 2679
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,37.5
     parent: 0
     type: Transform
 - uid: 2680
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,35.5
     parent: 0
     type: Transform
 - uid: 2681
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,34.5
     parent: 0
     type: Transform
 - uid: 2682
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,35.5
     parent: 0
@@ -35665,25 +35665,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2684
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,36.5
     parent: 0
     type: Transform
 - uid: 2685
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,34.5
     parent: 0
     type: Transform
 - uid: 2686
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,37.5
     parent: 0
     type: Transform
 - uid: 2687
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,34.5
     parent: 0
@@ -35711,49 +35711,49 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2690
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,34.5
     parent: 0
     type: Transform
 - uid: 2691
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 22.5,34.5
     parent: 0
     type: Transform
 - uid: 2692
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,34.5
     parent: 0
     type: Transform
 - uid: 2693
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,34.5
     parent: 0
     type: Transform
 - uid: 2694
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,34.5
     parent: 0
     type: Transform
 - uid: 2695
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,34.5
     parent: 0
     type: Transform
 - uid: 2696
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,34.5
     parent: 0
     type: Transform
 - uid: 2697
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,33.5
     parent: 0
@@ -36234,13 +36234,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 2760
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,35.5
     parent: 0
     type: Transform
 - uid: 2761
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,34.5
     parent: 0
@@ -36715,37 +36715,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 2822
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,49.5
     parent: 0
     type: Transform
 - uid: 2823
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,48.5
     parent: 0
     type: Transform
 - uid: 2824
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,47.5
     parent: 0
     type: Transform
 - uid: 2825
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,47.5
     parent: 0
     type: Transform
 - uid: 2826
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,47.5
     parent: 0
     type: Transform
 - uid: 2827
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,47.5
     parent: 0
@@ -36775,43 +36775,43 @@ entities:
     parent: 0
     type: Transform
 - uid: 2832
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,46.5
     parent: 0
     type: Transform
 - uid: 2833
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,47.5
     parent: 0
     type: Transform
 - uid: 2834
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,47.5
     parent: 0
     type: Transform
 - uid: 2835
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,47.5
     parent: 0
     type: Transform
 - uid: 2836
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,47.5
     parent: 0
     type: Transform
 - uid: 2837
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,48.5
     parent: 0
     type: Transform
 - uid: 2838
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,49.5
     parent: 0
@@ -37032,67 +37032,67 @@ entities:
     parent: 0
     type: Transform
 - uid: 2870
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-12.5
     parent: 0
     type: Transform
 - uid: 2871
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-11.5
     parent: 0
     type: Transform
 - uid: 2872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-10.5
     parent: 0
     type: Transform
 - uid: 2873
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-9.5
     parent: 0
     type: Transform
 - uid: 2874
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-8.5
     parent: 0
     type: Transform
 - uid: 2875
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-8.5
     parent: 0
     type: Transform
 - uid: 2876
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-8.5
     parent: 0
     type: Transform
 - uid: 2877
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-8.5
     parent: 0
     type: Transform
 - uid: 2878
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-9.5
     parent: 0
     type: Transform
 - uid: 2879
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-10.5
     parent: 0
     type: Transform
 - uid: 2880
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-11.5
     parent: 0
@@ -37152,61 +37152,61 @@ entities:
     parent: 0
     type: Transform
 - uid: 2890
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,-12.5
     parent: 0
     type: Transform
 - uid: 2891
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,-13.5
     parent: 0
     type: Transform
 - uid: 2892
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,-14.5
     parent: 0
     type: Transform
 - uid: 2893
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 65.5,-12.5
     parent: 0
     type: Transform
 - uid: 2894
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 66.5,-12.5
     parent: 0
     type: Transform
 - uid: 2895
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,-12.5
     parent: 0
     type: Transform
 - uid: 2896
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-12.5
     parent: 0
     type: Transform
 - uid: 2897
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-13.5
     parent: 0
     type: Transform
 - uid: 2898
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-14.5
     parent: 0
     type: Transform
 - uid: 2899
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-15.5
     parent: 0
@@ -37242,31 +37242,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 2905
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-17.5
     parent: 0
     type: Transform
 - uid: 2906
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-18.5
     parent: 0
     type: Transform
 - uid: 2907
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,-18.5
     parent: 0
     type: Transform
 - uid: 2908
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-18.5
     parent: 0
     type: Transform
 - uid: 2909
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 61.5,-18.5
     parent: 0
@@ -37332,7 +37332,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 2918
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: 65.52396,-13.395477
     parent: 0
@@ -37340,7 +37340,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2919
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: 65.85208,-13.442352
     parent: 0
@@ -37545,229 +37545,229 @@ entities:
       ReagentDispenser-beaker: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 2945
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-3.5
     parent: 0
     type: Transform
 - uid: 2946
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-4.5
     parent: 0
     type: Transform
 - uid: 2947
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-2.5
     parent: 0
     type: Transform
 - uid: 2948
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-1.5
     parent: 0
     type: Transform
 - uid: 2949
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-0.5
     parent: 0
     type: Transform
 - uid: 2950
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-0.5
     parent: 0
     type: Transform
 - uid: 2951
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 66.5,-0.5
     parent: 0
     type: Transform
 - uid: 2952
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,-0.5
     parent: 0
     type: Transform
 - uid: 2953
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-0.5
     parent: 0
     type: Transform
 - uid: 2954
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-1.5
     parent: 0
     type: Transform
 - uid: 2955
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-2.5
     parent: 0
     type: Transform
 - uid: 2956
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-3.5
     parent: 0
     type: Transform
 - uid: 2957
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-4.5
     parent: 0
     type: Transform
 - uid: 2958
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-5.5
     parent: 0
     type: Transform
 - uid: 2959
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-6.5
     parent: 0
     type: Transform
 - uid: 2960
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-7.5
     parent: 0
     type: Transform
 - uid: 2961
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,-7.5
     parent: 0
     type: Transform
 - uid: 2962
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-8.5
     parent: 0
     type: Transform
 - uid: 2963
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 65.5,-7.5
     parent: 0
     type: Transform
 - uid: 2964
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-8.5
     parent: 0
     type: Transform
 - uid: 2965
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-7.5
     parent: 0
     type: Transform
 - uid: 2966
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,-6.5
     parent: 0
     type: Transform
 - uid: 2967
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-7.5
     parent: 0
     type: Transform
 - uid: 2968
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-9.5
     parent: 0
     type: Transform
 - uid: 2969
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-10.5
     parent: 0
     type: Transform
 - uid: 2970
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,-11.5
     parent: 0
     type: Transform
 - uid: 2971
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-10.5
     parent: 0
     type: Transform
 - uid: 2972
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,-11.5
     parent: 0
     type: Transform
 - uid: 2973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-3.5
     parent: 0
     type: Transform
 - uid: 2974
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-2.5
     parent: 0
     type: Transform
 - uid: 2975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-2.5
     parent: 0
     type: Transform
 - uid: 2976
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-8.5
     parent: 0
     type: Transform
 - uid: 2977
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,-9.5
     parent: 0
     type: Transform
 - uid: 2978
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-9.5
     parent: 0
     type: Transform
 - uid: 2979
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-9.5
     parent: 0
     type: Transform
 - uid: 2980
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,-7.5
     parent: 0
     type: Transform
 - uid: 2981
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,-2.5
     parent: 0
     type: Transform
 - uid: 2982
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,-2.5
     parent: 0
@@ -37823,103 +37823,103 @@ entities:
     parent: 0
     type: Transform
 - uid: 2991
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,1.5
     parent: 0
     type: Transform
 - uid: 2992
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,2.5
     parent: 0
     type: Transform
 - uid: 2993
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 48.5,5.5
     parent: 0
     type: Transform
 - uid: 2994
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 47.5,5.5
     parent: 0
     type: Transform
 - uid: 2995
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 46.5,5.5
     parent: 0
     type: Transform
 - uid: 2996
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 45.5,5.5
     parent: 0
     type: Transform
 - uid: 2997
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 44.5,5.5
     parent: 0
     type: Transform
 - uid: 2998
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,5.5
     parent: 0
     type: Transform
 - uid: 2999
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,6.5
     parent: 0
     type: Transform
 - uid: 3000
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,4.5
     parent: 0
     type: Transform
 - uid: 3001
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,3.5
     parent: 0
     type: Transform
 - uid: 3002
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 43.5,2.5
     parent: 0
     type: Transform
 - uid: 3003
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,5.5
     parent: 0
     type: Transform
 - uid: 3004
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,5.5
     parent: 0
     type: Transform
 - uid: 3005
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,5.5
     parent: 0
     type: Transform
 - uid: 3006
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 51.5,5.5
     parent: 0
     type: Transform
 - uid: 3007
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,1.5
     parent: 0
@@ -37979,103 +37979,103 @@ entities:
     parent: 0
     type: Transform
 - uid: 3017
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,5.5
     parent: 0
     type: Transform
 - uid: 3018
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,5.5
     parent: 0
     type: Transform
 - uid: 3019
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,4.5
     parent: 0
     type: Transform
 - uid: 3020
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 55.5,4.5
     parent: 0
     type: Transform
 - uid: 3021
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,5.5
     parent: 0
     type: Transform
 - uid: 3022
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,4.5
     parent: 0
     type: Transform
 - uid: 3023
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 58.5,4.5
     parent: 0
     type: Transform
 - uid: 3024
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 59.5,5.5
     parent: 0
     type: Transform
 - uid: 3025
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 60.5,5.5
     parent: 0
     type: Transform
 - uid: 3026
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 61.5,5.5
     parent: 0
     type: Transform
 - uid: 3027
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 62.5,5.5
     parent: 0
     type: Transform
 - uid: 3028
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,5.5
     parent: 0
     type: Transform
 - uid: 3029
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,5.5
     parent: 0
     type: Transform
 - uid: 3030
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 65.5,5.5
     parent: 0
     type: Transform
 - uid: 3031
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 66.5,5.5
     parent: 0
     type: Transform
 - uid: 3032
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,5.5
     parent: 0
     type: Transform
 - uid: 3033
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,6.5
     parent: 0
@@ -38141,139 +38141,139 @@ entities:
     parent: 0
     type: Transform
 - uid: 3044
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,12.5
     parent: 0
     type: Transform
 - uid: 3045
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,11.5
     parent: 0
     type: Transform
 - uid: 3046
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,10.5
     parent: 0
     type: Transform
 - uid: 3047
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,9.5
     parent: 0
     type: Transform
 - uid: 3048
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,8.5
     parent: 0
     type: Transform
 - uid: 3049
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,8.5
     parent: 0
     type: Transform
 - uid: 3050
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,8.5
     parent: 0
     type: Transform
 - uid: 3051
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,8.5
     parent: 0
     type: Transform
 - uid: 3052
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,8.5
     parent: 0
     type: Transform
 - uid: 3053
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,8.5
     parent: 0
     type: Transform
 - uid: 3054
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,7.5
     parent: 0
     type: Transform
 - uid: 3055
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,7.5
     parent: 0
     type: Transform
 - uid: 3056
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,7.5
     parent: 0
     type: Transform
 - uid: 3057
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,7.5
     parent: 0
     type: Transform
 - uid: 3058
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,7.5
     parent: 0
     type: Transform
 - uid: 3059
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,7.5
     parent: 0
     type: Transform
 - uid: 3060
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,7.5
     parent: 0
     type: Transform
 - uid: 3061
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,7.5
     parent: 0
     type: Transform
 - uid: 3062
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,8.5
     parent: 0
     type: Transform
 - uid: 3063
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,9.5
     parent: 0
     type: Transform
 - uid: 3064
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,10.5
     parent: 0
     type: Transform
 - uid: 3065
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,11.5
     parent: 0
     type: Transform
 - uid: 3066
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,12.5
     parent: 0
@@ -38291,121 +38291,121 @@ entities:
     parent: 0
     type: Transform
 - uid: 3069
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,13.5
     parent: 0
     type: Transform
 - uid: 3070
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,12.5
     parent: 0
     type: Transform
 - uid: 3071
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,15.5
     parent: 0
     type: Transform
 - uid: 3072
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,16.5
     parent: 0
     type: Transform
 - uid: 3073
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 46.5,20.5
     parent: 0
     type: Transform
 - uid: 3074
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,20.5
     parent: 0
     type: Transform
 - uid: 3075
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,16.5
     parent: 0
     type: Transform
 - uid: 3076
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,16.5
     parent: 0
     type: Transform
 - uid: 3077
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 51.5,16.5
     parent: 0
     type: Transform
 - uid: 3078
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,16.5
     parent: 0
     type: Transform
 - uid: 3079
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,15.5
     parent: 0
     type: Transform
 - uid: 3080
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,13.5
     parent: 0
     type: Transform
 - uid: 3081
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 52.5,12.5
     parent: 0
     type: Transform
 - uid: 3082
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 51.5,12.5
     parent: 0
     type: Transform
 - uid: 3083
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 50.5,12.5
     parent: 0
     type: Transform
 - uid: 3084
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 49.5,12.5
     parent: 0
     type: Transform
 - uid: 3085
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,39.5
     parent: 0
     type: Transform
 - uid: 3086
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,40.5
     parent: 0
     type: Transform
 - uid: 3087
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,40.5
     parent: 0
     type: Transform
 - uid: 3088
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,39.5
     parent: 0
@@ -38435,91 +38435,91 @@ entities:
     parent: 0
     type: Transform
 - uid: 3093
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,43.5
     parent: 0
     type: Transform
 - uid: 3094
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,43.5
     parent: 0
     type: Transform
 - uid: 3095
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,43.5
     parent: 0
     type: Transform
 - uid: 3096
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,43.5
     parent: 0
     type: Transform
 - uid: 3097
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,44.5
     parent: 0
     type: Transform
 - uid: 3098
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,45.5
     parent: 0
     type: Transform
 - uid: 3099
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,46.5
     parent: 0
     type: Transform
 - uid: 3100
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,47.5
     parent: 0
     type: Transform
 - uid: 3101
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,45.5
     parent: 0
     type: Transform
 - uid: 3102
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,44.5
     parent: 0
     type: Transform
 - uid: 3103
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,43.5
     parent: 0
     type: Transform
 - uid: 3104
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,43.5
     parent: 0
     type: Transform
 - uid: 3105
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,42.5
     parent: 0
     type: Transform
 - uid: 3106
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,41.5
     parent: 0
     type: Transform
 - uid: 3107
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,40.5
     parent: 0
@@ -38759,7 +38759,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3147
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,45.5
     parent: 0
@@ -38885,325 +38885,325 @@ entities:
     parent: 0
     type: Transform
 - uid: 3168
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,36.5
     parent: 0
     type: Transform
 - uid: 3169
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,34.5
     parent: 0
     type: Transform
 - uid: 3170
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,35.5
     parent: 0
     type: Transform
 - uid: 3171
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,33.5
     parent: 0
     type: Transform
 - uid: 3172
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,32.5
     parent: 0
     type: Transform
 - uid: 3173
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,31.5
     parent: 0
     type: Transform
 - uid: 3174
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,30.5
     parent: 0
     type: Transform
 - uid: 3175
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,29.5
     parent: 0
     type: Transform
 - uid: 3176
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,28.5
     parent: 0
     type: Transform
 - uid: 3177
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,28.5
     parent: 0
     type: Transform
 - uid: 3178
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,28.5
     parent: 0
     type: Transform
 - uid: 3179
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,28.5
     parent: 0
     type: Transform
 - uid: 3180
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,28.5
     parent: 0
     type: Transform
 - uid: 3181
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,29.5
     parent: 0
     type: Transform
 - uid: 3182
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,30.5
     parent: 0
     type: Transform
 - uid: 3183
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,31.5
     parent: 0
     type: Transform
 - uid: 3184
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,32.5
     parent: 0
     type: Transform
 - uid: 3185
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,33.5
     parent: 0
     type: Transform
 - uid: 3186
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,34.5
     parent: 0
     type: Transform
 - uid: 3187
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,35.5
     parent: 0
     type: Transform
 - uid: 3188
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,36.5
     parent: 0
     type: Transform
 - uid: 3189
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,37.5
     parent: 0
     type: Transform
 - uid: 3190
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,38.5
     parent: 0
     type: Transform
 - uid: 3191
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,37.5
     parent: 0
     type: Transform
 - uid: 3192
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,38.5
     parent: 0
     type: Transform
 - uid: 3193
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,39.5
     parent: 0
     type: Transform
 - uid: 3194
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,39.5
     parent: 0
     type: Transform
 - uid: 3195
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,38.5
     parent: 0
     type: Transform
 - uid: 3196
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,39.5
     parent: 0
     type: Transform
 - uid: 3197
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,40.5
     parent: 0
     type: Transform
 - uid: 3198
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,40.5
     parent: 0
     type: Transform
 - uid: 3199
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,39.5
     parent: 0
     type: Transform
 - uid: 3200
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,39.5
     parent: 0
     type: Transform
 - uid: 3201
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,40.5
     parent: 0
     type: Transform
 - uid: 3202
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,40.5
     parent: 0
     type: Transform
 - uid: 3203
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,39.5
     parent: 0
     type: Transform
 - uid: 3204
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,39.5
     parent: 0
     type: Transform
 - uid: 3205
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,40.5
     parent: 0
     type: Transform
 - uid: 3206
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,39.5
     parent: 0
     type: Transform
 - uid: 3207
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,39.5
     parent: 0
     type: Transform
 - uid: 3208
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,38.5
     parent: 0
     type: Transform
 - uid: 3209
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,38.5
     parent: 0
     type: Transform
 - uid: 3210
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,37.5
     parent: 0
     type: Transform
 - uid: 3211
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,38.5
     parent: 0
     type: Transform
 - uid: 3212
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,37.5
     parent: 0
     type: Transform
 - uid: 3213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,35.5
     parent: 0
     type: Transform
 - uid: 3214
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,34.5
     parent: 0
     type: Transform
 - uid: 3215
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,36.5
     parent: 0
     type: Transform
 - uid: 3216
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,33.5
     parent: 0
     type: Transform
 - uid: 3217
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,32.5
     parent: 0
     type: Transform
 - uid: 3218
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,31.5
     parent: 0
     type: Transform
 - uid: 3219
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,30.5
     parent: 0
     type: Transform
 - uid: 3220
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,29.5
     parent: 0
     type: Transform
 - uid: 3221
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,28.5
     parent: 0
@@ -39219,7 +39219,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3223
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,29.5
     parent: 0
@@ -39235,37 +39235,37 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3225
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,36.5
     parent: 0
     type: Transform
 - uid: 3226
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,37.5
     parent: 0
     type: Transform
 - uid: 3227
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,37.5
     parent: 0
     type: Transform
 - uid: 3228
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 55.5,37.5
     parent: 0
     type: Transform
 - uid: 3229
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 55.5,35.5
     parent: 0
     type: Transform
 - uid: 3230
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,35.5
     parent: 0
@@ -39307,49 +39307,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 3237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,32.5
     parent: 0
     type: Transform
 - uid: 3238
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,32.5
     parent: 0
     type: Transform
 - uid: 3239
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,32.5
     parent: 0
     type: Transform
 - uid: 3240
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,32.5
     parent: 0
     type: Transform
 - uid: 3241
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,32.5
     parent: 0
     type: Transform
 - uid: 3242
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,32.5
     parent: 0
     type: Transform
 - uid: 3243
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,32.5
     parent: 0
     type: Transform
 - uid: 3244
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,32.5
     parent: 0
@@ -39541,55 +39541,55 @@ entities:
     parent: 0
     type: Transform
 - uid: 3276
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,28.5
     parent: 0
     type: Transform
 - uid: 3277
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,28.5
     parent: 0
     type: Transform
 - uid: 3278
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,28.5
     parent: 0
     type: Transform
 - uid: 3279
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,28.5
     parent: 0
     type: Transform
 - uid: 3280
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,28.5
     parent: 0
     type: Transform
 - uid: 3281
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,28.5
     parent: 0
     type: Transform
 - uid: 3282
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,28.5
     parent: 0
     type: Transform
 - uid: 3283
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,28.5
     parent: 0
     type: Transform
 - uid: 3284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,29.5
     parent: 0
@@ -39605,7 +39605,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3286
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,45.5
     parent: 0
@@ -39617,109 +39617,109 @@ entities:
     parent: 0
     type: Transform
 - uid: 3288
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,45.5
     parent: 0
     type: Transform
 - uid: 3289
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,45.5
     parent: 0
     type: Transform
 - uid: 3290
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,45.5
     parent: 0
     type: Transform
 - uid: 3291
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,44.5
     parent: 0
     type: Transform
 - uid: 3292
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,43.5
     parent: 0
     type: Transform
 - uid: 3293
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,30.5
     parent: 0
     type: Transform
 - uid: 3294
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,31.5
     parent: 0
     type: Transform
 - uid: 3295
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,32.5
     parent: 0
     type: Transform
 - uid: 3296
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,33.5
     parent: 0
     type: Transform
 - uid: 3297
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,34.5
     parent: 0
     type: Transform
 - uid: 3298
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,35.5
     parent: 0
     type: Transform
 - uid: 3299
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,36.5
     parent: 0
     type: Transform
 - uid: 3300
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,37.5
     parent: 0
     type: Transform
 - uid: 3301
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,38.5
     parent: 0
     type: Transform
 - uid: 3302
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,39.5
     parent: 0
     type: Transform
 - uid: 3303
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,40.5
     parent: 0
     type: Transform
 - uid: 3304
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,41.5
     parent: 0
     type: Transform
 - uid: 3305
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,42.5
     parent: 0
@@ -39911,13 +39911,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3337
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,49.5
     parent: 0
     type: Transform
 - uid: 3338
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,49.5
     parent: 0
@@ -39929,13 +39929,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3340
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,50.5
     parent: 0
     type: Transform
 - uid: 3341
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,50.5
     parent: 0
@@ -39947,13 +39947,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3343
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,51.5
     parent: 0
     type: Transform
 - uid: 3344
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,51.5
     parent: 0
@@ -40133,73 +40133,73 @@ entities:
     parent: 0
     type: Transform
 - uid: 3374
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,47.5
     parent: 0
     type: Transform
 - uid: 3375
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,47.5
     parent: 0
     type: Transform
 - uid: 3376
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,47.5
     parent: 0
     type: Transform
 - uid: 3377
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,47.5
     parent: 0
     type: Transform
 - uid: 3378
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,46.5
     parent: 0
     type: Transform
 - uid: 3379
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,45.5
     parent: 0
     type: Transform
 - uid: 3380
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,44.5
     parent: 0
     type: Transform
 - uid: 3381
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,43.5
     parent: 0
     type: Transform
 - uid: 3382
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,41.5
     parent: 0
     type: Transform
 - uid: 3383
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,41.5
     parent: 0
     type: Transform
 - uid: 3384
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,41.5
     parent: 0
     type: Transform
 - uid: 3385
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,42.5
     parent: 0
@@ -40241,97 +40241,97 @@ entities:
     parent: 0
     type: Transform
 - uid: 3392
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,43.5
     parent: 0
     type: Transform
 - uid: 3393
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,43.5
     parent: 0
     type: Transform
 - uid: 3394
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,43.5
     parent: 0
     type: Transform
 - uid: 3395
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,35.5
     parent: 0
     type: Transform
 - uid: 3396
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,35.5
     parent: 0
     type: Transform
 - uid: 3397
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,36.5
     parent: 0
     type: Transform
 - uid: 3398
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,38.5
     parent: 0
     type: Transform
 - uid: 3399
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,37.5
     parent: 0
     type: Transform
 - uid: 3400
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,39.5
     parent: 0
     type: Transform
 - uid: 3401
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,40.5
     parent: 0
     type: Transform
 - uid: 3402
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,40.5
     parent: 0
     type: Transform
 - uid: 3403
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,41.5
     parent: 0
     type: Transform
 - uid: 3404
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,41.5
     parent: 0
     type: Transform
 - uid: 3405
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,35.5
     parent: 0
     type: Transform
 - uid: 3406
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,35.5
     parent: 0
     type: Transform
 - uid: 3407
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,35.5
     parent: 0
@@ -40347,13 +40347,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3409
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,37.5
     parent: 0
     type: Transform
 - uid: 3410
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,38.5
     parent: 0
@@ -40401,7 +40401,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3418
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 66.5,45.5
     parent: 0
@@ -40545,187 +40545,187 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3436
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,31.5
     parent: 0
     type: Transform
 - uid: 3437
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,30.5
     parent: 0
     type: Transform
 - uid: 3438
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,30.5
     parent: 0
     type: Transform
 - uid: 3439
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,22.5
     parent: 0
     type: Transform
 - uid: 3440
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,22.5
     parent: 0
     type: Transform
 - uid: 3441
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,22.5
     parent: 0
     type: Transform
 - uid: 3442
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,21.5
     parent: 0
     type: Transform
 - uid: 3443
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,20.5
     parent: 0
     type: Transform
 - uid: 3444
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,19.5
     parent: 0
     type: Transform
 - uid: 3445
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,19.5
     parent: 0
     type: Transform
 - uid: 3446
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,19.5
     parent: 0
     type: Transform
 - uid: 3447
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,19.5
     parent: 0
     type: Transform
 - uid: 3448
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,19.5
     parent: 0
     type: Transform
 - uid: 3449
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,19.5
     parent: 0
     type: Transform
 - uid: 3450
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,20.5
     parent: 0
     type: Transform
 - uid: 3451
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,21.5
     parent: 0
     type: Transform
 - uid: 3452
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,22.5
     parent: 0
     type: Transform
 - uid: 3453
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,22.5
     parent: 0
     type: Transform
 - uid: 3454
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,23.5
     parent: 0
     type: Transform
 - uid: 3455
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,24.5
     parent: 0
     type: Transform
 - uid: 3456
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,24.5
     parent: 0
     type: Transform
 - uid: 3457
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,24.5
     parent: 0
     type: Transform
 - uid: 3458
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,24.5
     parent: 0
     type: Transform
 - uid: 3459
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,24.5
     parent: 0
     type: Transform
 - uid: 3460
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,24.5
     parent: 0
     type: Transform
 - uid: 3461
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,25.5
     parent: 0
     type: Transform
 - uid: 3462
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,26.5
     parent: 0
     type: Transform
 - uid: 3463
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,27.5
     parent: 0
     type: Transform
 - uid: 3464
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,29.5
     parent: 0
     type: Transform
 - uid: 3465
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,33.5
     parent: 0
     type: Transform
 - uid: 3466
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 68.5,34.5
     parent: 0
@@ -40769,43 +40769,43 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3471
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,28.5
     parent: 0
     type: Transform
 - uid: 3472
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,27.5
     parent: 0
     type: Transform
 - uid: 3473
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,26.5
     parent: 0
     type: Transform
 - uid: 3474
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,25.5
     parent: 0
     type: Transform
 - uid: 3475
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,27.5
     parent: 0
     type: Transform
 - uid: 3476
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,26.5
     parent: 0
     type: Transform
 - uid: 3477
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,25.5
     parent: 0
@@ -40847,85 +40847,85 @@ entities:
     parent: 0
     type: Transform
 - uid: 3484
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,22.5
     parent: 0
     type: Transform
 - uid: 3485
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,21.5
     parent: 0
     type: Transform
 - uid: 3486
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,21.5
     parent: 0
     type: Transform
 - uid: 3487
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,21.5
     parent: 0
     type: Transform
 - uid: 3488
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,21.5
     parent: 0
     type: Transform
 - uid: 3489
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,21.5
     parent: 0
     type: Transform
 - uid: 3490
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,22.5
     parent: 0
     type: Transform
 - uid: 3491
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,23.5
     parent: 0
     type: Transform
 - uid: 3492
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,20.5
     parent: 0
     type: Transform
 - uid: 3493
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,19.5
     parent: 0
     type: Transform
 - uid: 3494
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,18.5
     parent: 0
     type: Transform
 - uid: 3495
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,17.5
     parent: 0
     type: Transform
 - uid: 3496
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,26.5
     parent: 0
     type: Transform
 - uid: 3497
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,26.5
     parent: 0
@@ -40961,25 +40961,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 3503
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,26.5
     parent: 0
     type: Transform
 - uid: 3504
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,26.5
     parent: 0
     type: Transform
 - uid: 3505
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,22.5
     parent: 0
     type: Transform
 - uid: 3506
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,22.5
     parent: 0
@@ -40995,19 +40995,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3508
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,23.5
     parent: 0
     type: Transform
 - uid: 3509
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,25.5
     parent: 0
     type: Transform
 - uid: 3510
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,26.5
     parent: 0
@@ -41029,13 +41029,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3513
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,22.5
     parent: 0
     type: Transform
 - uid: 3514
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,22.5
     parent: 0
@@ -41047,7 +41047,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3516
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,27.5
     parent: 0
@@ -41071,7 +41071,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3520
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,26.5
     parent: 0
@@ -41113,37 +41113,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 3527
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,22.5
     parent: 0
     type: Transform
 - uid: 3528
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,23.5
     parent: 0
     type: Transform
 - uid: 3529
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,24.5
     parent: 0
     type: Transform
 - uid: 3530
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,25.5
     parent: 0
     type: Transform
 - uid: 3531
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,26.5
     parent: 0
     type: Transform
 - uid: 3532
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,26.5
     parent: 0
@@ -41172,37 +41172,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 3536
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,21.5
     parent: 0
     type: Transform
 - uid: 3537
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,22.5
     parent: 0
     type: Transform
 - uid: 3538
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,21.5
     parent: 0
     type: Transform
 - uid: 3539
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,21.5
     parent: 0
     type: Transform
 - uid: 3540
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,21.5
     parent: 0
     type: Transform
 - uid: 3541
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,21.5
     parent: 0
@@ -41226,37 +41226,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 3545
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 57.5,16.5
     parent: 0
     type: Transform
 - uid: 3546
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 56.5,16.5
     parent: 0
     type: Transform
 - uid: 3547
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 55.5,16.5
     parent: 0
     type: Transform
 - uid: 3548
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 54.5,16.5
     parent: 0
     type: Transform
 - uid: 3549
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 53.5,16.5
     parent: 0
     type: Transform
 - uid: 3550
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,16.5
     parent: 0
@@ -41304,43 +41304,43 @@ entities:
     parent: 0
     type: Transform
 - uid: 3558
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 74.5,19.5
     parent: 0
     type: Transform
 - uid: 3559
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,19.5
     parent: 0
     type: Transform
 - uid: 3560
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,18.5
     parent: 0
     type: Transform
 - uid: 3561
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,14.5
     parent: 0
     type: Transform
 - uid: 3562
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,13.5
     parent: 0
     type: Transform
 - uid: 3563
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,13.5
     parent: 0
     type: Transform
 - uid: 3564
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 81.5,13.5
     parent: 0
@@ -41360,13 +41360,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3567
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-5.5
     parent: 0
     type: Transform
 - uid: 3568
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-4.5
     parent: 0
@@ -41378,19 +41378,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3570
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-3.5
     parent: 0
     type: Transform
 - uid: 3571
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-2.5
     parent: 0
     type: Transform
 - uid: 3572
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-1.5
     parent: 0
@@ -41406,13 +41406,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3574
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 88.5,-1.5
     parent: 0
     type: Transform
 - uid: 3575
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,2.5
     parent: 0
@@ -41426,85 +41426,85 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3577
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-1.5
     parent: 0
     type: Transform
 - uid: 3578
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-0.5
     parent: 0
     type: Transform
 - uid: 3579
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,6.5
     parent: 0
     type: Transform
 - uid: 3580
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,6.5
     parent: 0
     type: Transform
 - uid: 3581
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,2.5
     parent: 0
     type: Transform
 - uid: 3582
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,2.5
     parent: 0
     type: Transform
 - uid: 3583
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,2.5
     parent: 0
     type: Transform
 - uid: 3584
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,3.5
     parent: 0
     type: Transform
 - uid: 3585
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,5.5
     parent: 0
     type: Transform
 - uid: 3586
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,6.5
     parent: 0
     type: Transform
 - uid: 3587
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,6.5
     parent: 0
     type: Transform
 - uid: 3588
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 89.5,6.5
     parent: 0
     type: Transform
 - uid: 3589
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,10.5
     parent: 0
     type: Transform
 - uid: 3590
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,9.5
     parent: 0
@@ -41516,115 +41516,115 @@ entities:
     parent: 0
     type: Transform
 - uid: 3592
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,3.5
     parent: 0
     type: Transform
 - uid: 3593
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 78.5,11.5
     parent: 0
     type: Transform
 - uid: 3594
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 77.5,11.5
     parent: 0
     type: Transform
 - uid: 3595
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,8.5
     parent: 0
     type: Transform
 - uid: 3596
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,7.5
     parent: 0
     type: Transform
 - uid: 3597
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,9.5
     parent: 0
     type: Transform
 - uid: 3598
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,9.5
     parent: 0
     type: Transform
 - uid: 3599
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 74.5,9.5
     parent: 0
     type: Transform
 - uid: 3600
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,9.5
     parent: 0
     type: Transform
 - uid: 3601
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,9.5
     parent: 0
     type: Transform
 - uid: 3602
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 71.5,9.5
     parent: 0
     type: Transform
 - uid: 3603
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 83.5,9.5
     parent: 0
     type: Transform
 - uid: 3604
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,12.5
     parent: 0
     type: Transform
 - uid: 3605
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,11.5
     parent: 0
     type: Transform
 - uid: 3606
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,9.5
     parent: 0
     type: Transform
 - uid: 3607
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,6.5
     parent: 0
     type: Transform
 - uid: 3608
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,11.5
     parent: 0
     type: Transform
 - uid: 3609
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,11.5
     parent: 0
     type: Transform
 - uid: 3610
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 89.5,2.5
     parent: 0
@@ -41636,19 +41636,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3612
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,13.5
     parent: 0
     type: Transform
 - uid: 3613
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,13.5
     parent: 0
     type: Transform
 - uid: 3614
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,13.5
     parent: 0
@@ -41686,61 +41686,61 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3619
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,7.5
     parent: 0
     type: Transform
 - uid: 3620
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,2.5
     parent: 0
     type: Transform
 - uid: 3621
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 83.5,6.5
     parent: 0
     type: Transform
 - uid: 3622
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,13.5
     parent: 0
     type: Transform
 - uid: 3623
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,12.5
     parent: 0
     type: Transform
 - uid: 3624
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,11.5
     parent: 0
     type: Transform
 - uid: 3625
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,10.5
     parent: 0
     type: Transform
 - uid: 3626
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,9.5
     parent: 0
     type: Transform
 - uid: 3627
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,9.5
     parent: 0
     type: Transform
 - uid: 3628
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,8.5
     parent: 0
@@ -41752,19 +41752,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3630
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,13.5
     parent: 0
     type: Transform
 - uid: 3631
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,13.5
     parent: 0
     type: Transform
 - uid: 3632
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 84.5,9.5
     parent: 0
@@ -41794,25 +41794,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 3637
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,3.5
     parent: 0
     type: Transform
 - uid: 3638
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,3.5
     parent: 0
     type: Transform
 - uid: 3639
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 67.5,7.5
     parent: 0
     type: Transform
 - uid: 3640
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,7.5
     parent: 0
@@ -41860,163 +41860,163 @@ entities:
     parent: 0
     type: Transform
 - uid: 3648
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,3.5
     parent: 0
     type: Transform
 - uid: 3649
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,2.5
     parent: 0
     type: Transform
 - uid: 3650
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,1.5
     parent: 0
     type: Transform
 - uid: 3651
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,0.5
     parent: 0
     type: Transform
 - uid: 3652
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,-1.5
     parent: 0
     type: Transform
 - uid: 3653
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,-0.5
     parent: 0
     type: Transform
 - uid: 3654
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,-2.5
     parent: 0
     type: Transform
 - uid: 3655
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-2.5
     parent: 0
     type: Transform
 - uid: 3656
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-8.5
     parent: 0
     type: Transform
 - uid: 3657
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,12.5
     parent: 0
     type: Transform
 - uid: 3658
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,12.5
     parent: 0
     type: Transform
 - uid: 3659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,12.5
     parent: 0
     type: Transform
 - uid: 3660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,12.5
     parent: 0
     type: Transform
 - uid: 3661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,13.5
     parent: 0
     type: Transform
 - uid: 3662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,14.5
     parent: 0
     type: Transform
 - uid: 3663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,15.5
     parent: 0
     type: Transform
 - uid: 3664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,16.5
     parent: 0
     type: Transform
 - uid: 3665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,17.5
     parent: 0
     type: Transform
 - uid: 3666
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,17.5
     parent: 0
     type: Transform
 - uid: 3667
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,17.5
     parent: 0
     type: Transform
 - uid: 3668
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,17.5
     parent: 0
     type: Transform
 - uid: 3669
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,17.5
     parent: 0
     type: Transform
 - uid: 3670
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,12.5
     parent: 0
     type: Transform
 - uid: 3671
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 67.5,12.5
     parent: 0
     type: Transform
 - uid: 3672
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 67.5,17.5
     parent: 0
     type: Transform
 - uid: 3673
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 66.5,17.5
     parent: 0
     type: Transform
 - uid: 3674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,17.5
     parent: 0
@@ -42034,139 +42034,139 @@ entities:
     parent: 0
     type: Transform
 - uid: 3677
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 65.5,13.5
     parent: 0
     type: Transform
 - uid: 3678
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 66.5,12.5
     parent: 0
     type: Transform
 - uid: 3679
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,12.5
     parent: 0
     type: Transform
 - uid: 3680
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,17.5
     parent: 0
     type: Transform
 - uid: 3681
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,17.5
     parent: 0
     type: Transform
 - uid: 3682
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,17.5
     parent: 0
     type: Transform
 - uid: 3683
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,7.5
     parent: 0
     type: Transform
 - uid: 3684
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,7.5
     parent: 0
     type: Transform
 - uid: 3685
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,8.5
     parent: 0
     type: Transform
 - uid: 3686
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,9.5
     parent: 0
     type: Transform
 - uid: 3687
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,10.5
     parent: 0
     type: Transform
 - uid: 3688
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,11.5
     parent: 0
     type: Transform
 - uid: 3689
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 59.5,12.5
     parent: 0
     type: Transform
 - uid: 3690
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 64.5,12.5
     parent: 0
     type: Transform
 - uid: 3691
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,11.5
     parent: 0
     type: Transform
 - uid: 3692
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,10.5
     parent: 0
     type: Transform
 - uid: 3693
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,9.5
     parent: 0
     type: Transform
 - uid: 3694
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,8.5
     parent: 0
     type: Transform
 - uid: 3695
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,7.5
     parent: 0
     type: Transform
 - uid: 3696
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,7.5
     parent: 0
     type: Transform
 - uid: 3697
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,7.5
     parent: 0
     type: Transform
 - uid: 3698
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,7.5
     parent: 0
     type: Transform
 - uid: 3699
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,7.5
     parent: 0
@@ -42190,19 +42190,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3703
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,8.5
     parent: 0
     type: Transform
 - uid: 3704
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,9.5
     parent: 0
     type: Transform
 - uid: 3705
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,4.5
     parent: 0
@@ -42248,7 +42248,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3712
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,3.5
     parent: 0
@@ -42278,61 +42278,61 @@ entities:
     parent: 0
     type: Transform
 - uid: 3717
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,3.5
     parent: 0
     type: Transform
 - uid: 3718
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 77.5,3.5
     parent: 0
     type: Transform
 - uid: 3719
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,3.5
     parent: 0
     type: Transform
 - uid: 3720
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 82.5,6.5
     parent: 0
     type: Transform
 - uid: 3721
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,4.5
     parent: 0
     type: Transform
 - uid: 3722
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,5.5
     parent: 0
     type: Transform
 - uid: 3723
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,6.5
     parent: 0
     type: Transform
 - uid: 3724
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,8.5
     parent: 0
     type: Transform
 - uid: 3725
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,7.5
     parent: 0
     type: Transform
 - uid: 3726
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,10.5
     parent: 0
@@ -42376,67 +42376,67 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3732
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-7.5
     parent: 0
     type: Transform
 - uid: 3733
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-8.5
     parent: 0
     type: Transform
 - uid: 3734
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-9.5
     parent: 0
     type: Transform
 - uid: 3735
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-10.5
     parent: 0
     type: Transform
 - uid: 3736
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-11.5
     parent: 0
     type: Transform
 - uid: 3737
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-11.5
     parent: 0
     type: Transform
 - uid: 3738
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 89.5,-11.5
     parent: 0
     type: Transform
 - uid: 3739
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-11.5
     parent: 0
     type: Transform
 - uid: 3740
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-9.5
     parent: 0
     type: Transform
 - uid: 3741
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-8.5
     parent: 0
     type: Transform
 - uid: 3742
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-7.5
     parent: 0
@@ -42470,85 +42470,85 @@ entities:
       PaperLabel: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 3745
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-3.5
     parent: 0
     type: Transform
 - uid: 3746
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-4.5
     parent: 0
     type: Transform
 - uid: 3747
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-7.5
     parent: 0
     type: Transform
 - uid: 3748
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-5.5
     parent: 0
     type: Transform
 - uid: 3749
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-6.5
     parent: 0
     type: Transform
 - uid: 3750
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-6.5
     parent: 0
     type: Transform
 - uid: 3751
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,-6.5
     parent: 0
     type: Transform
 - uid: 3752
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,-4.5
     parent: 0
     type: Transform
 - uid: 3753
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,-5.5
     parent: 0
     type: Transform
 - uid: 3754
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 84.5,-4.5
     parent: 0
     type: Transform
 - uid: 3755
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 86.5,-1.5
     parent: 0
     type: Transform
 - uid: 3756
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 86.5,-0.5
     parent: 0
     type: Transform
 - uid: 3757
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 86.5,0.5
     parent: 0
     type: Transform
 - uid: 3758
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,0.5
     parent: 0
@@ -42564,187 +42564,187 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3760
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-7.5
     parent: 0
     type: Transform
 - uid: 3761
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-8.5
     parent: 0
     type: Transform
 - uid: 3762
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-9.5
     parent: 0
     type: Transform
 - uid: 3763
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-10.5
     parent: 0
     type: Transform
 - uid: 3764
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-11.5
     parent: 0
     type: Transform
 - uid: 3765
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,-12.5
     parent: 0
     type: Transform
 - uid: 3766
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 85.5,-13.5
     parent: 0
     type: Transform
 - uid: 3767
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 81.5,0.5
     parent: 0
     type: Transform
 - uid: 3768
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 80.5,0.5
     parent: 0
     type: Transform
 - uid: 3769
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,0.5
     parent: 0
     type: Transform
 - uid: 3770
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,-0.5
     parent: 0
     type: Transform
 - uid: 3771
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,-1.5
     parent: 0
     type: Transform
 - uid: 3772
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,-2.5
     parent: 0
     type: Transform
 - uid: 3773
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,-2.5
     parent: 0
     type: Transform
 - uid: 3774
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,-8.5
     parent: 0
     type: Transform
 - uid: 3775
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,-9.5
     parent: 0
     type: Transform
 - uid: 3776
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 77.5,-9.5
     parent: 0
     type: Transform
 - uid: 3777
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-9.5
     parent: 0
     type: Transform
 - uid: 3778
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-9.5
     parent: 0
     type: Transform
 - uid: 3779
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-8.5
     parent: 0
     type: Transform
 - uid: 3780
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-7.5
     parent: 0
     type: Transform
 - uid: 3781
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-6.5
     parent: 0
     type: Transform
 - uid: 3782
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-5.5
     parent: 0
     type: Transform
 - uid: 3783
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-4.5
     parent: 0
     type: Transform
 - uid: 3784
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-3.5
     parent: 0
     type: Transform
 - uid: 3785
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-2.5
     parent: 0
     type: Transform
 - uid: 3786
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-2.5
     parent: 0
     type: Transform
 - uid: 3787
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-1.5
     parent: 0
     type: Transform
 - uid: 3788
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-0.5
     parent: 0
     type: Transform
 - uid: 3789
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,0.5
     parent: 0
     type: Transform
 - uid: 3790
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,0.5
     parent: 0
@@ -42774,187 +42774,187 @@ entities:
     parent: 0
     type: Transform
 - uid: 3795
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,0.5
     parent: 0
     type: Transform
 - uid: 3796
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 74.5,0.5
     parent: 0
     type: Transform
 - uid: 3797
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,0.5
     parent: 0
     type: Transform
 - uid: 3798
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 74.5,-4.5
     parent: 0
     type: Transform
 - uid: 3799
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 71.5,0.5
     parent: 0
     type: Transform
 - uid: 3800
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,0.5
     parent: 0
     type: Transform
 - uid: 3801
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,-0.5
     parent: 0
     type: Transform
 - uid: 3802
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,-0.5
     parent: 0
     type: Transform
 - uid: 3803
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-4.5
     parent: 0
     type: Transform
 - uid: 3804
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-4.5
     parent: 0
     type: Transform
 - uid: 3805
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,-4.5
     parent: 0
     type: Transform
 - uid: 3806
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,-4.5
     parent: 0
     type: Transform
 - uid: 3807
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 74.5,-7.5
     parent: 0
     type: Transform
 - uid: 3808
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-7.5
     parent: 0
     type: Transform
 - uid: 3809
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,-6.5
     parent: 0
     type: Transform
 - uid: 3810
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,-5.5
     parent: 0
     type: Transform
 - uid: 3811
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-8.5
     parent: 0
     type: Transform
 - uid: 3812
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-9.5
     parent: 0
     type: Transform
 - uid: 3813
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-10.5
     parent: 0
     type: Transform
 - uid: 3814
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 73.5,-11.5
     parent: 0
     type: Transform
 - uid: 3815
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 74.5,-11.5
     parent: 0
     type: Transform
 - uid: 3816
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 75.5,-11.5
     parent: 0
     type: Transform
 - uid: 3817
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 77.5,-11.5
     parent: 0
     type: Transform
 - uid: 3818
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 76.5,-11.5
     parent: 0
     type: Transform
 - uid: 3819
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 78.5,-11.5
     parent: 0
     type: Transform
 - uid: 3820
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 79.5,-11.5
     parent: 0
     type: Transform
 - uid: 3821
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 80.5,-11.5
     parent: 0
     type: Transform
 - uid: 3822
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 81.5,-11.5
     parent: 0
     type: Transform
 - uid: 3823
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 82.5,-11.5
     parent: 0
     type: Transform
 - uid: 3824
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 83.5,-11.5
     parent: 0
     type: Transform
 - uid: 3825
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,-11.5
     parent: 0
@@ -42990,163 +42990,163 @@ entities:
     parent: 0
     type: Transform
 - uid: 3831
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 78.5,-12.5
     parent: 0
     type: Transform
 - uid: 3832
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 78.5,-13.5
     parent: 0
     type: Transform
 - uid: 3833
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 78.5,-14.5
     parent: 0
     type: Transform
 - uid: 3834
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 77.5,-14.5
     parent: 0
     type: Transform
 - uid: 3835
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 76.5,-14.5
     parent: 0
     type: Transform
 - uid: 3836
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,-14.5
     parent: 0
     type: Transform
 - uid: 3837
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,-13.5
     parent: 0
     type: Transform
 - uid: 3838
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 75.5,-12.5
     parent: 0
     type: Transform
 - uid: 3839
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 73.5,-14.5
     parent: 0
     type: Transform
 - uid: 3840
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-14.5
     parent: 0
     type: Transform
 - uid: 3841
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-13.5
     parent: 0
     type: Transform
 - uid: 3842
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-12.5
     parent: 0
     type: Transform
 - uid: 3843
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 72.5,-11.5
     parent: 0
     type: Transform
 - uid: 3844
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,-14.5
     parent: 0
     type: Transform
 - uid: 3845
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,-14.5
     parent: 0
     type: Transform
 - uid: 3846
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 84.5,-13.5
     parent: 0
     type: Transform
 - uid: 3847
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 84.5,-14.5
     parent: 0
     type: Transform
 - uid: 3848
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 83.5,-14.5
     parent: 0
     type: Transform
 - uid: 3849
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 81.5,-14.5
     parent: 0
     type: Transform
 - uid: 3850
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 80.5,-14.5
     parent: 0
     type: Transform
 - uid: 3851
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 79.5,-14.5
     parent: 0
     type: Transform
 - uid: 3852
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-12.5
     parent: 0
     type: Transform
 - uid: 3853
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-13.5
     parent: 0
     type: Transform
 - uid: 3854
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 89.5,-13.5
     parent: 0
     type: Transform
 - uid: 3855
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 88.5,-13.5
     parent: 0
     type: Transform
 - uid: 3856
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 88.5,-12.5
     parent: 0
     type: Transform
 - uid: 3857
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 87.5,-13.5
     parent: 0
@@ -43160,43 +43160,43 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3859
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,-20.5
     parent: 0
     type: Transform
 - uid: 3860
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,-20.5
     parent: 0
     type: Transform
 - uid: 3861
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,-20.5
     parent: 0
     type: Transform
 - uid: 3862
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 67.5,-20.5
     parent: 0
     type: Transform
 - uid: 3863
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 68.5,-20.5
     parent: 0
     type: Transform
 - uid: 3864
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 65.5,-20.5
     parent: 0
     type: Transform
 - uid: 3865
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 66.5,-20.5
     parent: 0
@@ -43210,13 +43210,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3867
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 57.5,-20.5
     parent: 0
     type: Transform
 - uid: 3868
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-19.5
     parent: 0
@@ -43230,25 +43230,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3870
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,-20.5
     parent: 0
     type: Transform
 - uid: 3871
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,-19.5
     parent: 0
     type: Transform
 - uid: 3872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,-18.5
     parent: 0
     type: Transform
 - uid: 3873
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,-17.5
     parent: 0
@@ -43422,37 +43422,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 3902
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-14.5
     parent: 0
     type: Transform
 - uid: 3903
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-15.5
     parent: 0
     type: Transform
 - uid: 3904
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-16.5
     parent: 0
     type: Transform
 - uid: 3905
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-17.5
     parent: 0
     type: Transform
 - uid: 3906
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-17.5
     parent: 0
     type: Transform
 - uid: 3907
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-18.5
     parent: 0
@@ -43468,19 +43468,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3909
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-21.5
     parent: 0
     type: Transform
 - uid: 3910
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 91.5,-22.5
     parent: 0
     type: Transform
 - uid: 3911
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 90.5,-22.5
     parent: 0
@@ -43492,13 +43492,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 88.5,-22.5
     parent: 0
     type: Transform
 - uid: 3914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-22.5
     parent: 0
@@ -43516,49 +43516,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 3917
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 93.5,-21.5
     parent: 0
     type: Transform
 - uid: 3918
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-21.5
     parent: 0
     type: Transform
 - uid: 3919
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 89.5,-22.5
     parent: 0
     type: Transform
 - uid: 3920
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-19.5
     parent: 0
     type: Transform
 - uid: 3921
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-19.5
     parent: 0
     type: Transform
 - uid: 3922
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 92.5,-18.5
     parent: 0
     type: Transform
 - uid: 3923
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-18.5
     parent: 0
     type: Transform
 - uid: 3924
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,-17.5
     parent: 0
@@ -43826,19 +43826,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3968
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-21.5
     parent: 0
     type: Transform
 - uid: 3969
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,-31.5
     parent: 0
     type: Transform
 - uid: 3970
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-21.5
     parent: 0
@@ -43856,7 +43856,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-21.5
     parent: 0
@@ -43868,7 +43868,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-27.5
     parent: 0
@@ -43928,7 +43928,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3985
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-30.5
     parent: 0
@@ -43958,7 +43958,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 3990
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-31.5
     parent: 0
@@ -43976,19 +43976,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 3993
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-33.5
     parent: 0
     type: Transform
 - uid: 3994
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-33.5
     parent: 0
     type: Transform
 - uid: 3995
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-58.5
     parent: 0
@@ -44000,13 +44000,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3997
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-31.5
     parent: 0
     type: Transform
 - uid: 3998
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-31.5
     parent: 0
@@ -44094,49 +44094,49 @@ entities:
     parent: 0
     type: Transform
 - uid: 4012
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-59.5
     parent: 0
     type: Transform
 - uid: 4013
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-59.5
     parent: 0
     type: Transform
 - uid: 4014
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-59.5
     parent: 0
     type: Transform
 - uid: 4015
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-56.5
     parent: 0
     type: Transform
 - uid: 4016
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-59.5
     parent: 0
     type: Transform
 - uid: 4017
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-59.5
     parent: 0
     type: Transform
 - uid: 4018
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-59.5
     parent: 0
     type: Transform
 - uid: 4019
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-59.5
     parent: 0
@@ -44969,19 +44969,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4112
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-13.5
     parent: 0
     type: Transform
 - uid: 4113
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-12.5
     parent: 0
     type: Transform
 - uid: 4114
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-12.5
     parent: 0
@@ -45137,7 +45137,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4133
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 21.5,-8.5
     parent: 0
@@ -45153,7 +45153,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4135
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-13.5
     parent: 0
@@ -45175,7 +45175,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4138
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,-2.5
     parent: 0
@@ -51133,7 +51133,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4766
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,27.5
     parent: 0
@@ -52432,7 +52432,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4908
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,35.5
     parent: 0
@@ -56710,7 +56710,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 5387
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,12.5
     parent: 0
@@ -57040,13 +57040,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5424
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,18.5
     parent: 0
     type: Transform
 - uid: 5425
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,19.5
     parent: 0
@@ -57060,7 +57060,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5427
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 63.5,20.5
     parent: 0
@@ -57374,19 +57374,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5464
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 71.5,38.5
     parent: 0
     type: Transform
 - uid: 5465
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 70.5,38.5
     parent: 0
     type: Transform
 - uid: 5466
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 69.5,38.5
     parent: 0
@@ -57660,37 +57660,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5500
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,34.5
     parent: 0
     type: Transform
 - uid: 5501
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,30.5
     parent: 0
     type: Transform
 - uid: 5502
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 72.5,26.5
     parent: 0
     type: Transform
 - uid: 5503
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 71.5,26.5
     parent: 0
     type: Transform
 - uid: 5504
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,26.5
     parent: 0
     type: Transform
 - uid: 5505
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,26.5
     parent: 0
@@ -59631,13 +59631,13 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 5747
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-10.5
     parent: 0
     type: Transform
 - uid: 5748
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-11.5
     parent: 0
@@ -63271,25 +63271,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 6145
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-41.5
     parent: 0
     type: Transform
 - uid: 6146
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-40.5
     parent: 0
     type: Transform
 - uid: 6147
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-40.5
     parent: 0
     type: Transform
 - uid: 6148
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-40.5
     parent: 0
@@ -63379,13 +63379,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 6163
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-41.5
     parent: 0
     type: Transform
 - uid: 6164
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-43.5
     parent: 0
@@ -63881,13 +63881,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 6221
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 69.5,-12.5
     parent: 0
     type: Transform
 - uid: 6222
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 70.5,-12.5
     parent: 0
@@ -63981,25 +63981,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 6234
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 62.5,-20.5
     parent: 0
     type: Transform
 - uid: 6235
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 64.5,-20.5
     parent: 0
     type: Transform
 - uid: 6236
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 60.5,-20.5
     parent: 0
     type: Transform
 - uid: 6237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-20.5
     parent: 0
@@ -69263,25 +69263,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 6808
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 58.5,-20.5
     parent: 0
     type: Transform
 - uid: 6809
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 59.5,-20.5
     parent: 0
     type: Transform
 - uid: 6810
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 61.5,-20.5
     parent: 0
     type: Transform
 - uid: 6811
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 63.5,-20.5
     parent: 0
@@ -75202,7 +75202,7 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 7322
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-27.5
     parent: 0
@@ -75261,61 +75261,61 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 7328
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-27.5
     parent: 0
     type: Transform
 - uid: 7329
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 50.5,-29.5
     parent: 0
     type: Transform
 - uid: 7330
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-27.5
     parent: 0
     type: Transform
 - uid: 7331
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-39.5
     parent: 0
     type: Transform
 - uid: 7332
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-39.5
     parent: 0
     type: Transform
 - uid: 7333
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-39.5
     parent: 0
     type: Transform
 - uid: 7334
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-39.5
     parent: 0
     type: Transform
 - uid: 7335
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-39.5
     parent: 0
     type: Transform
 - uid: 7336
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-39.5
     parent: 0
     type: Transform
 - uid: 7337
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-39.5
     parent: 0
@@ -75426,19 +75426,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 7347
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,-39.5
     parent: 0
     type: Transform
 - uid: 7348
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-39.5
     parent: 0
     type: Transform
 - uid: 7349
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,-33.5
     parent: 0
@@ -80968,151 +80968,151 @@ entities:
     parent: 0
     type: Transform
 - uid: 7911
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,-48.5
     parent: 0
     type: Transform
 - uid: 7912
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,-48.5
     parent: 0
     type: Transform
 - uid: 7913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,-48.5
     parent: 0
     type: Transform
 - uid: 7914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,-48.5
     parent: 0
     type: Transform
 - uid: 7915
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-48.5
     parent: 0
     type: Transform
 - uid: 7916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-48.5
     parent: 0
     type: Transform
 - uid: 7917
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-47.5
     parent: 0
     type: Transform
 - uid: 7918
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-47.5
     parent: 0
     type: Transform
 - uid: 7919
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-47.5
     parent: 0
     type: Transform
 - uid: 7920
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-47.5
     parent: 0
     type: Transform
 - uid: 7921
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-47.5
     parent: 0
     type: Transform
 - uid: 7922
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-47.5
     parent: 0
     type: Transform
 - uid: 7923
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-47.5
     parent: 0
     type: Transform
 - uid: 7924
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-47.5
     parent: 0
     type: Transform
 - uid: 7925
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-46.5
     parent: 0
     type: Transform
 - uid: 7926
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-42.5
     parent: 0
     type: Transform
 - uid: 7927
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,-41.5
     parent: 0
     type: Transform
 - uid: 7928
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-41.5
     parent: 0
     type: Transform
 - uid: 7929
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-41.5
     parent: 0
     type: Transform
 - uid: 7930
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-41.5
     parent: 0
     type: Transform
 - uid: 7931
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-41.5
     parent: 0
     type: Transform
 - uid: 7932
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-41.5
     parent: 0
     type: Transform
 - uid: 7933
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-41.5
     parent: 0
     type: Transform
 - uid: 7934
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-41.5
     parent: 0
     type: Transform
 - uid: 7935
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-40.5
     parent: 0
@@ -81271,7 +81271,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 7956
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-31.5
     parent: 0
@@ -81295,7 +81295,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 7960
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-30.5
     parent: 0
@@ -81307,19 +81307,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 7962
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-26.5
     parent: 0
     type: Transform
 - uid: 7963
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-25.5
     parent: 0
     type: Transform
 - uid: 7964
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-25.5
     parent: 0
@@ -81331,7 +81331,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 7966
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-25.5
     parent: 0
@@ -81349,19 +81349,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 7969
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-25.5
     parent: 0
     type: Transform
 - uid: 7970
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-26.5
     parent: 0
     type: Transform
 - uid: 7971
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-25.5
     parent: 0
@@ -82270,7 +82270,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8068
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-27.5
     parent: 0
@@ -82286,25 +82286,25 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 8070
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-29.5
     parent: 0
     type: Transform
 - uid: 8071
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-29.5
     parent: 0
     type: Transform
 - uid: 8072
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-29.5
     parent: 0
     type: Transform
 - uid: 8073
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-29.5
     parent: 0
@@ -82322,7 +82322,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8076
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-27.5
     parent: 0
@@ -88783,7 +88783,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8758
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 93.5,-18.5
     parent: 0
@@ -88801,13 +88801,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 8761
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 94.5,-18.5
     parent: 0
     type: Transform
 - uid: 8762
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 94.5,-21.5
     parent: 0
@@ -88819,7 +88819,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8764
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 92.5,-21.5
     parent: 0
@@ -89021,7 +89021,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8796
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-10.5
     parent: 0
@@ -89037,37 +89037,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 8798
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 99.5,-18.5
     parent: 0
     type: Transform
 - uid: 8799
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 99.5,-21.5
     parent: 0
     type: Transform
 - uid: 8800
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 100.5,-18.5
     parent: 0
     type: Transform
 - uid: 8801
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-18.5
     parent: 0
     type: Transform
 - uid: 8802
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 100.5,-21.5
     parent: 0
     type: Transform
 - uid: 8803
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-21.5
     parent: 0
@@ -89083,43 +89083,43 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 8806
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-17.5
     parent: 0
     type: Transform
 - uid: 8807
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-16.5
     parent: 0
     type: Transform
 - uid: 8808
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-15.5
     parent: 0
     type: Transform
 - uid: 8809
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-14.5
     parent: 0
     type: Transform
 - uid: 8810
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-13.5
     parent: 0
     type: Transform
 - uid: 8811
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-12.5
     parent: 0
     type: Transform
 - uid: 8812
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 101.5,-11.5
     parent: 0
@@ -89143,7 +89143,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8816
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-9.5
     parent: 0
@@ -89162,19 +89162,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 8818
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-11.5
     parent: 0
     type: Transform
 - uid: 8819
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 103.5,-11.5
     parent: 0
     type: Transform
 - uid: 8820
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 102.5,-11.5
     parent: 0
@@ -89238,19 +89238,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 8830
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 102.5,-21.5
     parent: 0
     type: Transform
 - uid: 8831
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 103.5,-21.5
     parent: 0
     type: Transform
 - uid: 8832
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-21.5
     parent: 0
@@ -89318,7 +89318,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8843
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 104.5,-20.5
     parent: 0
@@ -89358,37 +89358,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 8849
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-25.5
     parent: 0
     type: Transform
 - uid: 8850
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-24.5
     parent: 0
     type: Transform
 - uid: 8851
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-23.5
     parent: 0
     type: Transform
 - uid: 8852
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-22.5
     parent: 0
     type: Transform
 - uid: 8853
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-21.5
     parent: 0
     type: Transform
 - uid: 8854
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-20.5
     parent: 0
@@ -89506,31 +89506,31 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 8870
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 104.5,-13.5
     parent: 0
     type: Transform
 - uid: 8871
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 103.5,-13.5
     parent: 0
     type: Transform
 - uid: 8872
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 103.5,-14.5
     parent: 0
     type: Transform
 - uid: 8873
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 104.5,-14.5
     parent: 0
     type: Transform
 - uid: 8874
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 102.5,-14.5
     parent: 0
@@ -89789,37 +89789,37 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 8903
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-10.5
     parent: 0
     type: Transform
 - uid: 8904
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-9.5
     parent: 0
     type: Transform
 - uid: 8905
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-11.5
     parent: 0
     type: Transform
 - uid: 8906
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-12.5
     parent: 0
     type: Transform
 - uid: 8907
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-13.5
     parent: 0
     type: Transform
 - uid: 8908
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 108.5,-14.5
     parent: 0
@@ -89849,25 +89849,25 @@ entities:
     parent: 0
     type: Transform
 - uid: 8913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 109.5,-20.5
     parent: 0
     type: Transform
 - uid: 8914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 110.5,-20.5
     parent: 0
     type: Transform
 - uid: 8915
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 113.5,-20.5
     parent: 0
     type: Transform
 - uid: 8916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 116.5,-20.5
     parent: 0
@@ -89897,31 +89897,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 8921
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 109.5,-19.5
     parent: 0
     type: Transform
 - uid: 8922
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 109.5,-18.5
     parent: 0
     type: Transform
 - uid: 8923
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 109.5,-14.5
     parent: 0
     type: Transform
 - uid: 8924
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 109.5,-15.5
     parent: 0
     type: Transform
 - uid: 8925
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 109.5,-16.5
     parent: 0
@@ -90251,19 +90251,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 8973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 110.5,-14.5
     parent: 0
     type: Transform
 - uid: 8974
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 113.5,-14.5
     parent: 0
     type: Transform
 - uid: 8975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 116.5,-14.5
     parent: 0
@@ -90376,7 +90376,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 8993
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 116.5,-17.5
     parent: 0
@@ -92858,31 +92858,31 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 9255
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-13.5
     parent: 0
     type: Transform
 - uid: 9256
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-14.5
     parent: 0
     type: Transform
 - uid: 9257
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-15.5
     parent: 0
     type: Transform
 - uid: 9258
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-17.5
     parent: 0
     type: Transform
 - uid: 9259
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 39.5,-18.5
     parent: 0
@@ -97878,7 +97878,7 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 9673
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,13.5
     parent: 0
@@ -111390,37 +111390,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 10783
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-19.5
     parent: 0
     type: Transform
 - uid: 10784
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,-19.5
     parent: 0
     type: Transform
 - uid: 10785
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,-19.5
     parent: 0
     type: Transform
 - uid: 10786
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 84.5,-21.5
     parent: 0
     type: Transform
 - uid: 10787
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 85.5,-21.5
     parent: 0
     type: Transform
 - uid: 10788
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 86.5,-21.5
     parent: 0
@@ -111851,7 +111851,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 10850
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 89.5,-17.5
     parent: 0
@@ -112378,7 +112378,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 10916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,-59.5
     parent: 0
@@ -114387,7 +114387,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 11164
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: 54.520523,-14.325092
     parent: 0
@@ -115290,7 +115290,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 11279
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 30.5,-8.5
     parent: 0
@@ -116427,19 +116427,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 11437
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,5.5
     parent: 0
     type: Transform
 - uid: 11438
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,4.5
     parent: 0
     type: Transform
 - uid: 11439
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 87.5,3.5
     parent: 0
@@ -119096,13 +119096,13 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 11862
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-24.5
     parent: 0
     type: Transform
 - uid: 11863
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-23.5
     parent: 0
@@ -119118,7 +119118,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 11865
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-22.5
     parent: 0
@@ -119144,7 +119144,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 11868
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-22.5
     parent: 0
@@ -119179,67 +119179,67 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 11872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-21.5
     parent: 0
     type: Transform
 - uid: 11873
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-21.5
     parent: 0
     type: Transform
 - uid: 11874
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-21.5
     parent: 0
     type: Transform
 - uid: 11875
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-21.5
     parent: 0
     type: Transform
 - uid: 11876
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-21.5
     parent: 0
     type: Transform
 - uid: 11877
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-21.5
     parent: 0
     type: Transform
 - uid: 11878
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,-21.5
     parent: 0
     type: Transform
 - uid: 11879
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,-21.5
     parent: 0
     type: Transform
 - uid: 11880
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,-21.5
     parent: 0
     type: Transform
 - uid: 11881
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,-21.5
     parent: 0
     type: Transform
 - uid: 11882
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-21.5
     parent: 0
@@ -119255,7 +119255,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 11884
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-22.5
     parent: 0
@@ -119382,25 +119382,25 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 11898
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-24.5
     parent: 0
     type: Transform
 - uid: 11899
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-23.5
     parent: 0
     type: Transform
 - uid: 11900
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-22.5
     parent: 0
     type: Transform
 - uid: 11901
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 104.5,-25.5
     parent: 0

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -344,13 +344,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 32
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,2.5
     parent: 853
     type: Transform
 - uid: 33
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-0.5
     parent: 853
@@ -846,19 +846,19 @@ entities:
     parent: 853
     type: Transform
 - uid: 99
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -10.5,-28.5
     parent: 853
     type: Transform
 - uid: 100
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -11.5,-28.5
     parent: 853
     type: Transform
 - uid: 101
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -12.5,-28.5
     parent: 853
@@ -973,13 +973,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 118
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -14.5,26.5
     parent: 853
     type: Transform
 - uid: 119
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -13.5,26.5
     parent: 853
@@ -1186,7 +1186,7 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 141
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -15.5,-1.5
     parent: 853
@@ -1349,7 +1349,7 @@ entities:
         reagents: []
     type: SolutionContainerManager
 - uid: 160
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-1.5
     parent: 853
@@ -3332,7 +3332,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 302
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,11.5
     parent: 853
@@ -4839,56 +4839,56 @@ entities:
     parent: 853
     type: Transform
 - uid: 409
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -23.5,-12.5
     parent: 853
     type: Transform
 - uid: 410
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,-12.5
     parent: 853
     type: Transform
 - uid: 411
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,-12.5
     parent: 853
     type: Transform
 - uid: 412
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -20.5,-12.5
     parent: 853
     type: Transform
 - uid: 413
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,-12.5
     parent: 853
     type: Transform
 - uid: 414
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,-13.5
     parent: 853
     type: Transform
 - uid: 415
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,-14.5
     parent: 853
     type: Transform
 - uid: 416
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,-15.5
@@ -5139,7 +5139,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 452
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,21.5
@@ -5679,14 +5679,14 @@ entities:
     parent: 853
     type: Transform
 - uid: 526
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,-3.5
     parent: 853
     type: Transform
 - uid: 527
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,-1.5
@@ -5901,7 +5901,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 557
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 13.5,25.5
@@ -5959,13 +5959,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 563
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -38.5,1.5
     parent: 853
     type: Transform
 - uid: 564
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,-8.5
     parent: 853
@@ -6160,7 +6160,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 583
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -29.5,-3.5
@@ -6453,7 +6453,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 611
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -7.5,-7.5
@@ -6648,7 +6648,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 629
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,1.5
     parent: 853
@@ -7028,7 +7028,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,-8.5
     parent: 853
@@ -7093,7 +7093,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 672
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-19.5
@@ -7107,28 +7107,28 @@ entities:
     parent: 853
     type: Transform
 - uid: 674
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-20.5
     parent: 853
     type: Transform
 - uid: 675
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-21.5
     parent: 853
     type: Transform
 - uid: 676
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-22.5
     parent: 853
     type: Transform
 - uid: 677
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-23.5
@@ -7142,28 +7142,28 @@ entities:
     parent: 853
     type: Transform
 - uid: 679
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 17.5,-23.5
     parent: 853
     type: Transform
 - uid: 680
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-23.5
     parent: 853
     type: Transform
 - uid: 681
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-22.5
     parent: 853
     type: Transform
 - uid: 682
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-21.5
@@ -7177,21 +7177,21 @@ entities:
     parent: 853
     type: Transform
 - uid: 684
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-20.5
     parent: 853
     type: Transform
 - uid: 685
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-19.5
     parent: 853
     type: Transform
 - uid: 686
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,-8.5
     parent: 853
@@ -7204,31 +7204,31 @@ entities:
     parent: 853
     type: Transform
 - uid: 688
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,-8.5
     parent: 853
     type: Transform
 - uid: 689
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-8.5
     parent: 853
     type: Transform
 - uid: 690
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-8.5
     parent: 853
     type: Transform
 - uid: 691
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,-8.5
     parent: 853
     type: Transform
 - uid: 692
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,-8.5
     parent: 853
@@ -7248,13 +7248,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 695
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-8.5
     parent: 853
     type: Transform
 - uid: 696
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-7.5
     parent: 853
@@ -7267,7 +7267,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 698
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-6.5
     parent: 853
@@ -7351,19 +7351,19 @@ entities:
       cellslot_cell_container: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 708
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-26.5
     parent: 853
     type: Transform
 - uid: 709
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-26.5
     parent: 853
     type: Transform
 - uid: 710
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-26.5
     parent: 853
@@ -7376,7 +7376,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 712
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 45.5,9.5
@@ -7509,7 +7509,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 731
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 14.5,-12.5
@@ -7693,7 +7693,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 756
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,25.5
@@ -18161,52 +18161,52 @@ entities:
     parent: 853
     type: Transform
 - uid: 860
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 50.5,-1.5
     parent: 853
     type: Transform
 - uid: 861
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 48.5,-1.5
     parent: 853
     type: Transform
 - uid: 862
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-26.5
     parent: 853
     type: Transform
 - uid: 863
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 50.5,5.5
     parent: 853
     type: Transform
 - uid: 864
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -18.5,-19.5
     parent: 853
     type: Transform
 - uid: 865
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -18.5,-20.5
     parent: 853
     type: Transform
 - uid: 866
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -18.5,-21.5
     parent: 853
     type: Transform
 - uid: 867
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 49.5,5.5
@@ -18226,14 +18226,14 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 869
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 47.5,-1.5
     parent: 853
     type: Transform
 - uid: 870
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 51.5,-1.5
@@ -18252,7 +18252,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-18.5
     parent: 853
@@ -18292,20 +18292,20 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 876
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-19.5
     parent: 853
     type: Transform
 - uid: 877
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 51.5,-7.5
     parent: 853
     type: Transform
 - uid: 878
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 50.5,-7.5
@@ -18323,63 +18323,63 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 880
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 48.5,-7.5
     parent: 853
     type: Transform
 - uid: 881
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 47.5,-7.5
     parent: 853
     type: Transform
 - uid: 882
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-7.5
     parent: 853
     type: Transform
 - uid: 883
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-6.5
     parent: 853
     type: Transform
 - uid: 884
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-5.5
     parent: 853
     type: Transform
 - uid: 885
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-4.5
     parent: 853
     type: Transform
 - uid: 886
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-3.5
     parent: 853
     type: Transform
 - uid: 887
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-2.5
     parent: 853
     type: Transform
 - uid: 888
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-1.5
@@ -18460,7 +18460,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 897
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-19.5
     parent: 853
@@ -18512,7 +18512,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 904
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -13.5,-6.5
     parent: 853
@@ -18532,77 +18532,77 @@ entities:
     parent: 853
     type: Transform
 - uid: 907
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,-5.5
     parent: 853
     type: Transform
 - uid: 908
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,-5.5
     parent: 853
     type: Transform
 - uid: 909
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-5.5
     parent: 853
     type: Transform
 - uid: 910
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,-5.5
     parent: 853
     type: Transform
 - uid: 911
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-3.5
     parent: 853
     type: Transform
 - uid: 912
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -9.5,-3.5
     parent: 853
     type: Transform
 - uid: 913
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,-2.5
     parent: 853
     type: Transform
 - uid: 914
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,-2.5
     parent: 853
     type: Transform
 - uid: 915
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,-2.5
     parent: 853
     type: Transform
 - uid: 916
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-2.5
     parent: 853
     type: Transform
 - uid: 917
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,-2.5
@@ -18621,91 +18621,91 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 919
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,-0.5
     parent: 853
     type: Transform
 - uid: 920
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,-3.5
     parent: 853
     type: Transform
 - uid: 921
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,1.5
     parent: 853
     type: Transform
 - uid: 922
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,2.5
     parent: 853
     type: Transform
 - uid: 923
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,2.5
     parent: 853
     type: Transform
 - uid: 924
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,2.5
     parent: 853
     type: Transform
 - uid: 925
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,2.5
     parent: 853
     type: Transform
 - uid: 926
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -20.5,-8.5
     parent: 853
     type: Transform
 - uid: 927
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,-10.5
     parent: 853
     type: Transform
 - uid: 928
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,-10.5
     parent: 853
     type: Transform
 - uid: 929
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,-10.5
     parent: 853
     type: Transform
 - uid: 930
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -20.5,-10.5
     parent: 853
     type: Transform
 - uid: 931
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -20.5,-9.5
@@ -18740,21 +18740,21 @@ entities:
     parent: 853
     type: Transform
 - uid: 936
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,-6.5
     parent: 853
     type: Transform
 - uid: 937
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,-6.5
     parent: 853
     type: Transform
 - uid: 938
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 33.5,11.5
     parent: 853
@@ -18784,67 +18784,67 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 942
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-28.5
     parent: 853
     type: Transform
 - uid: 943
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-28.5
     parent: 853
     type: Transform
 - uid: 944
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,-28.5
     parent: 853
     type: Transform
 - uid: 945
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-28.5
     parent: 853
     type: Transform
 - uid: 946
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,-28.5
     parent: 853
     type: Transform
 - uid: 947
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,-28.5
     parent: 853
     type: Transform
 - uid: 948
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -6.5,-28.5
     parent: 853
     type: Transform
 - uid: 949
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -34.5,-8.5
     parent: 853
     type: Transform
 - uid: 950
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -34.5,-9.5
     parent: 853
     type: Transform
 - uid: 951
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-14.5
     parent: 853
     type: Transform
 - uid: 952
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-16.5
     parent: 853
@@ -18891,7 +18891,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 959
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-12.5
     parent: 853
@@ -18904,7 +18904,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 961
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-9.5
     parent: 853
@@ -18971,7 +18971,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 971
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-8.5
     parent: 853
@@ -18983,7 +18983,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -34.5,-10.5
     parent: 853
@@ -19197,7 +19197,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 999
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -7.5,2.5
@@ -19242,14 +19242,14 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1004
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,2.5
     parent: 853
     type: Transform
 - uid: 1005
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,2.5
@@ -19306,7 +19306,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1011
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -8.5,2.5
@@ -19336,7 +19336,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1014
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -34.5,-11.5
     parent: 853
@@ -19860,37 +19860,37 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1075
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,4.5
     parent: 853
     type: Transform
 - uid: 1076
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,5.5
     parent: 853
     type: Transform
 - uid: 1077
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,-0.5
     parent: 853
     type: Transform
 - uid: 1078
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,-0.5
     parent: 853
     type: Transform
 - uid: 1079
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,0.5
     parent: 853
     type: Transform
 - uid: 1080
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,0.5
     parent: 853
@@ -20042,7 +20042,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1101
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,0.5
     parent: 853
@@ -20267,7 +20267,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1129
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-17.5
@@ -20288,7 +20288,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1132
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-16.5
@@ -20325,7 +20325,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1137
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-3.5
     parent: 853
@@ -20522,7 +20522,7 @@ entities:
   - location: eva
     type: WarpPoint
 - uid: 1160
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,-3.5
     parent: 853
@@ -20623,13 +20623,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1171
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,2.5
     parent: 853
     type: Transform
 - uid: 1172
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,0.5
     parent: 853
@@ -20741,13 +20741,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1187
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,0.5
     parent: 853
     type: Transform
 - uid: 1188
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-0.5
     parent: 853
@@ -20895,7 +20895,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1207
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,23.5
     parent: 853
@@ -21279,7 +21279,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1248
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -33.5,9.5
     parent: 853
@@ -21302,7 +21302,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1251
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -33.5,2.5
@@ -21395,7 +21395,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1262
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -33.5,1.5
@@ -21522,13 +21522,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1276
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,11.5
     parent: 853
     type: Transform
 - uid: 1277
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-2.5
     parent: 853
@@ -21580,21 +21580,21 @@ entities:
     parent: 853
     type: Transform
 - uid: 1283
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,1.5
     parent: 853
     type: Transform
 - uid: 1284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,22.5
     parent: 853
     type: Transform
 - uid: 1285
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,21.5
@@ -21750,14 +21750,14 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 1300
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,0.5
     parent: 853
     type: Transform
 - uid: 1301
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,-0.5
@@ -21771,28 +21771,28 @@ entities:
     parent: 853
     type: Transform
 - uid: 1303
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,-1.5
     parent: 853
     type: Transform
 - uid: 1304
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,-2.5
     parent: 853
     type: Transform
 - uid: 1305
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 8.5,15.5
     parent: 853
     type: Transform
 - uid: 1306
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 7.5,15.5
@@ -21945,14 +21945,14 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 1320
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,-3.5
     parent: 853
     type: Transform
 - uid: 1321
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,-4.5
@@ -22013,13 +22013,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1327
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-1.5
     parent: 853
     type: Transform
 - uid: 1328
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,-5.5
@@ -22045,7 +22045,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1331
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-2.5
@@ -22100,13 +22100,13 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 1336
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-1.5
     parent: 853
     type: Transform
 - uid: 1337
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 47.5,5.5
@@ -22180,7 +22180,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1345
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-1.5
@@ -22218,14 +22218,14 @@ entities:
     parent: 853
     type: Transform
 - uid: 1349
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-0.5
     parent: 853
     type: Transform
 - uid: 1350
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,0.5
@@ -22242,7 +22242,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1352
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,2.5
@@ -22255,7 +22255,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1354
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 45.5,6.5
@@ -22304,7 +22304,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1361
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,2.5
@@ -22345,7 +22345,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1367
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-21.5
     parent: 853
@@ -22455,14 +22455,14 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 1378
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -27.5,2.5
     parent: 853
     type: Transform
 - uid: 1379
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,2.5
@@ -22521,7 +22521,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1385
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 12.5,25.5
@@ -22591,7 +22591,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1393
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,1.5
@@ -22634,31 +22634,31 @@ entities:
     parent: 853
     type: Transform
 - uid: 1399
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-2.5
     parent: 853
     type: Transform
 - uid: 1400
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-3.5
     parent: 853
     type: Transform
 - uid: 1401
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-4.5
     parent: 853
     type: Transform
 - uid: 1402
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-5.5
     parent: 853
     type: Transform
 - uid: 1403
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-5.5
     parent: 853
@@ -22853,13 +22853,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1430
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -11.5,7.5
     parent: 853
     type: Transform
 - uid: 1431
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -11.5,9.5
     parent: 853
@@ -22894,14 +22894,14 @@ entities:
     parent: 853
     type: Transform
 - uid: 1436
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -28.5,2.5
     parent: 853
     type: Transform
 - uid: 1437
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -29.5,2.5
@@ -22929,13 +22929,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1441
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-5.5
     parent: 853
     type: Transform
 - uid: 1442
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -25.5,1.5
@@ -23082,7 +23082,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1463
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,-5.5
     parent: 853
@@ -23179,7 +23179,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1477
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,-6.5
     parent: 853
@@ -23395,7 +23395,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1506
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-3.5
     parent: 853
@@ -23478,19 +23478,19 @@ entities:
     parent: 853
     type: Transform
 - uid: 1518
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,2.5
     parent: 853
     type: Transform
 - uid: 1519
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,2.5
     parent: 853
     type: Transform
 - uid: 1520
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,2.5
     parent: 853
@@ -23565,13 +23565,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1531
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,16.5
     parent: 853
     type: Transform
 - uid: 1532
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,16.5
     parent: 853
@@ -23583,7 +23583,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1534
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,16.5
     parent: 853
@@ -23699,13 +23699,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1548
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,16.5
     parent: 853
     type: Transform
 - uid: 1549
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,17.5
     parent: 853
@@ -23718,14 +23718,14 @@ entities:
     parent: 853
     type: Transform
 - uid: 1551
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-7.5
     parent: 853
     type: Transform
 - uid: 1552
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,-5.5
     parent: 853
@@ -23926,13 +23926,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1573
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,-5.5
     parent: 853
     type: Transform
 - uid: 1574
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-26.5
     parent: 853
@@ -24089,147 +24089,147 @@ entities:
     parent: 853
     type: Transform
 - uid: 1596
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,1.5
     parent: 853
     type: Transform
 - uid: 1597
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 39.5,10.5
     parent: 853
     type: Transform
 - uid: 1598
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 38.5,10.5
     parent: 853
     type: Transform
 - uid: 1599
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,10.5
     parent: 853
     type: Transform
 - uid: 1600
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,11.5
     parent: 853
     type: Transform
 - uid: 1601
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,12.5
     parent: 853
     type: Transform
 - uid: 1602
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,13.5
     parent: 853
     type: Transform
 - uid: 1603
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,14.5
     parent: 853
     type: Transform
 - uid: 1604
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 38.5,14.5
     parent: 853
     type: Transform
 - uid: 1605
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 39.5,14.5
     parent: 853
     type: Transform
 - uid: 1606
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 40.5,14.5
     parent: 853
     type: Transform
 - uid: 1607
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 41.5,14.5
     parent: 853
     type: Transform
 - uid: 1608
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 42.5,14.5
     parent: 853
     type: Transform
 - uid: 1609
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 43.5,14.5
     parent: 853
     type: Transform
 - uid: 1610
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 44.5,14.5
     parent: 853
     type: Transform
 - uid: 1611
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 44.5,13.5
     parent: 853
     type: Transform
 - uid: 1612
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 44.5,12.5
     parent: 853
     type: Transform
 - uid: 1613
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 44.5,11.5
     parent: 853
     type: Transform
 - uid: 1614
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 44.5,10.5
     parent: 853
     type: Transform
 - uid: 1615
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 43.5,10.5
     parent: 853
     type: Transform
 - uid: 1616
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 42.5,10.5
@@ -24282,56 +24282,56 @@ entities:
     parent: 853
     type: Transform
 - uid: 1623
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,-0.5
     parent: 853
     type: Transform
 - uid: 1624
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,9.5
     parent: 853
     type: Transform
 - uid: 1625
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,8.5
     parent: 853
     type: Transform
 - uid: 1626
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,7.5
     parent: 853
     type: Transform
 - uid: 1627
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,7.5
     parent: 853
     type: Transform
 - uid: 1628
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 35.5,7.5
     parent: 853
     type: Transform
 - uid: 1629
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -8.5,-3.5
     parent: 853
     type: Transform
 - uid: 1630
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,6.5
@@ -24352,91 +24352,91 @@ entities:
     parent: 853
     type: Transform
 - uid: 1633
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 41.5,1.5
     parent: 853
     type: Transform
 - uid: 1634
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 41.5,0.5
     parent: 853
     type: Transform
 - uid: 1635
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 41.5,-0.5
     parent: 853
     type: Transform
 - uid: 1636
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 41.5,-1.5
     parent: 853
     type: Transform
 - uid: 1637
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 41.5,-2.5
     parent: 853
     type: Transform
 - uid: 1638
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 40.5,-2.5
     parent: 853
     type: Transform
 - uid: 1639
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 39.5,-2.5
     parent: 853
     type: Transform
 - uid: 1640
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 38.5,-2.5
     parent: 853
     type: Transform
 - uid: 1641
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 37.5,-2.5
     parent: 853
     type: Transform
 - uid: 1642
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,-2.5
     parent: 853
     type: Transform
 - uid: 1643
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,-1.5
     parent: 853
     type: Transform
 - uid: 1644
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,1.5
     parent: 853
     type: Transform
 - uid: 1645
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,0.5
@@ -24450,7 +24450,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 1647
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,2.5
@@ -24464,34 +24464,34 @@ entities:
     parent: 853
     type: Transform
 - uid: 1649
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 35.5,1.5
     parent: 853
     type: Transform
 - uid: 1650
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 31.5,1.5
     parent: 853
     type: Transform
 - uid: 1651
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 42.5,0.5
     parent: 853
     type: Transform
 - uid: 1652
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-26.5
     parent: 853
     type: Transform
 - uid: 1653
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-26.5
     parent: 853
@@ -24504,13 +24504,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 1655
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,-8.5
     parent: 853
     type: Transform
 - uid: 1656
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,-8.5
     parent: 853
@@ -24522,79 +24522,79 @@ entities:
     parent: 853
     type: Transform
 - uid: 1658
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-25.5
     parent: 853
     type: Transform
 - uid: 1659
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-26.5
     parent: 853
     type: Transform
 - uid: 1660
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-19.5
     parent: 853
     type: Transform
 - uid: 1661
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-20.5
     parent: 853
     type: Transform
 - uid: 1662
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-21.5
     parent: 853
     type: Transform
 - uid: 1663
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-22.5
     parent: 853
     type: Transform
 - uid: 1664
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 23.5,-23.5
     parent: 853
     type: Transform
 - uid: 1665
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-15.5
     parent: 853
     type: Transform
 - uid: 1666
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-17.5
     parent: 853
     type: Transform
 - uid: 1667
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-13.5
     parent: 853
     type: Transform
 - uid: 1668
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-11.5
     parent: 853
     type: Transform
 - uid: 1669
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-10.5
     parent: 853
     type: Transform
 - uid: 1670
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-19.5
     parent: 853
@@ -24608,19 +24608,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1672
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,-19.5
     parent: 853
     type: Transform
 - uid: 1673
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -16.5,26.5
     parent: 853
     type: Transform
 - uid: 1674
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -15.5,26.5
     parent: 853
@@ -24638,92 +24638,92 @@ entities:
     parent: 853
     type: Transform
 - uid: 1677
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -12.5,26.5
     parent: 853
     type: Transform
 - uid: 1678
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -11.5,26.5
     parent: 853
     type: Transform
 - uid: 1679
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,26.5
     parent: 853
     type: Transform
 - uid: 1680
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 28.5,-7.5
     parent: 853
     type: Transform
 - uid: 1681
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -10.5,26.5
     parent: 853
     type: Transform
 - uid: 1682
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -6.5,25.5
     parent: 853
     type: Transform
 - uid: 1683
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,25.5
     parent: 853
     type: Transform
 - uid: 1684
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,25.5
     parent: 853
     type: Transform
 - uid: 1685
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -18.5,-17.5
     parent: 853
     type: Transform
 - uid: 1686
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -20.5,15.5
     parent: 853
     type: Transform
 - uid: 1687
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -21.5,15.5
     parent: 853
     type: Transform
 - uid: 1688
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -22.5,15.5
     parent: 853
     type: Transform
 - uid: 1689
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -23.5,15.5
     parent: 853
     type: Transform
 - uid: 1690
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -24.5,15.5
     parent: 853
     type: Transform
 - uid: 1691
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -20.5,17.5
     parent: 853
@@ -24739,37 +24739,37 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1693
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -26.5,15.5
     parent: 853
     type: Transform
 - uid: 1694
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -27.5,15.5
     parent: 853
     type: Transform
 - uid: 1695
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -28.5,15.5
     parent: 853
     type: Transform
 - uid: 1696
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -29.5,15.5
     parent: 853
     type: Transform
 - uid: 1697
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,26.5
     parent: 853
     type: Transform
 - uid: 1698
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,25.5
     parent: 853
@@ -24783,19 +24783,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1700
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,24.5
     parent: 853
     type: Transform
 - uid: 1701
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,23.5
     parent: 853
     type: Transform
 - uid: 1702
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,22.5
     parent: 853
@@ -24815,27 +24815,27 @@ entities:
     parent: 853
     type: Transform
 - uid: 1705
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 18.5,-23.5
     parent: 853
     type: Transform
 - uid: 1706
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 19.5,-23.5
     parent: 853
     type: Transform
 - uid: 1707
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,21.5
     parent: 853
     type: Transform
 - uid: 1708
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -20.5,20.5
     parent: 853
@@ -24873,79 +24873,79 @@ entities:
     parent: 853
     type: Transform
 - uid: 1713
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -30.5,15.5
     parent: 853
     type: Transform
 - uid: 1714
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -31.5,15.5
     parent: 853
     type: Transform
 - uid: 1715
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -6.5,26.5
     parent: 853
     type: Transform
 - uid: 1716
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,26.5
     parent: 853
     type: Transform
 - uid: 1717
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -7.5,26.5
     parent: 853
     type: Transform
 - uid: 1718
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -18.5,-16.5
     parent: 853
     type: Transform
 - uid: 1719
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -19.5,-16.5
     parent: 853
     type: Transform
 - uid: 1720
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -20.5,-16.5
     parent: 853
     type: Transform
 - uid: 1721
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -21.5,-16.5
     parent: 853
     type: Transform
 - uid: 1722
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -22.5,-16.5
     parent: 853
     type: Transform
 - uid: 1723
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -23.5,-16.5
     parent: 853
     type: Transform
 - uid: 1724
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,-16.5
     parent: 853
     type: Transform
 - uid: 1725
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 45.5,10.5
@@ -24966,63 +24966,63 @@ entities:
     parent: 853
     type: Transform
 - uid: 1728
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 31.5,7.5
     parent: 853
     type: Transform
 - uid: 1729
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 30.5,7.5
     parent: 853
     type: Transform
 - uid: 1730
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 29.5,7.5
     parent: 853
     type: Transform
 - uid: 1731
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 29.5,8.5
     parent: 853
     type: Transform
 - uid: 1732
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 29.5,9.5
     parent: 853
     type: Transform
 - uid: 1733
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 28.5,7.5
     parent: 853
     type: Transform
 - uid: 1734
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 30.5,6.5
     parent: 853
     type: Transform
 - uid: 1735
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 30.5,2.5
     parent: 853
     type: Transform
 - uid: 1736
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 30.5,1.5
@@ -25163,28 +25163,28 @@ entities:
   - color: '#FF0000FF'
     type: AtmosPipeColor
 - uid: 1749
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 29.5,11.5
     parent: 853
     type: Transform
 - uid: 1750
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 29.5,12.5
     parent: 853
     type: Transform
 - uid: 1751
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 29.5,13.5
     parent: 853
     type: Transform
 - uid: 1752
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -25.5,-16.5
     parent: 853
@@ -25199,19 +25199,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1754
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,15.5
     parent: 853
     type: Transform
 - uid: 1755
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,14.5
     parent: 853
     type: Transform
 - uid: 1756
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -25.5,-15.5
     parent: 853
@@ -25233,119 +25233,119 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1759
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,13.5
     parent: 853
     type: Transform
 - uid: 1760
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,12.5
     parent: 853
     type: Transform
 - uid: 1761
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,11.5
     parent: 853
     type: Transform
 - uid: 1762
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,10.5
     parent: 853
     type: Transform
 - uid: 1763
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,8.5
     parent: 853
     type: Transform
 - uid: 1764
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,7.5
     parent: 853
     type: Transform
 - uid: 1765
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 26.5,7.5
     parent: 853
     type: Transform
 - uid: 1766
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,7.5
     parent: 853
     type: Transform
 - uid: 1767
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,6.5
     parent: 853
     type: Transform
 - uid: 1768
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 23.5,6.5
     parent: 853
     type: Transform
 - uid: 1769
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 18.5,6.5
     parent: 853
     type: Transform
 - uid: 1770
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 17.5,6.5
     parent: 853
     type: Transform
 - uid: 1771
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 17.5,7.5
     parent: 853
     type: Transform
 - uid: 1772
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 17.5,8.5
     parent: 853
     type: Transform
 - uid: 1773
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 17.5,9.5
     parent: 853
     type: Transform
 - uid: 1774
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,8.5
     parent: 853
     type: Transform
 - uid: 1775
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 12.5,8.5
@@ -25421,239 +25421,239 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1785
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,-7.5
     parent: 853
     type: Transform
 - uid: 1786
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -25.5,-14.5
     parent: 853
     type: Transform
 - uid: 1787
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -25.5,-13.5
     parent: 853
     type: Transform
 - uid: 1788
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 17.5,12.5
     parent: 853
     type: Transform
 - uid: 1789
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 17.5,13.5
     parent: 853
     type: Transform
 - uid: 1790
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -25.5,-12.5
     parent: 853
     type: Transform
 - uid: 1791
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -26.5,-12.5
     parent: 853
     type: Transform
 - uid: 1792
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -34.5,11.5
     parent: 853
     type: Transform
 - uid: 1793
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -40.5,11.5
     parent: 853
     type: Transform
 - uid: 1794
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,13.5
     parent: 853
     type: Transform
 - uid: 1795
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 15.5,13.5
     parent: 853
     type: Transform
 - uid: 1796
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 14.5,13.5
     parent: 853
     type: Transform
 - uid: 1797
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 13.5,13.5
     parent: 853
     type: Transform
 - uid: 1798
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 12.5,13.5
     parent: 853
     type: Transform
 - uid: 1799
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,13.5
     parent: 853
     type: Transform
 - uid: 1800
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,12.5
     parent: 853
     type: Transform
 - uid: 1801
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,12.5
     parent: 853
     type: Transform
 - uid: 1802
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 9.5,12.5
     parent: 853
     type: Transform
 - uid: 1803
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 7.5,12.5
     parent: 853
     type: Transform
 - uid: 1804
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,12.5
     parent: 853
     type: Transform
 - uid: 1805
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,12.5
     parent: 853
     type: Transform
 - uid: 1806
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,11.5
     parent: 853
     type: Transform
 - uid: 1807
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,10.5
     parent: 853
     type: Transform
 - uid: 1808
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,9.5
     parent: 853
     type: Transform
 - uid: 1809
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,8.5
     parent: 853
     type: Transform
 - uid: 1810
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,7.5
     parent: 853
     type: Transform
 - uid: 1811
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,6.5
     parent: 853
     type: Transform
 - uid: 1812
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,6.5
     parent: 853
     type: Transform
 - uid: 1813
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,11.5
     parent: 853
     type: Transform
 - uid: 1814
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,10.5
     parent: 853
     type: Transform
 - uid: 1815
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,9.5
     parent: 853
     type: Transform
 - uid: 1816
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,8.5
     parent: 853
     type: Transform
 - uid: 1817
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,7.5
     parent: 853
     type: Transform
 - uid: 1818
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,6.5
     parent: 853
     type: Transform
 - uid: 1819
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,6.5
@@ -25667,20 +25667,20 @@ entities:
     parent: 853
     type: Transform
 - uid: 1821
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 14.5,15.5
     parent: 853
     type: Transform
 - uid: 1822
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -39.5,11.5
     parent: 853
     type: Transform
 - uid: 1823
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -38.5,11.5
     parent: 853
@@ -25711,83 +25711,83 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1827
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -18.5,-18.5
     parent: 853
     type: Transform
 - uid: 1828
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,2.5
     parent: 853
     type: Transform
 - uid: 1829
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -20.5,2.5
     parent: 853
     type: Transform
 - uid: 1830
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,2.5
     parent: 853
     type: Transform
 - uid: 1831
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,21.5
     parent: 853
     type: Transform
 - uid: 1832
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,19.5
     parent: 853
     type: Transform
 - uid: 1833
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,18.5
     parent: 853
     type: Transform
 - uid: 1834
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,17.5
     parent: 853
     type: Transform
 - uid: 1835
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,16.5
     parent: 853
     type: Transform
 - uid: 1836
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,15.5
     parent: 853
     type: Transform
 - uid: 1837
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,15.5
     parent: 853
     type: Transform
 - uid: 1838
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 9.5,15.5
@@ -25805,105 +25805,105 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 1840
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,0.5
     parent: 853
     type: Transform
 - uid: 1841
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,15.5
     parent: 853
     type: Transform
 - uid: 1842
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,15.5
     parent: 853
     type: Transform
 - uid: 1843
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,16.5
     parent: 853
     type: Transform
 - uid: 1844
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,13.5
     parent: 853
     type: Transform
 - uid: 1845
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,21.5
     parent: 853
     type: Transform
 - uid: 1846
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,22.5
     parent: 853
     type: Transform
 - uid: 1847
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 9.5,22.5
     parent: 853
     type: Transform
 - uid: 1848
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 8.5,22.5
     parent: 853
     type: Transform
 - uid: 1849
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 7.5,22.5
     parent: 853
     type: Transform
 - uid: 1850
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,22.5
     parent: 853
     type: Transform
 - uid: 1851
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,22.5
     parent: 853
     type: Transform
 - uid: 1852
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,23.5
     parent: 853
     type: Transform
 - uid: 1853
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,24.5
     parent: 853
     type: Transform
 - uid: 1854
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,25.5
@@ -25916,91 +25916,91 @@ entities:
     parent: 853
     type: Transform
 - uid: 1856
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,27.5
     parent: 853
     type: Transform
 - uid: 1857
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,28.5
     parent: 853
     type: Transform
 - uid: 1858
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,30.5
     parent: 853
     type: Transform
 - uid: 1859
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,31.5
     parent: 853
     type: Transform
 - uid: 1860
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,31.5
     parent: 853
     type: Transform
 - uid: 1861
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,30.5
     parent: 853
     type: Transform
 - uid: 1862
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,28.5
     parent: 853
     type: Transform
 - uid: 1863
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,27.5
     parent: 853
     type: Transform
 - uid: 1864
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,26.5
     parent: 853
     type: Transform
 - uid: 1865
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,25.5
     parent: 853
     type: Transform
 - uid: 1866
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,22.5
     parent: 853
     type: Transform
 - uid: 1867
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,22.5
     parent: 853
     type: Transform
 - uid: 1868
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,22.5
@@ -26017,119 +26017,119 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1870
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,22.5
     parent: 853
     type: Transform
 - uid: 1871
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,22.5
     parent: 853
     type: Transform
 - uid: 1872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,23.5
     parent: 853
     type: Transform
 - uid: 1873
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,24.5
     parent: 853
     type: Transform
 - uid: 1874
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,26.5
     parent: 853
     type: Transform
 - uid: 1875
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,27.5
     parent: 853
     type: Transform
 - uid: 1876
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,27.5
     parent: 853
     type: Transform
 - uid: 1877
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,27.5
     parent: 853
     type: Transform
 - uid: 1878
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,23.5
     parent: 853
     type: Transform
 - uid: 1879
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,23.5
     parent: 853
     type: Transform
 - uid: 1880
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,24.5
     parent: 853
     type: Transform
 - uid: 1881
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,26.5
     parent: 853
     type: Transform
 - uid: 1882
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,27.5
     parent: 853
     type: Transform
 - uid: 1883
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,27.5
     parent: 853
     type: Transform
 - uid: 1884
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 7.5,27.5
     parent: 853
     type: Transform
 - uid: 1885
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 8.5,27.5
     parent: 853
     type: Transform
 - uid: 1886
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 9.5,27.5
@@ -26304,84 +26304,84 @@ entities:
     parent: 853
     type: Transform
 - uid: 1911
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,15.5
     parent: 853
     type: Transform
 - uid: 1912
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,15.5
     parent: 853
     type: Transform
 - uid: 1913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,15.5
     parent: 853
     type: Transform
 - uid: 1914
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,15.5
     parent: 853
     type: Transform
 - uid: 1915
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,15.5
     parent: 853
     type: Transform
 - uid: 1916
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,15.5
     parent: 853
     type: Transform
 - uid: 1917
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -4.5,15.5
     parent: 853
     type: Transform
 - uid: 1918
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -4.5,16.5
     parent: 853
     type: Transform
 - uid: 1919
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -4.5,17.5
     parent: 853
     type: Transform
 - uid: 1920
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -4.5,18.5
     parent: 853
     type: Transform
 - uid: 1921
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -4.5,19.5
     parent: 853
     type: Transform
 - uid: 1922
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,19.5
@@ -26395,70 +26395,70 @@ entities:
     parent: 853
     type: Transform
 - uid: 1924
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,19.5
     parent: 853
     type: Transform
 - uid: 1925
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,19.5
     parent: 853
     type: Transform
 - uid: 1926
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,19.5
     parent: 853
     type: Transform
 - uid: 1927
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,19.5
     parent: 853
     type: Transform
 - uid: 1928
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,19.5
     parent: 853
     type: Transform
 - uid: 1929
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,18.5
     parent: 853
     type: Transform
 - uid: 1930
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,16.5
     parent: 853
     type: Transform
 - uid: 1931
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,20.5
     parent: 853
     type: Transform
 - uid: 1932
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,21.5
     parent: 853
     type: Transform
 - uid: 1933
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,22.5
@@ -26498,91 +26498,91 @@ entities:
     parent: 853
     type: Transform
 - uid: 1939
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,22.5
     parent: 853
     type: Transform
 - uid: 1940
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,22.5
     parent: 853
     type: Transform
 - uid: 1941
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,22.5
     parent: 853
     type: Transform
 - uid: 1942
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,22.5
     parent: 853
     type: Transform
 - uid: 1943
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,22.5
     parent: 853
     type: Transform
 - uid: 1944
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,22.5
     parent: 853
     type: Transform
 - uid: 1945
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,23.5
     parent: 853
     type: Transform
 - uid: 1946
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,23.5
     parent: 853
     type: Transform
 - uid: 1947
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,23.5
     parent: 853
     type: Transform
 - uid: 1948
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,23.5
     parent: 853
     type: Transform
 - uid: 1949
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,23.5
     parent: 853
     type: Transform
 - uid: 1950
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,23.5
     parent: 853
     type: Transform
 - uid: 1951
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,23.5
@@ -26596,154 +26596,154 @@ entities:
     parent: 853
     type: Transform
 - uid: 1953
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,21.5
     parent: 853
     type: Transform
 - uid: 1954
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,20.5
     parent: 853
     type: Transform
 - uid: 1955
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,19.5
     parent: 853
     type: Transform
 - uid: 1956
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,18.5
     parent: 853
     type: Transform
 - uid: 1957
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,17.5
     parent: 853
     type: Transform
 - uid: 1958
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,21.5
     parent: 853
     type: Transform
 - uid: 1959
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,20.5
     parent: 853
     type: Transform
 - uid: 1960
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,19.5
     parent: 853
     type: Transform
 - uid: 1961
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,18.5
     parent: 853
     type: Transform
 - uid: 1962
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,17.5
     parent: 853
     type: Transform
 - uid: 1963
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,17.5
     parent: 853
     type: Transform
 - uid: 1964
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,17.5
     parent: 853
     type: Transform
 - uid: 1965
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,17.5
     parent: 853
     type: Transform
 - uid: 1966
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,17.5
     parent: 853
     type: Transform
 - uid: 1967
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,18.5
     parent: 853
     type: Transform
 - uid: 1968
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,19.5
     parent: 853
     type: Transform
 - uid: 1969
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,8.5
     parent: 853
     type: Transform
 - uid: 1970
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,7.5
     parent: 853
     type: Transform
 - uid: 1971
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,6.5
     parent: 853
     type: Transform
 - uid: 1972
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,6.5
     parent: 853
     type: Transform
 - uid: 1973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,6.5
     parent: 853
     type: Transform
 - uid: 1974
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,6.5
@@ -26777,41 +26777,41 @@ entities:
     parent: 853
     type: Transform
 - uid: 1978
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,7.5
     parent: 853
     type: Transform
 - uid: 1979
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,12.5
     parent: 853
     type: Transform
 - uid: 1980
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,12.5
     parent: 853
     type: Transform
 - uid: 1981
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,13.5
     parent: 853
     type: Transform
 - uid: 1982
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,14.5
     parent: 853
     type: Transform
 - uid: 1983
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,15.5
@@ -26829,21 +26829,21 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1985
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,10.5
     parent: 853
     type: Transform
 - uid: 1986
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,9.5
     parent: 853
     type: Transform
 - uid: 1987
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,18.5
@@ -26857,168 +26857,168 @@ entities:
     parent: 853
     type: Transform
 - uid: 1989
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -9.5,18.5
     parent: 853
     type: Transform
 - uid: 1990
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,16.5
     parent: 853
     type: Transform
 - uid: 1991
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,13.5
     parent: 853
     type: Transform
 - uid: 1992
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,12.5
     parent: 853
     type: Transform
 - uid: 1993
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,12.5
     parent: 853
     type: Transform
 - uid: 1994
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,12.5
     parent: 853
     type: Transform
 - uid: 1995
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,12.5
     parent: 853
     type: Transform
 - uid: 1996
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,18.5
     parent: 853
     type: Transform
 - uid: 1997
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,14.5
     parent: 853
     type: Transform
 - uid: 1998
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,13.5
     parent: 853
     type: Transform
 - uid: 1999
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,12.5
     parent: 853
     type: Transform
 - uid: 2000
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,11.5
     parent: 853
     type: Transform
 - uid: 2001
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,10.5
     parent: 853
     type: Transform
 - uid: 2002
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,9.5
     parent: 853
     type: Transform
 - uid: 2003
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,8.5
     parent: 853
     type: Transform
 - uid: 2004
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,7.5
     parent: 853
     type: Transform
 - uid: 2005
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,6.5
     parent: 853
     type: Transform
 - uid: 2006
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,6.5
     parent: 853
     type: Transform
 - uid: 2007
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,6.5
     parent: 853
     type: Transform
 - uid: 2008
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,9.5
     parent: 853
     type: Transform
 - uid: 2009
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -7.5,6.5
     parent: 853
     type: Transform
 - uid: 2010
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -6.5,6.5
     parent: 853
     type: Transform
 - uid: 2011
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -6.5,7.5
     parent: 853
     type: Transform
 - uid: 2012
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -6.5,8.5
     parent: 853
     type: Transform
 - uid: 2013
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -6.5,9.5
     parent: 853
@@ -27067,63 +27067,63 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2019
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,6.5
     parent: 853
     type: Transform
 - uid: 2020
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,6.5
     parent: 853
     type: Transform
 - uid: 2021
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,6.5
     parent: 853
     type: Transform
 - uid: 2022
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,7.5
     parent: 853
     type: Transform
 - uid: 2023
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,8.5
     parent: 853
     type: Transform
 - uid: 2024
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,9.5
     parent: 853
     type: Transform
 - uid: 2025
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,10.5
     parent: 853
     type: Transform
 - uid: 2026
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,11.5
     parent: 853
     type: Transform
 - uid: 2027
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,11.5
@@ -27221,19 +27221,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2036
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-21.5
     parent: 853
     type: Transform
 - uid: 2037
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 7.5,-21.5
     parent: 853
     type: Transform
 - uid: 2038
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-21.5
     parent: 853
@@ -27252,49 +27252,49 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 2040
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-21.5
     parent: 853
     type: Transform
 - uid: 2041
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-21.5
     parent: 853
     type: Transform
 - uid: 2042
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-21.5
     parent: 853
     type: Transform
 - uid: 2043
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-22.5
     parent: 853
     type: Transform
 - uid: 2044
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-23.5
     parent: 853
     type: Transform
 - uid: 2045
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-24.5
     parent: 853
     type: Transform
 - uid: 2046
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-25.5
     parent: 853
     type: Transform
 - uid: 2047
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -18.5,-22.5
     parent: 853
@@ -27352,13 +27352,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2054
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 6.5,-22.5
     parent: 853
     type: Transform
 - uid: 2055
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-22.5
     parent: 853
@@ -27384,13 +27384,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2058
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-25.5
     parent: 853
     type: Transform
 - uid: 2059
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-26.5
     parent: 853
@@ -27404,139 +27404,139 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2061
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -34.5,-12.5
     parent: 853
     type: Transform
 - uid: 2062
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -33.5,-12.5
     parent: 853
     type: Transform
 - uid: 2063
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -32.5,-12.5
     parent: 853
     type: Transform
 - uid: 2064
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -31.5,-12.5
     parent: 853
     type: Transform
 - uid: 2065
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -30.5,-12.5
     parent: 853
     type: Transform
 - uid: 2066
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -29.5,-12.5
     parent: 853
     type: Transform
 - uid: 2067
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -28.5,-12.5
     parent: 853
     type: Transform
 - uid: 2068
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -27.5,-12.5
     parent: 853
     type: Transform
 - uid: 2069
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -33.5,11.5
     parent: 853
     type: Transform
 - uid: 2070
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -33.5,12.5
     parent: 853
     type: Transform
 - uid: 2071
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -33.5,13.5
     parent: 853
     type: Transform
 - uid: 2072
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -33.5,14.5
     parent: 853
     type: Transform
 - uid: 2073
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -33.5,15.5
     parent: 853
     type: Transform
 - uid: 2074
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -32.5,15.5
     parent: 853
     type: Transform
 - uid: 2075
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -18.5,26.5
     parent: 853
     type: Transform
 - uid: 2076
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -33.5,10.5
     parent: 853
     type: Transform
 - uid: 2077
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,1.5
     parent: 853
     type: Transform
 - uid: 2078
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -33.5,7.5
     parent: 853
     type: Transform
 - uid: 2079
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -33.5,6.5
     parent: 853
     type: Transform
 - uid: 2080
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -32.5,6.5
     parent: 853
     type: Transform
 - uid: 2081
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,6.5
     parent: 853
     type: Transform
 - uid: 2082
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,6.5
@@ -27567,14 +27567,14 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2086
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,6.5
     parent: 853
     type: Transform
 - uid: 2087
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,7.5
@@ -27589,175 +27589,175 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2089
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,7.5
     parent: 853
     type: Transform
 - uid: 2090
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,8.5
     parent: 853
     type: Transform
 - uid: 2091
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,9.5
     parent: 853
     type: Transform
 - uid: 2092
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,10.5
     parent: 853
     type: Transform
 - uid: 2093
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,11.5
     parent: 853
     type: Transform
 - uid: 2094
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,12.5
     parent: 853
     type: Transform
 - uid: 2095
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -28.5,12.5
     parent: 853
     type: Transform
 - uid: 2096
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -27.5,12.5
     parent: 853
     type: Transform
 - uid: 2097
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,12.5
     parent: 853
     type: Transform
 - uid: 2098
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -25.5,12.5
     parent: 853
     type: Transform
 - uid: 2099
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -24.5,12.5
     parent: 853
     type: Transform
 - uid: 2100
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -23.5,12.5
     parent: 853
     type: Transform
 - uid: 2101
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,12.5
     parent: 853
     type: Transform
 - uid: 2102
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -29.5,12.5
     parent: 853
     type: Transform
 - uid: 2103
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,11.5
     parent: 853
     type: Transform
 - uid: 2104
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,11.5
     parent: 853
     type: Transform
 - uid: 2105
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,11.5
     parent: 853
     type: Transform
 - uid: 2106
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,10.5
     parent: 853
     type: Transform
 - uid: 2107
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,8.5
     parent: 853
     type: Transform
 - uid: 2108
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,7.5
     parent: 853
     type: Transform
 - uid: 2109
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,7.5
     parent: 853
     type: Transform
 - uid: 2110
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,6.5
     parent: 853
     type: Transform
 - uid: 2111
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -20.5,6.5
     parent: 853
     type: Transform
 - uid: 2112
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,6.5
     parent: 853
     type: Transform
 - uid: 2113
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -25.5,11.5
@@ -27803,98 +27803,98 @@ entities:
     parent: 853
     type: Transform
 - uid: 2120
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 30.5,-0.5
     parent: 853
     type: Transform
 - uid: 2121
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 30.5,0.5
     parent: 853
     type: Transform
 - uid: 2122
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 29.5,-0.5
     parent: 853
     type: Transform
 - uid: 2123
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 28.5,-0.5
     parent: 853
     type: Transform
 - uid: 2124
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 27.5,-0.5
     parent: 853
     type: Transform
 - uid: 2125
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 26.5,-0.5
     parent: 853
     type: Transform
 - uid: 2126
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-0.5
     parent: 853
     type: Transform
 - uid: 2127
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,-0.5
     parent: 853
     type: Transform
 - uid: 2128
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,0.5
     parent: 853
     type: Transform
 - uid: 2129
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,1.5
     parent: 853
     type: Transform
 - uid: 2130
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,2.5
     parent: 853
     type: Transform
 - uid: 2131
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 23.5,2.5
     parent: 853
     type: Transform
 - uid: 2132
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 22.5,2.5
     parent: 853
     type: Transform
 - uid: 2133
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,2.5
     parent: 853
@@ -27906,7 +27906,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 2135
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,2.5
     parent: 853
@@ -27947,35 +27947,35 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2140
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 12.5,2.5
     parent: 853
     type: Transform
 - uid: 2141
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,2.5
     parent: 853
     type: Transform
 - uid: 2142
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,2.5
     parent: 853
     type: Transform
 - uid: 2143
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,1.5
     parent: 853
     type: Transform
 - uid: 2144
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,2.5
@@ -28057,56 +28057,56 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2153
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 13.5,-6.5
     parent: 853
     type: Transform
 - uid: 2154
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,-3.5
     parent: 853
     type: Transform
 - uid: 2155
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,-4.5
     parent: 853
     type: Transform
 - uid: 2156
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,-5.5
     parent: 853
     type: Transform
 - uid: 2157
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,-6.5
     parent: 853
     type: Transform
 - uid: 2158
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,-7.5
     parent: 853
     type: Transform
 - uid: 2159
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,-12.5
     parent: 853
     type: Transform
 - uid: 2160
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 5.5,-11.5
@@ -28267,133 +28267,133 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2181
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-3.5
     parent: 853
     type: Transform
 - uid: 2182
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 21.5,-3.5
     parent: 853
     type: Transform
 - uid: 2183
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 22.5,-3.5
     parent: 853
     type: Transform
 - uid: 2184
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 23.5,-3.5
     parent: 853
     type: Transform
 - uid: 2185
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,-3.5
     parent: 853
     type: Transform
 - uid: 2186
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-3.5
     parent: 853
     type: Transform
 - uid: 2187
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-4.5
     parent: 853
     type: Transform
 - uid: 2188
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-5.5
     parent: 853
     type: Transform
 - uid: 2189
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-7.5
     parent: 853
     type: Transform
 - uid: 2190
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-8.5
     parent: 853
     type: Transform
 - uid: 2191
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,-8.5
     parent: 853
     type: Transform
 - uid: 2192
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 23.5,-8.5
     parent: 853
     type: Transform
 - uid: 2193
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 22.5,-8.5
     parent: 853
     type: Transform
 - uid: 2194
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 21.5,-8.5
     parent: 853
     type: Transform
 - uid: 2195
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-8.5
     parent: 853
     type: Transform
 - uid: 2196
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-7.5
     parent: 853
     type: Transform
 - uid: 2197
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-18.5
     parent: 853
     type: Transform
 - uid: 2198
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-4.5
     parent: 853
     type: Transform
 - uid: 2199
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-9.5
@@ -28407,63 +28407,63 @@ entities:
     parent: 853
     type: Transform
 - uid: 2201
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-11.5
     parent: 853
     type: Transform
 - uid: 2202
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 21.5,-11.5
     parent: 853
     type: Transform
 - uid: 2203
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 22.5,-11.5
     parent: 853
     type: Transform
 - uid: 2204
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 23.5,-11.5
     parent: 853
     type: Transform
 - uid: 2205
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,-11.5
     parent: 853
     type: Transform
 - uid: 2206
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-11.5
     parent: 853
     type: Transform
 - uid: 2207
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-12.5
     parent: 853
     type: Transform
 - uid: 2208
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-13.5
     parent: 853
     type: Transform
 - uid: 2209
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-14.5
@@ -28480,42 +28480,42 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2211
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 25.5,-16.5
     parent: 853
     type: Transform
 - uid: 2212
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 24.5,-16.5
     parent: 853
     type: Transform
 - uid: 2213
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 23.5,-16.5
     parent: 853
     type: Transform
 - uid: 2214
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 22.5,-16.5
     parent: 853
     type: Transform
 - uid: 2215
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 21.5,-16.5
     parent: 853
     type: Transform
 - uid: 2216
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-16.5
@@ -28529,41 +28529,41 @@ entities:
     parent: 853
     type: Transform
 - uid: 2218
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 15.5,-18.5
     parent: 853
     type: Transform
 - uid: 2219
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,-17.5
     parent: 853
     type: Transform
 - uid: 2220
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 20.5,-18.5
     parent: 853
     type: Transform
 - uid: 2221
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,5.5
     parent: 853
     type: Transform
 - uid: 2222
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 45.5,5.5
     parent: 853
     type: Transform
 - uid: 2223
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 48.5,5.5
@@ -28612,7 +28612,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 2230
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,-12.5
@@ -28626,7 +28626,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 2232
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,-12.5
@@ -28640,70 +28640,70 @@ entities:
     parent: 853
     type: Transform
 - uid: 2234
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,-13.5
     parent: 853
     type: Transform
 - uid: 2235
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,-14.5
     parent: 853
     type: Transform
 - uid: 2236
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,-15.5
     parent: 853
     type: Transform
 - uid: 2237
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,-16.5
     parent: 853
     type: Transform
 - uid: 2238
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,-17.5
     parent: 853
     type: Transform
 - uid: 2239
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 7.5,-17.5
     parent: 853
     type: Transform
 - uid: 2240
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 8.5,-17.5
     parent: 853
     type: Transform
 - uid: 2241
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 9.5,-17.5
     parent: 853
     type: Transform
 - uid: 2242
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 10.5,-17.5
     parent: 853
     type: Transform
 - uid: 2243
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,-17.5
@@ -28717,336 +28717,336 @@ entities:
     parent: 853
     type: Transform
 - uid: 2245
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,-18.5
     parent: 853
     type: Transform
 - uid: 2246
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 12.5,-18.5
     parent: 853
     type: Transform
 - uid: 2247
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 13.5,-18.5
     parent: 853
     type: Transform
 - uid: 2248
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,-18.5
     parent: 853
     type: Transform
 - uid: 2249
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 6.5,-20.5
     parent: 853
     type: Transform
 - uid: 2250
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 28.5,-1.5
     parent: 853
     type: Transform
 - uid: 2251
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 28.5,-2.5
     parent: 853
     type: Transform
 - uid: 2252
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 28.5,-3.5
     parent: 853
     type: Transform
 - uid: 2253
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 28.5,-4.5
     parent: 853
     type: Transform
 - uid: 2254
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 28.5,-5.5
     parent: 853
     type: Transform
 - uid: 2255
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 29.5,-5.5
     parent: 853
     type: Transform
 - uid: 2256
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 30.5,-5.5
     parent: 853
     type: Transform
 - uid: 2257
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 31.5,-5.5
     parent: 853
     type: Transform
 - uid: 2258
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 32.5,-5.5
     parent: 853
     type: Transform
 - uid: 2259
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 34.5,-5.5
     parent: 853
     type: Transform
 - uid: 2260
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 35.5,-5.5
     parent: 853
     type: Transform
 - uid: 2261
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,-5.5
     parent: 853
     type: Transform
 - uid: 2262
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,-4.5
     parent: 853
     type: Transform
 - uid: 2263
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 36.5,-3.5
     parent: 853
     type: Transform
 - uid: 2264
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,1.5
     parent: 853
     type: Transform
 - uid: 2265
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,2.5
     parent: 853
     type: Transform
 - uid: 2266
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,2.5
     parent: 853
     type: Transform
 - uid: 2267
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-3.5
     parent: 853
     type: Transform
 - uid: 2268
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-4.5
     parent: 853
     type: Transform
 - uid: 2269
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-5.5
     parent: 853
     type: Transform
 - uid: 2270
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-6.5
     parent: 853
     type: Transform
 - uid: 2271
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,-5.5
     parent: 853
     type: Transform
 - uid: 2272
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,-5.5
     parent: 853
     type: Transform
 - uid: 2273
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-5.5
     parent: 853
     type: Transform
 - uid: 2274
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,-5.5
     parent: 853
     type: Transform
 - uid: 2275
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-9.5
     parent: 853
     type: Transform
 - uid: 2276
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-10.5
     parent: 853
     type: Transform
 - uid: 2277
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-11.5
     parent: 853
     type: Transform
 - uid: 2278
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-12.5
     parent: 853
     type: Transform
 - uid: 2279
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-8.5
     parent: 853
     type: Transform
 - uid: 2280
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,-12.5
     parent: 853
     type: Transform
 - uid: 2281
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,-12.5
     parent: 853
     type: Transform
 - uid: 2282
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-12.5
     parent: 853
     type: Transform
 - uid: 2283
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,-12.5
     parent: 853
     type: Transform
 - uid: 2284
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,-13.5
     parent: 853
     type: Transform
 - uid: 2285
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,-18.5
     parent: 853
     type: Transform
 - uid: 2286
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,-17.5
     parent: 853
     type: Transform
 - uid: 2287
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,-18.5
     parent: 853
     type: Transform
 - uid: 2288
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,-18.5
     parent: 853
     type: Transform
 - uid: 2289
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-18.5
     parent: 853
     type: Transform
 - uid: 2290
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-18.5
     parent: 853
     type: Transform
 - uid: 2291
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,-11.5
     parent: 853
     type: Transform
 - uid: 2292
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,-11.5
@@ -29063,56 +29063,56 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2294
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,-11.5
     parent: 853
     type: Transform
 - uid: 2295
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-11.5
     parent: 853
     type: Transform
 - uid: 2296
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-12.5
     parent: 853
     type: Transform
 - uid: 2297
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-13.5
     parent: 853
     type: Transform
 - uid: 2298
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-14.5
     parent: 853
     type: Transform
 - uid: 2299
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-15.5
     parent: 853
     type: Transform
 - uid: 2300
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-16.5
     parent: 853
     type: Transform
 - uid: 2301
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-17.5
@@ -29140,42 +29140,42 @@ entities:
     parent: 853
     type: Transform
 - uid: 2305
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -7.5,-21.5
     parent: 853
     type: Transform
 - uid: 2306
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 1.5,-22.5
     parent: 853
     type: Transform
 - uid: 2307
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,-22.5
     parent: 853
     type: Transform
 - uid: 2308
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 0.5,-21.5
     parent: 853
     type: Transform
 - uid: 2309
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -0.5,-21.5
     parent: 853
     type: Transform
 - uid: 2310
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-21.5
@@ -29189,91 +29189,91 @@ entities:
     parent: 853
     type: Transform
 - uid: 2312
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-22.5
     parent: 853
     type: Transform
 - uid: 2313
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-23.5
     parent: 853
     type: Transform
 - uid: 2314
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-24.5
     parent: 853
     type: Transform
 - uid: 2315
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -1.5,-25.5
     parent: 853
     type: Transform
 - uid: 2316
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,-25.5
     parent: 853
     type: Transform
 - uid: 2317
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,-25.5
     parent: 853
     type: Transform
 - uid: 2318
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -4.5,-25.5
     parent: 853
     type: Transform
 - uid: 2319
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,-25.5
     parent: 853
     type: Transform
 - uid: 2320
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-25.5
     parent: 853
     type: Transform
 - uid: 2321
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-24.5
     parent: 853
     type: Transform
 - uid: 2322
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-23.5
     parent: 853
     type: Transform
 - uid: 2323
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-22.5
     parent: 853
     type: Transform
 - uid: 2324
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-21.5
@@ -29294,163 +29294,163 @@ entities:
     parent: 853
     type: Transform
 - uid: 2327
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -9.5,-21.5
     parent: 853
     type: Transform
 - uid: 2328
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-27.5
     parent: 853
     type: Transform
 - uid: 2329
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,-27.5
     parent: 853
     type: Transform
 - uid: 2330
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,-27.5
     parent: 853
     type: Transform
 - uid: 2331
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,-27.5
     parent: 853
     type: Transform
 - uid: 2332
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,-27.5
     parent: 853
     type: Transform
 - uid: 2333
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,-27.5
     parent: 853
     type: Transform
 - uid: 2334
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,-27.5
     parent: 853
     type: Transform
 - uid: 2335
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,-26.5
     parent: 853
     type: Transform
 - uid: 2336
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,-25.5
     parent: 853
     type: Transform
 - uid: 2337
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,-24.5
     parent: 853
     type: Transform
 - uid: 2338
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,-23.5
     parent: 853
     type: Transform
 - uid: 2339
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,-23.5
     parent: 853
     type: Transform
 - uid: 2340
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,-23.5
     parent: 853
     type: Transform
 - uid: 2341
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-23.5
     parent: 853
     type: Transform
 - uid: 2342
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-24.5
     parent: 853
     type: Transform
 - uid: 2343
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-25.5
     parent: 853
     type: Transform
 - uid: 2344
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-26.5
     parent: 853
     type: Transform
 - uid: 2345
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -17.5,26.5
     parent: 853
     type: Transform
 - uid: 2346
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,14.5
     parent: 853
     type: Transform
 - uid: 2347
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,14.5
     parent: 853
     type: Transform
 - uid: 2348
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,14.5
     parent: 853
     type: Transform
 - uid: 2349
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 18.5,14.5
     parent: 853
     type: Transform
 - uid: 2350
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,14.5
     parent: 853
@@ -29466,7 +29466,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2352
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,16.5
     parent: 853
@@ -29484,133 +29484,133 @@ entities:
     parent: 853
     type: Transform
 - uid: 2355
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-21.5
     parent: 853
     type: Transform
 - uid: 2356
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-22.5
     parent: 853
     type: Transform
 - uid: 2357
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-23.5
     parent: 853
     type: Transform
 - uid: 2358
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-24.5
     parent: 853
     type: Transform
 - uid: 2359
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-25.5
     parent: 853
     type: Transform
 - uid: 2360
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-22.5
     parent: 853
     type: Transform
 - uid: 2361
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-21.5
     parent: 853
     type: Transform
 - uid: 2362
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-18.5
     parent: 853
     type: Transform
 - uid: 2363
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-17.5
     parent: 853
     type: Transform
 - uid: 2364
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-16.5
     parent: 853
     type: Transform
 - uid: 2365
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,-16.5
     parent: 853
     type: Transform
 - uid: 2366
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-16.5
     parent: 853
     type: Transform
 - uid: 2367
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -9.5,-16.5
     parent: 853
     type: Transform
 - uid: 2368
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -8.5,-16.5
     parent: 853
     type: Transform
 - uid: 2369
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -7.5,-16.5
     parent: 853
     type: Transform
 - uid: 2370
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,-16.5
     parent: 853
     type: Transform
 - uid: 2371
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,-16.5
     parent: 853
     type: Transform
 - uid: 2372
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,-16.5
     parent: 853
     type: Transform
 - uid: 2373
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,-16.5
@@ -29661,7 +29661,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2380
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-28.5
     parent: 853
@@ -29703,70 +29703,70 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 2385
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,-13.5
     parent: 853
     type: Transform
 - uid: 2386
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -15.5,-13.5
     parent: 853
     type: Transform
 - uid: 2387
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,-13.5
     parent: 853
     type: Transform
 - uid: 2388
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -12.5,-13.5
     parent: 853
     type: Transform
 - uid: 2389
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,-13.5
     parent: 853
     type: Transform
 - uid: 2390
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-13.5
     parent: 853
     type: Transform
 - uid: 2391
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-12.5
     parent: 853
     type: Transform
 - uid: 2392
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-11.5
     parent: 853
     type: Transform
 - uid: 2393
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-10.5
     parent: 853
     type: Transform
 - uid: 2394
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-9.5
@@ -29783,96 +29783,96 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2396
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,-8.5
     parent: 853
     type: Transform
 - uid: 2397
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -13.5,-8.5
     parent: 853
     type: Transform
 - uid: 2398
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -15.5,-9.5
     parent: 853
     type: Transform
 - uid: 2399
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -10.5,-8.5
     parent: 853
     type: Transform
 - uid: 2400
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,-8.5
     parent: 853
     type: Transform
 - uid: 2401
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,-9.5
     parent: 853
     type: Transform
 - uid: 2402
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,-10.5
     parent: 853
     type: Transform
 - uid: 2403
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,-11.5
     parent: 853
     type: Transform
 - uid: 2404
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,-12.5
     parent: 853
     type: Transform
 - uid: 2405
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -9.5,-24.5
     parent: 853
     type: Transform
 - uid: 2406
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -8.5,-24.5
     parent: 853
     type: Transform
 - uid: 2407
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -7.5,-24.5
     parent: 853
     type: Transform
 - uid: 2408
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,-6.5
     parent: 853
     type: Transform
 - uid: 2409
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -2.5,-7.5
@@ -29908,7 +29908,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 2413
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -8.5,-4.5
@@ -29939,14 +29939,14 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2417
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -6.5,-7.5
     parent: 853
     type: Transform
 - uid: 2418
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -8.5,-5.5
@@ -29963,14 +29963,14 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2420
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -9.5,-5.5
     parent: 853
     type: Transform
 - uid: 2421
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,-5.5
@@ -30029,28 +30029,28 @@ entities:
     parent: 853
     type: Transform
 - uid: 2428
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -10.5,2.5
     parent: 853
     type: Transform
 - uid: 2429
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -4.5,2.5
     parent: 853
     type: Transform
 - uid: 2430
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -9.5,2.5
     parent: 853
     type: Transform
 - uid: 2431
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -11.5,2.5
@@ -30164,14 +30164,14 @@ entities:
     parent: 853
     type: Transform
 - uid: 2446
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,-9.5
     parent: 853
     type: Transform
 - uid: 2447
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -22.5,-9.5
@@ -30184,70 +30184,70 @@ entities:
     parent: 853
     type: Transform
 - uid: 2449
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -24.5,-9.5
     parent: 853
     type: Transform
 - uid: 2450
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -25.5,-9.5
     parent: 853
     type: Transform
 - uid: 2451
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,-9.5
     parent: 853
     type: Transform
 - uid: 2452
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -27.5,-9.5
     parent: 853
     type: Transform
 - uid: 2453
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -28.5,-9.5
     parent: 853
     type: Transform
 - uid: 2454
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -29.5,-9.5
     parent: 853
     type: Transform
 - uid: 2455
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,-9.5
     parent: 853
     type: Transform
 - uid: 2456
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-9.5
     parent: 853
     type: Transform
 - uid: 2457
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,-3.5
     parent: 853
     type: Transform
 - uid: 2458
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-8.5
@@ -30274,28 +30274,28 @@ entities:
     parent: 853
     type: Transform
 - uid: 2462
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -34.5,-7.5
     parent: 853
     type: Transform
 - uid: 2463
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-5.5
     parent: 853
     type: Transform
 - uid: 2464
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-4.5
     parent: 853
     type: Transform
 - uid: 2465
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-3.5
@@ -30376,14 +30376,14 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 2475
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,-8.5
     parent: 853
     type: Transform
 - uid: 2476
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -6.5,23.5
     parent: 853
@@ -30408,28 +30408,28 @@ entities:
     parent: 853
     type: Transform
 - uid: 2479
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -20.5,-6.5
     parent: 853
     type: Transform
 - uid: 2480
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,-6.5
     parent: 853
     type: Transform
 - uid: 2481
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,-6.5
     parent: 853
     type: Transform
 - uid: 2482
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,-6.5
@@ -30467,119 +30467,119 @@ entities:
     parent: 853
     type: Transform
 - uid: 2487
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,-4.5
     parent: 853
     type: Transform
 - uid: 2488
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,-5.5
     parent: 853
     type: Transform
 - uid: 2489
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -17.5,-3.5
     parent: 853
     type: Transform
 - uid: 2490
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -18.5,-3.5
     parent: 853
     type: Transform
 - uid: 2491
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -19.5,-3.5
     parent: 853
     type: Transform
 - uid: 2492
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -20.5,-3.5
     parent: 853
     type: Transform
 - uid: 2493
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,-3.5
     parent: 853
     type: Transform
 - uid: 2494
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -21.5,-2.5
     parent: 853
     type: Transform
 - uid: 2495
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 11.5,22.5
     parent: 853
     type: Transform
 - uid: 2496
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 14.5,23.5
     parent: 853
     type: Transform
 - uid: 2497
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 13.5,22.5
     parent: 853
     type: Transform
 - uid: 2498
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 14.5,22.5
     parent: 853
     type: Transform
 - uid: 2499
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 14.5,24.5
     parent: 853
     type: Transform
 - uid: 2500
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 14.5,25.5
     parent: 853
     type: Transform
 - uid: 2501
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,15.5
     parent: 853
     type: Transform
 - uid: 2502
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -14.5,16.5
     parent: 853
     type: Transform
 - uid: 2503
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -16.5,15.5
@@ -30766,7 +30766,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2524
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 12.5,-11.5
@@ -31097,7 +31097,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2557
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -17.5,17.5
     parent: 853
@@ -32823,7 +32823,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 2719
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,1.5
@@ -37519,7 +37519,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3163
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,24.5
     parent: 853
@@ -40677,7 +40677,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3487
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,16.5
     parent: 853
@@ -40818,7 +40818,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3503
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,15.5
     parent: 853
@@ -40844,7 +40844,7 @@ entities:
     supplyRampPosition: 1.347667
     type: PowerNetworkBattery
 - uid: 3506
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -17.5,15.5
     parent: 853
@@ -41404,7 +41404,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3564
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,17.5
     parent: 853
@@ -44658,7 +44658,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3877
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 23.5,-9.5
@@ -45356,13 +45356,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3941
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -9.5,-8.5
     parent: 853
     type: Transform
 - uid: 3942
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -13.5,-7.5
     parent: 853
@@ -45734,7 +45734,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3981
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -25.5,7.5
@@ -46010,7 +46010,7 @@ entities:
   - airBlocked: False
     type: Airtight
 - uid: 4011
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-14.5
@@ -46169,7 +46169,7 @@ entities:
   - airBlocked: False
     type: Airtight
 - uid: 4030
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,-7.5
     parent: 853
@@ -46314,7 +46314,7 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 4047
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,-7.5
     parent: 853
@@ -46416,7 +46416,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 4060
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 15.5,-12.5
@@ -46553,28 +46553,28 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4076
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -3.5,-7.5
     parent: 853
     type: Transform
 - uid: 4077
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -4.5,-7.5
     parent: 853
     type: Transform
 - uid: 4078
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -5.5,-7.5
     parent: 853
     type: Transform
 - uid: 4079
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,-8.5
     parent: 853
@@ -46665,98 +46665,98 @@ entities:
     parent: 853
     type: Transform
 - uid: 4090
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,-0.5
     parent: 853
     type: Transform
 - uid: 4091
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -27.5,-0.5
     parent: 853
     type: Transform
 - uid: 4092
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -28.5,-0.5
     parent: 853
     type: Transform
 - uid: 4093
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -29.5,-0.5
     parent: 853
     type: Transform
 - uid: 4094
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,-0.5
     parent: 853
     type: Transform
 - uid: 4095
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,-3.5
     parent: 853
     type: Transform
 - uid: 4096
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -27.5,-3.5
     parent: 853
     type: Transform
 - uid: 4097
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -28.5,-3.5
     parent: 853
     type: Transform
 - uid: 4098
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -31.5,-6.5
     parent: 853
     type: Transform
 - uid: 4099
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,-6.5
     parent: 853
     type: Transform
 - uid: 4100
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -27.5,-6.5
     parent: 853
     type: Transform
 - uid: 4101
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -28.5,-6.5
     parent: 853
     type: Transform
 - uid: 4102
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -29.5,-6.5
     parent: 853
     type: Transform
 - uid: 4103
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -30.5,-6.5
@@ -46781,14 +46781,14 @@ entities:
     parent: 853
     type: Transform
 - uid: 4106
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,-1.5
     parent: 853
     type: Transform
 - uid: 4107
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: -26.5,-4.5
@@ -47067,13 +47067,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 4141
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,9.5
     parent: 853
     type: Transform
 - uid: 4142
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,6.5
     parent: 853
@@ -47245,21 +47245,21 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 4158
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 16.5,-13.5
     parent: 853
     type: Transform
 - uid: 4159
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 12.5,-12.5
     parent: 853
     type: Transform
 - uid: 4160
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 13.5,-12.5
@@ -47675,19 +47675,19 @@ entities:
     parent: 853
     type: Transform
 - uid: 4207
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,23.5
     parent: 853
     type: Transform
 - uid: 4208
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,23.5
     parent: 853
     type: Transform
 - uid: 4209
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -7.5,23.5
     parent: 853
@@ -48242,49 +48242,49 @@ entities:
     parent: 853
     type: Transform
 - uid: 4283
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-1.5
     parent: 853
     type: Transform
 - uid: 4284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-2.5
     parent: 853
     type: Transform
 - uid: 4285
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-3.5
     parent: 853
     type: Transform
 - uid: 4286
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-4.5
     parent: 853
     type: Transform
 - uid: 4287
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-5.5
     parent: 853
     type: Transform
 - uid: 4288
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-6.5
     parent: 853
     type: Transform
 - uid: 4289
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-7.5
@@ -48298,25 +48298,25 @@ entities:
     parent: 853
     type: Transform
 - uid: 4291
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,14.5
     parent: 853
     type: Transform
 - uid: 4292
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,14.5
     parent: 853
     type: Transform
 - uid: 4293
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,14.5
     parent: 853
     type: Transform
 - uid: 4294
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,14.5
     parent: 853
@@ -48385,14 +48385,14 @@ entities:
     parent: 853
     type: Transform
 - uid: 4304
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 51.5,6.5
     parent: 853
     type: Transform
 - uid: 4305
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 45.5,14.5
@@ -48411,7 +48411,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 4308
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,25.5
     parent: 853
@@ -48848,7 +48848,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4351
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-8.5
@@ -48915,14 +48915,14 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4360
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 43.5,-14.5
     parent: 853
     type: Transform
 - uid: 4361
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 55.5,-14.5
@@ -48995,49 +48995,49 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4370
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-8.5
     parent: 853
     type: Transform
 - uid: 4371
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-10.5
     parent: 853
     type: Transform
 - uid: 4372
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-11.5
     parent: 853
     type: Transform
 - uid: 4373
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 46.5,-12.5
     parent: 853
     type: Transform
 - uid: 4374
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-12.5
     parent: 853
     type: Transform
 - uid: 4375
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-11.5
     parent: 853
     type: Transform
 - uid: 4376
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 4.371139006309477E-08 rad
     pos: 52.5,-10.5
@@ -50048,25 +50048,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4493
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,-7.5
     parent: 853
     type: Transform
 - uid: 4494
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,-7.5
     parent: 853
     type: Transform
 - uid: 4495
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,-7.5
     parent: 853
     type: Transform
 - uid: 4496
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-7.5
     parent: 853
@@ -50746,13 +50746,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 4575
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-8.5
     parent: 853
     type: Transform
 - uid: 4576
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-9.5
     parent: 853
@@ -50786,7 +50786,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 4581
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-10.5
     parent: 853
@@ -50799,13 +50799,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 4583
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-11.5
     parent: 853
     type: Transform
 - uid: 4584
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-12.5
     parent: 853
@@ -50927,7 +50927,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 4601
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-13.5
     parent: 853
@@ -51549,25 +51549,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4676
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,-14.5
     parent: 853
     type: Transform
 - uid: 4677
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,-7.5
     parent: 853
     type: Transform
 - uid: 4678
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,-7.5
     parent: 853
     type: Transform
 - uid: 4679
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 55.5,-7.5
     parent: 853
@@ -52050,7 +52050,7 @@ entities:
       BatteryBarrel-ammo-container: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 4735
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -20.5,-4.5
     parent: 853
@@ -52172,19 +52172,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 4751
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-28.5
     parent: 853
     type: Transform
 - uid: 4752
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-28.5
     parent: 853
     type: Transform
 - uid: 4753
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-28.5
     parent: 853
@@ -52266,7 +52266,7 @@ entities:
       cellslot_cell_container: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 4760
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-12.5
     parent: 853
@@ -52333,7 +52333,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4768
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-29.5
     parent: 853
@@ -52417,13 +52417,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 4776
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-29.5
     parent: 853
     type: Transform
 - uid: 4777
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 5.5,-30.5
     parent: 853
@@ -53101,37 +53101,37 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 4839
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-26.5
     parent: 853
     type: Transform
 - uid: 4840
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-27.5
     parent: 853
     type: Transform
 - uid: 4841
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-28.5
     parent: 853
     type: Transform
 - uid: 4842
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-29.5
     parent: 853
     type: Transform
 - uid: 4843
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-30.5
     parent: 853
     type: Transform
 - uid: 4844
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-31.5
     parent: 853
@@ -53144,25 +53144,25 @@ entities:
     parent: 853
     type: Transform
 - uid: 4846
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-24.5
     parent: 853
     type: Transform
 - uid: 4847
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-25.5
     parent: 853
     type: Transform
 - uid: 4848
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-26.5
     parent: 853
     type: Transform
 - uid: 4849
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,-27.5
     parent: 853
@@ -53255,79 +53255,79 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4859
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-28.5
     parent: 853
     type: Transform
 - uid: 4860
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-28.5
     parent: 853
     type: Transform
 - uid: 4861
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-29.5
     parent: 853
     type: Transform
 - uid: 4862
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-30.5
     parent: 853
     type: Transform
 - uid: 4863
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-31.5
     parent: 853
     type: Transform
 - uid: 4864
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-31.5
     parent: 853
     type: Transform
 - uid: 4865
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-31.5
     parent: 853
     type: Transform
 - uid: 4866
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-31.5
     parent: 853
     type: Transform
 - uid: 4867
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-31.5
     parent: 853
     type: Transform
 - uid: 4868
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-31.5
     parent: 853
     type: Transform
 - uid: 4869
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 10.5,-31.5
     parent: 853
     type: Transform
 - uid: 4870
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,-31.5
     parent: 853
     type: Transform
 - uid: 4871
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,-31.5
     parent: 853
@@ -53401,7 +53401,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 4883
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -13.5,-9.5
     parent: 853
@@ -53647,7 +53647,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 4913
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-3.5
     parent: 853
@@ -54078,79 +54078,79 @@ entities:
     parent: 853
     type: Transform
 - uid: 4961
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-22.5
     parent: 853
     type: Transform
 - uid: 4962
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,-26.5
     parent: 853
     type: Transform
 - uid: 4963
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,-26.5
     parent: 853
     type: Transform
 - uid: 4964
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,-26.5
     parent: 853
     type: Transform
 - uid: 4965
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-20.5
     parent: 853
     type: Transform
 - uid: 4966
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-23.5
     parent: 853
     type: Transform
 - uid: 4967
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-21.5
     parent: 853
     type: Transform
 - uid: 4968
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-24.5
     parent: 853
     type: Transform
 - uid: 4969
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-25.5
     parent: 853
     type: Transform
 - uid: 4970
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-26.5
     parent: 853
     type: Transform
 - uid: 4971
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-26.5
     parent: 853
     type: Transform
 - uid: 4972
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,-24.5
     parent: 853
     type: Transform
 - uid: 4973
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,-25.5
     parent: 853
@@ -54166,25 +54166,25 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 4975
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,-21.5
     parent: 853
     type: Transform
 - uid: 4976
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 27.5,-21.5
     parent: 853
     type: Transform
 - uid: 4977
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 26.5,-21.5
     parent: 853
     type: Transform
 - uid: 4978
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,-15.5
     parent: 853
@@ -54198,7 +54198,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4980
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 25.5,-22.5
     parent: 853
@@ -54334,7 +54334,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4995
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -20.5,16.5
     parent: 853
@@ -54405,31 +54405,31 @@ entities:
       PaperLabel: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 5003
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -27.5,17.5
     parent: 853
     type: Transform
 - uid: 5004
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -27.5,18.5
     parent: 853
     type: Transform
 - uid: 5005
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -27.5,19.5
     parent: 853
     type: Transform
 - uid: 5006
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -27.5,20.5
     parent: 853
     type: Transform
 - uid: 5007
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -20.5,18.5
     parent: 853
@@ -54447,61 +54447,61 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 5009
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -22.5,18.5
     parent: 853
     type: Transform
 - uid: 5010
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -21.5,18.5
     parent: 853
     type: Transform
 - uid: 5011
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -24.5,18.5
     parent: 853
     type: Transform
 - uid: 5012
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -24.5,17.5
     parent: 853
     type: Transform
 - uid: 5013
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -24.5,16.5
     parent: 853
     type: Transform
 - uid: 5014
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -27.5,21.5
     parent: 853
     type: Transform
 - uid: 5015
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -26.5,21.5
     parent: 853
     type: Transform
 - uid: 5016
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -25.5,21.5
     parent: 853
     type: Transform
 - uid: 5017
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,21.5
     parent: 853
     type: Transform
 - uid: 5018
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -23.5,21.5
     parent: 853
@@ -54520,13 +54520,13 @@ entities:
       PaperLabel: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 5020
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -21.5,21.5
     parent: 853
     type: Transform
 - uid: 5021
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -20.5,21.5
     parent: 853
@@ -54700,7 +54700,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 5040
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-7.5
     parent: 853
@@ -55051,25 +55051,25 @@ entities:
     parent: 853
     type: Transform
 - uid: 5085
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,27.5
     parent: 853
     type: Transform
 - uid: 5086
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,27.5
     parent: 853
     type: Transform
 - uid: 5087
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,27.5
     parent: 853
     type: Transform
 - uid: 5088
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,26.5
     parent: 853
@@ -55104,7 +55104,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 5093
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -2.5,9.5
     parent: 853
@@ -55483,7 +55483,7 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 5137
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-8.5
     parent: 853
@@ -55601,7 +55601,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5152
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-9.5
     parent: 853
@@ -55943,49 +55943,49 @@ entities:
     parent: 853
     type: Transform
 - uid: 5206
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,22.5
     parent: 853
     type: Transform
 - uid: 5207
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,23.5
     parent: 853
     type: Transform
 - uid: 5208
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,25.5
     parent: 853
     type: Transform
 - uid: 5209
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,26.5
     parent: 853
     type: Transform
 - uid: 5210
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -23.5,26.5
     parent: 853
     type: Transform
 - uid: 5211
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -22.5,26.5
     parent: 853
     type: Transform
 - uid: 5212
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -21.5,26.5
     parent: 853
     type: Transform
 - uid: 5213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -20.5,26.5
     parent: 853
@@ -56082,25 +56082,25 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 5223
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -26.5,23.5
     parent: 853
     type: Transform
 - uid: 5224
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -25.5,23.5
     parent: 853
     type: Transform
 - uid: 5225
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -26.5,25.5
     parent: 853
     type: Transform
 - uid: 5226
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -25.5,25.5
     parent: 853
@@ -56505,37 +56505,37 @@ entities:
     parent: 853
     type: Transform
 - uid: 5282
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-27.5
     parent: 853
     type: Transform
 - uid: 5283
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-28.5
     parent: 853
     type: Transform
 - uid: 5284
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-29.5
     parent: 853
     type: Transform
 - uid: 5285
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-30.5
     parent: 853
     type: Transform
 - uid: 5286
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-30.5
     parent: 853
     type: Transform
 - uid: 5287
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-30.5
     parent: 853
@@ -56567,7 +56567,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 5291
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-10.5
     parent: 853
@@ -56802,31 +56802,31 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 5324
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 13.5,-32.5
     parent: 853
     type: Transform
 - uid: 5325
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 14.5,-32.5
     parent: 853
     type: Transform
 - uid: 5326
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-32.5
     parent: 853
     type: Transform
 - uid: 5327
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-32.5
     parent: 853
     type: Transform
 - uid: 5328
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-32.5
     parent: 853
@@ -69551,7 +69551,7 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 6365
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 47.5,25.5
     parent: 853
@@ -69732,13 +69732,13 @@ entities:
   - color: '#7F007FFF'
     type: AtmosPipeColor
 - uid: 6382
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,20.5
     parent: 853
     type: Transform
 - uid: 6383
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,20.5
     parent: 853
@@ -69777,7 +69777,7 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6387
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,20.5
     parent: 853
@@ -69805,7 +69805,7 @@ entities:
   - color: '#7F007FFF'
     type: AtmosPipeColor
 - uid: 6390
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,20.5
     parent: 853
@@ -69833,7 +69833,7 @@ entities:
   - color: '#7F007FFF'
     type: AtmosPipeColor
 - uid: 6393
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,15.5
     parent: 853
@@ -69873,7 +69873,7 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 6397
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,22.5
     parent: 853
@@ -69890,7 +69890,7 @@ entities:
   - color: '#7F007FFF'
     type: AtmosPipeColor
 - uid: 6399
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,23.5
     parent: 853
@@ -70005,13 +70005,13 @@ entities:
   - color: '#7F007FFF'
     type: AtmosPipeColor
 - uid: 6410
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,24.5
     parent: 853
     type: Transform
 - uid: 6411
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 31.5,25.5
     parent: 853
@@ -70027,7 +70027,7 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6413
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 32.5,25.5
     parent: 853
@@ -70088,7 +70088,7 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6419
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 33.5,25.5
     parent: 853
@@ -70104,7 +70104,7 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6421
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 34.5,25.5
     parent: 853
@@ -70196,13 +70196,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 6431
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,25.5
     parent: 853
     type: Transform
 - uid: 6432
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,24.5
     parent: 853
@@ -70248,7 +70248,7 @@ entities:
   - color: '#0000FFFF'
     type: AtmosPipeColor
 - uid: 6438
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,23.5
     parent: 853
@@ -70544,7 +70544,7 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6466
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 35.5,22.5
     parent: 853
@@ -70600,13 +70600,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 6472
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,24.5
     parent: 853
     type: Transform
 - uid: 6473
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,23.5
     parent: 853
@@ -70624,43 +70624,43 @@ entities:
     parent: 853
     type: Transform
 - uid: 6476
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 37.5,25.5
     parent: 853
     type: Transform
 - uid: 6477
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 38.5,25.5
     parent: 853
     type: Transform
 - uid: 6478
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 39.5,25.5
     parent: 853
     type: Transform
 - uid: 6479
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,25.5
     parent: 853
     type: Transform
 - uid: 6480
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,24.5
     parent: 853
     type: Transform
 - uid: 6481
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,23.5
     parent: 853
     type: Transform
 - uid: 6482
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 40.5,22.5
     parent: 853
@@ -70686,7 +70686,7 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6485
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,25.5
     parent: 853
@@ -70825,7 +70825,7 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6501
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 41.5,25.5
     parent: 853
@@ -70901,79 +70901,79 @@ entities:
     parent: 853
     type: Transform
 - uid: 6513
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,22.5
     parent: 853
     type: Transform
 - uid: 6514
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,23.5
     parent: 853
     type: Transform
 - uid: 6515
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,24.5
     parent: 853
     type: Transform
 - uid: 6516
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 44.5,25.5
     parent: 853
     type: Transform
 - uid: 6517
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 43.5,25.5
     parent: 853
     type: Transform
 - uid: 6518
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 42.5,25.5
     parent: 853
     type: Transform
 - uid: 6519
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 46.5,25.5
     parent: 853
     type: Transform
 - uid: 6520
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,19.5
     parent: 853
     type: Transform
 - uid: 6521
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,19.5
     parent: 853
     type: Transform
 - uid: 6522
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,18.5
     parent: 853
     type: Transform
 - uid: 6523
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,17.5
     parent: 853
     type: Transform
 - uid: 6524
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,16.5
     parent: 853
     type: Transform
 - uid: 6525
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,15.5
     parent: 853
@@ -70989,7 +70989,7 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6527
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 45.5,25.5
     parent: 853
@@ -71611,25 +71611,25 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 6607
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 49.5,16.5
     parent: 853
     type: Transform
 - uid: 6608
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,16.5
     parent: 853
     type: Transform
 - uid: 6609
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,16.5
     parent: 853
     type: Transform
 - uid: 6610
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,16.5
     parent: 853
@@ -71934,13 +71934,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 6644
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,23.5
     parent: 853
     type: Transform
 - uid: 6645
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 48.5,22.5
     parent: 853
@@ -72133,7 +72133,7 @@ entities:
     parent: 853
     type: Transform
 - uid: 6671
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,16.5
     parent: 853
@@ -73150,43 +73150,43 @@ entities:
     parent: 853
     type: Transform
 - uid: 6838
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,17.5
     parent: 853
     type: Transform
 - uid: 6839
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,18.5
     parent: 853
     type: Transform
 - uid: 6840
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,19.5
     parent: 853
     type: Transform
 - uid: 6841
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 54.5,20.5
     parent: 853
     type: Transform
 - uid: 6842
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 53.5,20.5
     parent: 853
     type: Transform
 - uid: 6843
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 52.5,20.5
     parent: 853
     type: Transform
 - uid: 6844
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 51.5,20.5
     parent: 853
@@ -73823,7 +73823,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 6927
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 36.5,22.5
     parent: 853
@@ -73978,25 +73978,25 @@ entities:
   - color: '#007F7FFF'
     type: AtmosPipeColor
 - uid: 6952
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-11.5
     parent: 853
     type: Transform
 - uid: 6953
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-12.5
     parent: 853
     type: Transform
 - uid: 6954
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-13.5
     parent: 853
     type: Transform
 - uid: 6955
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 56.5,-14.5
     parent: 853
@@ -75161,13 +75161,13 @@ entities:
     parent: 853
     type: Transform
 - uid: 7129
-  type: WallMetal
+  type: WallSteel
   components:
   - pos: 21.5,23.5
     parent: 853
     type: Transform
 - uid: 7130
-  type: WallMetal
+  type: WallSteel
   components:
   - pos: 24.5,23.5
     parent: 853

--- a/Resources/Maps/ssreach.yml
+++ b/Resources/Maps/ssreach.yml
@@ -77,25 +77,25 @@ grids:
     tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAACMAAAAjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACUAAAAlAAAAIwAAACMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlAAAAJQAAACUAAAAjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJQAAACUAAAAlAAAAIwAAACMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
 entities:
 - uid: 0
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-0.5
     parent: 4
     type: Transform
 - uid: 1
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-0.5
     parent: 4
     type: Transform
 - uid: 2
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-0.5
     parent: 4
     type: Transform
 - uid: 3
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,1.5
     parent: 4
@@ -3476,7 +3476,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 10
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 3.141592653589793 rad
     pos: 12.5,1.5
@@ -3489,7 +3489,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 12
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: 3.141592653589793 rad
     pos: 9.5,1.5
@@ -3661,7 +3661,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 32
-  type: PartRodMetal
+  type: PartRodSteel
   components:
   - pos: -11.337089,0.7524755
     parent: 4
@@ -3973,7 +3973,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 71
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,2.5
     parent: 4
@@ -4261,21 +4261,21 @@ entities:
     parent: 4
     type: Transform
 - uid: 108
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 4.5,-10.5
     parent: 4
     type: Transform
 - uid: 109
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 4.5,-7.5
     parent: 4
     type: Transform
 - uid: 110
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 1.5,-6.5
@@ -4312,7 +4312,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 116
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,5.5
     parent: 4
@@ -4360,21 +4360,21 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 123
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 4.5,-11.5
     parent: 4
     type: Transform
 - uid: 124
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 2.5,-6.5
     parent: 4
     type: Transform
 - uid: 125
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 0.5,-6.5
@@ -4667,19 +4667,19 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 158
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -7.5,5.5
     parent: 4
     type: Transform
 - uid: 159
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,5.5
     parent: 4
     type: Transform
 - uid: 160
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,4.5
     parent: 4
@@ -4698,61 +4698,61 @@ entities:
   - color: '#00DEF7FF'
     type: AtmosPipeColor
 - uid: 162
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -11.5,5.5
     parent: 4
     type: Transform
 - uid: 163
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -11.5,4.5
     parent: 4
     type: Transform
 - uid: 164
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -12.5,4.5
     parent: 4
     type: Transform
 - uid: 165
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -13.5,4.5
     parent: 4
     type: Transform
 - uid: 166
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -13.5,3.5
     parent: 4
     type: Transform
 - uid: 167
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -14.5,3.5
     parent: 4
     type: Transform
 - uid: 168
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -15.5,3.5
     parent: 4
     type: Transform
 - uid: 169
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -16.5,3.5
     parent: 4
     type: Transform
 - uid: 170
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -16.5,2.5
     parent: 4
     type: Transform
 - uid: 171
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -17.5,2.5
     parent: 4
@@ -4788,426 +4788,426 @@ entities:
     parent: 4
     type: Transform
 - uid: 177
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -17.5,-3.5
     parent: 4
     type: Transform
 - uid: 178
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -16.5,-3.5
     parent: 4
     type: Transform
 - uid: 179
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -16.5,-4.5
     parent: 4
     type: Transform
 - uid: 180
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -15.5,-4.5
     parent: 4
     type: Transform
 - uid: 181
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -14.5,-4.5
     parent: 4
     type: Transform
 - uid: 182
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -13.5,-4.5
     parent: 4
     type: Transform
 - uid: 183
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -13.5,-5.5
     parent: 4
     type: Transform
 - uid: 184
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -12.5,-5.5
     parent: 4
     type: Transform
 - uid: 185
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -11.5,-5.5
     parent: 4
     type: Transform
 - uid: 186
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -10.5,-5.5
     parent: 4
     type: Transform
 - uid: 187
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -9.5,-5.5
     parent: 4
     type: Transform
 - uid: 188
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,-5.5
     parent: 4
     type: Transform
 - uid: 189
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,-6.5
     parent: 4
     type: Transform
 - uid: 190
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -7.5,-6.5
     parent: 4
     type: Transform
 - uid: 191
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,-6.5
     parent: 4
     type: Transform
 - uid: 192
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-6.5
     parent: 4
     type: Transform
 - uid: 193
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 4.5,-8.5
     parent: 4
     type: Transform
 - uid: 194
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 4.5,-6.5
     parent: 4
     type: Transform
 - uid: 195
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 3.5,-6.5
     parent: 4
     type: Transform
 - uid: 196
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-6.5
     parent: 4
     type: Transform
 - uid: 197
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,-6.5
     parent: 4
     type: Transform
 - uid: 198
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 15.5,-6.5
     parent: 4
     type: Transform
 - uid: 199
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 17.5,-6.5
     parent: 4
     type: Transform
 - uid: 200
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 19.5,-6.5
     parent: 4
     type: Transform
 - uid: 201
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-6.5
     parent: 4
     type: Transform
 - uid: 202
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-6.5
     parent: 4
     type: Transform
 - uid: 203
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,-6.5
     parent: 4
     type: Transform
 - uid: 204
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-6.5
     parent: 4
     type: Transform
 - uid: 205
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-5.5
     parent: 4
     type: Transform
 - uid: 206
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,-5.5
     parent: 4
     type: Transform
 - uid: 207
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,-5.5
     parent: 4
     type: Transform
 - uid: 208
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,-5.5
     parent: 4
     type: Transform
 - uid: 209
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 30.5,4.5
     parent: 4
     type: Transform
 - uid: 210
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 29.5,4.5
     parent: 4
     type: Transform
 - uid: 211
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 28.5,4.5
     parent: 4
     type: Transform
 - uid: 212
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-4.5
     parent: 4
     type: Transform
 - uid: 213
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-3.5
     parent: 4
     type: Transform
 - uid: 214
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,-2.5
     parent: 4
     type: Transform
 - uid: 215
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,-2.5
     parent: 4
     type: Transform
 - uid: 216
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,-2.5
     parent: 4
     type: Transform
 - uid: 217
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 22.5,-2.5
     parent: 4
     type: Transform
 - uid: 218
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 21.5,-2.5
     parent: 4
     type: Transform
 - uid: 219
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-5.5
     parent: 4
     type: Transform
 - uid: 220
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-4.5
     parent: 4
     type: Transform
 - uid: 221
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-3.5
     parent: 4
     type: Transform
 - uid: 222
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,-2.5
     parent: 4
     type: Transform
 - uid: 223
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -5.5,5.5
     parent: 4
     type: Transform
 - uid: 224
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -3.5,5.5
     parent: 4
     type: Transform
 - uid: 225
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,5.5
     parent: 4
     type: Transform
 - uid: 226
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -4.5,5.5
     parent: 4
     type: Transform
 - uid: 227
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,5.5
     parent: 4
     type: Transform
 - uid: 228
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,5.5
     parent: 4
     type: Transform
 - uid: 229
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,5.5
     parent: 4
     type: Transform
 - uid: 230
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,5.5
     parent: 4
     type: Transform
 - uid: 231
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,5.5
     parent: 4
     type: Transform
 - uid: 232
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 20.5,5.5
     parent: 4
     type: Transform
 - uid: 233
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,5.5
     parent: 4
     type: Transform
 - uid: 234
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,5.5
     parent: 4
     type: Transform
 - uid: 235
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,4.5
     parent: 4
     type: Transform
 - uid: 236
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,3.5
     parent: 4
     type: Transform
 - uid: 237
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,2.5
     parent: 4
     type: Transform
 - uid: 238
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 27.5,1.5
     parent: 4
     type: Transform
 - uid: 239
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,5.5
     parent: 4
     type: Transform
 - uid: 240
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 26.5,5.5
     parent: 4
     type: Transform
 - uid: 241
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 25.5,5.5
     parent: 4
     type: Transform
 - uid: 242
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 12.5,5.5
     parent: 4
     type: Transform
 - uid: 243
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 16.5,5.5
     parent: 4
     type: Transform
 - uid: 244
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 6.5,-12.5
     parent: 4
     type: Transform
 - uid: 245
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 7.5,-13.5
     parent: 4
     type: Transform
 - uid: 246
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 8.5,-14.5
@@ -5272,14 +5272,14 @@ entities:
     parent: 4
     type: Transform
 - uid: 254
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 11.5,5.5
     parent: 4
     type: Transform
 - uid: 255
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 18.5,5.5
@@ -5328,42 +5328,42 @@ entities:
     parent: 4
     type: Transform
 - uid: 263
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,-7.5
     parent: 4
     type: Transform
 - uid: 264
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,-13.5
     parent: 4
     type: Transform
 - uid: 265
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,-11.5
     parent: 4
     type: Transform
 - uid: 266
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,-8.5
     parent: 4
     type: Transform
 - uid: 267
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 13.5,-6.5
     parent: 4
     type: Transform
 - uid: 268
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 11.5,-6.5
@@ -5484,14 +5484,14 @@ entities:
     parent: 4
     type: Transform
 - uid: 288
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 6.5,-13.5
     parent: 4
     type: Transform
 - uid: 289
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 7.5,-14.5
@@ -5563,42 +5563,42 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 297
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,-12.5
     parent: 4
     type: Transform
 - uid: 298
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,-10.5
     parent: 4
     type: Transform
 - uid: 299
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 14.5,-6.5
     parent: 4
     type: Transform
 - uid: 300
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 12.5,-6.5
     parent: 4
     type: Transform
 - uid: 301
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 10.5,-6.5
     parent: 4
     type: Transform
 - uid: 302
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 18.5,-6.5
@@ -5636,14 +5636,14 @@ entities:
     parent: 4
     type: Transform
 - uid: 308
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 17.5,5.5
     parent: 4
     type: Transform
 - uid: 309
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,5.5
@@ -5782,49 +5782,49 @@ entities:
     parent: 4
     type: Transform
 - uid: 332
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,1.5
     parent: 4
     type: Transform
 - uid: 333
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 1.5,1.5
     parent: 4
     type: Transform
 - uid: 334
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 2.5,1.5
     parent: 4
     type: Transform
 - uid: 335
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 3.5,1.5
     parent: 4
     type: Transform
 - uid: 336
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,1.5
     parent: 4
     type: Transform
 - uid: 337
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,2.5
     parent: 4
     type: Transform
 - uid: 338
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,3.5
     parent: 4
     type: Transform
 - uid: 339
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,4.5
     parent: 4
@@ -5852,163 +5852,163 @@ entities:
     parent: 4
     type: Transform
 - uid: 343
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-5.5
     parent: 4
     type: Transform
 - uid: 344
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-2.5
     parent: 4
     type: Transform
 - uid: 345
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-3.5
     parent: 4
     type: Transform
 - uid: 346
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,-0.5
     parent: 4
     type: Transform
 - uid: 347
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-0.5
     parent: 4
     type: Transform
 - uid: 348
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,0.5
     parent: 4
     type: Transform
 - uid: 349
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,1.5
     parent: 4
     type: Transform
 - uid: 350
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,1.5
     parent: 4
     type: Transform
 - uid: 351
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,0.5
     parent: 4
     type: Transform
 - uid: 352
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,-0.5
     parent: 4
     type: Transform
 - uid: 353
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,0.5
     parent: 4
     type: Transform
 - uid: 354
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-0.5
     parent: 4
     type: Transform
 - uid: 355
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-0.5
     parent: 4
     type: Transform
 - uid: 356
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-2.5
     parent: 4
     type: Transform
 - uid: 357
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,-2.5
     parent: 4
     type: Transform
 - uid: 358
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-2.5
     parent: 4
     type: Transform
 - uid: 359
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,-2.5
     parent: 4
     type: Transform
 - uid: 360
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-2.5
     parent: 4
     type: Transform
 - uid: 361
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-2.5
     parent: 4
     type: Transform
 - uid: 362
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-2.5
     parent: 4
     type: Transform
 - uid: 363
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-2.5
     parent: 4
     type: Transform
 - uid: 364
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 9.5,-2.5
     parent: 4
     type: Transform
 - uid: 365
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-2.5
     parent: 4
     type: Transform
 - uid: 366
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-3.5
     parent: 4
     type: Transform
 - uid: 367
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,-5.5
     parent: 4
     type: Transform
 - uid: 368
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 8.5,1.5
     parent: 4
     type: Transform
 - uid: 369
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-0.5
     parent: 4
@@ -6021,7 +6021,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 371
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 5.5,-12.5
@@ -6041,19 +6041,19 @@ entities:
   - color: '#00DEF7FF'
     type: AtmosPipeColor
 - uid: 373
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,4.5
     parent: 4
     type: Transform
 - uid: 374
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,1.5
     parent: 4
     type: Transform
 - uid: 375
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 24.5,3.5
     parent: 4
@@ -6197,133 +6197,133 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 390
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 19.5,-0.5
     parent: 4
     type: Transform
 - uid: 391
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,-0.5
     parent: 4
     type: Transform
 - uid: 392
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 20.5,0.5
     parent: 4
     type: Transform
 - uid: 393
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,2.5
     parent: 4
     type: Transform
 - uid: 394
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 0.5,4.5
     parent: 4
     type: Transform
 - uid: 395
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,4.5
     parent: 4
     type: Transform
 - uid: 396
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,2.5
     parent: 4
     type: Transform
 - uid: 397
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -4.5,1.5
     parent: 4
     type: Transform
 - uid: 398
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,1.5
     parent: 4
     type: Transform
 - uid: 399
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -7.5,1.5
     parent: 4
     type: Transform
 - uid: 400
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -6.5,1.5
     parent: 4
     type: Transform
 - uid: 401
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -5.5,1.5
     parent: 4
     type: Transform
 - uid: 402
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,2.5
     parent: 4
     type: Transform
 - uid: 403
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,3.5
     parent: 4
     type: Transform
 - uid: 404
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,-2.5
     parent: 4
     type: Transform
 - uid: 405
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,-3.5
     parent: 4
     type: Transform
 - uid: 406
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -8.5,-4.5
     parent: 4
     type: Transform
 - uid: 407
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-2.5
     parent: 4
     type: Transform
 - uid: 408
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-3.5
     parent: 4
     type: Transform
 - uid: 409
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-4.5
     parent: 4
     type: Transform
 - uid: 410
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 4.5,-5.5
     parent: 4
     type: Transform
 - uid: 411
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -23.5,-2.5
     parent: 4
@@ -10734,73 +10734,73 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 871
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -23.5,-3.5
     parent: 4
     type: Transform
 - uid: 872
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-9.5
     parent: 4
     type: Transform
 - uid: 873
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -22.5,-2.5
     parent: 4
     type: Transform
 - uid: 874
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -24.5,1.5
     parent: 4
     type: Transform
 - uid: 875
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -23.5,1.5
     parent: 4
     type: Transform
 - uid: 876
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -22.5,1.5
     parent: 4
     type: Transform
 - uid: 877
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -22.5,3.5
     parent: 4
     type: Transform
 - uid: 878
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -24.5,3.5
     parent: 4
     type: Transform
 - uid: 879
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -24.5,-4.5
     parent: 4
     type: Transform
 - uid: 880
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -22.5,-4.5
     parent: 4
     type: Transform
 - uid: 881
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -22.5,2.5
     parent: 4
     type: Transform
 - uid: 882
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -22.5,-3.5
     parent: 4
@@ -10815,19 +10815,19 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 884
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -23.5,3.5
     parent: 4
     type: Transform
 - uid: 885
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -23.5,-4.5
     parent: 4
     type: Transform
 - uid: 886
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -21.5,-3.5
     parent: 4
@@ -10842,7 +10842,7 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 888
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -21.5,2.5
     parent: 4
@@ -10902,7 +10902,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 897
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -11.5,6.5
     parent: 4
@@ -10914,7 +10914,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 899
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -8.5,6.5
     parent: 4
@@ -11161,13 +11161,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 937
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-14.5
     parent: 4
     type: Transform
 - uid: 938
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,-9.5
     parent: 4
@@ -11244,196 +11244,196 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 947
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-10.5
     parent: 4
     type: Transform
 - uid: 948
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-7.5
     parent: 4
     type: Transform
 - uid: 949
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-14.5
     parent: 4
     type: Transform
 - uid: 950
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-17.5
     parent: 4
     type: Transform
 - uid: 951
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-17.5
     parent: 4
     type: Transform
 - uid: 952
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-14.5
     parent: 4
     type: Transform
 - uid: 953
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-9.5
     parent: 4
     type: Transform
 - uid: 954
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,8.5
     parent: 4
     type: Transform
 - uid: 955
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,13.5
     parent: 4
     type: Transform
 - uid: 956
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,16.5
     parent: 4
     type: Transform
 - uid: 957
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,16.5
     parent: 4
     type: Transform
 - uid: 958
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,12.5
     parent: 4
     type: Transform
 - uid: 959
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,13.5
     parent: 4
     type: Transform
 - uid: 960
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,1.5
     parent: 4
     type: Transform
 - uid: 961
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,-15.5
     parent: 4
     type: Transform
 - uid: 962
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 18.5,-15.5
     parent: 4
     type: Transform
 - uid: 963
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 18.5,-16.5
     parent: 4
     type: Transform
 - uid: 964
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 18.5,-17.5
     parent: 4
     type: Transform
 - uid: 965
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 17.5,-17.5
     parent: 4
     type: Transform
 - uid: 966
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 17.5,-18.5
     parent: 4
     type: Transform
 - uid: 967
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 15.5,-18.5
     parent: 4
     type: Transform
 - uid: 968
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 14.5,-18.5
     parent: 4
     type: Transform
 - uid: 969
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 13.5,-18.5
     parent: 4
     type: Transform
 - uid: 970
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 11.5,-18.5
     parent: 4
     type: Transform
 - uid: 971
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 11.5,-17.5
     parent: 4
     type: Transform
 - uid: 972
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 10.5,-17.5
     parent: 4
     type: Transform
 - uid: 973
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 10.5,-16.5
     parent: 4
     type: Transform
 - uid: 974
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 10.5,-15.5
     parent: 4
     type: Transform
 - uid: 975
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 9.5,-15.5
     parent: 4
     type: Transform
 - uid: 976
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 9.5,-13.5
@@ -11452,46 +11452,46 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 978
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-8.5
     parent: 4
     type: Transform
 - uid: 979
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 9.5,-10.5
     parent: 4
     type: Transform
 - uid: 980
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 9.5,-8.5
     parent: 4
     type: Transform
 - uid: 981
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 9.5,-7.5
     parent: 4
     type: Transform
 - uid: 982
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-10.5
     parent: 4
     type: Transform
 - uid: 983
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 10.5,-13.5
     parent: 4
     type: Transform
 - uid: 984
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-14.5
     parent: 4
@@ -11517,97 +11517,97 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 987
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-15.5
     parent: 4
     type: Transform
 - uid: 988
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-16.5
     parent: 4
     type: Transform
 - uid: 989
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-16.5
     parent: 4
     type: Transform
 - uid: 990
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-17.5
     parent: 4
     type: Transform
 - uid: 991
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,-17.5
     parent: 4
     type: Transform
 - uid: 992
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,-17.5
     parent: 4
     type: Transform
 - uid: 993
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-16.5
     parent: 4
     type: Transform
 - uid: 994
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,-16.5
     parent: 4
     type: Transform
 - uid: 995
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,-15.5
     parent: 4
     type: Transform
 - uid: 996
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,-14.5
     parent: 4
     type: Transform
 - uid: 997
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-13.5
     parent: 4
     type: Transform
 - uid: 998
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-12.5
     parent: 4
     type: Transform
 - uid: 999
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-11.5
     parent: 4
     type: Transform
 - uid: 1000
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-10.5
     parent: 4
     type: Transform
 - uid: 1001
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-8.5
     parent: 4
     type: Transform
 - uid: 1002
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,-7.5
     parent: 4
@@ -11633,428 +11633,428 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1005
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,14.5
     parent: 4
     type: Transform
 - uid: 1006
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,14.5
     parent: 4
     type: Transform
 - uid: 1007
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,14.5
     parent: 4
     type: Transform
 - uid: 1008
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,13.5
     parent: 4
     type: Transform
 - uid: 1009
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,6.5
     parent: 4
     type: Transform
 - uid: 1010
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,7.5
     parent: 4
     type: Transform
 - uid: 1011
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 9.5,14.5
     parent: 4
     type: Transform
 - uid: 1012
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 10.5,14.5
     parent: 4
     type: Transform
 - uid: 1013
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 10.5,15.5
     parent: 4
     type: Transform
 - uid: 1014
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 10.5,16.5
     parent: 4
     type: Transform
 - uid: 1015
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 11.5,16.5
     parent: 4
     type: Transform
 - uid: 1016
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 11.5,17.5
     parent: 4
     type: Transform
 - uid: 1017
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 13.5,17.5
     parent: 4
     type: Transform
 - uid: 1018
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 13.5,18.5
     parent: 4
     type: Transform
 - uid: 1019
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 15.5,17.5
     parent: 4
     type: Transform
 - uid: 1020
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 17.5,17.5
     parent: 4
     type: Transform
 - uid: 1021
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 17.5,16.5
     parent: 4
     type: Transform
 - uid: 1022
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 18.5,16.5
     parent: 4
     type: Transform
 - uid: 1023
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 18.5,15.5
     parent: 4
     type: Transform
 - uid: 1024
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 18.5,14.5
     parent: 4
     type: Transform
 - uid: 1025
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,14.5
     parent: 4
     type: Transform
 - uid: 1026
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,12.5
     parent: 4
     type: Transform
 - uid: 1027
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,11.5
     parent: 4
     type: Transform
 - uid: 1028
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,10.5
     parent: 4
     type: Transform
 - uid: 1029
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,9.5
     parent: 4
     type: Transform
 - uid: 1030
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,7.5
     parent: 4
     type: Transform
 - uid: 1031
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 19.5,6.5
     parent: 4
     type: Transform
 - uid: 1032
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,9.5
     parent: 4
     type: Transform
 - uid: 1033
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,10.5
     parent: 4
     type: Transform
 - uid: 1034
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,11.5
     parent: 4
     type: Transform
 - uid: 1035
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 18.5,12.5
     parent: 4
     type: Transform
 - uid: 1036
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,13.5
     parent: 4
     type: Transform
 - uid: 1037
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,14.5
     parent: 4
     type: Transform
 - uid: 1038
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,15.5
     parent: 4
     type: Transform
 - uid: 1039
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-16.5
     parent: 4
     type: Transform
 - uid: 1040
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,-16.5
     parent: 4
     type: Transform
 - uid: 1041
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,-13.5
     parent: 4
     type: Transform
 - uid: 1042
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-13.5
     parent: 4
     type: Transform
 - uid: 1043
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,-7.5
     parent: 4
     type: Transform
 - uid: 1044
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,-7.5
     parent: 4
     type: Transform
 - uid: 1045
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-7.5
     parent: 4
     type: Transform
 - uid: 1046
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 14.5,-7.5
     parent: 4
     type: Transform
 - uid: 1047
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,-7.5
     parent: 4
     type: Transform
 - uid: 1048
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,-7.5
     parent: 4
     type: Transform
 - uid: 1049
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,-7.5
     parent: 4
     type: Transform
 - uid: 1050
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,14.5
     parent: 4
     type: Transform
 - uid: 1051
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,6.5
     parent: 4
     type: Transform
 - uid: 1052
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,6.5
     parent: 4
     type: Transform
 - uid: 1053
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,6.5
     parent: 4
     type: Transform
 - uid: 1054
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 17.5,12.5
     parent: 4
     type: Transform
 - uid: 1055
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 16.5,15.5
     parent: 4
     type: Transform
 - uid: 1056
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,16.5
     parent: 4
     type: Transform
 - uid: 1057
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,16.5
     parent: 4
     type: Transform
 - uid: 1058
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,15.5
     parent: 4
     type: Transform
 - uid: 1059
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 11.5,15.5
     parent: 4
     type: Transform
 - uid: 1060
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 15.5,18.5
     parent: 4
     type: Transform
 - uid: 1061
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,9.5
     parent: 4
     type: Transform
 - uid: 1062
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,10.5
     parent: 4
     type: Transform
 - uid: 1063
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,11.5
     parent: 4
     type: Transform
 - uid: 1064
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,15.5
     parent: 4
     type: Transform
 - uid: 1065
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 15.5,15.5
     parent: 4
     type: Transform
 - uid: 1066
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -24.5,-2.5
     parent: 4
     type: Transform
 - uid: 1067
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 13.5,-0.5
     parent: 4
     type: Transform
 - uid: 1068
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 15.5,22.5
     parent: 4
     type: Transform
 - uid: 1069
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 15.5,21.5
     parent: 4
     type: Transform
 - uid: 1070
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 13.5,22.5
     parent: 4
     type: Transform
 - uid: 1071
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - rot: 1.5707963267948966 rad
     pos: 13.5,21.5
@@ -12187,49 +12187,49 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1087
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,9.5
     parent: 4
     type: Transform
 - uid: 1088
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,10.5
     parent: 4
     type: Transform
 - uid: 1089
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,7.5
     parent: 4
     type: Transform
 - uid: 1090
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,8.5
     parent: 4
     type: Transform
 - uid: 1091
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,9.5
     parent: 4
     type: Transform
 - uid: 1092
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,10.5
     parent: 4
     type: Transform
 - uid: 1093
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,11.5
     parent: 4
     type: Transform
 - uid: 1094
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,14.5
     parent: 4
@@ -13220,7 +13220,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1221
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: -23.5,2.5
     parent: 4
@@ -13526,7 +13526,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1253
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,11.5
     parent: 4
@@ -13562,19 +13562,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1257
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,12.5
     parent: 4
     type: Transform
 - uid: 1258
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,11.5
     parent: 4
     type: Transform
 - uid: 1259
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,13.5
     parent: 4
@@ -13746,19 +13746,19 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1277
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,12.5
     parent: 4
     type: Transform
 - uid: 1278
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,10.5
     parent: 4
     type: Transform
 - uid: 1279
-  type: WallSolid
+  type: WallSteel
   components:
   - pos: 12.5,13.5
     parent: 4
@@ -13858,7 +13858,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1290
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,12.5
     parent: 4
@@ -14834,7 +14834,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1402
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,7.5
     parent: 4
@@ -14852,13 +14852,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1404
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,7.5
     parent: 4
     type: Transform
 - uid: 1405
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,6.5
     parent: 4
@@ -14885,7 +14885,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 1409
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,8.5
     parent: 4
@@ -14897,7 +14897,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 1411
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,6.5
     parent: 4
@@ -15430,13 +15430,13 @@ entities:
         ent: 1493
     type: ContainerContainer
 - uid: 1462
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,8.5
     parent: 4
     type: Transform
 - uid: 1463
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,8.5
     parent: 4
@@ -15707,7 +15707,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1494
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 11.5,7.5
     parent: 4
@@ -15720,7 +15720,7 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 1496
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,9.5
     parent: 4
@@ -18349,13 +18349,13 @@ entities:
   - color: '#00DEF7FF'
     type: AtmosPipeColor
 - uid: 1726
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-8.5
     parent: 4
     type: Transform
 - uid: 1727
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-11.5
     parent: 4
@@ -18387,31 +18387,31 @@ entities:
     parent: 4
     type: Transform
 - uid: 1732
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-11.5
     parent: 4
     type: Transform
 - uid: 1733
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-10.5
     parent: 4
     type: Transform
 - uid: 1734
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-10.5
     parent: 4
     type: Transform
 - uid: 1735
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-9.5
     parent: 4
     type: Transform
 - uid: 1736
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-9.5
     parent: 4
@@ -18441,31 +18441,31 @@ entities:
     parent: 4
     type: Transform
 - uid: 1741
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-8.5
     parent: 4
     type: Transform
 - uid: 1742
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-7.5
     parent: 4
     type: Transform
 - uid: 1743
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-12.5
     parent: 4
     type: Transform
 - uid: 1744
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-12.5
     parent: 4
     type: Transform
 - uid: 1745
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-13.5
     parent: 4
@@ -19230,7 +19230,7 @@ entities:
   - color: '#F70000FF'
     type: AtmosPipeColor
 - uid: 1810
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-13.5
     parent: 4
@@ -19778,95 +19778,95 @@ entities:
     parent: 4
     type: Transform
 - uid: 1862
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 5.5,-14.5
     parent: 4
     type: Transform
 - uid: 1863
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-14.5
     parent: 4
     type: Transform
 - uid: 1864
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 8.5,-6.5
     parent: 4
     type: Transform
 - uid: 1865
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 8.5,-7.5
     parent: 4
     type: Transform
 - uid: 1866
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 8.5,-8.5
     parent: 4
     type: Transform
 - uid: 1867
-  type: WallSolid
+  type: WallSteel
   components:
   - rot: -1.5707963267948966 rad
     pos: 8.5,-9.5
     parent: 4
     type: Transform
 - uid: 1868
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -23.5,1.5
     parent: 4
     type: Transform
 - uid: 1869
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -22.5,1.5
     parent: 4
     type: Transform
 - uid: 1870
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -21.5,2.5
     parent: 4
     type: Transform
 - uid: 1871
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -22.5,2.5
     parent: 4
     type: Transform
 - uid: 1872
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -22.5,3.5
     parent: 4
     type: Transform
 - uid: 1873
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -23.5,3.5
     parent: 4
     type: Transform
 - uid: 1874
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,3.5
     parent: 4
     type: Transform
 - uid: 1875
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,-2.5
     parent: 4
     type: Transform
 - uid: 1876
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -23.5,-2.5
     parent: 4
@@ -20016,37 +20016,37 @@ entities:
   - color: '#F70000FF'
     type: AtmosPipeColor
 - uid: 1889
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -22.5,-2.5
     parent: 4
     type: Transform
 - uid: 1890
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -22.5,-3.5
     parent: 4
     type: Transform
 - uid: 1891
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -21.5,-3.5
     parent: 4
     type: Transform
 - uid: 1892
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -22.5,-4.5
     parent: 4
     type: Transform
 - uid: 1893
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -23.5,-4.5
     parent: 4
     type: Transform
 - uid: 1894
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -24.5,-4.5
     parent: 4
@@ -20220,19 +20220,19 @@ entities:
     parent: 4
     type: Transform
 - uid: 1923
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 6.5,-15.5
     parent: 4
     type: Transform
 - uid: 1924
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 7.5,-15.5
     parent: 4
     type: Transform
 - uid: 1925
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 8.5,-15.5
     parent: 4
@@ -20589,7 +20589,7 @@ entities:
     parent: 4
     type: Transform
 - uid: 1960
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 9.5,5.5
     parent: 4

--- a/Resources/Maps/syndipuddle.yml
+++ b/Resources/Maps/syndipuddle.yml
@@ -565,19 +565,19 @@ entities:
     parent: 0
     type: Transform
 - uid: 10
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-3.5
     parent: 0
     type: Transform
 - uid: 11
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-3.5
     parent: 0
     type: Transform
 - uid: 12
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-4.5
     parent: 0
@@ -595,37 +595,37 @@ entities:
     parent: 0
     type: Transform
 - uid: 15
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-7.5
     parent: 0
     type: Transform
 - uid: 16
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-8.5
     parent: 0
     type: Transform
 - uid: 17
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-7.5
     parent: 0
     type: Transform
 - uid: 18
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-7.5
     parent: 0
     type: Transform
 - uid: 19
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-7.5
     parent: 0
     type: Transform
 - uid: 20
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-8.5
     parent: 0
@@ -641,13 +641,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 22
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-8.5
     parent: 0
     type: Transform
 - uid: 23
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-7.5
     parent: 0
@@ -665,31 +665,31 @@ entities:
     parent: 0
     type: Transform
 - uid: 26
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-4.5
     parent: 0
     type: Transform
 - uid: 27
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-3.5
     parent: 0
     type: Transform
 - uid: 28
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-3.5
     parent: 0
     type: Transform
 - uid: 29
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-9.5
     parent: 0
     type: Transform
 - uid: 30
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-10.5
     parent: 0
@@ -707,67 +707,67 @@ entities:
   - radius: 2.5
     type: PointLight
 - uid: 32
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-12.5
     parent: 0
     type: Transform
 - uid: 33
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-12.5
     parent: 0
     type: Transform
 - uid: 34
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-12.5
     parent: 0
     type: Transform
 - uid: 35
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-12.5
     parent: 0
     type: Transform
 - uid: 36
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-12.5
     parent: 0
     type: Transform
 - uid: 37
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-11.5
     parent: 0
     type: Transform
 - uid: 38
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-10.5
     parent: 0
     type: Transform
 - uid: 39
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-9.5
     parent: 0
     type: Transform
 - uid: 40
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-7.5
     parent: 0
     type: Transform
 - uid: 41
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-13.5
     parent: 0
     type: Transform
 - uid: 42
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-12.5
     parent: 0
@@ -783,13 +783,13 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 44
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-9.5
     parent: 0
     type: Transform
 - uid: 45
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-10.5
     parent: 0
@@ -1341,73 +1341,73 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 108
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-14.5
     parent: 0
     type: Transform
 - uid: 109
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-15.5
     parent: 0
     type: Transform
 - uid: 110
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -1.5,-16.5
     parent: 0
     type: Transform
 - uid: 111
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: -0.5,-16.5
     parent: 0
     type: Transform
 - uid: 112
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 0.5,-16.5
     parent: 0
     type: Transform
 - uid: 113
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 1.5,-16.5
     parent: 0
     type: Transform
 - uid: 114
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 2.5,-16.5
     parent: 0
     type: Transform
 - uid: 115
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 3.5,-16.5
     parent: 0
     type: Transform
 - uid: 116
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-16.5
     parent: 0
     type: Transform
 - uid: 117
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-15.5
     parent: 0
     type: Transform
 - uid: 118
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-14.5
     parent: 0
     type: Transform
 - uid: 119
-  type: WallReinforced
+  type: WallPlasteel
   components:
   - pos: 4.5,-13.5
     parent: 0

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -13,19 +13,19 @@
 
 - type: entity
   parent: PartBase
-  id: PartRodMetal
-  name: metals rods
+  id: PartRodSteel
+  name: steel rods
   suffix: Full
   components:
   - type: Stack
-    stackType: MetalRod
+    stackType: SteelRod
   - type: Sprite
     state: rods_5
 #  - type: Item
 #    HeldPrefix: rods
   - type: Construction
-    graph: metalRod
-    node: MetalRod
+    graph: steelRod
+    node: SteelRod
   - type: Appearance
     visuals:
     - type: StackVisualizer
@@ -41,14 +41,14 @@
     - floor_reinforced
 
 - type: entity
-  parent: PartRodMetal
-  id: PartRodMetal1
-  name: metal rod
+  parent: PartRodSteel
+  id: PartRodSteel1
+  name: steel rod
   suffix: Single
   components:
   - type: Tag
     tags:
-    - RodMetal1
+    - RodSteel1
   - type: Sprite
     state: rods
   - type: Stack

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -22,7 +22,7 @@
           path: /Audio/Effects/metalbreak.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
-          PartRodMetal1:
+          PartRodSteel1:
             min: 1
             max: 1
       - !type:DoActsBehavior
@@ -148,7 +148,7 @@
           ShardGlass:
             min: 1
             max: 1
-          PartRodMetal1:
+          PartRodSteel1:
             min: 1
             max: 1
       - !type:DoActsBehavior
@@ -181,7 +181,7 @@
           ShardGlassPlasma:
             min: 1
             max: 1
-          PartRodMetal1:
+          PartRodSteel1:
             min: 1
             max: 1
       - !type:DoActsBehavior

--- a/Resources/Prototypes/Entities/Structures/Walls/railing.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/railing.yml
@@ -40,7 +40,7 @@
           path: /Audio/Effects/metalbreak.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
-          PartRodMetal1:
+          PartRodSteel1:
             min: 0
             max: 1
       - !type:DoActsBehavior
@@ -100,7 +100,7 @@
           path: /Audio/Effects/metalbreak.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
-          PartRodMetal1:
+          PartRodSteel1:
             min: 0
             max: 2
       - !type:DoActsBehavior
@@ -152,7 +152,7 @@
           path: /Audio/Effects/metalbreak.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
-          PartRodMetal1:
+          PartRodSteel1:
             min: 0
             max: 2
       - !type:DoActsBehavior

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -313,7 +313,7 @@
     state: rgeneric
   - type: Construction
     graph: girder
-    node: reinforcedWall
+    node: plasteelWall
   - type: Destructible
     thresholds:
     - trigger:
@@ -324,6 +324,7 @@
         node: girder
       - !type:DoActsBehavior
         acts: ["Destruction"]
+# This should probably be renamed at some point.
   - type: ReinforcedWall
     key: walls
     base: solid
@@ -436,7 +437,7 @@
     sprite: Structures/Walls/solid.rsi
   - type: Construction
     graph: girder
-    node: wall
+    node: steelWall
   - type: Icon
     sprite: Structures/Walls/solid.rsi
   - type: Destructible

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -243,36 +243,6 @@
 
 - type: entity
   parent: WallBase
-  id: WallMetal
-  name: metal wall
-  components:
-  - type: Tag
-    tags:
-      - Wall
-      - RCDDeconstructWhitelist
-  - type: Sprite
-    sprite: Structures/Walls/metal.rsi
-  - type: Icon
-    sprite: Structures/Walls/metal.rsi
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          Girder:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: IconSmooth
-    key: walls
-    base: metal
-
-- type: entity
-  parent: WallBase
   id: WallPlasma
   name: plasma wall
   components:
@@ -333,8 +303,8 @@
 
 - type: entity
   parent: WallBase
-  id: WallReinforced
-  name: reinforced wall
+  id: WallPlasteel
+  name: plasteel wall
   components:
   - type: Sprite
     sprite: Structures/Walls/solid.rsi
@@ -455,8 +425,8 @@
 
 - type: entity
   parent: WallBase
-  id: WallSolid
-  name: solid wall
+  id: WallSteel
+  name: steel wall
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -25,7 +25,7 @@
           ShardGlassPlasma:
             min: 1
             max: 2
-          PartRodMetal:
+          PartRodSteel:
             min: 1
             max: 2
       - !type:DoActsBehavior
@@ -79,7 +79,7 @@
           ShardGlassPlasma:
             min: 1
             max: 2
-          PartRodMetal:
+          PartRodSteel:
             min: 1
             max: 2
       - !type:DoActsBehavior

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
@@ -11,7 +11,7 @@
             - !type:SnapToGrid
               southRotation: true
           steps:
-            - material: MetalRod
+            - material: SteelRod
               amount: 2
               doAfter: 1
 
@@ -21,7 +21,7 @@
         - to: start
           completed:
             - !type:SpawnPrototype
-                prototype: PartRodMetal
+                prototype: PartRodSteel
                 amount: 2
           steps:
             - tool: Anchoring

--- a/Resources/Prototypes/Recipes/Construction/Graphs/materials/glass.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/materials/glass.yml
@@ -11,7 +11,7 @@
           steps:
             - material: Glass
               amount: 1
-            - material: MetalRod
+            - material: SteelRod
               amount: 1
         - to: SheetPGlass
           completed:
@@ -31,7 +31,7 @@
               amount: 1
             - material: Plasma
               amount: 1
-            - material: MetalRod
+            - material: SteelRod
               amount: 1
 
     - node: SheetGlass

--- a/Resources/Prototypes/Recipes/Construction/Graphs/materials/steel_rod.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/materials/steel_rod.yml
@@ -1,10 +1,10 @@
 ﻿- type: constructionGraph
-  id: metalRod
+  id: steelRod
   start: start
   graph:
     - node: start
       edges:
-        - to: MetalRod
+        - to: SteelRod
           completed:
             - !type:SetStackCount
               amount: 2
@@ -12,5 +12,5 @@
             - material: Steel
               amount: 1
 
-    - node: MetalRod
-      entity: PartRodMetal
+    - node: SteelRod
+      entity: PartRodSteel

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/catwalk.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/catwalk.yml
@@ -9,7 +9,7 @@
             - !type:SnapToGrid
               southRotation: true
           steps:
-            - material: MetalRod
+            - material: SteelRod
               amount: 2
 
     - node: Catwalk
@@ -18,7 +18,7 @@
         - to: start
           completed:
           - !type:SpawnPrototype
-                prototype: PartRodMetal1
+                prototype: PartRodSteel1
                 amount: 2
           - !type:DeleteEntity {}
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -34,7 +34,7 @@
             - tool: Screwing
               doAfter: 2
 
-        - to: wall
+        - to: steelWall
           completed:
             - !type:SnapToGrid
               southRotation: true
@@ -54,8 +54,8 @@
             - material: Plasteel
               amount: 2
 
-    - node: wall
-      entity: WallSolid
+    - node: steelWall
+      entity: WallSteel
       edges:
         - to: girder
           completed:
@@ -73,7 +73,7 @@
             sprite: /Textures/Structures/Walls/solid.rsi
             state: reinforced_wall_girder
       edges:
-        - to: reinforcedWall
+        - to: plasteelWall
           completed:
             - !type:SnapToGrid
               southRotation: true
@@ -94,8 +94,8 @@
             - tool: Welding
               doAfter: 2
 
-    - node: reinforcedWall
-      entity: WallReinforced
+    - node: plasteelWall
+      entity: WallPlasteel
       edges:
         - to: girder
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/grille.yml
@@ -9,7 +9,7 @@
             - !type:SnapToGrid
               southRotation: true
           steps:
-            - material: MetalRod
+            - material: SteelRod
               amount: 2
               doAfter: 1
 
@@ -19,7 +19,7 @@
         - to: start
           completed:
             - !type:SpawnPrototype
-              prototype: PartRodMetal1
+              prototype: PartRodSteel1
               amount: 2
             - !type:DeleteEntity
           steps:
@@ -32,13 +32,13 @@
         - to: start
           completed:
             - !type:SpawnPrototype
-              prototype: PartRodMetal1
+              prototype: PartRodSteel1
               amount: 1
             - !type:DeleteEntity
           steps:
             - tool: Cutting
         - to: grille
           steps:
-            - material: MetalRod
+            - material: SteelRod
               amount: 1
               doAfter: 0.5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
@@ -9,7 +9,7 @@
             - !type:SnapToGrid
               southRotation: true
           steps:
-            - material: MetalRod
+            - material: SteelRod
               amount: 1
               doAfter: 2
         - to: railingCorner
@@ -17,7 +17,7 @@
             - !type:SnapToGrid
               southRotation: true
           steps:
-            - material: MetalRod
+            - material: SteelRod
               amount: 2
               doAfter: 2.5
         - to: railingCornerSmall
@@ -25,7 +25,7 @@
             - !type:SnapToGrid
               southRotation: true
           steps:
-            - material: MetalRod
+            - material: SteelRod
               amount: 1
               doAfter: 2
 
@@ -35,7 +35,7 @@
         - to: start
           completed:
             - !type:SpawnPrototype
-              prototype: PartRodMetal1
+              prototype: PartRodSteel1
               amount: 1
             - !type:DeleteEntity
           steps:
@@ -48,7 +48,7 @@
         - to: start
           completed:
             - !type:SpawnPrototype
-              prototype: PartRodMetal1
+              prototype: PartRodSteel1
               amount: 2
             - !type:DeleteEntity
           steps:
@@ -61,7 +61,7 @@
         - to: start
           completed:
             - !type:SpawnPrototype
-              prototype: PartRodMetal1
+              prototype: PartRodSteel1
               amount: 1
             - !type:DeleteEntity
           steps:

--- a/Resources/Prototypes/Recipes/Construction/materials.yml
+++ b/Resources/Prototypes/Recipes/Construction/materials.yml
@@ -1,11 +1,11 @@
 ﻿- type: construction
-  name: Metal Rod
-  id: metalRod
-  graph: metalRod
+  name: Steel Rod
+  id: steelRod
+  graph: steelRod
   startNode: start
-  targetNode: MetalRod
+  targetNode: SteelRod
   category: Materials
-  description: A sturdy metal rod that can be used for various purposes.
+  description: A sturdy steel rod that can be used for various purposes.
   icon: Objects/Materials/parts.rsi/rods.png
   objectType: Item
 

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -17,11 +17,11 @@
     - !type:TileNotBlocked
 
 - type: construction
-  name: wall
-  id: wall
+  name: steel wall
+  id: steelWall
   graph: girder
   startNode: start
-  targetNode: wall
+  targetNode: steelWall
   category: Structures
   description: Keeps the air in and the greytide out.
   icon:
@@ -36,10 +36,10 @@
 
 - type: construction
   name: reinforced wall
-  id: reinforcedWall
+  id: plasteelWall
   graph: girder
   startNode: start
-  targetNode: reinforcedWall
+  targetNode: plasteelWall
   category: Structures
   description: Keeps the air in and the greytide out.
   icon:

--- a/Resources/Prototypes/Stacks/Materials/parts.yml
+++ b/Resources/Prototypes/Stacks/Materials/parts.yml
@@ -1,5 +1,5 @@
 - type: stack
-  id: MetalRod
-  name: rods
+  id: SteelRod
+  name: steel rods
   icon: /Textures/Objects/Materials/parts.rsi/rods.png
-  spawn: PartRodMetal1
+  spawn: PartRodSteel1

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -211,7 +211,7 @@
   id: RCDDeconstructWhitelist
 
 - type: Tag
-  id: RodMetal1
+  id: RodSteel1
 
 - type: Tag
   id: RollingPaper


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR consistently names derivatives of materials making it easier to add more walls and rods based off different materials in the future.

Solid walls have been renamed to steel walls, reinforced walls have been renamed to plasteel walls and metal rods have been renamed to steel rods to reflect the materials used in their construction. Their construction graphs and their entity IDs have also been changed to reflect this (i.e wall -> steelWall, WallSolid -> WallSteel, etc) as well as the graphs of relevant entities (such as grilles, etc.).

C# code has mostly been untouched except for the RCD which now builds steel walls instead of solid walls, the reinforced wall handler is still named as such.

WallMetal has been removed, combined with #6063 this fully resolves #5297.

A full list of renamed entity IDs:
WallSolid -> WallSteel
WallReinforced -> WallPlasteel
PartRodMetal -> PartRodSteel
PartRodMetal1 -> PartRodSteel1

**A notice to cartographers;**
All maps have been updated to use the new entity IDs, however any other maps out there will have to be updated after this PR is merged. 

There are two ways to do this, 1) using a text editor and finding & replacing entity IDs by hand or 2) by using this [python script that I made](https://gist.github.com/Lamrr/7d9f425b98bcf66f86a427ac00ed308f) which will do it for you - with your map file in the same directory as the script simply use `python3 replace_deprecated.py` and then enter your map's filename (incl. extension) when prompted.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: The naming department has corrected product names to better reflect the materials used in their construction.