### PR TITLE
Fix taser visuals not updating after charging.

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -21,6 +21,7 @@ public class PowerCellSystem : SharedPowerCellSystem
     [Dependency] private readonly SolutionContainerSystem _solutionsSystem = default!;
     [Dependency] private readonly ExplosionSystem _explosionSystem = default!;
     [Dependency] private readonly AdminLogSystem _logSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
 
     public override void Initialize()
     {
@@ -51,7 +52,7 @@ public class PowerCellSystem : SharedPowerCellSystem
         appearance.SetData(PowerCellVisuals.ChargeLevel, level);
 
         // If this power cell is inside a cell-slot, inform that entity that the power has changed (for updating visuals n such).
-        if (uid.TryGetContainer(out var container)
+        if (_containerSystem.TryGetContainingContainer(uid, out var container)
             && TryComp(container.Owner, out PowerCellSlotComponent? slot)
             && slot.CellSlot.Item == uid)
         {

--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Examine;
 using Content.Shared.PowerCell;
 using Content.Shared.PowerCell.Components;
 using Content.Shared.Rounding;
+using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
@@ -48,6 +49,14 @@ public class PowerCellSystem : SharedPowerCellSystem
         var frac = battery.CurrentCharge / battery.MaxCharge;
         var level = (byte) ContentHelpers.RoundToNearestLevels(frac, 1, PowerCellComponent.PowerCellVisualsLevels);
         appearance.SetData(PowerCellVisuals.ChargeLevel, level);
+
+        // If this power cell is inside a cell-slot, inform that entity that the power has changed (for updating visuals n such).
+        if (uid.TryGetContainer(out var container)
+            && TryComp(container.Owner, out PowerCellSlotComponent? slot)
+            && slot.CellSlot.Item == uid)
+        {
+            RaiseLocalEvent(container.Owner, new PowerCellChangedEvent(false), false);
+        }
     }
 
     private void Explode(EntityUid uid, BatteryComponent? battery = null)

--- a/Content.Server/Stunnable/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/StunbatonSystem.cs
@@ -99,7 +99,12 @@ namespace Content.Server.Stunnable
 
         private void OnPowerCellChanged(EntityUid uid, StunbatonComponent comp, PowerCellChangedEvent args)
         {
-            if (args.Ejected)
+            if (!comp.Activated)
+                return;
+
+            if (args.Ejected
+                || !_cellSystem.TryGetBatteryFromSlot(comp.Owner, out var battery)
+                || battery.CurrentCharge < comp.EnergyPerUse)
             {
                 TurnOff(comp);
             }
@@ -175,9 +180,6 @@ namespace Content.Server.Stunnable
                 return;
 
             var playerFilter = Filter.Pvs(comp.Owner);
-            if (!EntityManager.TryGetComponent<PowerCellSlotComponent?>(comp.Owner, out var slot))
-                return;
-
             if (!_cellSystem.TryGetBatteryFromSlot(comp.Owner, out var battery))
             {
                 SoundSystem.Play(playerFilter, comp.TurnOnFailSound.GetSound(), comp.Owner, AudioHelpers.WithVariation(0.25f));

--- a/Content.Server/Weapon/Ranged/Barrels/Components/ServerBatteryBarrelComponent.cs
+++ b/Content.Server/Weapon/Ranged/Barrels/Components/ServerBatteryBarrelComponent.cs
@@ -163,8 +163,8 @@ namespace Content.Server.Weapon.Ranged.Barrels.Components
                 throw new InvalidOperationException("Ammo doesn't have hitscan or projectile?");
             }
 
-            Dirty();
-            UpdateAppearance();
+            // capacitor.UseCharge() triggers a PowerCellChangedEvent which will cause appearance to be updated.
+            // So let's not double-call UpdateAppearance() here.
             return entity.Value;
         }
     }

--- a/Content.Shared/PowerCell/Components/PowerCellSlotComponent.cs
+++ b/Content.Shared/PowerCell/Components/PowerCellSlotComponent.cs
@@ -64,6 +64,9 @@ public sealed class PowerCellSlotComponent : Component
     public bool FitsInCharger = true;
 }
 
+/// <summary>
+///     Raised directed at an entity with a power cell slot when the power cell inside has its charge updated or is ejected/inserted.
+/// </summary>
 public class PowerCellChangedEvent : EntityEventArgs
 {
     public readonly bool Ejected;


### PR DESCRIPTION
Tasers updated their visual charge indicators when firing, but not when the cell itself has it's power modified directly (e.g., by a charger). This just makes it so that events get fired directed at an entity that contains a power cell, when its charge gets updated.

:cl:
- fix: Fixed the charge indicators on tasers and laser weapons not properly updating after charging.
