### PR TITLE
Prevent inventory events from being relayed to pockets

### DIFF
--- a/Content.Server/Atmos/PressureEvent.cs
+++ b/Content.Server/Atmos/PressureEvent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameObjects;
 
 namespace Content.Server.Atmos
 {
-    public abstract class PressureEvent : EntityEventArgs
+    public abstract class PressureEvent : EntityEventArgs, IInventoryRelayEvent
     {
         /// <summary>
         ///     The environment pressure.
@@ -29,21 +29,24 @@ namespace Content.Server.Atmos
         /// </remarks>
         public float Multiplier { get; set; } = 1f;
 
+        /// <summary>
+        ///     The inventory slots that should be checked for pressure protecting equipment.
+        /// </summary>
+        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
+
         protected PressureEvent(float pressure)
         {
             Pressure = pressure;
         }
     }
 
-    public class LowPressureEvent : PressureEvent, IInventoryRelayEvent
+    public class LowPressureEvent : PressureEvent
     {
-        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
         public LowPressureEvent(float pressure) : base(pressure) { }
     }
 
-    public class HighPressureEvent : PressureEvent, IInventoryRelayEvent
+    public class HighPressureEvent : PressureEvent
     {
-        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
         public HighPressureEvent(float pressure) : base(pressure) { }
     }
 }

--- a/Content.Server/Atmos/PressureEvent.cs
+++ b/Content.Server/Atmos/PressureEvent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameObjects;
+using Content.Shared.Inventory;
+using Robust.Shared.GameObjects;
 
 namespace Content.Server.Atmos
 {
@@ -34,13 +35,15 @@ namespace Content.Server.Atmos
         }
     }
 
-    public class LowPressureEvent : PressureEvent
+    public class LowPressureEvent : PressureEvent, IInventoryRelayEvent
     {
+        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
         public LowPressureEvent(float pressure) : base(pressure) { }
     }
 
-    public class HighPressureEvent : PressureEvent
+    public class HighPressureEvent : PressureEvent, IInventoryRelayEvent
     {
+        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
         public HighPressureEvent(float pressure) : base(pressure) { }
     }
 }

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Temperature.Components;
 using Content.Shared.Alert;
 using Content.Shared.Damage;
 using Content.Shared.Database;
+using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 
@@ -212,8 +213,10 @@ namespace Content.Server.Temperature.Systems
         }
     }
 
-    public class ModifyChangedTemperatureEvent : EntityEventArgs
+    public class ModifyChangedTemperatureEvent : EntityEventArgs, IInventoryRelayEvent
     {
+        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
+
         public float TemperatureDelta;
 
         public ModifyChangedTemperatureEvent(float temperature)

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
+using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
@@ -216,8 +217,11 @@ namespace Content.Shared.Damage
     ///
     ///     For example, armor.
     /// </summary>
-    public class DamageModifyEvent : EntityEventArgs
+    public class DamageModifyEvent : EntityEventArgs, IInventoryRelayEvent
     {
+        // Whenever locational damage is a thing, this should just check only that bit of armour.
+        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
+
         public DamageSpecifier Damage;
 
         public DamageModifyEvent(DamageSpecifier damage)

--- a/Content.Shared/Electrocution/ElectrocutionEvents.cs
+++ b/Content.Shared/Electrocution/ElectrocutionEvents.cs
@@ -1,9 +1,12 @@
+using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Electrocution
 {
-    public class ElectrocutionAttemptEvent : CancellableEntityEventArgs
+    public class ElectrocutionAttemptEvent : CancellableEntityEventArgs, IInventoryRelayEvent
     {
+        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
+
         public readonly EntityUid TargetUid;
         public readonly EntityUid? SourceUid;
         public float SiemensCoefficient = 1f;

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -16,16 +16,28 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, RefreshMovementSpeedModifiersEvent>(RelayInventoryEvent);
     }
 
-    protected void RelayInventoryEvent<T>(EntityUid uid, InventoryComponent component, T args) where T : EntityEventArgs
+    protected void RelayInventoryEvent<T>(EntityUid uid, InventoryComponent component, T args) where T : EntityEventArgs, IInventoryRelayEvent
     {
-        // Insulated gloves in you pockets ain't gonna save you.
-        var flags = ~SlotFlags.POCKET; 
-
-        var containerEnumerator = new ContainerSlotEnumerator(uid, component.TemplateId, _prototypeManager, this, flags);
+        var containerEnumerator = new ContainerSlotEnumerator(uid, component.TemplateId, _prototypeManager, this, args.TargetSlots);
         while(containerEnumerator.MoveNext(out var container))
         {
             if(!container.ContainedEntity.HasValue) continue;
             RaiseLocalEvent(container.ContainedEntity.Value, args, false);
         }
     }
+}
+
+/// <summary>
+///     Events that should be relayed to inventory slots should implement this interface.
+/// </summary>
+public interface IInventoryRelayEvent
+{
+    /// <summary>
+    ///     What inventory slots should this event be relayed to, if any?
+    /// </summary>
+    /// <remarks>
+    ///     In general you may want to exclude <see cref="SlotFlags.POCKET"/>, given that those items are not truly
+    ///     "equipped" by the user.
+    /// </remarks>
+    public SlotFlags TargetSlots { get; }
 }

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -18,7 +18,10 @@ public partial class InventorySystem
 
     protected void RelayInventoryEvent<T>(EntityUid uid, InventoryComponent component, T args) where T : EntityEventArgs
     {
-        var containerEnumerator = new ContainerSlotEnumerator(uid, component.TemplateId, _prototypeManager, this);
+        // Insulated gloves in you pockets ain't gonna save you.
+        var flags = ~SlotFlags.POCKET; 
+
+        var containerEnumerator = new ContainerSlotEnumerator(uid, component.TemplateId, _prototypeManager, this, flags);
         while(containerEnumerator.MoveNext(out var container))
         {
             if(!container.ContainedEntity.HasValue) continue;

--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -87,33 +87,28 @@ public partial class InventorySystem : EntitySystem
         private readonly EntityUid _uid;
         private readonly SlotDefinition[] _slots;
         private readonly SlotFlags _flags;
-        private int _nextIdx = int.MaxValue;
+        private int _nextIdx = 0;
 
         public ContainerSlotEnumerator(EntityUid uid, string prototypeId, IPrototypeManager prototypeManager, InventorySystem inventorySystem, SlotFlags flags = SlotFlags.All)
         {
             _uid = uid;
             _inventorySystem = inventorySystem;
             _flags = flags;
+
             if (prototypeManager.TryIndex<InventoryTemplatePrototype>(prototypeId, out var prototype))
-            {
                 _slots = prototype.Slots;
-                if(_slots.Length > 0)
-                    _nextIdx = 0;
-            }
             else
-            {
                 _slots = Array.Empty<SlotDefinition>();
-            }
         }
 
         public bool MoveNext([NotNullWhen(true)] out ContainerSlot? container)
         {
             container = null;
-            if (_nextIdx >= _slots.Length) return false;
 
-            for (; _nextIdx < _slots.Length; _nextIdx++)
+            while (_nextIdx < _slots.Length)
             {
                 var slot = _slots[_nextIdx];
+                _nextIdx++;
 
                 if ((slot.SlotFlags & _flags) == 0)
                     continue;

--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -111,9 +111,9 @@ public partial class InventorySystem : EntitySystem
             container = null;
             if (_nextIdx >= _slots.Length) return false;
 
-            while (_nextIdx < _slots.Length)
+            for (; _nextIdx < _slots.Length; _nextIdx++)
             {
-                var slot = _slots[_nextIdx++];
+                var slot = _slots[_nextIdx];
 
                 if ((slot.SlotFlags & _flags) == 0)
                     continue;

--- a/Content.Shared/Inventory/SlotFlags.cs
+++ b/Content.Shared/Inventory/SlotFlags.cs
@@ -26,4 +26,5 @@ public enum SlotFlags
     POCKET = 1 << 12,
     LEGS = 1 << 13,
     FEET = 1 << 14,
+    All = ~NONE,
 }

--- a/Content.Shared/Movement/EntitySystems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/EntitySystems/MovementSpeedModifierSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Content.Shared.Inventory;
 using Content.Shared.Movement.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
@@ -84,8 +85,10 @@ namespace Content.Shared.Movement.EntitySystems
     ///     should hook into this event and set it then. If you want this event to be raised,
     ///     call <see cref="MovementSpeedModifierSystem.RefreshMovementSpeedModifiers"/>.
     /// </summary>
-    public class RefreshMovementSpeedModifiersEvent : EntityEventArgs
+    public class RefreshMovementSpeedModifiersEvent : EntityEventArgs, IInventoryRelayEvent
     {
+        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
+
         public float WalkSpeedModifier { get; private set; } = 1.0f;
         public float SprintSpeedModifier { get; private set; } = 1.0f;
 

--- a/Content.Shared/Slippery/SharedSlipperySystem.cs
+++ b/Content.Shared/Slippery/SharedSlipperySystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.Inventory;
 using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
 using JetBrains.Annotations;
@@ -158,7 +159,8 @@ namespace Content.Shared.Slippery
     /// <summary>
     ///     Raised on an entity to determine if it can slip or not.
     /// </summary>
-    public class SlipAttemptEvent : CancellableEntityEventArgs
+    public class SlipAttemptEvent : CancellableEntityEventArgs, IInventoryRelayEvent
     {
+        public SlotFlags TargetSlots { get; } = SlotFlags.FEET;
     }
 }


### PR DESCRIPTION
Currently shoving insulated gloves or galoshes in your pockets works just as well as wearing them. This PR fixes this by just excluding pockets from the inventory event relay.

:cl:
- fix: Insulated gloves and galoshes no longer work when in your pockets. You actually have to wear them.

