### PR TITLE
Allow chaplain to spawn with other bag options.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -19,4 +19,5 @@
     id: ChaplainPDA
     ears: ClothingHeadsetService
   innerclothingskirt: ClothingUniformJumpskirtChaplain
-
+  satchel: ClothingBackpackSatchelFilled
+  duffelbag: ClothingBackpackDuffelFilled


### PR DESCRIPTION
Currently chaplain can only spawn with the normal backpack, regardless of the players preference.