### PR TITLE
Only show the Uplink to players with Uplink Accounts

### DIFF
--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Light.Components;
 using Content.Server.Light.EntitySystems;
 using Content.Server.Light.Events;
 using Content.Server.Traitor.Uplink;
+using Content.Server.Traitor.Uplink.Account;
 using Content.Server.Traitor.Uplink.Components;
 using Content.Server.UserInterface;
 using Content.Shared.Containers.ItemSlots;
@@ -94,7 +95,7 @@ namespace Content.Server.PDA
                 appearance.SetData(PDAVisuals.IDCardInserted, pda.ContainedID != null);
         }
 
-        private void UpdatePDAUserInterface(PDAComponent pda)
+        private void UpdatePDAUserInterface(PDAComponent pda, EntityUid? user = default)
         {
             var ownerInfo = new PDAIdInfoText
             {
@@ -104,6 +105,10 @@ namespace Content.Server.PDA
             };
 
             var hasUplink = EntityManager.HasComponent<UplinkComponent>(pda.Owner);
+
+            var acctSys = Get<UplinkAccountsSystem>();
+            if (user is not null)
+                hasUplink &= acctSys.HasAccount(user.Value);
 
             var ui = pda.Owner.GetUIOrNull(PDAUiKey.Key);
             ui?.SetState(new PDAUpdateState(pda.FlashlightOn, pda.PenSlot.HasItem, ownerInfo, hasUplink));
@@ -118,7 +123,7 @@ namespace Content.Server.PDA
             switch (msg.Message)
             {
                 case PDARequestUpdateInterfaceMessage _:
-                    UpdatePDAUserInterface(pda);
+                    UpdatePDAUserInterface(pda, playerUid);
                     break;
                 case PDAToggleFlashlightMessage _:
                     {

--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -18,6 +18,7 @@ namespace Content.Server.PDA
     public sealed class PDASystem : SharedPDASystem
     {
         [Dependency] private readonly UplinkSystem _uplinkSystem = default!;
+        [Dependency] private readonly UplinkAccountsSystem _uplinkAccounts = default!;
         [Dependency] private readonly UnpoweredFlashlightSystem _unpoweredFlashlight = default!;
 
         public override void Initialize()
@@ -107,9 +108,8 @@ namespace Content.Server.PDA
 
             var hasUplink = EntityManager.HasComponent<UplinkComponent>(pda.Owner);
 
-            var acctSys = Get<UplinkAccountsSystem>();
             if (user is not null)
-                hasUplink &= acctSys.HasAccount(user.Value);
+                hasUplink &= _uplinkAccounts.HasAccount(user.Value);
 
             var ui = pda.Owner.GetUIOrNull(PDAUiKey.Key);
             ui?.SetState(new PDAUpdateState(pda.FlashlightOn, pda.PenSlot.HasItem, ownerInfo, hasUplink));

--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -83,6 +83,7 @@ namespace Content.Server.PDA
             if (!EntityManager.TryGetComponent(user, out ActorComponent? actor))
                 return false;
 
+            UpdatePDAUserInterface(pda, user);
             var ui = pda.Owner.GetUIOrNull(PDAUiKey.Key);
             ui?.Toggle(actor.PlayerSession);
 

--- a/Content.Server/Traitor/Uplink/Account/UplinkAccountsSystem.cs
+++ b/Content.Server/Traitor/Uplink/Account/UplinkAccountsSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Shared.Stacks;
 using Content.Shared.Traitor.Uplink;
 using Robust.Shared.GameObjects;
@@ -28,6 +29,8 @@ namespace Content.Server.Traitor.Uplink.Account
             return _accounts.Add(acc);
         }
 
+        public bool HasAccount(EntityUid holder) =>
+            _accounts.Any(acct => acct.AccountHolder == holder);
 
         /// <summary>
         /// Add TC to uplinks account balance


### PR DESCRIPTION
## About the PR
^

**Screenshots**
nope

**Changelog**
:cl:
- tweak: The Syndicate has gotten smarter. Now, only traitors can access the Uplink menu.
- remove: Removed PDA checks.

