### PR TITLE
Fix ghost role exceptions

### DIFF
--- a/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
@@ -5,7 +5,9 @@ using JetBrains.Annotations;
 using Robust.Server.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.ViewVariables;
 
 namespace Content.Server.Ghost.Roles.Components
@@ -31,7 +33,7 @@ namespace Content.Server.Ghost.Roles.Components
 
         [CanBeNull]
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("prototype")]
+        [DataField("prototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string? Prototype { get; private set; }
 
         public override bool Take(IPlayerSession session)

--- a/Content.Server/Ghost/Roles/Components/GhostTakeoverAvailableComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostTakeoverAvailableComponent.cs
@@ -1,11 +1,8 @@
-using System;
 using Content.Server.Mind.Commands;
 using Content.Server.Mind.Components;
-using Content.Server.Players;
 using Robust.Server.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Ghost.Roles.Components
 {

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -47,14 +47,7 @@ namespace Content.Server.Ghost.Roles
             SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
             SubscribeLocalEvent<GhostTakeoverAvailableComponent, MindRemovedMessage>(OnMindRemoved);
             SubscribeLocalEvent<GhostTakeoverAvailableComponent, MobStateChangedEvent>(OnMobStateChanged);
-            SubscribeLocalEvent<GhostTakeoverAvailableComponent, ComponentShutdown>(OnTakeoverShutdown);
-
             _playerManager.PlayerStatusChanged += PlayerStatusChanged;
-        }
-
-        private void OnTakeoverShutdown(EntityUid uid, GhostTakeoverAvailableComponent component, ComponentShutdown args)
-        {
-            UnregisterGhostRole(component);
         }
 
         private void OnMobStateChanged(EntityUid uid, GhostRoleComponent component, MobStateChangedEvent args)

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -47,8 +47,14 @@ namespace Content.Server.Ghost.Roles
             SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
             SubscribeLocalEvent<GhostTakeoverAvailableComponent, MindRemovedMessage>(OnMindRemoved);
             SubscribeLocalEvent<GhostTakeoverAvailableComponent, MobStateChangedEvent>(OnMobStateChanged);
+            SubscribeLocalEvent<GhostTakeoverAvailableComponent, ComponentShutdown>(OnTakeoverShutdown);
 
             _playerManager.PlayerStatusChanged += PlayerStatusChanged;
+        }
+
+        private void OnTakeoverShutdown(EntityUid uid, GhostTakeoverAvailableComponent component, ComponentShutdown args)
+        {
+            UnregisterGhostRole(component);
         }
 
         private void OnMobStateChanged(EntityUid uid, GhostRoleComponent component, MobStateChangedEvent args)

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -230,8 +230,10 @@ namespace Content.Server.Ghost.Roles
 
         private void OnMindRemoved(EntityUid uid, GhostRoleComponent component, MindRemovedMessage args)
         {
-            if (!component.ReregisterOnGhost)
+            // Avoid re-registering it for duplicate entries and potential exceptions.
+            if (!component.ReregisterOnGhost || component.LifeStage > ComponentLifeStage.Running)
                 return;
+
             component.Taken = false;
             RegisterGhostRole(component);
         }

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -34,7 +34,7 @@
     sprite: Markers/jobs.rsi
     state: centcom
   - type: GhostRoleMobSpawner
-    prototype: HumanMob_CentcomOfficial
+    prototype: MobHumanCentcomOfficial
     deleteOnSpawn: true
     makeSentient: false
     name: centcom official


### PR DESCRIPTION
- Invalid prototype for mob spawner
- Avoids re-registering when it gets deleted. The easiest way to replicate this is use MakeSentient on holoparasite, control it, then aghost again, and on master deleting holoparasite still leaves the role registered.