### PR TITLE
Plastic autolathe recipes fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -53,8 +53,6 @@
   - type: LatheDatabase
     static: true
     recipes:
-      - Brutepack
-      - Ointment
       - Wirecutter
       - Screwdriver
       - Welder

--- a/Resources/Prototypes/Recipes/Lathes/Parts.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Parts.yml
@@ -5,7 +5,7 @@
   completetime: 250
   materials:
     Steel: 50
-    Glass: 50
+    Plastic: 50
 
 - type: latheRecipe
   id: MatterBinStockPart
@@ -14,7 +14,7 @@
   completetime: 250
   materials:
     Steel: 50
-    Glass: 50
+    Plastic: 50
 
 - type: latheRecipe
   id: MicroLaserStockPart
@@ -24,6 +24,7 @@
   materials:
     Steel: 50
     Glass: 50
+    Plastic: 50
 
 - type: latheRecipe
   id: MicroManipulatorStockPart
@@ -32,7 +33,7 @@
   completetime: 250
   materials:
     Steel: 50
-    Glass: 50
+    Plastic: 50
 
 - type: latheRecipe
   id: ScanningModuleStockPart
@@ -42,3 +43,4 @@
   materials:
     Steel: 50
     Glass: 50
+    Plastic: 50

--- a/Resources/Prototypes/Recipes/Lathes/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cargo.yml
@@ -7,4 +7,4 @@
   completetime: 1000
   materials:
     Steel: 1000
-    Glass: 50
+    Plastic: 50

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -27,7 +27,8 @@
   completetime: 500
   materials:
     Steel: 250
-
+    Plastic: 50
+    
 - type: latheRecipe
   id: Dropper
   icon:
@@ -47,7 +48,8 @@
   result: Syringe
   completetime: 500
   materials:
-    Glass: 200
+    Plastic: 100
+    Steel: 25
 
 - type: latheRecipe
   id: PillCanister

--- a/Resources/Prototypes/Recipes/Lathes/cooking.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cooking.yml
@@ -7,6 +7,7 @@
   completetime: 500
   materials:
     Steel: 300
+    Plastic: 50
 
 - type: latheRecipe
   id: KitchenKnife
@@ -17,6 +18,7 @@
   completetime: 500
   materials:
     Steel: 200
+    Plastic: 50
 
 - type: latheRecipe
   id: DrinkMug

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -5,7 +5,7 @@
   completetime: 500
   materials:
      Steel: 50
-     Glass: 50
+     Plastic: 50
 
 - type: latheRecipe
   id: DoorElectronics
@@ -14,7 +14,7 @@
   completetime: 500
   materials:
      Steel: 50
-     Glass: 50
+     Plastic: 50
 
 - type: latheRecipe
   id: APCElectronics
@@ -23,7 +23,7 @@
   completetime: 500
   materials:
      Steel: 50
-     Glass: 50
+     Plastic: 50
      
 - type: latheRecipe
   id: AirAlarmElectronics
@@ -32,7 +32,7 @@
   completetime: 500
   materials:
      Steel: 50
-     Glass: 50
+     Plastic: 50
 
 - type: latheRecipe
   id: FireAlarmElectronics
@@ -41,7 +41,7 @@
   completetime: 500
   materials:
      Steel: 50
-     Glass: 50
+     Plastic: 50
 
 - type: latheRecipe
   id: CloningPodMachineCircuitboard
@@ -50,7 +50,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: MedicalScannerMachineCircuitboard
@@ -59,7 +59,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: ChemMasterMachineCircuitboard
@@ -68,7 +68,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: ChemDispenserMachineCircuitboard
@@ -77,7 +77,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: SolarControlComputerCircuitboard
@@ -86,7 +86,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: HydroponicsTrayMachineCircuitboard
@@ -95,7 +95,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: AutolatheMachineCircuitboard
@@ -104,7 +104,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: ProtolatheMachineCircuitboard
@@ -113,7 +113,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: KitchenReagentGrinderMachineCircuitboard
@@ -122,7 +122,7 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100
 
 - type: latheRecipe
   id: CrewMonitoringComputerCircuitboard
@@ -131,4 +131,4 @@
   completetime: 1000
   materials:
      Steel: 100
-     Glass: 100
+     Plastic: 100

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -1,22 +1,4 @@
 - type: latheRecipe
-  id: Brutepack
-  icon: Objects/Specific/Medical/medical.rsi/brutepack.png
-  result: Brutepack
-  completetime: 500
-  materials:
-    Steel: 400
-    Glass: 100
-
-- type: latheRecipe
-  id: Ointment
-  icon: Objects/Specific/Medical/medical.rsi/ointment.png
-  result: Ointment
-  completetime: 500
-  materials:
-    Steel: 400
-    Glass: 100
-
-- type: latheRecipe
   id: Gauze
   icon: Objects/Specific/Medical/medical.rsi/gauze.png
   result: Gauze
@@ -55,6 +37,7 @@
   completetime: 500
   materials:
     Steel: 200
+    Plastic: 100
 
 - type: latheRecipe
   id: Saw

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -5,6 +5,7 @@
   completetime: 500
   materials:
     Steel: 200
+    Plastic: 50
 
 - type: latheRecipe
   id: Screwdriver
@@ -15,6 +16,7 @@
   completetime: 500
   materials:
     Steel: 200
+    Plastic: 50
 
 - type: latheRecipe
   id: Welder


### PR DESCRIPTION
Simple fix to rebalance the autolathe recipes. Replaced glass with plastic in a lot of recipes where appropriate, and added plastic to recipes that had non but their sprites clearly have it or it makes sense to.

For example:
- Knives have plastic handles. Now they require a small amount of plastic.
- Syringes are plastic, they used to require glass. Now they are plastic with a tiny amount of metal.
- Circuit boards all required glass. Now they require plastic instead (Stop gap until I get around to making or attempting to make the circuit board printer). At which point maybe the lathe will make blank boards for the printer.
- Plus many more small changes for balance or realism.

Also removed brutepacks and ointment from the printer as that was a stop gap until we got chemistry. Now for someone to make crafting for them at which point possibly medication tubes and patches can get added back to the lathe to be filled with ointment etc.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- Fix: Some Autolathe recipes now require plastic instead of glass.

