### PR TITLE
Personnel crate (ID cards and PDAs)

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -57,3 +57,15 @@
   cost: 1000
   category: Service
   group: market
+  
+- type: cargoProduct
+  name: "personnel crate"
+  id: ServicePersonnel
+  description: "Contains a box of blank ID cards and PDAs"
+  icon:
+    sprite: Objects/Misc/id_cards.rsi
+    state: default
+  product: CrateServicePersonnel
+  cost: 1000
+  category: Service
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -113,7 +113,7 @@
     capacity: 60
     whitelist:
       components:
-      - AssistantIDCard
+      - IdCard
 
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -76,7 +76,7 @@
       - LightBulb
 
 - type: entity
-  name: pda box
+  name: PDA box
   parent: BoxCardboard
   id: BoxPDA
   description: A box of spare PDA microcomputers.
@@ -94,6 +94,27 @@
     whitelist:
       components:
       - PDA
+
+- type: entity
+  name: ID card box
+  parent: BoxCardboard
+  id: BoxID
+  description: A box of spare blank ID cards.
+  components:
+  - type: StorageFill
+    contents:
+      - id: AssistantIDCard
+        amount: 6
+  - type: Sprite
+    layers:
+      - state: box
+      - state: pda
+  - type: Storage
+    capacity: 60
+    whitelist:
+      components:
+      - AssistantIDCard
+
 
 - type: entity
   name: meson box

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -87,3 +87,16 @@
       amount: 15
     - id: Pen
       amount: 2
+
+- type: entity
+  id: CrateServicePersonnel
+  name: personnel crate
+  description: Contains a box of blank ID cards and PDAs.
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+    - id: BoxPDA
+      amount: 1
+    - id: BoxID
+      amount: 1

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -314,6 +314,7 @@
       - ServiceSmokeables
       - ServiceCustomSmokable
       - ServiceBureaucracy
+      - ServicePersonnel
       - EngineeringCableLv
       - EngineeringCableMv
       - EngineeringCableHv


### PR DESCRIPTION
Had complaints in game of people losing PDAs and also noticed we had a box of them in entities but no box of spare IDs.

Made this personnel crate for cargo which includes a box of 6 PDAs as well as 6 assistant IDs so HoP can be fully self sufficient now.

:cl:
- add: Added Personnel Crate to cargo. Includes a box of spare PDAs and ID cards.

