### PR TITLE
Hide deconstruct verb if user cannot interact.

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Guided.cs
+++ b/Content.Server/Construction/ConstructionSystem.Guided.cs
@@ -33,7 +33,7 @@ namespace Content.Server.Construction
 
         private void AddDeconstructVerb(EntityUid uid, ConstructionComponent component, GetOtherVerbsEvent args)
         {
-            if (!args.CanAccess)
+            if (!args.CanAccess || !args.CanInteract)
                 return;
 
             if (component.TargetNode == component.DeconstructionNode ||


### PR DESCRIPTION
After the new ghost-follow verb I realised ghosts all had the option to begin deconstructing misc entities. They couldn't actually follow the steps, but its still weird that it shows up.