### PR TITLE
Make any mind added remove ghost role

### DIFF
--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -48,6 +48,7 @@ namespace Content.Server.Ghost.Roles
 
             SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
+            SubscribeLocalEvent<GhostTakeoverAvailableComponent, MindAddedMessage>(OnMindAdded);
             SubscribeLocalEvent<GhostTakeoverAvailableComponent, MindRemovedMessage>(OnMindRemoved);
             SubscribeLocalEvent<GhostTakeoverAvailableComponent, MobStateChangedEvent>(OnMobStateChanged);
             _playerManager.PlayerStatusChanged += PlayerStatusChanged;
@@ -226,6 +227,12 @@ namespace Content.Server.Ghost.Roles
             if (!_openUis.ContainsKey(message.Player)) return;
             if (EntityManager.HasComponent<GhostComponent>(message.Entity)) return;
             CloseEui(message.Player);
+        }
+
+        private void OnMindAdded(EntityUid uid, GhostTakeoverAvailableComponent component, MindAddedMessage args)
+        {
+            component.Taken = true;
+            UnregisterGhostRole(component);
         }
 
         private void OnMindRemoved(EntityUid uid, GhostRoleComponent component, MindRemovedMessage args)

--- a/Content.Shared/Ghost/Roles/SharedGhostRoleSystem.cs
+++ b/Content.Shared/Ghost/Roles/SharedGhostRoleSystem.cs
@@ -4,11 +4,6 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Ghost.Roles
 {
-    public abstract class SharedGhostRoleSystem : EntitySystem
-    {
-
-    }
-
     [Serializable, NetSerializable]
     public class GhostRole
     {


### PR DESCRIPTION
e.g. if Control Mob is used.

:cl:
- fix: Remove duplicate ghost takeovers when an admin controls a mob.