### PR TITLE
Fix typo in CentCom Official prototype id.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -1,5 +1,5 @@
 - type: job
-  id: CentralCommandOffical
+  id: CentralCommandOfficial
   name: "centcom official"
   setPreference: false
   startingGear: CentcomGear


### PR DESCRIPTION
CentralCommandOffical --> CentralCommandOfficial