### PR TITLE
Verb confirmation

### DIFF
--- a/Content.Client/ContextMenu/UI/ContextMenuElement.xaml.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuElement.xaml.cs
@@ -95,7 +95,8 @@ namespace Content.Client.ContextMenu.UI
             if (_subMenu?.Visible ?? true)
                 return;
 
-            RemoveStylePseudoClass(StylePseudoClassHover);
+            if (HasStylePseudoClass(StylePseudoClassHover))
+                RemoveStylePseudoClass(StylePseudoClassHover);
         }
     }
 }

--- a/Content.Client/ContextMenu/UI/ContextMenuElement.xaml.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuElement.xaml.cs
@@ -45,7 +45,7 @@ namespace Content.Client.ContextMenu.UI
         /// <summary>
         ///     Convenience property to set label text.
         /// </summary>
-        public string Text { set => Label.SetMessage(FormattedMessage.FromMarkupPermissive(value.Trim())); }
+        public virtual string Text { set => Label.SetMessage(FormattedMessage.FromMarkupPermissive(value.Trim())); }
 
         public ContextMenuElement(string? text = null)
         {

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -623,6 +623,26 @@ namespace Content.Client.Stylesheets
                 Element<RichTextLabel>().Class(VerbMenuElement.StyleClassVerbOtherText)
                     .Prop(Label.StylePropertyFont, notoSans12),
 
+                // Context menu confirm buttons
+                Element<ContextMenuElement>().Class(ConfirmationMenuElement.StyleClassConfirmationContextMenuButton)
+                    .Prop(ContainerButton.StylePropertyStyleBox, buttonContext),
+
+                Element<ContextMenuElement>().Class(ConfirmationMenuElement.StyleClassConfirmationContextMenuButton)
+                    .Pseudo(ContainerButton.StylePseudoClassNormal)
+                    .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionDefault),
+
+                Element<ContextMenuElement>().Class(ConfirmationMenuElement.StyleClassConfirmationContextMenuButton)
+                    .Pseudo(ContainerButton.StylePseudoClassHover)
+                    .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionHovered),
+
+                Element<ContextMenuElement>().Class(ConfirmationMenuElement.StyleClassConfirmationContextMenuButton)
+                    .Pseudo(ContainerButton.StylePseudoClassPressed)
+                    .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionPressed),
+
+                Element<ContextMenuElement>().Class(ConfirmationMenuElement.StyleClassConfirmationContextMenuButton)
+                    .Pseudo(ContainerButton.StylePseudoClassDisabled)
+                    .Prop(Control.StylePropertyModulateSelf, ButtonColorCautionDisabled),
+
                 // Thin buttons (No padding nor vertical margin)
                 Element<EntityContainerButton>().Class(StyleClassStorageButton)
                     .Prop(ContainerButton.StylePropertyStyleBox, buttonStorage),

--- a/Content.Client/Verbs/UI/ConfirmationMenuElement.cs
+++ b/Content.Client/Verbs/UI/ConfirmationMenuElement.cs
@@ -27,7 +27,6 @@ public partial class ConfirmationMenuElement : ContextMenuElement
     {
         Verb = verb;
         Type = type;
-        SubMenu = null;
 
         SetOnlyStyleClass(StyleClassConfirmationContextMenuButton);
     }

--- a/Content.Client/Verbs/UI/ConfirmationMenuElement.cs
+++ b/Content.Client/Verbs/UI/ConfirmationMenuElement.cs
@@ -1,17 +1,34 @@
 ﻿using Content.Client.ContextMenu.UI;
 using Content.Shared.Verbs;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
 
 namespace Content.Client.Verbs.UI;
 
 public partial class ConfirmationMenuElement : ContextMenuElement
 {
+    public const string StyleClassConfirmationContextMenuButton = "confirmationContextMenuButton";
+
     public readonly Verb Verb;
     public readonly VerbType Type;
+
+    public override string Text
+    {
+        set
+        {
+            var message = new FormattedMessage();
+            message.PushColor(Color.White);
+            message.AddMarkupPermissive(value.Trim());
+            Label.SetMessage(message);
+        }
+    }
 
     public ConfirmationMenuElement(Verb verb, string? text, VerbType type) : base(text)
     {
         Verb = verb;
         Type = type;
         SubMenu = null;
+
+        SetOnlyStyleClass(StyleClassConfirmationContextMenuButton);
     }
 }

--- a/Content.Client/Verbs/UI/ConfirmationMenuElement.cs
+++ b/Content.Client/Verbs/UI/ConfirmationMenuElement.cs
@@ -1,0 +1,17 @@
+﻿using Content.Client.ContextMenu.UI;
+using Content.Shared.Verbs;
+
+namespace Content.Client.Verbs.UI;
+
+public partial class ConfirmationMenuElement : ContextMenuElement
+{
+    public readonly Verb Verb;
+    public readonly VerbType Type;
+
+    public ConfirmationMenuElement(Verb verb, string? text, VerbType type) : base(text)
+    {
+        Verb = verb;
+        Type = type;
+        SubMenu = null;
+    }
+}

--- a/Content.Client/Verbs/UI/VerbMenuPresenter.cs
+++ b/Content.Client/Verbs/UI/VerbMenuPresenter.cs
@@ -174,9 +174,7 @@ namespace Content.Client.Verbs.UI
                 if (element is not ConfirmationMenuElement confElement)
                     return;
 
-                _verbSystem.ExecuteVerb(CurrentTarget, confElement.Verb, confElement.Type);
-                if (confElement.Verb.CloseMenu)
-                    _verbSystem.CloseAllMenus();
+                ExecuteVerb(confElement.Verb, confElement.Type);
                 return;
             }
 
@@ -217,10 +215,15 @@ namespace Content.Client.Verbs.UI
             }
             else
             {
-                _verbSystem.ExecuteVerb(CurrentTarget, verb, verbElement.Type);
-                if (verb.CloseMenu)
-                    _verbSystem.CloseAllMenus();
+                ExecuteVerb(verb, verbElement.Type);
             }
+        }
+
+        private void ExecuteVerb(Verb verb, VerbType verbType)
+        {
+            _verbSystem.ExecuteVerb(CurrentTarget, verb, verbType);
+            if (verb.CloseMenu)
+                _verbSystem.CloseAllMenus();
         }
     }
 }

--- a/Content.Client/Verbs/UI/VerbMenuPresenter.cs
+++ b/Content.Client/Verbs/UI/VerbMenuPresenter.cs
@@ -170,7 +170,15 @@ namespace Content.Client.Verbs.UI
                 return;
 
             if (element is not VerbMenuElement verbElement)
+            {
+                if (element is not ConfirmationMenuElement confElement)
+                    return;
+
+                _verbSystem.ExecuteVerb(CurrentTarget, confElement.Verb, confElement.Type);
+                if (confElement.Verb.CloseMenu)
+                    _verbSystem.CloseAllMenus();
                 return;
+            }
 
             args.Handle();
             var verb = verbElement.Verb;
@@ -196,9 +204,23 @@ namespace Content.Client.Verbs.UI
                     return;
             }
 
-            _verbSystem.ExecuteVerb(CurrentTarget, verb, verbElement.Type);
-            if (verb.CloseMenu)
-                _verbSystem.CloseAllMenus();
+            if (verb.ConfirmationPopup)
+            {
+                if (verbElement.SubMenu == null)
+                {
+                    var popupElement = new ConfirmationMenuElement(verb, "Confirm", verbElement.Type);
+                    verbElement.SubMenu = new ContextMenuPopup(this, verbElement);
+                    AddElement(verbElement.SubMenu, popupElement);
+                }
+
+                OpenSubMenu(verbElement);
+            }
+            else
+            {
+                _verbSystem.ExecuteVerb(CurrentTarget, verb, verbElement.Type);
+                if (verb.CloseMenu)
+                    _verbSystem.CloseAllMenus();
+            }
         }
     }
 }

--- a/Content.Server/Administration/AdminVerbSystem.cs
+++ b/Content.Server/Administration/AdminVerbSystem.cs
@@ -116,6 +116,7 @@ namespace Content.Server.Administration
                     }
                 };
                 verb.Impact = LogImpact.Extreme; // if you're just outright killing a person, I guess that deserves to be extreme?
+                verb.ConfirmationPopup = true;
                 args.Verbs.Add(verb);
             }
         }
@@ -136,6 +137,7 @@ namespace Content.Server.Administration
                 verb.IconTexture = "/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png";
                 verb.Act = () => EntityManager.DeleteEntity(args.Target);
                 verb.Impact = LogImpact.Medium;
+                verb.ConfirmationPopup = true;
                 args.Verbs.Add(verb);
             }
 
@@ -166,6 +168,7 @@ namespace Content.Server.Administration
                     player.ContentData()?.Mind?.TransferTo(args.Target, ghostCheckOverride: true);
                 };
                 verb.Impact = LogImpact.High;
+                verb.ConfirmationPopup = true;
                 args.Verbs.Add(verb);
             }
 

--- a/Content.Shared/Verbs/Verb.cs
+++ b/Content.Shared/Verbs/Verb.cs
@@ -95,7 +95,7 @@ namespace Content.Shared.Verbs
         public bool Disabled;
 
         /// <summary>
-        ///     Optional informative message.  
+        ///     Optional informative message.
         /// </summary>
         /// <remarks>
         ///     This will be shown as a tooltip when hovering over this verb in the context menu. Additionally, iF a
@@ -136,6 +136,11 @@ namespace Content.Shared.Verbs
         public LogImpact Impact = LogImpact.Low;
 
         /// <summary>
+        ///     Whether this verb requires confirmation before being executed.
+        /// </summary>
+        public bool ConfirmationPopup = false;
+
+        /// <summary>
         ///     Compares two verbs based on their <see cref="Priority"/>, <see cref="Category"/>, <see cref="Text"/>,
         ///     and <see cref="IconTexture"/>.
         /// </summary>
@@ -165,7 +170,7 @@ namespace Content.Shared.Verbs
             {
                 return string.Compare(Category?.Text, otherVerb.Category?.Text, StringComparison.CurrentCulture);
             }
-            
+
             // Then try use alphabetical verb text.
             if (Text != otherVerb.Text)
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a confirmation button for more destructive verbs.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/10494922/149106430-83f3f76a-5b62-4c61-8ac1-951958eb507c.mp4