### PR TITLE
Correct anchor events

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPortableSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPortableSystem.cs
@@ -22,8 +22,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             base.Initialize();
 
             SubscribeLocalEvent<GasPortableComponent, AnchorAttemptEvent>(OnPortableAnchorAttempt);
-            SubscribeLocalEvent<GasPortableComponent, AnchoredEvent>(OnPortableAnchored);
-            SubscribeLocalEvent<GasPortableComponent, UnanchoredEvent>(OnPortableUnanchored);
+            SubscribeLocalEvent<GasPortableComponent, AnchorStateChangedEvent>(OnAnchorChanged);
         }
 
         private void OnPortableAnchorAttempt(EntityUid uid, GasPortableComponent component, AnchorAttemptEvent args)
@@ -36,7 +35,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 args.Cancel();
         }
 
-        private void OnPortableAnchored(EntityUid uid, GasPortableComponent portable, AnchoredEvent args)
+        private void OnAnchorChanged(EntityUid uid, GasPortableComponent portable, ref AnchorStateChangedEvent args)
         {
             if (!EntityManager.TryGetComponent(uid, out NodeContainerComponent? nodeContainer))
                 return;
@@ -44,27 +43,11 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (!nodeContainer.TryGetNode(portable.PortName, out PipeNode? portableNode))
                 return;
 
-            portableNode.ConnectionsEnabled = true;
+            portableNode.ConnectionsEnabled = args.Anchored;
 
             if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
             {
-                appearance.SetData(GasPortableVisuals.ConnectedState, true);
-            }
-        }
-
-        private void OnPortableUnanchored(EntityUid uid, GasPortableComponent portable, UnanchoredEvent args)
-        {
-            if (!EntityManager.TryGetComponent(uid, out NodeContainerComponent? nodeContainer))
-                return;
-
-            if (!nodeContainer.TryGetNode(portable.PortName, out PipeNode? portableNode))
-                return;
-
-            portableNode.ConnectionsEnabled = false;
-
-            if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
-            {
-                appearance.SetData(GasPortableVisuals.ConnectedState, false);
+                appearance.SetData(GasPortableVisuals.ConnectedState, args.Anchored);
             }
         }
 

--- a/Content.Server/Construction/AnchorableSystem.cs
+++ b/Content.Server/Construction/AnchorableSystem.cs
@@ -103,7 +103,7 @@ namespace Content.Server.Construction
 
             transform.Anchored = true;
 
-            RaiseLocalEvent(uid, new AnchoredEvent(userUid, usingUid), false);
+            RaiseLocalEvent(uid, new UserAnchoredEvent(userUid, usingUid), false);
 
             return true;
         }
@@ -132,7 +132,7 @@ namespace Content.Server.Construction
 
             transform.Anchored = false;
 
-            RaiseLocalEvent(uid, new UnanchoredEvent(userUid, usingUid), false);
+            RaiseLocalEvent(uid, new UserUnanchoredEvent(userUid, usingUid), false);
 
             return true;
         }

--- a/Content.Server/Construction/Components/AnchorableComponent.cs
+++ b/Content.Server/Construction/Components/AnchorableComponent.cs
@@ -76,9 +76,9 @@ namespace Content.Server.Construction.Components
     ///     general <see cref="AnchorStateChangedEvent"/>. This event has the benefit of having user & tool information,
     ///     as a result of interactions mediated by the <see cref="AnchorableSystem"/>.
     /// </summary>
-    public class AnchoredEvent : BaseAnchoredEvent
+    public class UserAnchoredEvent : BaseAnchoredEvent
     {
-        public AnchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
+        public UserAnchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
     }
 
     /// <summary>
@@ -95,8 +95,8 @@ namespace Content.Server.Construction.Components
     ///     event has the benefit of having user & tool information, whereas the more general event may be due to
     ///     explosions or grid-destruction or other interactions not mediated by the <see cref="AnchorableSystem"/>.
     /// </summary>
-    public class UnanchoredEvent : BaseAnchoredEvent
+    public class UserUnanchoredEvent : BaseAnchoredEvent
     {
-        public UnanchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
+        public UserUnanchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
     }
 }

--- a/Content.Server/Construction/Components/AnchorableComponent.cs
+++ b/Content.Server/Construction/Components/AnchorableComponent.cs
@@ -71,6 +71,11 @@ namespace Content.Server.Construction.Components
         public BeforeAnchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
     }
 
+    /// <summary>
+    ///     Raised when an entity with an anchorable component is anchored. Note that you may instead want the more
+    ///     general <see cref="AnchorStateChangedEvent"/>. This event has the benefit of having user & tool information,
+    ///     as a result of interactions mediated by the <see cref="AnchorableSystem"/>.
+    /// </summary>
     public class AnchoredEvent : BaseAnchoredEvent
     {
         public AnchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
@@ -84,6 +89,12 @@ namespace Content.Server.Construction.Components
         public BeforeUnanchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }
     }
 
+    /// <summary>
+    ///     Raised when an entity with an anchorable component is unanchored. Note that you will probably also need to
+    ///     subscribe to the more general <see cref="AnchorStateChangedEvent"/>, which gets raised BEFORE this one. This
+    ///     event has the benefit of having user & tool information, whereas the more general event may be due to
+    ///     explosions or grid-destruction or other interactions not mediated by the <see cref="AnchorableSystem"/>.
+    /// </summary>
     public class UnanchoredEvent : BaseAnchoredEvent
     {
         public UnanchoredEvent(EntityUid user, EntityUid tool) : base(user, tool) { }

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -45,8 +45,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<DisposalUnitComponent, AnchoredEvent>(OnAnchored);
-            SubscribeLocalEvent<DisposalUnitComponent, UnanchoredEvent>(OnUnanchored);
+            SubscribeLocalEvent<DisposalUnitComponent, AnchorStateChangedEvent>(OnAnchorChanged);
             // TODO: Predict me when hands predicted
             SubscribeLocalEvent<DisposalUnitComponent, RelayMovementEntityEvent>(HandleMovement);
             SubscribeLocalEvent<DisposalUnitComponent, PowerChangedEvent>(HandlePowerChange);
@@ -313,15 +312,11 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             Remove(component, args.Entity);
         }
 
-        private void OnAnchored(EntityUid uid, DisposalUnitComponent component, AnchoredEvent args)
+        private void OnAnchorChanged(EntityUid uid, DisposalUnitComponent component, ref AnchorStateChangedEvent args)
         {
             UpdateVisualState(component);
-        }
-
-        private void OnUnanchored(EntityUid uid, DisposalUnitComponent component, UnanchoredEvent args)
-        {
-            UpdateVisualState(component);
-            TryEjectContents(component);
+            if (!args.Anchored)
+                TryEjectContents(component);
         }
         #endregion
 

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
 
             // Component lifetime
             SubscribeLocalEvent<DisposalUnitComponent, ComponentInit>(HandleDisposalInit);
-            SubscribeLocalEvent<DisposalUnitComponent, ComponentShutdown>(HandleDisposalShutdown);
+            SubscribeLocalEvent<DisposalUnitComponent, ComponentRemove>(HandleDisposalRemove);
 
             SubscribeLocalEvent<DisposalUnitComponent, ThrowHitByEvent>(HandleThrowCollide);
 
@@ -243,7 +243,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             }
         }
 
-        private void HandleDisposalShutdown(EntityUid uid, DisposalUnitComponent component, ComponentShutdown args)
+        private void HandleDisposalRemove(EntityUid uid, DisposalUnitComponent component, ComponentRemove args)
         {
             foreach (var entity in component.Container.ContainedEntities.ToArray())
             {

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -37,7 +37,7 @@ namespace Content.Server.Fluids.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<PuddleComponent, UnanchoredEvent>(OnUnanchored);
+            SubscribeLocalEvent<PuddleComponent, AnchorStateChangedEvent>(OnAnchorChanged);
             SubscribeLocalEvent<PuddleComponent, ExaminedEvent>(HandlePuddleExamined);
             SubscribeLocalEvent<PuddleComponent, SolutionChangedEvent>(OnUpdate);
             SubscribeLocalEvent<PuddleComponent, ComponentInit>(OnInit);
@@ -95,12 +95,10 @@ namespace Content.Server.Fluids.EntitySystems
             }
         }
 
-        private void OnUnanchored(EntityUid uid, PuddleComponent puddle, UnanchoredEvent unanchoredEvent)
+        private void OnAnchorChanged(EntityUid uid, PuddleComponent puddle, ref AnchorStateChangedEvent args)
         {
-            if (!EntityManager.GetComponent<TransformComponent>(puddle.Owner).Anchored)
-                return;
-
-            EntityManager.QueueDeleteEntity(puddle.Owner);
+            if (!args.Anchored)
+                QueueDel(uid);
         }
 
         /// <summary>

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -46,8 +46,7 @@ namespace Content.Server.Nuke
             // anchoring logic
             SubscribeLocalEvent<NukeComponent, AnchorAttemptEvent>(OnAnchorAttempt);
             SubscribeLocalEvent<NukeComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
-            SubscribeLocalEvent<NukeComponent, AnchoredEvent>(OnWasAnchored);
-            SubscribeLocalEvent<NukeComponent, UnanchoredEvent>(OnWasUnanchored);
+            SubscribeLocalEvent<NukeComponent, AnchorStateChangedEvent>(OnAnchorChanged);
 
             // ui events
             SubscribeLocalEvent<NukeComponent, NukeEjectMessage>(OnEjectButtonPressed);
@@ -154,12 +153,7 @@ namespace Content.Server.Nuke
             }
         }
 
-        private void OnWasUnanchored(EntityUid uid, NukeComponent component, UnanchoredEvent args)
-        {
-            UpdateUserInterface(uid, component);
-        }
-
-        private void OnWasAnchored(EntityUid uid, NukeComponent component, AnchoredEvent args)
+        private void OnAnchorChanged(EntityUid uid, NukeComponent component, ref AnchorStateChangedEvent args)
         {
             UpdateUserInterface(uid, component);
         }


### PR DESCRIPTION
Currently several systems subscribe to `UnanchoredEvent`, when they should be using the more general `AnchorStateChangedEvent`. The former is raised by the Anchorable system when an entity is "wrenched", while the latter is raised more generally when the state changes (e.g., when a tile is destroyed).

As an example, puddles were listening for `UnanchoredEvent` and then deleting themselves (no puddle smears in space). But obviously puddles are not wrenchable (no AnchorableComponent) and so this subscription has no effect.

This PR also renames the events to `UserUnanchoredEvent` to make it clear in future that these are specifically user-initiated anchoring events.