### PR TITLE
Whitelist for trashbags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -206,6 +206,9 @@
   - type: Item
     sprite: Objects/Consumable/Food/snacks.rsi
     HeldPrefix: packet
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
@@ -34,6 +34,9 @@
     - type: DrinkCanVisualizer
       stateClosed: icon
       stateOpen: icon_open
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   parent: DrinkCanBaseFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/trash_drinks.yml
@@ -50,7 +50,9 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-
+  - type: Tag
+    tags:
+    - Trash
 
 # Containers
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -23,6 +23,9 @@
     damage:
       types:
         Slash: 2
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   parent: ShardBase

--- a/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
@@ -18,4 +18,7 @@
     damage:
       types:
         Slash: 2
+  - type: Tag
+    tags:
+    - Trash
 

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -25,6 +25,9 @@
           enum.PaperStatus.Written: paper_words
   - type: Item
     size: 1
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   parent: Paper
@@ -37,6 +40,9 @@
     # Changing it here is fine - if the PaperStatus key is actually added,
     #  something happened, so that ought to override this either way.
     - state: paper_words
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   parent: PaperWritten

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -7,6 +7,9 @@
     sprite: Objects/Misc/utensils.rsi
   - type: Item
     sprite: Objects/Misc/utensils.rsi
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   parent: UtensilBase

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -47,6 +47,9 @@
   - type: Appearance
     visuals:
     - type: LightBulbVisualizer
+  - type: Tag
+    tags:
+    - Trash
 
 # Lighting color values gathered from
 # https://andi-siess.de/rgb-to-color-temperature/

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -15,6 +15,10 @@
     areaInsert: true
     storageSoundCollection:
       collection: trashBagRustle
+    whitelist:
+      tags:
+        - Cartridge
+        - Trash
 
 - type: entity
   name: trash bag

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -37,6 +37,9 @@
     sprite: Objects/Specific/Chemistry/beaker.rsi
   - type: Spillable
     solution: drink
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   name: bottle

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -8,6 +8,7 @@
   - type: Tag
     tags:
     - Bottle
+    - Trash
   - type: Sprite
     sprite: Objects/Specific/Chemistry/bottle.rsi
     netsync: false
@@ -37,9 +38,6 @@
     sprite: Objects/Specific/Chemistry/beaker.rsi
   - type: Spillable
     solution: drink
-  - type: Tag
-    tags:
-    - Trash
 
 - type: entity
   name: bottle

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -7,6 +7,7 @@
   - type: Tag
     tags:
     - Flare
+    - Trash
   - type: ExpendableLight
     spentName: spent flare
     spentDesc: It looks like this flare has burnt out. What a bummer.
@@ -78,6 +79,3 @@
         startValue: 8.0
         endValue: 1.0
         property: Radius
-  - type: Tag
-    tags:
-    - Trash

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -78,3 +78,6 @@
         startValue: 8.0
         endValue: 1.0
         property: Radius
+  - type: Tag
+    tags:
+    - Trash

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -60,6 +60,9 @@
           startValue: 5.0
           endValue: 1.5
           property: Radius
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   name: red glowstick

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -4,6 +4,9 @@
   id: GlowstickBase
   description: Useful for raves and emergencies.
   components:
+    - type: Tag
+      tags:
+      - Trash
     - type: ExpendableLight
       spentName: spent green glowstick
       spentDesc: It looks like this glowstick has stopped glowing. How tragic.
@@ -60,9 +63,6 @@
           startValue: 5.0
           endValue: 1.5
           property: Radius
-  - type: Tag
-    tags:
-    - Trash
 
 - type: entity
   name: red glowstick

--- a/Resources/Prototypes/Entities/Objects/Tools/matches.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/matches.yml
@@ -17,6 +17,7 @@
   - type: Tag
     tags:
     - Matchstick
+    - Trash
   - type: Sprite
     netsync: false
     sprite: Objects/Tools/matches.rsi
@@ -40,9 +41,6 @@
         unlitIcon: match_unlit
         litIcon: match_lit
         burntIcon: match_burnt
-  - type: Tag
-    tags:
-    - Trash
 
 - type: entity
   name: match box

--- a/Resources/Prototypes/Entities/Objects/Tools/matches.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/matches.yml
@@ -40,6 +40,9 @@
         unlitIcon: match_unlit
         litIcon: match_lit
         burntIcon: match_burnt
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   name: match box
@@ -76,3 +79,6 @@
           - matchbox1
           - matchbox2
           - matchbox3
+  - type: Tag
+    tags:
+    - Trash

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimaterial.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimaterial.yml
@@ -17,3 +17,6 @@
   - type: Appearance
     visuals:
     - type: SpentAmmoVisualizer
+  - type: Tag
+    tags:
+    - Cartridge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/clrifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/clrifle.yml
@@ -16,6 +16,9 @@
   - type: Appearance
     visuals:
     - type: SpentAmmoVisualizer
+  - type: Tag
+    tags:
+    - Cartridge
 
 - type: entity
   id: CartridgeClRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/lrifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/lrifle.yml
@@ -16,6 +16,9 @@
   - type: Appearance
     visuals:
     - type: SpentAmmoVisualizer
+  - type: Tag
+    tags:
+    - Cartridge
 
 - type: entity
   id: CartridgeLRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -16,6 +16,9 @@
   - type: Appearance
     visuals:
     - type: SpentAmmoVisualizer
+  - type: Tag
+    tags:
+    - Cartridge
 
 - type: entity
   id: CartridgeMagnum

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -16,6 +16,9 @@
   - type: Appearance
     visuals:
     - type: SpentAmmoVisualizer
+  - type: Tag
+    tags:
+    - Cartridge
 
 - type: entity
   id: CartridgePistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -7,6 +7,7 @@
   - type: Tag
     tags:
     - ShotgunShell
+    - Cartridge
   - type: Ammo
     caliber: Shotgun
     ammoSpread: 40
@@ -23,9 +24,6 @@
   - type: Appearance
     visuals:
     - type: SpentAmmoVisualizer
-  - type: Tag
-    tags:
-    - Cartridge
 
 - type: entity
   id: ShellShotgunBeanbag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -23,6 +23,9 @@
   - type: Appearance
     visuals:
     - type: SpentAmmoVisualizer
+  - type: Tag
+    tags:
+    - Cartridge
 
 - type: entity
   id: ShellShotgunBeanbag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/srifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/srifle.yml
@@ -16,6 +16,9 @@
   - type: Appearance
     visuals:
     - type: SpentAmmoVisualizer
+  - type: Tag
+    tags:
+    - Cartridge
 
 - type: entity
   id: CartridgeSRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/toy.yml
@@ -13,6 +13,9 @@
     layers:
     - state: base
       map: ["enum.AmmoVisualLayers.Base"]
+  - type: Tag
+    tags:
+    - Cartridge
 
 - type: entity
   id: CartridgeCap

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -44,6 +44,9 @@
 
 - type: Tag
   id: CaptainSabre
+  
+- type: Tag
+  id: Cartridge
 
 - type: Tag
   id: CigFilter
@@ -242,6 +245,9 @@
 
 - type: Tag
   id: Taser
+  
+- type: Tag
+  id: Trash
 
 - type: Tag
   id: Wall


### PR DESCRIPTION
Closes #6131

Added Trash tag to many items (not just trash but just things that should generally be picked up by the trashbag). As well as cartridge component to ammo cartridges so that they can also be picked up by the trashbag.

:cl:
- fix: Fixed trashbag so now only trash can be picked up.

