### PR TITLE
Added insertion blocking to Strap and Foldable components

### DIFF
--- a/Content.Server/Buckle/Systems/StrapSystem.cs
+++ b/Content.Server/Buckle/Systems/StrapSystem.cs
@@ -28,25 +28,9 @@ namespace Content.Server.Buckle.Systems
 
         private void OnInsertAttempt(EntityUid uid, StrapComponent component, ContainerGettingInsertedAttemptEvent args)
         {
-            // This strap is being inserted into a container. In general this is fine, But maybe, just maybe, there is a
-            // player strapped to some object that is somehow being bugged into a backpack.
-
-            // Firstly, check if the container is a backpack/storage entity?
-            if (!HasComp<SharedStorageComponent>(args.Container.Owner))
-                return;
-
-            // Ok, so we will check if any of the entities we contain is a mob, and if it is, we cancel this attempt. In
-            // general, nesting strap-entities inside of a storage is rare. This could happen for folded up roller-beds,
-            // but those should have no entities strapped to them anyways
-
-            foreach (var ent in component.BuckledEntities)
-            {
-                if (HasComp<MobStateComponent>(ent) || HasComp<SharedBodyComponent>(ent))
-                {
-                    args.Cancel();
-                    return;
-                }
-            }
+            // If someone is attempting to put this item inside of a backpack, ensure that it has no entities strapped to it.
+            if (HasComp<SharedStorageComponent>(args.Container.Owner) && component.BuckledEntities.Count != 0)
+                args.Cancel();
         }
 
         // TODO ECS BUCKLE/STRAP These 'Strap' verbs are an incestuous mess of buckle component and strap component

--- a/Content.Server/Buckle/Systems/StrapSystem.cs
+++ b/Content.Server/Buckle/Systems/StrapSystem.cs
@@ -31,7 +31,7 @@ namespace Content.Server.Buckle.Systems
             // This strap is being inserted into a container. In general this is fine, But maybe, just maybe, there is a
             // player strapped to some object that is somehow being bugged into a backpack.
 
-            // Firstly, is the container a backpack/storage entity?
+            // Firstly, check if the container is a backpack/storage entity?
             if (!HasComp<SharedStorageComponent>(args.Container.Owner))
                 return;
 

--- a/Content.Server/Foldable/FoldableSystem.cs
+++ b/Content.Server/Foldable/FoldableSystem.cs
@@ -40,7 +40,7 @@ namespace Content.Server.Foldable
             if (!Resolve(uid, ref fold))
                 return false;
 
-            // Can't un-fold in hands / inventory
+            // Can't un-fold in any container (locker, hands, inventory, whatever).
             if (_container.IsEntityInContainer(uid))
                 return false;
 

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -1,13 +1,8 @@
 using System.Collections.Generic;
 using Content.Server.Hands.Components;
-using Content.Server.Interaction;
-using Content.Server.Morgue.Components;
 using Content.Server.Storage.Components;
-using Content.Shared.Body.Components;
 using Content.Shared.Interaction;
-using Content.Shared.MobState.Components;
 using Content.Shared.Movement;
-using Content.Shared.Storage;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
@@ -38,30 +33,6 @@ namespace Content.Server.Storage.EntitySystems
             SubscribeLocalEvent<EntityStorageComponent, GetInteractionVerbsEvent>(AddToggleOpenVerb);
             SubscribeLocalEvent<ServerStorageComponent, GetActivationVerbsEvent>(AddOpenUiVerb);
             SubscribeLocalEvent<EntityStorageComponent, RelayMovementEntityEvent>(OnRelayMovement);
-            SubscribeLocalEvent<EntityStorageComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
-        }
-
-        private void OnInsertAttempt(EntityUid uid, EntityStorageComponent component, ContainerGettingInsertedAttemptEvent args)
-        {
-            // This entity-storage is being inserted into a container. In general this is fine (e.g., pizza box in a
-            // locker). But maybe, just maybe, this is a player somehow being bugged into a backpack.
-
-            // Firstly, check if the container is a backpack/storage entity?
-            if (!HasComp<SharedStorageComponent>(args.Container.Owner))
-                return;
-
-            // Ok, so we will check if any of the entities we contain is a mob, and if it is, we cancel this attempt. In
-            // general, nesting entity-storage inside of a storage is rare. So just checking every contained entity
-            // every time should be fine. The only instances I can think of is pizza boxes and body-bags.
-
-            foreach (var ent in component.Contents.ContainedEntities)
-            {
-                if (HasComp<MobStateComponent>(ent) || HasComp<SharedBodyComponent>(ent))
-                {
-                    args.Cancel();
-                    return;
-                }
-            }
         }
 
         private void OnRelayMovement(EntityUid uid, EntityStorageComponent component, RelayMovementEntityEvent args)

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -46,14 +46,13 @@ namespace Content.Server.Storage.EntitySystems
             // This entity-storage is being inserted into a container. In general this is fine (e.g., pizza box in a
             // locker). But maybe, just maybe, this is a player somehow being bugged into a backpack.
 
-            // Firstly, the container a backpack/storage entity?
+            // Firstly, check if the container is a backpack/storage entity?
             if (!HasComp<SharedStorageComponent>(args.Container.Owner))
                 return;
 
             // Ok, so we will check if any of the entities we contain is a mob, and if it is, we cancel this attempt. In
-            // general, nesting entity-storage inside of a storage is rare. So checking every contained entity should be
-            // fine. The only instances I can think of is pizza boxes and body-bags (which should only be insertable if
-            // they are folded up anyways).
+            // general, nesting entity-storage inside of a storage is rare. So just checking every contained entity
+            // every time should be fine. The only instances I can think of is pizza boxes and body-bags.
 
             foreach (var ent in component.Contents.ContainedEntities)
             {

--- a/Content.Shared/Foldable/FoldableComponent.cs
+++ b/Content.Shared/Foldable/FoldableComponent.cs
@@ -9,8 +9,11 @@ using System;
 namespace Content.Shared.Foldable;
 
 /// <summary>
-/// Used to create "foldable structures" that you can pickup like an item when folded. Used for rollerbeds and wheelchairs
+/// Used to create "foldable structures" that you can pickup like an item when folded. Used for rollerbeds and wheelchairs.
 /// </summary>
+/// <remarks>
+/// Wiill prevent any insertions into containers while this item is unfolded.
+/// </remarks>
 [RegisterComponent]
 [NetworkedComponent]
 [Friend(typeof(SharedFoldableSystem))]

--- a/Content.Shared/Foldable/SharedFoldableSystem.cs
+++ b/Content.Shared/Foldable/SharedFoldableSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Item;
 using JetBrains.Annotations;
+using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 
@@ -18,7 +19,7 @@ public abstract class SharedFoldableSystem : EntitySystem
         SubscribeLocalEvent<FoldableComponent, ComponentHandleState>(OnHandleState);
 
         SubscribeLocalEvent<FoldableComponent, ComponentInit>(OnFoldableInit);
-        SubscribeLocalEvent<FoldableComponent, AttemptItemPickupEvent>(OnPickedUpAttempt);
+        SubscribeLocalEvent<FoldableComponent, ContainerGettingInsertedAttemptEvent>(OnInsertEvent);
     }
 
     private void OnGetState(EntityUid uid, FoldableComponent component, ref ComponentGetState args)
@@ -54,7 +55,7 @@ public abstract class SharedFoldableSystem : EntitySystem
             appearance.SetData(FoldKey, folded);
     }
 
-    private void OnPickedUpAttempt(EntityUid uid, FoldableComponent component, AttemptItemPickupEvent args)
+    private void OnInsertEvent(EntityUid uid, FoldableComponent component, ContainerGettingInsertedAttemptEvent args)
     {
         if (!component.IsFolded)
             args.Cancel();


### PR DESCRIPTION
Each of these components now has a subscription to `ContainerGettingInsertedAttemptEvent`.  Foldable components will now cancel any insertions if they are un-folded, instead of just blocking hand-pickup attempts.