### PR TITLE
Fix cable unanchor bug

### DIFF
--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -37,7 +37,7 @@ public class CableSystem : EntitySystem
             return;
 
         Spawn(cable.CableDroppedOnCutPrototype, Transform(uid).Coordinates);
-        Del(uid);
+        QueueDel(uid);
     }
 
     private void OnAnchorChanged(EntityUid uid, CableComponent cable, ref AnchorStateChangedEvent args)
@@ -48,7 +48,7 @@ public class CableSystem : EntitySystem
         // This entity should not be un-anchorable. But this can happen if the grid-tile is deleted (RCD, explosion,
         // etc). In that case: behave as if the cable had been cut.
         Spawn(cable.CableDroppedOnCutPrototype, Transform(uid).Coordinates);
-        Del(uid);
+        QueueDel(uid);
     }
 }
 

--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -45,6 +45,11 @@ public class CableSystem : EntitySystem
         if (args.Anchored)
             return; // huh? it wasn't anchored?
 
+        // anchor state can change as a result of deletion (detach to null).
+        // We don't want to spawn an entity when deleted.
+        if (!TryLifeStage(uid, out var life) || life >= EntityLifeStage.Terminating)
+            return;
+
         // This entity should not be un-anchorable. But this can happen if the grid-tile is deleted (RCD, explosion,
         // etc). In that case: behave as if the cable had been cut.
         Spawn(cable.CableDroppedOnCutPrototype, Transform(uid).Coordinates);


### PR DESCRIPTION
I added two bugs in #6141.

Firstly, the cable system was immediately deleting an entity during the unanchor event handler, which causes issue for other systems subscribing to the same event. 

Secondly, the system did not check if the cable was being deleted during the un-anchoring (entities are un-anchored before being deleted), so it would spawn a cable even when it shouldn't