### PR TITLE
Pressure nerf

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -2,7 +2,7 @@
 - type: entity
   name: Xeno
   id: MobXeno
-  parent: SimpleMobBase
+  parent: SimpleSpaceMobBase
   description: They mostly come at night. Mostly.
   components:
   - type: UtilityAI

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -27,7 +27,7 @@
   - type: Barotrauma
     damage:
       types:
-        Blunt: 1 #per second, scales with pressure and other constants.
+        Blunt: 0.7 #per second, scales with pressure and other constants.
   - type: DamageOnHighSpeedImpact
     damage:
       types:


### PR DESCRIPTION
As per title. Nerfed pressure damage per second from 1 blunt per second to 0.7. This has the following effects:

- Previously you would be KO'd after 20 seconds and dead not long after.
- Now you last long enough for aspyxiation to take effect so you go down after **30 seconds** by combination of pressure and O2.
- With O2, you go down at around **36 seconds**.

So this is almost double the current amount. Sadly PressureProtection component is not good so can't buff the emergency suit to make it actually do anything to increase this slightly more.

The main benefit of this change is it gives people time to react when getting spaced now and a chance of getting a message out or making it back.

**I also changed Xeno to basespacemob so they don't take pressure and cold damage. I believe this is their intended behaviour I've been told but can axe it if it's not desirable.**

:cl:
- fix: You now take slightly less pressure damage from space so /might/ survive depressurisation.
- fix: Xenos can now survive in space. One less way to kill them.

