### PR TITLE
adds box of IDs to HoP locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -80,6 +80,8 @@
         prob: 1
       - id: BoxPDA
         prob: 1
+      - id: BoxID
+        prob: 1
       - id: IDComputerCircuitboard
         prob: 1
       - id: TaserGun


### PR DESCRIPTION
Oversight on my last PR that added a crate of HoP items. I should have added the box of spare ID's to the HoPs locker (When bard mentioned mapping it I stupidly thought actually mapping and forgot the PDA box was already in the locker).


:cl:
- add: HoP locker now has a box of spare IDs.
