### PR TITLE
Rebalanced traitor objective difficulty

### DIFF
--- a/Content.Server/Objectives/Conditions/KillPersonCondition.cs
+++ b/Content.Server/Objectives/Conditions/KillPersonCondition.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Objectives.Conditions
 
         public float Progress => (Target?.CharacterDeadIC ?? true) ? 1f : 0f;
 
-        public float Difficulty => 2.25f;
+        public float Difficulty => 2f;
 
         public bool Equals(IObjectiveCondition? other)
         {

--- a/Content.Server/Objectives/Conditions/StealCondition.cs
+++ b/Content.Server/Objectives/Conditions/StealCondition.cs
@@ -65,7 +65,7 @@ namespace Content.Server.Objectives.Conditions
             }
         }
 
-        public float Difficulty => 2f;
+        public float Difficulty => 2.25f;
 
         public bool Equals(IObjectiveCondition? other)
         {

--- a/Resources/Prototypes/Objectives/traitorObjectives..yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives..yml
@@ -1,6 +1,7 @@
 ﻿- type: objective
   id: CaptainIDStealObjective
   issuer: syndicate
+  difficultyOverride: 2.75
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -21,7 +22,7 @@
   conditions:
     - !type:KillRandomPersonCondition {}
   canBeDuplicate: true
-  
+
 - type: objective
   id: RandomTraitorAliveObjective
   issuer: syndicate
@@ -61,7 +62,7 @@
 - type: objective
   id: CMOHyposprayStealObjective
   issuer: syndicate
-  difficultyOverride: 2.25
+  difficultyOverride: 2.75
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -70,11 +71,11 @@
   conditions:
     - !type:StealCondition
       prototype: Hypospray
-      
+
 - type: objective
   id: RDHardsuitStealObjective
   issuer: syndicate
-  difficultyOverride: 2.5
+  difficultyOverride: 2.75
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -83,7 +84,7 @@
   conditions:
     - !type:StealCondition
       prototype: ClothingOuterHardsuitRd
-      
+
 - type: objective
   id: NukeDiskStealObjective
   issuer: syndicate
@@ -95,7 +96,7 @@
   conditions:
     - !type:StealCondition
       prototype: NukeDisk
-      
+
 - type: objective
   id: IDComputerBoardStealObjective
   issuer: syndicate
@@ -107,11 +108,11 @@
   conditions:
     - !type:StealCondition
       prototype: IDComputerCircuitboard
-      
+
 - type: objective
   id: MagbootsStealObjective #Replace this with CE magboots when we get those
   issuer: syndicate
-  difficultyOverride: 1.5
+  difficultyOverride: 1.75
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -120,20 +121,7 @@
   conditions:
     - !type:StealCondition
       prototype: ClothingShoesBootsMag
-      
-- type: objective
-  id: HOSHardsuitHelmStealObjective
-  issuer: syndicate
-  difficultyOverride: 2.5
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-  conditions:
-    - !type:StealCondition
-      prototype: ClothingHeadHelmetHardsuitSecurityRed
-      
+
 - type: objective
   id: SupplyConsoleBoardStealObjective
   issuer: syndicate


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Traitors redtext a bit too much for my liking right now, and most of the greentexts involve cheesing out the round AFK in solars with a backpack full of oxygen. I made most of the steal objectives harder and the kill objectives slightly easier.

**Question: Isn't this a buff to traitors that will make rounds worse?**
It's a buff to how often they get greentext but if anything it'll encourage them to mellow out earlier and use less force so they don't needlessly risk their current greentext.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Most traitor steal objectives are now considered more difficult.
- remove: Removed HOS Hardsuit Helmet steal objective.

