### PR TITLE
Fix cable cutting and allow tool system to raise directed events

### DIFF
--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -17,7 +17,7 @@ public class CableSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<CableComponent, InteractUsingEvent>(OnInteractUsing);
-        SubscribeLocalEvent<CableComponent, CuttingFinishedEvent>(OnCableCut);
+        SubscribeLocalEvent<CuttingFinishedEvent>(OnCableCut);
         SubscribeLocalEvent<CableComponent, AnchorStateChangedEvent>(OnAnchorChanged);
     }
 
@@ -31,13 +31,16 @@ public class CableSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void OnCableCut(EntityUid uid, CableComponent cable, CuttingFinishedEvent args)
+    private void OnCableCut(CuttingFinishedEvent args)
     {
-        if (_electrocutionSystem.TryDoElectrifiedAct(uid, args.User))
+        if (!TryComp(args.Target, out CableComponent? cable))
             return;
 
-        Spawn(cable.CableDroppedOnCutPrototype, Transform(uid).Coordinates);
-        QueueDel(uid);
+        if (_electrocutionSystem.TryDoElectrifiedAct(args.Target, args.User))
+            return;
+
+        Spawn(cable.CableDroppedOnCutPrototype, Transform(args.Target).Coordinates);
+        QueueDel(args.Target);
     }
 
     private void OnAnchorChanged(EntityUid uid, CableComponent cable, ref AnchorStateChangedEvent args)

--- a/Content.Server/Tools/ToolSystem.cs
+++ b/Content.Server/Tools/ToolSystem.cs
@@ -41,15 +41,27 @@ namespace Content.Server.Tools
         {
             // Actually finish the tool use! Depending on whether that succeeds or not, either event will be broadcast.
             if(ToolFinishUse(ev.Uid, ev.UserUid, ev.Fuel))
-                RaiseLocalEvent(ev.CompletedEvent);
+            {
+                if (ev.EventTarget != null)
+                    RaiseLocalEvent(ev.EventTarget.Value, ev.CompletedEvent, false);
+                else
+                    RaiseLocalEvent(ev.CompletedEvent);
+            }
             else if(ev.CancelledEvent != null)
-                RaiseLocalEvent(ev.CancelledEvent);
+            {
+                if (ev.EventTarget != null)
+                    RaiseLocalEvent(ev.EventTarget.Value, ev.CancelledEvent, false);
+                else
+                    RaiseLocalEvent(ev.CancelledEvent);
+            }
         }
 
         private void OnDoAfterCancelled(ToolDoAfterCancelled ev)
         {
-            // Broadcast wrapped event.
-            RaiseLocalEvent(ev.Event);
+            if (ev.EventTarget != null)
+                RaiseLocalEvent(ev.EventTarget.Value, ev.Event, false);
+            else
+                RaiseLocalEvent(ev.Event);
         }
 
         /// <summary>
@@ -77,8 +89,9 @@ namespace Content.Server.Tools
         /// <param name="fuel">An optional amount of fuel or energy to consume-</param>
         /// <param name="doAfterDelay">A doAfter delay in seconds.</param>
         /// <param name="toolQualitiesNeeded">The tool qualities needed to use the tool.</param>
-        /// <param name="doAfterCompleteEvent">An event to broadcast once the doAfter is completed successfully.</param>
-        /// <param name="doAfterCancelledEvent">An event to broadcast once the doAfter is cancelled.</param>
+        /// <param name="doAfterCompleteEvent">An event to raise once the doAfter is completed successfully.</param>
+        /// <param name="doAfterCancelledEvent">An event to raise once the doAfter is canceled.</param>
+        /// <param name="doAfterEventTarget">Where to direct the do-after events. If null, events are broadcast</param>
         /// <param name="doAfterCheck">An optional check to perform for the doAfter.</param>
         /// <param name="toolComponent">The tool component.</param>
         /// <returns>Whether initially, using the tool succeeded. If there's a doAfter delay, you'll need to listen to
@@ -87,7 +100,7 @@ namespace Content.Server.Tools
         ///          this simply returns whether using the tool succeeded or not.</returns>
         public bool UseTool(EntityUid tool, EntityUid user, EntityUid? target, float fuel,
             float doAfterDelay, IEnumerable<string> toolQualitiesNeeded,
-            object? doAfterCompleteEvent = null, object? doAfterCancelledEvent = null,
+            object? doAfterCompleteEvent = null, object? doAfterCancelledEvent = null, EntityUid? doAfterEventTarget = null,
             Func<bool>? doAfterCheck = null, ToolComponent? toolComponent = null)
         {
             // No logging here, after all that'd mean the caller would need to check if the component is there or not.
@@ -107,8 +120,8 @@ namespace Content.Server.Tools
                     BreakOnTargetMove = true,
                     BreakOnUserMove = true,
                     NeedHand = true,
-                    BroadcastFinishedEvent = doAfterCompleteEvent != null ? new ToolDoAfterComplete(doAfterCompleteEvent, doAfterCancelledEvent, tool, user, fuel) : null,
-                    BroadcastCancelledEvent = doAfterCancelledEvent != null ? new ToolDoAfterCancelled(doAfterCancelledEvent) : null,
+                    BroadcastFinishedEvent = doAfterCompleteEvent != null ? new ToolDoAfterComplete(doAfterCompleteEvent, doAfterCancelledEvent, tool, user, fuel, doAfterEventTarget) : null,
+                    BroadcastCancelledEvent = doAfterCancelledEvent != null ? new ToolDoAfterCancelled(doAfterCancelledEvent, doAfterEventTarget) : null,
                 };
 
                 _doAfterSystem.DoAfter(doAfterArgs);
@@ -121,11 +134,11 @@ namespace Content.Server.Tools
         // This is hilariously long.
         /// <inheritdoc cref="UseTool(Robust.Shared.GameObjects.EntityUid,Robust.Shared.GameObjects.EntityUid,System.Nullable{Robust.Shared.GameObjects.EntityUid},float,float,System.Collections.Generic.IEnumerable{string},Robust.Shared.GameObjects.EntityUid,object,object,System.Func{bool}?,Content.Server.Tools.Components.ToolComponent?)"/>
         public bool UseTool(EntityUid tool, EntityUid user, EntityUid? target, float fuel,
-            float doAfterDelay, string toolQualityNeeded, object doAfterCompleteEvent, object doAfterCancelledEvent,
+            float doAfterDelay, string toolQualityNeeded, object doAfterCompleteEvent, object doAfterCancelledEvent, EntityUid? doAfterEventTarget = null,
             Func<bool>? doAfterCheck = null, ToolComponent? toolComponent = null)
         {
             return UseTool(tool, user, target, fuel, doAfterDelay, new[] { toolQualityNeeded },
-                doAfterCompleteEvent, doAfterCancelledEvent, doAfterCheck, toolComponent);
+                doAfterCompleteEvent, doAfterCancelledEvent, doAfterEventTarget, doAfterCheck, toolComponent);
         }
 
         /// <summary>
@@ -239,24 +252,28 @@ namespace Content.Server.Tools
             public readonly EntityUid Uid;
             public readonly EntityUid UserUid;
             public readonly float Fuel;
+            public readonly EntityUid? EventTarget;
 
-            public ToolDoAfterComplete(object completedEvent, object? cancelledEvent, EntityUid uid, EntityUid userUid, float fuel)
+            public ToolDoAfterComplete(object completedEvent, object? cancelledEvent, EntityUid uid, EntityUid userUid, float fuel, EntityUid? eventTarget = null)
             {
                 CompletedEvent = completedEvent;
                 Uid = uid;
                 UserUid = userUid;
                 Fuel = fuel;
                 CancelledEvent = cancelledEvent;
+                EventTarget = eventTarget;
             }
         }
 
         private class ToolDoAfterCancelled : EntityEventArgs
         {
             public readonly object Event;
+            public readonly EntityUid? EventTarget;
 
-            public ToolDoAfterCancelled(object @event)
+            public ToolDoAfterCancelled(object @event, EntityUid? eventTarget = null)
             {
                 Event = @event;
+                EventTarget = eventTarget;
             }
         }
     }


### PR DESCRIPTION
But yeah more #6141 bugs. How could so simple a ECSing introduce so many bugs. Tool systems don't raise directed events.

Fixes #6174

:cl:
- fix: Fixed bug stopping cable from being cut.
