### PR TITLE
Extend RgbLightController

### DIFF
--- a/Content.Client/Light/RgbLightControllerSystem.cs
+++ b/Content.Client/Light/RgbLightControllerSystem.cs
@@ -1,15 +1,17 @@
 using System;
+using Content.Shared.Item;
 using Content.Shared.Light;
 using Content.Shared.Light.Component;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 
 namespace Content.Client.Light
 {
-    public class RgbLightControllerSystem : EntitySystem
+    public sealed class RgbLightControllerSystem : SharedRgbLightControllerSystem
     {
         [Dependency] private IGameTiming _gameTiming = default!;
 
@@ -17,24 +19,78 @@ namespace Content.Client.Light
         {
             base.Initialize();
 
-            UpdatesOutsidePrediction = true;
+            SubscribeLocalEvent<RgbLightControllerComponent, ComponentHandleState>(OnHandleState);
+            SubscribeLocalEvent<RgbLightControllerComponent, ComponentRemove>(OnComponentRemoved);
         }
 
-        public override void Update(float frameTime)
+        private void OnComponentRemoved(EntityUid uid, RgbLightControllerComponent rgb, ComponentRemove args)
         {
-            base.Update(frameTime);
-            var curTime = _gameTiming.CurTime;
+            if (TryComp(uid, out PointLightComponent? light))
+                light.Color = Color.White;
+
+            if (TryComp(uid, out SharedItemComponent? item))
+                item.Color = Color.White;
+
+            ResetSpriteColors(uid, rgb);
+        }
+
+        private void OnHandleState(EntityUid uid, RgbLightControllerComponent rgb, ref ComponentHandleState args)
+        {
+            if (args.Current is not RgbLightControllerState state)
+                return;
+
+            // just to be safe, un-colour the layers so they don't get stuck with some mid-transition one.
+            ResetSpriteColors(uid, rgb);
+
+            rgb.CycleRate = state.CycleRate;
+            rgb.Layers = state.Layers;
+        }
+
+        private void ResetSpriteColors(EntityUid uid, RgbLightControllerComponent? rgb = null, SpriteComponent? sprite = null)
+        {
+            if (!Resolve(uid, ref rgb, ref sprite))
+                return;
+
+            if (rgb.Layers == null)
+            {
+                sprite.Color = Color.White;
+                return;
+            }
+
+            foreach (var layer in rgb.Layers)
+            {
+                sprite.LayerSetColor(layer, Color.White);
+            }
+        }
+
+        public override void FrameUpdate(float frameTime)
+        {
             foreach (var (rgb, light, sprite) in EntityManager.EntityQuery<RgbLightControllerComponent, PointLightComponent, SpriteComponent>())
             {
-                light.Color = GetCurrentRgbColor(curTime, TimeSpan.FromSeconds(rgb.CreationTick.Value * _gameTiming.TickPeriod.TotalSeconds), rgb);
-                sprite.Color = GetCurrentRgbColor(curTime, TimeSpan.FromSeconds(rgb.CreationTick.Value * _gameTiming.TickPeriod.TotalSeconds), rgb);
+                var colour = GetCurrentRgbColor(_gameTiming.RealTime, rgb.CreationTick.Value * _gameTiming.TickPeriod, rgb);
+
+                light.Color = colour;
+
+                if (rgb.Layers == null)
+                    sprite.Color = colour;
+                else
+                {
+                    foreach (var layer in rgb.Layers)
+                    {
+                        sprite.LayerSetColor(layer, colour);
+                    }
+                }
+
+                // not all rgb is hand-held (Hence, not part of EntityQuery)
+                if (TryComp(rgb.Owner, out SharedItemComponent? item))
+                    item.Color = colour;
             }
         }
 
         public static Color GetCurrentRgbColor(TimeSpan curTime, TimeSpan offset, RgbLightControllerComponent rgb)
         {
             return Color.FromHsv(new Vector4(
-                (float) (((curTime.TotalSeconds - offset.TotalSeconds) / rgb.CycleRate + Math.Abs(rgb.Owner.GetHashCode() * 0.1)) % 1),
+                (float) (((curTime.TotalSeconds - offset.TotalSeconds) * rgb.CycleRate + Math.Abs(rgb.Owner.GetHashCode() * 0.1)) % 1),
                 1.0f,
                 1.0f,
                 1.0f

--- a/Content.Client/Light/RgbLightControllerSystem.cs
+++ b/Content.Client/Light/RgbLightControllerSystem.cs
@@ -39,7 +39,7 @@ namespace Content.Client.Light
             if (args.Current is not RgbLightControllerState state)
                 return;
 
-            // just to be safe, un-colour the layers so they don't get stuck with some mid-transition one.
+            // just to be safe, un-color the layers so they don't get stuck with some mid-transition one.
             ResetSpriteColors(uid, rgb);
 
             rgb.CycleRate = state.CycleRate;
@@ -67,23 +67,23 @@ namespace Content.Client.Light
         {
             foreach (var (rgb, light, sprite) in EntityManager.EntityQuery<RgbLightControllerComponent, PointLightComponent, SpriteComponent>())
             {
-                var colour = GetCurrentRgbColor(_gameTiming.RealTime, rgb.CreationTick.Value * _gameTiming.TickPeriod, rgb);
+                var color = GetCurrentRgbColor(_gameTiming.RealTime, rgb.CreationTick.Value * _gameTiming.TickPeriod, rgb);
 
-                light.Color = colour;
+                light.Color = color;
 
                 if (rgb.Layers == null)
-                    sprite.Color = colour;
+                    sprite.Color = color;
                 else
                 {
                     foreach (var layer in rgb.Layers)
                     {
-                        sprite.LayerSetColor(layer, colour);
+                        sprite.LayerSetColor(layer, color);
                     }
                 }
 
                 // not all rgb is hand-held (Hence, not part of EntityQuery)
                 if (TryComp(rgb.Owner, out SharedItemComponent? item))
-                    item.Color = colour;
+                    item.Color = color;
             }
         }
 

--- a/Content.Server/Light/EntitySystems/RgbLightControllerSystem.cs
+++ b/Content.Server/Light/EntitySystems/RgbLightControllerSystem.cs
@@ -1,0 +1,8 @@
+using Content.Shared.Light;
+
+namespace Content.Server.Light.EntitySystems;
+
+public sealed class RgbLightControllerSystem : SharedRgbLightControllerSystem
+{
+    // Howdy
+}

--- a/Content.Shared/Light/Component/RgbLightControllerComponent.cs
+++ b/Content.Shared/Light/Component/RgbLightControllerComponent.cs
@@ -1,9 +1,11 @@
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 using System;
+using System.Collections.Generic;
 
 namespace Content.Shared.Light.Component;
 
@@ -23,16 +25,22 @@ public sealed class RgbLightControllerComponent : Robust.Shared.GameObjects.Comp
     ///     What layers of the sprite to modulate? If null, will affect the whole sprite.
     /// </summary>
     [DataField("layers")]
-    public int[]? Layers;
+    public List<int>? Layers;
+
+    // original colors when rgb was added. Used to revert Colors when removed.
+    public Color OriginalLightColor;
+    public Color OriginalItemColor;
+    public Color OriginalSpriteColor;
+    public Dictionary<int, Color>? OriginalLayerColors;
 }
 
 [Serializable, NetSerializable]
 public class RgbLightControllerState : ComponentState
 {
     public readonly float CycleRate;
-    public readonly int[]? Layers;
+    public readonly List<int>? Layers;
 
-    public RgbLightControllerState(float cycleRate, int[]? layers)
+    public RgbLightControllerState(float cycleRate, List<int>? layers)
     {
         CycleRate = cycleRate;
         Layers = layers;

--- a/Content.Shared/Light/Component/RgbLightControllerComponent.cs
+++ b/Content.Shared/Light/Component/RgbLightControllerComponent.cs
@@ -1,21 +1,40 @@
+using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
+using System;
 
-namespace Content.Shared.Light.Component
+namespace Content.Shared.Light.Component;
+
+/// <summary>
+/// Networked ~~solely for admemes~~ for completely legitimate reasons, like hacked energy swords.
+/// </summary>
+[NetworkedComponent]
+[RegisterComponent]
+[ComponentProtoName("RgbLightController")]
+[Friend(typeof(SharedRgbLightControllerSystem))]
+public sealed class RgbLightControllerComponent : Robust.Shared.GameObjects.Component
 {
-    /// <summary>
-    /// Networked solely for admemes.
-    /// </summary>
-    [NetworkedComponent]
-    [RegisterComponent]
-    public class RgbLightControllerComponent : Robust.Shared.GameObjects.Component
-    {
-        public override string Name => "RgbLightController";
+    [DataField("cycleRate")]
+    public float CycleRate { get; set; } = 0.1f;
 
-        [DataField("cycleRate")]
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float CycleRate { get; set; } = 10.0f;
+    /// <summary>
+    ///     What layers of the sprite to modulate? If null, will affect the whole sprite.
+    /// </summary>
+    [DataField("layers")]
+    public int[]? Layers;
+}
+
+[Serializable, NetSerializable]
+public class RgbLightControllerState : ComponentState
+{
+    public readonly float CycleRate;
+    public readonly int[]? Layers;
+
+    public RgbLightControllerState(float cycleRate, int[]? layers)
+    {
+        CycleRate = cycleRate;
+        Layers = layers;
     }
 }

--- a/Content.Shared/Light/SharedRgbLightControllerSystem.cs
+++ b/Content.Shared/Light/SharedRgbLightControllerSystem.cs
@@ -1,0 +1,38 @@
+using Content.Shared.Light.Component;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Light;
+
+public abstract class SharedRgbLightControllerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RgbLightControllerComponent, ComponentGetState>(OnGetState);
+    }
+
+    private void OnGetState(EntityUid uid, RgbLightControllerComponent component, ref ComponentGetState args)
+    {
+        args.State = new RgbLightControllerState(component.CycleRate, component.Layers);
+    }
+
+    public void SetLayers(EntityUid uid, int[] layers,  RgbLightControllerComponent? rgb = null)
+    {
+        if (!Resolve(uid, ref rgb))
+            return;
+
+        rgb.Layers = layers;
+        rgb.Dirty();
+    }
+
+    public void SetCycleRate(EntityUid uid, float rate, RgbLightControllerComponent? rgb = null)
+    {
+        if (!Resolve(uid, ref rgb))
+            return;
+
+        rgb.CycleRate = rate;
+        rgb.Dirty();
+    }
+}

--- a/Content.Shared/Light/SharedRgbLightControllerSystem.cs
+++ b/Content.Shared/Light/SharedRgbLightControllerSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Light.Component;
 using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
+using System.Collections.Generic;
 
 namespace Content.Shared.Light;
 
@@ -18,7 +19,7 @@ public abstract class SharedRgbLightControllerSystem : EntitySystem
         args.State = new RgbLightControllerState(component.CycleRate, component.Layers);
     }
 
-    public void SetLayers(EntityUid uid, int[] layers,  RgbLightControllerComponent? rgb = null)
+    public void SetLayers(EntityUid uid, List<int>? layers,  RgbLightControllerComponent? rgb = null)
     {
         if (!Resolve(uid, ref rgb))
             return;


### PR DESCRIPTION
Adds
- the ability to color in-hand sprites
- ability to selectively color sprite layers (see video, only the pda's flashlight layer is changing)
- add networking for the server to set the rate & layers
- reset colors to their original values when shutting down the component.

https://user-images.githubusercontent.com/60421075/149616523-988325f3-f736-4a54-b438-5b4c6de46fc4.mp4

Why: e-sword rainbow effects

Could this be a visualizer instead of client-side frame-update system:
Maybe? You'd need to automatically add a visualizer that just starts looping animations. Is it worth the effort?
