### PR TITLE
Update admin overlay when player is renamed

### DIFF
--- a/Content.Server/Administration/AdminSystem.cs
+++ b/Content.Server/Administration/AdminSystem.cs
@@ -33,7 +33,7 @@ namespace Content.Server.Administration
             SubscribeLocalEvent<RoleRemovedEvent>(OnRoleEvent);
         }
 
-        private void UpdatePlayerList(IPlayerSession player)
+        public void UpdatePlayerList(IPlayerSession player)
         {
             _playerList[player.UserId] = GetPlayerInfo(player);
 

--- a/Content.Server/Mind/Commands/RenameCommand.cs
+++ b/Content.Server/Mind/Commands/RenameCommand.cs
@@ -8,6 +8,7 @@ using Content.Server.PDA;
 using Content.Shared.Access.Components;
 using Content.Shared.Administration;
 using Content.Shared.PDA;
+using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.GameObjects;
@@ -89,6 +90,13 @@ public class RenameCommand : IConsoleCommand
                     continue;
                 pdaSystem.SetOwner(pdaComponent, name);
             }
+        }
+
+        // Admin Overlay
+        if (entSysMan.TryGetEntitySystem<AdminSystem>(out var adminSystem)
+            && entMan.TryGetComponent<ActorComponent>(entityUid, out var actorComp))
+        {
+            adminSystem.UpdatePlayerList(actorComp.PlayerSession);
         }
     }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes admin overlay not updating when the rename command is used.