### PR TITLE
Adds trash tag to more items

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -191,6 +191,9 @@
       mass: 5
       mask:
         - SmallImpassable
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   name: carrot

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cartons.yml
@@ -21,6 +21,9 @@
     visuals:
       - type: BagOpenCloseVisualizer
         openIcon: open
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   id: CigCartonRed

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -14,6 +14,7 @@
   - type: Tag
     tags:
       - Cigarette
+      - Trash
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigarettes/cigarette.rsi
     Slots: [ mask ]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
@@ -11,6 +11,7 @@
   - type: Tag
     tags:
       - Cigarette
+      - Trash
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigarettes/blunt.rsi
     Slots: [ mask ]
@@ -40,6 +41,7 @@
   - type: Tag
     tags:
       - Cigarette
+      - Trash
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigarettes/blunt.rsi
     Slots: [ mask ]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -7,6 +7,7 @@
   - type: Tag
     tags:
     - CigPack
+    - Trash
   - type: Storage
     capacity: 6
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/rolling_paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/rolling_paper.yml
@@ -58,6 +58,7 @@
   - type: Tag
     tags:
     - RollingPaper
+    - Trash
 
 - type: entity
   id: CigaretteFilter
@@ -78,3 +79,4 @@
   - type: Tag
     tags:
     - CigFilter
+    - Trash

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -10,6 +10,9 @@
   - type: Appearance
     visuals:
       - type: BurnStateVisualizer
+  - type: Tag
+    tags:
+    - Trash
 
 # Base for all cigars and cigarettes.
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks_cans.yml
@@ -54,6 +54,7 @@
   - type: Tag
     tags:
     - Cola
+    - Trash
   - type: Sprite
     sprite: Objects/Consumable/Drinks/cola.rsi
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -25,9 +25,6 @@
           enum.PaperStatus.Written: paper_words
   - type: Item
     size: 1
-  - type: Tag
-    tags:
-    - Trash
 
 - type: entity
   parent: Paper
@@ -40,9 +37,6 @@
     # Changing it here is fine - if the PaperStatus key is actually added,
     #  something happened, so that ought to override this either way.
     - state: paper_words
-  - type: Tag
-    tags:
-    - Trash
 
 - type: entity
   parent: PaperWritten


### PR DESCRIPTION
Some janitors ingame noted they couldn't pick up banana peels or cigarette butts so went through and added trash tags to more items that needed it (and removed it from paper as identified in my other PR).

This is a stop gap until decision is made on #6166 in maintainer meeting as janitors need this now to function better but there is some overlap in the two PRs.


:cl:
- fix: Trashbag can now pick up banana peels, cigarette ends and more!

