### PR TITLE
fixed metal table construction menu icon

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -145,7 +145,7 @@
   category: Furniture
   description: A square piece of metal standing on four metal legs.
   icon:
-    sprite: Structures/Furniture/Tables/carpet.rsi
+    sprite: Structures/Furniture/Tables/generic.rsi
     state: full
   objectType: Structure
   placementMode: SnapgridCenter


### PR DESCRIPTION
See above, no changelog needed. 1 LOC.

"Table" showed icon for poker table whereas it should be the metal table.