### PR TITLE
Cut corners on excessive damage

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -41,6 +41,10 @@ namespace Content.Server.Destructible
 
                     threshold.Execute(uid, this, EntityManager);
                 }
+
+                // if destruction behavior (or some other deletion effect) occurred, don't run other triggers.
+                if (EntityManager.IsQueuedForDeletion(uid) || Deleted(uid))
+                    return;
             }
         }
     }

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -23,6 +23,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 100
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 5
       behaviors:
       - !type:PlaySoundBehavior

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -45,6 +45,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 400
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 200
       behaviors:
       - !type:SpawnEntitiesBehavior
@@ -122,6 +128,12 @@
       visible: false
   - type: Destructible
     thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
         damage: 400

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -24,7 +24,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 100 #excess damage (nuke?). avoid computational cost of spawning entities.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
       behaviors:
       - !type:DoActsBehavior
         acts: ["Breakage"]

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -26,7 +26,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 50
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -68,6 +68,12 @@
     - trigger:
         !type:DamageTrigger
         damage: 100
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -109,6 +115,12 @@
     - trigger:
         !type:DamageTrigger
         damage: 100
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -153,6 +165,12 @@
     - trigger:
         !type:DamageTrigger
         damage: 100
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -57,6 +57,12 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
+            damage: 50 #excess damage (nuke?). avoid computational cost of spawning entities.
+          behaviors:
+            - !type:DoActsBehavior
+              acts: ["Destruction"]
+        - trigger:
+            !type:DamageTrigger
             damage: 20
           behaviors:
             - !type:ChangeConstructionNodeBehavior

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -348,6 +348,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 1200 #excess damage (nuke?). avoid computational cost of spawning entities.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
         damage: 600
       behaviors:
       - !type:ChangeConstructionNodeBehavior
@@ -471,6 +477,12 @@
     sprite: Structures/Walls/solid.rsi
   - type: Destructible
     thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600 # #excess damage (nuke?). avoid computational cost of spawning entities.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 300

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -15,6 +15,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 300 #excess damage (nuke?). Avoid computational cost of spawning entities.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 150
       behaviors:
       - !type:PlaySoundBehavior

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -40,6 +40,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 150 #excess damage (nuke?). avoid computational cost of spawning entities.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 50
       behaviors:
       - !type:PlaySoundBehavior


### PR DESCRIPTION
This PR changes the destructible system behaviour such that it stops running additional threshold behaviours if the entity is already queued for deletion. It also adds several new damage triggers for the most common station entities. The new behaviour is that these entities are simply being deleted when they take **excessive** damage, rather than having each one spawn entities.

This is done purely for the sake of explosion performance. When a very large number of entities are all damaged by a large explosion, a large chunk of the time is spent spawning in things like cable-bits from LV wires or glass-shards from windows. This also """fixes""" a separate issue where excess damage cannot currently be passed onto the spawned entity. No matter how much damage is dealt to a solid wall, it would always leave behind a fully intact girder. With this change, very large explosions can properly vaporize walls.

Obviously in an ideal world, entity spawning wouldn't be slow and the correct approach would be to just perform destruction acts, spawn in the entity, pass on excess damage, and then perform the new entity's own destruction acts (and repeat as needed). But even if entity spawning were faster, I'd still consider having a "vaporization" damage threshold, just so nukes can be that little bit faster. Though perhaps the vaporization threshold could be moved than it is now.

The vaporization threshold values are pretty arbitrary. In general I just chose double the value required to destroy the entity. For things like windows I made it a bit higher to ensure that reasonable quantities of glass shards still spawn for smallish explosions

requires space-wizards/RobustToolbox/pull/2421