### PR TITLE
Stops InteractionOutline when the mouse is off screen.

### DIFF
--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -52,7 +52,8 @@ public sealed class InteractionOutlineSystem : EntitySystem
 
         EntityUid? entityToClick = null;
         var renderScale = 1;
-        if (_uiManager.CurrentlyHovered is IViewportControl vp)
+        if (_uiManager.CurrentlyHovered is IViewportControl vp
+            && _inputManager.MouseScreenPosition.IsValid)
         {
             var mousePosWorld = vp.ScreenToMap(_inputManager.MouseScreenPosition.Position);
             entityToClick = screen.GetEntityUnderPosition(mousePosWorld);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the mouse was outside of the Space Station 14 Client window, it would default the MouseScreenPosition to 0, 0 and outline the entity there. This makes it check for a valid coordinate before checking for the outlined entity.