### PR TITLE
Fix Clickable click maps

### DIFF
--- a/Content.Client/Clickable/ClickableComponent.cs
+++ b/Content.Client/Clickable/ClickableComponent.cs
@@ -58,8 +58,6 @@ namespace Content.Client.Clickable
                 var modAngle = sprite.NoRotation ? SpriteComponent.CalcRectWorldAngle(worldRotation, 4) : Angle.Zero;
                 var dir = sprite.EnableDirectionOverride ? sprite.DirectionOverride : worldRotation.GetCardinalDir();
 
-                modAngle += dir.ToAngle();
-
                 var layerPos = modAngle.RotateVec(localPos);
 
                 var boundsForDir = dir switch
@@ -86,7 +84,6 @@ namespace Content.Client.Clickable
                     var dirCount = sprite.GetLayerDirectionCount(layer);
                     var dir = layer.EffectiveDirection(worldRotation);
                     var modAngle = sprite.NoRotation ? SpriteComponent.CalcRectWorldAngle(worldRotation, dirCount) : Angle.Zero;
-                    modAngle += dir.Convert().ToAngle();
 
                     var layerPos = modAngle.RotateVec(localPos);
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I looked around at this code for a bit to see what was changing when moving my mouse around a table and then started trying to simplify the code. First thing I tried was to remove these lines and see if it still worked and apparently that fixed the click maps for tables.

Fixes #4080

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
Old:

https://user-images.githubusercontent.com/10494922/149650414-37c15f82-a1ac-405e-9d5c-a91e72d0fa9b.mp4

New:

https://user-images.githubusercontent.com/10494922/149650496-630f80b7-2d4c-4c57-a570-7adcaf55907b.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Click dragging onto tables now works fully again. You don't have to aim for the lower right corner anymore.

