### PR TITLE
Mop & Bucket Behaviour Change

### DIFF
--- a/Content.Server/Fluids/Components/BucketComponent.cs
+++ b/Content.Server/Fluids/Components/BucketComponent.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.DoAfter;
 using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Helpers;
@@ -70,11 +71,7 @@ namespace Content.Server.Fluids.Components
                 return false;
             }
 
-            if (mopComponent.CurrentVolume == mopComponent.MaxVolume)
-            {
-                Owner.PopupMessage(eventArgs.User, Loc.GetString("bucket-component-mop-is-full-message"));
-                return false;
-            }
+
 
             _currentlyUsing.Add(eventArgs.Using);
 
@@ -92,25 +89,49 @@ namespace Content.Server.Fluids.Components
                 CurrentVolume <= 0 || !Owner.InRangeUnobstructed(mopComponent.Owner))
                 return false;
 
-            // Top up mops solution given it needs it to annihilate puddles I guess
-
-            var transferAmount = FixedPoint2.Min(mopComponent.MaxVolume - mopComponent.CurrentVolume, CurrentVolume);
-            if (transferAmount == 0)
+            //Checks if the mop is empty
+            if(mopComponent.CurrentVolume == 0)
             {
-                return false;
+                // Transfers up to half the mop's available capacity to the mop
+                // Takes the lower of the mop's available volume and the bucket's current volume.
+                var transferAmount = FixedPoint2.Min(0.5*mopComponent.AvailableVolume, CurrentVolume);
+                if (transferAmount == 0)
+                {
+                    return false;
+                }
+
+                var mopContents = mopComponent.MopSolution;
+
+                if (mopContents == null)
+                {
+                    return false;
+                }
+
+                // Transfer solution from the bucket to the mop
+                // Owner is the bucket being interacted with. contents is the Solution contained by said bucket.
+                var solution = solutionsSys.SplitSolution(Owner, contents, transferAmount);
+                if (!solutionsSys.TryAddSolution(mopComponent.Owner, mopComponent.MopSolution, solution))
+                {
+                    return false; //if the attempt fails
+                }
+                Owner.PopupMessage(eventArgs.User, Loc.GetString("bucket-component-mop-is-now-wet-message"));
+
             }
-
-            var mopContents = mopComponent.MopSolution;
-
-            if (mopContents == null)
+            else //if mop is not empty
             {
-                return false;
-            }
+                //Transfer the mop solution to the bucket
 
-            var solution = solutionsSys.SplitSolution(Owner, contents, transferAmount);
-            if (!solutionsSys.TryAddSolution(mopComponent.Owner, mopContents, solution))
-            {
-                return false;
+                if (mopComponent.MopSolution == null)
+                    return false;
+
+                var solutionFromMop = solutionsSys.SplitSolution(mopComponent.Owner, mopComponent.MopSolution, mopComponent.CurrentVolume);
+                EntitySystem.Get<SolutionContainerSystem>().TryGetSolution(Owner, SolutionName, out var solution);
+                if (!solutionsSys.TryAddSolution(Owner, solution, solutionFromMop))
+                {
+                    return false; //if the attempt fails
+                }
+                Owner.PopupMessage(eventArgs.User, Loc.GetString("bucket-component-mop-is-now-dry-message"));
+
             }
 
             SoundSystem.Play(Filter.Pvs(Owner), _sound.GetSound(), Owner);

--- a/Resources/Locale/en-US/fluids/components/bucket-component.ftl
+++ b/Resources/Locale/en-US/fluids/components/bucket-component.ftl
@@ -1,2 +1,3 @@
 bucket-component-bucket-is-empty-message = Bucket is empty
-bucket-component-mop-is-full-message = Bucket is full
+bucket-component-mop-is-now-wet-message = Mop is now wet
+bucket-component-mop-is-now-dry-message = Mop is now dry

--- a/Resources/Locale/en-US/fluids/components/mop-component.ftl
+++ b/Resources/Locale/en-US/fluids/components/mop-component.ftl
@@ -1,1 +1,2 @@
 mop-component-mop-is-dry-message = Mop needs to be wet!
+mop-component-mop-is-full-message = Mop is full!

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -15,7 +15,7 @@
   - type: SolutionContainerManager
     solutions:
       mop:
-        maxVol: 10
+        maxVol: 50
 
 - type: entity
   name: mop bucket
@@ -38,7 +38,7 @@
         maxVol: 500
         reagents:
         - ReagentId: Water
-          Quantity: 500
+          Quantity: 250 # half-full at roundstart to leave room for puddles
   - type: Physics
     bodyType: Dynamic
   - type: Fixtures


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* changed janitor.yml so that mop capacity is 50u instead of 10u

MopComponent.cs:

* Added AvailableVolume variable alongside the existing MaxVolume and CurrentVolume

* Deleted a block of code that checked if the mop was dry

* Changed the calculations within transferAmount to reference the new AvailableVolume instead of CurrentVolume.

* Changed behaviour: The mop now transfers solution from the puddle to the mop instead of using water to destroy solutions within a puddle.

BucketComponent.cs:

* Added BucketSolution object (analogous to MopSolution object within MopComponent.cs) to easily reference the solution contained in the bucket.

* Made the give-water-to-mop sequence only run if the mop was empty.

* If the mop is not empty, clicking the bucket transfers all of the mop's solution into the bucket.

* Added to loc files for MopComponent and BucketComponent for new messages

_Note: Currently the mop no longer leaves behind small puddles (players will not slip on wet floors), however I'd like to discuss the wet floor mechanic and reimplement it later. The mop capacity of 50u was arbitrary and is open to discussion as well._ 

Fixes #6048

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/97707302/149650798-40d3cb82-9178-4820-ac7d-70fdb09d116e.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added ability for mop buckets to receive fluid from mops
- add: Popup messages informing when the mop becomes full (from puddles or mop bucket) or empty (from mop bucket)
- fix: The mop now transfers solution from the puddle to the mop instead of consuming water to destroy puddles
- tweak: The mop bucket now receives fluid from a wet mop, or gives fluid to a dry mop
