### PR TITLE
Make item slot containers nullable

### DIFF
--- a/Content.Server/Cabinet/ItemCabinetSystem.cs
+++ b/Content.Server/Cabinet/ItemCabinetSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Server.Cabinet
         private void OnComponentStartup(EntityUid uid, ItemCabinetComponent cabinet, ComponentStartup args)
         {
             UpdateAppearance(uid, cabinet);
-            _itemSlotsSystem.SetLock(uid, cabinet.CabinetSlot.ID, !cabinet.Opened);
+            _itemSlotsSystem.SetLock(uid, cabinet.CabinetSlot, !cabinet.Opened);
         }
 
         private void UpdateAppearance(EntityUid uid,
@@ -105,7 +105,7 @@ namespace Content.Server.Cabinet
 
             cabinet.Opened = !cabinet.Opened;
             SoundSystem.Play(Filter.Pvs(uid), cabinet.DoorSound.GetSound(), uid, AudioHelpers.WithVariation(0.15f));
-            _itemSlotsSystem.SetLock(uid, cabinet.CabinetSlot.ID, !cabinet.Opened);
+            _itemSlotsSystem.SetLock(uid, cabinet.CabinetSlot, !cabinet.Opened);
 
             UpdateAppearance(uid, cabinet);
         }

--- a/Content.Server/Containers/EmptyOnMachineDeconstructSystem.cs
+++ b/Content.Server/Containers/EmptyOnMachineDeconstructSystem.cs
@@ -27,7 +27,7 @@ namespace Content.Server.Containers
             foreach (var slot in component.Slots.Values)
             {
                 if (slot.EjectOnDeconstruct && slot.Item != null)
-                    slot.ContainerSlot.Remove(slot.Item.Value);
+                    slot.ContainerSlot?.Remove(slot.Item.Value);
             }
         }
 

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -156,7 +156,7 @@ namespace Content.Shared.Containers.ItemSlots
         public string? EjectVerbText;
 
         [ViewVariables]
-        public ContainerSlot ContainerSlot = default!;
+        public ContainerSlot? ContainerSlot = default!;
 
         /// <summary>
         ///     If this slot belongs to some de-constructible component, should the item inside the slot be ejected upon
@@ -192,10 +192,10 @@ namespace Content.Shared.Containers.ItemSlots
         [DataField("swap")]
         public bool Swap = true;
 
-        public string ID => ContainerSlot.ID;
+        public string? ID => ContainerSlot?.ID;
 
         // Convenience properties
-        public bool HasItem => ContainerSlot.ContainedEntity != null;
-        public EntityUid? Item => ContainerSlot.ContainedEntity;
+        public bool HasItem => ContainerSlot?.ContainedEntity != null;
+        public EntityUid? Item => ContainerSlot?.ContainedEntity;
     }
 }


### PR DESCRIPTION
When initially writing item slots I made a bad assumption about being able to assume that entities were initialized before event handlers or systems would try to make use of them, leading to errors. This corrects that by making the item slot containers nullable, seeing as they are only set on init.