### PR TITLE
NT Block Arcade correct session registeration

### DIFF
--- a/Content.Server/Arcade/Components/BlockGameArcadeComponent.cs
+++ b/Content.Server/Arcade/Components/BlockGameArcadeComponent.cs
@@ -56,7 +56,14 @@ namespace Content.Server.Arcade.Components
                 return;
 
             UserInterface?.Toggle(actor.PlayerSession);
-            RegisterPlayerSession(actor.PlayerSession);
+            if (UserInterface != null)
+            {
+                var isWindowOpened = UserInterface?.SubscribedSessions.Contains(actor.PlayerSession);
+                if (isWindowOpened == true)
+                {
+                    RegisterPlayerSession(actor.PlayerSession);
+                }
+            }
         }
 
         private void RegisterPlayerSession(IPlayerSession session)

--- a/Content.Server/Arcade/Components/BlockGameArcadeComponent.cs
+++ b/Content.Server/Arcade/Components/BlockGameArcadeComponent.cs
@@ -56,13 +56,9 @@ namespace Content.Server.Arcade.Components
                 return;
 
             UserInterface?.Toggle(actor.PlayerSession);
-            if (UserInterface != null)
+            if (UserInterface?.SessionHasOpen(actor.PlayerSession) == true)
             {
-                var isWindowOpened = UserInterface?.SubscribedSessions.Contains(actor.PlayerSession);
-                if (isWindowOpened == true)
-                {
-                    RegisterPlayerSession(actor.PlayerSession);
-                }
+                RegisterPlayerSession(actor.PlayerSession);
             }
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #2986 by adding a check to call the new session registration method only if player has opened the window.
Error happens, because when you click on machine second time with active window, is will closing but session will still try to create.

As a second option I see to implement this, make the `Toggle` method return a `boolean` if window opened or closed.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

