### PR TITLE
fixed wooden mosin inhand sprite

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -57,6 +57,8 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+  - type: Item
+    sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
   - type: RangedWeapon
   - type: BoltActionBarrel
   - type: Appearance
@@ -70,6 +72,8 @@
   description: A portable anti-armour rifle. Fires armor piercing 14.5mm shells.
   components:
   - type: Sprite
+    sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
+  - type: Item
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: RangedWeapon
   - type: BoltActionBarrel


### PR DESCRIPTION
## About the PR
This PR makes the wooden mosin and heavy sniper display their inhand sprites.

**Changelog**

:cl:
- fix: Wooden Mosin and Heavy Sniper inhand sprites displays properly now

