### PR TITLE
Add Gas Analyzers to YouTool and tool closets.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -23,6 +23,8 @@
         prob: 0.2
       - id: trayScanner
         prob: 0.7
+      - id: GasAnalyzer
+        prob: 0.7
       - id: ClothingBeltUtility
         prob: 0.2
       - id: ClothingHandsGlovesColorYellow

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -11,5 +11,6 @@
     Wrench: 5
     Screwdriver: 5
     trayScanner: 5
+    GasAnalyzer: 5
     ClothingHandsGlovesColorYellowBudget: 5
     ClothingBeltUtility: 3


### PR DESCRIPTION
## About the PR 

Gas analyzers were added a long time ago but were not currently obtainable in-game. They are now available in tool closets and the YouTool™ vending machines.

**Changelog**

:cl: Weaver
- add: Gas analyzers are now obtainable in-game in tool closets and YouTool™ vending machines.

