### PR TITLE
fix flashlight clothing prefix (hardsuit lights)

### DIFF
--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
+using Content.Shared.Item;
 using Content.Shared.Light.Component;
 using Content.Shared.Rounding;
 using Content.Shared.Verbs;
@@ -214,9 +215,9 @@ namespace Content.Server.Light.EntitySystems
                 light.Enabled = on;
             }
 
-            if (EntityManager.TryGetComponent(component.Owner, out ItemComponent? item))
+            if (EntityManager.TryGetComponent(component.Owner, out SharedItemComponent? item))
             {
-                item.EquippedPrefix = Loc.GetString(on ? "on" : "off");
+                item.EquippedPrefix = on ? "on" : "off";
             }
         }
 


### PR DESCRIPTION
This fixes the equipped hardsuit helmet light sprites not updating when the light is toggled on/off. Issue was component inheritance. hardsuits have a clothing component, not item component. both inherit from shared item component.

This doesn't fix the actual item sprite itself, only clothing/in-hands, as that requires going through and updating all the yaml files, and at that point I'd rather just finish reworking how flashlight visuals & item-prefixes work than spend time doing that.