### PR TITLE
Fixes hardsuit helmet and hardhat light sprites when lit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -50,6 +50,7 @@
   name: base hardsuit helmet with light
   components:
   - type: Sprite
+    netsync: true
     layers:
     - state: icon
     - state: icon-flash

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -4,6 +4,7 @@
   abstract: true
   components:
   - type: Sprite
+    netsync: true
     layers:
     - state: icon
     - state: light-icon


### PR DESCRIPTION
Added netsync: true to sprite component on both bases so that the icon updates correctly now.

The sprite however does not update when worn by the player so will need to fix that before PR ready.

:cl:
- fix: Hardsuit helmets and hardhats now show that they're lit.

