### PR TITLE
Add an exception to the soft max player cap for players who joined the game at some point during the current round.

### DIFF
--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
-using Content.Server.Administration.Managers;
 using Content.Server.Database;
+using Content.Server.GameTicking;
 using Content.Server.Preferences.Managers;
-using Content.Shared;
 using Content.Shared.CCVar;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Network;
@@ -76,9 +76,10 @@ The ban reason is: ""{ban.Reason}""
             }
 
             var adminData = await _dbManager.GetAdminDataForAsync(e.UserId);
-            if (_plyMgr.PlayerCount >= _cfg.GetCVar(CCVars.SoftMaxPlayers) && adminData is null)
+            var wasInGame = EntitySystem.TryGet<GameTicker>(out var ticker) && ticker.PlayersInGame.Contains(userId);
+            if ((_plyMgr.PlayerCount >= _cfg.GetCVar(CCVars.SoftMaxPlayers) && adminData is null) && !wasInGame )
             {
-                e.Deny("The server is full!");
+                e.Deny(Loc.GetString("soft-player-cap-full"));
                 return;
             }
 

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -16,6 +16,8 @@ namespace Content.Server.GameTicking
         [ViewVariables]
         private readonly Dictionary<IPlayerSession, LobbyPlayerStatus> _playersInLobby = new();
 
+        [ViewVariables] private readonly HashSet<NetUserId> _playersInGame = new();
+
         [ViewVariables]
         private TimeSpan _roundStartTime;
 
@@ -29,6 +31,7 @@ namespace Content.Server.GameTicking
         private bool _roundStartCountdownHasNotStartedYetDueToNoPlayers;
 
         public IReadOnlyDictionary<IPlayerSession, LobbyPlayerStatus> PlayersInLobby => _playersInLobby;
+        public IReadOnlySet<NetUserId> PlayersInGame => _playersInGame;
 
         private void UpdateInfoText()
         {

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -134,12 +134,15 @@ namespace Content.Server.GameTicking
             if (_playersInLobby.ContainsKey(session))
                 _playersInLobby.Remove(session);
 
+            _playersInGame.Add(session.UserId);
+
             RaiseNetworkEvent(new TickerJoinGameEvent(), session.ConnectedClient);
         }
 
         private void PlayerJoinLobby(IPlayerSession session)
         {
             _playersInLobby[session] = LobbyPlayerStatus.NotReady;
+            _playersInGame.Remove(session.UserId);
 
             var client = session.ConnectedClient;
             RaiseNetworkEvent(new TickerJoinLobbyEvent(), client);

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -429,7 +429,7 @@ namespace Content.Server.GameTicking
             }
             // This ordering mechanism isn't great (no ordering of minds) but functions
             var listOfPlayerInfoFinal = listOfPlayerInfo.OrderBy(pi => pi.PlayerOOCName).ToArray();
-
+            _playersInGame.Clear();
             RaiseNetworkEvent(new RoundEndMessageEvent(gamemodeTitle, roundEndText, roundDuration, listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal));
         }
 

--- a/Resources/Locale/en-US/connection-messages.ftl
+++ b/Resources/Locale/en-US/connection-messages.ftl
@@ -8,3 +8,5 @@ command-whitelistremove-help = whitelistremove <username>
 
 command-kicknonwhitelisted-description = Kicks all non-whitelisted players from the server.
 command-kicknonwhitelisted-help = kicknonwhitelisted
+
+soft-player-cap-full = The server is full!


### PR DESCRIPTION
finally

:cl: moony
- tweak: Players who have joined the game with a character (Not as an observer) are now exempt from the player cap for the duration of the round. This means you can no longer get locked out if you have to relog for some reason.