### PR TITLE
Readjust radiation collectors.

### DIFF
--- a/Content.Server/Singularity/Components/RadiationCollectorComponent.cs
+++ b/Content.Server/Singularity/Components/RadiationCollectorComponent.cs
@@ -33,6 +33,9 @@ namespace Content.Server.Singularity.Components
             }
         }
 
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float ChargeModifier = 30000f;
+
         bool IInteractHand.InteractHand(InteractHandEventArgs eventArgs)
         {
             var curTime = _gameTiming.CurTime;
@@ -67,7 +70,7 @@ namespace Content.Server.Singularity.Components
             // This still won't stop things being potentially hilarously unbalanced though.
             if (_entMan.TryGetComponent<BatteryComponent>(Owner, out var batteryComponent))
             {
-                batteryComponent.CurrentCharge += frameTime * radiation.RadsPerSecond * 30000f;
+                batteryComponent.CurrentCharge += frameTime * radiation.RadsPerSecond * ChargeModifier;
             }
         }
 

--- a/Content.Server/Singularity/Components/RadiationCollectorComponent.cs
+++ b/Content.Server/Singularity/Components/RadiationCollectorComponent.cs
@@ -67,7 +67,7 @@ namespace Content.Server.Singularity.Components
             // This still won't stop things being potentially hilarously unbalanced though.
             if (_entMan.TryGetComponent<BatteryComponent>(Owner, out var batteryComponent))
             {
-                batteryComponent.CurrentCharge += frameTime * radiation.RadsPerSecond * 3000f;
+                batteryComponent.CurrentCharge += frameTime * radiation.RadsPerSecond * 30000f;
             }
         }
 


### PR DESCRIPTION
When singularity radiation was nerfed it went from 10dps per level to 1dps per level of radiation damage.
Thus radiation collectors should be adjusted by x10 to compensate.
