### PR TITLE
Gitignore images generated by `Content.MapRenderer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,5 +288,8 @@ ehthumbs.db
 # Merge driver stuff
 Content.Tools/test/out.yml
 
-# Windows 
+# Windows
 desktop.ini
+
+# Images generated using the MapRenderer
+Resources/MapImages


### PR DESCRIPTION
## About the PR

Content.MapRenderer generates map images in `Resources/MapImages`. I've added this folder to `.gitignore`.

