### PR TITLE
Fix no lobby, no job spawn

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -94,7 +94,7 @@ namespace Content.Server.GameTicking
             // If no job available, stay in lobby, or if no lobby spawn as observer
             if (jobId is null)
             {
-                if(LobbyEnabled == false)
+                if (!LobbyEnabled)
                 {
                     MakeObserve(player);
                 }


### PR DESCRIPTION
## About the PR
If all jobs filtered out, and the lobby is off, you spawn as observer, instead of getting stuck at the connection screen.

Fix: https://github.com/space-wizards/space-station-14/issues/6081