### PR TITLE
No-Slip shoes are now only called such in the uplink catalog

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -189,6 +189,8 @@
   id: UplinkClothingNoSlipsShoes
   category: Armor
   itemId: ClothingShoesChameleonNoSlips
+  listingName: no-slip shoes
+  description: These protect you from slips while looking like normal sneakers.
   price: 2
 
 - type: uplinkListing

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -83,7 +83,8 @@
 - type: entity
   parent: ClothingShoesColorBlack
   id: ClothingShoesChameleonNoSlips
-  name: no-slip shoes
-  description: These protect you from slips while looking like normal sneakers.
+  name: black shoes #actual name and description in uplink_catalog.yml
+  suffix: no-slip
+  description: Stylish black shoes.
   components:
   - type: NoSlip


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This fixes an error where although no-slips were called 'indistinguishable' from regular shoes, anyone could instantly identify them. Now they look just like the black shoes they share a sprite with when you examine them.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![Screenshot from 2022-01-21 20-25-11](https://user-images.githubusercontent.com/60792108/150619334-5d313e2a-63be-43c3-b5aa-a0e3000de3a4.png)
![Screenshot from 2022-01-21 20-25-28](https://user-images.githubusercontent.com/60792108/150619339-0a558cb3-1c1d-4f78-8f7c-27f45fe65ec9.png)
![Screenshot from 2022-01-21 20-24-49](https://user-images.githubusercontent.com/60792108/150619341-6b542a27-4dd1-423c-bfd9-12dde0594510.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: No-slip shoes now appear to be regular shoes when examined.
