### PR TITLE
Fix wallmount constrution ghost rotation check.

### DIFF
--- a/Content.Shared/Construction/Conditions/WallmountCondition.cs
+++ b/Content.Shared/Construction/Conditions/WallmountCondition.cs
@@ -21,13 +21,13 @@ namespace Content.Shared.Construction.Conditions
             var entManager = IoCManager.Resolve<IEntityManager>();
 
             // get blueprint and user position
-            var userWorldPosition = IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(user).WorldPosition;
+            var userWorldPosition = entManager.GetComponent<TransformComponent>(user).WorldPosition;
             var objWorldPosition = location.ToMap(entManager).Position;
 
             // find direction from user to blueprint
             var userToObject = (objWorldPosition - userWorldPosition);
             // get direction of the grid being placed on as an offset.
-            var gridRotation = IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(location.EntityId).WorldRotation;
+            var gridRotation = entManager.GetComponent<TransformComponent>(location.EntityId).WorldRotation;
             var directionWithOffset = gridRotation.RotateVec(direction.ToVec());
 
             // dot product will be positive if user direction and blueprint are co-directed
@@ -39,7 +39,7 @@ namespace Content.Shared.Construction.Conditions
             var physics = EntitySystem.Get<SharedPhysicsSystem>();
             var rUserToObj = new CollisionRay(userWorldPosition, userToObject.Normalized, (int) CollisionGroup.Impassable);
             var length = userToObject.Length;
-            var userToObjRaycastResults = physics.IntersectRayWithPredicate(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(user).MapID, rUserToObj, maxLength: length,
+            var userToObjRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rUserToObj, maxLength: length,
                 predicate: (e) => !e.HasTag("Wall"));
             if (!userToObjRaycastResults.Any())
                 return false;
@@ -49,7 +49,7 @@ namespace Content.Shared.Construction.Conditions
 
             // check that we didn't try to build wallmount that facing another adjacent wall
             var rAdjWall = new CollisionRay(objWorldPosition, directionWithOffset.Normalized, (int) CollisionGroup.Impassable);
-            var adjWallRaycastResults = physics.IntersectRayWithPredicate(IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(user).MapID, rAdjWall, maxLength: 0.5f,
+            var adjWallRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rAdjWall, maxLength: 0.5f,
                predicate: (e) => e == targetWall || !e.HasTag("Wall"));
             return !adjWallRaycastResults.Any();
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes: #6271 
This adds the rotation of the grid that the construction ghost is being placed on as an offset to the direction check in WallmountCondition.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

