### PR TITLE
Fixes #6294 -  Stay alive objective shows an error sprite

### DIFF
--- a/Content.Server/Objectives/Conditions/StayAliveCondition.cs
+++ b/Content.Server/Objectives/Conditions/StayAliveCondition.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Objectives.Conditions
 
         public string Description => Loc.GetString("objective-condition-stay-alive-description");
 
-        public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Objects/Misc/bureaucracy.rsi"), "folder_white");
+        public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Objects/Misc/bureaucracy.rsi"), "folder-white");
 
         public float Progress => (_mind?.CharacterDeadIC ?? false) ? 0f : 1f;
 


### PR DESCRIPTION
## About the PR
Pretty descriptive title!

**Changelog**
:cl:
- fix: Fixed the Stay Alive objective icon

