### PR TITLE
Fixes RandomTraitorAliveCondition icon

### DIFF
--- a/Content.Server/Objectives/Conditions/RandomTraitorAliveCondition.cs
+++ b/Content.Server/Objectives/Conditions/RandomTraitorAliveCondition.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Content.Server.Mind.Components;
 using Content.Server.Objectives.Interfaces;
 using JetBrains.Annotations;
@@ -53,7 +53,7 @@ namespace Content.Server.Objectives.Conditions
 
         public string Description => Loc.GetString("objective-condition-other-traitor-alive-description");
 
-        public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Objects/Misc/bureaucracy.rsi"), "folder_red");
+        public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Objects/Misc/bureaucracy.rsi"), "folder-white");
 
         public float Progress => (!Target?.CharacterDeadIC ?? true) ? 1f : 0f;
 


### PR DESCRIPTION
## About the PR 

Does what it says. I switched the icon to folder-white since it's the only "already done" sprite currently, as other colors were removed in place for a colormapped folder system.

I can change it to another icon or even figure out how to paint the white folder itself, but I chose to simply switch to the white folder as I'm unsure what the maintainers would wish for, and this is "the easiest fix".

:cl:
- fix: Fixes Random Traitor Alive Objective's icon!

