### PR TITLE
Fix smoothing error

### DIFF
--- a/Content.Client/Wall/Components/ReinforcedWallComponent.cs
+++ b/Content.Client/Wall/Components/ReinforcedWallComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Client.Wall.Components
 {
     [RegisterComponent]
     [ComponentReference(typeof(IconSmoothComponent))]
-    public class ReinforcedWallComponent : IconSmoothComponent
+    public class ReinforcedWallComponent : IconSmoothComponent // whyyyyyyyyy
     {
         public override string Name => "ReinforcedWall";
 
@@ -36,7 +36,7 @@ namespace Content.Client.Wall.Components
             }
         }
 
-        internal override void CalculateNewSprite(IMapGrid grid)
+        internal override void CalculateNewSprite(IMapGrid? grid)
         {
             base.CalculateNewSprite(grid);
 


### PR DESCRIPTION
Gets rid of the client-side "missing grid" error spam that smoothing currently creates. Also fixes smoothing not properly updating when entities are unanchored. 
