### PR TITLE
Fix admin logs always causing an exception on first batch.

### DIFF
--- a/Content.Server/Administration/Logs/AdminLogSystem.cs
+++ b/Content.Server/Administration/Logs/AdminLogSystem.cs
@@ -108,6 +108,7 @@ public partial class AdminLogSystem : SharedAdminLogSystem
         }
 
         SubscribeLocalEvent<RoundStartingEvent>(RoundStarting);
+        SubscribeLocalEvent<GameRunLevelChangedEvent>(RunLevelChanged);
     }
 
     public override async void Shutdown()
@@ -232,14 +233,21 @@ public partial class AdminLogSystem : SharedAdminLogSystem
 
     private void RoundStarting(RoundStartingEvent ev)
     {
-        Interlocked.Exchange(ref _currentLogId, 0);
         CacheNewRound();
+    }
 
-        if (_metricsEnabled)
+    private void RunLevelChanged(GameRunLevelChangedEvent ev)
+    {
+        if (ev.New == GameRunLevel.PreRoundLobby)
         {
-            PreRoundQueueCapReached.Set(0);
-            QueueCapReached.Set(0);
-            LogsSent.Set(0);
+            Interlocked.Exchange(ref _currentLogId, 0);
+
+            if (_metricsEnabled)
+            {
+                PreRoundQueueCapReached.Set(0);
+                QueueCapReached.Set(0);
+                LogsSent.Set(0);
+            }
         }
     }
 


### PR DESCRIPTION
_currentLogId was being set at the start of the round so pre-round and in-round events got overlapping primary keys.
