### PR TITLE
Removes duplicate range check in `InRangeUnobstructed`

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -292,10 +292,11 @@ namespace Content.Shared.Interaction
             Ignored? predicate = null,
             bool ignoreInsideBlocker = false)
         {
+            if (range > 0f && !origin.InRange(other, range)) return false;
+
             var dir = other.Position - origin.Position;
 
             if (dir.LengthSquared.Equals(0f)) return true;
-            if (range >= 0f && !(dir.LengthSquared < range * range)) return false;
 
             predicate ??= _ => false;
 


### PR DESCRIPTION
Let's cherry pick thaat fix to a separate PR

<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently if one calls `InRangeUnobstructed` with range as 0 or a negative number it will not do as the XMLdoc claims and only check if there is an obstruction without checking the range due to a call to `MapCoordinates.InRange` without checking if range is a zero or a negative number.
This PR restores the functionality to what the XMLdoc describes by removing the check after `MapCoordinates.InRange` and only caring about `MapCoordinates.InRange`'s result when range > 0.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->