### PR TITLE
Removed SetSize from Window Size in Admin and AdminRank

### DIFF
--- a/Content.Client/Administration/UI/PermissionsEui.cs
+++ b/Content.Client/Administration/UI/PermissionsEui.cs
@@ -105,14 +105,14 @@ namespace Content.Client.Administration.UI
 
         private void RemoveButtonPressed(EditAdminWindow window)
         {
-            SendMessage(new RemoveAdmin {UserId = window.SourceData!.Value.UserId});
+            SendMessage(new RemoveAdmin { UserId = window.SourceData!.Value.UserId });
 
             window.Close();
         }
 
         private void RemoveRankButtonPressed(EditAdminRankWindow window)
         {
-            SendMessage(new RemoveAdminRank {Id = window.SourceId!.Value});
+            SendMessage(new RemoveAdminRank { Id = window.SourceId!.Value });
 
             window.Close();
         }
@@ -206,9 +206,9 @@ namespace Content.Client.Administration.UI
                 var al = _menu.AdminsList;
                 var name = admin.UserName ?? admin.UserId.ToString();
 
-                al.AddChild(new Label {Text = name});
+                al.AddChild(new Label { Text = name });
 
-                var titleControl = new Label {Text = admin.Title ?? Loc.GetString("permissions-eui-edit-admin-title-control-text").ToLowerInvariant()};
+                var titleControl = new Label { Text = admin.Title ?? Loc.GetString("permissions-eui-edit-admin-title-control-text").ToLowerInvariant() };
                 if (admin.Title == null) // none
                 {
                     titleControl.StyleClasses.Add(StyleBase.StyleClassItalic);
@@ -232,7 +232,7 @@ namespace Content.Client.Administration.UI
                     rank = Loc.GetString("permissions-eui-edit-no-rank-text").ToLowerInvariant();
                 }
 
-                var rankControl = new Label {Text = rank};
+                var rankControl = new Label { Text = rank };
                 if (italic)
                 {
                     rankControl.StyleClasses.Add(StyleBase.StyleClassItalic);
@@ -249,7 +249,7 @@ namespace Content.Client.Administration.UI
                     HorizontalAlignment = Control.HAlignment.Center,
                 });
 
-                var editButton = new Button {Text = Loc.GetString("permissions-eui-edit-title-button") };
+                var editButton = new Button { Text = Loc.GetString("permissions-eui-edit-title-button") };
                 editButton.OnPressed += _ => OnEditPressed(admin);
                 al.AddChild(editButton);
 
@@ -265,14 +265,14 @@ namespace Content.Client.Administration.UI
             {
                 var rank = kv.Value;
                 var flagsText = string.Join(' ', AdminFlagsHelper.FlagsToNames(rank.Flags).Select(f => $"+{f}"));
-                _menu.AdminRanksList.AddChild(new Label {Text = rank.Name});
+                _menu.AdminRanksList.AddChild(new Label { Text = rank.Name });
                 _menu.AdminRanksList.AddChild(new Label
                 {
                     Text = flagsText,
                     HorizontalExpand = true,
                     HorizontalAlignment = Control.HAlignment.Center,
                 });
-                var editButton = new Button {Text = Loc.GetString("permissions-eui-edit-admin-rank-button") };
+                var editButton = new Button { Text = Loc.GetString("permissions-eui-edit-admin-rank-button") };
                 editButton.OnPressed += _ => OnEditRankPressed(kv);
                 _menu.AdminRanksList.AddChild(editButton);
 
@@ -316,19 +316,19 @@ namespace Content.Client.Administration.UI
                     HorizontalAlignment = HAlignment.Right
                 };
 
-                AdminsList = new GridContainer {Columns = 5, VerticalExpand = true};
+                AdminsList = new GridContainer { Columns = 5, VerticalExpand = true };
                 var adminVBox = new BoxContainer
                 {
                     Orientation = LayoutOrientation.Vertical,
-                    Children = {new ScrollContainer(){VerticalExpand = true, Children = { AdminsList }}, AddAdminButton},
+                    Children = { new ScrollContainer() { VerticalExpand = true, Children = { AdminsList } }, AddAdminButton },
                 };
                 TabContainer.SetTabTitle(adminVBox, Loc.GetString("permissions-eui-menu-admins-tab-title"));
 
-                AdminRanksList = new GridContainer {Columns = 3, VerticalExpand = true};
+                AdminRanksList = new GridContainer { Columns = 3, VerticalExpand = true };
                 var rankVBox = new BoxContainer
                 {
                     Orientation = LayoutOrientation.Vertical,
-                    Children = { new ScrollContainer(){VerticalExpand = true, Children = {AdminRanksList}}, AddAdminRankButton}
+                    Children = { new ScrollContainer() { VerticalExpand = true, Children = { AdminRanksList } }, AddAdminRankButton }
                 };
                 TabContainer.SetTabTitle(rankVBox, Loc.GetString("permissions-eui-menu-admin-ranks-tab-title"));
 
@@ -355,7 +355,7 @@ namespace Content.Client.Administration.UI
 
             public EditAdminWindow(PermissionsEui ui, PermissionsEuiState.AdminData? data)
             {
-                SetSize = MinSize = (600, 400);
+                MinSize = (600, 400);
                 SourceData = data;
 
                 Control nameControl;
@@ -366,18 +366,18 @@ namespace Content.Client.Administration.UI
                     Title = Loc.GetString("permissions-eui-edit-admin-window-edit-admin-label",
                                           ("admin", name));
 
-                    nameControl = new Label {Text = name};
+                    nameControl = new Label { Text = name };
                 }
                 else
                 {
                     Title = Loc.GetString("permissions-eui-menu-add-admin-button");
 
-                    nameControl = NameEdit = new LineEdit {PlaceHolder = Loc.GetString("permissions-eui-edit-admin-window-name-edit-placeholder") };
+                    nameControl = NameEdit = new LineEdit { PlaceHolder = Loc.GetString("permissions-eui-edit-admin-window-name-edit-placeholder") };
                 }
 
-                TitleEdit = new LineEdit {PlaceHolder = Loc.GetString("permissions-eui-edit-admin-window-title-edit-placeholder") };
+                TitleEdit = new LineEdit { PlaceHolder = Loc.GetString("permissions-eui-edit-admin-window-title-edit-placeholder") };
                 RankButton = new OptionButton();
-                SaveButton = new Button {Text = Loc.GetString("permissions-eui-edit-admin-window-save-button"), HorizontalAlignment = HAlignment.Right};
+                SaveButton = new Button { Text = Loc.GetString("permissions-eui-edit-admin-window-save-button"), HorizontalAlignment = HAlignment.Right };
 
                 RankButton.AddItem(Loc.GetString("permissions-eui-edit-admin-window-no-rank-button"), NoRank);
                 foreach (var (rId, rank) in ui._ranks)
@@ -407,21 +407,21 @@ namespace Content.Client.Administration.UI
                     var inherit = new Button
                     {
                         Text = "I",
-                        StyleClasses = {StyleBase.ButtonOpenRight},
+                        StyleClasses = { StyleBase.ButtonOpenRight },
                         Disabled = disable,
                         Group = group,
                     };
                     var sub = new Button
                     {
                         Text = "-",
-                        StyleClasses = {StyleBase.ButtonOpenBoth},
+                        StyleClasses = { StyleBase.ButtonOpenBoth },
                         Disabled = disable,
                         Group = group
                     };
                     var plus = new Button
                     {
                         Text = "+",
-                        StyleClasses = {StyleBase.ButtonOpenLeft},
+                        StyleClasses = { StyleBase.ButtonOpenLeft },
                         Disabled = disable,
                         Group = group
                     };
@@ -446,7 +446,7 @@ namespace Content.Client.Administration.UI
                         inherit.Pressed = true;
                     }
 
-                    permGrid.AddChild(new Label {Text = flagName});
+                    permGrid.AddChild(new Label { Text = flagName });
                     permGrid.AddChild(inherit);
                     permGrid.AddChild(sub);
                     permGrid.AddChild(plus);
@@ -461,7 +461,7 @@ namespace Content.Client.Administration.UI
                 if (data != null)
                 {
                     // show remove button.
-                    RemoveButton = new Button {Text = Loc.GetString("permissions-eui-edit-admin-window-remove-flag-button") };
+                    RemoveButton = new Button { Text = Loc.GetString("permissions-eui-edit-admin-window-remove-flag-button") };
                     bottomButtons.AddChild(RemoveButton);
                 }
 
@@ -533,7 +533,7 @@ namespace Content.Client.Administration.UI
             public EditAdminRankWindow(PermissionsEui ui, KeyValuePair<int, PermissionsEuiState.AdminRankData>? data)
             {
                 Title = Loc.GetString("permissions-eui-edit-admin-rank-window-title");
-                MinSize = SetSize = (600, 400);
+                MinSize = (600, 400);
                 SourceId = data?.Key;
 
                 NameEdit = new LineEdit
@@ -546,10 +546,11 @@ namespace Content.Client.Administration.UI
                     NameEdit.Text = data.Value.Value.Name;
                 }
 
-                SaveButton = new Button {
+                SaveButton = new Button
+                {
                     Text = Loc.GetString("permissions-eui-menu-save-admin-rank-button"),
                     HorizontalAlignment = HAlignment.Right,
-                    HorizontalExpand = true
+                    HorizontalExpand = true,
                 };
                 var flagsBox = new BoxContainer
                 {
@@ -585,7 +586,7 @@ namespace Content.Client.Administration.UI
                 if (data != null)
                 {
                     // show remove button.
-                    RemoveButton = new Button {Text = Loc.GetString("permissions-eui-menu-remove-admin-rank-button") };
+                    RemoveButton = new Button { Text = Loc.GetString("permissions-eui-menu-remove-admin-rank-button") };
                     bottomButtons.AddChild(RemoveButton);
                 }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
SetSize was preventing the window from expanding properly and cutting off the save button. Rather than make the SetSize larger, I removed it as future additions to permissions or rank would cause it to be pushed off the page again. 
Fixes #6275 


**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/490702/151644319-25bf9299-a0de-4d17-81dd-22fa78cb094c.png)
![image](https://user-images.githubusercontent.com/490702/151644337-8826495a-df04-459a-ab91-e78823a46e1b.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Admin and AdminRank windows show the save button correctly now

