### PR TITLE
Fix firelock door init

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -34,15 +34,18 @@ namespace Content.Server.Doors.Systems
                 appearanceComponent.SetData(DoorVisuals.Powered, args.Powered);
             }
 
+            if (!TryComp(uid, out DoorComponent? door))
+                return;
+
             if (!args.Powered)
             {
                 // stop any scheduled auto-closing
-                DoorSystem.SetNextStateChange(uid, null);
+                if (door.State == DoorState.Open)
+                    DoorSystem.SetNextStateChange(uid, null);
             }
             else
             {
-                // door received power. Lets "wake" the door up, in case it is currently open and needs to auto-close.
-                DoorSystem.SetNextStateChange(uid, TimeSpan.FromSeconds(1));
+                UpdateAutoClose(uid, door: door);
             }
 
             // BoltLights also got out

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -28,10 +28,8 @@ public sealed class DoorComponent : Component
     /// This should never be set directly.
     /// </remarks>
     [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("state")]
     public DoorState State = DoorState.Closed;
-
-    [DataField("startOpen")]
-    public readonly bool StartOpen = false;
 
     #region Timing
     // if you want do dynamically adjust these times, you need to add networking for them. So for now, they are all

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -61,7 +61,7 @@
       closeTimeTwo: 0.6
       openTimeOne: 0.1
       openTimeTwo: 0.6
-      startOpen: true
+      state: Open
       bumpOpen: false
       clickOpen: false
       crushDamage:

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -31,4 +31,4 @@
   suffix: Open
   components:
   - type: Door
-    startOpen: true
+    state: Open

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -86,7 +86,7 @@
   suffix: Open
   components:
   - type: Door
-    startOpen: true
+    state: Open
 
 - type: entity
   id: ShuttersRadiation
@@ -108,7 +108,7 @@
   suffix: Open
   components:
   - type: Door
-    startOpen: true
+    state: Open
 
 - type: entity
   id: ShuttersWindow
@@ -129,4 +129,4 @@
   suffix: Open
   components:
   - type: Door
-    startOpen: true
+    state: Open


### PR DESCRIPTION
#5887 Added a bug for doors that are supposed to start opened (e.g., airlocks). Because the server handled the component state before running the init/startup code, players that joined mid game would always see firelocks as open, despite them maybe actually being closed.