### PR TITLE
+ Evidence locker, warden locker access and scientist locker fill

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/readmebeforeadding.txt
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/readmebeforeadding.txt
@@ -1,1 +1,0 @@
-See https://github.com/space-wizards/space-station-14/pull/2427#issuecomment-718152557

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: LockerScienceFilled
+  suffix: Filled
+  parent: LockerScientist
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingHandsGlovesLatex
+        prob: 1
+      - id: ClothingHeadsetScience
+        prob: 1
+      - id: ClothingMaskSterile
+        prob: 1
+      - id: ClothingOuterCoatLab
+        prob: 1

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -286,7 +286,7 @@
       state_open: warden_open
       state_closed: warden_door
   - type: AccessReader
-    access: [["Security", "Armory"]] # TODO access [["Brig"]]
+    access: [["Brig"]]
 
 # Security Officer
 - type: entity
@@ -312,6 +312,15 @@
   components:
   - type: AccessReader
     access: [["Security"]] # TODO access [["Detective"]]
+
+- type: entity
+  id: LockerEvidence
+  parent: LockerSecurity
+  name: evidence locker
+  description: To store bags of bullet casings and detainee belongings.
+  components:
+  - type: AccessReader
+    access: [["Security"]]
 
 # Syndicate
 - type: entity


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Warden locker is now brig access ONLY.
- Adds an empty evidence locker based on sec locker for storing confiscated items etc. Used by detective in future too.
- Adds a locker fill for scientist since it was missing. Contains headset, lab coat, latex gloves and sterile mask.
