### PR TITLE
Fix Dart being votable.

### DIFF
--- a/Resources/Prototypes/Maps/game.yml
+++ b/Resources/Prototypes/Maps/game.yml
@@ -131,6 +131,11 @@
     !type:NanotrasenNameGenerator
     prefixCreator: '14'
   mapPath: Maps/dart.yml
+  minPlayers: 0
+  votable: false
+  overflowJobs: []
+  availableJobs:
+    Captain: [ 1, 1 ]
   
 - type: gameMap
   id: sunrise


### PR DESCRIPTION
Fix Dart being votable.

Also makes the only default job Captain so admins can add their own jobs to the shuttle.