### PR TITLE
Fix Syndie Suit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -114,7 +114,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHelmetSyndicate
-  name: syndicate helmet
+  name: syndicate EVA helmet
   description: A stylish, robust syndicate helmet
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -114,7 +114,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHelmetSyndicate
-  name: syndicate EVA helmet
+  name: syndicate helmet
   description: A stylish, robust syndicate helmet
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -137,6 +137,22 @@
     highPressureMultiplier: 1
     lowPressureMultiplier: 100
 
+# Moved to hardsuits because this is where EVA capable suits are apparently.
+# Same stats as normal EVA suit.
+- type: entity
+  parent: ClothingOuterHardsuitBase
+  id: ClothingOuterHardsuitSyndicate
+  name: syndicate EVA suit
+  description: "Has a tag on it 'Totally not property of an enemy corporation, honest!'"
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Suits/syndicate.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Suits/syndicate.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 1
+    lowPressureMultiplier: 100
+
 - type: entity
   parent: ClothingOuterHardsuitBase
   id:  ClothingOuterHardsuitEVAPrisoner
@@ -240,7 +256,7 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSyndie
-  name: blood-red hardsuit
+  name: blood red hardsuit
   description: A dual-mode advanced hardsuit designed for work in special operations.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -137,22 +137,6 @@
     highPressureMultiplier: 1
     lowPressureMultiplier: 100
 
-# Moved to hardsuits because this is where EVA capable suits are apparently.
-# Same stats as normal EVA suit.
-- type: entity
-  parent: ClothingOuterHardsuitBase
-  id: ClothingOuterHardsuitSyndicate
-  name: syndicate EVA suit
-  description: "Has a tag on it 'Totally not property of an enemy corporation, honest!'"
-  components:
-  - type: Sprite
-    sprite: Clothing/OuterClothing/Suits/syndicate.rsi
-  - type: Clothing
-    sprite: Clothing/OuterClothing/Suits/syndicate.rsi
-  - type: PressureProtection
-    highPressureMultiplier: 1
-    lowPressureMultiplier: 100
-
 - type: entity
   parent: ClothingOuterHardsuitBase
   id:  ClothingOuterHardsuitEVAPrisoner
@@ -256,7 +240,7 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSyndie
-  name: blood red hardsuit
+  name: blood-red hardsuit
   description: A dual-mode advanced hardsuit designed for work in special operations.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -74,18 +74,6 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/rad.rsi
 
-# I think this is a suit? Looks baggy enough
-- type: entity
-  parent: ClothingOuterBase
-  id: ClothingOuterSuitSyndicate
-  name: syndicate suit
-  description: "Has a tag on it 'Totally not property of an enemy corporation, honest!'"
-  components:
-  - type: Sprite
-    sprite: Clothing/OuterClothing/Suits/syndicate.rsi
-  - type: Clothing
-    sprite: Clothing/OuterClothing/Suits/syndicate.rsi
-
 - type: entity
   parent: ClothingOuterBase
   id: ClothingOuterSuitSpaceninja

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -74,6 +74,18 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/rad.rsi
 
+# I think this is a suit? Looks baggy enough
+- type: entity
+  parent: ClothingOuterBase
+  id: ClothingOuterSuitSyndicate
+  name: syndicate suit
+  description: "Has a tag on it 'Totally not property of an enemy corporation, honest!'"
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Suits/syndicate.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Suits/syndicate.rsi
+
 - type: entity
   parent: ClothingOuterBase
   id: ClothingOuterSuitSpaceninja


### PR DESCRIPTION
Fix the old Syndicate suit to have the same stats as a normal EVA suit.
Moves Syndicate suit to hardsuits file because that's where EVA suits live apparently.

Adjust some item names.
syndicate suit --> syndicate EVA suit
syndicate helmet --> syndicate EVA helmet
blood-red hardsuit --> blood red hardsuit (for consistency)