### PR TITLE
ECS healing + add delay

### DIFF
--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -8,6 +8,9 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Server.Medical.Components
 {
+    /// <summary>
+    /// Applies a damage change to the target when used in an interaction.
+    /// </summary>
     [RegisterComponent]
     public sealed class HealingComponent : Component
     {

--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -9,8 +9,6 @@ using Content.Shared.Database;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Helpers;
 using Content.Shared.Stacks;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 
 namespace Content.Server.Medical;
 
@@ -86,9 +84,6 @@ public sealed class HealingSystem : EntitySystem
             return;
 
         if (component.DamageContainerID is not null && !component.DamageContainerID.Equals(targetDamage.DamageContainerID))
-            return;
-
-        if (!_blocker.CanInteract(user))
             return;
 
         if (user != target &&


### PR DESCRIPTION
3 second delay seemed okay so it can't be spammed in combat. It doesn't break on damage so if you have ticking damage you won't seethe off the face of the planet.

:cl:
- tweak: Healing (via ointments etc.) now takes time.
