### PR TITLE
Remove Sunrise prototype.

### DIFF
--- a/Resources/Prototypes/Maps/game.yml
+++ b/Resources/Prototypes/Maps/game.yml
@@ -136,27 +136,6 @@
   overflowJobs: []
   availableJobs:
     Captain: [ 1, 1 ]
-  
-- type: gameMap
-  id: sunrise
-  mapName: 'Sunrise'
-  mapNameTemplate: '{0} Sunrise {1}'
-  nameGenerator:
-    !type:NanotrasenNameGenerator
-    prefixCreator: 'SS'
-  mapPath: Maps/sunrise.yml
-  minPlayers: 0
-  maxPlayers: 8
-  overflowJobs: []
-  availableJobs:
-    Bartender: [ 1, 1 ]
-    Captain: [ 1, 1 ]
-    ChiefEngineer: [ 1, 1 ]
-    StationEngineer: [ 1, 1 ]
-    ChiefMedicalOfficer: [ 1, 1 ]
-    MedicalDoctor: [ 1, 1 ]
-    ResearchDirector: [ 1, 1 ]
-    Botanist: [ 1, 1 ]
 
 - type: gameMap
   id: moonrise


### PR DESCRIPTION
Removes the Sunrise prototype as the map file isn't even on `master` currently.
@LittleBuilderJane 