### PR TITLE
misc optimization

### DIFF
--- a/Content.IntegrationTests/Tests/Damageable/DamageSpecifierTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageSpecifierTest.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using NUnit.Framework;
+
+namespace Content.IntegrationTests.Tests.Damageable;
+
+[TestFixture]
+[TestOf(typeof(DamageSpecifier))]
+public class DamageSpecifierTest : ContentIntegrationTest
+{
+    [Test]
+    public void TestDamageSpecifierOperations()
+    {
+        // Test basic math operations.
+        // I've already nearly broken these once. When editing the operators.
+
+        DamageSpecifier input1 = new() { DamageDict = _input1 };
+        DamageSpecifier input2 = new() { DamageDict = _input2 };
+        DamageSpecifier output1 = new() { DamageDict = _output1 };
+        DamageSpecifier output2 = new() { DamageDict = _output2 };
+        DamageSpecifier output3 = new() { DamageDict = _output3 };
+        DamageSpecifier output4 = new() { DamageDict = _output4 };
+        DamageSpecifier output5 = new() { DamageDict = _output5 };
+
+        Assert.That((-input1).Equals(output1));
+        Assert.That((input1 / 2).Equals(output2));
+        Assert.That((input1 * 2).Equals(output3));
+
+        var difference = (input1 - input2);
+        Assert.That(difference.Equals(output4));
+
+        var difference2 = (-input2) + input1;
+        Assert.That(difference.Equals(difference2));
+
+        difference.Clamp(-0.25f, 0.25f);
+        Assert.That(difference.Equals(output5));
+    }
+
+    static Dictionary<string, FixedPoint2> _input1 = new()
+    {
+        { "A", 1.5f },
+        { "B", 2 },
+        { "C", 3 }
+    };
+
+    static Dictionary<string, FixedPoint2> _input2 = new()
+    {
+        { "A", 1 },
+        { "B", 2 },
+        { "C", 5 },
+        { "D", 0.05f }
+    };
+
+    static Dictionary<string, FixedPoint2> _output1 = new()
+    {
+        { "A", -1.5f },
+        { "B", -2 },
+        { "C", -3 }
+    };
+
+    static Dictionary<string, FixedPoint2> _output2 = new()
+    {
+        { "A", 0.75f },
+        { "B", 1 },
+        { "C", 1.5 }
+    };
+
+    static Dictionary<string, FixedPoint2> _output3 = new()
+    {
+        { "A", 3f },
+        { "B", 4 },
+        { "C", 6 }
+    };
+
+    static Dictionary<string, FixedPoint2> _output4 = new()
+    {
+        { "A", 0.5f },
+        { "B", 0 },
+        { "C", -2 },
+        { "D", -0.05f }
+    };
+
+    static Dictionary<string, FixedPoint2> _output5 = new()
+    {
+        { "A", 0.25f },
+        { "B", 0 },
+        { "C", -0.25f },
+        { "D", -0.05f }
+    };
+}

--- a/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
@@ -51,9 +51,6 @@ namespace Content.Server.Atmos.EntitySystems
             }
 
             SetAirblocked(airtight, false, xform);
-
-            InvalidatePosition(airtight.LastPosition.Item1, airtight.LastPosition.Item2, airtight.FixVacuum);
-            RaiseLocalEvent(new AirtightChanged(airtight));
         }
 
         private void OnAirtightPositionChanged(EntityUid uid, AirtightComponent airtight, ref AnchorStateChangedEvent args)

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -22,7 +22,7 @@ namespace Content.Shared.Damage
     ///     functions to apply resistance sets and supports basic math operations to modify this dictionary.
     /// </remarks>
     [DataDefinition]
-    public class DamageSpecifier
+    public class DamageSpecifier : IEquatable<DamageSpecifier>
     {
         [JsonPropertyName("types")]
         [DataField("types", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<FixedPoint2, DamageTypePrototype>))]
@@ -392,7 +392,7 @@ namespace Content.Shared.Damage
 
             foreach (var entry in damageSpecB.DamageDict)
             {
-                if (!newDamage.DamageDict.TryAdd(entry.Key, entry.Value))
+                if (!newDamage.DamageDict.TryAdd(entry.Key, -entry.Value))
                 {
                     newDamage.DamageDict[entry.Key] -= entry.Value;
                 }
@@ -407,6 +407,20 @@ namespace Content.Shared.Damage
         public static DamageSpecifier operator *(float factor, DamageSpecifier damageSpec) => damageSpec * factor;
 
         public static DamageSpecifier operator *(FixedPoint2 factor, DamageSpecifier damageSpec) => damageSpec * factor;
+
+        public bool Equals(DamageSpecifier? other)
+        {
+            if (other == null || DamageDict.Count != other.DamageDict.Count)
+                return false;
+
+            foreach (var (key, value) in DamageDict)
+            {
+                if (!other.DamageDict.TryGetValue(key, out var otherValue) || value != otherValue)
+                    return false;
+            }
+
+            return true;
+        }
     }
     #endregion
 }

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -384,8 +384,8 @@ namespace Content.Shared.Damage
             return newDamage;
         }
 
-        // Defining subtraction operator explicitly, rather implicitly via X + (-1 * Y) is faster because FixedPoint2
-        // multiplication is somewhat involved.
+        // Here we define the subtraction operator explicitly, rather than implicitly via something like X + (-1 * Y).
+        // This is faster because FixedPoint2 multiplication is somewhat involved.
         public static DamageSpecifier operator -(DamageSpecifier damageSpecA, DamageSpecifier damageSpecB)
         {
             DamageSpecifier newDamage = new(damageSpecA);

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -384,7 +384,8 @@ namespace Content.Shared.Damage
             return newDamage;
         }
 
-        // doing subtraction explicitly, rather than A + (-1 * B) is faster, because FixedPoint2 multiplication is somewhat involved.
+        // Defining subtraction operator explicitly, rather implicitly via X + (-1 * Y) is faster because FixedPoint2
+        // multiplication is somewhat involved.
         public static DamageSpecifier operator -(DamageSpecifier damageSpecA, DamageSpecifier damageSpecB)
         {
             DamageSpecifier newDamage = new(damageSpecA);

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -384,7 +384,20 @@ namespace Content.Shared.Damage
             return newDamage;
         }
 
-        public static DamageSpecifier operator -(DamageSpecifier damageSpecA, DamageSpecifier damageSpecB) => damageSpecA + -damageSpecB;
+        // doing subtraction explicitly, rather than A + (-1 * B) is faster, because FixedPoint2 multiplication is somewhat involved.
+        public static DamageSpecifier operator -(DamageSpecifier damageSpecA, DamageSpecifier damageSpecB)
+        {
+            DamageSpecifier newDamage = new(damageSpecA);
+
+            foreach (var entry in damageSpecB.DamageDict)
+            {
+                if (!newDamage.DamageDict.TryAdd(entry.Key, entry.Value))
+                {
+                    newDamage.DamageDict[entry.Key] -= entry.Value;
+                }
+            }
+            return newDamage;
+        }
 
         public static DamageSpecifier operator +(DamageSpecifier damageSpec) => damageSpec;
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -84,7 +84,7 @@ namespace Content.Shared.Damage
         {
             component.DamagePerGroup = component.Damage.GetDamagePerGroup();
             component.TotalDamage = component.Damage.Total;
-            component.Dirty();
+            Dirty(component);
 
             if (EntityManager.TryGetComponent<AppearanceComponent>(component.Owner, out var appearance) && damageDelta != null)
             {

--- a/Content.Shared/FixedPoint/FixedPoint2.cs
+++ b/Content.Shared/FixedPoint/FixedPoint2.cs
@@ -67,7 +67,7 @@ namespace Content.Shared.FixedPoint
             => new(a._value + b._value);
 
         public static FixedPoint2 operator -(FixedPoint2 a, FixedPoint2 b)
-            => a + -b;
+            => new(a._value - b._value);
 
         public static FixedPoint2 operator *(FixedPoint2 a, FixedPoint2 b)
         {

--- a/Content.Shared/Pulling/Components/PullableComponent.cs
+++ b/Content.Shared/Pulling/Components/PullableComponent.cs
@@ -78,13 +78,6 @@ namespace Content.Shared.Pulling.Components
             EntitySystem.Get<SharedPullingStateManagementSystem>().ForceRelationship(comp, this);
         }
 
-        protected override void Shutdown()
-        {
-            if (Puller != null)
-                EntitySystem.Get<SharedPullingStateManagementSystem>().ForceDisconnectPullable(this);
-            base.Shutdown();
-        }
-
         protected override void OnRemove()
         {
             if (Puller != null)

--- a/Content.Shared/Pulling/Components/PullableComponent.cs
+++ b/Content.Shared/Pulling/Components/PullableComponent.cs
@@ -31,7 +31,7 @@ namespace Content.Shared.Pulling.Components
         /// </summary>
         public DistanceJoint? PullJoint { get; set; }
 
-        public bool BeingPulled => Puller != default;
+        public bool BeingPulled => Puller != null;
 
         public EntityCoordinates? MovingTo { get; set; }
 
@@ -80,13 +80,14 @@ namespace Content.Shared.Pulling.Components
 
         protected override void Shutdown()
         {
-            EntitySystem.Get<SharedPullingStateManagementSystem>().ForceDisconnectPullable(this);
+            if (Puller != null)
+                EntitySystem.Get<SharedPullingStateManagementSystem>().ForceDisconnectPullable(this);
             base.Shutdown();
         }
 
         protected override void OnRemove()
         {
-            if (Puller != default)
+            if (Puller != null)
             {
                 // This is absolute paranoia but it's also absolutely necessary. Too many puller state bugs. - 20kdc
                 Logger.ErrorS("c.go.c.pulling", "PULLING STATE CORRUPTION IMMINENT IN PULLABLE {0} - OnRemove called when Puller is set!", Owner);

--- a/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingStateManagementSystem.cs
@@ -31,6 +31,19 @@ namespace Content.Shared.Pulling
     {
         [Dependency] private readonly SharedJointSystem _jointSystem = default!;
 
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<SharedPullableComponent, ComponentShutdown>(OnShutdown);
+        }
+
+        private void OnShutdown(EntityUid uid, SharedPullableComponent component, ComponentShutdown args)
+        {
+            if (component.Puller != null)
+                ForceRelationship(null, component);
+        }
+
         // A WARNING:
         // The following 2 functions are the most internal part of the pulling system's relationship management.
         // They do not expect to be cancellable.


### PR DESCRIPTION
Misc optimizations that become relevant when deleting / damaging many entities

- Make `OnAirtightShutdown` not call `InvalidatePosition()` and raise the same event twice (already done by `SetAirblocked`).
- Make `DamageSpecifier` subtraction faster
- Damageable `component.Dirty()` -> `Dirty(component)`
- Make pull able shutdown not do unnecessary resolves. Nearly everything on the station is pull able.