### PR TITLE
Reduce atmos system resolves

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPassiveGateSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPassiveGateSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Binary.Components;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.NodeContainer;
@@ -6,12 +7,15 @@ using Content.Server.NodeContainer.Nodes;
 using Content.Shared.Atmos;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 
 namespace Content.Server.Atmos.Piping.Binary.EntitySystems
 {
     [UsedImplicitly]
     public class GasPassiveGateSystem : EntitySystem
     {
+        [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -46,7 +50,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 var transferMoles = pressureDelta * outlet.Air.Volume / (inlet.Air.Temperature * Atmospherics.R);
 
                 // Actually transfer the gas.
-                outlet.AssumeAir(inlet.Air.Remove(transferMoles));
+                _atmosphereSystem.Merge(outlet.Air, inlet.Air.Remove(transferMoles));
             }
         }
     }

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using Content.Server.Administration.Logs;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Binary.Components;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.NodeContainer;
@@ -25,6 +26,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
     {
         [Dependency] private UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private AdminLogSystem _adminLogSystem = default!;
+        [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
 
         public override void Initialize()
         {
@@ -81,7 +83,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 var transferMoles = pressureDelta * outlet.Air.Volume / inlet.Air.Temperature * Atmospherics.R;
 
                 var removed = inlet.Air.Remove(transferMoles);
-                outlet.AssumeAir(removed);
+                _atmosphereSystem.Merge(outlet.Air, removed);
             }
         }
 

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -95,7 +95,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 }
             }
 
-            outlet.AssumeAir(removed);
+            _atmosphereSystem.Merge(outlet.Air, removed);
         }
 
         private void OnPumpInteractHand(EntityUid uid, GasVolumePumpComponent component, InteractHandEvent args)

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using Content.Server.Administration.Logs;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.Atmos.Piping.Trinary.Components;
 using Content.Server.NodeContainer;
@@ -26,6 +27,7 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
         [Dependency] private IGameTiming _gameTiming = default!;
         [Dependency] private UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private AdminLogSystem _adminLogSystem = default!;
+        [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
 
         public override void Initialize()
         {
@@ -76,10 +78,10 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
                 removed.SetMoles(filter.FilteredGas.Value, 0f);
 
                 var target = filterNode.Air.Pressure < Atmospherics.MaxOutputPressure ? filterNode : inletNode;
-                target.AssumeAir(filteredOut);
+                _atmosphereSystem.Merge(target.Air, filteredOut);
             }
 
-            outletNode.AssumeAir(removed);
+            _atmosphereSystem.Merge(outletNode.Air, removed);
         }
 
         private void OnFilterInteractHand(EntityUid uid, GasFilterComponent component, InteractHandEvent args)

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasMixerSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasMixerSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using Content.Server.Administration.Logs;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.Atmos.Piping.Trinary.Components;
 using Content.Server.NodeContainer;
@@ -22,6 +23,7 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
     {
         [Dependency] private UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private AdminLogSystem _adminLogSystem = default!;
+        [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
 
         public override void Initialize()
         {
@@ -98,13 +100,13 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
             if (transferMolesOne > 0f)
             {
                 var removed = inletOne.Air.Remove(transferMolesOne);
-                outlet.AssumeAir(removed);
+                _atmosphereSystem.Merge(outlet.Air, removed);
             }
 
             if (transferMolesTwo > 0f)
             {
                 var removed = inletTwo.Air.Remove(transferMolesTwo);
-                outlet.AssumeAir(removed);
+                _atmosphereSystem.Merge(outlet.Air, removed);
             }
         }
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
@@ -55,7 +55,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                     var transferMoles = (pressureDelta * outputVolume) / (airTemperature * Atmospherics.R);
                     transferMoles = MathF.Min(transferMoles, environment.TotalMoles * inlet.Air.Volume / environment.Volume);
                     var removed = environment.Remove(transferMoles);
-                    inlet.AssumeAir(removed);
+                    _atmosphereSystem.Merge(inlet.Air, removed);
                 }
             }
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -100,7 +100,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 if (molesDelta > 0)
                 {
                     var removed = environment.Remove(molesDelta);
-                    pipe.AssumeAir(removed);
+                    _atmosphereSystem.Merge(pipe.Air, removed);
                 }
             }
         }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -112,7 +112,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
                 var removed = tile.Remove(transferMoles);
 
-                outlet.AssumeAir(removed);
+                _atmosphereSystem.Merge(outlet.Air, removed);
             }
         }
 

--- a/Content.Server/NodeContainer/Nodes/PipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PipeNode.cs
@@ -112,12 +112,6 @@ namespace Content.Server.NodeContainer.Nodes
             }
         }
 
-        public void AssumeAir(GasMixture giver)
-        {
-            if(PipeNet != null)
-                EntitySystem.Get<AtmosphereSystem>().Merge(PipeNet.Air, giver);
-        }
-
         [ViewVariables]
         [DataField("volume")]
         public float Volume { get; set; } = DefaultVolume;


### PR DESCRIPTION
Currently every atmos pipe net device that moves air around will call `EntitySystem.Get<AtmosphereSystem>()`. This stops that. Spun off from #6435.