### PR TITLE
Global usings

### DIFF
--- a/Content.Client/GlobalUsings.cs
+++ b/Content.Client/GlobalUsings.cs
@@ -1,7 +1,12 @@
 ﻿// Global usings for Content.Client
 
+global using System;
+global using System.Collections.Generic;
+global using Robust.Shared.Analyzers;
 global using Robust.Shared.Log;
+global using Robust.Shared.Localization;
 global using Robust.Shared.GameObjects;
 global using Robust.Shared.IoC;
+global using Robust.Shared.Maths;
 global using Robust.Shared.ViewVariables;
 global using Robust.Shared.Serialization.Manager.Attributes;

--- a/Content.Server/GlobalUsings.cs
+++ b/Content.Server/GlobalUsings.cs
@@ -1,7 +1,12 @@
 ﻿// Global usings for Content.Server
 
+global using System;
+global using System.Collections.Generic;
+global using Robust.Shared.Analyzers;
 global using Robust.Shared.Log;
+global using Robust.Shared.Localization;
 global using Robust.Shared.GameObjects;
 global using Robust.Shared.IoC;
+global using Robust.Shared.Maths;
 global using Robust.Shared.ViewVariables;
 global using Robust.Shared.Serialization.Manager.Attributes;

--- a/Content.Shared/GlobalUsings.cs
+++ b/Content.Shared/GlobalUsings.cs
@@ -1,9 +1,15 @@
 ﻿// There isn't really a 'default place' to put these,
 // so a file in the project top level directory it is
 
+global using System;
+global using System.Collections.Generic;
+global using Robust.Shared.Analyzers;
 global using Robust.Shared.Log;
+global using Robust.Shared.Localization;
 global using Robust.Shared.GameObjects;
 global using Robust.Shared.IoC;
+global using Robust.Shared.Maths;
 global using Robust.Shared.ViewVariables;
 global using Robust.Shared.Serialization.Manager.Attributes;
+
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

These are project-specific so it has to be duplicated across client/shared/server sadly.

Impetus behind each choice:

`Robust.Shared.Log` - It's so easy to import the fluidsynth logger by accident or something, just really annoying to import it
`Robust.Shared.GameObjects` - No more importing component/entitysystem or basic stuff like that, very very common import
`Robust.Shared.IoC` - Another very common import, no more importing DependencyAttribute or accidentally importing the one in System.ComponentModel
`Robust.Shared.ViewVariables` - Commonly used, can't really clash with anything else
`Robust.Shared.Serialization.Manager.Attributes` - Listen man I just hate having to import these fucking attributes that I'm always going to use and which don't conflict with anything

Can take feedback on which more to add