### PR TITLE
Make windoors not crush people

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -73,9 +73,6 @@
   - type: Door
     canCrush: false
     weldable: false
-    crushDamage:
-      types:
-        Blunt: 10
     openSound:
       path: /Audio/Machines/windoor_open.ogg
     closeSound:


### PR DESCRIPTION
See the comment a couple of lines above the changed line. Either safety needs to be re-enabled or windoors need to have their motor strength reduced.

:cl:
- fix: Windoors should no longer crush people as they auto close.

