### PR TITLE
Makes brig access not an exact copy of armory and gives it to lawyers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -34,7 +34,7 @@
   components:
   - type: AccessReader
     access: [["Medical"]]
-    
+
 - type: entity
   parent: WindoorSecure
   id: WindoorChemistryLocked
@@ -78,7 +78,7 @@
     access: [["Security"]]
   - type: Wires
     LayoutId: WindoorSecurity
-    
+
 - type: entity
   parent: WindoorSecurityLocked
   id: WindoorBrigLocked
@@ -86,7 +86,15 @@
   components:
   - type: AccessReader
     access: [["Brig"]]
-    
+
+- type: entity
+  parent: WindoorSecurityLocked
+  id: WindoorArmoryLocked
+  suffix: Armory, Locked
+  components:
+  - type: AccessReader
+    access: [["Armory"]]
+
 - type: entity
   parent: WindoorSecure
   id: WindoorEngineeringLocked
@@ -94,7 +102,7 @@
   components:
   - type: AccessReader
     access: [["Engineering"]]
-    
+
 - type: entity
   parent: WindoorSecure
   id: WindoorChapelLocked
@@ -102,7 +110,7 @@
   components:
   - type: AccessReader
     access: [["Chapel"]]
-    
+
 - type: entity
   parent: WindoorSecure
   id: WindoorJanitorLocked
@@ -110,7 +118,7 @@
   components:
   - type: AccessReader
     access: [["Janitor"]]
-    
+
 - type: entity
   parent: WindoorSecure
   id: WindoorKitchenLocked

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -32,7 +32,7 @@
       state_open: qm_open
       state_closed: qm_door
   - type: AccessReader
-    access: [["Quartermaster"]] 
+    access: [["Quartermaster"]]
 
 # Command
 - type: entity
@@ -286,7 +286,7 @@
       state_open: warden_open
       state_closed: warden_door
   - type: AccessReader
-    access: [["Brig"]]
+    access: [["Armory"]]
 
 # Security Officer
 - type: entity

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -8,6 +8,7 @@
   supervisors: "the head of personnel"
   access:
   - Service
+  - Brig
   - Maintenance
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -9,6 +9,7 @@
   canBeAntag: false
   access:
   - Security
+  - Brig
   - Maintenance
   - Service
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Brig access was functionally identical to armory access and served no purpose, so I made it work like /tg/ brig access. It lets people enter sec but not interact with any cells or equipment (when mapped properly.) The changes are such that it shouldn't lead to any differences in current maps. Lawyers will be just as screwed over as before until maps update manually.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Brig access is now the least privileged form of security access and given to lawyers. It may take a while for stations to update their airlock software to the latest version.
