### PR TITLE
Adjust logs for physics-damage

### DIFF
--- a/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
@@ -1,17 +1,9 @@
-using System;
-using Content.Server.Administration.Logs;
 using Content.Server.Damage.Components;
 using Content.Server.Stunnable;
-using Content.Server.Stunnable.Components;
-using Content.Shared.Administration.Logs;
 using Content.Shared.Audio;
 using Content.Shared.Damage;
-using Content.Shared.Database;
-using Content.Shared.Stunnable;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
@@ -26,7 +18,6 @@ namespace Content.Server.Damage.Systems
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly DamageableSystem _damageableSystem = default!;
         [Dependency] private readonly StunSystem _stunSystem = default!;
-        [Dependency] private readonly AdminLogSystem _logSystem = default!;
 
         public override void Initialize()
         {
@@ -55,10 +46,7 @@ namespace Content.Server.Damage.Systems
 
             var damageScale = (speed / component.MinimumSpeed) * component.Factor;
 
-            var dmg = _damageableSystem.TryChangeDamage(uid, component.Damage * damageScale);
-
-            if (dmg != null)
-                _logSystem.Add(LogType.Damaged, $"{ToPrettyString(component.Owner):entity} took {dmg.Total:damage} damage from a high speed collision");
+            _damageableSystem.TryChangeDamage(uid, component.Damage * damageScale);
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOnLandSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnLandSystem.cs
@@ -1,18 +1,12 @@
-using Content.Server.Administration.Logs;
 using Content.Server.Damage.Components;
-using Content.Shared.Administration.Logs;
 using Content.Shared.Damage;
-using Content.Shared.Database;
 using Content.Shared.Throwing;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 
 namespace Content.Server.Damage.Systems
 {
     public sealed class DamageOnLandSystem : EntitySystem
     {
         [Dependency] private readonly DamageableSystem _damageableSystem = default!;
-        [Dependency] private readonly AdminLogSystem _logSystem = default!;
 
         public override void Initialize()
         {
@@ -22,11 +16,7 @@ namespace Content.Server.Damage.Systems
 
         private void DamageOnLand(EntityUid uid, DamageOnLandComponent component, LandEvent args)
         {
-            var dmg = _damageableSystem.TryChangeDamage(uid, component.Damage, component.IgnoreResistances);
-            if (dmg == null)
-                return;
-
-            _logSystem.Add(LogType.Landed, $"{ToPrettyString(component.Owner):entity} received {dmg.Total:damage} damage from landing");
+            _damageableSystem.TryChangeDamage(uid, component.Damage, component.IgnoreResistances);
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -1,11 +1,9 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Damage.Components;
-using Content.Shared.Administration.Logs;
 using Content.Shared.Damage;
 using Content.Shared.Database;
+using Content.Shared.MobState.Components;
 using Content.Shared.Throwing;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 
 namespace Content.Server.Damage.Systems
 {
@@ -22,7 +20,9 @@ namespace Content.Server.Damage.Systems
         private void OnDoHit(EntityUid uid, DamageOtherOnHitComponent component, ThrowDoHitEvent args)
         {
             var dmg = _damageableSystem.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances);
-            if (dmg != null)
+
+            // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
+            if (dmg != null && HasComp<MobStateComponent>(args.Target))
                 _logSystem.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total:damage} damage from collision");
         }
     }


### PR DESCRIPTION
Removes logs from `DamageOnHighSpeedImpact` and `DamageOnLand`, as these rarely affect players. Makes `DamageOtherOnHit` only log if the target is a mob.

If people want to keep the logs verbose, there should probably be some sort of way of temporarily disabling some log types, because explosions that send a large number of entities flying can easily generate 500+ logs in a couple of ticks.