### PR TITLE
Uplink price rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -118,8 +118,7 @@
   listingName: Holoparasite Kit
   description: The pride and joy of Cybersun. Contains an injector that hosts a sentient metaphysical guardian made of hard light which resides in the user's body when not active. The guardian can punch rapidly and is immune to hazardous environments and bullets, but shares any damage it takes with the user.
   icon: /Textures/Objects/Misc/guardian_info.rsi/icon.png
-  price: 16
-
+  price: 14
 
 # Bundles
 
@@ -127,29 +126,29 @@
   id: UplinkC20RBundle
   category: Bundles
   itemId: ClothingBackpackDuffelSyndicateFilledSMG
-  price: 14
+  price: 25
   icon: /Textures/Objects/Weapons/Guns/SMGs/c20r.rsi/icon.png
 
 - type: uplinkListing
   id: UplinkBojevicBundle
   category: Bundles
   itemId: ClothingBackpackDuffelSyndicateFilledShotgun
-  price: 13
+  price: 25
   icon: /Textures/Objects/Weapons/Guns/Shotguns/bojevic.rsi/icon.png
-
-- type: uplinkListing
-  id: UplinkL6SawBundle
-  category: Bundles
-  itemId: ClothingBackpackDuffelSyndicateFilledLMG
-  price: 18
-  icon: /Textures/Objects/Weapons/Guns/LMGs/l6.rsi/icon.png
 
 - type: uplinkListing
   id: UplinkGrenadeLauncherBundle
   category: Bundles
   itemId: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
-  price: 25
+  price: 30
   icon: /Textures/Objects/Weapons/Guns/Launchers/china_lake.rsi/icon.png
+
+- type: uplinkListing
+  id: UplinkL6SawBundle
+  category: Bundles
+  itemId: ClothingBackpackDuffelSyndicateFilledLMG
+  price: 40
+  icon: /Textures/Objects/Weapons/Guns/LMGs/l6.rsi/icon.png
 
 #- type: uplinkListing
 #  id: UplinkCarbineBundle


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Nukie guns should NOT be purchasable by normal traitors. Horrifically fucks up incentives and makes them essentially the only real option.

Holopara TC price also buffed to 14tc, some people were complaining it cost a bit too much.

:cl:
- tweak: The L6 Saw, C20r, Bojevic, and Grenade Launcher are no longer purchasable without another traitor's help. Do something more creative.
- tweak: Holoparasites cost 14TC down from 16TC.

