### PR TITLE
Make Pillar unvotable until Atmos is fixed.

### DIFF
--- a/Resources/Prototypes/Maps/game.yml
+++ b/Resources/Prototypes/Maps/game.yml
@@ -104,6 +104,7 @@
     !type:NanotrasenNameGenerator
     prefixCreator: '14'
   mapPath: /Maps/nss_pillar.yml
+  votable: false
   minPlayers: 40
   overflowJobs:
     - Assistant


### PR DESCRIPTION
Currently Atmos is configured wrong and the oxygen is drained from the station without 10 minutes.

