### PR TITLE
Fix manual valve

### DIFF
--- a/Content.Server/NodeContainer/Nodes/PipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PipeNode.cs
@@ -40,20 +40,22 @@ namespace Content.Server.NodeContainer.Nodes
 
         public void AddAlwaysReachable(PipeNode pipeNode)
         {
-            if (NodeGroup == null) return;
             if (pipeNode.NodeGroupID != NodeGroupID) return;
             _alwaysReachable ??= new();
             _alwaysReachable.Add(pipeNode);
-            EntitySystem.Get<NodeGroupSystem>().QueueRemakeGroup((BaseNodeGroup) NodeGroup);
+
+            if (NodeGroup != null)
+                EntitySystem.Get<NodeGroupSystem>().QueueRemakeGroup((BaseNodeGroup) NodeGroup);
         }
 
         public void RemoveAlwaysReachable(PipeNode pipeNode)
         {
             if (_alwaysReachable == null) return;
-            if (NodeGroup == null) return;
-            if (pipeNode.NodeGroupID != NodeGroupID) return;
+
             _alwaysReachable.Remove(pipeNode);
-            EntitySystem.Get<NodeGroupSystem>().QueueRemakeGroup((BaseNodeGroup) NodeGroup);
+
+            if (NodeGroup != null)
+                EntitySystem.Get<NodeGroupSystem>().QueueRemakeGroup((BaseNodeGroup) NodeGroup);
         }
 
         /// <summary>


### PR DESCRIPTION
Not sure if it was already like this or if it was broken by #6435, but currently manual valves initialize improperly and need to be toggled on and off to work. This is because the valve gets initialized before the entity is added to a node group. But really `AlwaysReachable` shouldn't require an existing group.
