### PR TITLE
Fix gas mixer visuals

### DIFF
--- a/Content.Server/Atmos/Piping/Trinary/Components/GasMixerComponent.cs
+++ b/Content.Server/Atmos/Piping/Trinary/Components/GasMixerComponent.cs
@@ -1,12 +1,11 @@
+using Content.Server.Atmos.Piping.Trinary.EntitySystems;
 using Content.Shared.Atmos;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Server.Atmos.Piping.Trinary.Components
 {
     [RegisterComponent]
-    public class GasMixerComponent : Component
+    [Friend(typeof(GasMixerSystem))]
+    public sealed class GasMixerComponent : Component
     {
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Enabled = true;

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasMixerSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasMixerSystem.cs
@@ -1,4 +1,3 @@
-using System;
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
@@ -6,20 +5,18 @@ using Content.Server.Atmos.Piping.Trinary.Components;
 using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Shared.Atmos;
+using Content.Shared.Atmos.Piping;
 using Content.Shared.Atmos.Piping.Trinary.Components;
 using Content.Shared.Database;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
 
 namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
 {
     [UsedImplicitly]
-    public class GasMixerSystem : EntitySystem
+    public sealed class GasMixerSystem : EntitySystem
     {
         [Dependency] private UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private AdminLogSystem _adminLogSystem = default!;
@@ -29,12 +26,18 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
         {
             base.Initialize();
 
+            SubscribeLocalEvent<GasMixerComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<GasMixerComponent, AtmosDeviceUpdateEvent>(OnMixerUpdated);
             SubscribeLocalEvent<GasMixerComponent, InteractHandEvent>(OnMixerInteractHand);
             // Bound UI subscriptions
             SubscribeLocalEvent<GasMixerComponent, GasMixerChangeOutputPressureMessage>(OnOutputPressureChangeMessage);
             SubscribeLocalEvent<GasMixerComponent, GasMixerChangeNodePercentageMessage>(OnChangeNodePercentageMessage);
             SubscribeLocalEvent<GasMixerComponent, GasMixerToggleStatusMessage>(OnToggleStatusMessage);
+        }
+
+        private void OnInit(EntityUid uid, GasMixerComponent component, ComponentInit args)
+        {
+            UpdateAppearance(uid, component);
         }
 
         private void OnMixerUpdated(EntityUid uid, GasMixerComponent mixer, AtmosDeviceUpdateEvent args)
@@ -137,12 +140,21 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
                 new GasMixerBoundUserInterfaceState(EntityManager.GetComponent<MetaDataComponent>(mixer.Owner).EntityName, mixer.TargetPressure, mixer.Enabled, mixer.InletOneConcentration));
         }
 
+        private void UpdateAppearance(EntityUid uid, GasMixerComponent? mixer = null, AppearanceComponent? appearance = null)
+        {
+            if (!Resolve(uid, ref mixer, ref appearance, false))
+                return;
+
+            appearance.SetData(FilterVisuals.Enabled, mixer.Enabled);
+        }
+
         private void OnToggleStatusMessage(EntityUid uid, GasMixerComponent mixer, GasMixerToggleStatusMessage args)
         {
             mixer.Enabled = args.Enabled;
             _adminLogSystem.Add(LogType.AtmosPowerChanged, LogImpact.Medium,
                 $"{ToPrettyString(args.Session.AttachedEntity!.Value):player} set the power on {ToPrettyString(uid):device} to {args.Enabled}");
             DirtyUI(uid, mixer);
+            UpdateAppearance(uid, mixer);
         }
 
         private void OnOutputPressureChangeMessage(EntityUid uid, GasMixerComponent mixer, GasMixerChangeOutputPressureMessage args)

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -116,12 +116,15 @@
           rotation: -90
           map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
         - state: gasMixer
-          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer" ]
+          map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer", "enum.GasFilterVisualizer+Layers.Enabled" ]
     - type: Appearance
       visuals:
         - type: SubFloorShowLayerVisualizer
         - type: PipeConnectorVisualizer
         - type: PipeColorVisualizer
+        - type: GasFilterVisualizer
+          disabledState: gasMixer
+          enabledState: gasMixerOn
     - type: UserInterface
       interfaces:
         - key: enum.GasMixerUiKey.Key
@@ -150,6 +153,14 @@
       map: [ "enum.PipeColorVisualizer+Layers.Pipe" ]
     - state: gasMixerF
       map: [ "enum.SubFloorShowLayerVisualizer+Layers.FirstLayer", "enum.GasFilterVisualizer+Layers.Enabled" ]
+  - type: Appearance
+    visuals:
+    - type: SubFloorShowLayerVisualizer
+    - type: PipeConnectorVisualizer
+    - type: PipeColorVisualizer
+    - type: GasFilterVisualizer
+      disabledState: gasMixerF
+      enabledState: gasMixerFOn
   - type: Flippable
     mirrorEntity: GasMixer
   - type: NodeContainer


### PR DESCRIPTION
The gas mixers RSI has an animation for when its on, and filters already use theirs. This just makes a couple of minor edits so that mixers also animate when on by re-using the filter visualizer.

https://user-images.githubusercontent.com/60421075/152823157-86d42596-bb7a-4638-81eb-a4a5c471ab08.mp4

:cl:
- fix: Gas mixers now properly animate when on. 

