### PR TITLE
Fix windoor deconstruction

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -151,7 +151,9 @@ public sealed class DoorSystem : SharedDoorSystem
         RaiseLocalEvent(target, canEv, false);
 
         if (canEv.Cancelled)
-            return true; // true, as airlock component will cancel after generating a pop-up.
+            // mark handled, as airlock component will cancel after generating a pop-up & you don't want to pry a tile
+            // under a windoor.
+            return true; 
 
         var modEv = new DoorGetPryTimeModifierEvent();
         RaiseLocalEvent(target, modEv, false);

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -5,7 +5,6 @@ using Content.Server.Construction;
 using Content.Server.Construction.Components;
 using Content.Server.Tools;
 using Content.Server.Tools.Components;
-using Content.Server.Doors.Components;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Doors;
@@ -15,8 +14,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Tag;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Player;
 using System.Linq;
@@ -154,7 +151,7 @@ public sealed class DoorSystem : SharedDoorSystem
         RaiseLocalEvent(target, canEv, false);
 
         if (canEv.Cancelled)
-            return false;
+            return true; // true, as airlock component will cancel after generating a pop-up.
 
         var modEv = new DoorGetPryTimeModifierEvent();
         RaiseLocalEvent(target, modEv, false);
@@ -293,19 +290,16 @@ public sealed class DoorSystem : SharedDoorSystem
 
         var container = uid.EnsureContainer<Container>("board", out var existed);
 
-        /* // TODO ShadowCommander: Re-enable when access is added to boards. Requires map update.
-           if (existed)
-           {
-        // We already contain a board. Note: We don't check if it's the right one!
-        if (container.ContainedEntities.Count != 0)
-        return;
+        if (existed & container.ContainedEntities.Count != 0)
+        {
+            // We already contain a board. Note: We don't check if it's the right one!
+            return;
         }
 
-        var board = Owner.EntityManager.SpawnEntity(_boardPrototype, Owner.Transform.Coordinates);
+        var board = EntityManager.SpawnEntity(door.BoardPrototype, Transform(uid).Coordinates);
 
         if(!container.Insert(board))
-        Logger.Warning($"Couldn't insert board {board} into door {Owner}!");
-        */
+            Logger.Warning($"Couldn't insert board {ToPrettyString(board)} into door {ToPrettyString(uid)}!");
     }
 }
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -76,6 +76,7 @@
   - type: Door
     canCrush: false
     weldable: false
+    board: DoorElectronics
     openSound:
       path: /Audio/Machines/windoor_open.ogg
     closeSound:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -76,32 +76,17 @@
     - node: airlock
       entity: Airlock
       edges:
-        - to: wired
+        - to: wired #TODO DOOR ELECTRONICS. If door electronics ever govern access permissions, this step should probably be further down? It makes it too easy to swap permissions around. See also windoor.
           conditions:
             - !type:EntityAnchored {}
             - !type:DoorWelded {}
             - !type:AirlockBolted
               value: false
             - !type:WirePanel {}
-            - !type:ContainerNotEmpty # TODO ShadowCommander: Remove when map gets updated
+            - !type:ContainerNotEmpty
               container: board
           completed:
             - !type:EmptyAllContainers {}
-          steps:
-            - tool: Prying
-              doAfter: 5
-        - to: wired # TODO ShadowCommander: Remove when board spawning is implemented in ServerDoorComponent.cs. Needs a map update.
-          conditions:
-            - !type:EntityAnchored {}
-            - !type:DoorWelded {}
-            - !type:AirlockBolted
-              value: false
-            - !type:WirePanel {}
-            - !type:ContainerEmpty
-              container: board
-          completed:
-            - !type:SpawnPrototype
-              prototype: DoorElectronics
           steps:
             - tool: Prying
               doAfter: 5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -83,8 +83,6 @@
             - !type:AirlockBolted
               value: false
             - !type:WirePanel {}
-            - !type:ContainerNotEmpty
-              container: board
           completed:
             - !type:EmptyAllContainers {}
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
@@ -112,8 +112,6 @@
       - !type:AirlockBolted
         value: false
       - !type:WirePanel {}
-      - !type:ContainerNotEmpty # TODO ShadowCommander: Remove when map gets updated
-        container: board
       completed:
       - !type:EmptyAllContainers {}
       steps:


### PR DESCRIPTION
Door & windoor construction require you to add door electronics. But for some reason I'm not sure of, doors & windoors don't start with door electronics (@ShadowCommander)? They don't currently serve a purpose outside of construction, but for that reason alone they should at least be spaned into doors.

Doors had a workaround with a separate deconstruction step that would spawn in door electronics when deconstructed with an empty container, windoors didn't have this. The result was that you could only deconstruct windoors that were constructed by players instead of spawned in.

This just makes doors start with door electronics and removes the deconstruct workaround.

:cl:
- fix: Fixed being unable to deconstruct windoors.

