### PR TITLE
Adds trash tag to more trash items

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -575,6 +575,9 @@
     pieces: 1
   - type: ReplacementAccent
     accent: mouse
+  - type: Tag
+    tags:
+    - Trash
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
@@ -47,12 +47,15 @@
   name: broken plate
   parent: BaseItem
   id: FoodPlateTrash
-  description: A large plate, broken and useless.
+  description: A broken plate. Useless.
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi
     state: plate-trash
     netsync: false
+  - type: Tag
+    tags:
+    - Trash
 
 # Small Plate
 
@@ -84,10 +87,8 @@
         acts: [ "Destruction" ]
 
 - type: entity
-  name: broken plate
-  parent: BaseItem
+  parent: FoodPlateTrash
   id: FoodPlateSmallTrash
-  description: A broken plate. Useless.
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
@@ -2101,9 +2101,12 @@
           Quantity: 30
   - type: Sprite
     sprite: Objects/Consumable/Drinks/ramen.rsi
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
-  parent: DrinkGlassBase
+  parent: DrinkRamen
   id: DrinkHellRamen
   name: hell ramen
   description: Just add 10ml water, self heats! Super spicy flavor.
@@ -2117,5 +2120,4 @@
           Quantity: 30
         - ReagentId: CapsaicinOil
           Quantity: 5
-  - type: Sprite
-    sprite: Objects/Consumable/Drinks/ramen.rsi
+          

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -9,6 +9,7 @@
     tags:
     - Write
     - Crayon
+    - Trash
   - type: UserInterface
     interfaces:
     - key: enum.CrayonUiKey.Key
@@ -36,6 +37,7 @@
     - Write
     - Crayon
     - CrayonWhite
+    - Trash
 
 - type: entity
   parent: Crayon
@@ -57,6 +59,7 @@
     - Write
     - Crayon
     - CrayonWhite
+    - Trash
 
 - type: entity
   parent: Crayon
@@ -78,6 +81,7 @@
     - Write
     - Crayon
     - CrayonBlack
+    - Trash
 
 - type: entity
   parent: Crayon
@@ -99,6 +103,7 @@
     - Write
     - Crayon
     - CrayonRed
+    - Trash
 
 - type: entity
   parent: Crayon
@@ -120,6 +125,7 @@
     - Write
     - Crayon
     - CrayonOrange
+    - Trash
 
 - type: entity
   parent: Crayon
@@ -141,6 +147,7 @@
     - Write
     - Crayon
     - CrayonYellow
+    - Trash
 
 - type: entity
   parent: Crayon
@@ -162,6 +169,7 @@
     - Write
     - Crayon
     - CrayonGreen
+    - Trash
 
 - type: entity
   parent: Crayon
@@ -183,6 +191,7 @@
     - Write
     - Crayon
     - CrayonBlue
+    - Trash
 
 - type: entity
   parent: Crayon
@@ -204,6 +213,7 @@
     - Write
     - Crayon
     - CrayonPurple
+    - Trash
 
 - type: entity
   parent: BoxCardboard

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -49,6 +49,9 @@
       maxFillLevels: 1
       changeColor: false
       emptySpriteName: medipen_empty
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   name: epinephrine medipen


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
By player request, trashbag didn't pick up a bunch of items which it probably should do which includes:

- Broken Plates
- Crayons
- Spent Epipens (Can't differentiate this so it just picks up all medipens)
- Ramen Cups
- Mice (again meant to be dead but why not alive I guess, seems natural).

Also made minor changes to ramen cup and plates so they parent the default item of both. Cuts down on a tiny amount of duplicate lines.

Excuse the browser PRs today. At work so getting through the backlog of tiny basic PRs.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: More things now fit in the trashbag! Crayons, medipens, mice, broken plates and ramen cups.

