### PR TITLE
command decal color

### DIFF
--- a/Resources/Prototypes/Palettes/departmental.yml
+++ b/Resources/Prototypes/Palettes/departmental.yml
@@ -2,7 +2,8 @@
   id: Departmental
   name: Departmental
   colors:
-    command: "#52B4E996"
+    command: "#334E6DC8"
+    medical: "#52B4E996"
     service: "#9FED5896"
     engineering: "#EFB34196"
     security: "#DE3A3A96"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

I was told to do this. If this doesn't jive with players or maintainers, feel free to nuke this PR. Totally using this color on my map either way. The color is the same as the command doors/captain's locker. I raised the alpha from 150 to 200 because the 150 all the rest were set to was pretty meh.

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
![image](https://user-images.githubusercontent.com/95458399/153239273-144baf66-cd98-4d8a-b372-5e3542d25fdd.png)

![image](https://user-images.githubusercontent.com/95458399/153239402-bc1c823a-f00b-491e-8845-38e79e0a61f9.png)
this shot is at full 255 alpha to show the color match.

<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: command decal color to departmental pallette


