### PR TITLE
Reduce verb menu pop-in / rearranging

### DIFF
--- a/Content.Client/Pointing/Components/PointingArrowComponent.cs
+++ b/Content.Client/Pointing/Components/PointingArrowComponent.cs
@@ -1,13 +1,12 @@
-﻿using Content.Shared.Pointing.Components;
+using Content.Shared.Pointing.Components;
 using Robust.Client.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
 
 namespace Content.Client.Pointing.Components
 {
     [RegisterComponent]
-    public class PointingArrowComponent : SharedPointingArrowComponent
+    [ComponentReference(typeof(SharedPointingArrowComponent))]
+    public sealed class PointingArrowComponent : SharedPointingArrowComponent
     {
         protected override void Startup()
         {

--- a/Content.Client/Pointing/PointingSystem.cs
+++ b/Content.Client/Pointing/PointingSystem.cs
@@ -1,0 +1,47 @@
+using Content.Client.Pointing.Components;
+using Content.Shared.MobState.Components;
+using Content.Shared.Pointing;
+using Content.Shared.Verbs;
+
+namespace Content.Client.Pointing;
+
+internal sealed class PointingSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddPointingVerb);
+    }
+
+    private void AddPointingVerb(GetVerbsEvent<Verb> args)
+    {
+        // Really this could probably be a properly predicted event, but that requires reworking pointing. For now
+        // I'm just adding this verb exclusively to clients so that the verb-loading pop-in on the verb menu isn't
+        // as bad. Important for this verb seeing as its usually an option on just about any entity.
+
+        if (HasComp<PointingArrowComponent>(args.Target))
+        {
+            // this is a pointing arrow. no pointing here...
+            return;
+        }
+
+        // Can the user point? Checking mob state directly instead of some action blocker, as many action blockers are blocked for
+        // ghosts and there is no obvious choice for pointing (unless ghosts CanEmote?).
+        if (TryComp(args.User, out MobStateComponent? mob) && mob.IsIncapacitated())
+            return;
+
+        // We won't check in range or visibility, as this verb is currently only executable via the context menu,
+        // and that should already have checked that, as well as handling the FOV-toggle stuff.
+
+        Verb verb = new()
+        {
+            Text = Loc.GetString("pointing-verb-get-data-text"),
+            IconTexture = "/Textures/Interface/VerbIcons/point.svg.192dpi.png",
+            ClientExclusive = true,
+            Act = () => RaiseNetworkEvent(new PointingAttemptEvent(args.Target))
+        };
+
+        args.Verbs.Add(verb);
+    }
+}

--- a/Content.Client/Verbs/UI/VerbMenuPresenter.cs
+++ b/Content.Client/Verbs/UI/VerbMenuPresenter.cs
@@ -54,13 +54,17 @@ namespace Content.Client.Verbs.UI
             CurrentTarget = target;
             CurrentVerbs = _verbSystem.GetVerbs(target, user, Verb.VerbTypes, force);
 
+            // Fill in client-side verbs.
+            FillVerbPopup();
+
+            // Add indicator that some verbs may be missing.
+            // I long for the day when verbs will all be predicted and this becomes unnecessary.
             if (!target.IsClientSide())
             {
                 AddElement(RootMenu, new ContextMenuElement(Loc.GetString("verb-system-waiting-on-server-text")));
             }
 
             // Show the menu
-            FillVerbPopup();
             RootMenu.SetPositionLast();
             var box = UIBox2.FromDimensions(_userInterfaceManager.MousePositionScaled.Position, (1, 1));
             RootMenu.Open(box);

--- a/Content.Server/Pointing/Components/PointingArrowComponent.cs
+++ b/Content.Server/Pointing/Components/PointingArrowComponent.cs
@@ -1,15 +1,12 @@
-﻿using Content.Shared.Pointing.Components;
+using Content.Shared.Pointing.Components;
 using Robust.Server.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
 
 namespace Content.Server.Pointing.Components
 {
     [RegisterComponent]
-    public class PointingArrowComponent : SharedPointingArrowComponent
+    [ComponentReference(typeof(SharedPointingArrowComponent))]
+    public sealed class PointingArrowComponent : SharedPointingArrowComponent
     {
         [Dependency] private readonly IEntityManager _entMan = default!;
 

--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Input;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Helpers;
 using Content.Shared.MobState.Components;
+using Content.Shared.Pointing;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
@@ -194,7 +195,7 @@ namespace Content.Server.Pointing.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddPointingVerb);
+            SubscribeNetworkEvent<PointingAttemptEvent>(OnPointAttempt);
 
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
 
@@ -203,26 +204,9 @@ namespace Content.Server.Pointing.EntitySystems
                 .Register<PointingSystem>();
         }
 
-        private void AddPointingVerb(GetVerbsEvent<Verb> args)
+        private void OnPointAttempt(PointingAttemptEvent ev, EntitySessionEventArgs args)
         {
-            if (args.Hands == null)
-                return;
-
-            //Check if the object is already being pointed at
-            if (HasComp<PointingArrowComponent>(args.Target))
-                return;
-
-            var transform = Transform(args.Target);
-
-            if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor)  ||
-                !InRange(args.User, transform.Coordinates))
-                return;
-
-            Verb verb = new();
-            verb.Text = Loc.GetString("pointing-verb-get-data-text");
-            verb.IconTexture = "/Textures/Interface/VerbIcons/point.svg.192dpi.png";
-            verb.Act = () => TryPoint(actor.PlayerSession, transform.Coordinates, args.Target);
-            args.Verbs.Add(verb);
+            TryPoint(args.SenderSession, Transform(ev.Target).Coordinates, ev.Target);
         }
 
         public override void Shutdown()

--- a/Content.Shared/Pointing/Components/SharedPointingArrowComponent.cs
+++ b/Content.Shared/Pointing/Components/SharedPointingArrowComponent.cs
@@ -1,8 +1,5 @@
-﻿using Robust.Shared.GameObjects;
+namespace Content.Shared.Pointing.Components;
 
-namespace Content.Shared.Pointing.Components
+public abstract class SharedPointingArrowComponent : Component
 {
-    public class SharedPointingArrowComponent : Component
-    {
-    }
 }

--- a/Content.Shared/Pointing/PointingEvents.cs
+++ b/Content.Shared/Pointing/PointingEvents.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Pointing;
+
+// TODO just make pointing properly predicted?
+/// <summary>
+///     Event raised when someone runs the client-side pointing verb.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class PointingAttemptEvent : EntityEventArgs
+{
+    public EntityUid Target;
+
+    public PointingAttemptEvent(EntityUid target)
+    {
+        Target = target;
+    }
+}


### PR DESCRIPTION
Currently opening the verb-menu with some network latency is annoying because the verbs all move around when the client receives the server's verbs. This can lead to misclicks.

This PR alleviates the problem by:
- Moving the "Waiting on server" to the BOTTOM instead of the top of the list
	- Previously this basically guaranteed that all verbs would jump around
- Making the point-at verb a client-side verb. Just about every target entity has this as a valid verb, so this helps a bit.

Pop-in/rearranging still happens due to some server-exclusive verbs (e.g., toggle light on the PDA or admin verbs), but this significantly improves it.
