### PR TITLE
Make more network-events check EntitySessionEventArgs.

### DIFF
--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -256,7 +256,7 @@ namespace Content.Client.Inventory
                                 if (e.Function != EngineKeyFunctions.UIClick &&
                                     e.Function != ContentKeyFunctions.ActivateItemInWorld)
                                     return;
-                                RaiseNetworkEvent(new OpenSlotStorageNetworkMessage(entityUid, definition.Name));
+                                RaiseNetworkEvent(new OpenSlotStorageNetworkMessage(definition.Name));
                             }
                         };
                         btn.OnHover = (_) =>

--- a/Content.Client/Tabletop/TabletopSystem.cs
+++ b/Content.Client/Tabletop/TabletopSystem.cs
@@ -225,7 +225,7 @@ namespace Content.Client.Tabletop
         /// <param name="viewport">The viewport in which we are dragging.</param>
         private void StartDragging(EntityUid draggedEntity, ScalingViewport viewport)
         {
-            RaiseNetworkEvent(new TabletopDraggingPlayerChangedEvent(draggedEntity, _playerManager.LocalPlayer?.UserId));
+            RaiseNetworkEvent(new TabletopDraggingPlayerChangedEvent(draggedEntity, true));
 
             if (EntityManager.TryGetComponent<AppearanceComponent>(draggedEntity, out var appearance))
             {
@@ -246,7 +246,7 @@ namespace Content.Client.Tabletop
             // Set the dragging player on the component to noone
             if (broadcast && _draggedEntity != null && EntityManager.HasComponent<TabletopDraggableComponent>(_draggedEntity.Value))
             {
-                RaiseNetworkEvent(new TabletopDraggingPlayerChangedEvent(_draggedEntity.Value, null));
+                RaiseNetworkEvent(new TabletopDraggingPlayerChangedEvent(_draggedEntity.Value, false));
             }
 
             _draggedEntity = null;

--- a/Content.Server/Inventory/ServerInventorySystem.cs
+++ b/Content.Server/Inventory/ServerInventorySystem.cs
@@ -7,7 +7,7 @@ using InventoryComponent = Content.Shared.Inventory.InventoryComponent;
 
 namespace Content.Server.Inventory
 {
-    class ServerInventorySystem : InventorySystem
+    sealed class ServerInventorySystem : InventorySystem
     {
         public override void Initialize()
         {
@@ -20,11 +20,14 @@ namespace Content.Server.Inventory
             SubscribeNetworkEvent<OpenSlotStorageNetworkMessage>(OnOpenSlotStorage);
         }
 
-        private void OnOpenSlotStorage(OpenSlotStorageNetworkMessage ev)
+        private void OnOpenSlotStorage(OpenSlotStorageNetworkMessage ev, EntitySessionEventArgs args)
         {
-            if (TryGetSlotEntity(ev.Uid, ev.Slot, out var entityUid) && TryComp<ServerStorageComponent>(entityUid, out var storageComponent))
+            if (args.SenderSession.AttachedEntity is not EntityUid { Valid: true } uid)
+                    return;
+
+            if (TryGetSlotEntity(uid, ev.Slot, out var entityUid) && TryComp<ServerStorageComponent>(entityUid, out var storageComponent))
             {
-                storageComponent.OpenStorageUI(ev.Uid);
+                storageComponent.OpenStorageUI(uid);
             }
         }
     }

--- a/Content.Server/Tabletop/TabletopSystem.Draggable.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Draggable.cs
@@ -56,13 +56,13 @@ namespace Content.Server.Tabletop
             transform.Coordinates = entityCoordinates;
         }
 
-        private void OnDraggingPlayerChanged(TabletopDraggingPlayerChangedEvent msg)
+        private void OnDraggingPlayerChanged(TabletopDraggingPlayerChangedEvent msg, EntitySessionEventArgs args)
         {
             var dragged = msg.DraggedEntityUid;
 
             if (!EntityManager.TryGetComponent<TabletopDraggableComponent?>(dragged, out var draggableComponent)) return;
 
-            draggableComponent.DraggingPlayer = msg.DraggingPlayer;
+            draggableComponent.DraggingPlayer = msg.IsDragging ? args.SenderSession.UserId : null;
 
             if (!EntityManager.TryGetComponent<AppearanceComponent?>(dragged, out var appearance)) return;
 

--- a/Content.Shared/Inventory/Events/OpenSlotStorageNetworkMessage.cs
+++ b/Content.Shared/Inventory/Events/OpenSlotStorageNetworkMessage.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Inventory.Events;
 
 [NetSerializable, Serializable]
-public class OpenSlotStorageNetworkMessage : EntityEventArgs
+public sealed class OpenSlotStorageNetworkMessage : EntityEventArgs
 {
-    public readonly EntityUid Uid;
     public readonly string Slot;
 
-    public OpenSlotStorageNetworkMessage(EntityUid uid, string slot)
+    public OpenSlotStorageNetworkMessage(string slot)
     {
-        Uid = uid;
         Slot = slot;
     }
 }

--- a/Content.Shared/Tabletop/Events/TabletopDraggingPlayerChangedEvent.cs
+++ b/Content.Shared/Tabletop/Events/TabletopDraggingPlayerChangedEvent.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Tabletop.Events
@@ -10,22 +7,19 @@ namespace Content.Shared.Tabletop.Events
     /// trying to move a single item at the same time.
     /// </summary>
     [Serializable, NetSerializable]
-    public class TabletopDraggingPlayerChangedEvent : EntityEventArgs
+    public sealed class TabletopDraggingPlayerChangedEvent : EntityEventArgs
     {
         /// <summary>
         /// The UID of the entity being dragged.
         /// </summary>
         public EntityUid DraggedEntityUid;
 
-        /// <summary>
-        /// The NetUserID of the player that is now dragging the item.
-        /// </summary>
-        public NetUserId? DraggingPlayer;
+        public bool IsDragging;
 
-        public TabletopDraggingPlayerChangedEvent(EntityUid draggedEntityUid, NetUserId? draggingPlayer)
+        public TabletopDraggingPlayerChangedEvent(EntityUid draggedEntityUid, bool isDragging)
         {
             DraggedEntityUid = draggedEntityUid;
-            DraggingPlayer = draggingPlayer;
+            IsDragging = isDragging;
         }
     }
 }


### PR DESCRIPTION
There were two server `SubscribeNetworkEvent` uses that were unnecessarily passing the "user" entity and the server was taking for granted that the client wasn't lying. This just makes those events check `EntitySessionEventArgs.SenderSession` instead.

The one instance where a non-`EntitySessionEventArgs` network event subscription is used by the server is now in the camera recoil system, but it should be fine there. Though if ever recoil causing things get predicted, that has to be reworked as currently clients can send network events to the server which waste some server processing time on updating recoil components which the server really doesn't care about.