### PR TITLE
Remove stack item status flicker

### DIFF
--- a/Content.Client/Atmos/Components/GasAnalyzerComponent.cs
+++ b/Content.Client/Atmos/Components/GasAnalyzerComponent.cs
@@ -43,7 +43,7 @@ namespace Content.Client.Atmos.Components
                 _label = new RichTextLabel { StyleClasses = { StyleNano.StyleClassItemStatus } };
                 AddChild(_label);
 
-                parent._uiUpdateNeeded = true;
+                Update();
             }
 
             /// <inheritdoc />
@@ -56,6 +56,11 @@ namespace Content.Client.Atmos.Components
                     return;
                 }
 
+                Update();
+            }
+
+            public void Update()
+            {
                 _parent._uiUpdateNeeded = false;
 
                 var color = _parent.Danger switch

--- a/Content.Client/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Client/Chemistry/Components/HyposprayComponent.cs
@@ -46,7 +46,7 @@ namespace Content.Client.Chemistry.Components
                 _label = new RichTextLabel {StyleClasses = {StyleNano.StyleClassItemStatus}};
                 AddChild(_label);
 
-                parent._uiUpdateNeeded = true;
+                Update();
             }
 
             /// <inheritdoc />
@@ -57,6 +57,11 @@ namespace Content.Client.Chemistry.Components
                 {
                     return;
                 }
+                Update();
+            }
+
+            public void Update()
+            {
 
                 _parent._uiUpdateNeeded = false;
 

--- a/Content.Client/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Client/Chemistry/Components/InjectorComponent.cs
@@ -56,7 +56,7 @@ namespace Content.Client.Chemistry.Components
                 _label = new RichTextLabel { StyleClasses = { StyleNano.StyleClassItemStatus } };
                 AddChild(_label);
 
-                parent._uiUpdateNeeded = true;
+                Update();
             }
 
             protected override void FrameUpdate(FrameEventArgs args)
@@ -66,7 +66,11 @@ namespace Content.Client.Chemistry.Components
                 {
                     return;
                 }
+                Update();
+            }
 
+            public void Update()
+            {
                 _parent._uiUpdateNeeded = false;
 
                 //Update current volume and injector state

--- a/Content.Client/Stack/StackComponent.cs
+++ b/Content.Client/Stack/StackComponent.cs
@@ -4,17 +4,13 @@ using Content.Client.Stylesheets;
 using Content.Shared.Stacks;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
-using Robust.Shared.Analyzers;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Localization;
 using Robust.Shared.Timing;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Client.Stack
 {
     [RegisterComponent, Friend(typeof(StackSystem), typeof(StatusControl))]
     [ComponentReference(typeof(SharedStackComponent))]
-    public class StackComponent : SharedStackComponent, IItemStatus
+    public sealed class StackComponent : SharedStackComponent, IItemStatus
     {
         [ViewVariables]
         public bool UiUpdateNeeded { get; set; }
@@ -33,9 +29,8 @@ namespace Content.Client.Stack
             {
                 _parent = parent;
                 _label = new RichTextLabel {StyleClasses = {StyleNano.StyleClassItemStatus}};
+                _label.SetMarkup(Loc.GetString("comp-stack-status", ("count", _parent.Count)));
                 AddChild(_label);
-
-                parent.UiUpdateNeeded = true;
             }
 
             protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Client/Tools/Components/MultipleToolComponent.cs
+++ b/Content.Client/Tools/Components/MultipleToolComponent.cs
@@ -47,7 +47,7 @@ namespace Content.Client.Tools.Components
                 _label = new RichTextLabel {StyleClasses = {StyleNano.StyleClassItemStatus}};
                 AddChild(_label);
 
-                parent._uiUpdateNeeded = true;
+                UpdateDraw();
             }
 
             protected override void FrameUpdate(FrameEventArgs args)
@@ -58,7 +58,11 @@ namespace Content.Client.Tools.Components
                 {
                     return;
                 }
+                Update();
+            }
 
+            public void Update()
+            {
                 _parent._uiUpdateNeeded = false;
 
                 _label.SetMarkup(_parent.StatusShowBehavior ? _parent.Behavior ?? string.Empty : string.Empty);

--- a/Content.Client/Tools/Components/WelderComponent.cs
+++ b/Content.Client/Tools/Components/WelderComponent.cs
@@ -38,7 +38,7 @@ namespace Content.Client.Tools.Components
                 _label = new RichTextLabel {StyleClasses = {StyleNano.StyleClassItemStatus}};
                 AddChild(_label);
 
-                parent.UiUpdateNeeded = true;
+                UpdateDraw();
             }
 
             /// <inheritdoc />
@@ -50,7 +50,11 @@ namespace Content.Client.Tools.Components
                 {
                     return;
                 }
+                Update();
+            }
 
+            public void Update()
+            {
                 _parent.UiUpdateNeeded = false;
 
                 var fuelCap = _parent.FuelCapacity;


### PR DESCRIPTION
Hold metal rods ->  `x` to swap hands repeatedly -> 1-frame overlapping text.

Actually more than one frame with client-side lag. Resetting hands predictions removes the UI, which it probably shouldn't do.
But fixing that is a separate problem