### PR TITLE
fix closed and open state of generic biocloset

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
@@ -81,8 +81,8 @@
     visuals:
     - type: StorageVisualizer
       state: bio
-      state_open: bio_sec_open
-      false: bio_sec_door
+      state_open: bio_open
+      state_closed: bio_door
 
 # Virology variant
 - type: entity


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
I think someone might have fat fingered this at some point. No closed state, and open state was set to security variant. Idk what the false: key means but I don't think it belongs there.

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/95458399/153349729-c2065b0e-22bf-4dda-ac42-015a49144bc6.mp4

fixing this

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: fixes generic bio-closet closed and open state
