### PR TITLE
Fix PAI throwing

### DIFF
--- a/Content.Server/Throwing/ThrowHelper.cs
+++ b/Content.Server/Throwing/ThrowHelper.cs
@@ -41,15 +41,9 @@ namespace Content.Server.Throwing
                 return;
             }
 
-            if (physicsComponent.BodyType == BodyType.Static)
+            if (physicsComponent.BodyType != BodyType.Dynamic)
             {
-                Logger.Warning("Tried to throw entity {entity} but can't throw static bodies!");
-                return;
-            }
-
-            if (entities.HasComponent<MobStateComponent>(entity))
-            {
-                Logger.Warning("Throwing not supported for mobs!");
+                Logger.Warning($"Tried to throw entity {entities.ToPrettyString(entity)} but can't throw {physicsComponent.BodyType} bodies!");
                 return;
             }
 


### PR DESCRIPTION
For dead creatures you'll need to adjust their bodytype on mobstate change but that's not a 10 second fix now is it.

:cl:
- add: PAIs can now be yeeted.
