### PR TITLE
Change underplating name to deprecated

### DIFF
--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -28,7 +28,7 @@
 # TODO kill underplating and all its usages since it is deprecated
 - type: tile
   id: underplating
-  name: underplating
+  name: [DEPRECATED]
   texture: underplating
   base_turfs:
   - lattice


### PR DESCRIPTION
to discourage mapper use until someone creates a script to remove them all.


