### PR TITLE
Lung tweaks

### DIFF
--- a/Content.Server/Body/Components/LungComponent.cs
+++ b/Content.Server/Body/Components/LungComponent.cs
@@ -11,7 +11,7 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.Body.Components;
 
 [RegisterComponent, Friend(typeof(LungSystem))]
-public class LungComponent : Component
+public sealed class LungComponent : Component
 {
     [DataField("air")]
     public GasMixture Air { get; set; } = new()
@@ -19,9 +19,6 @@ public class LungComponent : Component
         Volume = 6,
         Temperature = Atmospherics.NormalBodyTemperature
     };
-
-    [DataField("validReagentGases", required: true)]
-    public HashSet<Gas> ValidGases = default!;
 
     [ViewVariables]
     public Solution LungSolution = default!;

--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -9,7 +9,7 @@ using Robust.Shared.ViewVariables;
 namespace Content.Server.Body.Components
 {
     [RegisterComponent, Friend(typeof(RespiratorSystem))]
-    public class RespiratorComponent : Component
+    public sealed class RespiratorComponent : Component
     {
         /// <summary>
         ///     Saturation level. Reduced by CycleDelay each tick.
@@ -28,7 +28,7 @@ namespace Content.Server.Body.Components
         public float MaxSaturation = 5.0f;
 
         [DataField("minSaturation")]
-        public float MinSaturation = -5.0f;
+        public float MinSaturation = -2.0f;
 
         // TODO HYPEROXIA?
 

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -54,7 +54,7 @@ public class LungSystem : EntitySystem
 
     public void GasToReagent(EntityUid uid, LungComponent lung)
     {
-        foreach (var gas in lung.ValidGases)
+        foreach (var gas in Enum.GetValues<Gas>())
         {
             var i = (int) gas;
             var moles = lung.Air.Moles[i];

--- a/Resources/Prototypes/Body/Mechanisms/human.yml
+++ b/Resources/Prototypes/Body/Mechanisms/human.yml
@@ -100,11 +100,6 @@
     size: 1
     compatibility: Biological
   - type: Lung
-    validReagentGases:
-    - Oxygen
-    - Plasma
-    - Tritium
-    - CarbonDioxide
   - type: Metabolizer
     removeEmpty: true
     solutionOnBody: false

--- a/Resources/Prototypes/Body/Parts/animal.yml
+++ b/Resources/Prototypes/Body/Parts/animal.yml
@@ -82,11 +82,6 @@
     size: 1
     compatibility: Biological
   - type: Lung
-    validReagentGases:
-    - Oxygen
-    - Plasma
-    - Tritium
-    - CarbonDioxide
   - type: Metabolizer
     removeEmpty: true
     solutionOnBody: false

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -223,13 +223,6 @@
       normal: spacecat
       crit: spacecat_dead
       dead: spacecat_dead
-  - type: Respirator #Space kitty should be immune to Asphyxiation. Taken from xenos.yml
-    damage:
-      types:
-        Asphyxiation: 1
-    damageRecovery:
-      types:
-        Asphyxiation: -1
 
 - type: entity
   name: caracal cat

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -14,7 +14,7 @@
   - type: Respirator
     damage:
       types:
-        Asphyxiation: 3
+        Asphyxiation: 1.5
     damageRecovery:
       types:
         Asphyxiation: -1.5

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -101,6 +101,11 @@
     Gas:
       effects:
       - !type:HealthChange
+        conditions:
+        # Don't want people to get toxin damage from the gas they just
+        # exhaled, right?
+        - !type:ReagentThreshold
+          min: 0.5
         scaleByQuantity: true
         ignoreResistances: true
         damage:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Removes the `ValidGases` stuff, ended up being unnecessary after the reagenttogas changes, so thats nice
- Asphyxiation damage nerfed to 1.5 from 3
- Now takes considerably less time to recover from lack of oxygen
- Fixes #6630

:cl:
- tweak: Lack of oxygen is now slightly less deadly.
