### PR TITLE
Chem nerfs

### DIFF
--- a/Resources/Prototypes/Catalog/ReagentDispensers/beverage.yml
+++ b/Resources/Prototypes/Catalog/ReagentDispensers/beverage.yml
@@ -1,7 +1,6 @@
 - type: reagentDispenserInventory
   id: SodaDispenserInventory
   inventory:
-  - Water
   - Ice
   - Coffee
   - Cream

--- a/Resources/Prototypes/Catalog/ReagentDispensers/chemical.yml
+++ b/Resources/Prototypes/Catalog/ReagentDispensers/chemical.yml
@@ -24,5 +24,3 @@
   - Sulfur
   - SulfuricAcid
   - Uranium
-  - Water
-

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -94,7 +94,7 @@
       lightImpactRange: 0.075
       flashRange: 0.1
       scaled: true #Scaled proportionally to amount of potassium and water
-      maxScale: 20 #Explosion strength stops scaling at 30 potassium + 30 water
+      maxScale: 20 #Explosion strength stops scaling at 20 potassium + 20 water
 
 - type: reaction
   id: Smoke

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -89,12 +89,12 @@
   effects:
     - !type:ExplosionReactionEffect
       #Ranges used when 1 potassium + 1 water react (A unit reaction)
-      devastationRange: 0.05
-      heavyImpactRange: 0.1
-      lightImpactRange: 0.15
-      flashRange: 0.2
+      devastationRange: 0.025
+      heavyImpactRange: 0.05
+      lightImpactRange: 0.075
+      flashRange: 0.1
       scaled: true #Scaled proportionally to amount of potassium and water
-      maxScale: 30 #Explosion strength stops scaling at 30 potassium + 30 water
+      maxScale: 20 #Explosion strength stops scaling at 30 potassium + 30 water
 
 - type: reaction
   id: Smoke


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Removes water from the soda dispenser/chem dispenser. It's already very abundant with water tanks around the station (more can be added in salvage/cargo if necessary) so there's not really a need for it to be in the dispenser
- Nerfs potas/water explosions, these aren't supposed to be very large. Doesn't kill someone anymore afaict

:cl:
- tweak: Potassium/water explosions nerfed
- tweak: Water has been removed from the soda and chem dispensers