### PR TITLE
Mark Passable as obsolete

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -22,7 +22,9 @@ namespace Content.Shared.Physics
 		SmallImpassable = 1 <<  4, // 16 Things a smaller object - a cat, a crab - can't go through - a wall, but not a computer terminal or a table
         GhostImpassable = 1 <<  5, // 32 Things impassible by ghosts/observers, ie blessed tiles or forcefields
         Underplating    = 1 <<  6, // 64 Things that are under plating
-        Passable        = 1 <<  7, // 128 Things that are passable
+        [Obsolete("Don't use Passable for collision.")]
+        // Collision is for what things collide, not what they "don't collide with" so this makes 0 logical sense.
+        Passable        = 1 <<  7, // 128 Things that are passable.
         MapGrid         = MapGridHelpers.CollisionGroup, // Map grids, like shuttles. This is the actual grid itself, not the walls or other entities connected to the grid.
 
         MobMask = Impassable | MobImpassable | VaultImpassable | SmallImpassable,


### PR DESCRIPTION
Collision groups are dumb but let's not make it worse.
