### PR TITLE
Fix exhaling on salvage maps.

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -138,8 +138,11 @@ namespace Content.Server.Body.Systems
 
             if (ev.Gas == null)
             {
-                ev.Gas = _atmosSys.GetTileMixture(Transform(uid).Coordinates);
-                if (ev.Gas == null) return;
+                ev.Gas = _atmosSys.GetTileMixture(Transform(uid).Coordinates) ?? GasMixture.SpaceGas;
+
+                // Walls and grids without atmos comp return null. I guess it makes sense to not be able to exhale in walls,
+                // but this also means you cannot exhale on some grids.
+                ev.Gas ??= GasMixture.SpaceGas;
             }
 
             var outGas = new GasMixture(ev.Gas.Volume);

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -138,7 +138,7 @@ namespace Content.Server.Body.Systems
 
             if (ev.Gas == null)
             {
-                ev.Gas = _atmosSys.GetTileMixture(Transform(uid).Coordinates) ?? GasMixture.SpaceGas;
+                ev.Gas = _atmosSys.GetTileMixture(Transform(uid).Coordinates);
 
                 // Walls and grids without atmos comp return null. I guess it makes sense to not be able to exhale in walls,
                 // but this also means you cannot exhale on some grids.


### PR DESCRIPTION

:cl:
- fix: Salvage crew can breathe easy, a bug causing CO2 poisoning on some salvage maps has been fixed.

