### PR TITLE
Fix grid-check audio volume

### DIFF
--- a/Content.Server/StationEvents/Events/PowerGridCheck.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheck.cs
@@ -1,11 +1,7 @@
-using System.Collections.Generic;
 using System.Threading;
 using Content.Server.Power.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Timer = Robust.Shared.Timing.Timer;
@@ -68,7 +64,7 @@ namespace Content.Server.StationEvents.Events
             _announceCancelToken = new CancellationTokenSource();
             Timer.Spawn(3000, () =>
             {
-                SoundSystem.Play(Filter.Broadcast(), "/Audio/Announcements/power_on.ogg");
+                SoundSystem.Play(Filter.Broadcast(), "/Audio/Announcements/power_on.ogg", AudioParams);
             }, _announceCancelToken.Token);
             _powered.Clear();
 

--- a/Content.Server/StationEvents/Events/StationEvent.cs
+++ b/Content.Server/StationEvents/Events/StationEvent.cs
@@ -58,6 +58,8 @@ namespace Content.Server.StationEvents.Events
         /// </summary>
         public virtual string? EndAudio { get; } = null;
 
+        public virtual AudioParams AudioParams { get; } = AudioParams.Default.WithVolume(-10f);
+
         /// <summary>
         ///     In minutes, when is the first round time this event can start
         /// </summary>
@@ -135,7 +137,7 @@ namespace Content.Server.StationEvents.Events
 
             if (StartAudio != null)
             {
-                SoundSystem.Play(Filter.Broadcast(), StartAudio, AudioParams.Default.WithVolume(-10f));
+                SoundSystem.Play(Filter.Broadcast(), StartAudio, AudioParams);
             }
 
             Announced = true;
@@ -158,7 +160,7 @@ namespace Content.Server.StationEvents.Events
 
             if (EndAudio != null)
             {
-                SoundSystem.Play(Filter.Broadcast(), EndAudio, AudioParams.Default.WithVolume(-10f));
+                SoundSystem.Play(Filter.Broadcast(), EndAudio, AudioParams);
             }
 
             Started = false;


### PR DESCRIPTION
Ever notice that the power grid check event's ending-announcement is much louder than the start volume?