### PR TITLE
Security TechFab & Lathe Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -162,6 +162,7 @@
       - Syringe
       - PillCanister
       - Drone
+      - Flash
       - MicroManipulatorStockPart
       - ScanningModuleStockPart
       - MicroLaserStockPart
@@ -255,10 +256,6 @@
       - CartridgeLRifleRubber
       - CartridgeSRifleRubber #Everything below this is shared with other lathes
       - FlashlightLantern
-      - FirelockElectronics
-      - DoorElectronics
-      - APCElectronics
-      - FireAlarmElectronics
       - Bucket
       - MopItem
       - SprayBottle
@@ -272,4 +269,3 @@
       - CableStack
       - CableMVStack
       - CableHVStack
-

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -144,7 +144,6 @@
       - CableMVStack
       - CableHVStack
       - ConveyorBeltAssembly
-      - RCD
       - RCDAmmo
       - HydroponicsToolScythe
       - HydroponicsToolHatchet
@@ -163,19 +162,6 @@
       - Syringe
       - PillCanister
       - Drone
-      - Flash
-      - Handcuffs
-      - Stunbaton
-      - CartridgePistol
-      - ShellShotgun
-      - CartridgeLRifle
-      - CartridgeMagnum
-      - ShellShotgunBeanbag
-      - CartridgePistolRubber
-      - CartridgeMagnumRubber
-      - CartridgeClRifleRubber
-      - CartridgeLRifleRubber
-      - CartridgeSRifleRubber
       - MicroManipulatorStockPart
       - ScanningModuleStockPart
       - MicroLaserStockPart
@@ -246,4 +232,45 @@
       - DawInstrumentMachineCircuitboard
   - type: Machine
     board: CircuitImprinterMachineCircuitboard
+
+- type: entity
+  parent: Protolathe
+  id: SecurityTechFab
+  name: Security TechFab
+  description: Prints security equipment and some basics.
+  components:
+  - type: ProtolatheDatabase
+    protolatherecipes:
+      - Flash
+      - Handcuffs
+      - Stunbaton
+      - CartridgePistol
+      - ShellShotgun
+      - CartridgeLRifle
+      - CartridgeMagnum
+      - ShellShotgunBeanbag
+      - CartridgePistolRubber
+      - CartridgeMagnumRubber
+      - CartridgeClRifleRubber
+      - CartridgeLRifleRubber
+      - CartridgeSRifleRubber #Everything below this is shared with other lathes
+      - FlashlightLantern
+      - FirelockElectronics
+      - DoorElectronics
+      - APCElectronics
+      - AirAlarmElectronics
+      - FireAlarmElectronics
+      - Bucket
+      - MopItem
+      - SprayBottle
+      - FireExtinguisher
+      - LightTube
+      - LightBulb
+      - SheetSteel
+      - SheetGlass1
+      - SheetRGlass
+      - SheetPlastic
+      - CableStack
+      - CableMVStack
+      - CableHVStack
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -258,7 +258,6 @@
       - FirelockElectronics
       - DoorElectronics
       - APCElectronics
-      - AirAlarmElectronics
       - FireAlarmElectronics
       - Bucket
       - MopItem


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves all the security equipment and weapons to their own Techfab, so every scientist and engineer in the game no longer runs around with a baton, cuffs, and a flare shotgun.

I also removed the ability to build RCDs, leaving only their ammo. Its ability to space rooms makes it one of the most dangerous items in the game and it really should be a 'high risk item' with a limited number.

Q/A:
1. Is there a unique sprite?
No. It shares the protolathe sprite. Seems to work for /tg/. I looked at making a quick edit but the visualizer and animations make it a lot more involved than it seems.

2. Is it buildable?
I thought it'd be easier to observe the effects of changes if it wasn't. It doesn't have any station-critical utility so it shouldn't harm round health much by not being buildable for a while. Eventually it can get added onto the circuit imprinter during the next recipe refresh.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added security techfabs, which print the security weapons and equipment now instead of the protolathe.
- remove: Removed RCD recipe from the protolathe. You can still print more ammo for them.

