### PR TITLE
Unique name identifiers

### DIFF
--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -19,6 +19,7 @@ namespace Content.Client.Entry
             "WarpPoint",
             "EmitSoundOnUse",
             "EmitSoundOnLand",
+            "NameIdentifier",
             "EmitSoundOnActivate",
             "FootstepModifier",
             "HeatResistance",

--- a/Content.Server/NameIdentifier/NameIdentifierComponent.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierComponent.cs
@@ -4,5 +4,5 @@
 public class NameIdentifierComponent : Component
 {
     [DataField("group", required: true)]
-    public string Group = default!;
+    public string Group = string.Empty;
 }

--- a/Content.Server/NameIdentifier/NameIdentifierComponent.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierComponent.cs
@@ -1,0 +1,8 @@
+﻿namespace Content.Server.NameIdentifier;
+
+[RegisterComponent]
+public class NameIdentifierComponent : Component
+{
+    [DataField("group", required: true)]
+    public string Group = default!;
+}

--- a/Content.Server/NameIdentifier/NameIdentifierComponent.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierComponent.cs
@@ -1,8 +1,11 @@
-﻿namespace Content.Server.NameIdentifier;
+﻿using Content.Shared.NameIdentifier;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.NameIdentifier;
 
 [RegisterComponent]
-public class NameIdentifierComponent : Component
+public sealed class NameIdentifierComponent : Component
 {
-    [DataField("group", required: true)]
+    [DataField("group", required: true, customTypeSerializer:typeof(PrototypeIdSerializer<NameIdentifierGroupPrototype>))]
     public string Group = string.Empty;
 }

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -1,0 +1,116 @@
+﻿using Content.Shared.GameTicking;
+using Content.Shared.NameIdentifier;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server.NameIdentifier;
+
+/// <summary>
+///     Handles unique name identifiers for entities e.g. `monkey (MK-912)`
+/// </summary>
+public class NameIdentifierSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
+
+    [ViewVariables]
+    public Dictionary<NameIdentifierGroupPrototype, HashSet<int>> CurrentIds = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NameIdentifierComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(CleanupIds);
+
+        InitialSetupPrototypes();
+        _prototypeManager.PrototypesReloaded += OnReloadPrototypes;
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _prototypeManager.PrototypesReloaded -= OnReloadPrototypes;
+    }
+
+    /// <summary>
+    ///     Generates a new unique name/suffix for a given entity and adds it to <see cref="CurrentIds"/>
+    ///     but does not set the entity's name.
+    /// </summary>
+    public string GenerateUniqueName(EntityUid uid, NameIdentifierGroupPrototype proto)
+    {
+        var entityName = Name(uid);
+        if (!CurrentIds.TryGetValue(proto, out var set))
+            return entityName;
+
+        if (set.Count == proto.MaxValue + 1)
+        {
+            // Oh jeez. We're outta numbers.
+            return entityName;
+        }
+
+        // This is kind of inefficient with very large amounts of entities but its better than any other method
+        // I could come up with.
+        var randomVal = _robustRandom.Next(0, proto.MaxValue);
+        while (set.Contains(randomVal))
+        {
+            randomVal = _robustRandom.Next(0, proto.MaxValue);
+        }
+
+        set.Add(randomVal);
+
+        return proto.Prefix is not null
+            ? $"{proto.Prefix}-{randomVal}"
+            : $"{randomVal}";
+    }
+
+    private void OnComponentInit(EntityUid uid, NameIdentifierComponent component, ComponentInit args)
+    {
+        if (!_prototypeManager.TryIndex<NameIdentifierGroupPrototype>(component.Group, out var group))
+            return;
+
+        // Generate a new name.
+        var meta = MetaData(uid);
+        var uniqueName = GenerateUniqueName(uid, group);
+
+        // "DR-1234" as opposed to "drone (DR-1234)"
+        meta.EntityName = group.FullName
+            ? uniqueName
+            : $"{meta.EntityName} ({uniqueName})";
+    }
+
+    private void InitialSetupPrototypes()
+    {
+        foreach (var proto in _prototypeManager.EnumeratePrototypes<NameIdentifierGroupPrototype>())
+        {
+            CurrentIds.Add(proto, new());
+        }
+    }
+
+    private void OnReloadPrototypes(PrototypesReloadedEventArgs ev)
+    {
+        if (!ev.ByType.TryGetValue(typeof(NameIdentifierGroupPrototype), out var set))
+            return;
+
+        foreach (var (_, proto) in set.Modified)
+        {
+            if (proto is not NameIdentifierGroupPrototype group)
+                continue;
+
+            // Only bother adding new ones.
+            if (CurrentIds.ContainsKey(group))
+                continue;
+
+            CurrentIds.Add(group, new());
+        }
+    }
+
+    private void CleanupIds(RoundRestartCleanupEvent ev)
+    {
+        foreach (var (_, set) in CurrentIds)
+        {
+            set.Clear();
+        }
+    }
+}

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -9,7 +9,7 @@ namespace Content.Server.NameIdentifier;
 /// <summary>
 ///     Handles unique name identifiers for entities e.g. `monkey (MK-912)`
 /// </summary>
-public class NameIdentifierSystem : EntitySystem
+public sealed class NameIdentifierSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.GameTicking;
+﻿using System.Linq;
+using Content.Shared.GameTicking;
 using Content.Shared.NameIdentifier;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -44,7 +45,7 @@ public class NameIdentifierSystem : EntitySystem
         if (!CurrentIds.TryGetValue(proto, out var set))
             return entityName;
 
-        if (set.Count == proto.MaxValue + 1)
+        if (set.Count == (proto.MaxValue - proto.MinValue) + 1)
         {
             // Oh jeez. We're outta numbers.
             return entityName;
@@ -52,10 +53,11 @@ public class NameIdentifierSystem : EntitySystem
 
         // This is kind of inefficient with very large amounts of entities but its better than any other method
         // I could come up with.
-        var randomVal = _robustRandom.Next(0, proto.MaxValue);
+
+        var randomVal = _robustRandom.Next(proto.MinValue, proto.MaxValue);
         while (set.Contains(randomVal))
         {
-            randomVal = _robustRandom.Next(0, proto.MaxValue);
+            randomVal = _robustRandom.Next(proto.MinValue, proto.MaxValue);
         }
 
         set.Add(randomVal);

--- a/Content.Shared/NameIdentifier/NameIdentifierGroupPrototype.cs
+++ b/Content.Shared/NameIdentifier/NameIdentifierGroupPrototype.cs
@@ -19,4 +19,7 @@ public sealed class NameIdentifierGroupPrototype : IPrototype
 
     [DataField("maxValue")]
     public int MaxValue = 999;
+
+    [DataField("minValue")]
+    public int MinValue = 0;
 }

--- a/Content.Shared/NameIdentifier/NameIdentifierGroupPrototype.cs
+++ b/Content.Shared/NameIdentifier/NameIdentifierGroupPrototype.cs
@@ -1,0 +1,22 @@
+﻿using Robust.Shared.Prototypes;
+
+namespace Content.Shared.NameIdentifier;
+
+[Prototype("nameIdentifierGroup")]
+public sealed class NameIdentifierGroupPrototype : IPrototype
+{
+    [DataField("id", required: true)]
+    public string ID { get; } = default!;
+
+    /// <summary>
+    ///     Should the identifier become the full name, or just append?
+    /// </summary>
+    [DataField("fullName")]
+    public bool FullName = false;
+
+    [DataField("prefix")]
+    public string? Prefix;
+
+    [DataField("maxValue")]
+    public int MaxValue = 999;
+}

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -501,6 +501,8 @@
   parent: SimpleMobBase
   description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
   components:
+  - type: NameIdentifier
+    group: Monkey
   - type: GhostTakeoverAvailable
     makeSentient: true
     name: monkey

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -64,6 +64,8 @@
       - id: PowerDrill
       - id: JawsOfLife
       - id: WelderExperimental
+  - type: NameIdentifier
+    group: Drone
   - type: GhostTakeoverAvailable
     makeSentient: true
     name: Maintenance Drone

--- a/Resources/Prototypes/name_identifier_groups.yml
+++ b/Resources/Prototypes/name_identifier_groups.yml
@@ -7,4 +7,5 @@
   id: Drone
   prefix: DR
   fullName: true
+  minValue: 10000
   maxValue: 99999

--- a/Resources/Prototypes/name_identifier_groups.yml
+++ b/Resources/Prototypes/name_identifier_groups.yml
@@ -1,0 +1,10 @@
+﻿# Non-fungible apes, anyone?
+- type: nameIdentifierGroup
+  id: Monkey
+  prefix: MK
+
+- type: nameIdentifierGroup
+  id: Drone
+  prefix: DR
+  fullName: true
+  maxValue: 99999


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

IDs and data are stored per-prototype, always tries to use a unique number for each name identifier group (monkey, drone)

Drone names replace the entire name, monkey names are just a suffix

Fixes #6654

![image](https://user-images.githubusercontent.com/19853115/153780857-e1edf1ad-16da-4cbf-855a-12fb048efba7.png)

![image](https://user-images.githubusercontent.com/19853115/153780860-8f4336b1-35b2-4a5e-80f7-91e4bc5d07a6.png)

:cl:
- add: Drones and monkeys now have unique identifiers in their names.

