### PR TITLE
Move makeshift handcuffs into the Tools category

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/Recipes/Crafting/improvised.yml
@@ -17,7 +17,7 @@
   graph: makeshifthandcuffs
   startNode: start
   targetNode: cuffscable
-  category: Utility
+  category: Tools
   description: "Homemade handcuffs crafted from spare cables."
   icon: Objects/Misc/cablecuffs.rsi/cuff.png
   objectType: Item


### PR DESCRIPTION
## Move makeshift handcuffs into the Tools category

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: HoofedEar
- tweak: Moved makeshift cuffs into Tools category

