### PR TITLE
Minor Fixes (Spawner offset, icons and light suffixes)

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/donkpocketbox.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/donkpocketbox.yml
@@ -18,4 +18,4 @@
         - FoodBoxDonkpocketHonk
         - FoodBoxDonkpocketDink
       chance: 0.5
-      offset: 0.2
+      offset: 0.0

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -49,7 +49,7 @@
     - type: Sprite
       layers:
         - state: red
-        - texture: Clothing/Eyes/Glasses/gar.rsi/icon-super.png
+        - texture: Objects/Power/PowerCells/power_cell_large_sup.rsi/l_sup.png
     - type: RandomSpawner
       rarePrototypes:
         - lanternextrabright
@@ -84,7 +84,7 @@
     - type: Sprite
       layers:
         - state: red
-        - texture: Clothing/Eyes/Glasses/gar.rsi/icon-super.png
+        - texture: Objects/Weapons/Melee/machete.rsi/icon.png
     - type: RandomSpawner
       rarePrototypes:
         - Machete

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -66,7 +66,7 @@
   name: light
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
   id: PoweredlightEmpty
-  suffix: Empty, Powered
+  suffix: Powered, Empty
   parent: WallLight
   components:
   - type: Sprite
@@ -107,7 +107,7 @@
 - type: entity
   id: PoweredlightLED
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  suffix: LED tube, Powered
+  suffix: Powered, LED
   parent: Poweredlight
   components:
   - type: PoweredLight
@@ -130,7 +130,7 @@
 - type: entity
   id: PoweredlightExterior
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  suffix: Exterior tube, Powered
+  suffix: Powered, Exterior Blue
   parent: Poweredlight
   components:
   - type: PoweredLight
@@ -138,10 +138,11 @@
     damage:
       types:
         Heat: 20
+        
 - type: entity
   parent: WallLight
   id: UnpoweredLightExterior
-  suffix: Unpowered, Exterior
+  suffix: Unpowered, Exterior Blue
   components:
   - type: PointLight
     radius: 12
@@ -153,7 +154,7 @@
 - type: entity
   id: PoweredlightSodium
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  suffix: Sodium tube, Powered
+  suffix: Powered, Sodium Orange
   parent: Poweredlight
   components:
   - type: PoweredLight
@@ -165,7 +166,7 @@
 - type: entity
   parent: WallLight
   id: UnpoweredLightSodium
-  suffix: Unpowered, Sodium
+  suffix: Unpowered, Sodium Orange
   components:
   - type: PointLight
     radius: 10
@@ -217,7 +218,7 @@
   name: small light
   description: "A light fixture. Draws power and produces light when equipped with a light bulb."
   id: PoweredSmallLightEmpty
-  suffix: Empty, Powered
+  suffix: Powered, Empty
   parent: SmallLight
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Quick PR as I noticed the donk pocket spawner has an 0.2 offset when it shouldn't.

To beef up the PR a bit I also set unique icons for the maint spawners to better reflect what's in them and made the suffixes for the lights consistent so they're powered / unpowered first, then empty or type second. Should make spawning easier to go through.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

