### PR TITLE
X-Ray Mesons Traitor Item

### DIFF
--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -257,6 +257,7 @@ namespace Content.Client.Entry
             "BeingCloned",
             "Advertise",
             "Bible",
+            "XRayGlasses",
             "PowerNetworkBattery",
             "BatteryCharger",
             "UnpoweredFlashlight",

--- a/Content.Server/XRay/Components/XRayGlassesComponent.cs
+++ b/Content.Server/XRay/Components/XRayGlassesComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Xray.Components
+{
+    [RegisterComponent]
+    public sealed class XRayGlassesComponent : Component
+    {
+        [DataField("activationSlot")]
+        public string ActivationSlot = "eyes";
+
+    }
+}

--- a/Content.Server/XRay/Components/XRayGlassesComponent.cs
+++ b/Content.Server/XRay/Components/XRayGlassesComponent.cs
@@ -1,10 +1,12 @@
+using Content.Shared.Inventory;
+
 namespace Content.Server.Xray.Components
 {
     [RegisterComponent]
     public sealed class XRayGlassesComponent : Component
     {
         [DataField("activationSlot")]
-        public string ActivationSlot = "eyes";
+        public SlotFlags ActivationSlot = SlotFlags.EYES;
 
     }
 }

--- a/Content.Server/XRay/XRaySystem.cs
+++ b/Content.Server/XRay/XRaySystem.cs
@@ -4,7 +4,7 @@ using Robust.Server.GameObjects;
 
 namespace Content.Server.XRay
 {
-    public class XRaySystem : EntitySystem
+    public sealed class XRaySystem : EntitySystem
     {
         public override void Initialize()
         {

--- a/Content.Server/XRay/XRaySystem.cs
+++ b/Content.Server/XRay/XRaySystem.cs
@@ -1,0 +1,35 @@
+using Content.Server.Xray.Components;
+using Content.Shared.Inventory.Events;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.XRay
+{
+    public class XRaySystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<XRayGlassesComponent, GotEquippedEvent>(OnEquipped);
+            SubscribeLocalEvent<XRayGlassesComponent, GotUnequippedEvent>(OnUnequipped);
+        }
+
+        private void OnEquipped(EntityUid uid, XRayGlassesComponent component, GotEquippedEvent args)
+        {
+            if (args.Slot != component.ActivationSlot)
+                return;
+
+            TryComp<EyeComponent>(args.Equipee, out var eyeComponent);
+            if (eyeComponent == null) return;
+            eyeComponent.DrawFov = false;
+        }
+
+        private void OnUnequipped(EntityUid uid, XRayGlassesComponent component, GotUnequippedEvent args)
+        {
+            if (args.Slot != component.ActivationSlot)
+                return;
+            TryComp<EyeComponent>(args.Equipee, out var eyeComponent);
+            if (eyeComponent == null) return;
+            eyeComponent.DrawFov = true;
+        }
+    }
+}

--- a/Content.Server/XRay/XRaySystem.cs
+++ b/Content.Server/XRay/XRaySystem.cs
@@ -15,7 +15,7 @@ namespace Content.Server.XRay
 
         private void OnEquipped(EntityUid uid, XRayGlassesComponent component, GotEquippedEvent args)
         {
-            if (args.Slot != component.ActivationSlot)
+            if (args.SlotFlags != component.ActivationSlot)
                 return;
 
             TryComp<EyeComponent>(args.Equipee, out var eyeComponent);
@@ -25,8 +25,6 @@ namespace Content.Server.XRay
 
         private void OnUnequipped(EntityUid uid, XRayGlassesComponent component, GotUnequippedEvent args)
         {
-            if (args.Slot != component.ActivationSlot)
-                return;
             TryComp<EyeComponent>(args.Equipee, out var eyeComponent);
             if (eyeComponent == null) return;
             eyeComponent.DrawFov = true;

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -196,6 +196,14 @@
   price: 2
 
 - type: uplinkListing
+  id: UplinkClothingEyesXrayMesons
+  category: Armor
+  itemId: ClothingEyesGlassesMesonXRay
+  listingName: x-ray messon goggles
+  description: These let you see everything through walls, and give you flash resistance.
+  price: 5
+
+- type: uplinkListing
   id: UplinkClothingOuterVestWeb
   category: Armor
   itemId: ClothingOuterVestWeb

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -199,9 +199,9 @@
   id: UplinkClothingEyesXrayMesons
   category: Armor
   itemId: ClothingEyesGlassesMesonXRay
-  listingName: x-ray messon goggles
-  description: These let you see everything through walls, and give you flash resistance.
-  price: 5
+  listingName: x-ray meson goggles
+  description: These let you see everything through walls, and give you flash immunity.
+  price: 8
 
 - type: uplinkListing
   id: UplinkClothingOuterVestWeb

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -119,3 +119,11 @@
     sprite: Clothing/Eyes/Glasses/thermal.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/thermal.rsi
+
+- type: entity
+  parent: ClothingEyesGlassesMeson
+  id: ClothingEyesGlassesMesonXRay
+  suffix: X-Ray
+  components:
+  - type: XRayGlasses
+  - type: FlashImmunity


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Since we're looking to give stealth traitors some more options and I ran into this idea while looking at security cameras, I made goggles which give their user x-ray vision. They're a traitor item disguised as meson goggles. They also have flash resistance for a bit of extra utility.


https://user-images.githubusercontent.com/60792108/154187342-50fa2550-a802-431e-828b-89ffb025dafb.mp4


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- add: Added X-Ray meson goggles to the traitor uplink!

