### PR TITLE
Reduce resolve and cut more corners in destructible

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -1,12 +1,12 @@
 using Content.Server.Construction;
 using Content.Server.Destructible.Thresholds;
 using Content.Server.Explosion.EntitySystems;
+using Content.Server.Stack;
 using Content.Shared.Acts;
 using Content.Shared.Damage;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Destructible
@@ -21,6 +21,9 @@ namespace Content.Server.Destructible
         [Dependency] public readonly AudioSystem AudioSystem = default!;
         [Dependency] public readonly ConstructionSystem ConstructionSystem = default!;
         [Dependency] public readonly ExplosionSystem ExplosionSystem = default!;
+        [Dependency] public readonly StackSystem StackSystem = default!;
+        [Dependency] public readonly IPrototypeManager PrototypeManager = default!;
+        [Dependency] public readonly IComponentFactory ComponentFactory = default!;
 
         public override void Initialize()
         {

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -1,6 +1,5 @@
 using Content.Server.Stack;
 using Content.Shared.Prototypes;
-using Content.Shared.Random.Helpers;
 
 namespace Content.Server.Destructible.Thresholds.Behaviors
 {
@@ -33,19 +32,16 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
                 if (count == 0) continue;
 
-                if (EntityPrototypeHelpers.HasComponent<StackComponent>(entityId))
+                if (EntityPrototypeHelpers.HasComponent<StackComponent>(entityId, system.PrototypeManager, system.ComponentFactory))
                 {
                     var spawned = system.EntityManager.SpawnEntity(entityId, offsetPosition());
-                    var stack = system.EntityManager.GetComponent<StackComponent>(spawned);
-                    EntitySystem.Get<StackSystem>().SetCount(spawned, count, stack);
-                    spawned.RandomOffset(Offset);
+                    system.StackSystem.SetCount(spawned, count);
                 }
                 else
                 {
                     for (var i = 0; i < count; i++)
                     {
-                        var spawned = system.EntityManager.SpawnEntity(entityId, offsetPosition());
-                        spawned.RandomOffset(Offset);
+                        system.EntityManager.SpawnEntity(entityId, offsetPosition());
                     }
                 }
             }

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -19,10 +19,8 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
         public void Execute(EntityUid owner, DestructibleSystem system)
         {
             var position = system.EntityManager.GetComponent<TransformComponent>(owner).MapPosition;
-            
-            var offsetPosition = () => position.Offset((
-                (system.Random.NextFloat() * 2 - 1) * Offset,
-                (system.Random.NextFloat() * 2 - 1) * Offset));
+
+            var getRandomVector = () => new Vector2(system.Random.NextFloat(-Offset, Offset), system.Random.NextFloat(-Offset, Offset));
 
             foreach (var (entityId, minMax) in Spawn)
             {
@@ -34,14 +32,14 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
                 if (EntityPrototypeHelpers.HasComponent<StackComponent>(entityId, system.PrototypeManager, system.ComponentFactory))
                 {
-                    var spawned = system.EntityManager.SpawnEntity(entityId, offsetPosition());
+                    var spawned = system.EntityManager.SpawnEntity(entityId, position.Offset(getRandomVector()));
                     system.StackSystem.SetCount(spawned, count);
                 }
                 else
                 {
                     for (var i = 0; i < count; i++)
                     {
-                        system.EntityManager.SpawnEntity(entityId, offsetPosition());
+                        system.EntityManager.SpawnEntity(entityId, position.Offset(getRandomVector()));
                     }
                 }
             }

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
 using Content.Server.Stack;
 using Content.Shared.Prototypes;
 using Content.Shared.Random.Helpers;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Server.Destructible.Thresholds.Behaviors
 {
@@ -25,6 +20,10 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
         public void Execute(EntityUid owner, DestructibleSystem system)
         {
             var position = system.EntityManager.GetComponent<TransformComponent>(owner).MapPosition;
+            
+            var offsetPosition = () => position.Offset((
+                (system.Random.NextFloat() * 2 - 1) * Offset,
+                (system.Random.NextFloat() * 2 - 1) * Offset));
 
             foreach (var (entityId, minMax) in Spawn)
             {
@@ -36,8 +35,8 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
                 if (EntityPrototypeHelpers.HasComponent<StackComponent>(entityId))
                 {
-                    var spawned = system.EntityManager.SpawnEntity(entityId, position);
-                    var stack = IoCManager.Resolve<IEntityManager>().GetComponent<StackComponent>(spawned);
+                    var spawned = system.EntityManager.SpawnEntity(entityId, offsetPosition());
+                    var stack = system.EntityManager.GetComponent<StackComponent>(spawned);
                     EntitySystem.Get<StackSystem>().SetCount(spawned, count, stack);
                     spawned.RandomOffset(Offset);
                 }
@@ -45,7 +44,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                 {
                     for (var i = 0; i < count; i++)
                     {
-                        var spawned = system.EntityManager.SpawnEntity(entityId, position);
+                        var spawned = system.EntityManager.SpawnEntity(entityId, offsetPosition());
                         spawned.RandomOffset(Offset);
                     }
                 }

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -61,6 +61,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 100
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 15
       behaviors:
       - !type:PlaySoundBehavior
@@ -89,6 +95,12 @@
     sprite: Structures/Furniture/Tables/reinforced.rsi
   - type: Destructible
     thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
         damage: 75
@@ -167,6 +179,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 100
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 20
       behaviors:
       - !type:PlaySoundBehavior
@@ -209,6 +227,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 200
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 50
       behaviors:
       - !type:PlaySoundBehavior
@@ -244,6 +268,12 @@
     damageModifierSet: Wood
   - type: Destructible
     thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
         damage: 15

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -37,6 +37,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 300
+      behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 100
       behaviors:
       - !type:DoActsBehavior

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/lighting.yml
@@ -47,6 +47,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 200
+      behaviors: #excess damage, don't spawn entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 50
       behaviors:
       - !type:EmptyAllContainersBehaviour
@@ -198,6 +204,12 @@
       damageContainer: Inorganic
     - type: Destructible
       thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors: #excess damage, don't spawn entities.
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
       - trigger:
           !type:DamageTrigger
           damage: 25

--- a/Resources/Prototypes/Entities/Structures/Walls/girder.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/girder.yml
@@ -35,6 +35,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 200
+      behaviors: #excess damage, don't spawn entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 50
       behaviors:
       - !type:SpawnEntitiesBehavior

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -15,6 +15,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 1000
+      behaviors: #excess damage, don't spawn entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 600
       behaviors:
       - !type:PlaySoundBehavior
@@ -66,6 +72,12 @@
     node: plasmaReinforcedWindowDirectional
   - type: Destructible
     thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1000
+      behaviors: #excess damage, don't spawn entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
         damage: 600

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -133,6 +133,12 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
+        damage: 150 #excess damage (nuke?). avoid computational cost of spawning entities.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
         damage: 50
       behaviors:
       - !type:PlaySoundBehavior


### PR DESCRIPTION
This PR adds more yaml changes like in #6190, making some commonplace entities avoid spawning stuff when destroyed with excessive force.

Also reduces `IoCManager` resolves in `SpawnEntitiesBehavior`