### PR TITLE
Glasses no longer display the Opened text

### DIFF
--- a/Content.Server/Nutrition/Components/DrinkComponent.cs
+++ b/Content.Server/Nutrition/Components/DrinkComponent.cs
@@ -26,6 +26,10 @@ namespace Content.Server.Nutrition.Components
         [DataField("isOpen")]
         internal bool DefaultToOpened;
 
+        [ViewVariables]
+        [DataField("isOpenable")]
+        public bool IsOpenable = true;
+
         [ViewVariables(VVAccess.ReadWrite)]
         public FixedPoint2 TransferAmount { get; [UsedImplicitly] private set; } = FixedPoint2.New(5);
 

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -66,6 +66,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
         private void OnExamined(EntityUid uid, DrinkComponent component, ExaminedEvent args)
         {
+            /*
             if (!component.Opened || !args.IsInDetailsRange)
                 return;
 
@@ -73,6 +74,18 @@ namespace Content.Server.Nutrition.EntitySystems
             var openedText =
                 Loc.GetString(IsEmpty(uid, component) ? "drink-component-on-examine-is-empty" : "drink-component-on-examine-is-opened");
             args.Message.AddMarkup($"\n{Loc.GetString("drink-component-on-examine-details-text", ("colorName", color), ("text", openedText))}");
+            */
+
+            if (component.IsOpenable == true)
+            {
+                if (!component.Opened || !args.IsInDetailsRange)
+                    return;
+
+                var color = IsEmpty(uid, component) ? "gray" : "yellow";
+                var openedText =
+                    Loc.GetString(IsEmpty(uid, component) ? "drink-component-on-examine-is-empty" : "drink-component-on-examine-is-opened");
+                args.Message.AddMarkup($"\n{Loc.GetString("drink-component-on-examine-details-text", ("colorName", color), ("text", openedText))}");
+            }
         }
 
         private void SetOpen(EntityUid uid, bool opened = false, DrinkComponent? component = null)

--- a/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/drinks.yml
@@ -28,7 +28,8 @@
   abstract: true
   components:
   - type: Drink
-    isOpen: true
+    isOpen: false
+    isOpenable: false
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Glass


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

**Fixed the issue where glasses display the Opened text**
![Opened](https://user-images.githubusercontent.com/44257005/154306413-fa4d01c2-de7d-4b45-96ab-690f7eb6dad8.png)
![Opened2](https://user-images.githubusercontent.com/44257005/154306418-9d30bfd9-8b3c-4f44-a384-2387623202cf.png)

Fixes #4917


