### PR TITLE
Fix pipe connection bug

### DIFF
--- a/Content.Server/NodeContainer/EntitySystems/NodeContainerSystem.cs
+++ b/Content.Server/NodeContainer/EntitySystems/NodeContainerSystem.cs
@@ -61,6 +61,8 @@ namespace Content.Server.NodeContainer.EntitySystems
                 if (!node.NeedAnchored)
                     continue;
 
+                node.OnAnchorStateChanged(EntityManager, args.Anchored);
+
                 if (args.Anchored)
                     _nodeGroupSystem.QueueReflood(node);
                 else
@@ -75,14 +77,15 @@ namespace Content.Server.NodeContainer.EntitySystems
                 return;
             }
 
-            var anchored = Transform(uid).Anchored;
+            var xform = Transform(uid);
 
             foreach (var node in container.Nodes.Values)
             {
-                if (node.NeedAnchored && !anchored)
+                if (node is not IRotatableNode rotatableNode)
                     continue;
 
-                if (node is not IRotatableNode rotatableNode)
+                // Don't bother updating nodes that can't even be connected to anything atm.
+                if (!node.Connectable(EntityManager, xform))
                     continue;
 
                 if (rotatableNode.RotateEvent(ref ev))

--- a/Content.Server/NodeContainer/Nodes/Node.cs
+++ b/Content.Server/NodeContainer/Nodes/Node.cs
@@ -52,11 +52,11 @@ namespace Content.Server.NodeContainer.Nodes
             return xform.Anchored;
         }
 
-        protected bool Anchored => !NeedAnchored || IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(Owner).Anchored;
-
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("needAnchored")]
         public bool NeedAnchored { get; } = true;
+
+        public virtual void OnAnchorStateChanged(IEntityManager entityManager, bool anchored) { }
 
         /// <summary>
         ///    Prevents a node from being used by other nodes while midway through removal.

--- a/Content.Server/NodeContainer/Nodes/PipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PipeNode.cs
@@ -143,6 +143,23 @@ namespace Content.Server.NodeContainer.Nodes
             return true;
         }
 
+        public override void OnAnchorStateChanged(IEntityManager entityManager, bool anchored)
+        {
+            if (!anchored)
+                return;
+
+            // update valid pipe directions
+
+            if (!RotationsEnabled)
+            {
+                CurrentPipeDirection = _originalPipeDirection;
+                return;
+            }
+
+            var xform = entityManager.GetComponent<TransformComponent>(Owner);
+            CurrentPipeDirection = _originalPipeDirection.RotatePipeDirection(xform.LocalRotation);
+        }
+
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,
             EntityQuery<NodeContainerComponent> nodeQuery,
             EntityQuery<TransformComponent> xformQuery,

--- a/Content.Server/NodeContainer/Nodes/PipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PipeNode.cs
@@ -133,14 +133,12 @@ namespace Content.Server.NodeContainer.Nodes
                     return false;
 
                 CurrentPipeDirection = _originalPipeDirection;
-            }
-            else
-            {
-                CurrentPipeDirection = _originalPipeDirection.RotatePipeDirection(ev.NewRotation);
+                return true;
             }
 
-            // node connections need to be updated
-            return true;
+            var oldDirection = CurrentPipeDirection;
+            CurrentPipeDirection = _originalPipeDirection.RotatePipeDirection(ev.NewRotation);
+            return oldDirection != CurrentPipeDirection;
         }
 
         public override void OnAnchorStateChanged(IEntityManager entityManager, bool anchored)


### PR DESCRIPTION
I added a bug where pipes were only updating the cardinal directions that they could connect to if they were connectable (anchored) while being rotated. So rotating an unanchored pipe caused connection issues when it was re-anchored.

This fixed it by re-adding the on-anchor-changed node function, and having pipes update their directions/rotation when they actually get anchored.

:cl:
- fixed: Fixed a bug preventing atmos pipes from properly connecting after being rotated.

