### PR TITLE
Disable pushing

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -291,7 +291,7 @@ namespace Content.Shared.CCVar
         /// Technically client doesn't need to know about it but this may prevent a bug in the distant future so it stays.
         /// </remarks>
         public static readonly CVarDef<bool> MobPushing =
-            CVarDef.Create("physics.mob_pushing", true, CVar.REPLICATED);
+            CVarDef.Create("physics.mob_pushing", false, CVar.REPLICATED);
 
         /*
          * Lobby music

--- a/Content.Shared/Movement/EntitySystems/SharedMobMoverSystem.cs
+++ b/Content.Shared/Movement/EntitySystems/SharedMobMoverSystem.cs
@@ -16,7 +16,7 @@ namespace Content.Shared.Movement.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
-            Get<SharedPhysicsSystem>().KinematicControllerCollision += HandleCollisionMessage;
+            Get<SharedPhysicsSystem>().KinematicControllerCollision += OnMobCollision;
             IoCManager.Resolve<IConfigurationManager>().OnValueChanged(CCVars.MobPushing, SetPushing, true);
         }
 
@@ -29,13 +29,13 @@ namespace Content.Shared.Movement.EntitySystems
         {
             base.Shutdown();
             IoCManager.Resolve<IConfigurationManager>().UnsubValueChanged(CCVars.MobPushing, SetPushing);
-            Get<SharedPhysicsSystem>().KinematicControllerCollision -= HandleCollisionMessage;
+            Get<SharedPhysicsSystem>().KinematicControllerCollision -= OnMobCollision;
         }
 
         /// <summary>
         ///     Fake pushing for player collisions.
         /// </summary>
-        private void HandleCollisionMessage(Fixture ourFixture, Fixture otherFixture, float frameTime, Vector2 worldNormal)
+        private void OnMobCollision(Fixture ourFixture, Fixture otherFixture, float frameTime, Vector2 worldNormal)
         {
             if (!_pushingEnabled) return;
 


### PR DESCRIPTION
Potentially controversial change:

tl;dr
Pros:
- No longer have this

https://user-images.githubusercontent.com/31366439/154447413-f6c62d2d-c766-41d5-a90b-c7347bc9a7f6.mp4


Cons:
- Easier to block people in places

So my minimum ping to USW is like 100-150ms. For the longest time there's been 4 things that make the game frustrating to play at this level of ping:
1. Airlock prediction
2. Interaction prediction
3. Pushing things
4. Footstep sound prediction (also featured in the above vid)

Airlock prediction is now done so we're left with the 3 horseman of the apocalypse.

The problem with pushing is that predicting physics is hard. Most games don't predict and just lerp server states as they come in so physics stuff looks smooth. The reason it's hard is because you can't predict external factors like other players moving which means any time they start moving or change direction the physics sim may be vastly different so you'd get teleporting everywhere from mispredicts.

At the moment we don't predict pushing and because it's server side it feels really bad to push things. When trying to predict you now also have the above problem so doing that would be difficult. Source only allows you to push small objects in multiplayer and most of them just get knocked away and can't be continually pushed.

Unless someone else comes alone and somehow makes pushing good I think it's best we just kill it because it looks and feels awful.

:cl:
- tweak: Pushing objects has been disabled. Pulling is still okay.