### PR TITLE
Rises round-end restart time to one minute

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.RoundEnd
 
         public TimeSpan DefaultCooldownDuration { get; set; } = TimeSpan.FromSeconds(30);
         public TimeSpan DefaultCountdownDuration { get; set; } = TimeSpan.FromMinutes(4);
-        public TimeSpan DefaultRestartRoundDuration { get; set; } = TimeSpan.FromSeconds(20);
+        public TimeSpan DefaultRestartRoundDuration { get; set; } = TimeSpan.FromMinutes(1);
 
         private CancellationTokenSource? _countdownTokenSource = null;
         private CancellationTokenSource? _cooldownTokenSource = null;


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows a fair amount of time for extra EORG fun
From 20 seconds to 1 one minute

:cl: Slorktainer
- tweak: Round-end restart time increased to one minute.

