### PR TITLE
Remove Reach from the map rotation

### DIFF
--- a/Resources/Prototypes/Maps/game.yml
+++ b/Resources/Prototypes/Maps/game.yml
@@ -144,6 +144,7 @@
   mapPath: /Maps/ssreach.yml
   minPlayers: 0
   maxPlayers: 15
+  votable: false
   overflowJobs:
     - Assistant
   availableJobs:


### PR DESCRIPTION
While I do like Reach, it should be removed from the voteable maps for a variety of reasons.
Mainly, it lacks proper atmos. With lungs it only takes 1 breach or mis-opened airlock to completely ruin the pressure and oxygen on the entire ship.