### PR TITLE
Spill some of the chemstream when bleeding

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -71,7 +71,7 @@ namespace Content.Server.Body.Components
         ///     How much blood needs to be in the temporary solution in order to create a puddle?
         /// </summary>
         [DataField("bleedPuddleThreshold")]
-        public FixedPoint2 BleedPuddleThreshold = 10.0f;
+        public FixedPoint2 BleedPuddleThreshold = 5.0f;
 
         /// <summary>
         ///     A modifier set prototype ID corresponding to how damage should be modified

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -170,6 +170,9 @@ public sealed class BloodstreamSystem : EntitySystem
 
         if (component.BloodTemporarySolution.MaxVolume > component.BleedPuddleThreshold)
         {
+            // Pass some of the chemstream into the spilled blood.
+            var temp = component.ChemicalSolution.SplitSolution(component.BloodTemporarySolution.CurrentVolume / 10);
+            component.BloodTemporarySolution.AddSolution(temp);
             _spillableSystem.SpillAt(uid, component.BloodTemporarySolution, "PuddleBlood", false);
             component.BloodTemporarySolution.RemoveAllSolution();
         }

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -168,7 +168,7 @@ public sealed class BloodstreamSystem : EntitySystem
         var newSol = component.BloodSolution.SplitSolution(-amount);
         component.BloodTemporarySolution.AddSolution(newSol);
 
-        if (component.BloodTemporarySolution.MaxVolume > component.BleedPuddleThreshold)
+        if (component.BloodTemporarySolution.CurrentVolume > component.BleedPuddleThreshold)
         {
             // Pass some of the chemstream into the spilled blood.
             var temp = component.ChemicalSolution.SplitSolution(component.BloodTemporarySolution.CurrentVolume / 10);

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -90,7 +90,7 @@ public sealed class BloodstreamSystem : EntitySystem
 
         component.ChemicalSolution.MaxVolume = component.ChemicalMaxVolume;
         component.BloodSolution.MaxVolume = component.BloodMaxVolume;
-        component.BloodTemporarySolution.MaxVolume = component.BleedPuddleThreshold * 2; // give some leeway
+        component.BloodTemporarySolution.MaxVolume = component.BleedPuddleThreshold * 4; // give some leeway, for chemstream as well
 
         // Fill blood solution with BLOOD
         _solutionContainerSystem.TryAddReagent(uid, component.BloodSolution, component.BloodReagent,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This has the emergent quality of potentially being used for forensics once I add reagent scanners

also fixes a dumb ass bug (maxvolume instead of currentvolume) and tweaks a bit

:cl:
- tweak: A small amount of reagents from your chemstream are now spilled when losing blood. Use that information wisely, detectives.
