### PR TITLE
Created a harmless mob prototype, removed "Harm" from Mice

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -587,7 +587,7 @@
 
 - type: entity
   name: mouse
-  parent: SimpleMobBase
+  parent: HarmlessMobBase
   id: MobMouse
   description: Squeak!
   components:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/harmlessmob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/harmlessmob.yml
@@ -1,0 +1,177 @@
+- type: entity
+  save: false
+  abstract: true
+  id: HarmlessSpaceMobBase # Mob without barotrauma, freezing and asphyxiation (for space carps!?)
+  suffix: AI
+  components:
+  - type: Reactive
+    groups:
+      Flammable: [Touch]
+      Extinguish: [Touch]
+      Acidic: [Touch, Ingestion]
+  - type: UtilityAI
+    behaviorSets:
+    # - Clothing
+    - Idle
+    # No hunger and thirst for space mobs (need a way to eat station tiles for space carps)
+  - type: Input
+    context: "human"
+  - type: AiFactionTag
+    factions:
+    - SimpleNeutral
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 4
+    baseSprintSpeed : 4
+  - type: HealthExaminable
+    examinableTypes:
+    - Blunt
+    - Slash
+    - Piercing
+    - Heat
+    - Shock
+  - type: MovedByPressure
+  - type: DamageOnHighSpeedImpact
+    damage:
+      types:
+        Blunt: 5
+    soundHit:
+      path: /Audio/Effects/hit_kick.ogg
+  - type: Sprite
+    noRot: true
+    drawdepth: Mobs
+    netsync: false
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Physics
+    bodyType: KinematicController # Same for all inheritors
+  - type: Fixtures
+    fixtures:
+    - shape:
+        # Circles, cuz rotation of rectangles looks very bad
+        !type:PhysShapeCircle
+        radius: 0.35
+      mass: 20
+      mask:
+      - Impassable
+      - MobImpassable #Bullets?!
+      - VaultImpassable
+      - SmallImpassable
+      layer:
+      - Opaque
+  - type: SolutionContainerManager
+  - type: Bloodstream
+    bloodlossDamage:
+      types:
+        Bloodloss:
+          1
+    bloodlossHealDamage:
+      types:
+        Bloodloss:
+          -0.25
+  - type: Damageable
+    damageContainer: Biological
+  - type: AtmosExposed
+  - type: Flammable
+    fireSpread: true
+    canResistFire: true
+    damage:
+      types:
+        Heat: 1 #per second, scales with number of fire 'stacks'
+  - type: Temperature
+    heatDamageThreshold: 360
+    coldDamageThreshold: 260
+    currentTemperature: 310.15
+    coldDamage:
+      types:
+        Cold : 1 #per second, scales with temperature & other constants
+    specificHeat: 42
+    heatDamage:
+      types:
+        Heat : 1 #per second, scales with temperature & other constants
+  - type: MobState
+    thresholds:
+      0: !type:NormalMobState {}
+      50: !type:CriticalMobState {}
+      100: !type:DeadMobState {}
+  - type: HeatResistance
+  - type: CombatMode
+  - type: Internals
+  - type: StatusEffects
+    allowed:
+    - Stun
+    - KnockedDown
+    - SlowedDown
+    - Stutter
+    - Electrocution
+  - type: Body
+    template: AnimalTemplate
+    preset: AnimalPreset
+  - type: Examiner
+  - type: Appearance
+    visuals:
+    - type: BuckleVisualizer
+    - type: FireVisualizer
+      sprite: Mobs/Effects/onfire.rsi
+      normalState: Generic_mob_burning
+  - type: DoAfter
+  - type: Climbing
+  - type: Flashable
+  - type: Pullable
+  - type: Puller
+  - type: Buckle
+  - type: Recyclable
+    safe: false
+  - type: StandingState
+  - type: Alerts
+
+- type: entity
+  save: false
+  abstract: true
+  id: HarmlessMobBase # for air breathers
+  parent: HarmlessSpaceMobBase
+  suffix: AI
+  components:
+  - type: UtilityAI
+    behaviorSets:
+    - Idle
+    # - Hunger TODO: eating on the floor and fix weird AI endless stomach
+    # - Thirst
+  - type: Hunger
+    damage:
+      types:
+        Blunt: 2
+  - type: Thirst
+    damage:
+      types:
+        Blunt: 2
+  - type: Barotrauma
+    damage:
+      types:
+        Blunt: 1 #per second, scales with pressure and other constants.
+  - type: ThermalRegulator
+    metabolismHeat: 800
+    radiatedHeat: 100
+    implicitHeatRegulation: 250
+    sweatHeatRegulation: 500
+    shiveringHeatRegulation: 500
+    normalBodyTemperature: 310.15
+    thermalRegulationTemperatureThreshold: 25
+  - type: Respirator
+    damage:
+      types:
+        Asphyxiation: 3
+    damageRecovery:
+      types:
+        Asphyxiation: -1.5
+  - type: Temperature
+    heatDamageThreshold: 360
+    coldDamageThreshold: 260
+    currentTemperature: 310.15
+    specificHeat: 42
+    coldDamage:
+      types:
+        Cold : 1 #per second, scales with temperature & other constants
+    heatDamage:
+      types:
+        Heat : 1 #per second, scales with temperature & other constants
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Created a harmless mob prototype, removed "Harm" from Mice <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Thanks to [Elijahrane](https://github.com/Elijahrane) for suggesting this better method!

- Created a harmless mob prototype
  - Now other critters that become player-controlled in the future can be made without any combat capabilities.
- Removed "Harm" from Mice
  - This is to achieve parity with SS13 - [mice shouldn't be able to harm anything](https://wiki.ss13.co/Critter#Ghost_Critters)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Mice can no longer harm things.

