### PR TITLE
Ghost orbiting

### DIFF
--- a/Content.Client/Orbit/OrbitVisualsComponent.cs
+++ b/Content.Client/Orbit/OrbitVisualsComponent.cs
@@ -1,0 +1,17 @@
+﻿namespace Content.Client.Orbit;
+
+[RegisterComponent]
+public sealed class OrbitVisualsComponent : Component
+{
+    /// <summary>
+    ///     How long should the orbit animation last in seconds?
+    /// </summary>
+    [DataField("orbitLength")]
+    public float OrbitLength = 5.0f;
+
+    /// <summary>
+    ///     How long should the orbit stop animation last in seconds?
+    /// </summary>
+    [DataField("orbitStopLength")]
+    public float OrbitStopLength = 2.0f;
+}

--- a/Content.Client/Orbit/OrbitVisualsComponent.cs
+++ b/Content.Client/Orbit/OrbitVisualsComponent.cs
@@ -1,17 +1,39 @@
-﻿namespace Content.Client.Orbit;
+﻿using Robust.Shared.Animations;
+
+namespace Content.Client.Orbit;
 
 [RegisterComponent]
 public sealed class OrbitVisualsComponent : Component
 {
     /// <summary>
-    ///     How long should the orbit animation last in seconds?
+    ///     How long should the orbit animation last in seconds, before being randomized?
     /// </summary>
-    [DataField("orbitLength")]
-    public float OrbitLength = 5.0f;
+    [DataField("orbitLengthBase")]
+    public float OrbitLength = 2.0f;
+
+    /// <summary>
+    ///     How far away from the entity should the orbit be, before being randomized?
+    /// </summary>
+    [DataField("orbitDistanceBase")]
+    public float OrbitDistance = 1.0f;
+
+    /// <summary>
+    ///     Does this entity rotate clockwise or counterclockwise?
+    ///     Always randomized.
+    /// </summary>
+    public bool Clockwise = false;
 
     /// <summary>
     ///     How long should the orbit stop animation last in seconds?
     /// </summary>
     [DataField("orbitStopLength")]
-    public float OrbitStopLength = 2.0f;
+    public float OrbitStopLength = 1.0f;
+
+    /// <summary>
+    ///     How far along in the orbit, from 0 to 1, is this entity?
+    /// </summary>
+    [Animatable]
+    public float Orbit { get; set; } = 0.0f;
+
+    public bool Orbiting = false;
 }

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Follower;
+using Content.Shared.Follower.Components;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
 using Robust.Shared.Animations;
@@ -35,9 +36,6 @@ public sealed class OrbitVisualsSystem : VisualizerSystem<OrbitVisualsComponent>
 
         foreach (var (orbit, sprite) in EntityManager.EntityQuery<OrbitVisualsComponent, ISpriteComponent>())
         {
-            if (!orbit.Orbiting)
-                continue;
-
             var angle = new Angle(Math.PI * 2 * orbit.Orbit);
             var vec = angle.RotateVec(new Vector2(orbit.OrbitDistance, 0));
 
@@ -58,18 +56,14 @@ public sealed class OrbitVisualsSystem : VisualizerSystem<OrbitVisualsComponent>
 
         if (orbiting)
         {
-            if (component.Orbiting)
+            if (animationPlayer.HasRunningAnimation(_orbitAnimationKey))
                 return;
 
-            component.Orbiting = true;
             animationPlayer.Play(GetOrbitAnimation(component), _orbitAnimationKey);
         }
         else
         {
-            if (!component.Orbiting)
-                return;
-
-            component.Orbiting = false;
+            RemComp<OrbitVisualsComponent>(uid);
             if (animationPlayer.HasRunningAnimation(_orbitAnimationKey))
             {
                 animationPlayer.Stop(_orbitAnimationKey);

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -1,0 +1,130 @@
+﻿using Content.Shared.Follower;
+using Robust.Client.Animations;
+using Robust.Client.GameObjects;
+using Robust.Shared.Animations;
+
+namespace Content.Client.Orbit;
+
+// Not a visualizer system as we do not actually have any need for appearance events.
+public sealed class OrbitVisualsSystem : EntitySystem
+{
+    private readonly string _orbitAnimationKey = "orbiting";
+    private readonly string _orbitStopKey = "orbiting_stop";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<OrbitVisualsComponent, StartedFollowingEntityEvent>(OnStartedFollowingEntity);
+        SubscribeLocalEvent<OrbitVisualsComponent, StoppedFollowingEntityEvent>(OnStoppedFollowingEntity);
+        SubscribeLocalEvent<OrbitVisualsComponent, AnimationCompletedEvent>(OnAnimationCompleted);
+    }
+
+    private void OnStartedFollowingEntity(EntityUid uid, OrbitVisualsComponent component, StartedFollowingEntityEvent args)
+    {
+        if (!TryComp(uid, out ISpriteComponent? sprite))
+            return;
+
+        var animationPlayer = EntityManager.EnsureComponent<AnimationPlayerComponent>(uid);
+
+        if (animationPlayer.HasRunningAnimation(_orbitAnimationKey))
+        {
+            animationPlayer.Stop(_orbitAnimationKey);
+        }
+
+        animationPlayer.Play(GetOrbitAnimation(component, sprite), _orbitAnimationKey);
+    }
+
+    private void OnStoppedFollowingEntity(EntityUid uid, OrbitVisualsComponent component, StoppedFollowingEntityEvent args)
+    {
+        if (!TryComp(uid, out ISpriteComponent? sprite))
+            return;
+
+        var animationPlayer = EntityManager.EnsureComponent<AnimationPlayerComponent>(uid);
+        animationPlayer.Stop(_orbitAnimationKey);
+        animationPlayer.Play(GetStopAnimation(component, sprite), _orbitStopKey);
+    }
+
+    private void OnAnimationCompleted(EntityUid uid, OrbitVisualsComponent component, AnimationCompletedEvent args)
+    {
+        if (args.Key == _orbitAnimationKey)
+        {
+            if(EntityManager.TryGetComponent(uid, out AnimationPlayerComponent? animationPlayer)
+               && EntityManager.TryGetComponent(uid, out ISpriteComponent? sprite))
+
+            animationPlayer.Play(GetOrbitAnimation(component, sprite), _orbitAnimationKey);
+        }
+    }
+
+    private Animation GetOrbitAnimation(OrbitVisualsComponent component, ISpriteComponent sprite)
+    {
+        var length = component.OrbitLength;
+
+        return new Animation()
+        {
+            Length = TimeSpan.FromSeconds(length),
+            AnimationTracks =
+            {
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(ISpriteComponent),
+                    Property = nameof(ISpriteComponent.Offset),
+                    KeyFrames =
+                    {
+                        new AnimationTrackProperty.KeyFrame(new Vector2(0, -0.5f), 0f),
+                        new AnimationTrackProperty.KeyFrame(new Vector2(0.5f, 0), length / 4),
+                        new AnimationTrackProperty.KeyFrame(new Vector2(0, 0.5f), length / 2),
+                        new AnimationTrackProperty.KeyFrame(new Vector2(-0.5f, 0), length),
+                    },
+                    InterpolationMode = AnimationInterpolationMode.Linear
+                },
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(ISpriteComponent),
+                    Property = nameof(ISpriteComponent.Rotation),
+                    KeyFrames =
+                    {
+                        new AnimationTrackProperty.KeyFrame(sprite.Rotation, 0f),
+                        new AnimationTrackProperty.KeyFrame(new Angle(2 * Math.PI), length),
+                    },
+                    InterpolationMode = AnimationInterpolationMode.Linear
+                }
+            }
+        };
+    }
+
+    private Animation GetStopAnimation(OrbitVisualsComponent component, ISpriteComponent sprite)
+    {
+        var length = 2.0f;
+
+        return new Animation()
+        {
+            Length = TimeSpan.FromSeconds(length),
+            AnimationTracks =
+            {
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(ISpriteComponent),
+                    Property = nameof(ISpriteComponent.Offset),
+                    KeyFrames =
+                    {
+                        new AnimationTrackProperty.KeyFrame(sprite.Offset, 0f),
+                        new AnimationTrackProperty.KeyFrame(new Vector2(0, 0), length),
+                    },
+                    InterpolationMode = AnimationInterpolationMode.Linear
+                },
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(ISpriteComponent),
+                    Property = nameof(ISpriteComponent.Rotation),
+                    KeyFrames =
+                    {
+                        new AnimationTrackProperty.KeyFrame(sprite.Rotation, 0f),
+                        new AnimationTrackProperty.KeyFrame(Angle.Zero, length),
+                    },
+                    InterpolationMode = AnimationInterpolationMode.Linear
+                }
+            }
+        };
+    }
+}

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -59,6 +59,11 @@ public sealed class OrbitVisualsSystem : VisualizerSystem<OrbitVisualsComponent>
             if (animationPlayer.HasRunningAnimation(_orbitAnimationKey))
                 return;
 
+            if (animationPlayer.HasRunningAnimation(_orbitStopKey))
+            {
+                animationPlayer.Stop(_orbitStopKey);
+            }
+
             animationPlayer.Play(GetOrbitAnimation(component), _orbitAnimationKey);
         }
         else

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -17,7 +17,6 @@ namespace Content.Server.Entry
             "ClientEntitySpawner",
             "CharacterInfo",
             "ItemCabinetVisuals",
-            "OrbitVisuals"
         };
     }
 }

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -16,7 +16,8 @@ namespace Content.Server.Entry
             "Icon",
             "ClientEntitySpawner",
             "CharacterInfo",
-            "ItemCabinetVisuals"
+            "ItemCabinetVisuals",
+            "OrbitVisuals"
         };
     }
 }

--- a/Content.Shared/Follower/Components/OrbitVisualsComponent.cs
+++ b/Content.Shared/Follower/Components/OrbitVisualsComponent.cs
@@ -1,6 +1,6 @@
 ﻿using Robust.Shared.Animations;
 
-namespace Content.Client.Orbit;
+namespace Content.Shared.Follower.Components;
 
 [RegisterComponent]
 public sealed class OrbitVisualsComponent : Component
@@ -18,12 +18,6 @@ public sealed class OrbitVisualsComponent : Component
     public float OrbitDistance = 1.0f;
 
     /// <summary>
-    ///     Does this entity rotate clockwise or counterclockwise?
-    ///     Always randomized.
-    /// </summary>
-    public bool Clockwise = false;
-
-    /// <summary>
     ///     How long should the orbit stop animation last in seconds?
     /// </summary>
     [DataField("orbitStopLength")]
@@ -34,6 +28,4 @@ public sealed class OrbitVisualsComponent : Component
     /// </summary>
     [Animatable]
     public float Orbit { get; set; } = 0.0f;
-
-    public bool Orbiting = false;
 }

--- a/Content.Shared/Follower/Components/OrbitVisualsComponent.cs
+++ b/Content.Shared/Follower/Components/OrbitVisualsComponent.cs
@@ -8,19 +8,16 @@ public sealed class OrbitVisualsComponent : Component
     /// <summary>
     ///     How long should the orbit animation last in seconds, before being randomized?
     /// </summary>
-    [DataField("orbitLengthBase")]
     public float OrbitLength = 2.0f;
 
     /// <summary>
     ///     How far away from the entity should the orbit be, before being randomized?
     /// </summary>
-    [DataField("orbitDistanceBase")]
     public float OrbitDistance = 1.0f;
 
     /// <summary>
     ///     How long should the orbit stop animation last in seconds?
     /// </summary>
-    [DataField("orbitStopLength")]
     public float OrbitStopLength = 1.0f;
 
     /// <summary>

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -75,8 +75,15 @@ public sealed class FollowerSystem : EntitySystem
 
         if (TryComp<AppearanceComponent>(follower, out var appearance))
         {
+            EnsureComp<OrbitVisualsComponent>(follower);
             appearance.SetData(OrbitingVisuals.IsOrbiting, true);
         }
+
+        var followerEv = new StartedFollowingEntityEvent(entity, follower);
+        var entityEv = new EntityStartedFollowingEvent(entity, follower);
+
+        RaiseLocalEvent(follower, followerEv);
+        RaiseLocalEvent(entity, entityEv, false);
     }
 
     /// <summary>
@@ -102,6 +109,12 @@ public sealed class FollowerSystem : EntitySystem
         {
             appearance.SetData(OrbitingVisuals.IsOrbiting, false);
         }
+
+        var uidEv = new StoppedFollowingEntityEvent(target, uid);
+        var targetEv = new EntityStoppedFollowingEvent(target, uid);
+
+        RaiseLocalEvent(uid, uidEv);
+        RaiseLocalEvent(target, targetEv, false);
     }
 
     /// <summary>
@@ -117,6 +130,58 @@ public sealed class FollowerSystem : EntitySystem
         {
             StopFollowingEntity(player, uid, followed);
         }
+    }
+}
+
+public abstract class FollowEvent : EntityEventArgs
+{
+    public EntityUid Following;
+    public EntityUid Follower;
+
+    protected FollowEvent(EntityUid following, EntityUid follower)
+    {
+        Following = following;
+        Follower = follower;
+    }
+}
+
+/// <summary>
+///     Raised on an entity when it start following another entity.
+/// </summary>
+public sealed class StartedFollowingEntityEvent : FollowEvent
+{
+    public StartedFollowingEntityEvent(EntityUid following, EntityUid follower) : base(following, follower)
+    {
+    }
+}
+
+/// <summary>
+///     Raised on an entity when it stops following another entity.
+/// </summary>
+public sealed class StoppedFollowingEntityEvent : FollowEvent
+{
+    public StoppedFollowingEntityEvent(EntityUid following, EntityUid follower) : base(following, follower)
+    {
+    }
+}
+
+/// <summary>
+///     Raised on an entity when it start following another entity.
+/// </summary>
+public sealed class EntityStartedFollowingEvent : FollowEvent
+{
+    public EntityStartedFollowingEvent(EntityUid following, EntityUid follower) : base(following, follower)
+    {
+    }
+}
+
+/// <summary>
+///     Raised on an entity when it starts being followed by another entity.
+/// </summary>
+public sealed class EntityStoppedFollowingEvent : FollowEvent
+{
+    public EntityStoppedFollowingEvent(EntityUid following, EntityUid follower) : base(following, follower)
+    {
     }
 }
 

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -6,6 +6,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Localization;
 using Content.Shared.Follower.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Follower;
 
@@ -72,6 +73,11 @@ public sealed class FollowerSystem : EntitySystem
         xform.AttachParent(entity);
         xform.LocalPosition = Vector2.Zero;
 
+        if (TryComp<AppearanceComponent>(follower, out var appearance))
+        {
+            appearance.SetData(OrbitingVisuals.IsOrbiting, true);
+        }
+
         var followerEv = new StartedFollowingEntityEvent(entity, follower);
         var entityEv = new EntityStartedFollowingEvent(entity, follower);
 
@@ -97,6 +103,11 @@ public sealed class FollowerSystem : EntitySystem
         RemComp<FollowerComponent>(uid);
 
         Transform(uid).AttachToGridOrMap();
+
+        if (TryComp<AppearanceComponent>(uid, out var appearance))
+        {
+            appearance.SetData(OrbitingVisuals.IsOrbiting, false);
+        }
 
         var uidEv = new StoppedFollowingEntityEvent(target, uid);
         var targetEv = new EntityStoppedFollowingEvent(target, uid);
@@ -172,3 +183,10 @@ public sealed class EntityStoppedFollowingEvent : FollowEvent
     {
     }
 }
+
+[Serializable, NetSerializable]
+public enum OrbitingVisuals
+{
+    IsOrbiting
+}
+

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -77,12 +77,6 @@ public sealed class FollowerSystem : EntitySystem
         {
             appearance.SetData(OrbitingVisuals.IsOrbiting, true);
         }
-
-        var followerEv = new StartedFollowingEntityEvent(entity, follower);
-        var entityEv = new EntityStartedFollowingEvent(entity, follower);
-
-        RaiseLocalEvent(follower, followerEv, false);
-        RaiseLocalEvent(entity, entityEv, false);
     }
 
     /// <summary>
@@ -108,12 +102,6 @@ public sealed class FollowerSystem : EntitySystem
         {
             appearance.SetData(OrbitingVisuals.IsOrbiting, false);
         }
-
-        var uidEv = new StoppedFollowingEntityEvent(target, uid);
-        var targetEv = new EntityStoppedFollowingEvent(target, uid);
-
-        RaiseLocalEvent(uid, uidEv, false);
-        RaiseLocalEvent(target, targetEv, false);
     }
 
     /// <summary>
@@ -129,58 +117,6 @@ public sealed class FollowerSystem : EntitySystem
         {
             StopFollowingEntity(player, uid, followed);
         }
-    }
-}
-
-public abstract class FollowEvent : EntityEventArgs
-{
-    public EntityUid Following;
-    public EntityUid Follower;
-
-    protected FollowEvent(EntityUid following, EntityUid follower)
-    {
-        Following = following;
-        Follower = follower;
-    }
-}
-
-/// <summary>
-///     Raised on an entity when it start following another entity.
-/// </summary>
-public sealed class StartedFollowingEntityEvent : FollowEvent
-{
-    public StartedFollowingEntityEvent(EntityUid following, EntityUid follower) : base(following, follower)
-    {
-    }
-}
-
-/// <summary>
-///     Raised on an entity when it stops following another entity.
-/// </summary>
-public sealed class StoppedFollowingEntityEvent : FollowEvent
-{
-    public StoppedFollowingEntityEvent(EntityUid following, EntityUid follower) : base(following, follower)
-    {
-    }
-}
-
-/// <summary>
-///     Raised on an entity when it start following another entity.
-/// </summary>
-public sealed class EntityStartedFollowingEvent : FollowEvent
-{
-    public EntityStartedFollowingEvent(EntityUid following, EntityUid follower) : base(following, follower)
-    {
-    }
-}
-
-/// <summary>
-///     Raised on an entity when it starts being followed by another entity.
-/// </summary>
-public sealed class EntityStoppedFollowingEvent : FollowEvent
-{
-    public EntityStoppedFollowingEvent(EntityUid following, EntityUid follower) : base(following, follower)
-    {
     }
 }
 

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -107,6 +107,8 @@ public sealed class FollowerSystem : EntitySystem
 
         if (TryComp<AppearanceComponent>(uid, out var appearance))
         {
+            // We don't remove OrbitVisuals here since the OrbitVisualsSystem will handle that itself
+            // during the OnChangeData, which is deferred..
             appearance.SetData(OrbitingVisuals.IsOrbiting, false);
         }
 
@@ -186,7 +188,7 @@ public sealed class EntityStoppedFollowingEvent : FollowEvent
 }
 
 [Serializable, NetSerializable]
-public enum OrbitingVisuals
+public enum OrbitingVisuals : byte
 {
     IsOrbiting
 }

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -71,6 +71,12 @@ public sealed class FollowerSystem : EntitySystem
         var xform = Transform(follower);
         xform.AttachParent(entity);
         xform.LocalPosition = Vector2.Zero;
+
+        var followerEv = new StartedFollowingEntityEvent(entity, follower);
+        var entityEv = new EntityStartedFollowingEvent(entity, follower);
+
+        RaiseLocalEvent(follower, followerEv, false);
+        RaiseLocalEvent(entity, entityEv, false);
     }
 
     /// <summary>
@@ -89,7 +95,14 @@ public sealed class FollowerSystem : EntitySystem
         if (followed.Following.Count == 0)
             RemComp<FollowedComponent>(target);
         RemComp<FollowerComponent>(uid);
+
         Transform(uid).AttachToGridOrMap();
+
+        var uidEv = new StoppedFollowingEntityEvent(target, uid);
+        var targetEv = new EntityStoppedFollowingEvent(target, uid);
+
+        RaiseLocalEvent(uid, uidEv, false);
+        RaiseLocalEvent(target, targetEv, false);
     }
 
     /// <summary>
@@ -105,5 +118,57 @@ public sealed class FollowerSystem : EntitySystem
         {
             StopFollowingEntity(player, uid, followed);
         }
+    }
+}
+
+public abstract class FollowEvent : EntityEventArgs
+{
+    public EntityUid Following;
+    public EntityUid Follower;
+
+    protected FollowEvent(EntityUid following, EntityUid follower)
+    {
+        Following = following;
+        Follower = follower;
+    }
+}
+
+/// <summary>
+///     Raised on an entity when it start following another entity.
+/// </summary>
+public sealed class StartedFollowingEntityEvent : FollowEvent
+{
+    public StartedFollowingEntityEvent(EntityUid following, EntityUid follower) : base(following, follower)
+    {
+    }
+}
+
+/// <summary>
+///     Raised on an entity when it stops following another entity.
+/// </summary>
+public sealed class StoppedFollowingEntityEvent : FollowEvent
+{
+    public StoppedFollowingEntityEvent(EntityUid following, EntityUid follower) : base(following, follower)
+    {
+    }
+}
+
+/// <summary>
+///     Raised on an entity when it start following another entity.
+/// </summary>
+public sealed class EntityStartedFollowingEvent : FollowEvent
+{
+    public EntityStartedFollowingEvent(EntityUid following, EntityUid follower) : base(following, follower)
+    {
+    }
+}
+
+/// <summary>
+///     Raised on an entity when it starts being followed by another entity.
+/// </summary>
+public sealed class EntityStoppedFollowingEvent : FollowEvent
+{
+    public EntityStoppedFollowingEvent(EntityUid following, EntityUid follower) : base(following, follower)
+    {
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -22,6 +22,7 @@
       - GhostImpassable
   - type: PlayerInputMover
   - type: OrbitVisuals
+  - type: Appearance
   - type: Eye
     drawFov: false
   - type: Input

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -21,7 +21,6 @@
       mask:
       - GhostImpassable
   - type: PlayerInputMover
-  - type: OrbitVisuals
   - type: Appearance
   - type: Eye
     drawFov: false

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -21,6 +21,7 @@
       mask:
       - GhostImpassable
   - type: PlayerInputMover
+  - type: OrbitVisuals
   - type: Eye
     drawFov: false
   - type: Input


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If you could define your own custom lerp functions that would be neat and I could remove the update loop in `OrbitVisualsSystem`

Orbit params are randomized whenever a ghost starts orbiting someone. Yes this means other clients dont sync the orbit params but i think that's fine since this is purely visual. This makes lots of ghosts following an entity look a lot cooler I think. Can maybe tweak the bounds for how far it randomizes but other than that I think its a good idea

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/19853115/154784506-3f1ca404-e070-4069-9370-bb72a085742d.mp4

https://user-images.githubusercontent.com/19853115/154785165-b9653761-bafb-492a-abc6-0d70adc2a8ae.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Ghosts now orbit around entities they follow, rather than just sitting on top of them.
