### PR TITLE
Blood stuff in health examine

### DIFF
--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.Body.Components;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Fluids.EntitySystems;
+using Content.Server.HealthExaminable;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
@@ -33,7 +34,7 @@ public sealed class BloodstreamSystem : EntitySystem
 
         SubscribeLocalEvent<BloodstreamComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<BloodstreamComponent, DamageChangedEvent>(OnDamageChanged);
-        SubscribeLocalEvent<BloodstreamComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<BloodstreamComponent, HealthBeingExaminedEvent>(OnHealthBeingExamined);
         SubscribeLocalEvent<BloodstreamComponent, BeingGibbedEvent>(OnBeingGibbed);
     }
 
@@ -125,11 +126,23 @@ public sealed class BloodstreamSystem : EntitySystem
         }
     }
 
-    private void OnExamined(EntityUid uid, BloodstreamComponent component, ExaminedEvent args)
+    private void OnHealthBeingExamined(EntityUid uid, BloodstreamComponent component, HealthBeingExaminedEvent args)
     {
+        if (component.BleedAmount > 10)
+        {
+            args.Message.PushNewline();
+            args.Message.AddMarkup(Loc.GetString("bloodstream-component-profusely-bleeding", ("target", uid)));
+        }
+        else if (component.BleedAmount > 0)
+        {
+            args.Message.PushNewline();
+            args.Message.AddMarkup(Loc.GetString("bloodstream-component-bleeding", ("target", uid)));
+        }
+
         if (GetBloodLevelPercentage(uid, component) < component.BloodlossThreshold)
         {
-            args.PushMarkup(Loc.GetString("bloodstream-component-looks-pale", ("target", uid)));
+            args.Message.PushNewline();
+            args.Message.AddMarkup(Loc.GetString("bloodstream-component-looks-pale", ("target", uid)));
         }
     }
 

--- a/Content.Server/HealthExaminable/HealthExaminableComponent.cs
+++ b/Content.Server/HealthExaminable/HealthExaminableComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Server.HealthExaminable;
 
-[RegisterComponent]
+[RegisterComponent, Friend(typeof(HealthExaminableSystem))]
 public sealed class HealthExaminableComponent : Component
 {
     public List<FixedPoint2> Thresholds = new()

--- a/Content.Server/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Server/HealthExaminable/HealthExaminableSystem.cs
@@ -68,10 +68,11 @@ public sealed class HealthExaminableSystem : EntitySystem
                 if (tempLocStr == str)
                     continue;
 
-                chosenLocStr = tempLocStr;
-
                 if (dmg > threshold && threshold > closest)
+                {
+                    chosenLocStr = tempLocStr;
                     closest = threshold;
+                }
             }
 
             if (closest == FixedPoint2.Zero)
@@ -93,6 +94,24 @@ public sealed class HealthExaminableSystem : EntitySystem
             msg.AddMarkup(Loc.GetString($"health-examinable-{component.LocPrefix}-none"));
         }
 
+        // Anything else want to add on to this?
+        RaiseLocalEvent(uid, new HealthBeingExaminedEvent(msg));
+
         return msg;
+    }
+}
+
+/// <summary>
+///     A class raised on an entity whose health is being examined
+///     in order to add special text that is not handled by the
+///     damage thresholds.
+/// </summary>
+public sealed class HealthBeingExaminedEvent
+{
+    public FormattedMessage Message;
+
+    public HealthBeingExaminedEvent(FormattedMessage message)
+    {
+        Message = message;
     }
 }

--- a/Resources/Locale/en-US/bloodstream/bloodstream.ftl
+++ b/Resources/Locale/en-US/bloodstream/bloodstream.ftl
@@ -1,3 +1,3 @@
 ﻿bloodstream-component-looks-pale = [color=bisque]{CAPITALIZE(SUBJECT($target))} looks pale.[/color]
-bloodstream-component-bleeding = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} bleeding.[/color]
+bloodstream-component-bleeding = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} bleeding.[/color]
 bloodstream-component-profusely-bleeding = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} profusely bleeding![/color]

--- a/Resources/Locale/en-US/bloodstream/bloodstream.ftl
+++ b/Resources/Locale/en-US/bloodstream/bloodstream.ftl
@@ -1,1 +1,3 @@
 ﻿bloodstream-component-looks-pale = [color=bisque]{CAPITALIZE(SUBJECT($target))} looks pale.[/color]
+bloodstream-component-bleeding = [color=red]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-HAVE($target)} bleeding.[/color]
+bloodstream-component-profusely-bleeding = [color=crimson]{CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} profusely bleeding![/color]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Moves "looks pale" text to health examine
- Adds "is bleeding" text to health examine
- Fixes bug in health examine code where it would show the max damage for any threshold as long as it was above its min threshold. Whoops thats a big one

**Screenshots**

![image](https://user-images.githubusercontent.com/19853115/154788290-6390f2ef-9515-409c-8ce1-0a2131e38ff9.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Health examine now actually accurately assesses damage.
- tweak: Moved the "is pale" text to health examinations.
- add: Examining someone's health now will tell you if they are still bleeding.

