### PR TITLE
Disposals air + new atmos expose event

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosExposedSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosExposedSystem.cs
@@ -24,4 +24,10 @@ namespace Content.Server.Atmos.EntitySystems
             GasMixture = mixture;
         }
     }
+
+    [ByRefEvent]
+    public struct AtmosExposedGetAirEvent
+    {
+        public GasMixture? Gas;
+    }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -87,7 +87,7 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 // Used for things like disposals/cryo to change which air people are exposed to.
                 var airEvent = new AtmosExposedGetAirEvent();
-                RaiseLocalEvent(exposed.Owner, ref airEvent);
+                RaiseLocalEvent(exposed.Owner, ref airEvent, false);
 
                 airEvent.Gas ??= GetTileMixture(transform.Coordinates);
                 if (airEvent.Gas == null)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -85,9 +85,15 @@ namespace Content.Server.Atmos.EntitySystems
 
             foreach (var (exposed, transform) in EntityManager.EntityQuery<AtmosExposedComponent, TransformComponent>())
             {
-                var tile = GetTileMixture(transform.Coordinates);
-                if (tile == null) continue;
-                var updateEvent = new AtmosExposedUpdateEvent(transform.Coordinates, tile);
+                // Used for things like disposals/cryo to change which air people are exposed to.
+                var airEvent = new AtmosExposedGetAirEvent();
+                RaiseLocalEvent(exposed.Owner, ref airEvent);
+
+                airEvent.Gas ??= GetTileMixture(transform.Coordinates);
+                if (airEvent.Gas == null)
+                    continue;
+
+                var updateEvent = new AtmosExposedUpdateEvent(transform.Coordinates, airEvent.Gas);
                 RaiseLocalEvent(exposed.Owner, ref updateEvent);
             }
 

--- a/Content.Server/Disposal/Unit/Components/BeingDisposedComponent.cs
+++ b/Content.Server/Disposal/Unit/Components/BeingDisposedComponent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Server.Disposal.Unit.Components;
+
+/// <summary>
+///     A component added to entities that are currently in disposals.
+/// </summary>
+[RegisterComponent]
+public sealed class BeingDisposedComponent : Component
+{
+    [ViewVariables]
+    public EntityUid Holder;
+}

--- a/Content.Server/Disposal/Unit/Components/DisposalHolderComponent.cs
+++ b/Content.Server/Disposal/Unit/Components/DisposalHolderComponent.cs
@@ -63,7 +63,7 @@ namespace Content.Server.Disposal.Unit.Components
 
         [ViewVariables]
         [DataField("air")]
-        public GasMixture Air { get; set; } = new GasMixture(Atmospherics.CellVolume);
+        public GasMixture Air { get; set; } = new (70);
 
         protected override void Initialize()
         {

--- a/Content.Server/Disposal/Unit/EntitySystems/BeingDisposedSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/BeingDisposedSystem.cs
@@ -1,0 +1,40 @@
+﻿using Content.Server.Atmos.EntitySystems;
+using Content.Server.Disposal.Unit.Components;
+
+namespace Content.Server.Disposal.Unit.EntitySystems;
+
+public sealed class BeingDisposedSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BeingDisposedComponent, InhaleLocationEvent>(OnInhaleLocation);
+        SubscribeLocalEvent<BeingDisposedComponent, ExhaleLocationEvent>(OnExhaleLocation);
+        SubscribeLocalEvent<BeingDisposedComponent, AtmosExposedGetAirEvent>(OnGetAir);
+    }
+
+    private void OnGetAir(EntityUid uid, BeingDisposedComponent component, ref AtmosExposedGetAirEvent args)
+    {
+        if (TryComp<DisposalHolderComponent>(component.Holder, out var holder))
+        {
+            args.Gas = holder.Air;
+        }
+    }
+
+    private void OnInhaleLocation(EntityUid uid, BeingDisposedComponent component, InhaleLocationEvent args)
+    {
+        if (TryComp<DisposalHolderComponent>(component.Holder, out var holder))
+        {
+            args.Gas = holder.Air;
+        }
+    }
+
+    private void OnExhaleLocation(EntityUid uid, BeingDisposedComponent component, ExhaleLocationEvent args)
+    {
+        if (TryComp<DisposalHolderComponent>(component.Holder, out var holder))
+        {
+            args.Gas = holder.Air;
+        }
+    }
+}

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
@@ -47,6 +47,9 @@ namespace Content.Server.Disposal.Unit.EntitySystems
 
             foreach (var entity in holder.Container.ContainedEntities.ToArray())
             {
+                if (HasComp<BeingDisposedComponent>(entity))
+                    RemComp <BeingDisposedComponent>(entity);
+
                 if (EntityManager.TryGetComponent(entity, out IPhysBody? physics))
                 {
                     physics.CanCollide = true;
@@ -99,6 +102,12 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             {
                 ExitDisposals(holderUid, holder, holderTransform);
                 return false;
+            }
+
+            foreach (var ent in holder.Container.ContainedEntities)
+            {
+                var comp = EnsureComp<BeingDisposedComponent>(ent);
+                comp.Holder = holder.Owner;
             }
 
             // Insert into next tube

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -486,7 +486,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
 
             if (_atmosSystem.GetTileMixture(EntityManager.GetComponent<TransformComponent>(component.Owner).Coordinates, true) is {Temperature: > 0} environment)
             {
-                var transferMoles = 0.1f * (0.05f * Atmospherics.OneAtmosphere * 1.01f - air.Pressure) * air.Volume / (environment.Temperature * Atmospherics.R);
+                var transferMoles = 0.1f * (0.25f * Atmospherics.OneAtmosphere * 1.01f - air.Pressure) * air.Volume / (environment.Temperature * Atmospherics.R);
 
                 component.Air = environment.Remove(transferMoles);
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- You now breathe in and exhale to the gas that your disposal holder took with you
- Adds a new atmos exposed event for -which- gas to expose to, so that plasma fires don't affect you while in a disposals (as it exposes you to the holder gas). This will eventually be used for cryotubes as well as mechs. Maybe has perf implications so its by ref struct, not sure how to make it any more performant while retaining the features needed @Zumorica 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/19853115/154820855-73dd0704-bd9c-4638-bea9-d4f75b97ed30.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Being in disposals no longer exposes you to the air above the disposal tube--you will now inhale, exhale, and be exposed to the gas inside the tube itself.
