### PR TITLE
Don't log on midi resolve failure

### DIFF
--- a/Content.Client/Instruments/InstrumentSystem.cs
+++ b/Content.Client/Instruments/InstrumentSystem.cs
@@ -108,7 +108,7 @@ namespace Content.Client.Instruments
 
         public override void EndRenderer(EntityUid uid, bool fromStateChange, SharedInstrumentComponent? component = null)
         {
-            if (!Resolve(uid, ref component))
+            if (!Resolve(uid, ref component, false))
                 return;
 
             if (component is not InstrumentComponent instrument)


### PR DESCRIPTION
Looking at the code a bunch of the networked events can try to do stuff with midi. The issue is there's no guarantee the entity may still exist on the client end (hence the resolve failing) so not logging is probably better.
