### PR TITLE
Door collision fixes

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -140,7 +140,7 @@ public sealed class DoorComponent : Component, ISerializationHooks
     /// List of EntityUids of entities we're currently crushing. Cleared in OnPartialOpen().
     /// </summary>
     [DataField("currentlyCrushing")]
-    public List<EntityUid> CurrentlyCrushing = new();
+    public HashSet<EntityUid> CurrentlyCrushing = new();
     #endregion
 
     #region Serialization
@@ -238,7 +238,7 @@ public enum DoorVisuals
 public sealed class DoorComponentState : ComponentState
 {
     public readonly DoorState DoorState;
-    public readonly List<EntityUid> CurrentlyCrushing;
+    public readonly HashSet<EntityUid> CurrentlyCrushing;
     public readonly TimeSpan? NextStateChange;
     public readonly bool Partial;
 


### PR DESCRIPTION
Fixed some door issues:
- collideable is now set **after** doing the last door crushing/safety check 
  - Previously would lead to doors visually opening when aborting close, but still being impassable.
- Make the client's state handling copy the list of colliding entities, rather than copy the reference.
- Make get-colliding use collision layers.
  - I just pilfered the collision mask check from `SharedMoverController.IsAroundCollider()`
  - Should stop ghosts from blocking doors. Windoors & tables still seem to work fine.

:cl:
- fixed: Fixed some door bugs that resulted doors that were impassable despite being open.

