### PR TITLE
Quick box size + capacity fix (no more boxed hardsuits)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -143,9 +143,6 @@
     layers:
       - state: box
       - state: writing
-  - type: Storage
-    capacity: 30
-    size: 30
 
 - type: entity
   name: box of hugs
@@ -163,9 +160,6 @@
     contents:
       - id: Brutepack
         amount: 6
-  - type: Storage
-    capacity: 30
-    size: 30
 
 - type: entity
   name: inflatable wall box

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -7,11 +7,6 @@
   - type: Sprite
     layers:
       - state: box
-  - type: Item
-    size: 20
-  - type: Storage
-    capacity: 20
-    size: 20
 
 - type: entity
   name: lightbulb box

--- a/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/medical.yml
@@ -12,10 +12,6 @@
     layers:
       - state: box
       - state: syringe
-  - type: Item
-    size: 30
-  - type: Storage
-    capacity: 30
 
 - type: entity
   name: pill canister box
@@ -31,10 +27,6 @@
     layers:
       - state: box
       - state: pillbox
-  - type: Item
-    size: 30
-  - type: Storage
-    capacity: 30
 
 - type: entity
   name: sterile box
@@ -76,10 +68,6 @@
     contents:
       - id: BodyBag_Folded
         amount: 5
-  - type: Item
-    size: 30
-  - type: Storage
-    capacity: 30
   - type: Sprite
     layers:
       - state: box

--- a/Resources/Prototypes/Catalog/Fills/Boxes/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/science.yml
@@ -14,7 +14,3 @@
     layers:
       - state: box
       - state: beaker
-  - type: Item
-    size: 30
-  - type: Storage
-    capacity: 30

--- a/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/security.yml
@@ -71,8 +71,6 @@
   - type: Sprite
     layers:
       - state: box_beanbag
-  - type: Storage
-    capacity: 30
 
 - type: entity
   name: box of lethal shots
@@ -87,5 +85,3 @@
   - type: Sprite
     layers:
       - state: box_lethalshot
-  - type: Storage
-    capacity: 30

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -21,7 +21,7 @@
   - type: TemperatureProtection
     coefficient: 0.001 # yes it needs to be this low, fires are fucking deadly apparently!!!!
   - type: Clothing
-    size: 25
+    size: 50
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Objects/Misc/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/box.yml
@@ -8,7 +8,7 @@
     sprite: Objects/Storage/boxes.rsi
   - type: Item
     sprite: Objects/Storage/boxes.rsi
-    size: 25
+    size: 31
   - type: Storage
     capacity: 30
     size: 10

--- a/Resources/Prototypes/Entities/Objects/Misc/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/box.yml
@@ -8,7 +8,7 @@
     sprite: Objects/Storage/boxes.rsi
   - type: Item
     sprite: Objects/Storage/boxes.rsi
-    size: 9999
+    size: 25
   - type: Storage
     capacity: 60
-    size: 9999
+    size: 10

--- a/Resources/Prototypes/Entities/Objects/Misc/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/box.yml
@@ -10,5 +10,5 @@
     sprite: Objects/Storage/boxes.rsi
     size: 25
   - type: Storage
-    capacity: 60
+    capacity: 30
     size: 10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So apparently you can put hardsuits in cardboard boxes. Big no no.

This is a quick fix that reduces cardboard boxes from 9999 size and 9999 capacity to a humble 30 size max (boxes are now 31 size so no boxes in boxes).

This means you can fit 1 of most things in a box (like a SAW which I kinda didn't want that to happen but apparently storage size doesn't do much. At least capacity down to 30 makes it so it's a max of 6 items in a box and hardsuits don't fit anymore at least.

Also removed the subsequent duplicate code from all the different box fills.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Reduced the size and capacity of all cardboard boxes. No more hardsuits in boxes.

