### PR TITLE
Fix interact using sometimes having target==used

### DIFF
--- a/Content.Shared/Interaction/IInteractUsing.cs
+++ b/Content.Shared/Interaction/IInteractUsing.cs
@@ -4,6 +4,7 @@ using JetBrains.Annotations;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Interaction
 {
@@ -78,6 +79,11 @@ namespace Content.Shared.Interaction
 
         public InteractUsingEvent(EntityUid user, EntityUid used, EntityUid target, EntityCoordinates clickLocation, bool predicted = false)
         {
+            // Interact using should not have the same used and target.
+            // That should be a use-in-hand event instead.
+            // If this is not the case, can lead to bugs (e.g., attempting to merge a item stack into itself).
+            DebugTools.Assert(used != target);
+
             User = user;
             Used = used;
             Target = target;

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -216,6 +216,12 @@ namespace Content.Shared.Interaction
             if (checkCanUse && !_actionBlockerSystem.CanUseHeldEntity(user))
                 return;
 
+            if (target == hand.HeldEntity)
+            {
+                UseInHandInteraction(user, target.Value, checkCanUse: false, checkCanInteract: false);
+                return;
+            }
+
             if (inRangeUnobstructed && target != null)
             {
                 InteractUsing(


### PR DESCRIPTION
Could result in attempting to merge a stack into itself when clicked rapidly with some latency.

https://discord.com/channels/310555209753690112/790656972801572905/945387988630777866