### PR TITLE
Change mandella to not beep loudly on mag empty

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -258,7 +258,6 @@
     magazineTypes:
     - Pistol
     magFillPrototype: MagazineClRiflePistol
-    autoEjectMag: true
     canMuzzleFlash: false # Dat in-built suppressor
     minAngle: 0
     maxAngle: 45


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sorry, another one liner PR:
this simply removes the auto-eject which is what causes the loud beeping. The mandella shouldn't be dropping its mag anyway.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![gun](https://user-images.githubusercontent.com/47410468/155187997-c1a81184-6ff4-41e4-b4aa-35370375b08d.gif)

