### PR TITLE
Furniture dragging and climbing

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -45,6 +45,11 @@
           SheetSteel1:
             min: 1
             max: 2
+  - type: Transform
+    anchored: true
+  - type: Anchorable
+  - type: Pullable
+
 
 - type: entity
   parent: Bed

--- a/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
@@ -40,3 +40,9 @@
   - type: Tag
     tags:
     - Wooden
+  - type: Transform
+    anchored: true
+  - type: Physics
+    bodyType: Static
+  - type: Anchorable
+  - type: Pullable

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -24,8 +24,11 @@
     visuals:
     - type: PowerChargerVisualizer
   - type: Anchorable
+  - type: Pullable
   - type: Clickable
   - type: InteractionOutline
+  - type: Physics
+    bodyType: Static
 
 - type: entity
   name: recharger

--- a/Resources/Prototypes/Entities/Structures/Storage/storage.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/storage.yml
@@ -21,9 +21,10 @@
           bounds: "-0.3,-0.3,0.3,0.3"
       mass: 50
       layer:
-      - MobImpassable
-      mask:
       - VaultImpassable
+      mask:
+      - Impassable
+      - SmallImpassable
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
@@ -43,3 +44,4 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Climbable


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Makes chargers and rechargers draggable so they can be properly moved around.
- Makes racks vaultable - no more OP firing defence. Personally don't like the sprite since it's not like a shelf but whatever.
- Makes beds draggable too. Why not.
- Makes bookshelves draggable. Time to defend the bar from zombies.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Chargers, beds and bookshelves can be dragged and anchored now.
- tweak: Racks can be vaulted over.
