### PR TITLE
add airtight flaps for mapping

### DIFF
--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -64,3 +64,39 @@
   - type: Occluder
     sizeX: 32
     sizeY: 32
+
+- type: entity
+  id: PlasticFlapsAirtightClear
+  parent: PlasticFlapsClear
+  name: airtight plastic flaps
+  suffix: Airtight Clear
+  description: Heavy duty, slightly stronger, airtight plastic flaps. Definitely can't get past those. No way.
+  components:
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: Airtight
+    fixVacuum: true
+
+- type: entity
+  id: PlasticFlapsAirtightOpaque
+  parent: PlasticFlapsOpaque
+  name: airtight plastic flaps
+  suffix: Airtight Opaque
+  description: Heavy duty, slightly stronger, airtight plastic flaps. Definitely can't get past those. No way.
+  components:
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 150
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: Airtight
+    fixVacuum: true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
These add variants of the plastic flap which are slightly stronger and airtight for use with mapping, these can't be constructed. but can be deconstructed
This was requested for the delta map

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![airtight](https://user-images.githubusercontent.com/47410468/155414245-35a6acb5-a47d-4dd8-8af1-a37a1e726d12.gif)

