### PR TITLE
Remove the singuloth toy from maint spawners.

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -17,7 +17,6 @@
         - Basketball
         - Football
         - BalloonCorgi
-        - SingularityToy
         - PonderingOrb
         - Skub
       rareChance: 0.01


### PR DESCRIPTION
Who thought this was a good idea.