### PR TITLE
Fix midi verb

### DIFF
--- a/Content.Server/UserInterface/ActivatableUIComponent.cs
+++ b/Content.Server/UserInterface/ActivatableUIComponent.cs
@@ -40,6 +40,9 @@ namespace Content.Server.UserInterface
         [DataField("key", readOnly: true, required: true)]
         private string _keyRaw = default!;
 
+        [DataField("verbText")]
+        public string VerbText = "ui-verb-toggle-open";
+
         /// <summary>
         ///     The client channel currently using the object, or null if there's none/not single user.
         ///     NOTE: DO NOT DIRECTLY SET, USE ActivatableUISystem.SetCurrentSingleUser

--- a/Content.Server/UserInterface/ActivatableUISystem.cs
+++ b/Content.Server/UserInterface/ActivatableUISystem.cs
@@ -34,12 +34,15 @@ namespace Content.Server.UserInterface
             if (!args.CanAccess)
                 return;
 
+            if (component.InHandsOnly && args.Using != uid)
+                return;
+
             if (!args.CanInteract && !HasComp<GhostComponent>(args.User))
                 return;
 
             ActivationVerb verb = new();
             verb.Act = () => InteractUI(args.User, component);
-            verb.Text = Loc.GetString("ui-verb-toggle-open");
+            verb.Text = Loc.GetString(component.VerbText);
             // TODO VERBS add "open UI" icon?
             args.Verbs.Add(verb);
         }

--- a/Resources/Locale/en-US/ui/verbs.ftl
+++ b/Resources/Locale/en-US/ui/verbs.ftl
@@ -1,2 +1,3 @@
 ### Loc for the various UI-related verbs
 ui-verb-toggle-open = Toggle UI
+verb-instrument-openui = Play Music

--- a/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
@@ -10,7 +10,7 @@
   - type: ActivatableUI
     inHandsOnly: true
     singleUser: true
-    verbText: "verb-instrument-openui"
+    verbText: verb-instrument-openui
     key: enum.InstrumentUiKey.Key
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
@@ -10,6 +10,7 @@
   - type: ActivatableUI
     inHandsOnly: true
     singleUser: true
+    verbText: "verb-instrument-openui"
     key: enum.InstrumentUiKey.Key
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Structures/Furniture/instruments.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/instruments.yml
@@ -8,6 +8,7 @@
   - type: ActivatableUI
     inHandsOnly: false
     singleUser: true
+    verbText: verb-instrument-openui
     key: enum.InstrumentUiKey.Key
   - type: InteractionOutline
   - type: Sprite


### PR DESCRIPTION
Currently the open UI verb doesn't respect the `InHandsOnly`  bool, so you can currently open more than one midi/instrument window simultaneously. This fixes that, and also changes the verb text to be more descriptive ("Open UI" -> "Play Music").

:cl:
- fix: Fixed a bug that allowed you to play multiple instruments simultaneously.

