### PR TITLE
Prevent non-airlock doors from closing on people.

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -130,11 +130,18 @@ public sealed class DoorComponent : Component, ISerializationHooks
     public DamageSpecifier? CrushDamage;
 
     /// <summary>
-    /// If false, this door is incapable of crushing entities. Note that this differs from the airlock's "safety"
-    /// feature that checks for colliding entities.
+    /// If false, this door is incapable of crushing entities. This just determines whether it will apply damage and
+    /// stun, not whether it can close despite entities being in the way.
     /// </summary>
     [DataField("canCrush")]
     public readonly bool CanCrush = true;
+
+    /// <summary>
+    /// Whether to check for colliding entities before closing. This may be overridden by other system by subscribing to
+    /// <see cref="BeforeDoorClosedEvent"/>. For example, hacked airlocks will set this to false.
+    /// </summary>
+    [DataField("performCollisionCheck")]
+    public readonly bool PerformCollisionCheck = true;
 
     /// <summary>
     /// List of EntityUids of entities we're currently crushing. Cleared in OnPartialOpen().

--- a/Content.Shared/Doors/DoorEvents.cs
+++ b/Content.Shared/Doors/DoorEvents.cs
@@ -25,16 +25,23 @@ namespace Content.Shared.Doors
     }
 
     /// <summary>
-    /// Raised when the door is determining whether it is able to close.
-    /// Cancel to stop the door from being closed.
+    /// Raised when the door is determining whether it is able to close. If the event is canceled, the door will not
+    /// close. Additionally this event also has a bool that determines whether or not the door should perform a
+    /// safety/collision check before closing. This check has to be proactively disabled by things like hacked airlocks.
     /// </summary>
     /// <remarks>
     /// This event is raised both when the door is initially closed, and when it is just about to become "partially"
-    /// closed (opaque & collidable). If canceled while partially closing, it will start opening again. Useful for
-    /// things like airlock anti-crush safety features.
+    /// closed (opaque & collidable). If canceled while partially closing, it will start opening again. Useful in case
+    /// an entity entered the door just as it was about to become "solid".
     /// </remarks>
     public sealed class BeforeDoorClosedEvent : CancellableEntityEventArgs
     {
+        public bool PerformCollisionCheck;
+
+        public BeforeDoorClosedEvent(bool performCollisionCheck)
+        {
+            PerformCollisionCheck = performCollisionCheck;
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -35,8 +35,8 @@ public abstract class SharedAirlockSystem : EntitySystem
 
     protected virtual void OnBeforeDoorClosed(EntityUid uid, SharedAirlockComponent airlock, BeforeDoorClosedEvent args)
     {
-        if (airlock.Safety && DoorSystem.GetColliding(uid).Any())
-            args.Cancel();
+        if (!airlock.Safety)
+            args.PerformCollisionCheck = false;
     }
 
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -309,12 +309,15 @@ public abstract class SharedDoorSystem : EntitySystem
         if (!Resolve(uid, ref door))
             return false;
 
-        var ev = new BeforeDoorClosedEvent();
+        var ev = new BeforeDoorClosedEvent(door.PerformCollisionCheck);
         RaiseLocalEvent(uid, ev, false);
         if (ev.Cancelled)
             return false;
 
-        return HasAccess(uid, user);
+        if (!HasAccess(uid, user))
+            return false;
+
+        return !ev.PerformCollisionCheck || !GetColliding(uid).Any();
     }
 
     public virtual void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
@@ -387,11 +390,10 @@ public abstract class SharedDoorSystem : EntitySystem
         if (!Resolve(uid, ref door))
             return;
 
-        // is this door capable of crushing? NOT the same as an airlock safety check. The door will still close.
         if (!door.CanCrush)
             return;
 
-        // Crush
+        // Find entities and apply curshing effects
         var stunTime = door.DoorStunTime + door.OpenTimeOne;
         foreach (var entity in GetColliding(uid, physics))
         {


### PR DESCRIPTION
Related to #6850. Currently the safety-check that prevents doors from closing when there are people in the way is enabled by the airlock component. This basically changes that around so that it is enabled by default for doors (data-field configurable), and has to be proactively disabled by hacked airlocks.

The main reason for this change is so that you can have "dumb" material doors that can't crush people, but also won't result in them getting wedged between the door and a wall.