### PR TITLE
Fix RoleUnban referring to the wrong ban type

### DIFF
--- a/Content.Server.Database/Model.cs
+++ b/Content.Server.Database/Model.cs
@@ -432,7 +432,7 @@ namespace Content.Server.Database
         [Column("role_unban_id")] public int Id { get; set; }
 
         public int BanId { get; set; }
-        public ServerBan Ban { get; set; } = null!;
+        public ServerRoleBan Ban { get; set; } = null!;
 
         public Guid? UnbanningAdmin { get; set; }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change ServerRoleUnban reference from ServerBan to ServerRoleBan.