### PR TITLE
update mapping command

### DIFF
--- a/Content.Client/Commands/DebugCommands.cs
+++ b/Content.Client/Commands/DebugCommands.cs
@@ -72,30 +72,4 @@ namespace Content.Client.Commands
             EntitySystem.Get<PopupSystem>().PopupCursor(message);
         }
     }
-
-    internal sealed class MappingCommand : IConsoleCommand
-    {
-        public string Command => "mapping";
-        public string Description => "Creates and teleports you to a new uninitialized map for mapping.";
-        public string Help => $"Usage: {Command} <mapname> / {Command} <id> <mapname>";
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
-        {
-            if (args.Length == 0)
-            {
-                shell.WriteLine(Help);
-                return;
-            }
-
-#if DEBUG
-            shell.WriteError("WARNING: The client is using a debug build. You are risking losing your changes.");
-#endif
-
-            shell.ConsoleHost.RegisteredCommands["togglelight"].Execute(shell, string.Empty, Array.Empty<string>());
-            shell.ConsoleHost.RegisteredCommands["showsubfloorforever"].Execute(shell, string.Empty, Array.Empty<string>());
-            shell.ConsoleHost.RegisteredCommands["showmarkers"].Execute(shell, string.Empty, Array.Empty<string>());
-
-            shell.RemoteExecuteCommand(argStr);
-        }
-    }
 }

--- a/Content.Server/GameTicking/Commands/MappingCommand.cs
+++ b/Content.Server/GameTicking/Commands/MappingCommand.cs
@@ -92,7 +92,7 @@ namespace Content.Server.GameTicking.Commands
             if (args.Length != 0)
                 shell.WriteLine($"Created uninitialized map from file {args[0]} with id {mapId}.");
             else
-                shell.WriteLine($"Created a new uninitialized map with id {mapId}. If you create a new grid on the map you can use \"savebp <gridId> foo.yml\" to save it as a map.");
+                shell.WriteLine($"Created a new uninitialized map with id {mapId}.");
         }
     }
 }

--- a/Content.Server/GameTicking/Commands/MappingCommand.cs
+++ b/Content.Server/GameTicking/Commands/MappingCommand.cs
@@ -1,16 +1,11 @@
 // ReSharper disable once RedundantUsingDirective
 // Used to warn the player in big red letters in debug mode
 
-using System.Linq;
 using Content.Server.Administration;
 using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Server.GameTicking.Commands
@@ -22,7 +17,7 @@ namespace Content.Server.GameTicking.Commands
 
         public string Command => "mapping";
         public string Description => "Creates and teleports you to a new uninitialized map for mapping.";
-        public string Help => $"Usage: {Command} <mapname> / {Command} <id> <mapname>";
+        public string Help => $"Usage: {Command} [mapname] [id]";
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
@@ -33,65 +28,71 @@ namespace Content.Server.GameTicking.Commands
                 return;
             }
 
+            if (args.Length > 2)
+            {
+                shell.WriteLine(Help);
+                return;
+            }
+
 #if DEBUG
             shell.WriteError("WARNING: The server is using a debug build. You are risking losing your changes.");
 #endif
 
             var mapManager = IoCManager.Resolve<IMapManager>();
-            int mapId;
-            string mapName;
+            MapId mapId;
 
-            switch (args.Length)
+            // Get the map ID to use
+            if (args.Length == 2)
             {
-                case 1:
-                    if (player.AttachedEntity == null)
-                    {
-                        shell.WriteError("The map name argument cannot be omitted if you have no entity.");
-                        return;
-                    }
-
-                    mapId = (int) mapManager.NextMapId();
-                    mapName = args[0];
-                    break;
-                case 2:
-                    if (!int.TryParse(args[0], out var id))
-                    {
-                        shell.WriteError($"{args[0]} is not a valid integer.");
-                        return;
-                    }
-
-                    mapId = id;
-                    mapName = args[1];
-                    break;
-                default:
-                    shell.WriteLine(Help);
+                if (!int.TryParse(args[1], out var id))
+                {
+                    shell.WriteError($"{args[1]} is not a valid integer.");
                     return;
+                }
+
+                mapId = new MapId(id);
+                if (mapManager.MapExists(mapId))
+                {
+                    shell.WriteError($"Map {mapId} already exists");
+                    return;
+                }
+            }
+            else
+            {
+                mapId = mapManager.NextMapId();
             }
 
-            // loadmap checks for this on its own but we want to avoid running our other commands.
-            if (mapManager.MapExists(new MapId(mapId)))
+            // either load a map or create a new one.
+            if (args.Length == 0)
+                shell.ExecuteCommand($"addmap {mapId}");
+            else
+                shell.ExecuteCommand($"loadmap {mapId} \"{CommandParsing.Escape(args[0])}\"");
+
+            // was the map actually created?
+            if (!mapManager.MapExists(mapId))
             {
-                shell.WriteError($"Map {mapId} already exists");
+                shell.WriteError($"An error occurred when creating the new map.");
                 return;
             }
 
-            shell.ExecuteCommand("sudo cvar events.enabled false");
-            shell.ExecuteCommand($"loadmap {mapId} \"{CommandParsing.Escape(mapName)}\" true");
-
-            if (player.AttachedEntity is {Valid: true} playerEntity &&
+            // map successfully created. run misc helpful mapping commands
+            if (player.AttachedEntity is { Valid: true } playerEntity &&
                 _entities.GetComponent<MetaDataComponent>(playerEntity).EntityPrototype?.ID != "AdminObserver")
             {
                 shell.ExecuteCommand("aghost");
             }
 
+            shell.ExecuteCommand("sudo cvar events.enabled false");
             shell.ExecuteCommand($"tp 0 0 {mapId}");
             shell.RemoteExecuteCommand("showmarkers");
+            shell.RemoteExecuteCommand("togglelight");
+            shell.RemoteExecuteCommand("showsubfloorforever");
+            mapManager.SetMapPaused(mapId, true);
 
-            var newGrid = mapManager.GetAllGrids().OrderByDescending(g => (int) g.Index).First();
-
-            mapManager.SetMapPaused(newGrid.ParentMapId, true);
-
-            shell.WriteLine($"Created unloaded map from file {mapName} with id {mapId}. Use \"savebp {newGrid.Index} foo.yml\" to save the new grid as a map.");
+            if (args.Length != 0)
+                shell.WriteLine($"Created uninitialized map from file {args[0]} with id {mapId}.");
+            else
+                shell.WriteLine($"Created a new uninitialized map with id {mapId}. If you create a new grid on the map you can use \"savebp <gridId> foo.yml\" to save it as a map.");
         }
     }
 }


### PR DESCRIPTION
Updates the mapping command so it can actually initialize a new paused map. Also makes it not run misc client-side commands if it fails to load the map (i.e, a typo in the filename will no longer result in lights & markers being toggled).

This will require the mapping docs to be updated, but they were already out of date anyways.

:cl:
- tweak: The /mapping command syntax has changed. The filename now comes before the Id, and a new blank map is created by providing no arguments.

