### PR TITLE
Load Maps on Round Start, not Round Restart

### DIFF
--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -234,8 +234,6 @@ public sealed class AddTests : ContentIntegrationTest
         await server.WaitIdleAsync();
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
-        var sEntities = server.ResolveDependency<IEntityManager>();
-        var sMaps = server.ResolveDependency<IMapManager>();
         var sSystems = server.ResolveDependency<IEntitySystemManager>();
 
         var sAdminLogSystem = sSystems.GetEntitySystem<AdminLogSystem>();
@@ -245,10 +243,7 @@ public sealed class AddTests : ContentIntegrationTest
 
         await server.WaitPost(() =>
         {
-            var coordinates = GetMainEntityCoordinates(sMaps);
-            var entity = sEntities.SpawnEntity(null, coordinates);
-
-            sAdminLogSystem.Add(LogType.Unknown, $"{entity} test log: {guid}");
+            sAdminLogSystem.Add(LogType.Unknown, $"test log: {guid}");
         });
 
         await server.WaitPost(() =>
@@ -284,8 +279,7 @@ public sealed class AddTests : ContentIntegrationTest
         await foreach (var json in sDatabase.GetAdminLogsJson(filter))
         {
             var root = json.RootElement;
-
-            Assert.That(root.TryGetProperty("entity", out _), Is.True);
+            
             Assert.That(root.TryGetProperty("guid", out _), Is.True);
 
             json.Dispose();

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -190,6 +190,8 @@ namespace Content.Server.GameTicking
 
                 SendServerMessage(Loc.GetString("game-ticker-start-round"));
 
+                LoadMaps();
+
                 StartGamePresetRules();
 
                 RoundLengthMetric.Set(0);
@@ -373,7 +375,6 @@ namespace Content.Server.GameTicking
             RunLevel = GameRunLevel.PreRoundLobby;
             LobbySong = _robustRandom.Pick(_lobbyMusicCollection.PickFiles).ToString();
             ResettingCleanup();
-            LoadMaps();
 
             if (!LobbyEnabled)
             {
@@ -411,17 +412,17 @@ namespace Content.Server.GameTicking
                 unCastData.ContentData()?.WipeMind();
             }
 
-            // Delete all entities.
-            foreach (var entity in EntityManager.GetEntities().ToList())
+            _startingRound = false;
+
+            _mapManager.Restart();
+
+            // Delete all remaining entities.
+            foreach (var entity in EntityManager.GetEntities().ToArray())
             {
                 // TODO: Maybe something less naive here?
                 // FIXME: Actually, definitely.
                 EntityManager.DeleteEntity(entity);
             }
-
-            _startingRound = false;
-
-            _mapManager.Restart();
 
             _roleBanManager.Restart();
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Load the map when the round starts, not when the round restarts.
This allows map votes during pre-round to actually affect the loaded map on roundstart. Seems to work fine locally.
- Move the loop deleting every entity in `EntityManager` *under* `IMapManager.Restart()` call.
My rationale behind this is that map manager restart already deletes every single map, and ensures nullspace is clean. This means that it should essentially delete *every single entity* properly. Might or might not fix the "stuck round start" bug. 

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Map votes during the pre-round period actually affect the chosen map on round start.
