### PR TITLE
Fix some collision flag issues

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
@@ -17,7 +17,7 @@
           bounds: "-0.49,-0.49,0.49,0.49"
       mass: 100
       mask:
-      - MobImpassable
+      - MobMask
       layer:
       - MobImpassable
       - VaultImpassable

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
@@ -19,6 +19,7 @@
       - VaultImpassable
       mask:
       - Impassable
+      - VaultImpassable # tables should collide with other tables
       - SmallImpassable
   - type: Sprite
     netsync: false

--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -15,7 +15,7 @@
         radius: 0.2
       mass: 25
       mask:
-        - MobImpassable
+        - SmallImpassable
       layer:
         - Opaque
         - MobImpassable

--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -16,6 +16,7 @@
       mass: 25
       mask:
         - SmallImpassable
+        - VaultImpassable
       layer:
         - Opaque
         - MobImpassable

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -13,7 +13,7 @@
           bounds: "-0.25,-0.5,0.25,0.5"
       mass: 25
       mask:
-        - MobImpassable
+        - MobMask
       layer:
         - Opaque
         - MobImpassable

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -25,7 +25,7 @@
       layer:
       - Opaque
       mask:
-      - MobImpassable
+      - MobMask
   - type: Transform
     anchored: true
   - type: Anchorable

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -53,7 +53,7 @@
             bounds: "-0.25,-0.25,0.25,0.25"
           mass: 25
           mask:
-            - MobImpassable
+          - MobMask
           layer:
             - Opaque
             - MobImpassable
@@ -380,7 +380,7 @@
               bounds: "-0.4,-0.3,0.4,0.3"
           mass: 25
           mask:
-            - MobImpassable
+          - MobMask
           layer:
             - Opaque
             - MobImpassable


### PR DESCRIPTION
After the `MobImpassable` layer was removed from walls and doors, a bunch of entities could be pushed into walls because that was their only mask. This mostly just gives those entities a `MobMask` mask, just so that anything that would stop a mob will also stop them. This might just be contributing to the collision layer abuse/misuse, so feel free to correct this @metalgearsloth.

:cl:
- fix: Fixed being able to push some entities (computers, canisters, plants) through walls and doors.

