### PR TITLE
Adds 2 new windoor types and fixes glass EVA airlock

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -441,7 +441,7 @@
     access: [["Armory"]]
 
 - type: entity
-  parent: AirlockEVALocked
+  parent: AirlockCommandGlassLocked
   id: AirlockEVAGlassLocked
   suffix: EVA, Locked
   components:

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -104,6 +104,14 @@
 
 - type: entity
   parent: WindoorSecure
+  id: WindoorSecureCargoLocked
+  suffix: Cargo, Locked
+  components:
+  - type: AccessReader
+    access: [["Cargo"]]
+
+- type: entity
+  parent: WindoorSecure
   id: WindoorSecureChapelLocked
   suffix: Chapel, Locked
   components:
@@ -135,6 +143,14 @@
   components:
   - type: AccessReader
     access: [["Engineering"]]
+    
+- type: entity
+  parent: WindoorSecure
+  id: WindoorExternalLocked
+  suffix: External, Locked
+  components:
+  - type: AccessReader
+    access: [["External"]]
 
 - type: entity
   parent: WindoorSecure


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
People were requesting a secure cargo windoor, so added that as well as adding a secure external windoor as an option for EVA storage or making impromptu improved airlocks that might cycle fast enough to not space tiles.

This pretty much covers every windoor access type bar the heads now so should be final.

Also fixed the glass eva door since it had the same sprite as the regular one.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added secure cargo and external windoors. Fixed glass EVA airlock sprite.
