### PR TITLE
Fix how movement sets an entities' rotation.

### DIFF
--- a/Content.Shared/Movement/SharedMoverController.cs
+++ b/Content.Shared/Movement/SharedMoverController.cs
@@ -149,7 +149,7 @@ namespace Content.Shared.Movement
             {
                 // This should have its event run during island solver soooo
                 xform.DeferUpdates = true;
-                xform.WorldRotation = worldTotal.GetDir().ToAngle();
+                xform.LocalRotation = total.GetDir().ToAngle();
                 xform.DeferUpdates = false;
                 HandleFootsteps(mover, mobMover);
             }


### PR DESCRIPTION
Currently while walking around, the players local rotation depends on the grid's world rotation, and doesn't nicely snap to 90-degree intervals when moving in cardinal directions.

This can easily be seen by getting the station spinning and then either VV-ing the players local rotation, or just equipping a flashlight and watching it's cone wave around as the player walks in a straight line.