### PR TITLE
Fix rcd obstruction check

### DIFF
--- a/Content.Server/RCD/Systems/RCDSystem.cs
+++ b/Content.Server/RCD/Systems/RCDSystem.cs
@@ -160,14 +160,8 @@ namespace Content.Server.RCD.Systems
                 return false;
             }
 
-            var coordinates = mapGrid.ToCoordinates(tile.GridIndices);
-            if (coordinates == EntityCoordinates.Invalid)
-            {
-                return false;
-            }
-
             var unobstructed = eventArgs.Target == null
-                ? _interactionSystem.InRangeUnobstructed(eventArgs.User, coordinates, popup: true)
+                ? _interactionSystem.InRangeUnobstructed(eventArgs.User, mapGrid.GridTileToWorld(tile.GridIndices), popup: true)
                 : _interactionSystem.InRangeUnobstructed(eventArgs.User, eventArgs.Target.Value, popup: true);
 
             if (!unobstructed)


### PR DESCRIPTION
If not targeting an entity, then the RCD currently checks the bottom left corner of a tile for obstructions, rather than the centre of a tile. This can prevent it from building on empty tiles if there is something like a wall touching that corner.

:cl:
- fix: Fixed a bug preventing the RCD from constructing entities on some empty tiles.

