### PR TITLE
Let items on conveyor belts round corners

### DIFF
--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -87,21 +87,17 @@ namespace Content.Server.Physics.Controllers
              * is not on the centerline.
              */
 
-            /* TODO: Figure out how to fix corner cuts.
-            direction = direction.Normalized;
-
-            var dirNormal = new Vector2(direction.Y, direction.X);
-            var dot = Vector2.Dot(itemRelative, dirNormal);
-            */
-
             var p = direction * (Vector2.Dot(itemRelative, direction) / Vector2.Dot(direction, direction));
             var r = itemRelative - p;
 
-            if (r.Length < 0.1) {
+            if (r.Length < 0.1)
+            {
                 var velocity = direction * speed;
                 return velocity * frameTime;
-            } else {
-                var velocity = r * speed;
+            }
+            else
+            {
+                var velocity = r.Normalized * speed;
                 return velocity * frameTime;
             }
         }

--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -77,6 +77,16 @@ namespace Content.Server.Physics.Controllers
         {
             if (speed == 0 || direction.Length == 0) return Vector2.Zero;
 
+            /*
+             * Basic idea: if the item is not in the middle of the conveyor in the direction that the conveyor is running,
+             * move the item towards the middle. Otherwise, move the item along the direction. This lets conveyors pick up
+             * items that are not perfectly aligned in the middle, and also makes corner cuts work.
+             *
+             * We do this by computing the projection of 'itemRelative' on 'direction', yielding a vector 'p' in the direction
+             * of 'direction'. We also compute the rejection 'r'. If the magnitude of 'r' is not (near) zero, then the item
+             * is not on the centerline.
+             */
+
             /* TODO: Figure out how to fix corner cuts.
             direction = direction.Normalized;
 
@@ -84,15 +94,16 @@ namespace Content.Server.Physics.Controllers
             var dot = Vector2.Dot(itemRelative, dirNormal);
             */
 
-            var velocity = direction * speed;
+            var p = direction * (Vector2.Dot(itemRelative, direction) / Vector2.Dot(direction, direction));
+            var r = itemRelative - p;
 
-            return velocity * frameTime;
-
-            /*
-            velocity += dirNormal * speed * -dot;
-
-            return velocity * frameTime;
-            */
+            if (r.Length < 0.1) {
+                var velocity = direction * speed;
+                return velocity * frameTime;
+            } else {
+                var velocity = r * speed;
+                return velocity * frameTime;
+            }
         }
 
         public IEnumerable<(EntityUid, TransformComponent)> GetEntitiesToMove(ConveyorComponent comp, TransformComponent xform)


### PR DESCRIPTION
Basic idea: if the item is not in the middle of the conveyor in the direction that the conveyor is running, move the item towards the middle. Otherwise, move the item along the direction. This lets conveyors pick up items that are not perfectly aligned in the middle, and also makes corner cuts work.

We do this by computing the projection of 'itemRelative' on 'direction', yielding a vector 'p' in the direction of 'direction'. We also compute the rejection 'r'. If the magnitude of 'r' is not (near) zero, then the item is not on the centerline.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: notafet
- add: Items on conveyor belts now round corners correctly.

