### PR TITLE
Quickfix: Add Salvage access to QM door remote, and Armory access to HoS remote

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -45,6 +45,7 @@
     tags:
     - HeadOfSecurity
     - Security
+    - Armory
 
 - type: entity
   parent: DoorRemoteDefault

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -101,6 +101,7 @@
     tags:
     - Cargo
     - Quartermaster
+    - Salvage
 
 - type: entity
   parent: DoorRemoteDefault


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
QM remote doesn't work on Salvage access airlocks, this fixes that issue.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Cargo door remote now works on Salvage access airlocks.
- fix: Security door remote now works on Armory access airlocks.

