### PR TITLE
Fix drone hat offset

### DIFF
--- a/Content.Client/Hands/HandsComponent.cs
+++ b/Content.Client/Hands/HandsComponent.cs
@@ -1,7 +1,4 @@
 using Content.Shared.Hands.Components;
-using Robust.Shared.Analyzers;
-using Robust.Shared.GameObjects;
-using System.Collections.Generic;
 
 namespace Content.Client.Hands
 {
@@ -10,6 +7,12 @@ namespace Content.Client.Hands
     [Friend(typeof(HandsSystem))]
     public sealed class HandsComponent : SharedHandsComponent
     {
+        /// <summary>
+        ///     Whether or not to add in-hand sprites for held items. Some entities (e.g., drones) don't want these.
+        /// </summary>
+        [DataField("showInHands")]
+        public bool ShowInHands = true;
+
         public HandsGui? Gui { get; set; }
 
         /// <summary>

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -203,6 +203,9 @@ namespace Content.Client.Hands
             if (uid == _playerManager.LocalPlayer?.ControlledEntity)
                 UpdateGui();
 
+            if (!handComp.ShowInHands)
+                return;
+
             // Remove old layers. We could also just set them to invisible, but as items may add arbitrary layers, this
             // may eventually bloat the player with lots of layers.
             if (handComp.RevealedLayers.TryGetValue(hand.Location, out var revealedLayers))

--- a/Content.Shared/Clothing/ClothingEvents.cs
+++ b/Content.Shared/Clothing/ClothingEvents.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using Robust.Shared.GameObjects;
 using static Robust.Shared.GameObjects.SharedSpriteComponent;
 
 namespace Content.Shared.Clothing;
@@ -7,7 +5,7 @@ namespace Content.Shared.Clothing;
 /// <summary>
 ///     Raised directed at a piece of clothing to get the set of layers to show on the wearer's sprite
 /// </summary>
-public class GetEquipmentVisualsEvent : EntityEventArgs
+public sealed class GetEquipmentVisualsEvent : EntityEventArgs
 {
     /// <summary>
     ///     Entity that is wearing the item.
@@ -37,7 +35,7 @@ public class GetEquipmentVisualsEvent : EntityEventArgs
 /// <remarks>
 ///     Useful for systems/components that modify the visual layers that an item adds to a player. (e.g. RGB memes)
 /// </remarks>
-public class EquipmentVisualsUpdatedEvent : EntityEventArgs
+public sealed class EquipmentVisualsUpdatedEvent : EntityEventArgs
 {
     /// <summary>
     ///     Entity that is wearing the item.

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -34,6 +34,11 @@ public sealed class SlotDefinition
     [DataField("dependsOn")] public string? DependsOn { get; }
 
     [DataField("displayName", required: true)] public string DisplayName { get; } = string.Empty;
+
+    /// <summary>
+    ///     Offset for the clothing sprites.
+    /// </summary>
+    [DataField("offset")] public Vector2 Offset { get; } = Vector2.Zero;
 }
 
 public enum SlotUIContainer

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -575,7 +575,7 @@
   - type: SentienceTarget
     flavorKind: primate
   - type: Inventory
-    templateId: head
+    templateId: monkey
   - type: Strippable
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -52,6 +52,7 @@
   - type: Physics
     bodyType: KinematicController
   - type: Hands
+    showInHands: false
   - type: Body
     template: DroneTemplate
     preset: DronePreset

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -77,7 +77,7 @@
   - type: NameIdentifier
     group: Drone
   - type: Inventory
-    templateId: head
+    templateId: drone
   - type: Strippable
   - type: UserInterface
     interfaces:
@@ -105,8 +105,6 @@
     layers:
     - state: shell
       sprite: Mobs/Silicon/drone.rsi
-    - map: [ "head" ]
-      offset: 0, -0.45
   - type: MovementIgnoreGravity
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/InventoryTemplates/drone_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/drone_inventory_template.yml
@@ -1,0 +1,10 @@
+- type: inventoryTemplate
+  id: drone
+  slots:
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    uiContainer: BottomLeft
+    uiWindowPos: 0,0
+    displayName: Head
+    offset: 0, -0.45

--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -1,5 +1,5 @@
 - type: inventoryTemplate
-  id: head
+  id: monkey
   slots:
   - name: head
     slotTexture: head


### PR DESCRIPTION
#6740 was created before, but merged after, drone hats. I never thought to check if they still worked, so merging it broke them.

Currently drone hats specify an offset in the drone's head sprite layer. This doesn't work anymore, and would cause issues for helmets that have more than one layer. I've moved the offset to the inventory slot definition (in the `inventoryTemplate` prototype). This way the offset should apply to any layers that get added due to clothing in that slot. I think this is probably the best way of handling this?

Edit:
Now also hides drone in-hands, which also started appearing after #6740.