### PR TITLE
Positional audio for Monkey Cubes.

### DIFF
--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -48,7 +48,7 @@ namespace Content.Server.Storage.EntitySystems
             }
 
             if (component.Sound != null)
-                SoundSystem.Play(Filter.Pvs(uid), component.Sound.GetSound());
+                SoundSystem.Play(Filter.Pvs(uid), component.Sound.GetSound(), uid);
 
             component.Uses--;
             if (component.Uses == 0)


### PR DESCRIPTION
Add `uid` to the SoundSystem.Play to make Monkey Cube unwrapping respect position.
Note: SpawnItemOnUse is only use for chocolate bars, energy bars, and monkey cubes.