### PR TITLE
Make hardsuit helmets hide hair.

### DIFF
--- a/Content.Client/Clothing/ClothingSystem.cs
+++ b/Content.Client/Clothing/ClothingSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Clothing;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
+using Content.Shared.Tag;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
@@ -42,6 +43,7 @@ public sealed class ClothingSystem : EntitySystem
 
     [Dependency] private IResourceCache _cache = default!;
     [Dependency] private InventorySystem _inventorySystem = default!;
+    [Dependency] private TagSystem _tagSystem = default!;
 
     public override void Initialize()
     {
@@ -146,6 +148,17 @@ public sealed class ClothingSystem : EntitySystem
 
     private void OnGotUnequipped(EntityUid uid, ClothingComponent component, GotUnequippedEvent args)
     {
+        if (component.InSlot == "head"
+            && _tagSystem.HasTag(uid, "HidesHair")
+            && TryComp(args.Equipee, out SpriteComponent? sprite))
+        {
+            if (sprite.LayerMapTryGet(HumanoidVisualLayers.FacialHair, out var facial))
+                sprite[facial].Visible = true;
+
+            if (sprite.LayerMapTryGet(HumanoidVisualLayers.Hair, out var hair))
+                sprite[hair].Visible = true;
+        }
+
         component.InSlot = null;
     }
 
@@ -182,6 +195,17 @@ public sealed class ClothingSystem : EntitySystem
     private void OnGotEquipped(EntityUid uid, ClothingComponent component, GotEquippedEvent args)
     {
         component.InSlot = args.Slot;
+
+        if (args.Slot == "head"
+            && _tagSystem.HasTag(uid, "HidesHair")
+            && TryComp(args.Equipee, out SpriteComponent? sprite))
+        {
+            if (sprite.LayerMapTryGet(HumanoidVisualLayers.FacialHair, out var facial))
+                sprite[facial].Visible = false;
+
+            if (sprite.LayerMapTryGet(HumanoidVisualLayers.Hair, out var hair))
+                sprite[hair].Visible = false;
+        }
 
         RenderEquipment(args.Equipee, uid, args.Slot, clothingComponent: component);
     }

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -42,6 +42,9 @@
         Heat: 0.90
         Radiation: 0.25
   - type: IngestionBlocker
+  - type: Tag
+    tags:
+    - HidesHair
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -163,6 +163,9 @@
   id: HideContextMenu
 
 - type: Tag
+  id: HidesHair # for headwear.
+  
+- type: Tag
   id: Hoe
 
 - type: Tag


### PR DESCRIPTION
This adds a tag that makes headwear toggle the visibility of hair, and adds it to hardsuits. Very noticeable for some hair styles like `Floorlength Bedhead` where the hair just oddly stuck out of the airtight hardsuit.