### PR TITLE
Load Maps on Round Start, not Round Restart v3

### DIFF
--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -234,8 +234,6 @@ public sealed class AddTests : ContentIntegrationTest
         await server.WaitIdleAsync();
 
         var sDatabase = server.ResolveDependency<IServerDbManager>();
-        var sEntities = server.ResolveDependency<IEntityManager>();
-        var sMaps = server.ResolveDependency<IMapManager>();
         var sSystems = server.ResolveDependency<IEntitySystemManager>();
 
         var sAdminLogSystem = sSystems.GetEntitySystem<AdminLogSystem>();
@@ -245,10 +243,7 @@ public sealed class AddTests : ContentIntegrationTest
 
         await server.WaitPost(() =>
         {
-            var coordinates = GetMainEntityCoordinates(sMaps);
-            var entity = sEntities.SpawnEntity(null, coordinates);
-
-            sAdminLogSystem.Add(LogType.Unknown, $"{entity} test log: {guid}");
+            sAdminLogSystem.Add(LogType.Unknown, $"test log: {guid}");
         });
 
         await server.WaitPost(() =>
@@ -284,8 +279,7 @@ public sealed class AddTests : ContentIntegrationTest
         await foreach (var json in sDatabase.GetAdminLogsJson(filter))
         {
             var root = json.RootElement;
-
-            Assert.That(root.TryGetProperty("entity", out _), Is.True);
+            
             Assert.That(root.TryGetProperty("guid", out _), Is.True);
 
             json.Dispose();

--- a/Content.Server/GameTicking/GameTicker.CVars.cs
+++ b/Content.Server/GameTicking/GameTicker.CVars.cs
@@ -27,6 +27,11 @@ namespace Content.Server.GameTicking
         [ViewVariables]
         public float MaxStationOffset { get; private set; } = 0f;
 
+#if EXCEPTION_TOLERANCE
+        [ViewVariables]
+        public int RoundStartFailShutdownCount { get; private set; } = 0;
+#endif
+
         private void InitializeCVars()
         {
             _configurationManager.OnValueChanged(CCVars.GameLobbyEnabled, value => LobbyEnabled = value, true);
@@ -37,6 +42,9 @@ namespace Content.Server.GameTicking
             _configurationManager.OnValueChanged(CCVars.StationOffset, value => StationOffset = value, true);
             _configurationManager.OnValueChanged(CCVars.StationRotation, value => StationRotation = value, true);
             _configurationManager.OnValueChanged(CCVars.MaxStationOffset, value => MaxStationOffset = value, true);
+#if EXCEPTION_TOLERANCE
+            _configurationManager.OnValueChanged(CCVars.RoundStartFailShutdownCount, value => RoundStartFailShutdownCount = value, true);
+#endif
         }
     }
 }

--- a/Content.Server/GameTicking/GameTicker.JobController.cs
+++ b/Content.Server/GameTicking/GameTicker.JobController.cs
@@ -108,6 +108,9 @@ namespace Content.Server.GameTicking
         private string? PickBestAvailableJob(IPlayerSession playerSession, HumanoidCharacterProfile profile,
             StationId station)
         {
+            if (station == StationId.Invalid)
+                return null;
+
             var available = _stationSystem.StationInfo[station].JobList;
 
             bool TryPick(JobPriority priority, [NotNullWhen(true)] out string? jobId)

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -190,6 +190,8 @@ namespace Content.Server.GameTicking
 
                 SendServerMessage(Loc.GetString("game-ticker-start-round"));
 
+                LoadMaps();
+
                 StartGamePresetRules();
 
                 RoundLengthMetric.Set(0);
@@ -373,7 +375,6 @@ namespace Content.Server.GameTicking
             RunLevel = GameRunLevel.PreRoundLobby;
             LobbySong = _robustRandom.Pick(_lobbyMusicCollection.PickFiles).ToString();
             ResettingCleanup();
-            LoadMaps();
 
             if (!LobbyEnabled)
             {
@@ -411,17 +412,17 @@ namespace Content.Server.GameTicking
                 unCastData.ContentData()?.WipeMind();
             }
 
-            // Delete all entities.
-            foreach (var entity in EntityManager.GetEntities().ToList())
+            _startingRound = false;
+
+            _mapManager.Restart();
+
+            // Delete all remaining entities.
+            foreach (var entity in EntityManager.GetEntities().ToArray())
             {
                 // TODO: Maybe something less naive here?
                 // FIXME: Actually, definitely.
                 EntityManager.DeleteEntity(entity);
             }
-
-            _startingRound = false;
-
-            _mapManager.Restart();
 
             _roleBanManager.Restart();
 

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -1,32 +1,21 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using Content.Server.Database;
 using Content.Server.GameTicking.Events;
 using Content.Server.Ghost;
 using Content.Server.Maps;
 using Content.Server.Mind;
 using Content.Server.Players;
 using Content.Server.Station;
-using Content.Shared.CCVar;
 using Content.Shared.Coordinates;
 using Content.Shared.GameTicking;
 using Content.Shared.Preferences;
 using Content.Shared.Station;
 using Prometheus;
-using Robust.Server;
 using Robust.Server.Player;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Log;
 using Robust.Shared.Map;
-using Robust.Shared.Maths;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Server.GameTicking
 {
@@ -176,7 +165,7 @@ namespace Content.Server.GameTicking
             }
         }
 
-        public async void StartRound(bool force = false)
+        public void StartRound(bool force = false)
         {
 #if EXCEPTION_TOLERANCE
             try
@@ -200,7 +189,7 @@ namespace Content.Server.GameTicking
             RoundLengthMetric.Set(0);
 
             var playerIds = _playersInLobby.Keys.Select(player => player.UserId.UserId).ToArray();
-            RoundId = await _db.AddNewRound(playerIds);
+            RoundId = _db.AddNewRound(playerIds).Result;
 
             var startingEvent = new RoundStartingEvent();
             RaiseLocalEvent(startingEvent);
@@ -481,8 +470,7 @@ namespace Content.Server.GameTicking
                 RoundLengthMetric.Inc(frameTime);
             }
 
-            if (RunLevel != GameRunLevel.PreRoundLobby ||
-                Paused ||
+            if (RunLevel != GameRunLevel.PreRoundLobby || Paused ||
                 _roundStartTime > _gameTiming.CurTime ||
                 _roundStartCountdownHasNotStartedYetDueToNoPlayers)
             {

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -14,6 +14,7 @@ using Content.Shared.GameTicking;
 using Content.Shared.Preferences;
 using Content.Shared.Station;
 using Prometheus;
+using Robust.Server;
 using Robust.Server.Player;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -39,7 +40,10 @@ namespace Content.Server.GameTicking
             "ss14_round_length",
             "Round length in seconds.");
 
-        [Dependency] private readonly IServerDbManager _db = default!;
+#if EXCEPTION_TOLERANCE
+        [ViewVariables]
+        private int _roundStartFailCount = 0;
+#endif
 
         [ViewVariables]
         private TimeSpan _roundStartTimeSpan;
@@ -260,11 +264,24 @@ namespace Content.Server.GameTicking
             }
             catch(Exception e)
             {
+                _roundStartFailCount++;
 
-                Logger.WarningS("ticker", $"Exception caught while trying to start the round! Restarting...");
+                if (RoundStartFailShutdownCount > 0 && _roundStartFailCount >= RoundStartFailShutdownCount)
+                {
+                    Logger.FatalS("ticker", $"Failed to start a round {_roundStartFailCount} time(s) in a row... Shutting down!");
+                    _runtimeLog.LogException(e, nameof(GameTicker));
+                    _baseServer.Shutdown("Restarting server");
+                    return;
+                }
+
+                Logger.WarningS("ticker", $"Exception caught while trying to start the round! Restarting round...");
                 _runtimeLog.LogException(e, nameof(GameTicker));
                 RestartRound();
+                return;
             }
+
+            // Round started successfully! Reset counter...
+            _roundStartFailCount = 0;
 #endif
         }
 

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.CharacterAppearance.Systems;
 using Content.Server.Chat.Managers;
+using Content.Server.Database;
 using Content.Server.Ghost;
 using Content.Server.Maps;
 using Content.Server.PDA;
@@ -89,6 +90,7 @@ namespace Content.Server.GameTicking
         [Dependency] private readonly IBaseServer _baseServer = default!;
         [Dependency] private readonly IWatchdogApi _watchdogApi = default!;
         [Dependency] private readonly IGameMapManager _gameMapManager = default!;
+        [Dependency] private readonly IServerDbManager _db = default!;
 #if EXCEPTION_TOLERANCE
         [Dependency] private readonly IRuntimeLog _runtimeLog = default!;
 #endif

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -60,6 +60,9 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool>
             EventsEnabled = CVarDef.Create("events.enabled", true, CVar.ARCHIVE | CVar.SERVERONLY);
 
+        /// <summary>
+        ///     Disables most functionality in the GameTicker.
+        /// </summary>
         public static readonly CVarDef<bool>
             GameDummyTicker = CVarDef.Create("game.dummyticker", false, CVar.ARCHIVE | CVar.SERVERONLY);
 
@@ -153,6 +156,15 @@ namespace Content.Shared.CCVar
 
         public static readonly CVarDef<int> SoftMaxPlayers =
             CVarDef.Create("game.soft_max_players", 30, CVar.SERVERONLY | CVar.ARCHIVE);
+
+#if EXCEPTION_TOLERANCE
+        /// <summary>
+        ///     Amount of times round start must fail before the server is shut down.
+        ///     Set to 0 or a negative number to disable.
+        /// </summary>
+        public static readonly CVarDef<int> RoundStartFailShutdownCount =
+            CVarDef.Create("game.round_start_fail_shutdown_count", 5, CVar.SERVERONLY | CVar.SERVER);
+#endif
 
         /*
          * Discord


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See #6980, #6977, #6945 and #6930.
Why am I trying this again, you ask?
Well, I noticed something interesting: Every single exception that happened during the "game state corruption" was caught in either Timer or Async callbacks. And then, looking at the tracebacks more closely I noticed some round starts/restarts were happening from timers/async callbacks. That's pretty awful already (in the future, the GameTicker's public API should only allow to REQUEST round start/end/restarts.) but thing is

The `StartRound` method was `async void`. I hadn't noticed. Apparently, this is so it can get a proper round ID with some DB stuff.
Thing is, nothing ever awaited `StartRound`. So instead, I made it sync again, and made it synchronously wait for the round ID result.

Look, I still couldn't replicate the bug locally, but I'm certain this is it, this time.
Merge if you're brave. Just be sure to keep an eye on the server in case we need a quick revert.
(God, I can't wait for proper fucking testmerges...)