### PR TITLE
Fix medkit item size and storage capacity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -9,9 +9,9 @@
     netsync: false
     state: firstaid
   - type: Storage
-    capacity: 50
+    capacity: 26
   - type: Item
-    size: 5
+    size: 26
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     HeldPrefix: firstaid
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is just a simple fix to give all current medkits only enough room for the highest medkit fill and make their actual size the same.

It's 26 because that's exactly how much the largest storage filled medkit needs right now.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/47410468/156849323-f16d5f2d-0753-4734-8c80-fda2ae1b8d04.png)


