### PR TITLE
Fix the mass scanner ui

### DIFF
--- a/Content.Server/Radar/RadarConsoleSystem.cs
+++ b/Content.Server/Radar/RadarConsoleSystem.cs
@@ -32,7 +32,7 @@ public sealed class RadarConsoleSystem : EntitySystem
         {
             var s = component.Owner.GetUIOrNull(RadarConsoleUiKey.Key);
 
-            if (s is null)
+            if (s is null || s.SubscribedSessions.Count == 0)
                 continue;
 
             var (radarPos, _, radarInvMatrix) = xform.GetWorldPositionRotationInvMatrix();


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the mass scanner minimap not displaying properly and adds support to changing the scanner range at runtime. Now the minimap has a fixed radius and it scales depending on the real range. Addresses all the points in #6408 except the scroll support.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![Content Client_afTOPHAH8z](https://user-images.githubusercontent.com/76271993/156945140-4c9faec5-3977-478e-bcd1-fda463906f5f.png)
![Content Client_7eFuYZxdtY](https://user-images.githubusercontent.com/76271993/156945231-dd346a0b-7c6b-429d-a7ab-c8dd4ab9bbe4.png)
![Content Client_8EcEpR7BfV](https://user-images.githubusercontent.com/76271993/156945236-2ba4f8cb-e4ef-4dbb-ab7d-a58076733e57.png)
**Changelog**


<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed the mass scanner console.

