### PR TITLE
Fix electrocution

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -47,6 +47,7 @@ namespace Content.Server.Electrocution
         [Dependency] private readonly DamageableSystem _damageableSystem = default!;
         [Dependency] private readonly NodeGroupSystem _nodeGroupSystem = default!;
         [Dependency] private readonly AdminLogSystem _logSystem = default!;
+        [Dependency] private readonly TagSystem _tagSystem = default!;
 
         private const string StatusEffectKey = "Electrocution";
         private const string DamageType = "Shock";
@@ -166,14 +167,12 @@ namespace Content.Server.Electrocution
             if (!electrified.Enabled)
                 return false;
 
-            var tagSystem = EntitySystem.Get<TagSystem>();
-
             if (electrified.NoWindowInTile)
             {
                 foreach (var entity in transform.Coordinates.GetEntitiesInTile(
                     LookupFlags.Approximate | LookupFlags.IncludeAnchored, _entityLookup))
                 {
-                    if (tagSystem.HasTag(entity, "Window"))
+                    if (_tagSystem.HasTag(entity, "Window"))
                         return false;
                 }
             }

--- a/Resources/Prototypes/Entities/Virtual/electrocution.yml
+++ b/Resources/Prototypes/Entities/Virtual/electrocution.yml
@@ -8,7 +8,7 @@
     nodes:
       electrocution: !type:ElectrocutionNode
         nodeGroupID: HVPower
-
+        needAnchored: false
   - type: PowerConsumer
     voltage: High
     drawRate: 50000
@@ -23,7 +23,7 @@
     nodes:
       electrocution: !type:ElectrocutionNode
         nodeGroupID: MVPower
-
+        needAnchored: false
   - type: PowerConsumer
     voltage: Medium
     drawRate: 50000
@@ -38,6 +38,7 @@
     nodes:
       electrocution: !type:ElectrocutionNode
         nodeGroupID: Apc
+        needAnchored: false
   - type: PowerConsumer
     voltage: Apc
     drawRate: 50000


### PR DESCRIPTION
the electrocution node entity is not anchored and was failing to connect to the power net
--> no power drawn and no damage dealt

:cl:
- fix: Fixed electrocution not dealing damage.

