### PR TITLE
Fix more movement-rotation issues

### DIFF
--- a/Content.Shared/Movement/SharedMoverController.cs
+++ b/Content.Shared/Movement/SharedMoverController.cs
@@ -86,7 +86,9 @@ namespace Content.Shared.Movement
                 mover.LastGridAngle = parentRotation;
 
             if (worldTotal != Vector2.Zero)
-                transform.WorldRotation = worldTotal.GetDir().ToAngle();
+                transform.LocalRotation = transform.GridID != GridId.Invalid
+                    ? total.ToWorldAngle()
+                    : worldTotal.ToWorldAngle();
 
             _physics.SetLinearVelocity(physicsComponent, worldTotal);
         }
@@ -149,7 +151,9 @@ namespace Content.Shared.Movement
             {
                 // This should have its event run during island solver soooo
                 xform.DeferUpdates = true;
-                xform.LocalRotation = total.GetDir().ToAngle();
+                xform.LocalRotation = xform.GridID != GridId.Invalid
+                    ? total.ToWorldAngle()
+                    : worldTotal.ToWorldAngle();
                 xform.DeferUpdates = false;
                 HandleFootsteps(mover, mobMover);
             }


### PR DESCRIPTION
Fixes some issues related to #6960
- If an entity is not on a grid, `total` is still relative to the last grid that the entity was on, so in that case `worldTotal` should be used instead to set the local rotation.
- #6960 Updated `HandleMobMovement()` but didn't similarly update change `HandleKinematicMovement()`
- The vector -> dir -> angle conversion can cause issues for movement in space, so it now just does a direct vector -> angle conversion, which works just as well.
