### PR TITLE
Make combat check CanInteract

### DIFF
--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -298,6 +298,11 @@ namespace Content.Server.Interaction
             if (!ValidateInteractAndFace(user, coordinates))
                 return;
 
+            // Check general interaction blocking.
+            if (!_actionBlockerSystem.CanInteract(user, target))
+                return;
+
+            // Check combat-specific action blocking.
             if (!_actionBlockerSystem.CanAttack(user, target))
                 return;
 

--- a/Content.Shared/Administration/AdminFrozenSystem.cs
+++ b/Content.Shared/Administration/AdminFrozenSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Interaction.Events;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Movement;
 using Content.Shared.Throwing;
@@ -14,7 +14,6 @@ public sealed class AdminFrozenSystem : EntitySystem
         SubscribeLocalEvent<AdminFrozenComponent, UseAttemptEvent>((_, _, args) => args.Cancel());
         SubscribeLocalEvent<AdminFrozenComponent, PickupAttemptEvent>((_, _, args) => args.Cancel());
         SubscribeLocalEvent<AdminFrozenComponent, ThrowAttemptEvent>((_, _, args) => args.Cancel());
-        SubscribeLocalEvent<AdminFrozenComponent, AttackAttemptEvent>((_, _, args) => args.Cancel());
         SubscribeLocalEvent<AdminFrozenComponent, MovementAttemptEvent>((_, _, args) => args.Cancel());
         SubscribeLocalEvent<AdminFrozenComponent, InteractionAttemptEvent>((_, _, args) => args.Cancel());
     }

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -20,7 +20,6 @@ namespace Content.Shared.Cuffs
             SubscribeLocalEvent<SharedCuffableComponent, InteractionAttemptEvent>(OnInteractAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, IsEquippingAttemptEvent>(OnEquipAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
-            SubscribeLocalEvent<SharedCuffableComponent, AttackAttemptEvent>(OnAttackAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, DropAttemptEvent>(OnDropAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, PickupAttemptEvent>(OnPickupAttempt);
         }
@@ -73,11 +72,6 @@ namespace Content.Shared.Cuffs
             // is this a self-equip, or are they being stripped?
             if (args.Unequipee == uid)
                 CheckAct(uid, component, args);
-        }
-
-        private void OnAttackAttempt(EntityUid uid, SharedCuffableComponent component, AttackAttemptEvent args)
-        {
-            CheckAct(uid, component, args);
         }
 
         private void OnDropAttempt(EntityUid uid, SharedCuffableComponent component, DropAttemptEvent args)

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Content.Shared.DragDrop;
 using Content.Shared.Emoting;
@@ -21,7 +21,6 @@ namespace Content.Shared.Ghost
             SubscribeLocalEvent<SharedGhostComponent, UseAttemptEvent>(OnAttempt);
             SubscribeLocalEvent<SharedGhostComponent, InteractionAttemptEvent>(OnAttempt);
             SubscribeLocalEvent<SharedGhostComponent, EmoteAttemptEvent>(OnAttempt);
-            SubscribeLocalEvent<SharedGhostComponent, AttackAttemptEvent>(OnAttempt);
             SubscribeLocalEvent<SharedGhostComponent, DropAttemptEvent>(OnAttempt);
             SubscribeLocalEvent<SharedGhostComponent, PickupAttemptEvent>(OnAttempt);
         }

--- a/Content.Shared/Interaction/Events/AttackAttemptEvent.cs
+++ b/Content.Shared/Interaction/Events/AttackAttemptEvent.cs
@@ -1,7 +1,12 @@
-﻿using Robust.Shared.GameObjects;
-
 namespace Content.Shared.Interaction.Events
 {
+    /// <summary>
+    ///     Raised Directed at a user to check whether they are allowed to attack a target.
+    /// </summary>
+    /// <remarks>
+    ///     Combat will also check the general interaction blockers, so this event should only be used for combat-specific
+    ///     action blocking.
+    /// </remarks>
     public sealed class AttackAttemptEvent : CancellableEntityEventArgs
     {
         public EntityUid Uid { get; }

--- a/Content.Shared/MobState/EntitySystems/MobStateSystem.cs
+++ b/Content.Shared/MobState/EntitySystems/MobStateSystem.cs
@@ -29,7 +29,6 @@ namespace Content.Shared.MobState.EntitySystems
             SubscribeLocalEvent<MobStateComponent, IsEquippingAttemptEvent>(OnEquipAttempt);
             SubscribeLocalEvent<MobStateComponent, EmoteAttemptEvent>(OnEmoteAttempt);
             SubscribeLocalEvent<MobStateComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
-            SubscribeLocalEvent<MobStateComponent, AttackAttemptEvent>(OnAttackAttempt);
             SubscribeLocalEvent<MobStateComponent, DropAttemptEvent>(OnDropAttempt);
             SubscribeLocalEvent<MobStateComponent, PickupAttemptEvent>(OnPickupAttempt);
             SubscribeLocalEvent<MobStateComponent, StartPullAttemptEvent>(OnStartPullAttempt);
@@ -94,11 +93,6 @@ namespace Content.Shared.MobState.EntitySystems
             // is this a self-equip, or are they being stripped?
             if (args.Unequipee == uid)
                 CheckAct(uid, component, args);
-        }
-
-        private void OnAttackAttempt(EntityUid uid, MobStateComponent component, AttackAttemptEvent args)
-        {
-            CheckAct(uid, component, args);
         }
 
         private void OnDropAttempt(EntityUid uid, MobStateComponent component, DropAttemptEvent args)

--- a/Content.Shared/PAI/SharedPAISystem.cs
+++ b/Content.Shared/PAI/SharedPAISystem.cs
@@ -24,7 +24,6 @@ namespace Content.Shared.PAI
             base.Initialize();
             SubscribeLocalEvent<PAIComponent, UseAttemptEvent>(OnUseAttempt);
             SubscribeLocalEvent<PAIComponent, InteractionAttemptEvent>(OnInteractAttempt);
-            SubscribeLocalEvent<PAIComponent, AttackAttemptEvent>(OnAttackAttempt);
             SubscribeLocalEvent<PAIComponent, DropAttemptEvent>(OnDropAttempt);
             SubscribeLocalEvent<PAIComponent, PickupAttemptEvent>(OnPickupAttempt);
             SubscribeLocalEvent<PAIComponent, MovementAttemptEvent>(OnMoveAttempt);
@@ -50,11 +49,6 @@ namespace Content.Shared.PAI
         }
 
         private void OnInteractAttempt(EntityUid uid, PAIComponent component, InteractionAttemptEvent args)
-        {
-            args.Cancel();
-        }
-
-        private void OnAttackAttempt(EntityUid uid, PAIComponent component, AttackAttemptEvent args)
         {
             args.Cancel();
         }

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -54,7 +54,6 @@ namespace Content.Shared.Stunnable
             SubscribeLocalEvent<StunnedComponent, ThrowAttemptEvent>(OnThrowAttempt);
             SubscribeLocalEvent<StunnedComponent, DropAttemptEvent>(OnDropAttempt);
             SubscribeLocalEvent<StunnedComponent, PickupAttemptEvent>(OnPickupAttempt);
-            SubscribeLocalEvent<StunnedComponent, AttackAttemptEvent>(OnAttackAttempt);
             SubscribeLocalEvent<StunnedComponent, IsEquippingAttemptEvent>(OnEquipAttempt);
             SubscribeLocalEvent<StunnedComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
         }
@@ -232,11 +231,6 @@ namespace Content.Shared.Stunnable
         }
 
         private void OnPickupAttempt(EntityUid uid, StunnedComponent stunned, PickupAttemptEvent args)
-        {
-            args.Cancel();
-        }
-
-        private void OnAttackAttempt(EntityUid uid, StunnedComponent stunned, AttackAttemptEvent args)
         {
             args.Cancel();
         }


### PR DESCRIPTION
This PR makes combat check the CanInteract action blocker in addition to CanAttack. It also removes some AttackAttemptEvent subscriptions that are now unnecessary.

:cl:
- fix: You can no longer accidentally punch sub-floor entities when using a T-Ray scanner

