### PR TITLE
Buffs window resistance and nerfs spears

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -45,9 +45,9 @@
 - type: damageModifierSet
   id: Glass
   coefficients:
-    Blunt: 0.5
+    Blunt: 1
     Slash: 0.5
-    Piercing: 1.5
+    Piercing: 1.1
     Heat: 0
     Shock: 0
   flatReductions:
@@ -56,9 +56,9 @@
 - type: damageModifierSet
   id: RGlass
   coefficients:
-    Blunt: 0.5
+    Blunt: 0.8
     Slash: 0.5
-    Piercing: 1.2
+    Piercing: 0.7
     Heat: 0
     Shock: 0
   flatReductions:

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -52,6 +52,17 @@
     Shock: 0
   flatReductions:
     Blunt: 5
+    
+- type: damageModifierSet
+  id: RGlass
+  coefficients:
+    Blunt: 0.5
+    Slash: 0.5
+    Piercing: 1.2
+    Heat: 0
+    Shock: 0
+  flatReductions:
+    Blunt: 5
 
 - type: damageModifierSet
   id: Wood

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -23,7 +23,7 @@
       types:
         Piercing: 15
   - type: Clothing
-    size: 24
+    size: 40
     sprite: Objects/Weapons/Melee/spear.rsi
     QuickEquip: false
     Slots:
@@ -50,12 +50,11 @@
         Piercing: -7
   - type: Damageable
     damageContainer: Inorganic
-    damageModifierSet: Glass
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 30 #excess damage (nuke?). avoid computational cost of spawning entities.
+        damage: 30 #excess damage avoids cost of spawning entities.
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -68,17 +67,15 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          MetalRod:
+          PartRodMetal1:
             min: 1
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: DamageOnHighSpeedImpact
+  - type: DamageOnLand
     damage:
       types:
         Blunt: 5
-    soundHit:
-      path: /Audio/Effects/glass_hit.ogg
 
 - type: MeleeWeaponAnimation
   id: spear

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -48,6 +48,37 @@
     modifiers:
       flatReductions:
         Piercing: -7
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Glass
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 30 #excess damage (nuke?). avoid computational cost of spawning entities.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 20
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MetalRod:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: DamageOnHighSpeedImpact
+    damage:
+      types:
+        Blunt: 5
+    soundHit:
+      path: /Audio/Effects/glass_hit.ogg
 
 - type: MeleeWeaponAnimation
   id: spear

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -10,7 +10,7 @@
     sprite: Structures/Windows/plasma_window.rsi
   - type: Damageable
     damageContainer: Inorganic
-    damageModifierSet: Glass
+    damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -11,6 +11,9 @@
   - type: Repairable
     fuelCost: 10
     doAfterDelay: 2
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -10,7 +10,7 @@
     sprite: Structures/Windows/reinforced_plasma_window.rsi
   - type: Damageable
     damageContainer: Inorganic
-    damageModifierSet: Glass
+    damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/spear.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/spear.yml
@@ -6,12 +6,17 @@
       edges:
         - to: spear
           steps:
-            - material: Steel
+            - material: MetalRod
               amount: 2
               doAfter: 2
-            - material: Glass
+            - material: Cable
               amount: 2
-              doAfter: 2
-
+              doAfter: 1
+            - prototype: ShardGlass
+              name: Glass Shard
+              icon: 
+                sprite: Objects/Materials/Shards/shard.rsi
+                state: shard1
+              doAfter: 1
     - node: spear
       entity: Spear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Added a new damage modifier set for RGlass. It's glass but takes less blunt and piercing damage.
- Changed glass to take more blunt damage and less piercing in general.
- Makes plasma and reinforced glass take the new RGlass modifier.
- Changed spear crafting to take 2 cable, 1 shard and 2 rods instead of just sheets and glass.
- Spears now break after being thrown 4 times (they have a fragile glass shard tip after all). They only produce a metal rod. My head canon is the shard and cable will be useless after being damaged.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![Content Client_y9OpaZOJ87](https://user-images.githubusercontent.com/78795277/157564938-bef4b229-a134-4281-bdf8-c7b780a5fa8a.gif)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: All windows are now less susceptible to piercing damage and more to blunt.
- tweak: Spears now take cable, a glass shard and 2 rods to craft. They break after 4 throws.

