### PR TITLE
Fix toolbar size issue

### DIFF
--- a/Content.Client/Actions/UI/ActionMenuItem.cs
+++ b/Content.Client/Actions/UI/ActionMenuItem.cs
@@ -41,7 +41,7 @@ namespace Content.Client.Actions.UI
             Action = action;
             _onControlFocusExited = onControlFocusExited;
 
-            MinSize = (64, 64);
+            SetSize = (64, 64);
             VerticalAlignment = VAlignment.Top;
 
             _bigActionIcon = new TextureRect

--- a/Content.Client/Actions/UI/ActionSlot.cs
+++ b/Content.Client/Actions/UI/ActionSlot.cs
@@ -64,7 +64,7 @@ namespace Content.Client.Actions.UI
             SlotIndex = slotIndex;
             MouseFilter = MouseFilterMode.Stop;
 
-            MinSize = (64, 64);
+            SetSize = (64, 64);
             VerticalAlignment = VAlignment.Top;
             TooltipDelay = CustomTooltipDelay;
             TooltipSupplier = SupplyTooltip;


### PR DESCRIPTION
Previously the action icons specified a minimum size rather than a fixed size. This causes issues with mapping actions and the new tile variants, because the action icon was now larger than 64x64 pixels causing the toolbar to stretch oddly.

The action preview Icon is still a bit weird, and should probably just be showing a single variant rather than the whole variant sprite sheet, but that probably has to be redone anyways if ever the ability to place specific variants is added.