### PR TITLE
Update clickmap test for world rotation preservation

### DIFF
--- a/Content.IntegrationTests/Tests/ClickableTest.cs
+++ b/Content.IntegrationTests/Tests/ClickableTest.cs
@@ -68,21 +68,16 @@ namespace Content.IntegrationTests.Tests
         [TestCase("ClickTestRotatingCornerInvisibleNoRot", 0.25f, 0.25f, DirSouthEastJustShy, 1, ExpectedResult = true)]
         public async Task<bool> Test(string prototype, float clickPosX, float clickPosY, double angle, float scale)
         {
-            Vector2? worldPos = null;
             EntityUid entity = default;
             var clientEntManager = _client.ResolveDependency<IEntityManager>();
             var serverEntManager = _server.ResolveDependency<IEntityManager>();
             var eyeManager = _client.ResolveDependency<IEyeManager>();
             var mapManager = _server.ResolveDependency<IMapManager>();
-            var gameTicker = _server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<GameTicker>();
 
             await _server.WaitPost(() =>
             {
-                var gridEnt = mapManager.GetAllGrids().First().GridEntityId;
-                worldPos = serverEntManager.GetComponent<TransformComponent>(gridEnt).WorldPosition;
-
-                var ent = serverEntManager.SpawnEntity(prototype, new EntityCoordinates(gridEnt, 0f, 0f));
-                serverEntManager.GetComponent<TransformComponent>(ent).LocalRotation = angle;
+                var ent = serverEntManager.SpawnEntity(prototype, GetMainEntityCoordinates(mapManager));
+                serverEntManager.GetComponent<TransformComponent>(ent).WorldRotation = angle;
                 serverEntManager.GetComponent<SpriteComponent>(ent).Scale = (scale, scale);
                 entity = ent;
             });
@@ -97,9 +92,10 @@ namespace Content.IntegrationTests.Tests
                 // these tests currently all assume player eye is 0
                 eyeManager.CurrentEye.Rotation = 0;
 
+                var pos = clientEntManager.GetComponent<TransformComponent>(entity).WorldPosition;
                 var clickable = clientEntManager.GetComponent<ClickableComponent>(entity);
 
-                hit = clickable.CheckClick((clickPosX, clickPosY) + worldPos!.Value, out _, out _);
+                hit = clickable.CheckClick((clickPosX, clickPosY) + pos, out _, out _);
             });
 
             await _server.WaitPost(() =>


### PR DESCRIPTION
If world rotation is preserved on parent changes, the current clickmap tests break. This fixes that, so that without this, space-wizards/RobustToolbox/pull/2594 will cause this test to fail.

