### PR TITLE
Botany fix

### DIFF
--- a/Content.Server/Botany/Systems/BotanySystem.Plant.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Plant.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Content.Server.Botany.Components;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Popups;
@@ -44,7 +44,8 @@ namespace Content.Server.Botany.Systems
 
             foreach (var seed in _prototypeManager.EnumeratePrototypes<SeedPrototype>())
             {
-                AddSeedToDatabase(seed);
+                seed.Uid = GetNextSeedUid();
+                Seeds[seed.Uid] = seed;
             }
         }
 

--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantDiethylamine.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantDiethylamine.cs
@@ -1,13 +1,7 @@
-﻿using Content.Server.Botany.Components;
-using Content.Shared.Botany;
-using Content.Shared.Chemistry.Components;
+using Content.Server.Botany.Components;
 using Content.Shared.Chemistry.Reagent;
 using JetBrains.Annotations;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 using Robust.Shared.Random;
-using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
 {
@@ -24,15 +18,13 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
 
             var random = IoCManager.Resolve<IRobustRandom>();
 
-            var chance = MathHelper.Lerp(15f, 125f, plantHolderComp.Seed.Lifespan) * 2f;
-            if (random.Prob(chance))
+            if (random.Prob(0.1f))
             {
                 plantHolderComp.CheckForDivergence(true);
                 plantHolderComp.Seed.Lifespan++;
             }
 
-            chance = MathHelper.Lerp(15f, 125f, plantHolderComp.Seed.Endurance) * 2f;
-            if (random.Prob(chance))
+            if (random.Prob(0.1f))
             {
                 plantHolderComp.CheckForDivergence(true);
                 plantHolderComp.Seed.Endurance++;

--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/RobustHarvest.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/RobustHarvest.cs
@@ -1,13 +1,7 @@
-﻿using Content.Server.Botany.Components;
-using Content.Shared.Botany;
-using Content.Shared.Chemistry.Components;
+using Content.Server.Botany.Components;
 using Content.Shared.Chemistry.Reagent;
 using JetBrains.Annotations;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 using Robust.Shared.Random;
-using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
 {
@@ -24,17 +18,13 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
 
             var random = IoCManager.Resolve<IRobustRandom>();
 
-            var chance = MathHelper.Lerp(15f, 150f, plantHolderComp.Seed.Potency) * 3.5f;
-
-            if (random.Prob(chance))
+            if (plantHolderComp.Seed.Potency < 100 && random.Prob(0.1f))
             {
                 plantHolderComp.CheckForDivergence(true);
                 plantHolderComp.Seed.Potency++;
             }
 
-            chance = MathHelper.Lerp(6f, 2f, plantHolderComp.Seed.Yield) * 0.15f;
-
-            if (random.Prob(chance))
+            if (plantHolderComp.Seed.Yield > 1 && random.Prob(0.1f))
             {
                 plantHolderComp.CheckForDivergence(true);
                 plantHolderComp.Seed.Yield--;


### PR DESCRIPTION
Fixes #6979, caused by yaml seed prototypes not being properly added to the seed list after a round reset.

Also fixes the plant metabolism probabilities, so that they are not always be larger than 100%. I have no idea what they were supposed to be, other than the fact that the probabilities were seemingly meant to depend on the value being modified, I just set them to 10% each. Someone might want to actually put better thought out values in there.

:cl:
- fix: Fixed a bug allowing some botany seeds to preserve their potency across rounds.

