### PR TITLE
Fix use-in-hand interactions

### DIFF
--- a/Content.Client/Clothing/ClothingComponent.cs
+++ b/Content.Client/Clothing/ClothingComponent.cs
@@ -1,9 +1,6 @@
 using Content.Client.Items.Components;
 using Content.Shared.Item;
-using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Client.Clothing
 {
@@ -16,6 +13,9 @@ namespace Content.Client.Clothing
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("femaleMask")]
         public FemaleClothingMask FemaleMask { get; } = FemaleClothingMask.UniformFull;
+
+        [DataField("quickEquip")]
+        public bool QuickEquip = true;
 
         public string? InSlot;
     }

--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -25,6 +25,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
+using Content.Shared.Interaction.Events;
 
 namespace Content.Client.Inventory
 {
@@ -67,7 +68,17 @@ namespace Content.Client.Inventory
             SubscribeLocalEvent<ClientInventoryComponent, DidEquipEvent>(OnDidEquip);
             SubscribeLocalEvent<ClientInventoryComponent, DidUnequipEvent>(OnDidUnequip);
 
+            SubscribeLocalEvent<ClothingComponent, UseInHandEvent>(OnUseInHand);
+
             _config.OnValueChanged(CCVars.HudTheme, UpdateHudTheme);
+        }
+
+        private void OnUseInHand(EntityUid uid, ClothingComponent component, UseInHandEvent args)
+        {
+            if (args.Handled || !component.QuickEquip)
+                return;
+
+            QuickEquip(uid, component, args);
         }
 
         private void OnDidUnequip(EntityUid uid, ClientInventoryComponent component, DidUnequipEvent args)

--- a/Content.Server/Clothing/Components/ClothingComponent.cs
+++ b/Content.Server/Clothing/Components/ClothingComponent.cs
@@ -16,6 +16,9 @@ namespace Content.Server.Clothing.Components
         [DataField("HeatResistance")]
         private int _heatResistance = 323;
 
+        [DataField("quickEquip")]
+        public bool QuickEquip = true;
+
         [ViewVariables(VVAccess.ReadWrite)]
         public int HeatResistance => _heatResistance;
     }

--- a/Content.Server/Inventory/ServerInventorySystem.cs
+++ b/Content.Server/Inventory/ServerInventorySystem.cs
@@ -1,6 +1,8 @@
 using Content.Server.Atmos;
+using Content.Server.Clothing.Components;
 using Content.Server.Storage.Components;
 using Content.Server.Temperature.Systems;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using InventoryComponent = Content.Shared.Inventory.InventoryComponent;
@@ -17,7 +19,17 @@ namespace Content.Server.Inventory
             SubscribeLocalEvent<InventoryComponent, LowPressureEvent>(RelayInventoryEvent);
             SubscribeLocalEvent<InventoryComponent, ModifyChangedTemperatureEvent>(RelayInventoryEvent);
 
+            SubscribeLocalEvent<ClothingComponent, UseInHandEvent>(OnUseInHand);
+
             SubscribeNetworkEvent<OpenSlotStorageNetworkMessage>(OnOpenSlotStorage);
+        }
+
+        private void OnUseInHand(EntityUid uid, ClothingComponent component, UseInHandEvent args)
+        {
+            if (args.Handled || !component.QuickEquip)
+                return;
+
+            QuickEquip(uid, component, args);
         }
 
         private void OnOpenSlotStorage(OpenSlotStorageNetworkMessage ev, EntitySessionEventArgs args)

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -29,16 +29,11 @@ public abstract partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
         SubscribeLocalEvent<InventoryComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
 
-        SubscribeLocalEvent<SharedItemComponent, UseInHandEvent>(OnUseInHand);
-
         SubscribeAllEvent<UseSlotNetworkMessage>(OnUseSlot);
     }
 
-    private void OnUseInHand(EntityUid uid, SharedItemComponent component, UseInHandEvent args)
+    protected void QuickEquip(EntityUid uid, SharedItemComponent component, UseInHandEvent args)
     {
-        if (args.Handled || !component.QuickEquip)
-            return;
-
         if (!TryComp(args.User, out InventoryComponent? inv)
             || !TryComp(args.User, out SharedHandsComponent? hands)
             || !_prototypeManager.TryIndex<InventoryTemplatePrototype>(inv.TemplateId, out var prototype))

--- a/Content.Shared/Item/SharedItemComponent.cs
+++ b/Content.Shared/Item/SharedItemComponent.cs
@@ -15,9 +15,6 @@ namespace Content.Shared.Item
     {
         [Dependency] private readonly IEntityManager _entMan = default!;
 
-        [DataField("quickEquip")]
-        public bool QuickEquip = true;
-
         /// <summary>
         ///     How much big this item is.
         /// </summary>


### PR DESCRIPTION
I added a bug in #7074, where I moved the clothing quick-equip interaction from the clothing component to shared inventory system. Because there is no such thing as a shared clothing component, I just used item comp & moved the can-quick-equip bool to that component. But this then conflicts with any item that has an activation interaction, because instead of activating the item when using it in your hands, it will instead get quipped to the pockets.

This **could** be fixed by just differentiating between item & clothing by selectively setting the quick-equip bool in yaml, but that would be a lot of work.

So this just moves the bool back to clothing component, and moves the interaction handling subscriptions to both the server- and client-side inventory systems
