### PR TITLE
Generic clothing speed modifiers + hardsuit slowdown

### DIFF
--- a/Content.Client/Clothing/MagbootsSystem.cs
+++ b/Content.Client/Clothing/MagbootsSystem.cs
@@ -5,16 +5,5 @@ namespace Content.Client.Clothing
 {
     public sealed class MagbootsSystem : SharedMagbootsSystem
     {
-        public override void Initialize()
-        {
-            base.Initialize();
-
-            SubscribeLocalEvent<MagbootsComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
-        }
-
-        private void OnRefreshMovespeed(EntityUid uid, MagbootsComponent component, RefreshMovementSpeedModifiersEvent args)
-        {
-            args.ModifySpeed(component.WalkSpeedModifier, component.SprintSpeedModifier);
-        }
     }
 }

--- a/Content.Server/Clothing/MagbootsSystem.cs
+++ b/Content.Server/Clothing/MagbootsSystem.cs
@@ -21,7 +21,6 @@ namespace Content.Server.Clothing
 
             SubscribeLocalEvent<MagbootsComponent, GetVerbsEvent<ActivationVerb>>(AddToggleVerb);
             SubscribeLocalEvent<MagbootsComponent, SlipAttemptEvent>(OnSlipAttempt);
-            SubscribeLocalEvent<MagbootsComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
             SubscribeLocalEvent<MagbootsComponent, GotEquippedEvent>(OnGotEquipped);
             SubscribeLocalEvent<MagbootsComponent, GotUnequippedEvent>(OnGotUnequipped);
         }
@@ -61,11 +60,6 @@ namespace Content.Server.Clothing
             {
                 UpdateMagbootEffects(args.Equipee, uid, true, component);
             }
-        }
-
-        private void OnRefreshMovespeed(EntityUid uid, MagbootsComponent component, RefreshMovementSpeedModifiersEvent args)
-        {
-            args.ModifySpeed(component.WalkSpeedModifier, component.SprintSpeedModifier);
         }
 
         private void AddToggleVerb(EntityUid uid, MagbootsComponent component, GetVerbsEvent<ActivationVerb> args)

--- a/Content.Shared/Clothing/ClothingSpeedModifierComponent.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierComponent.cs
@@ -1,0 +1,33 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Clothing;
+
+[RegisterComponent, NetworkedComponent]
+public sealed class ClothingSpeedModifierComponent : Component
+{
+    [DataField("walkModifier", required: true)] [ViewVariables(VVAccess.ReadWrite)]
+    public float WalkModifier = 1.0f;
+
+    [DataField("sprintModifier", required: true)] [ViewVariables(VVAccess.ReadWrite)]
+    public float SprintModifier = 1.0f;
+
+    /// <summary>
+    ///     Is this clothing item currently 'actively' slowing you down?
+    ///     e.g. magboots can be turned on and off.
+    /// </summary>
+    [DataField("enabled")] public bool Enabled = true;
+}
+
+[Serializable, NetSerializable]
+public sealed class ClothingSpeedModifierComponentState : ComponentState
+{
+    public float WalkModifier;
+    public float SprintModifier;
+
+    public ClothingSpeedModifierComponentState(float walkModifier, float sprintModifier)
+    {
+        WalkModifier = walkModifier;
+        SprintModifier = sprintModifier;
+    }
+}

--- a/Content.Shared/Clothing/ClothingSpeedModifierComponent.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Clothing;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, Friend(typeof(ClothingSpeedModifierSystem))]
 public sealed class ClothingSpeedModifierComponent : Component
 {
     [DataField("walkModifier", required: true)] [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Clothing/ClothingSpeedModifierComponent.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierComponent.cs
@@ -25,9 +25,12 @@ public sealed class ClothingSpeedModifierComponentState : ComponentState
     public float WalkModifier;
     public float SprintModifier;
 
-    public ClothingSpeedModifierComponentState(float walkModifier, float sprintModifier)
+    public bool Enabled;
+
+    public ClothingSpeedModifierComponentState(float walkModifier, float sprintModifier, bool enabled)
     {
         WalkModifier = walkModifier;
         SprintModifier = sprintModifier;
+        Enabled = enabled;
     }
 }

--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -20,7 +20,7 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
 
     // Public API
 
-    public void SetClothingSpeedModifier(EntityUid uid, bool enabled, ClothingSpeedModifierComponent? component = null)
+    public void SetClothingSpeedModifierEnabled(EntityUid uid, bool enabled, ClothingSpeedModifierComponent? component = null)
     {
         if (!Resolve(uid, ref component, false))
             return;
@@ -41,7 +41,7 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
 
     private void OnGetState(EntityUid uid, ClothingSpeedModifierComponent component, ref ComponentGetState args)
     {
-        args.State = new ClothingSpeedModifierComponentState(component.WalkModifier, component.SprintModifier);
+        args.State = new ClothingSpeedModifierComponentState(component.WalkModifier, component.SprintModifier, component.Enabled);
     }
 
     private void OnHandleState(EntityUid uid, ClothingSpeedModifierComponent component, ref ComponentHandleState args)
@@ -50,6 +50,7 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
         {
             component.WalkModifier = state.WalkModifier;
             component.SprintModifier = state.SprintModifier;
+            SetClothingSpeedModifierEnabled(uid, state.Enabled, component);
         }
     }
 

--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -28,6 +28,7 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
         if (component.Enabled != enabled)
         {
             component.Enabled = enabled;
+            Dirty(component);
 
             // inventory system will automatically hook into the event raised by this and update accordingly
             if (_container.TryGetContainingContainer(uid, out var container))

--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -51,7 +51,12 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
         {
             component.WalkModifier = state.WalkModifier;
             component.SprintModifier = state.SprintModifier;
-            SetClothingSpeedModifierEnabled(uid, state.Enabled, component);
+            component.Enabled = state.Enabled;
+
+            if (_container.TryGetContainingContainer(uid, out var container))
+            {
+                _movementSpeed.RefreshMovementSpeedModifiers(container.Owner);
+            }
         }
     }
 

--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -1,0 +1,63 @@
+﻿using Content.Shared.Movement.EntitySystems;
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing;
+
+public sealed class ClothingSpeedModifierSystem : EntitySystem
+{
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ClothingSpeedModifierComponent, ComponentGetState>(OnGetState);
+        SubscribeLocalEvent<ClothingSpeedModifierComponent, ComponentHandleState>(OnHandleState);
+        SubscribeLocalEvent<ClothingSpeedModifierComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMoveSpeed);
+    }
+
+    // Public API
+
+    public void SetClothingSpeedModifier(EntityUid uid, bool enabled, ClothingSpeedModifierComponent? component = null)
+    {
+        if (!Resolve(uid, ref component, false))
+            return;
+
+        if (component.Enabled != enabled)
+        {
+            component.Enabled = enabled;
+
+            // inventory system will automatically hook into the event raised by this and update accordingly
+            if (_container.TryGetContainingContainer(uid, out var container))
+            {
+                _movementSpeed.RefreshMovementSpeedModifiers(container.Owner);
+            }
+        }
+    }
+
+    // Event handlers
+
+    private void OnGetState(EntityUid uid, ClothingSpeedModifierComponent component, ref ComponentGetState args)
+    {
+        args.State = new ClothingSpeedModifierComponentState(component.WalkModifier, component.SprintModifier);
+    }
+
+    private void OnHandleState(EntityUid uid, ClothingSpeedModifierComponent component, ref ComponentHandleState args)
+    {
+        if (args.Current is ClothingSpeedModifierComponentState state)
+        {
+            component.WalkModifier = state.WalkModifier;
+            component.SprintModifier = state.SprintModifier;
+        }
+    }
+
+    private void OnRefreshMoveSpeed(EntityUid uid, ClothingSpeedModifierComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        if (!component.Enabled)
+            return;
+
+        args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+    }
+}

--- a/Content.Shared/Clothing/SharedMagbootsComponent.cs
+++ b/Content.Shared/Clothing/SharedMagbootsComponent.cs
@@ -18,22 +18,8 @@ namespace Content.Shared.Clothing
         protected void OnChanged()
         {
             EntitySystem.Get<SharedActionsSystem>().SetToggled(ToggleAction, On);
-
-            // inventory system will automatically hook into the event raised by this and update accordingly
-            if (Owner.TryGetContainer(out var container))
-            {
-                EntitySystem.Get<MovementSpeedModifierSystem>().RefreshMovementSpeedModifiers(container.Owner);
-            }
+            EntitySystem.Get<ClothingSpeedModifierSystem>().SetClothingSpeedModifier(Owner, On);
         }
-        [DataField("walkMoveCoeffecient", required: true)]
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float WalkMoveCoeffecient = 0.85f;
-
-        [DataField("sprintMoveCoeffecient", required: true)]
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float SprintMoveCoeffecient = 0.65f;
-        public float WalkSpeedModifier => On ? WalkMoveCoeffecient : 1;
-        public float SprintSpeedModifier => On ? SprintMoveCoeffecient : 1;
 
         [Serializable, NetSerializable]
         public sealed class MagbootsComponentState : ComponentState

--- a/Content.Shared/Clothing/SharedMagbootsComponent.cs
+++ b/Content.Shared/Clothing/SharedMagbootsComponent.cs
@@ -18,7 +18,7 @@ namespace Content.Shared.Clothing
         protected void OnChanged()
         {
             EntitySystem.Get<SharedActionsSystem>().SetToggled(ToggleAction, On);
-            EntitySystem.Get<ClothingSpeedModifierSystem>().SetClothingSpeedModifier(Owner, On);
+            EntitySystem.Get<ClothingSpeedModifierSystem>().SetClothingSpeedModifierEnabled(Owner, On);
         }
 
         [Serializable, NetSerializable]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -20,6 +20,9 @@
     lowPressureMultiplier: 100
   - type: TemperatureProtection
     coefficient: 0.001 # yes it needs to be this low, fires are fucking deadly apparently!!!!
+  - type: ClothingSpeedModifier
+    walkModifier: 0.6
+    sprintModifier: 0.4
   - type: Clothing
     size: 50
   - type: Armor

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -33,6 +33,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 100
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: Armor
     modifiers:
       coefficients:
@@ -55,6 +58,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 100
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: Armor
     modifiers:
       coefficients:
@@ -133,6 +139,9 @@
     sprite: Clothing/OuterClothing/Hardsuits/eva.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/eva.rsi
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: PressureProtection
     highPressureMultiplier: 1
     lowPressureMultiplier: 100
@@ -152,6 +161,9 @@
   - type: PressureProtection
     highPressureMultiplier: 1
     lowPressureMultiplier: 100
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
 
 - type: entity
   parent: ClothingOuterHardsuitBase
@@ -266,6 +278,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 100
+  - type: ClothingSpeedModifier
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: Armor
     modifiers:
       coefficients:
@@ -288,6 +303,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 100
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -17,6 +17,10 @@
         description: action-decription-magboot-toggle
         itemIconStyle: NoItem
         event: !type:ToggleActionEvent
+    - type: ClothingSpeedModifier
+      walkModifier: 0.85
+      sprintModifier: 0.65
+      enabled: false
 
 - type: entity
   parent: ClothingShoesBootsMag
@@ -30,5 +34,7 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-advanced.rsi
   - type: Magboots
-    walkMoveCoeffecient: 1
-    sprintMoveCoeffecient: 1
+  - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 1
+    enabled: false


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Repurposes the magboot slowdown stuff into a more generic networked clothing speed modifier component
- Makes hardsuits slow you down. Caps/wizards/blood-red hardsuit slow you down less.

reasoning behind hardsuit slowdown is that they basically powercreep over everything else because temperature resist + good armor + pressure resist + harder to identify. slowdown means that they're basically unusable for normal gameplay and you'll opt to only use them when absolutely necessary (spacewalking)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Hardsuits now noticeably slow you down. Wear something else.

