### PR TITLE
Make mech's bullets caseless

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/hrifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/hrifle.yml
@@ -24,3 +24,4 @@
   components:
   - type: Ammo
     projectile: BulletMinigun
+    caseless: true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This should avoid some of the lag, 600 casings moved by atmos and stuff.

- tweak: The Onestar mech's bullets are now caseless, the sheer amount of casings caused lag in its systems.