### PR TITLE
Potency sprite scaling

### DIFF
--- a/Content.Client/Botany/PotencyVisualsComponent.cs
+++ b/Content.Client/Botany/PotencyVisualsComponent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Client.Botany;
+
+[RegisterComponent]
+public sealed class PotencyVisualsComponent : Component
+{
+    [DataField("minimumScale")]
+    public float MinimumScale = 0.5f;
+
+    [DataField("maximumScale")]
+    public float MaximumScale = 1.5f;
+}

--- a/Content.Client/Botany/PotencyVisualsSystem.cs
+++ b/Content.Client/Botany/PotencyVisualsSystem.cs
@@ -1,0 +1,21 @@
+﻿using Content.Shared.Botany;
+using Robust.Client.GameObjects;
+
+namespace Content.Client.Botany;
+
+public sealed class PotencyVisualsSystem : VisualizerSystem<PotencyVisualsComponent>
+{
+    protected override void OnAppearanceChange(EntityUid uid, PotencyVisualsComponent component, ref AppearanceChangeEvent args)
+    {
+        base.OnAppearanceChange(uid, component, ref args);
+
+        if (!TryComp<SpriteComponent>(uid, out var sprite))
+            return;
+
+        if (args.Component.TryGetData(ProduceVisuals.Potency, out float potency))
+        {
+            var scale = MathHelper.Lerp(component.MinimumScale, component.MaximumScale, potency / 100);
+            sprite.Scale = new Vector2(scale, scale);
+        }
+    }
+}

--- a/Content.Server/Botany/Systems/BotanySystem.Seed.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Seed.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Content.Server.Botany.Components;
 using Content.Server.Kitchen.Components;
+using Content.Shared.Botany;
 using Content.Shared.Examine;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Tag;
@@ -123,6 +124,11 @@ public sealed partial class BotanySystem
 
             produce.SeedName = proto.ID;
             ProduceGrown(entity, produce);
+
+            if (TryComp<AppearanceComponent>(entity, out var appearance))
+            {
+                appearance.SetData(ProduceVisuals.Potency, proto.Potency);
+            }
 
             if (proto.Mysterious)
             {

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -17,7 +17,8 @@ namespace Content.Server.Entry
             "ClientEntitySpawner",
             "CharacterInfo",
             "ItemCabinetVisuals",
-            "HandheldGPS"
+            "HandheldGPS",
+            "PotencyVisuals"
         };
     }
 }

--- a/Content.Shared/Botany/ProduceVisuals.cs
+++ b/Content.Shared/Botany/ProduceVisuals.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.Botany;
 
 [Serializable, NetSerializable]
-public enum ProduceVisuals
+public enum ProduceVisuals : byte
 {
     Potency
 }

--- a/Content.Shared/Botany/ProduceVisuals.cs
+++ b/Content.Shared/Botany/ProduceVisuals.cs
@@ -1,0 +1,9 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared.Botany;
+
+[Serializable, NetSerializable]
+public enum ProduceVisuals
+{
+    Potency
+}

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -10,6 +10,8 @@
     netsync: false
     state: produce
   - type: Produce
+  - type: PotencyVisuals
+  - type: Appearance
   - type: Extractable
     grindableSolutionName: food
 
@@ -25,6 +27,8 @@
     netsync: false
     state: produce
   - type: Produce
+  - type: PotencyVisuals
+  - type: Appearance
   - type: Extractable
     grindableSolutionName: food
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Scales sprite size of produce based on its potency, from 0.5 to 1.5 size

**Screenshots**

shitty ass weed!! Cant slonk this

![image](https://user-images.githubusercontent.com/19853115/158046108-812ac891-59d3-4f3d-8edb-45caecab3e2f.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Plant produce now scales in size depending on its potency.

