### PR TITLE
Make ClF3 no longer meta

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -41,7 +41,7 @@
   - !type:ExplosionReactionEffect
     devastationRange: 0
     heavyImpactRange: 0
-    lightImpactRange: 2
+    lightImpactRange: 0.1
     scaled: true
     maxScale: 10 # explosion strength stops scaling at 10 chlorine + 30 fluorine
   - !type:PopupMessage

--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -42,7 +42,8 @@
     devastationRange: 0
     heavyImpactRange: 0
     lightImpactRange: 2
-    scaled: false
+    scaled: true
+    maxScale: 10 # explosion strength stops scaling at 10 chlorine + 30 fluorine
   - !type:PopupMessage
     messages: [ "clf3-explosion" ]
     type: Pvs

--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -41,9 +41,9 @@
   - !type:ExplosionReactionEffect
     devastationRange: 0
     heavyImpactRange: 0
-    lightImpactRange: 0.1
+    lightImpactRange: 0.5
     scaled: true
-    maxScale: 10 # explosion strength stops scaling at 10 chlorine + 30 fluorine
+    maxScale: 6 # explosion strength stops scaling at 6 chlorine + 18 fluorine
   - !type:PopupMessage
     messages: [ "clf3-explosion" ]
     type: Pvs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Ditto.

People have been using ClF3 smoke a lot, since it doesn't scale when exploding. This means that breathing in even 0.01 chlorine will damage you as much as say, a 25+75 mix.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: router
- remove: Chlorine trifluoride smoke no longer annihilates everyone. This will persist until the explosion rework happens.

