### PR TITLE
Gas analyzers now analyze gases in pipes

### DIFF
--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -191,6 +191,7 @@ namespace Content.Client.Entry
             "Rehydratable",
             "Headset",
             "ComputerBoard",
+            "GasAnalyzable",
             "GasCanister",
             "GasPort",
             "GasPortable",

--- a/Content.Server/Atmos/Components/GasAnalyzableComponent.cs
+++ b/Content.Server/Atmos/Components/GasAnalyzableComponent.cs
@@ -1,0 +1,18 @@
+using Content.Server.Atmos.Piping.EntitySystems;
+using JetBrains.Annotations;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.ViewVariables;
+
+/**
+ * GasAnalyzableComponent is a component for anything that can be examined with a gas analyzer.
+ */
+namespace Content.Server.Atmos.Components
+{
+    [RegisterComponent]
+    public sealed class GasAnalyzableComponent : Component
+    {
+        // Empty
+    }
+}

--- a/Content.Server/Atmos/EntitySystems/GasAnalyzableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzableSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.NodeContainer.NodeGroups;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.NodeContainer;
 using Content.Server.Tools;
+using Content.Shared.Atmos.Components;
 using Content.Shared.Examine;
 using Content.Shared.Temperature;
 using Content.Shared.Verbs;
@@ -30,8 +31,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (_examineSystem.IsInDetailsRange(args.User, args.Target))
             {
                 var held = args.Using;
-
-                var enabled = held != null;
+                var enabled = held != null && EntityManager.HasComponent<SharedGasAnalyzerComponent>(held);
                 var verb = new ExamineVerb
                 {
                     Disabled = !enabled,
@@ -57,9 +57,8 @@ namespace Content.Server.Atmos.EntitySystems
 
             foreach (var node in nodeContainer.Nodes)
             {
-                if (!(node.Value is PipeNode))
+                if (node.Value is not PipeNode pn)
                     continue;
-                var pn = (PipeNode)node.Value;
                 float pressure = pn.Air.Pressure;
                 float temp = pn.Air.Temperature;
                 return Loc.GetString("gas-analyzable-system-statistics",

--- a/Content.Server/Atmos/EntitySystems/GasAnalyzableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzableSystem.cs
@@ -1,0 +1,74 @@
+using Content.Server.Atmos.Components;
+using Content.Server.NodeContainer.NodeGroups;
+using Content.Server.NodeContainer.Nodes;
+using Content.Server.NodeContainer;
+using Content.Server.Tools;
+using Content.Shared.Examine;
+using Content.Shared.Temperature;
+using Content.Shared.Verbs;
+using JetBrains.Annotations;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Atmos.EntitySystems
+{
+    [UsedImplicitly]
+    public sealed class GasAnalyzableSystem : EntitySystem
+    {
+        [Dependency] private readonly ToolSystem _toolSystem = default!;
+        [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<GasAnalyzableComponent, GetVerbsEvent<ExamineVerb>>(OnGetExamineVerbs);
+        }
+
+        private void OnGetExamineVerbs(EntityUid uid, GasAnalyzableComponent component, GetVerbsEvent<ExamineVerb> args)
+        {
+            // Must be in details range to try this.
+            if (_examineSystem.IsInDetailsRange(args.User, args.Target))
+            {
+                var held = args.Using;
+
+                var enabled = held != null;
+                var verb = new ExamineVerb
+                {
+                    Disabled = !enabled,
+                    Message = Loc.GetString("gas-analyzable-system-verb-tooltip"),
+                    Text = Loc.GetString("gas-analyzable-system-verb-name"),
+                    Category = VerbCategory.Examine,
+                    IconTexture = "/Textures/Interface/VerbIcons/examine.svg.192dpi.png",
+                    Act = () =>
+                    {
+                        var markup = FormattedMessage.FromMarkup(GeneratePipeMarkup(uid));
+                        _examineSystem.SendExamineTooltip(args.User, uid, markup, false, false);
+                    }
+                };
+
+                args.Verbs.Add(verb);
+            }
+        }
+
+        private string GeneratePipeMarkup(EntityUid uid, NodeContainerComponent? nodeContainer = null)
+        {
+            if (!Resolve(uid, ref nodeContainer))
+                return Loc.GetString("gas-analyzable-system-internal-error-missing-component");
+
+            foreach (var node in nodeContainer.Nodes)
+            {
+                if (!(node.Value is PipeNode))
+                    continue;
+                var pn = (PipeNode)node.Value;
+                float pressure = pn.Air.Pressure;
+                float temp = pn.Air.Temperature;
+                return Loc.GetString("gas-analyzable-system-statistics",
+                    ("pressure", pressure),
+                    ("tempK", $"{temp:0.#}"),
+                    ("tempC", $"{TemperatureHelpers.KelvinToCelsius(temp):0.#}")
+                );
+            }
+            return Loc.GetString("gas-anlayzable-system-internal-error-no-gas-node");
+        }
+    }
+}

--- a/Resources/Locale/en-US/atmos/gas-analyzable-system.ftl
+++ b/Resources/Locale/en-US/atmos/gas-analyzable-system.ftl
@@ -1,0 +1,8 @@
+gas-analyzable-system-internal-error-missing-component = Your gas analyzer whirrs for a while, then stops.
+gas-anlayzable-system-internal-error-no-gas-node = Your gas analyzer reads, "NO GAS FOUND".
+gas-analyzable-system-verb-name = Analyze
+gas-analyzable-system-verb-tooltip = Analyze Contents
+
+gas-analyzable-system-statistics = Your gas analyzer shows a list of statistics:
+                                   Pressure: {PRESSURE($pressure)}
+                                   Temperature: {$tempK}K ({$tempC}°C)

--- a/Resources/Locale/en-US/atmos/gas-analyzable-system.ftl
+++ b/Resources/Locale/en-US/atmos/gas-analyzable-system.ftl
@@ -2,7 +2,6 @@ gas-analyzable-system-internal-error-missing-component = Your gas analyzer whirr
 gas-anlayzable-system-internal-error-no-gas-node = Your gas analyzer reads, "NO GAS FOUND".
 gas-analyzable-system-verb-name = Analyze
 gas-analyzable-system-verb-tooltip = Analyze Contents
-
-gas-analyzable-system-statistics = Your gas analyzer shows a list of statistics:
-                                   Pressure: {PRESSURE($pressure)}
+gas-analyzable-system-header = Your gas analyzer shows a list of statistics:
+gas-analyzable-system-statistics = Pressure: {PRESSURE($pressure)}
                                    Temperature: {$tempK}K ({$tempC}°C)

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -71,6 +71,7 @@
     range: 2
     sound:
       path: /Audio/Ambience/Objects/gas_hiss.ogg
+  - type: GasAnalyzable
 
 #Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (south)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows gas analyzers to examine the pressure and temperature of gases in pipes.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![Untitled](https://user-images.githubusercontent.com/3229565/158082235-1ab7b78b-a178-418a-a7ff-f20110b374a3.png)

**Changelog**
:cl: notafet
- add: Gas analyzers can now be used to examine contents of pipes.