### PR TITLE
Fix AUI interaction checks

### DIFF
--- a/Content.Server/UserInterface/ActivatableUIComponent.cs
+++ b/Content.Server/UserInterface/ActivatableUIComponent.cs
@@ -34,6 +34,22 @@ namespace Content.Server.UserInterface
         public string VerbText = "ui-verb-toggle-open";
 
         /// <summary>
+        ///     Whether you need a hand to operate this UI. The hand does not need to be free, you just need to have one.
+        /// </summary>
+        /// <remarks>
+        ///     This should probably be true for most machines & computers, but there will still be UIs that represent a
+        ///     more generic interaction / configuration that might not require hands.
+        /// </remarks>
+        [DataField("requireHands")]
+        public bool RequireHands = true;
+
+        /// <summary>
+        ///     Whether spectators (non-admin ghosts) should be allowed to view this UI.
+        /// </summary>
+        [DataField("allowSpectator")]
+        public bool AllowSpectator = true;
+
+        /// <summary>
         ///     The client channel currently using the object, or null if there's none/not single user.
         ///     NOTE: DO NOT DIRECTLY SET, USE ActivatableUISystem.SetCurrentSingleUser
         /// </summary>

--- a/Content.Server/UserInterface/ActivatableUISystem.cs
+++ b/Content.Server/UserInterface/ActivatableUISystem.cs
@@ -1,8 +1,7 @@
 using Content.Server.Administration.Managers;
 using Content.Server.Ghost.Components;
-using Content.Shared.Actions;
-using Content.Shared.Actions.ActionTypes;
 using Content.Shared.Hands;
+using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Verbs;
@@ -28,10 +27,23 @@ namespace Content.Server.UserInterface
             // *THIS IS A BLATANT WORKAROUND!* RATIONALE: Microwaves need it
             SubscribeLocalEvent<ActivatableUIComponent, EntParentChangedMessage>(OnParentChanged);
             SubscribeLocalEvent<ActivatableUIComponent, BoundUIClosedEvent>(OnUIClose);
+            SubscribeLocalEvent<BoundUserInterfaceMessageAttempt>(OnBoundInterfaceInteractAttempt);
 
             SubscribeLocalEvent<ActivatableUIComponent, GetVerbsEvent<ActivationVerb>>(AddOpenUiVerb);
 
             SubscribeLocalEvent<ServerUserInterfaceComponent, OpenUiActionEvent>(OnActionPerform);
+        }
+
+        private void OnBoundInterfaceInteractAttempt(BoundUserInterfaceMessageAttempt ev)
+        {
+            if (!TryComp(ev.Target, out ActivatableUIComponent? comp))
+                return;
+
+            if (!comp.RequireHands)
+                return;
+
+            if (!TryComp(ev.Sender.AttachedEntity, out SharedHandsComponent? hands) || hands.Hands.Count == 0)
+                ev.Cancel();
         }
 
         private void OnActionPerform(EntityUid uid, ServerUserInterfaceComponent component, OpenUiActionEvent args)
@@ -57,7 +69,7 @@ namespace Content.Server.UserInterface
             if (component.InHandsOnly && args.Using != uid)
                 return;
 
-            if (!args.CanInteract && !HasComp<GhostComponent>(args.User))
+            if (!args.CanInteract && (!component.AllowSpectator || !HasComp<GhostComponent>(args.User)))
                 return;
 
             ActivationVerb verb = new();

--- a/Resources/Prototypes/Entities/Structures/Furniture/instruments.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/instruments.yml
@@ -6,6 +6,7 @@
   components:
   - type: Instrument
   - type: ActivatableUI
+    allowSpectator: false # otherwise they can play client-side music
     inHandsOnly: false
     singleUser: true
     verbText: verb-instrument-openui


### PR DESCRIPTION
Fixes #7078 by adding an optional requirement to AUIs that users need to have hands. Defaults to true. Also blocks ghosts from opening MIDI instrument UIs, seeing as they apparently bypass the BUI can-interact checks.

:cl:
- fix: Fixed some UI bugs. Ian should no longer be able to make announcements

