### PR TITLE
fix gas tank UI

### DIFF
--- a/Content.Client/UserInterface/Atmos/GasTank/GasTankBoundUserInterface.cs
+++ b/Content.Client/UserInterface/Atmos/GasTank/GasTankBoundUserInterface.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Atmos.Components;
+using Content.Shared.Atmos.Components;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
@@ -38,7 +38,8 @@ namespace Content.Client.UserInterface.Atmos.GasTank
         {
             base.UpdateState(state);
 
-            _window?.UpdateState((GasTankBoundUserInterfaceState) state);
+            if (state is GasTankBoundUserInterfaceState cast)
+                _window?.UpdateState(cast);
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -91,12 +91,6 @@ namespace Content.Server.Atmos.Components
             }
         }
 
-        public void OpenInterface(IPlayerSession session)
-        {
-            _userInterface?.Open(session);
-            UpdateUserInterface(true);
-        }
-
         public void Examine(FormattedMessage message, bool inDetailsRange)
         {
             message.AddMarkup(Loc.GetString("comp-gas-tank-examine", ("pressure", Math.Round(Air?.Pressure ?? 0))));


### PR DESCRIPTION
After #7028 gas tank UIs no longer sent the output pressure when first opened, so they always showed 0kpa. This fixes that, and also removes a duplicate open-ui verb.

:cl:
- fix: Fixed gas tank UIs not showing the current output pressure when opened.

