### PR TITLE
Remove destroyed machine frame from construction menu

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Recipes/Construction/machines.yml
@@ -23,15 +23,3 @@
   icon:
     sprite: Structures/Machines/parts.rsi
     state: "box_0"
-
-- type: construction
-  name: destroyed machine frame
-  id: MachineFrameDestroyed
-  graph: Machine
-  startNode: start
-  targetNode: destroyedMachineFrame
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  icon:
-    sprite: Structures/Machines/parts.rsi
-    state: "destroyed"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

my direct pushing habits have been MERCILESSLY SLANDERED and ATTACKED or else i would have done that

:cl:
- tweak: You can no longer construct 'destroyed machine frames'.