### PR TITLE
Adds support for a map rotation system.

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -71,7 +71,7 @@ namespace Content.Server.GameTicking
             DefaultMap = _mapManager.CreateMap();
             _mapManager.AddUninitializedMap(DefaultMap);
             var startTime = _gameTiming.RealTime;
-            var maps = new List<GameMapPrototype>() { _gameMapManager.GetSelectedMapChecked(true) };
+            var maps = new List<GameMapPrototype>() { _gameMapManager.GetSelectedMapChecked(true, true) };
 
             // Let game rules dictate what maps we should load.
             RaiseLocalEvent(new LoadingMapsEvent(maps));

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -39,7 +39,7 @@ public sealed class GameMapManager : IGameMapManager
         }, true);
         _configurationManager.OnValueChanged(CCVars.GameMapForced, value => _currentMapForced = value, true);
         _configurationManager.OnValueChanged(CCVars.GameMapRotation, value => _mapRotationEnabled = value, true);
-        _configurationManager.OnValueChanged(CCVars.GameMapQueueDepth, value =>
+        _configurationManager.OnValueChanged(CCVars.GameMapMemoryDepth, value =>
         {
             _mapQueueDepth = value;
             // Drain excess.

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -49,7 +49,9 @@ public sealed class GameMapManager : IGameMapManager
             }
         }, true);
 
-        foreach (var map in AllVotableMaps())
+        var maps = AllVotableMaps().ToArray();
+        _random.Shuffle(maps);
+        foreach (var map in maps)
         {
             if (_previousMaps.Count >= _mapQueueDepth)
                 break;
@@ -95,8 +97,7 @@ public sealed class GameMapManager : IGameMapManager
     public void SelectRandomMap()
     {
         var maps = CurrentlyEligibleMaps().ToList();
-        _random.Shuffle(maps);
-        _currentMap = maps[0];
+        _currentMap = _random.Pick(maps);
         _currentMapForced = false;
     }
 

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -162,7 +162,6 @@ public sealed class GameMapManager : IGameMapManager
 
     public GameMapPrototype? SelectMapInQueue()
     {
-        Logger.Debug(string.Join(", ", _previousMaps));
         var eligible = CurrentlyEligibleMaps()
             .Where(x => x.Votable)
             .Select(x => (proto: x, weight: GetMapQueuePriority(x.ID)))

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -22,8 +22,11 @@ public sealed class GameMapManager : IGameMapManager
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
 
+    private readonly Queue<string> _previousMaps = new Queue<string>();
     private GameMapPrototype _currentMap = default!;
     private bool _currentMapForced;
+    private bool _mapRotationEnabled;
+    private int _mapQueueDepth = 1;
 
     public void Initialize()
     {
@@ -35,6 +38,16 @@ public sealed class GameMapManager : IGameMapManager
                 throw new ArgumentException($"Unknown map prototype {value} was selected!");
         }, true);
         _configurationManager.OnValueChanged(CCVars.GameMapForced, value => _currentMapForced = value, true);
+        _configurationManager.OnValueChanged(CCVars.GameMapRotation, value => _mapRotationEnabled = value, true);
+        _configurationManager.OnValueChanged(CCVars.GameMapQueueDepth, value =>
+        {
+            _mapQueueDepth = value;
+            // Drain excess.
+            while (_previousMaps.Count > _mapQueueDepth)
+            {
+                _previousMaps.Dequeue();
+            }
+        }, true);
     }
 
     public IEnumerable<GameMapPrototype> CurrentlyEligibleMaps()
@@ -82,10 +95,12 @@ public sealed class GameMapManager : IGameMapManager
 
     public GameMapPrototype GetSelectedMap()
     {
-        return _currentMap;
+        if (!_mapRotationEnabled || _currentMapForced)
+            return _currentMap;
+        return SelectMapInQueue() ?? CurrentlyEligibleMaps().First();
     }
 
-    public GameMapPrototype GetSelectedMapChecked(bool loud = false)
+    public GameMapPrototype GetSelectedMapChecked(bool loud = false, bool markAsPlayed = false)
     {
         if (!_currentMapForced && !IsMapEligible(GetSelectedMap()))
         {
@@ -100,7 +115,11 @@ public sealed class GameMapManager : IGameMapManager
             }
         }
 
-        return GetSelectedMap();
+        var map = GetSelectedMap();
+
+        if (markAsPlayed)
+            _previousMaps.Enqueue(map.ID);
+        return map;
     }
 
     public bool CheckMapExists(string gameMap)
@@ -126,5 +145,41 @@ public sealed class GameMapManager : IGameMapManager
             return gameMap.NameGenerator.FormatName(gameMap.MapNameTemplate);
         else
             return gameMap.MapName;
+    }
+
+    public int GetMapQueuePriority(string gameMapProtoName)
+    {
+        var i = 0;
+        foreach (var map in _previousMaps.Reverse())
+        {
+            if (map == gameMapProtoName)
+                return i;
+            i++;
+        }
+
+        return _mapQueueDepth;
+    }
+
+    public GameMapPrototype? SelectMapInQueue()
+    {
+        Logger.Debug(string.Join(", ", _previousMaps));
+        var eligible = CurrentlyEligibleMaps()
+            .Where(x => x.Votable)
+            .Select(x => (proto: x, weight: GetMapQueuePriority(x.ID)))
+            .OrderByDescending(x => x.weight).ToArray();
+        if (eligible.Length is 0)
+            return null;
+
+        var weight = eligible[0].weight;
+        return eligible.Where(x => x.Item2 == weight).OrderBy(x => x.proto.ID).First().proto;
+    }
+
+    private void EnqueueMap(string mapProtoName)
+    {
+        _previousMaps.Enqueue(mapProtoName);
+        while (_previousMaps.Count > _mapQueueDepth)
+        {
+            _previousMaps.Dequeue();
+        }
     }
 }

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -48,6 +48,13 @@ public sealed class GameMapManager : IGameMapManager
                 _previousMaps.Dequeue();
             }
         }, true);
+
+        foreach (var map in AllVotableMaps())
+        {
+            if (_previousMaps.Count >= _mapQueueDepth)
+                break;
+            _previousMaps.Enqueue(map.ID);
+        }
     }
 
     public IEnumerable<GameMapPrototype> CurrentlyEligibleMaps()

--- a/Content.Server/Maps/IGameMapManager.cs
+++ b/Content.Server/Maps/IGameMapManager.cs
@@ -56,7 +56,7 @@ public interface IGameMapManager
     /// Gets the currently selected map, double-checking if it can be used.
     /// </summary>
     /// <returns>selected map</returns>
-    GameMapPrototype GetSelectedMapChecked(bool loud = false);
+    GameMapPrototype GetSelectedMapChecked(bool loud = false, bool markAsPlayed = false);
 
     /// <summary>
     /// Checks if the given map exists

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -127,6 +127,15 @@ namespace Content.Shared.CCVar
             GameMapForced = CVarDef.Create("game.mapforced", false, CVar.SERVERONLY);
 
         /// <summary>
+        /// The depth of the queue used to calculate which map is next in rotation.
+        /// </summary>
+        public static readonly CVarDef<int>
+            GameMapQueueDepth = CVarDef.Create("game.map_queue_depth", 16, CVar.SERVERONLY);
+
+        public static readonly CVarDef<bool>
+            GameMapRotation = CVarDef.Create<bool>("game.map_rotation", true, CVar.SERVERONLY);
+
+        /// <summary>
         ///     Whether a random position offset will be applied to the station on roundstart.
         /// </summary>
         public static readonly CVarDef<bool> StationOffset =
@@ -562,7 +571,7 @@ namespace Content.Shared.CCVar
         ///     See vote.enabled, but specific to map votes
         /// </summary>
         public static readonly CVarDef<bool> VoteMapEnabled =
-            CVarDef.Create("vote.map_enabled", true, CVar.SERVERONLY);
+            CVarDef.Create("vote.map_enabled", false, CVar.SERVERONLY);
 
         /// <summary>
         ///     The required ratio of the server that must agree for a restart round vote to go through.

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -128,10 +128,14 @@ namespace Content.Shared.CCVar
 
         /// <summary>
         /// The depth of the queue used to calculate which map is next in rotation.
+        /// This is how long the game "remembers" that some map was put in play. Default is 16 rounds.
         /// </summary>
         public static readonly CVarDef<int>
-            GameMapQueueDepth = CVarDef.Create("game.map_queue_depth", 16, CVar.SERVERONLY);
+            GameMapMemoryDepth = CVarDef.Create("game.map_memory_depth", 16, CVar.SERVERONLY);
 
+        /// <summary>
+        /// Is map rotation enabled?
+        /// </summary>
         public static readonly CVarDef<bool>
             GameMapRotation = CVarDef.Create<bool>("game.map_rotation", true, CVar.SERVERONLY);
 

--- a/Resources/Prototypes/Maps/game.yml
+++ b/Resources/Prototypes/Maps/game.yml
@@ -88,6 +88,7 @@
     !type:NanotrasenNameGenerator
     prefixCreator: '14'
   mapPath: /Maps/knightship.yml
+  votable: false
   minPlayers: 0
   maxPlayers: 8
   overflowJobs: []


### PR DESCRIPTION
## About the PR
It is now the default way of selecting a map, map votes have been disabled.

**Changelog**
:cl: moony
- add: The game now supports an automated map rotation that cycles through all eligible maps, preferring whatever maps haven't been played recently.
- tweak: Map voting has been disabled on Wizard's Den, in favor of automated rotation.

