### PR TITLE
Make more entities destructible

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -14,6 +14,28 @@
     tags:
     - Sheet
     - DroneUsable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ShardGlass:
+            min: 0
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: SheetGlassBase

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -15,6 +15,14 @@
     - Sheet
     - Metal
     - DroneUsable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: SheetMetalBase

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -14,6 +14,14 @@
     tags:
     - Sheet
     - DroneUsable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: SheetOtherBase

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -13,6 +13,14 @@
   - type: Tag
     tags:
     - Ingot
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 500
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: IngotBase

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -13,6 +13,14 @@
   - type: Tag
     tags:
       - DroneUsable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: MaterialBase

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -13,6 +13,14 @@
   - type: Tag
     tags:
     - Ore
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: OreBase

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -13,6 +13,14 @@
   - type: Tag
     tags:
       - DroneUsable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: PartBase

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -28,6 +28,14 @@
     - Recyclable
     - Trash
   - type: Recyclable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: ShardBase

--- a/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
@@ -18,6 +18,14 @@
   - type: Tag
     tags:
       - DroneUsable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   name: steel tile

--- a/Resources/Prototypes/Entities/Structures/catwalk.yml
+++ b/Resources/Prototypes/Entities/Structures/catwalk.yml
@@ -33,3 +33,22 @@
   - type: Construction
     graph: Catwalk
     node: Catwalk
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 500
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          PartRodMetal: # takes two to construct, so drop less than that
+            min: 0
+            max: 1 
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -33,6 +33,15 @@
   - type: Construction
     graph: ConveyorGraph
     node: entity
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      # if ConveyorBeltAssembly becomes craftable, maybe spawn some of the ingredients?
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   id: ConveyorBeltAssembly
@@ -79,3 +88,11 @@
     - type: Construction
       graph: LeverGraph
       node: lever
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]


### PR DESCRIPTION
Catwalks, floor tiles, conveyers, and materials.

The damage values weren't really balanced, a cloth requires as much damage as diamond. But I don't think that really matters, in the majority of cases no one is directly attacking sheets of materials. This is mostly just so that consecutive large explosions don't just lave behind lots of metal sheets or floor tiles.

