### PR TITLE
Update butchering popups

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
@@ -60,11 +60,11 @@ namespace Content.Server.Kitchen.EntitySystems
             if(args.Handled)
                 return;
 
-            if (!Spikeable(uid, args.User, args.Dragged, component))
-                return;
+            args.Handled = true;
 
-            if (TrySpike(uid, args.User, args.Dragged, component))
-                args.Handled = true;
+            if (Spikeable(uid, args.User, args.Dragged, component))
+                TrySpike(uid, args.User, args.Dragged, component);
+                
         }
         private void OnInteractHand(EntityUid uid, KitchenSpikeComponent component, InteractHandEvent args)
         {
@@ -170,7 +170,17 @@ namespace Content.Server.Kitchen.EntitySystems
                 return false;
             }
 
-            return true;
+            switch (butcherable.Type)
+            {
+                case ButcheringType.Spike:
+                    return true;
+                case ButcheringType.Knife:
+                    _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-deny-butcher-knife", ("victim", victimUid), ("this", uid)), victimUid, Filter.Entities(userUid));
+                    return false;
+                default:
+                    _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-deny-butcher", ("victim", victimUid), ("this", uid)), victimUid, Filter.Entities(userUid));
+                    return false;
+            }
         }
 
         public bool TrySpike(EntityUid uid, EntityUid userUid, EntityUid victimUid, KitchenSpikeComponent? component = null,
@@ -178,9 +188,6 @@ namespace Content.Server.Kitchen.EntitySystems
         {
             if (!Resolve(uid, ref component) || component.InUse ||
                 !Resolve(victimUid, ref butcherable) || butcherable.BeingButchered)
-                return false;
-
-            if (butcherable.Type != ButcheringType.Spike)
                 return false;
 
             // THE WHAT? (again)

--- a/Resources/Locale/en-US/kitchen/components/kitchen-spike-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/kitchen-spike-component.ftl
@@ -1,5 +1,6 @@
 comp-kitchen-spike-deny-collect = { CAPITALIZE(THE($this)) } already has something on it, finish collecting its meat first!
 comp-kitchen-spike-deny-butcher = { CAPITALIZE(THE($victim)) } can't be butchered on { THE($this) }.
+comp-kitchen-spike-deny-butcher-knife = { CAPITALIZE(THE($victim)) } can't be butchered on { THE($this) }, you need to butcher it using a knife.
 comp-kitchen-spike-deny-not-dead = { CAPITALIZE(THE($victim)) } can't be butchered. { CAPITALIZE(SUBJECT($victim)) } { CONJUGATE-BE($victim) } is not dead!
 
 comp-kitchen-spike-begin-hook-victim = { THE($user) } begins dragging you onto { THE($this) }!


### PR DESCRIPTION
Currently if you try to butcher a cow using a meatspike there is no feedback that you can't do that and need to use a knife instead. This adds those popups.

