### PR TITLE
Make grinder use item slots (& misc eject-button changes)

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
+++ b/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
+using Content.Shared.Containers.ItemSlots;
 using Robust.Client.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 using static Content.Shared.Access.Components.SharedIdCardConsoleComponent;
 
@@ -23,6 +21,10 @@ namespace Content.Client.Access.UI
             base.Open();
 
             _window = new IdCardConsoleWindow(this, _prototypeManager) {Title = _entityManager.GetComponent<MetaDataComponent>(Owner.Owner).EntityName};
+
+            _window.PrivilegedIdButton.OnPressed += _ => SendMessage(new ItemSlotButtonPressedEvent(PrivilegedIdCardSlotId));
+            _window.TargetIdButton.OnPressed += _ => SendMessage(new ItemSlotButtonPressedEvent(TargetIdCardSlotId));
+
             _window.OnClose += Close;
             _window.OpenCentered();
         }
@@ -39,11 +41,6 @@ namespace Content.Client.Access.UI
             base.UpdateState(state);
             var castState = (IdCardConsoleBoundUserInterfaceState) state;
             _window?.UpdateState(castState);
-        }
-
-        public void ButtonPressed(UiButton button)
-        {
-            SendMessage(new IdButtonPressedMessage(button));
         }
 
         public void SubmitData(string newFullName, string newJobTitle, List<string> newAccessList)

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml
@@ -1,13 +1,13 @@
-﻿<DefaultWindow xmlns="https://spacestation14.io"
+<DefaultWindow xmlns="https://spacestation14.io"
             MinSize="650 290">
     <BoxContainer Orientation="Vertical">
         <GridContainer Columns="3">
             <Label Text="{Loc 'id-card-console-window-privileged-id'}" />
-            <Button Name="PrivilegedIdButton" />
+            <Button Name="PrivilegedIdButton" Access="Public"/>
             <Label Name="PrivilegedIdLabel" />
 
             <Label Text="{Loc 'id-card-console-window-target-id'}" />
-            <Button Name="TargetIdButton" />
+            <Button Name="TargetIdButton" Access="Public"/>
             <Label Name="TargetIdLabel" />
         </GridContainer>
         <Control MinSize="0 8" />

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -28,9 +28,6 @@ namespace Content.Client.Access.UI
 
             _owner = owner;
 
-            PrivilegedIdButton.OnPressed += _ => _owner.ButtonPressed(UiButton.PrivilegedId);
-            TargetIdButton.OnPressed += _ => _owner.ButtonPressed(UiButton.TargetId);
-
             FullNameLineEdit.OnTextEntered += _ => SubmitData();
             FullNameLineEdit.OnTextChanged += _ =>
             {

--- a/Content.Client/Chemistry/UI/ChemMasterBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterBoundUserInterface.cs
@@ -1,8 +1,7 @@
 using Content.Shared.Chemistry.Dispenser;
+using Content.Shared.Containers.ItemSlots;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Localization;
 using static Content.Shared.Chemistry.Components.SharedChemMasterComponent;
 
 namespace Content.Client.Chemistry.UI
@@ -38,7 +37,7 @@ namespace Content.Client.Chemistry.UI
             _window.OnClose += Close;
 
             //Setup static button actions.
-            _window.EjectButton.OnPressed += _ => PrepareData(UiAction.Eject, null, null, null, null, null);
+            _window.EjectButton.OnPressed += _ => SendMessage(new ItemSlotButtonPressedEvent(BeakerSlotId));
             _window.BufferTransferButton.OnPressed += _ => PrepareData(UiAction.Transfer, null, null, null, null, null);
             _window.BufferDiscardButton.OnPressed += _ => PrepareData(UiAction.Discard, null, null, null, null, null);
             _window.CreatePillButton.OnPressed += _ => PrepareData(UiAction.CreatePills, null, _window.LabelLine, null, _window.PillAmount.Value, null);

--- a/Content.Client/Chemistry/UI/ReagentDispenserBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserBoundUserInterface.cs
@@ -1,11 +1,9 @@
-using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.Chemistry.Dispenser;
+using Content.Shared.Containers.ItemSlots;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.UserInterface.Controls;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Localization;
 using static Content.Shared.Chemistry.Dispenser.SharedReagentDispenserComponent;
 
 namespace Content.Client.Chemistry.UI
@@ -39,7 +37,7 @@ namespace Content.Client.Chemistry.UI
             _window.OnClose += Close;
 
             //Setup static button actions.
-            _window.EjectButton.OnPressed += _ => ButtonPressed(UiButton.Eject);
+            _window.EjectButton.OnPressed += _ => SendMessage(new ItemSlotButtonPressedEvent(BeakerSlotId));
             _window.ClearButton.OnPressed += _ => ButtonPressed(UiButton.Clear);
             _window.DispenseButton1.OnPressed += _ => ButtonPressed(UiButton.SetDispenseAmount1);
             _window.DispenseButton5.OnPressed += _ => ButtonPressed(UiButton.SetDispenseAmount5);

--- a/Content.Client/Kitchen/UI/ReagentGrinderBoundUserInterface.cs
+++ b/Content.Client/Kitchen/UI/ReagentGrinderBoundUserInterface.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Kitchen.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.UserInterface.Controls;
@@ -57,7 +58,7 @@ namespace Content.Client.Kitchen.UI
         public void StartGrinding(BaseButton.ButtonEventArgs? args = null) => SendMessage(new SharedReagentGrinderComponent.ReagentGrinderGrindStartMessage());
         public void StartJuicing(BaseButton.ButtonEventArgs? args = null) => SendMessage(new SharedReagentGrinderComponent.ReagentGrinderJuiceStartMessage());
         public void EjectAll(BaseButton.ButtonEventArgs? args = null) => SendMessage(new SharedReagentGrinderComponent.ReagentGrinderEjectChamberAllMessage());
-        public void EjectBeaker(BaseButton.ButtonEventArgs? args = null) => SendMessage(new SharedReagentGrinderComponent.ReagentGrinderEjectBeakerMessage());
+        public void EjectBeaker(BaseButton.ButtonEventArgs? args = null) => SendMessage(new ItemSlotButtonPressedEvent(SharedReagentGrinderComponent.BeakerSlotId));
         public void EjectChamberContent(EntityUid uid) => SendMessage(new SharedReagentGrinderComponent.ReagentGrinderEjectChamberContentMessage(uid));
     }
 }

--- a/Content.Client/Nuke/NukeBoundUserInterface.cs
+++ b/Content.Client/Nuke/NukeBoundUserInterface.cs
@@ -1,9 +1,7 @@
-using Content.Client.Traitor.Uplink;
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Nuke;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Localization;
 
 namespace Content.Client.Nuke
 {
@@ -37,7 +35,7 @@ namespace Content.Client.Nuke
 
             _menu.EjectButton.OnPressed += _ =>
             {
-                SendMessage(new NukeEjectMessage());
+                SendMessage(new ItemSlotButtonPressedEvent(SharedNukeComponent.NukeDiskSlotId));
             };
             _menu.AnchorButton.OnPressed += _ =>
             {

--- a/Content.Client/PDA/PDABoundUserInterface.cs
+++ b/Content.Client/PDA/PDABoundUserInterface.cs
@@ -1,14 +1,8 @@
 using Content.Client.Message;
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.PDA;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
-using Robust.Client.UserInterface.Controls;
-using Robust.Client.UserInterface.CustomControls;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Prototypes;
-using static Robust.Client.UserInterface.Controls.BoxContainer;
 
 namespace Content.Client.PDA
 {
@@ -35,12 +29,12 @@ namespace Content.Client.PDA
 
             _menu.EjectIdButton.OnPressed += _ =>
             {
-                SendMessage(new PDAEjectIDMessage());
+                SendMessage(new ItemSlotButtonPressedEvent(PDAComponent.PDAIdSlotId));
             };
 
             _menu.EjectPenButton.OnPressed += _ =>
             {
-                SendMessage(new PDAEjectPenMessage());
+                SendMessage(new ItemSlotButtonPressedEvent(PDAComponent.PDAPenSlotId));
             };
 
             _menu.ActivateUplinkButton.OnPressed += _ =>

--- a/Content.Server/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Server/Access/Components/IdCardConsoleComponent.cs
@@ -1,18 +1,11 @@
-using System.Collections.Generic;
 using System.Linq;
 using Content.Server.Access.Systems;
-using Content.Server.Power.Components;
 using Content.Server.UserInterface;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
-using Content.Shared.Containers.ItemSlots;
 using Robust.Server.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Log;
 using Robust.Shared.Prototypes;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Server.Access.Components
 {
@@ -24,7 +17,6 @@ namespace Content.Server.Access.Components
         [Dependency] private readonly IEntityManager _entities = default!;
 
         [ViewVariables] private BoundUserInterface? UserInterface => Owner.GetUIOrNull(IdCardConsoleUiKey.Key);
-        [ViewVariables] private bool Powered => !_entities.TryGetComponent(Owner, out ApcPowerReceiverComponent? receiver) || receiver.Powered;
 
         protected override void Initialize()
         {
@@ -48,17 +40,6 @@ namespace Content.Server.Access.Components
 
             switch (obj.Message)
             {
-                case IdButtonPressedMessage msg:
-                    switch (msg.Button)
-                    {
-                        case UiButton.PrivilegedId:
-                            HandleIdButton(player, PrivilegedIdSlot);
-                            break;
-                        case UiButton.TargetId:
-                            HandleIdButton(player, TargetIdSlot);
-                            break;
-                    }
-                    break;
                 case WriteToTargetIdMessage msg:
                     TryWriteToTargetId(msg.FullName, msg.JobTitle, msg.AccessList);
                     UpdateUserInterface();
@@ -102,17 +83,6 @@ namespace Content.Server.Access.Components
 
             var accessSystem = EntitySystem.Get<AccessSystem>();
             accessSystem.TrySetTags(targetIdEntity, newAccessList);
-        }
-
-        /// <summary>
-        /// Called when one of the insert/remove ID buttons gets pressed.
-        /// </summary>
-        private void HandleIdButton(EntityUid user, ItemSlot slot)
-        {
-            if (slot.HasItem)
-                EntitySystem.Get<ItemSlotsSystem>().TryEjectToHands(Owner, slot, user);
-            else
-                EntitySystem.Get<ItemSlotsSystem>().TryInsertFromHand(Owner, slot, user);
         }
 
         public void UpdateUserInterface()

--- a/Content.Server/Chemistry/Components/ChemMasterComponent.cs
+++ b/Content.Server/Chemistry/Components/ChemMasterComponent.cs
@@ -97,21 +97,14 @@ namespace Content.Server.Chemistry.Components
             if (obj.Session.AttachedEntity is not {Valid: true} player)
                 return;
 
-            var msg = (UiActionMessage) obj.Message;
-            var needsPower = msg.Action switch
-            {
-                UiAction.Eject => false,
-                _ => true,
-            };
+            if (obj.Message is not UiActionMessage msg)
+                return;
 
-            if (!PlayerCanUseChemMaster(player, needsPower))
+            if (!PlayerCanUseChemMaster(player, true))
                 return;
 
             switch (msg.Action)
             {
-                case UiAction.Eject:
-                    EntitySystem.Get<ItemSlotsSystem>().TryEjectToHands(Owner, BeakerSlot, player);
-                    break;
                 case UiAction.ChemButton:
                     TransferReagent(msg.Id, msg.Amount, msg.IsBuffer);
                     break;

--- a/Content.Server/Chemistry/Components/ReagentDispenserComponent.cs
+++ b/Content.Server/Chemistry/Components/ReagentDispenserComponent.cs
@@ -4,7 +4,6 @@ using Content.Server.Power.Components;
 using Content.Server.UserInterface;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Dispenser;
-using Content.Shared.Containers.ItemSlots;
 using Content.Shared.FixedPoint;
 using Content.Shared.Sound;
 using JetBrains.Annotations;
@@ -145,21 +144,14 @@ namespace Content.Server.Chemistry.Components
                 return;
             }
 
-            var msg = (UiButtonPressedMessage) obj.Message;
-            var needsPower = msg.Button switch
-            {
-                UiButton.Eject => false,
-                _ => true,
-            };
+            if (obj.Message is not UiButtonPressedMessage msg )
+                return;
 
-            if (!PlayerCanUseDispenser(obj.Session.AttachedEntity, needsPower))
+            if (!PlayerCanUseDispenser(obj.Session.AttachedEntity, true))
                 return;
 
             switch (msg.Button)
             {
-                case UiButton.Eject:
-                    EntitySystem.Get<ItemSlotsSystem>().TryEjectToHands(Owner, BeakerSlot, obj.Session.AttachedEntity);
-                    break;
                 case UiButton.Clear:
                     TryClear();
                     break;

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -27,7 +27,8 @@ namespace Content.Server.Construction
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
-
+        [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
+        
         // --- WARNING! LEGACY CODE AHEAD! ---
         // This entire file contains the legacy code for initial construction.
         // This is bound to be replaced by a better alternative (probably using dummy entities)
@@ -75,9 +76,12 @@ namespace Content.Server.Construction
                 }
             }
 
-            foreach (var near in EntitySystem.Get<EntityLookupSystem>().GetEntitiesInRange(user!, 2f, LookupFlags.Approximate))
+            var pos = Transform(user).MapPosition;
+
+            foreach (var near in _lookupSystem.GetEntitiesInRange(user!, 2f, LookupFlags.Approximate))
             {
-                yield return near;
+                if (_interactionSystem.InRangeUnobstructed(pos, near, 2f)) 
+                    yield return near;
             }
         }
 

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -27,8 +27,7 @@ namespace Content.Server.Construction
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
-        [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
-        
+
         // --- WARNING! LEGACY CODE AHEAD! ---
         // This entire file contains the legacy code for initial construction.
         // This is bound to be replaced by a better alternative (probably using dummy entities)
@@ -76,12 +75,9 @@ namespace Content.Server.Construction
                 }
             }
 
-            var pos = Transform(user).MapPosition;
-
-            foreach (var near in _lookupSystem.GetEntitiesInRange(user!, 2f, LookupFlags.Approximate))
+            foreach (var near in EntitySystem.Get<EntityLookupSystem>().GetEntitiesInRange(user!, 2f, LookupFlags.Approximate))
             {
-                if (_interactionSystem.InRangeUnobstructed(pos, near, 2f)) 
-                    yield return near;
+                yield return near;
             }
         }
 

--- a/Content.Server/Kitchen/Components/ReagentGrinderComponent.cs
+++ b/Content.Server/Kitchen/Components/ReagentGrinderComponent.cs
@@ -18,7 +18,7 @@ namespace Content.Server.Kitchen.Components
         /// <summary>
         /// Can be null since we won't always have a beaker in the grinder.
         /// </summary>
-        [ViewVariables] public Solution? HeldBeaker;
+        [ViewVariables] public Solution? BeakerSolution;
 
         /// <summary>
         /// Contains the things that are going to be ground or juiced.

--- a/Content.Server/Kitchen/Components/ReagentGrinderComponent.cs
+++ b/Content.Server/Kitchen/Components/ReagentGrinderComponent.cs
@@ -1,10 +1,8 @@
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Kitchen.Components;
 using Content.Shared.Sound;
 using Robust.Shared.Containers;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Server.Kitchen.Components
 {
@@ -17,12 +15,10 @@ namespace Content.Server.Kitchen.Components
     [RegisterComponent]
     public sealed class ReagentGrinderComponent : SharedReagentGrinderComponent
     {
-        [ViewVariables] public ContainerSlot BeakerContainer = default!;
-
         /// <summary>
         /// Can be null since we won't always have a beaker in the grinder.
         /// </summary>
-        [ViewVariables] public Solution? HeldBeaker = default!;
+        [ViewVariables] public Solution? HeldBeaker;
 
         /// <summary>
         /// Contains the things that are going to be ground or juiced.
@@ -40,5 +36,8 @@ namespace Content.Server.Kitchen.Components
         [DataField("clickSound")] public SoundSpecifier ClickSound { get; set; } = new SoundPathSpecifier("/Audio/Machines/machine_switch.ogg");
         [DataField("grindSound")] public SoundSpecifier GrindSound { get; set; } = new SoundPathSpecifier("/Audio/Machines/blender.ogg");
         [DataField("juiceSound")] public SoundSpecifier JuiceSound { get; set; } = new SoundPathSpecifier("/Audio/Machines/juicer.ogg");
+
+        [DataField("beakerSlot")]
+        public ItemSlot BeakerSlot = new();
     }
 }

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -7,6 +7,8 @@ using Content.Server.Kitchen.Events;
 using Content.Server.Power.Components;
 using Content.Server.Stack;
 using Content.Server.UserInterface;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -27,6 +29,7 @@ namespace Content.Server.Kitchen.EntitySystems
     {
         [Dependency] private readonly SolutionContainerSystem _solutionsSystem = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+        [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
 
         private Queue<ReagentGrinderComponent> _uiUpdateQueue = new();
 
@@ -35,11 +38,29 @@ namespace Content.Server.Kitchen.EntitySystems
             base.Initialize();
 
             SubscribeLocalEvent<ReagentGrinderComponent, ComponentInit>(OnComponentInit);
-            SubscribeLocalEvent<ReagentGrinderComponent, PowerChangedEvent>((_, component, _) =>
-                EnqueueUiUpdate(component));
-            SubscribeLocalEvent<ReagentGrinderComponent, InteractHandEvent>(OnInteractHand);
+            SubscribeLocalEvent<ReagentGrinderComponent, ComponentRemove>(OnComponentRemove);
+
+            SubscribeLocalEvent<ReagentGrinderComponent, PowerChangedEvent>((_, component, _) => EnqueueUiUpdate(component));
             SubscribeLocalEvent<ReagentGrinderComponent, InteractUsingEvent>(OnInteractUsing);
             SubscribeLocalEvent<StackComponent, ExtractableScalingEvent>(ExtractableScaling);
+
+            SubscribeLocalEvent<ReagentGrinderComponent, EntInsertedIntoContainerMessage>(OnContainerModified);
+            SubscribeLocalEvent<ReagentGrinderComponent, EntRemovedFromContainerMessage>(OnContainerModified);
+            SubscribeLocalEvent<ReagentGrinderComponent, ContainerIsRemovingAttemptEvent>(OnEntRemoveAttempt);
+        }
+
+        private void OnEntRemoveAttempt(EntityUid uid, ReagentGrinderComponent component, ContainerIsRemovingAttemptEvent args)
+        {
+            if (component.Busy)
+                args.Cancel();
+        }
+
+        private void OnContainerModified(EntityUid uid, ReagentGrinderComponent component, ContainerModifiedMessage args)
+        {
+            if (TryComp(component.Owner, out AppearanceComponent? appearance))
+                appearance.SetData(SharedReagentGrinderComponent.ReagentGrinderVisualState.BeakerAttached, component.BeakerSlot.HasItem);
+
+            EnqueueUiUpdate(component);
         }
 
         private void ExtractableScaling(EntityUid uid, StackComponent component, ExtractableScalingEvent args)
@@ -51,38 +72,10 @@ namespace Content.Server.Kitchen.EntitySystems
         {
             if (args.Handled) return;
 
-            if (!EntityManager.HasComponent<HandsComponent>(args.User))
-            {
-                component.Owner.PopupMessage(args.User,
-                    Loc.GetString("reagent-grinder-component-interact-using-no-hands"));
-                args.Handled = true;
-                return;
-            }
-
             var heldEnt = args.Used;
 
-            // First, check if user is trying to insert a beaker.
-            // No promise it will be a beaker right now, but whatever.
-            // Maybe this should whitelist "beaker" in the prototype id of heldEnt?
-            if (_solutionsSystem.TryGetFitsInDispenser(heldEnt, out var beaker))
-            {
-                component.BeakerContainer.Insert(heldEnt);
-                component.HeldBeaker = beaker;
-                EnqueueUiUpdate(component);
-                //We are done, return. Insert the beaker and exit!
-                if (EntityManager.TryGetComponent(component.Owner, out AppearanceComponent? appearance))
-                {
-                    appearance.SetData(SharedReagentGrinderComponent.ReagentGrinderVisualState.BeakerAttached,
-                        component.BeakerContainer.ContainedEntity != null);
-                }
-
-                ClickSound(component);
-                args.Handled = true;
-                return;
-            }
-
-            //Next, see if the user is trying to insert something they want to be ground/juiced.
-            if (!EntityManager.TryGetComponent(heldEnt, out ExtractableComponent? juice))
+            //See if the user is trying to insert something they want to be ground/juiced.
+            if (!HasComp<ExtractableComponent>(heldEnt))
             {
                 //Entity did NOT pass the whitelist for grind/juice.
                 //Wouldn't want the clown grinding up the Captain's ID card now would you?
@@ -93,31 +86,11 @@ namespace Content.Server.Kitchen.EntitySystems
             //Cap the chamber. Don't want someone putting in 500 entities and ejecting them all at once.
             //Maybe I should have done that for the microwave too?
             if (component.Chamber.ContainedEntities.Count >= component.StorageCap)
-            {
                 return;
-            }
 
-            if (!component.Chamber.Insert(heldEnt))
-            {
+            if (!component.Chamber.Insert(heldEnt, EntityManager))
                 return;
-            }
 
-            EnqueueUiUpdate(component);
-            args.Handled = true;
-        }
-
-        private void OnInteractHand(EntityUid uid, ReagentGrinderComponent component, InteractHandEvent args)
-        {
-            if (args.Handled) return;
-
-            if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
-            {
-                return;
-            }
-
-            EnqueueUiUpdate(component);
-            component.Owner.GetUIOrNull(SharedReagentGrinderComponent.ReagentGrinderUiKey.Key)
-                ?.Toggle(actor.PlayerSession);
             args.Handled = true;
         }
 
@@ -130,16 +103,14 @@ namespace Content.Server.Kitchen.EntitySystems
         {
             EnqueueUiUpdate(component);
 
-            //A slot for the beaker where the grounds/juices will go.
-            component.BeakerContainer =
-                ContainerHelpers.EnsureContainer<ContainerSlot>(component.Owner,
-                    $"{component.Name}-reagentContainerContainer");
+            _itemSlotsSystem.AddItemSlot(uid, SharedReagentGrinderComponent.BeakerSlotId, component.BeakerSlot);
 
             //A container for the things that WILL be ground/juiced. Useful for ejecting them instead of deleting them from the hands of the user.
             component.Chamber =
                 ContainerHelpers.EnsureContainer<Container>(component.Owner,
                     $"{component.Name}-entityContainerContainer");
 
+            // TODO just directly subscribe to UI events.
             var bui = component.Owner.GetUIOrNull(SharedReagentGrinderComponent.ReagentGrinderUiKey.Key);
             if (bui != null)
             {
@@ -147,6 +118,11 @@ namespace Content.Server.Kitchen.EntitySystems
             }
         }
 
+        private void OnComponentRemove(EntityUid uid, ReagentGrinderComponent component, ComponentRemove args)
+        {
+            _itemSlotsSystem.RemoveItemSlot(uid, component.BeakerSlot);
+        }
+        
         private void OnUIMessageReceived(EntityUid uid, ReagentGrinderComponent component,
             ServerBoundUserInterfaceMessage message)
         {
@@ -199,12 +175,6 @@ namespace Content.Server.Kitchen.EntitySystems
                     }
 
                     break;
-
-                case SharedReagentGrinderComponent.ReagentGrinderEjectBeakerMessage msg:
-                    ClickSound(component);
-                    EjectBeaker(component, message.Session.AttachedEntity);
-                    EnqueueUiUpdate(component);
-                    break;
             }
         }
 
@@ -219,7 +189,7 @@ namespace Content.Server.Kitchen.EntitySystems
 
                 bool canJuice = false;
                 bool canGrind = false;
-                if (comp.BeakerContainer.ContainedEntity != null)
+                if (comp.BeakerSlot.HasItem)
                 {
                     foreach (var entity in comp.Chamber.ContainedEntities)
                     {
@@ -235,7 +205,7 @@ namespace Content.Server.Kitchen.EntitySystems
                     new ReagentGrinderInterfaceState
                     (
                         comp.Busy,
-                        comp.BeakerContainer.ContainedEntity != null,
+                        comp.BeakerSlot.HasItem,
                         EntityManager.TryGetComponent(comp.Owner, out ApcPowerReceiverComponent? receiver) && receiver.Powered,
                         canJuice,
                         canGrind,
@@ -243,36 +213,6 @@ namespace Content.Server.Kitchen.EntitySystems
                         //Remember the beaker can be null!
                         comp.HeldBeaker?.Contents.ToArray()
                     ));
-            }
-        }
-
-        /// <summary>
-        /// Tries to eject whatever is in the beaker slot. Puts the item in the user's hands or failing that on top
-        /// of the grinder.
-        /// </summary>
-        private void EjectBeaker(ReagentGrinderComponent component, EntityUid? user)
-        {
-            if (component.BeakerContainer.ContainedEntity == null || component.HeldBeaker == null || component.Busy)
-                return;
-
-            if (component.BeakerContainer.ContainedEntity is not {Valid: true} beaker)
-                return;
-
-            component.BeakerContainer.Remove(beaker);
-
-            if (user == null ||
-                !EntityManager.TryGetComponent<HandsComponent?>(user.Value, out var hands) ||
-                !EntityManager.TryGetComponent<SharedItemComponent?>(beaker, out var item))
-                return;
-
-            _handsSystem.PickupOrDrop(user.Value, beaker, handsComp: hands, item: item);
-
-            component.HeldBeaker = null;
-            EnqueueUiUpdate(component);
-            if (EntityManager.TryGetComponent(component.Owner, out AppearanceComponent? appearance))
-            {
-                appearance.SetData(SharedReagentGrinderComponent.ReagentGrinderVisualState.BeakerAttached,
-                    component.BeakerContainer.ContainedEntity != null);
             }
         }
 
@@ -286,7 +226,8 @@ namespace Content.Server.Kitchen.EntitySystems
             //Have power, are  we busy, chamber has anything to grind, a beaker for the grounds to go?
             if (!EntityManager.TryGetComponent(component.Owner, out ApcPowerReceiverComponent? receiver) || !receiver.Powered ||
                 component.Busy || component.Chamber.ContainedEntities.Count <= 0 ||
-                component.BeakerContainer.ContainedEntity == null || component.HeldBeaker == null)
+                component.BeakerSlot.Item is not EntityUid beakerEntity ||
+                !_solutionsSystem.TryGetFitsInDispenser(beakerEntity, out var beaker))
             {
                 return;
             }
@@ -295,7 +236,6 @@ namespace Content.Server.Kitchen.EntitySystems
 
             var bui = component.Owner.GetUIOrNull(SharedReagentGrinderComponent.ReagentGrinderUiKey.Key);
             bui?.SendMessage(new SharedReagentGrinderComponent.ReagentGrinderWorkStartedMessage(program));
-            var beakerEntity = component.BeakerContainer.ContainedEntity;
             switch (program)
             {
                 case SharedReagentGrinderComponent.GrinderProgram.Grind:
@@ -312,10 +252,10 @@ namespace Content.Server.Kitchen.EntitySystems
 
                             var juiceEvent = new ExtractableScalingEvent(); // default of scalar is always 1.0
                             RaiseLocalEvent(item, juiceEvent, false);
-                            if (component.HeldBeaker.CurrentVolume + solution.CurrentVolume * juiceEvent.Scalar >
-                                component.HeldBeaker.MaxVolume) continue;
+                            if (beaker.CurrentVolume + solution.CurrentVolume * juiceEvent.Scalar >
+                                beaker.MaxVolume) continue;
                             solution.ScaleSolution(juiceEvent.Scalar);
-                            _solutionsSystem.TryAddSolution(beakerEntity.Value, component.HeldBeaker, solution);
+                            _solutionsSystem.TryAddSolution(beakerEntity, beaker, solution);
                             EntityManager.DeleteEntity(item);
                         }
 
@@ -343,11 +283,10 @@ namespace Content.Server.Kitchen.EntitySystems
                                 RaiseLocalEvent(item, juiceEvent);
                             }
 
-                            if (component.HeldBeaker.CurrentVolume +
-                                juiceMe.JuiceSolution.TotalVolume * juiceEvent.Scalar >
-                                component.HeldBeaker.MaxVolume) continue;
+                            if (beaker.CurrentVolume + juiceMe.JuiceSolution.TotalVolume * juiceEvent.Scalar > beaker.MaxVolume)
+                                continue;
                             juiceMe.JuiceSolution.ScaleSolution(juiceEvent.Scalar);
-                            _solutionsSystem.TryAddSolution(beakerEntity.Value, component.HeldBeaker, juiceMe.JuiceSolution);
+                            _solutionsSystem.TryAddSolution(beakerEntity, component.HeldBeaker, juiceMe.JuiceSolution);
                             EntityManager.DeleteEntity(item);
                         }
 

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Nuke
     /// </summary>
     [RegisterComponent]
     [Friend(typeof(NukeSystem))]
-    public sealed class NukeComponent : Component
+    public sealed class NukeComponent : SharedNukeComponent
     {
         /// <summary>
         ///     Default bomb timer value in seconds.

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -36,7 +36,6 @@ namespace Content.Server.Nuke
             SubscribeLocalEvent<NukeComponent, AnchorStateChangedEvent>(OnAnchorChanged);
 
             // ui events
-            SubscribeLocalEvent<NukeComponent, NukeEjectMessage>(OnEjectButtonPressed);
             SubscribeLocalEvent<NukeComponent, NukeAnchorMessage>(OnAnchorButtonPressed);
             SubscribeLocalEvent<NukeComponent, NukeArmedMessage>(OnArmButtonPressed);
             SubscribeLocalEvent<NukeComponent, NukeKeypadMessage>(OnKeypadButtonPressed);
@@ -47,7 +46,7 @@ namespace Content.Server.Nuke
         private void OnInit(EntityUid uid, NukeComponent component, ComponentInit args)
         {
             component.RemainingTime = component.Timer;
-            _itemSlots.AddItemSlot(uid, component.Name, component.DiskSlot);
+            _itemSlots.AddItemSlot(uid, SharedNukeComponent.NukeDiskSlotId, component.DiskSlot);
 
             UpdateStatus(uid, component);
             UpdateUserInterface(uid, component);
@@ -118,14 +117,6 @@ namespace Content.Server.Nuke
         #endregion
 
         #region UI Events
-        private void OnEjectButtonPressed(EntityUid uid, NukeComponent component, NukeEjectMessage args)
-        {
-            if (!component.DiskSlot.HasItem)
-                return;
-
-            _itemSlots.TryEjectToHands(uid, component.DiskSlot, args.Session.AttachedEntity);
-        }
-
         private async void OnAnchorButtonPressed(EntityUid uid, NukeComponent component, NukeAnchorMessage args)
         {
             if (!component.DiskSlot.HasItem)

--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -175,16 +175,6 @@ namespace Content.Server.PDA
                         break;
                     }
 
-                case PDAEjectIDMessage _:
-                    {
-                        ItemSlotsSystem.TryEjectToHands(pda.Owner, pda.IdSlot, playerUid);
-                        break;
-                    }
-                case PDAEjectPenMessage _:
-                    {
-                        ItemSlotsSystem.TryEjectToHands(pda.Owner, pda.PenSlot, playerUid);
-                        break;
-                    }
                 case PDAShowUplinkMessage _:
                     {
                         if (EntityManager.TryGetComponent(pda.Owner, out UplinkComponent? uplink))

--- a/Content.Shared/Access/Components/SharedIdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/SharedIdCardConsoleComponent.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
 using Content.Shared.Containers.ItemSlots;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Shared.Access.Components
 {
@@ -12,28 +8,14 @@ namespace Content.Shared.Access.Components
         public const int MaxFullNameLength = 256;
         public const int MaxJobTitleLength = 256;
 
+        public static string PrivilegedIdCardSlotId = "IdCardConsole-privilegedId";
+        public static string TargetIdCardSlotId = "IdCardConsole-targetId";
+
         [DataField("privilegedIdSlot")]
         public ItemSlot PrivilegedIdSlot = new();
 
         [DataField("targetIdSlot")]
         public ItemSlot TargetIdSlot = new();
-
-        public enum UiButton
-        {
-            PrivilegedId,
-            TargetId,
-        }
-
-        [Serializable, NetSerializable]
-        public sealed class IdButtonPressedMessage : BoundUserInterfaceMessage
-        {
-            public readonly UiButton Button;
-
-            public IdButtonPressedMessage(UiButton button)
-            {
-                Button = button;
-            }
-        }
 
         [Serializable, NetSerializable]
         public sealed class WriteToTargetIdMessage : BoundUserInterfaceMessage

--- a/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
+++ b/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
@@ -1,8 +1,6 @@
 using Content.Shared.Access.Components;
 using Content.Shared.Containers.ItemSlots;
 using JetBrains.Annotations;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 
 namespace Content.Shared.Access.Systems
 {
@@ -21,8 +19,8 @@ namespace Content.Shared.Access.Systems
 
         private void OnComponentInit(EntityUid uid, SharedIdCardConsoleComponent component, ComponentInit args)
         {
-            _itemSlotsSystem.AddItemSlot(uid, $"{component.Name}-privilegedId", component.PrivilegedIdSlot);
-            _itemSlotsSystem.AddItemSlot(uid, $"{component.Name}-targetId", component.TargetIdSlot);
+            _itemSlotsSystem.AddItemSlot(uid, SharedIdCardConsoleComponent.PrivilegedIdCardSlotId, component.PrivilegedIdSlot);
+            _itemSlotsSystem.AddItemSlot(uid, SharedIdCardConsoleComponent.TargetIdCardSlotId, component.TargetIdSlot);
         }
 
         private void OnComponentRemove(EntityUid uid, SharedIdCardConsoleComponent component, ComponentRemove args)

--- a/Content.Shared/Chemistry/Components/SharedChemMasterComponent.cs
+++ b/Content.Shared/Chemistry/Components/SharedChemMasterComponent.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
 using Content.Shared.Cloning;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.FixedPoint;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Shared.Chemistry.Components
 {
@@ -16,6 +12,8 @@ namespace Content.Shared.Chemistry.Components
     [Virtual]
     public class SharedChemMasterComponent : Component
     {
+        public static string BeakerSlotId = "ChemMaster-beaker";
+
         [DataField("beakerSlot")]
         public ItemSlot BeakerSlot = new();
         public const string SolutionName = "buffer";
@@ -124,7 +122,6 @@ namespace Content.Shared.Chemistry.Components
         /// </summary>
         public enum UiAction
         {
-            Eject,
             Transfer,
             Discard,
             ChemButton,

--- a/Content.Shared/Chemistry/Dispenser/SharedReagentDispenserComponent.cs
+++ b/Content.Shared/Chemistry/Dispenser/SharedReagentDispenserComponent.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.FixedPoint;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Shared.Chemistry.Dispenser
 {
@@ -18,6 +13,8 @@ namespace Content.Shared.Chemistry.Dispenser
     [Virtual]
     public class SharedReagentDispenserComponent : Component
     {
+        public const string BeakerSlotId = "ReagentDispenser-beaker";
+
         [DataField("beakerSlot")]
         public ItemSlot BeakerSlot = new();
 
@@ -87,7 +84,6 @@ namespace Content.Shared.Chemistry.Dispenser
         /// </summary>
         public enum UiButton
         {
-            Eject,
             Clear,
             SetDispenseAmount1,
             SetDispenseAmount5,

--- a/Content.Shared/Chemistry/EntitySystems/SharedChemMasterSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedChemMasterSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Shared.Chemistry.EntitySystems
 
         private void OnComponentInit(EntityUid uid, SharedChemMasterComponent component, ComponentInit args)
         {
-            _itemSlotsSystem.AddItemSlot(uid, $"{component.Name}-beaker", component.BeakerSlot);
+            _itemSlotsSystem.AddItemSlot(uid, SharedChemMasterComponent.BeakerSlotId, component.BeakerSlot);
         }
 
         private void OnComponentRemove(EntityUid uid, SharedChemMasterComponent component, ComponentRemove args)

--- a/Content.Shared/Chemistry/EntitySystems/SharedReagentDispenserSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedReagentDispenserSystem.cs
@@ -1,6 +1,4 @@
 using JetBrains.Annotations;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Chemistry.Dispenser;
 
@@ -21,7 +19,7 @@ namespace Content.Shared.Chemistry.EntitySystems
 
         private void OnComponentInit(EntityUid uid, SharedReagentDispenserComponent component, ComponentInit args)
         {
-            _itemSlotsSystem.AddItemSlot(uid, $"{component.Name}-beaker", component.BeakerSlot);
+            _itemSlotsSystem.AddItemSlot(uid, SharedReagentDispenserComponent.BeakerSlotId, component.BeakerSlot);
         }
 
         private void OnComponentRemove(EntityUid uid, SharedReagentDispenserComponent component, ComponentRemove args)

--- a/Content.Shared/Containers/ItemSlot/ItemSlotEvents.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotEvents.cs
@@ -1,0 +1,32 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Containers.ItemSlots;
+
+/// <summary>
+///     Used for various "eject this item" buttons.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class ItemSlotButtonPressedEvent : BoundUserInterfaceMessage
+{
+    /// <summary>
+    ///     The name of the slot/container from which to insert or eject an item.
+    /// </summary>
+    public string SlotId;
+
+    /// <summary>
+    ///     Whether to attempt to insert an item into the slot, if there is not already one inside.
+    /// </summary>
+    public bool TryInsert;
+
+    /// <summary>
+    ///     Whether to attempt to eject the item from the slot, if it has one.
+    /// </summary>
+    public bool TryEject;
+
+    public ItemSlotButtonPressedEvent(string slotId, bool tryEject = true, bool tryInsert = true)
+    {
+        SlotId = slotId;
+        TryEject = tryEject;
+        TryInsert = tryInsert;
+    }
+}

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -45,6 +45,8 @@ namespace Content.Shared.Containers.ItemSlots
 
             SubscribeLocalEvent<ItemSlotsComponent, ComponentGetState>(GetItemSlotsState);
             SubscribeLocalEvent<ItemSlotsComponent, ComponentHandleState>(HandleItemSlotsState);
+
+            SubscribeLocalEvent<ItemSlotsComponent, ItemSlotButtonPressedEvent>(HandleButtonPressed);
         }
 
         #region ComponentManagement
@@ -291,7 +293,7 @@ namespace Content.Shared.Containers.ItemSlots
                 return false;
 
             // hands.Drop(item) checks CanDrop action blocker
-            if (_handsSystem.TryDrop(user, hands.ActiveHand))
+            if (!_handsSystem.TryDrop(user, hands.ActiveHand))
                 return false;
 
             Insert(uid, slot, held, user);
@@ -487,6 +489,19 @@ namespace Content.Shared.Containers.ItemSlots
 
                 args.Verbs.Add(insertVerb);
             }
+        }
+        #endregion
+
+        #region BUIs
+        private void HandleButtonPressed(EntityUid uid, ItemSlotsComponent component, ItemSlotButtonPressedEvent args)
+        {
+            if (!component.Slots.TryGetValue(args.SlotId, out var slot))
+                return;
+
+            if (args.TryEject && slot.HasItem)
+                TryEjectToHands(uid, slot, args.Session.AttachedEntity);
+            else if (args.TryInsert && !slot.HasItem && args.Session.AttachedEntity is EntityUid user)
+                TryInsertFromHand(uid, slot, user);
         }
         #endregion
 

--- a/Content.Shared/Kitchen/Components/SharedReagentGrinderComponent.cs
+++ b/Content.Shared/Kitchen/Components/SharedReagentGrinderComponent.cs
@@ -5,8 +5,11 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Kitchen.Components
 {
+    
     public abstract class SharedReagentGrinderComponent : Component
     {
+        public static string BeakerSlotId = "ReagentGrinder-reagentContainerContainer";
+
         [Serializable, NetSerializable]
         public sealed class ReagentGrinderGrindStartMessage : BoundUserInterfaceMessage
         {
@@ -27,14 +30,6 @@ namespace Content.Shared.Kitchen.Components
         public sealed class ReagentGrinderEjectChamberAllMessage : BoundUserInterfaceMessage
         {
             public ReagentGrinderEjectChamberAllMessage()
-            {
-            }
-        }
-
-        [Serializable, NetSerializable]
-        public sealed class ReagentGrinderEjectBeakerMessage : BoundUserInterfaceMessage
-        {
-            public ReagentGrinderEjectBeakerMessage()
             {
             }
         }

--- a/Content.Shared/Nuke/NukeUiMessages.cs
+++ b/Content.Shared/Nuke/NukeUiMessages.cs
@@ -1,12 +1,10 @@
-using System;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Nuke
 {
-    [Serializable, NetSerializable]
-    public sealed class NukeEjectMessage : BoundUserInterfaceMessage
+    public abstract class SharedNukeComponent : Component
     {
+        public const string NukeDiskSlotId = "Nuke";
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/PDA/PDAComponent.cs
+++ b/Content.Shared/PDA/PDAComponent.cs
@@ -1,16 +1,16 @@
 using Content.Shared.Access.Components;
 using Content.Shared.Containers.ItemSlots;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Shared.PDA
 {
     [RegisterComponent]
     public sealed class PDAComponent : Component
     {
+        public const string PDAIdSlotId = "PDA-id";
+        public const string PDAPenSlotId = "PDA-pen";
+
         [DataField("idSlot")]
         public ItemSlot IdSlot = new();
 

--- a/Content.Shared/PDA/PDAMessagesUI.cs
+++ b/Content.Shared/PDA/PDAMessagesUI.cs
@@ -14,23 +14,6 @@ namespace Content.Shared.PDA
     }
 
     [Serializable, NetSerializable]
-    public sealed class PDAEjectIDMessage : BoundUserInterfaceMessage
-    {
-        public PDAEjectIDMessage()
-        {
-
-        }
-    }
-
-    [Serializable, NetSerializable]
-    public sealed class PDAEjectPenMessage : BoundUserInterfaceMessage
-    {
-        public PDAEjectPenMessage()
-        {
-
-        }
-    }
-    [Serializable, NetSerializable]
     public sealed class PDAShowRingtoneMessage : BoundUserInterfaceMessage
     {
         public PDAShowRingtoneMessage()

--- a/Content.Shared/PDA/SharedPDASystem.cs
+++ b/Content.Shared/PDA/SharedPDASystem.cs
@@ -26,8 +26,8 @@ namespace Content.Shared.PDA
             if (pda.IdCard != null)
                 pda.IdSlot.StartingItem = pda.IdCard;
 
-            ItemSlotsSystem.AddItemSlot(uid, $"{pda.Name}-id", pda.IdSlot);
-            ItemSlotsSystem.AddItemSlot(uid, $"{pda.Name}-pen", pda.PenSlot);
+            ItemSlotsSystem.AddItemSlot(uid, PDAComponent.PDAIdSlotId, pda.IdSlot);
+            ItemSlotsSystem.AddItemSlot(uid, PDAComponent.PDAPenSlotId, pda.PenSlot);
 
             UpdatePDAAppearance(pda);
         }

--- a/Resources/Locale/en-US/kitchen/components/reagent-grinder-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/reagent-grinder-component.ftl
@@ -11,6 +11,3 @@ grinder-menu-chamber-content-box-button = Eject Contents
 grinder-menu-beaker-content-box-label = Beaker
 grinder-menu-beaker-content-box-button = Eject Beaker
 grinder-menu-beaker-content-box-is-empty = Empty
-
-## Entity
-reagent-grinder-component-interact-using-no-hands = You have no hands.

--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -8,6 +8,12 @@
   - type: Transform
     anchored: true
   - type: ReagentGrinder
+    beakerSlot:
+      whitelist:
+        components:
+        - FitsInDispenser
+  - type: ActivatableUI
+    key: enum.ReagentGrinderUiKey.Key
   - type: UserInterface
     interfaces:
     - key: enum.ReagentGrinderUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -9,6 +9,10 @@
     anchored: true
   - type: ReagentGrinder
     beakerSlot:
+      insertSound: /Audio/Machines/machine_switch.ogg
+      ejectSound: /Audio/Machines/machine_switch.ogg
+      soundOptions:
+        volume: -2
       whitelist:
         components:
         - FitsInDispenser


### PR DESCRIPTION
This PR:
- Makes the reagent grinder use item slots
  - adds alt clicking to eject & eject/insert verbs
- Makes reagent grinder use ActivatableUI component
  - Less interact-to-open-ui code duplication
- Adds BUI eject-button event handling to item slots
  - Previously many BUIs (ID card console, chem machines, pda) each implemented their own eject button messages & message event handlers
  - These all just ended up calling ItemSlotSystem.TryEjectToHands(), and had nothing to do with those component/systems specifically.
  - So this PR just replaces them all these with a new BUI event that is handled directly by the item slot system
  - This required making some of the container id strings constants, which they probably should already have been.    