### PR TITLE
Crafting obstruction check.

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -28,7 +28,7 @@ namespace Content.Server.Construction
         [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
         [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
-        
+
         // --- WARNING! LEGACY CODE AHEAD! ---
         // This entire file contains the legacy code for initial construction.
         // This is bound to be replaced by a better alternative (probably using dummy entities)
@@ -80,7 +80,7 @@ namespace Content.Server.Construction
 
             foreach (var near in _lookupSystem.GetEntitiesInRange(user!, 2f, LookupFlags.Approximate))
             {
-                if (_interactionSystem.InRangeUnobstructed(pos, near, 2f)) 
+                if (_interactionSystem.InRangeUnobstructed(pos, near, 2f) && _containerSystem.IsInSameOrParentContainer(user, near)) 
                     yield return near;
             }
         }

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -27,7 +27,8 @@ namespace Content.Server.Construction
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
-
+        [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
+        
         // --- WARNING! LEGACY CODE AHEAD! ---
         // This entire file contains the legacy code for initial construction.
         // This is bound to be replaced by a better alternative (probably using dummy entities)
@@ -75,9 +76,12 @@ namespace Content.Server.Construction
                 }
             }
 
-            foreach (var near in EntitySystem.Get<EntityLookupSystem>().GetEntitiesInRange(user!, 2f, LookupFlags.Approximate))
+            var pos = Transform(user).MapPosition;
+
+            foreach (var near in _lookupSystem.GetEntitiesInRange(user!, 2f, LookupFlags.Approximate))
             {
-                yield return near;
+                if (_interactionSystem.InRangeUnobstructed(pos, near, 2f)) 
+                    yield return near;
             }
         }
 


### PR DESCRIPTION
Fixes the ability to steal items through walls or from other peoples inventory via the construction system.

Fixes #6966

:cl:
- fix: Crafting items via the construction menu should no longer attempt to take items from other users inventories.

