### PR TITLE
Structures rotate with the grid they are on

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/memorial.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/memorial.yml
@@ -7,7 +7,6 @@
   - type: Sprite
     sprite: Structures/Furniture/memorial.rsi
     state: memorial
-    noRot: true
   - type: Transform
     noRot: true
   - type: Fixtures

--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -25,7 +25,6 @@
   - type: Sprite
     drawdepth: Overdoors
     offset: "0.0,0.3"
-    noRot: true
     sprite: Structures/Furniture/potted_plants.rsi
   - type: PottedPlantHide
   - type: SecretStash

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -15,7 +15,6 @@
     color: "#3db83b"
   - type: Sprite
     sprite: Structures/Machines/arcade.rsi
-    noRot: true
     layers:
     - state: arcade
       map: ["enum.ComputerVisualizer+Layers.Body"]

--- a/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/medical_scanner.yml
@@ -7,7 +7,6 @@
   - type: MedicalScanner
   - type: Sprite
     netsync: false
-    noRot: true
     sprite: Structures/Machines/scanner.rsi
     layers:
     - state: open

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -165,7 +165,6 @@
     - type: Sprite
       netsync: false
       sprite: Structures/Piping/Atmospherics/thermomachine.rsi
-      noRot: true
     - type: Appearance
       visuals:
         - type: PipeColorVisualizer

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -8,7 +8,6 @@
   - type: Transform
     noRot: true
   - type: Sprite
-    noRot: true
     netsync: false
     sprite: Structures/Storage/Crates/generic.rsi
     layers:
@@ -72,7 +71,6 @@
   - type: Transform
     noRot: true
   - type: Sprite
-    noRot: true
     netsync: false
     sprite: Structures/Storage/Crates/generic.rsi
     layers:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
(Screenshots to be added)

This PR removes `noRot` from most structure prototypes, allowing them to rotate with a grid. Before, structures like crates, lockers, and medical scanners would orient themselves to be upright, regardless of the grid they were on. This looks really odd from an external view of a rotating grid, and causes the sprite bounding boxes / physics bounding boxes to become misaligned. That has been fixed by removing `noRot`.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- improved: Crates, lockers, and other miscellaneous objects now rotate with the grid they are on