### PR TITLE
Alleviate attack log spam

### DIFF
--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -229,7 +229,7 @@ namespace Content.Server.Interaction
 
                         if (ev.Handled)
                         {
-                            _adminLogSystem.Add(LogType.AttackArmedWide, LogImpact.Medium, $"{ToPrettyString(user):user} wide attacked with {ToPrettyString(item.Value):used} at {coordinates}");
+                            _adminLogSystem.Add(LogType.AttackArmedWide, LogImpact.Low, $"{ToPrettyString(user):user} wide attacked with {ToPrettyString(item.Value):used} at {coordinates}");
                             return;
                         }
                     }
@@ -242,12 +242,12 @@ namespace Content.Server.Interaction
                         {
                             if (target != null)
                             {
-                                _adminLogSystem.Add(LogType.AttackArmedClick, LogImpact.Medium,
+                                _adminLogSystem.Add(LogType.AttackArmedClick, LogImpact.Low,
                                     $"{ToPrettyString(user):user} attacked {ToPrettyString(target.Value):target} with {ToPrettyString(item.Value):used} at {coordinates}");
                             }
                             else
                             {
-                                _adminLogSystem.Add(LogType.AttackArmedClick, LogImpact.Medium,
+                                _adminLogSystem.Add(LogType.AttackArmedClick, LogImpact.Low,
                                     $"{ToPrettyString(user):user} attacked with {ToPrettyString(item.Value):used} at {coordinates}");
                             }
 
@@ -270,7 +270,7 @@ namespace Content.Server.Interaction
                 var ev = new WideAttackEvent(user, user, coordinates);
                 RaiseLocalEvent(user, ev, false);
                 if (ev.Handled)
-                    _adminLogSystem.Add(LogType.AttackUnarmedWide, $"{ToPrettyString(user):user} wide attacked at {coordinates}");
+                    _adminLogSystem.Add(LogType.AttackUnarmedWide, LogImpact.Low, $"{ToPrettyString(user):user} wide attacked at {coordinates}");
             }
             else
             {
@@ -280,12 +280,12 @@ namespace Content.Server.Interaction
                 {
                     if (target != null)
                     {
-                        _adminLogSystem.Add(LogType.AttackUnarmedClick, LogImpact.Medium,
+                        _adminLogSystem.Add(LogType.AttackUnarmedClick, LogImpact.Low,
                             $"{ToPrettyString(user):user} attacked {ToPrettyString(target.Value):target} at {coordinates}");
                     }
                     else
                     {
-                        _adminLogSystem.Add(LogType.AttackUnarmedClick, LogImpact.Medium,
+                        _adminLogSystem.Add(LogType.AttackUnarmedClick, LogImpact.Low,
                             $"{ToPrettyString(user):user} attacked at {coordinates}");
                     }
                 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes attack LogImpact to low so that it's easier to filter them out when looking for damage logs.

Partial fix for #7212