### PR TITLE
Changed the sound that plays when you lock a locker

### DIFF
--- a/Content.Server/Lock/LockComponent.cs
+++ b/Content.Server/Lock/LockComponent.cs
@@ -14,6 +14,6 @@ namespace Content.Server.Storage.Components
         [ViewVariables(VVAccess.ReadWrite)] [DataField("locked")] public bool Locked { get; set; } = true;
         [ViewVariables(VVAccess.ReadWrite)] [DataField("lockOnClick")] public bool LockOnClick { get; set; } = false;
         [ViewVariables(VVAccess.ReadWrite)] [DataField("unlockingSound")] public SoundSpecifier UnlockSound { get; set; } = new SoundPathSpecifier("/Audio/Machines/door_lock_off.ogg");
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("lockingSound")] public SoundSpecifier LockSound { get; set; } = new SoundPathSpecifier("/Audio/Machines/door_lock_off.ogg");
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("lockingSound")] public SoundSpecifier LockSound { get; set; } = new SoundPathSpecifier("/Audio/Machines/door_lock_on.ogg");
     }
 }


### PR DESCRIPTION
## About the PR
I was going through the game files and noticed there are two different sounds for locking and unlocking the lockers, crates and such, but only one of them plays in-game 

**Screenshots**

**Changelog**
:cl: areit
- tweak: A slightly different sound now plays when you lock a locker/crate/etc

