### PR TITLE
Fix Research Server

### DIFF
--- a/Content.Client/Research/UI/ResearchClientServerSelectionMenu.xaml.cs
+++ b/Content.Client/Research/UI/ResearchClientServerSelectionMenu.xaml.cs
@@ -56,7 +56,7 @@ namespace Content.Client.Research.UI
                 Servers.AddItem(Loc.GetString("research-client-server-selection-menu-server-entry-text", ("id", id), ("serverName", _serverNames[i])));
                 if (id == _selectedServerId)
                 {
-                    Servers[id].Selected = true;
+                    Servers[i].Selected = true;
                 }
             }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -34,6 +34,7 @@
     range: 5
     sound:
       path: /Audio/Ambience/Objects/server_fans.ogg
+      
 - type: entity
   id: BaseResearchAndDevelopmentPointSource
   parent: BaseMachinePowered
@@ -54,6 +55,9 @@
     radius: 1.5
     energy: 1.6
     color: "#3db83b"
+  - type: ActivatableUI
+    key: enum.ResearchClientUiKey.Key
+  - type: ActivatableUIRequiresPower
   - type: UserInterface
     interfaces:
     - key: enum.ResearchClientUiKey.Key


### PR DESCRIPTION
So. Bagel Station's RD server was "id: 1" meaning when it went to populate the server list the index of the list was 1, which is out of range. This should be fixed now.

The UI for the point source should also be fixed now.

:cl: Pancake
- fix: Research servers now work correctly.

