### PR TITLE
Fix and refactor SolutionContainerSystem.RemoveEachReagent

### DIFF
--- a/Content.Server/Botany/Components/PlantHolderComponent.cs
+++ b/Content.Server/Botany/Components/PlantHolderComponent.cs
@@ -569,10 +569,10 @@ namespace Content.Server.Botany.Components
             else
             {
                 var amt = FixedPoint2.New(1);
-                foreach (var reagent in solutionSystem.RemoveEachReagent(Owner, solution, amt))
+                foreach (var (reagentId, quantity) in solutionSystem.RemoveEachReagent(Owner, solution, amt))
                 {
-                    var reagentProto = _prototypeManager.Index<ReagentPrototype>(reagent);
-                    reagentProto.ReactionPlant(Owner, new Solution.ReagentQuantity(reagent, amt), solution);
+                    var reagentProto = _prototypeManager.Index<ReagentPrototype>(reagentId);
+                    reagentProto.ReactionPlant(Owner, new Solution.ReagentQuantity(reagentId, quantity), solution);
                 }
             }
 

--- a/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
@@ -304,11 +304,10 @@ public sealed partial class SolutionContainerSystem : EntitySystem
 
         var removedSolution = new Solution();
 
-        // We have to make a clone of contents as the original list might change...
-        var contents = solution.Contents.ToArray();
-        for (var i = 0; i < contents.Length; i++)
+        // RemoveReagent does a RemoveSwap, meaning we don't have to copy the list if we iterate it backwards.
+        for (var i = solution.Contents.Count-1; i >= 0; i--)
         {
-            var (reagentId, _) = contents[i];
+            var (reagentId, _) = solution.Contents[i];
 
             var removedQuantity = solution.RemoveReagent(reagentId, quantity);
 

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -176,7 +176,7 @@ namespace Content.Shared.Chemistry.Components
         public FixedPoint2 RemoveReagent(string reagentId, FixedPoint2 quantity)
         {
             if(quantity <= 0)
-                return 0;
+                return FixedPoint2.Zero;
 
             for (var i = 0; i < Contents.Count; i++)
             {
@@ -201,7 +201,7 @@ namespace Content.Shared.Chemistry.Components
             }
 
             // Reagent is not on the solution...
-            return 0;
+            return FixedPoint2.Zero;
         }
 
         /// <summary>

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -167,34 +167,41 @@ namespace Content.Shared.Chemistry.Components
             return FixedPoint2.New(0);
         }
 
-        public void RemoveReagent(string reagentId, FixedPoint2 quantity)
+        /// <summary>
+        ///     Attempts to remove an amount of reagent from the solution.
+        /// </summary>
+        /// <param name="reagentId">The reagent to be removed.</param>
+        /// <param name="quantity">The amount of reagent to remove.</param>
+        /// <returns>How much reagent was actually removed. Zero if the reagent is not present on the solution.</returns>
+        public FixedPoint2 RemoveReagent(string reagentId, FixedPoint2 quantity)
         {
             if(quantity <= 0)
-                return;
+                return 0;
 
             for (var i = 0; i < Contents.Count; i++)
             {
                 var reagent = Contents[i];
+
                 if(reagent.ReagentId != reagentId)
                     continue;
-                if (!IoCManager.Resolve<IPrototypeManager>().TryIndex(reagentId, out ReagentPrototype? proto))
-                    proto = new ReagentPrototype();
 
                 var curQuantity = reagent.Quantity;
                 var newQuantity = curQuantity - quantity;
+
                 if (newQuantity <= 0)
                 {
                     Contents.RemoveSwap(i);
                     TotalVolume -= curQuantity;
-                }
-                else
-                {
-                    Contents[i] = new ReagentQuantity(reagentId, newQuantity);
-                    TotalVolume -= quantity;
+                    return curQuantity;
                 }
 
-                return;
+                Contents[i] = new ReagentQuantity(reagentId, newQuantity);
+                TotalVolume -= quantity;
+                return quantity;
             }
+
+            // Reagent is not on the solution...
+            return 0;
         }
 
         /// <summary>


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Fixes a bug where plantholder would constantly try to index a `null` prototype.
![image](https://user-images.githubusercontent.com/6766154/159694481-a9f415d2-bf4e-4551-8cc8-6f9d4ba652c3.png)

- Solution.RemoveReagent now returns how much reagent was *actually* removed.
- Removes useless IPrototypeManager resolves.

Solutions need some cleanup.