### PR TITLE
Move random artifact trigger adding to mapinit

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -13,10 +13,10 @@ public sealed class ArtifactSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<ArtifactComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<ArtifactComponent, MapInitEvent>(OnInit);
     }
 
-    private void OnInit(EntityUid uid, ArtifactComponent component, ComponentInit args)
+    private void OnInit(EntityUid uid, ArtifactComponent component, MapInitEvent args)
     {
         if (component.RandomTrigger)
         {
@@ -32,6 +32,12 @@ public sealed class ArtifactSystem : EntitySystem
         var triggerName = _random.Pick(component.PossibleTriggers);
         var trigger = (Component) _componentFactory.GetComponent(triggerName);
         trigger.Owner = uid;
+
+        if (EntityManager.HasComponent(uid, trigger.GetType()))
+        {
+            Logger.Error($"Attempted to add a random artifact trigger ({triggerName}) to an entity ({ToPrettyString(uid)}), but it already has the trigger");
+            return;
+        }
 
         EntityManager.AddComponent(uid, trigger);
         RaiseLocalEvent(uid, new RandomizeTriggerEvent());

--- a/Resources/Maps/Salvage/medium-pirate.yml
+++ b/Resources/Maps/Salvage/medium-pirate.yml
@@ -759,13 +759,6 @@ entities:
   - pos: -0.5,-0.5
     parent: 52
     type: Transform
-  - gas: Plasma
-    possibleGas:
-    - Oxygen
-    - Plasma
-    - Nitrogen
-    - CarbonDioxide
-    type: ArtifactGasTrigger
 - uid: 80
   type: Stool
   components:

--- a/Resources/Maps/Salvage/medium-pirate.yml
+++ b/Resources/Maps/Salvage/medium-pirate.yml
@@ -422,7 +422,7 @@ entities:
       -1,-1:
         0:
           color: '#9FED5896'
-          id: antilizard
+          id: prolizard
           coordinates: -2,-4
     type: DecalGrid
   - tiles:


### PR DESCRIPTION
And removes an artifact trigger from some salvage, under the assumption that it is there by accident.

This was discussed a bit in #6282, and AFAIK after the addition of the `RandomizeTriggerEvent`, this shouldn't cause issues? @Macoron 