### PR TITLE
Small amendment to server sec rules

### DIFF
--- a/Resources/Server Info/Rules.txt
+++ b/Resources/Server Info/Rules.txt
@@ -41,3 +41,4 @@ RULES FOR SECURITY
     - If you still manage to kill someone as security, get them cloned immediately, and make sure their stuff is returned.
 
 [color=#a4885c]13.[/color] Prisoners should not be given sentences longer than 10 minutes. Certain extreme exceptions like bombers, assassins or employees of a hostile corporation (i.e. traitor status) of a may warrant permabrigging, or [color=#ff0000]in the very worst cases[/color], execution.
+    - Note that employment at a hostile corporation (i.e. traitor status) alone [color=#ff0000]does not[/color] qualify someone for perma or execution.

--- a/Resources/Server Info/Rules.txt
+++ b/Resources/Server Info/Rules.txt
@@ -40,5 +40,5 @@ RULES FOR SECURITY
 [color=#a4885c]12.[/color] Security is expected to use non-lethal measures unless faced with lethal force or a situation where non-lethal measures aren't possible. Ideally, do not enter combat mode, as security stun batons do not deal damage, but still stun, when outside of combat mode.
     - If you still manage to kill someone as security, get them cloned immediately, and make sure their stuff is returned.
 
-[color=#a4885c]13.[/color] Prisoners should not be given sentences longer than 10 minutes. Certain extreme exceptions like bombers, assassins or employees of a hostile corporation (i.e. traitor status) of a may warrant permabrigging, or [color=#ff0000]in the very worst cases[/color], execution.
+[color=#a4885c]13.[/color] Prisoners should not be given sentences longer than 10 minutes. Certain extreme exceptions like bombers and assassins may warrant permabrigging, or [color=#ff0000]in the very worst cases[/color], execution.
     - Note that employment at a hostile corporation (i.e. traitor status) alone [color=#ff0000]does not[/color] qualify someone for perma or execution.

--- a/Resources/Server Info/Rules.txt
+++ b/Resources/Server Info/Rules.txt
@@ -40,5 +40,4 @@ RULES FOR SECURITY
 [color=#a4885c]12.[/color] Security is expected to use non-lethal measures unless faced with lethal force or a situation where non-lethal measures aren't possible. Ideally, do not enter combat mode, as security stun batons do not deal damage, but still stun, when outside of combat mode.
     - If you still manage to kill someone as security, get them cloned immediately, and make sure their stuff is returned.
 
-[color=#a4885c]13.[/color] Prisoners should not be given sentences longer than 5 minutes. Certain extreme exceptions like bombers or assassins may warrant permabrigging, or [color=#ff0000]in the very worst cases[/color], execution.
-    - Note that employment at a hostile corporation (i.e. traitor status) alone [color=#ff0000]does not[/color] qualify someone for perma or execution.
+[color=#a4885c]13.[/color] Prisoners should not be given sentences longer than 10 minutes. Certain extreme exceptions like bombers, assassins or employees of a hostile corporation (i.e. traitor status) of a may warrant permabrigging, or [color=#ff0000]in the very worst cases[/color], execution.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The current server rules include a section that says; "Note that employment at a hostile corporation (i.e. traitor status) alone does not qualify someone for perma or execution."

This is 
A) A rule taken purely from current space law, which I understand is intended to be an entirely unofficial, unenforced and optional set of RP guidelines, fully separate to server rules, but is here, for some reason, included among them.
B) Fundamentally at odds with the design of social deception antags, explicitly disallowing sec from permabrigging confirmed antags until they do a murder. If you find a traitor with a backpack full of guns, you have to take the guns, give him a slap on the wrist, and let him go.

This is a bad rule that explicitly disallows sec from doing their job, robs tension from the antag roles and forces the bad kind of RP where sec have to pretend that a 5 minute sentence will make an antag not be an antag anymore and release them. The justification I've been given is that 'if traitors have rules preventing them murderboning, security need rules hindering them too' which feels more like spite than anything else. I've never once seen this rule on a ss13 server, and for good reason.

This PR removes that line, and folds the "employment at a hostile corporation" section into the list of legitimate cases for permabrig/execution.

Also increased the maximum non-perma brig time rule to ten minutes, in line with standard ss13 brig time limits for MRP (which, afaik, the server will be moving to), but this could be changed back if it's an issue.

-->

:cl:
- tweak: Nanotrasen has rewritten the laws themselves to allow security officers to brig for up to 10 minutes instead of five.