### PR TITLE
Buff flashlight duration, minor buff for flare.

### DIFF
--- a/Content.Server/Light/Components/HandheldLightComponent.cs
+++ b/Content.Server/Light/Components/HandheldLightComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Light.Components
     [Friend(typeof(HandheldLightSystem))]
     public sealed class HandheldLightComponent : SharedHandheldLightComponent
     {
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("wattage")] public float Wattage { get; set; } = .7f;
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("wattage")] public float Wattage { get; set; } = .8f;
 
         /// <summary>
         ///     Status of light, whether or not it is emitting light.

--- a/Content.Server/Light/Components/HandheldLightComponent.cs
+++ b/Content.Server/Light/Components/HandheldLightComponent.cs
@@ -1,25 +1,7 @@
-using System.Threading.Tasks;
-using Content.Server.Clothing.Components;
 using Content.Server.Light.EntitySystems;
-using Content.Shared.ActionBlocker;
-using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Light.Component;
-using Content.Shared.Popups;
-using Content.Shared.Rounding;
 using Content.Shared.Sound;
-using JetBrains.Annotations;
-using Robust.Server.GameObjects;
-using Robust.Shared.Analyzers;
-using Robust.Shared.Audio;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Maths;
-using Robust.Shared.Player;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Utility;
-using Robust.Shared.ViewVariables;
+
 
 namespace Content.Server.Light.Components
 {
@@ -30,7 +12,7 @@ namespace Content.Server.Light.Components
     [Friend(typeof(HandheldLightSystem))]
     public sealed class HandheldLightComponent : SharedHandheldLightComponent
     {
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("wattage")] public float Wattage { get; set; } = 3f;
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("wattage")] public float Wattage { get; set; } = .7f;
 
         /// <summary>
         ///     Status of light, whether or not it is emitting light.

--- a/Content.Server/Light/Components/HandheldLightComponent.cs
+++ b/Content.Server/Light/Components/HandheldLightComponent.cs
@@ -2,7 +2,6 @@ using Content.Server.Light.EntitySystems;
 using Content.Shared.Light.Component;
 using Content.Shared.Sound;
 
-
 namespace Content.Server.Light.Components
 {
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -13,7 +13,7 @@
   - type: ExpendableLight
     spentName: spent flare
     spentDesc: It looks like this flare has burnt out. What a bummer.
-    glowDuration: 45
+    glowDuration: 165
     fadeOutDuration: 15
     iconStateOn: flare_unlit
     iconStateSpent: flare_spent


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes flashlights to last about 15 minutes with their standard cell (high cap small battery) and flares to last 3 minutes instead of 1.

The way wattage works right now is that the listed wattage is used every second.
High cap small power cells are 720 watt seconds = 720 / 3 = 240 seconds = 4 minutes. (current length)
with new being 720 / .8 = 900 seconds = 15 minutes.

This seemed like the way to go for now without overhauling all batteries depending on their use and how much power is generated on the station itself, which actually might need to happen eventually.

:cl:
- tweak: Flashlights and flares now last a decent bit longer.

