### PR TITLE
Fix mercury/uranium groups

### DIFF
--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -132,7 +132,7 @@
   meltingPoint: -38.83
   boilingPoint: 356.73
   metabolisms:
-    Medicine:
+    Poison:
       effects:
       - !type:HealthChange
         damage:
@@ -237,7 +237,7 @@
     prob: 0.2
     amount: 0.1
   metabolisms:
-    Medicine:
+    Poison:
       effects:
       - !type:HealthChange
         damage:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

oops

:cl:
- tweak: Mercury and Uranium are no longer mistakenly metabolized as medicines.

