### PR TITLE
Cybersun pen functionality pass

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -94,6 +94,17 @@
     damage:
       types:
         Piercing: 5
+  - type: ItemCooldown
+  - type: MeleeWeapon
+    damage:
+      types:
+        Piercing: 15
+    arcCooldownTime: 2 
+  - type: Tool
+    qualities:
+      - Screwing
+    useSound:
+      collection: Screwdriver
   - type: Item
     sprite: Objects/Misc/bureaucracy.rsi
     HeldPrefix: overpriced_pen

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -99,7 +99,6 @@
     damage:
       types:
         Piercing: 15
-    arcCooldownTime: 2 
   - type: Tool
     qualities:
       - Screwing

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -81,7 +81,7 @@
   name: Cybersun pen
   parent: BaseItem
   id: CyberPen
-  description: A high-tech pen straight from Cybersun's legal department, capable of refracting hard-light at impossible angles through its diamond tip in order to write. It's not literally pointless, only figuratively.
+  description: A high-tech pen straight from Cybersun's legal department, capable of refracting hard-light at impossible angles through its diamond tip in order to write. 
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
Gives the cybersun pen screwdriver functionality with slightly more damage than a screwdriver. This change will make it slightly more worth buying as it's a hidden screwdriver you can hide in your pda. For comparison the e-pen does the same damage but it's half slash and half heat and is half the price of this in the uplink catalog.

:cl: emisse
- add: Cybersun pen has been discovered to work as an excellent screwdriver.
