### PR TITLE
Changes for collision wake ECS

### DIFF
--- a/Content.Shared/MobState/State/SharedDeadMobState.cs
+++ b/Content.Shared/MobState/State/SharedDeadMobState.cs
@@ -11,8 +11,7 @@ namespace Content.Shared.MobState.State
         public override void EnterState(EntityUid uid, IEntityManager entityManager)
         {
             base.EnterState(uid, entityManager);
-            var wake = entityManager.EnsureComponent<CollisionWakeComponent>(uid);
-            wake.Enabled = true;
+            entityManager.EnsureComponent<CollisionWakeComponent>(uid);
             var standingState = EntitySystem.Get<StandingStateSystem>();
             standingState.Down(uid);
 


### PR DESCRIPTION
Required to make CollisionWakeComponent a friend of CollisionWakeSystem. Collision wake component defaults to enabled, so setting `enabled = true` is not required.

Required for space-wizards/RobustToolbox/pull/2656, but this content PR can be merged on its own.

