### PR TITLE
PDA uplink visibility fix

### DIFF
--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -36,7 +36,10 @@ namespace Content.Server.PDA
         {
             base.OnComponentInit(uid, pda, args);
 
-            if (_uiSystem.TryGetUi(uid, PDAUiKey.Key, out var ui))
+            if (!TryComp(uid, out ServerUserInterfaceComponent? uiComponent))
+                return;
+
+            if (_uiSystem.TryGetUi(uid, PDAUiKey.Key, out var ui, uiComponent))
                 ui.OnReceiveMessage += (msg) => OnUIMessage(pda, msg);
         }
 

--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -146,7 +146,6 @@ namespace Content.Server.PDA
             }
         }
 
-
         private void AfterUIOpen(EntityUid uid, PDAComponent pda, AfterActivatableUIOpenEvent args)
         {
             // A new user opened the UI --> Check if they are a traitor and should get a user specific UI state override.
@@ -167,6 +166,5 @@ namespace Content.Server.PDA
 
             ui.SetState(state, args.Session);
         }
-
     }
 }

--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -28,6 +28,8 @@ namespace Content.Server.PDA
 
             SubscribeLocalEvent<PDAComponent, LightToggleEvent>(OnLightToggle);
             SubscribeLocalEvent<PDAComponent, AfterActivatableUIOpenEvent>(AfterUIOpen);
+            SubscribeLocalEvent<PDAComponent, UplinkInitEvent>(OnUplinkInit);
+            SubscribeLocalEvent<PDAComponent, UplinkRemovedEvent>(OnUplinkRemoved);
         }
 
         protected override void OnComponentInit(EntityUid uid, PDAComponent pda, ComponentInit args)
@@ -59,6 +61,16 @@ namespace Content.Server.PDA
         public void SetOwner(PDAComponent pda, string ownerName)
         {
             pda.OwnerName = ownerName;
+            UpdatePDAUserInterface(pda);
+        }
+
+        private void OnUplinkInit(EntityUid uid, PDAComponent pda, UplinkInitEvent args)
+        {
+            UpdatePDAUserInterface(pda);
+        }
+
+        private void OnUplinkRemoved(EntityUid uid, PDAComponent pda, UplinkRemovedEvent args)
+        {
             UpdatePDAUserInterface(pda);
         }
 

--- a/Content.Server/PDA/PDASystem.cs
+++ b/Content.Server/PDA/PDASystem.cs
@@ -7,7 +7,6 @@ using Content.Server.Traitor.Uplink.Account;
 using Content.Server.Traitor.Uplink.Components;
 using Content.Server.PDA.Ringer;
 using Content.Server.UserInterface;
-using Content.Shared.Containers.ItemSlots;
 using Content.Shared.PDA;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
@@ -21,20 +20,21 @@ namespace Content.Server.PDA
         [Dependency] private readonly UnpoweredFlashlightSystem _unpoweredFlashlight = default!;
         [Dependency] private readonly RingerSystem _ringerSystem = default!;
         [Dependency] private readonly InstrumentSystem _instrumentSystem = default!;
+        [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 
         public override void Initialize()
         {
             base.Initialize();
 
             SubscribeLocalEvent<PDAComponent, LightToggleEvent>(OnLightToggle);
+            SubscribeLocalEvent<PDAComponent, AfterActivatableUIOpenEvent>(AfterUIOpen);
         }
 
         protected override void OnComponentInit(EntityUid uid, PDAComponent pda, ComponentInit args)
         {
             base.OnComponentInit(uid, pda, args);
 
-            var ui = pda.Owner.GetUIOrNull(PDAUiKey.Key);
-            if (ui != null)
+            if (_uiSystem.TryGetUi(uid, PDAUiKey.Key, out var ui))
                 ui.OnReceiveMessage += (msg) => OnUIMessage(pda, msg);
         }
 
@@ -62,35 +62,7 @@ namespace Content.Server.PDA
             UpdatePDAUserInterface(pda);
         }
 
-        private void OnUplinkInit(EntityUid uid, PDAComponent pda, UplinkInitEvent args)
-        {
-            UpdatePDAUserInterface(pda);
-        }
-
-        private void OnUplinkRemoved(EntityUid uid, PDAComponent pda, UplinkRemovedEvent args)
-        {
-            UpdatePDAUserInterface(pda);
-        }
-
-        private bool OpenUI(PDAComponent pda, EntityUid user)
-        {
-            if (!EntityManager.TryGetComponent(user, out ActorComponent? actor))
-                return false;
-
-            UpdatePDAUserInterface(pda, user);
-            var ui = pda.Owner.GetUIOrNull(PDAUiKey.Key);
-            ui?.Toggle(actor.PlayerSession);
-
-            return true;
-        }
-
-        private void UpdatePDAAppearance(PDAComponent pda)
-        {
-            if (EntityManager.TryGetComponent(pda.Owner, out AppearanceComponent? appearance))
-                appearance.SetData(PDAVisuals.IDCardInserted, pda.ContainedID != null);
-        }
-
-        private void UpdatePDAUserInterface(PDAComponent pda, EntityUid? user = null)
+        private void UpdatePDAUserInterface(PDAComponent pda)
         {
             var ownerInfo = new PDAIdInfoText
             {
@@ -99,54 +71,40 @@ namespace Content.Server.PDA
                 JobTitle = pda.ContainedID?.JobTitle
             };
 
-            var ui = pda.Owner.GetUIOrNull(PDAUiKey.Key);
-            if (ui == null)
+            if (!_uiSystem.TryGetUi(pda.Owner, PDAUiKey.Key, out var ui))
                 return;
 
-            ui.SetState(new PDAUpdateState(pda.FlashlightOn, pda.PenSlot.HasItem, ownerInfo,
-                ShouldShowUplink(pda.Owner, ui, user),
-                HasComp<InstrumentComponent>(pda.Owner)));
-        }
+            var hasInstrument = HasComp<InstrumentComponent>(pda.Owner);
+            var state = new PDAUpdateState(pda.FlashlightOn, pda.PenSlot.HasItem, ownerInfo, false, hasInstrument);
 
-        /// <summary>
-        ///     Check whether the PDA has an uplink, and ensure that the only person that can see the PDA UI has an
-        ///     uplink account.
-        /// </summary>
-        public bool ShouldShowUplink(EntityUid uid, BoundUserInterface ui, EntityUid? user = null)
-        {
+            ui.SetState(state);
+
             // TODO UPLINK RINGTONES/SECRETS This is just a janky placeholder way of hiding uplinks from non syndicate
             // players. This should really use a sort of key-code entry system that selects an account which is not directly tied to
             // a player entity.
 
-            if (!HasComp<UplinkComponent>(uid))
-                return false;
+            if (!HasComp<UplinkComponent>(pda.Owner))
+                return;
 
-            // If a user is trying to open the UI, make sure that they have an uplink account before showing the UI.
-            if (user != null && !_uplinkAccounts.HasAccount(user.Value))
-                return false;
+            var uplinkState = new PDAUpdateState(pda.FlashlightOn, pda.PenSlot.HasItem, ownerInfo, true, hasInstrument);
 
-            // If other users currently have the UI open, check that they too should be allowed to see the button..
             foreach (var session in ui.SubscribedSessions)
             {
-                if (session.AttachedEntity != null && !_uplinkAccounts.HasAccount(session.AttachedEntity.Value))
-                    return false;
-            }
+                if (session.AttachedEntity is not EntityUid { Valid: true } user)
+                    continue;
 
-            // everyone has an uplink account, show the button.
-            return true;
+                if (_uplinkAccounts.HasAccount(user))
+                    ui.SetState(uplinkState, session);
+            }
         }
 
         private void OnUIMessage(PDAComponent pda, ServerBoundUserInterfaceMessage msg)
         {
-            // cast EntityUid? to EntityUid
-            if (msg.Session.AttachedEntity is not {Valid: true} playerUid)
-                return;
-
             // todo: move this to entity events
             switch (msg.Message)
             {
                 case PDARequestUpdateInterfaceMessage _:
-                    UpdatePDAUserInterface(pda, playerUid);
+                    UpdatePDAUserInterface(pda);
                     break;
                 case PDAToggleFlashlightMessage _:
                     {
@@ -175,5 +133,28 @@ namespace Content.Server.PDA
                 }
             }
         }
+
+
+        private void AfterUIOpen(EntityUid uid, PDAComponent pda, AfterActivatableUIOpenEvent args)
+        {
+            // A new user opened the UI --> Check if they are a traitor and should get a user specific UI state override.
+            if (!HasComp<UplinkComponent>(pda.Owner) || !_uplinkAccounts.HasAccount(args.User))
+                return;
+
+            if (!_uiSystem.TryGetUi(pda.Owner, PDAUiKey.Key, out var ui))
+                return;
+
+            var ownerInfo = new PDAIdInfoText
+            {
+                ActualOwnerName = pda.OwnerName,
+                IdOwner = pda.ContainedID?.FullName,
+                JobTitle = pda.ContainedID?.JobTitle
+            };
+
+            var state = new PDAUpdateState(pda.FlashlightOn, pda.PenSlot.HasItem, ownerInfo, true, HasComp<InstrumentComponent>(pda.Owner));
+
+            ui.SetState(state, args.Session);
+        }
+
     }
 }

--- a/Content.Server/UserInterface/ActivatableUISystem.cs
+++ b/Content.Server/UserInterface/ActivatableUISystem.cs
@@ -138,7 +138,7 @@ namespace Content.Server.UserInterface
             ui.Toggle(actor.PlayerSession);
 
             //Let the component know a user opened it so it can do whatever it needs to do
-            var aae = new AfterActivatableUIOpenEvent(user);
+            var aae = new AfterActivatableUIOpenEvent(user, actor.PlayerSession);
             RaiseLocalEvent((aui).Owner, aae, false);
 
             return true;
@@ -186,9 +186,12 @@ namespace Content.Server.UserInterface
     public sealed class AfterActivatableUIOpenEvent : EntityEventArgs
     {
         public EntityUid User { get; }
-        public AfterActivatableUIOpenEvent(EntityUid who)
+        public readonly IPlayerSession Session;
+
+        public AfterActivatableUIOpenEvent(EntityUid who, IPlayerSession session)
         {
             User = who;
+            Session = session;
         }
     }
 


### PR DESCRIPTION
PDA uplink checks are apparently possible again. Probably happened after the ui opening interactions were offloaded to the activatable UI system. This PR makes PDAs use player-specific UI states for traitors. This fixes it for now, but again, someone should probably implement the secret code entry stuff.

:cl:
- fix: Fix the PDA UI briefly showing the uplink button to non-traitors.

