### PR TITLE
Makes ElectroJr a boomer

### DIFF
--- a/Tools/dump_contributors_since.ps1
+++ b/Tools/dump_contributors_since.ps1
@@ -11,7 +11,8 @@ param(
 $replacements = @{
     "moonheart08" = "moony",
     "Elijahrane" = "Rane",
-    "ZeroDayDaemon" = "Daemon"
+    "ZeroDayDaemon" = "Daemon",
+    "ElectroJr" = "ElectroSR"
 }
 
 $ignore = @{


### PR DESCRIPTION
Updates the progress report contributors script to override @ElectroJr with `ElectroSR` per:

![image](https://user-images.githubusercontent.com/5714543/160737263-b6c1be0d-604a-4f1c-ae47-db5aa98b31c9.png)

[Link](https://discord.com/channels/310555209753690112/770682801607278632/912510596463874118).