### PR TITLE
Advanced Magboots Noslip

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -34,13 +34,13 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-advanced.rsi
   - type: Magboots
-      toggleAction:
-        icon: Clothing/Shoes/Boots/magboots-advanced.rsi/icon.png
-        iconOn: Clothing/Shoes/Boots/magboots-advanced.rsi/icon-on.png  
-        name: action-name-magboot-toggle
-        description: action-decription-magboot-toggle
-        itemIconStyle: NoItem
-        event: !type:ToggleActionEvent
+    toggleAction:
+      icon: Clothing/Shoes/Boots/magboots-advanced.rsi/icon.png
+      iconOn: Clothing/Shoes/Boots/magboots-advanced.rsi/icon-on.png  
+      name: action-name-magboot-toggle
+      description: action-decription-magboot-toggle
+      itemIconStyle: NoItem
+      event: !type:ToggleActionEvent
   - type: Magboots
   - type: ClothingSpeedModifier
     walkModifier: 1

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -36,12 +36,11 @@
   - type: Magboots
     toggleAction:
       icon: Clothing/Shoes/Boots/magboots-advanced.rsi/icon.png
-      iconOn: Clothing/Shoes/Boots/magboots-advanced.rsi/icon-on.png  
+      iconOn: Clothing/Shoes/Boots/magboots-advanced.rsi/icon-on.png
       name: action-name-magboot-toggle
       description: action-decription-magboot-toggle
       itemIconStyle: NoItem
       event: !type:ToggleActionEvent
-  - type: Magboots
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -34,6 +34,10 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-advanced.rsi
   - type: Magboots
+      toggleAction:
+        icon: Clothing/Shoes/Boots/magboots-advanced.rsi/icon.png
+        iconOn: Clothing/Shoes/Boots/magboots-advanced.rsi/icon-on.png  
+  - type: Magboots
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: ClothingShoesBase
   id: ClothingShoesBootsMag
   name: magboots
@@ -38,3 +38,4 @@
     walkModifier: 1
     sprintModifier: 1
     enabled: false
+  - type: NoSlip

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -37,6 +37,10 @@
       toggleAction:
         icon: Clothing/Shoes/Boots/magboots-advanced.rsi/icon.png
         iconOn: Clothing/Shoes/Boots/magboots-advanced.rsi/icon-on.png  
+        name: action-name-magboot-toggle
+        description: action-decription-magboot-toggle
+        itemIconStyle: NoItem
+        event: !type:ToggleActionEvent
   - type: Magboots
   - type: ClothingSpeedModifier
     walkModifier: 1


### PR DESCRIPTION
Gives advanced magboots proper noslip because right now it still slips you for half a second and then prediction shoves your character around a lot. 

