### PR TITLE
Fix two interaction prediction issues

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -180,7 +180,7 @@ namespace Content.Shared.Containers.ItemSlots
                 if (slot.Item != null)
                     _handsSystem.TryPickupAnyHand(args.User, slot.Item.Value, handsComp: hands);
 
-                Insert(uid, slot, args.Used, args.User, excludeUserAudio: args.Predicted);
+                Insert(uid, slot, args.Used, args.User, excludeUserAudio: true);
                 args.Handled = true;
                 return;
             }

--- a/Content.Shared/Emag/Components/EmagComponent.cs
+++ b/Content.Shared/Emag/Components/EmagComponent.cs
@@ -3,13 +3,13 @@ namespace Content.Shared.Emag.Components
     [RegisterComponent]
     public sealed class EmagComponent : Component
     {
-        [DataField("maxCharges")]
+        [DataField("maxCharges"), ViewVariables(VVAccess.ReadWrite)]
         public int MaxCharges = 3;
 
-        [DataField("charges")]
+        [DataField("charges"), ViewVariables(VVAccess.ReadWrite)]
         public int Charges = 3;
 
-        [DataField("rechargeTime")]
+        [DataField("rechargeTime"), ViewVariables(VVAccess.ReadWrite)]
         public float RechargeTime = 90f;
         public float Accumulator = 0f;
     }

--- a/Content.Shared/Interaction/IInteractUsing.cs
+++ b/Content.Shared/Interaction/IInteractUsing.cs
@@ -71,13 +71,7 @@ namespace Content.Shared.Interaction
         /// </summary>
         public EntityCoordinates ClickLocation { get; }
 
-        /// <summary>
-        ///     If true, this prediction is also being predicted client-side. So care has to be taken to avoid audio
-        ///     duplication.
-        /// </summary>
-        public bool Predicted { get; }
-
-        public InteractUsingEvent(EntityUid user, EntityUid used, EntityUid target, EntityCoordinates clickLocation, bool predicted = false)
+        public InteractUsingEvent(EntityUid user, EntityUid used, EntityUid target, EntityCoordinates clickLocation)
         {
             // Interact using should not have the same used and target.
             // That should be a use-in-hand event instead.
@@ -88,7 +82,6 @@ namespace Content.Shared.Interaction
             Used = used;
             Target = target;
             ClickLocation = clickLocation;
-            Predicted = predicted;
         }
     }
 }

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -627,7 +627,6 @@ namespace Content.Shared.Interaction
             EntityUid used,
             EntityUid target,
             EntityCoordinates clickLocation,
-            bool predicted = false,
             bool checkCanInteract = true,
             bool checkCanUse = true)
         {
@@ -641,7 +640,7 @@ namespace Content.Shared.Interaction
                 return;
 
             // all interactions should only happen when in range / unobstructed, so no range check is needed
-            var interactUsingEvent = new InteractUsingEvent(user, used, target, clickLocation, predicted);
+            var interactUsingEvent = new InteractUsingEvent(user, used, target, clickLocation);
             RaiseLocalEvent(target, interactUsingEvent);
             if (interactUsingEvent.Handled)
                 return;

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -110,7 +110,7 @@ public abstract partial class InventorySystem
         if (held != null && itemUid != null)
         {
             _interactionSystem.InteractUsing(actor, held.Value, itemUid.Value,
-                new EntityCoordinates(), predicted: true);
+                new EntityCoordinates());
             return;
         }
 


### PR DESCRIPTION
Fixes double audio on some interactions. Forgot to remove the `predicted` bool from interaction events now that every interaction should be predicted.

Also fixes some emag pop-up spam by moving the interaction handling to the server side system. Given that a lot of hacked-interactions will be server-side, and that properly predicting this would require networking & state management for the emag component, its just not worth predicting.

:cl:
- fix: Fixed some double-audio issues for some machines (chemistry, id card console, etc). Also fixed some double pop-ups for emags.

