### PR TITLE
Disease artifact cleanup

### DIFF
--- a/Content.Server/Disease/DiseaseSystem.cs
+++ b/Content.Server/Disease/DiseaseSystem.cs
@@ -322,9 +322,13 @@ namespace Content.Server.Disease
         /// rolls the dice to see if they get
         /// the disease.
         /// </summary>
-        public void TryInfect(DiseaseCarrierComponent carrier, DiseasePrototype? disease, float chance = 0.7f)
+        /// <param name="carrier">The target of the disease</param>
+        /// <param name="disease">The disease to apply</param>
+        /// <param name="chance">% chance of the disease being applied, before considering resistance</param>
+        /// <param name="forced">Bypass the disease's infectious trait.</param>
+        public void TryInfect(DiseaseCarrierComponent carrier, DiseasePrototype? disease, float chance = 0.7f, bool forced = false)
         {
-            if(disease is not { Infectious: true })
+            if(disease == null || !forced && !disease.Infectious)
                 return;
             var infectionChance = chance - carrier.DiseaseResist;
             if (infectionChance <= 0)

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/DiseaseArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/DiseaseArtifactComponent.cs
@@ -12,9 +12,9 @@ public sealed class DiseaseArtifactComponent : Component
     /// Disease the artifact will spawn
     /// If empty, picks a random one from its list
     /// </summary>
-    [DataField("disease", customTypeSerializer: typeof(PrototypeIdSerializer<DiseasePrototype>))]
+    [DataField("disease")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public string? SpawnDisease;
+    public DiseasePrototype? SpawnDisease;
 
     /// <summary>
     /// How far away it will check for people
@@ -23,15 +23,4 @@ public sealed class DiseaseArtifactComponent : Component
     [DataField("range")]
     [ViewVariables(VVAccess.ReadWrite)]
     public float Range = 5f;
-
-    // TODO: YAML Serializer won't catch this.
-    [ViewVariables(VVAccess.ReadWrite)]
-    public readonly IReadOnlyList<string> ArtifactDiseases = new[]
-    {
-        "VanAusdallsRobovirus",
-        "OwOnavirus",
-        "BleedersBite",
-        "Ultragigacancer",
-        "AMIV"
-    };
 }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/DiseaseArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/DiseaseArtifactComponent.cs
@@ -8,14 +8,14 @@ namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
 [RegisterComponent]
 public sealed class DiseaseArtifactComponent : Component
 {
-    public override string Name => "DiseaseArtifact";
     /// <summary>
     /// Disease the artifact will spawn
     /// If empty, picks a random one from its list
     /// </summary>
     [DataField("disease", customTypeSerializer: typeof(PrototypeIdSerializer<DiseasePrototype>))]
     [ViewVariables(VVAccess.ReadWrite)]
-    public string SpawnDisease = string.Empty;
+    public string? SpawnDisease;
+
     /// <summary>
     /// How far away it will check for people
     /// If empty, picks a random one from its list
@@ -23,8 +23,8 @@ public sealed class DiseaseArtifactComponent : Component
     [DataField("range")]
     [ViewVariables(VVAccess.ReadWrite)]
     public float Range = 5f;
-    [ViewVariables(VVAccess.ReadWrite)]
-    public DiseasePrototype ResolveDisease = default!;
+
+    // TODO: YAML Serializer won't catch this.
     [ViewVariables(VVAccess.ReadWrite)]
     public readonly IReadOnlyList<string> ArtifactDiseases = new[]
     {

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/DiseaseArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/DiseaseArtifactSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Disease.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Prototypes;
 using Content.Shared.Interaction;
+using Robust.Shared.Map;
 
 namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems
 {
@@ -14,9 +15,10 @@ namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems
     /// </summary>
     public sealed class DiseaseArtifactSystem : EntitySystem
     {
-        [Dependency] private readonly EntityLookupSystem _lookup = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] private readonly DiseaseSystem _disease = default!;
+        [Dependency] private readonly EntityLookupSystem _lookup = default!;
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
 
         public override void Initialize()
@@ -31,31 +33,38 @@ namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems
         /// </summary>
         private void OnMapInit(EntityUid uid, DiseaseArtifactComponent component, MapInitEvent args)
         {
-            if (component.SpawnDisease == string.Empty && component.ArtifactDiseases.Count != 0)
-            {
-                var diseaseName = _random.Pick(component.ArtifactDiseases);
+            if (!string.IsNullOrEmpty(component.SpawnDisease) || component.ArtifactDiseases.Count == 0) return;
+            var diseaseName = _random.Pick(component.ArtifactDiseases);
 
-                component.SpawnDisease = diseaseName;
+            if (!_prototypeManager.HasIndex<DiseasePrototype>(diseaseName))
+            {
+                Logger.ErrorS("disease", $"Invalid disease {diseaseName} selected from random diseases.");
+                return;
             }
 
-            if (_prototypeManager.TryIndex(component.SpawnDisease, out DiseasePrototype? disease) && disease != null)
-                component.ResolveDisease = disease;
+            component.SpawnDisease = diseaseName;
         }
 
         /// <summary>
-        /// When activated, blasts everyone in LOS within 3 tiles
+        /// When activated, blasts everyone in LOS within n tiles
         /// with a high-probability disease infection attempt
         /// </summary>
         private void OnActivate(EntityUid uid, DiseaseArtifactComponent component, ArtifactActivatedEvent args)
         {
+            if (component.SpawnDisease == null) return;
+
             var xform = Transform(uid);
-            foreach (var entity in _lookup.GetEntitiesInRange(xform.MapID, xform.WorldPosition, 3f))
+            var carrierQuery = GetEntityQuery<DiseaseCarrierComponent>();
+            var disease = _prototypeManager.Index<DiseasePrototype>(component.SpawnDisease);
+
+            foreach (var entity in _lookup.GetEntitiesInRange(xform.MapPosition, component.Range))
             {
-                if (!_interactionSystem.InRangeUnobstructed(uid, entity, 3f))
+                if (!carrierQuery.TryGetComponent(entity, out var carrier)) continue;
+
+                if (!_interactionSystem.InRangeUnobstructed(uid, entity, component.Range))
                     continue;
 
-                if (TryComp<DiseaseCarrierComponent>(entity, out var carrier))
-                    EntitySystem.Get<DiseaseSystem>().TryInfect(carrier, component.ResolveDisease);
+                _disease.TryInfect(carrier, disease);
             }
         }
     }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/DiseaseArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/DiseaseArtifactSystem.cs
@@ -74,7 +74,7 @@ namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems
                 if (!_interactionSystem.InRangeUnobstructed(uid, entity, component.Range))
                     continue;
 
-                _disease.TryAddDisease(entity, component.SpawnDisease, carrier);
+                _disease.TryInfect(carrier, component.SpawnDisease, forced: true);
             }
         }
     }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/DiseaseArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/DiseaseArtifactSystem.cs
@@ -21,6 +21,17 @@ namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
 
+        // TODO: YAML Serializer won't catch this.
+        [ViewVariables(VVAccess.ReadWrite)]
+        public readonly IReadOnlyList<string> ArtifactDiseases = new[]
+        {
+            "VanAusdallsRobovirus",
+            "OwOnavirus",
+            "BleedersBite",
+            "Ultragigacancer",
+            "AMIV"
+        };
+
         public override void Initialize()
         {
             base.Initialize();
@@ -33,16 +44,16 @@ namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems
         /// </summary>
         private void OnMapInit(EntityUid uid, DiseaseArtifactComponent component, MapInitEvent args)
         {
-            if (!string.IsNullOrEmpty(component.SpawnDisease) || component.ArtifactDiseases.Count == 0) return;
-            var diseaseName = _random.Pick(component.ArtifactDiseases);
+            if (component.SpawnDisease != null || ArtifactDiseases.Count == 0) return;
+            var diseaseName = _random.Pick(ArtifactDiseases);
 
-            if (!_prototypeManager.HasIndex<DiseasePrototype>(diseaseName))
+            if (!_prototypeManager.TryIndex<DiseasePrototype>(diseaseName, out var disease))
             {
                 Logger.ErrorS("disease", $"Invalid disease {diseaseName} selected from random diseases.");
                 return;
             }
 
-            component.SpawnDisease = diseaseName;
+            component.SpawnDisease = disease;
         }
 
         /// <summary>
@@ -55,16 +66,15 @@ namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems
 
             var xform = Transform(uid);
             var carrierQuery = GetEntityQuery<DiseaseCarrierComponent>();
-            var disease = _prototypeManager.Index<DiseasePrototype>(component.SpawnDisease);
 
-            foreach (var entity in _lookup.GetEntitiesInRange(xform.MapPosition, component.Range))
+            foreach (var entity in _lookup.GetEntitiesInRange(xform.Coordinates, component.Range))
             {
                 if (!carrierQuery.TryGetComponent(entity, out var carrier)) continue;
 
                 if (!_interactionSystem.InRangeUnobstructed(uid, entity, component.Range))
                     continue;
 
-                _disease.TryInfect(carrier, disease);
+                _disease.TryAddDisease(entity, component.SpawnDisease, carrier);
             }
         }
     }


### PR DESCRIPTION
1. Range is now used
2. Removed unneeded field
3. It used TryInfect which fails on non-infectious diseases, e.g. if an artifact had "ultragigacancer" it wouldn't actually do anything.
4. Raycast after trycomp because it's significantly more expensive.