### PR TITLE
Fix incorrectly ported emote sanitization

### DIFF
--- a/Content.Server/Chat/ChatSystem.cs
+++ b/Content.Server/Chat/ChatSystem.cs
@@ -82,22 +82,21 @@ public sealed class ChatSystem : EntitySystem
             return;
         }
 
+        // Sus
+        if (player?.AttachedEntity is { Valid: true } entity && source != entity)
+        {
+            return;
+        }
+
         if (!CanSendInGame(message, shell, player))
             return;
 
         message = SanitizeInGameICMessage(source, message, out var emoteStr);
 
-        // Is this -actually- an emote, and is a player sending it?
+        // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
         {
             SendEntityEmote(source, emoteStr, hideChat);
-            return;
-        }
-
-        // Sus
-        if (player?.AttachedEntity is { Valid: true } entity && source != entity)
-        {
-            return;
         }
 
         // Otherwise, send whatever type.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

this is so that 'hello :)' turns into 'hello' and '*smiles*' instead of just '*smiles*'

it just doesnt return now. also minor ordering change
