### PR TITLE
Fix smoke fork bomb

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/SolutionAreaEffectSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionAreaEffectSystem.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using Content.Server.Chemistry.Components;
+using Content.Server.Chemistry.ReactionEffects;
+using Content.Shared.Chemistry.Reaction;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 
@@ -8,11 +10,34 @@ namespace Content.Server.Chemistry.EntitySystems
     [UsedImplicitly]
     public sealed class SolutionAreaEffectSystem : EntitySystem
     {
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<SolutionAreaEffectComponent, ReactionAttemptEvent>(OnReactionAttempt);
+        }
+
         public override void Update(float frameTime)
         {
             foreach (var inception in EntityManager.EntityQuery<SolutionAreaEffectInceptionComponent>().ToArray())
             {
                 inception.InceptionUpdate(frameTime);
+            }
+        }
+
+        private void OnReactionAttempt(EntityUid uid, SolutionAreaEffectComponent component, ReactionAttemptEvent args)
+        {
+            if (args.Solution.Name != SolutionAreaEffectComponent.SolutionName)
+                return;
+
+            // Prevent smoke/foam fork bombs (smoke creating more smoke).
+            foreach (var effect in args.Reaction.Effects)
+            {
+                if (effect is AreaReactionEffect)
+                {
+                    args.Cancel();
+                    return;
+                }
             }
         }
     }

--- a/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.Capabilities.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.Capabilities.cs
@@ -131,7 +131,10 @@ public sealed partial class SolutionContainerSystem
     public static string ToPrettyString(Solution solution)
     {
         var sb = new StringBuilder();
-        sb.Append("[");
+        if (solution.Name == null)
+            sb.Append("[");
+        else
+            sb.Append($"{solution.Name}:[");
         var first = true;
         foreach (var (id, quantity) in solution.Contents)
         {

--- a/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionContainerSystem.cs
@@ -41,9 +41,9 @@ public sealed partial class SolutionContainerSystem : EntitySystem
 
     private void InitSolution(EntityUid uid, SolutionContainerManagerComponent component, ComponentInit args)
     {
-        foreach (var keyValue in component.Solutions)
+        foreach (var (name, solutionHolder) in component.Solutions)
         {
-            var solutionHolder = keyValue.Value;
+            solutionHolder.Name = name;
             if (solutionHolder.MaxVolume == FixedPoint2.Zero)
             {
                 solutionHolder.MaxVolume = solutionHolder.TotalVolume > solutionHolder.InitialMaxVolume
@@ -283,7 +283,7 @@ public sealed partial class SolutionContainerSystem : EntitySystem
 
         if (!solutionsMgr.Solutions.ContainsKey(name))
         {
-            var newSolution = new Solution();
+            var newSolution = new Solution() { Name = name };
             solutionsMgr.Solutions.Add(name, newSolution);
         }
 

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -45,6 +45,11 @@ namespace Content.Shared.Chemistry.Components
         public Color Color => GetColor();
 
         /// <summary>
+        ///     The name of this solution, if it is contained in some <see cref="SolutionContainerManagerComponent"/>
+        /// </summary>
+        public string? Name;
+
+        /// <summary>
         ///     Constructs an empty solution (ex. an empty beaker).
         /// </summary>
         public Solution() { }


### PR DESCRIPTION
This PR:
- Stores the name of managed solutions in the actual solution itself
- Makes chemical reactions raise a reaction-attempt event 
- Makes the bloodstream and area-effect  components block certain reactions.

Fixes #7357. 
Fixes #6223.

:cl:
- fix: Fixed some interactions with smoke, foam, and the bloodstream that enabled mass smoke/foam production.

