### PR TITLE
Fix entity-specific component states networking

### DIFF
--- a/Content.Server/Actions/ActionsSystem.cs
+++ b/Content.Server/Actions/ActionsSystem.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Actions
         private void OnPlayerAttached(EntityUid uid, ActionsComponent component, PlayerAttachedEvent args)
         {
             // need to send state to new player.
-            component.Dirty();
+            Dirty(component);
         }
 
         protected override bool PerformBasicActions(EntityUid user, ActionType action)

--- a/Content.Server/Alert/ServerAlertsSystem.cs
+++ b/Content.Server/Alert/ServerAlertsSystem.cs
@@ -1,7 +1,19 @@
 using Content.Shared.Alert;
+using Robust.Server.GameObjects;
 
 namespace Content.Server.Alert;
 
-// The only reason this exists is because the DI system requires the shared AlertsSystem
-// to be abstract.
-internal sealed class ServerAlertsSystem : AlertsSystem { }
+internal sealed class ServerAlertsSystem : AlertsSystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AlertsComponent, PlayerAttachedEvent>(OnPlayerAttached);
+    }
+
+    private void OnPlayerAttached(EntityUid uid, AlertsComponent component, PlayerAttachedEvent args)
+    {
+        Dirty(component);
+    }
+}

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -41,6 +41,12 @@ namespace Content.Server.Flash
             SubscribeLocalEvent<FlashableComponent, ComponentStartup>(OnFlashableStartup);
             SubscribeLocalEvent<FlashableComponent, ComponentShutdown>(OnFlashableShutdown);
             SubscribeLocalEvent<FlashableComponent, MetaFlagRemoveAttemptEvent>(OnMetaFlagRemoval);
+            SubscribeLocalEvent<FlashableComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        }
+
+        private void OnPlayerAttached(EntityUid uid, FlashableComponent component, PlayerAttachedEvent args)
+        {
+            Dirty(component);
         }
 
         private void OnMetaFlagRemoval(EntityUid uid, FlashableComponent component, ref MetaFlagRemoveAttemptEvent args)


### PR DESCRIPTION
Some components only send state data to players if the component's owner is the attached entity. This makes sure that those components gets dirtied when a player is attached to an entity.
