### PR TITLE
Fix disarm action

### DIFF
--- a/Content.Shared/CombatMode/SharedCombatModeComponent.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeComponent.cs
@@ -30,22 +30,7 @@ namespace Content.Shared.CombatMode
         // These are chonky default definitions for combat actions. But its a pain to add a yaml version of this for
         // every entity that wants combat mode, especially given that they're currently all identical... so ummm.. yeah.
         [DataField("disarmAction")]
-        public readonly EntityTargetAction DisarmAction = new()
-        {
-            Icon = new SpriteSpecifier.Texture(new ResourcePath("Interface/Actions/disarmOff.png")),
-            IconOn = new SpriteSpecifier.Texture(new ResourcePath("Interface/Actions/disarm.png")),
-            Name = "action-name-disarm",
-            Description = "action-description-disarm",
-            Repeat = true,
-            UseDelay = TimeSpan.FromSeconds(1.5f),
-            InteractOnMiss = true,
-            Event = new DisarmActionEvent(),
-            CanTargetSelf = false,
-            Whitelist = new()
-            {
-                Components = new[] { "Hands", "StatusEffects" },
-            },
-        };
+        public readonly EntityTargetAction DisarmAction = new();
 
         [DataField("combatToggleAction")]
         public readonly InstantAction CombatToggleAction = new()

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -95,6 +95,20 @@
       100: !type:DeadMobState {}
   - type: HeatResistance
   - type: CombatMode
+    disarmAction:
+      name: action-name-disarm
+      description: action-description-disarm
+      icon: Interface/Actions/disarmOff.png
+      iconOn: Interface/Actions/disarm.png
+      repeat: true
+      useDelay: 1.5
+      interactOnMiss: true
+      event: !type:DisarmActionEvent
+      canTargetSelf: false
+      whitelist:
+        components:
+        - Hands
+        - StatusEffects
   - type: Internals
   - type: StatusEffects
     allowed:

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -12,6 +12,20 @@
   - type: Hands
   - type: DoAfter
   - type: CombatMode
+    disarmAction:
+      name: action-name-disarm
+      description: action-description-disarm
+      icon: Interface/Actions/disarmOff.png
+      iconOn: Interface/Actions/disarm.png
+      repeat: true
+      useDelay: 1.5
+      interactOnMiss: true
+      event: !type:DisarmActionEvent
+      canTargetSelf: false
+      whitelist:
+        components:
+        - Hands
+        - StatusEffects
   - type: Actions
   - type: PlayerInputMover
   - type: MovementSpeedModifier

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -53,6 +53,20 @@
       0: !type:NormalMobState {}
   - type: HeatResistance
   - type: CombatMode
+    disarmAction:
+      name: action-name-disarm
+      description: action-description-disarm
+      icon: Interface/Actions/disarmOff.png
+      iconOn: Interface/Actions/disarm.png
+      repeat: true
+      useDelay: 1.5
+      interactOnMiss: true
+      event: !type:DisarmActionEvent
+      canTargetSelf: false
+      whitelist:
+        components:
+        - Hands
+        - StatusEffects
   - type: Internals
   - type: Examiner
   - type: Speech

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -225,3 +225,17 @@
       normal: onestar_boss
       dead: onestar_boss_wrecked
   - type: CombatMode
+    disarmAction:
+      name: action-name-disarm
+      description: action-description-disarm
+      icon: Interface/Actions/disarmOff.png
+      iconOn: Interface/Actions/disarm.png
+      repeat: true
+      useDelay: 1.5
+      interactOnMiss: true
+      event: !type:DisarmActionEvent
+      canTargetSelf: false
+      whitelist:
+        components:
+        - Hands
+        - StatusEffects

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -258,6 +258,20 @@
         Burn:
           sprite: Mobs/Effects/burn_damage.rsi
   - type: CombatMode
+    disarmAction:
+      name: action-name-disarm
+      description: action-description-disarm
+      icon: Interface/Actions/disarmOff.png
+      iconOn: Interface/Actions/disarm.png
+      repeat: true
+      useDelay: 1.5
+      interactOnMiss: true
+      event: !type:DisarmActionEvent
+      canTargetSelf: false
+      whitelist:
+        components:
+        - Hands
+        - StatusEffects
   - type: Climbing
   - type: Cuffable
   - type: CharacterInfo


### PR DESCRIPTION
Something with the recent serv3 PRs changed how/if deserialization hooks are called which broke the after deserialization hooks for the disarm action entity whitelist.

TBF they are defined in a weird way and should really be using action prototypes. I'll create a PR make em use prototypes eventually, but for now this just moves them all over to yaml.

:cl:
- fix: Fixed the disarm action not working.
