### PR TITLE
Add default link verb for machine linking

### DIFF
--- a/Content.Server/MachineLinking/Components/SignalLinkerComponent.cs
+++ b/Content.Server/MachineLinking/Components/SignalLinkerComponent.cs
@@ -1,15 +1,12 @@
-﻿using Robust.Shared.GameObjects;
-using Robust.Shared.ViewVariables;
-
 namespace Content.Server.MachineLinking.Components
 {
     [RegisterComponent]
     public sealed class SignalLinkerComponent : Component
     {
         [ViewVariables]
-        public EntityUid? savedTransmitter;
+        public EntityUid? SavedTransmitter;
 
         [ViewVariables]
-        public EntityUid? savedReceiver;
+        public EntityUid? SavedReceiver;
     }
 }

--- a/Resources/Locale/en-US/machine-linking/components/signal-linker-component.ftl
+++ b/Resources/Locale/en-US/machine-linking/components/signal-linker-component.ftl
@@ -8,3 +8,10 @@ signal-linker-component-max-connections-transmitter = Maximum connections reache
 signal-linker-component-type-mismatch = The port's type does not match the type of the saved port!
 
 signal-linker-component-out-of-range = Connection is out of range!
+
+# Verbs
+signal-linking-verb-text-link-default = Link default ports
+signal-linking-verb-success = Connected all default {$machine} links.
+signal-linking-verb-fail = Failed to connect all default {$machine} links.
+signal-linking-verb-disabled-no-transmitter = You first need to interact with a transmitter.
+signal-linking-verb-disabled-no-receiver = You first need to interact with a receiver.


### PR DESCRIPTION
Adds an alternative verb (alt click interaction) that allows you to link the default ports for devices. This doesn't require opening the UI, and should make it easier to do things like linking lots of lights to a single light switch.

@DubiousDoggo 

