### PR TITLE
Increase dragging dead zone

### DIFF
--- a/Content.Client/Actions/UI/ActionsUI.cs
+++ b/Content.Client/Actions/UI/ActionsUI.cs
@@ -210,7 +210,8 @@ namespace Content.Client.Actions.UI
                 _slots[i] = slot;
             }
 
-            DragDropHelper = new DragDropHelper<ActionSlot>(OnBeginActionDrag, OnContinueActionDrag, OnEndActionDrag, DragDeadZone);
+            DragDropHelper = new DragDropHelper<ActionSlot>(OnBeginActionDrag, OnContinueActionDrag, OnEndActionDrag);
+            DragDropHelper.Deadzone = DragDeadZone;
 
             MinSize = (10, 400);
         }

--- a/Content.Client/DragDrop/DragDropHelper.cs
+++ b/Content.Client/DragDrop/DragDropHelper.cs
@@ -21,14 +21,12 @@ namespace Content.Client.DragDrop
     /// <typeparam name="T">thing being dragged and dropped</typeparam>
     public sealed class DragDropHelper<T>
     {
-        private const float DefaultDragDeadzone = 2f;
-
         private readonly IInputManager _inputManager;
 
         private readonly OnBeginDrag _onBeginDrag;
         private readonly OnEndDrag _onEndDrag;
         private readonly OnContinueDrag _onContinueDrag;
-        private readonly float _deadzone;
+        public float Deadzone = 2f;
 
         /// <summary>
         /// Convenience method, current mouse screen position as provided by inputmanager.
@@ -67,9 +65,8 @@ namespace Content.Client.DragDrop
         /// <param name="deadzone">drag will be triggered when mouse leaves
         ///     this deadzone around the mousedown position</param>
         public DragDropHelper(OnBeginDrag onBeginDrag, OnContinueDrag onContinueDrag,
-            OnEndDrag onEndDrag, float deadzone = DefaultDragDeadzone)
+            OnEndDrag onEndDrag)
         {
-            _deadzone = deadzone;
             _inputManager = IoCManager.Resolve<IInputManager>();
             _onBeginDrag = onBeginDrag;
             _onEndDrag = onEndDrag;
@@ -128,7 +125,7 @@ namespace Content.Client.DragDrop
                 case DragState.MouseDown:
                 {
                     var screenPos = _inputManager.MouseScreenPosition;
-                    if ((_mouseDownScreenPos.Position - screenPos.Position).Length > _deadzone)
+                    if ((_mouseDownScreenPos.Position - screenPos.Position).Length > Deadzone)
                     {
                         StartDragging();
                     }

--- a/Content.Client/DragDrop/DragDropSystem.cs
+++ b/Content.Client/DragDrop/DragDropSystem.cs
@@ -35,6 +35,8 @@ namespace Content.Client.DragDrop
         [Dependency] private readonly InputSystem _inputSystem = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
 
+        public static float DragDeadZone = 12f;
+
         // how often to recheck possible targets (prevents calling expensive
         // check logic each update)
         private const float TargetRecheckInterval = 0.25f;
@@ -74,7 +76,7 @@ namespace Content.Client.DragDrop
         {
             UpdatesOutsidePrediction = true;
 
-            _dragDropHelper = new DragDropHelper<EntityUid>(OnBeginDrag, OnContinueDrag, OnEndDrag);
+            _dragDropHelper = new DragDropHelper<EntityUid>(OnBeginDrag, OnContinueDrag, OnEndDrag, DragDeadZone);
 
             _dropTargetInRangeShader = _prototypeManager.Index<ShaderPrototype>(ShaderDropTargetInRange).Instance();
             _dropTargetOutOfRangeShader = _prototypeManager.Index<ShaderPrototype>(ShaderDropTargetOutOfRange).Instance();

--- a/Content.Client/DragDrop/DragDropSystem.cs
+++ b/Content.Client/DragDrop/DragDropSystem.cs
@@ -1,6 +1,7 @@
 using Content.Client.Outline;
 using Content.Client.Viewport;
 using Content.Shared.ActionBlocker;
+using Content.Shared.CCVar;
 using Content.Shared.DragDrop;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
@@ -11,6 +12,7 @@ using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
 using Robust.Client.State;
+using Robust.Shared.Configuration;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Prototypes;
@@ -30,12 +32,11 @@ namespace Content.Client.DragDrop
         [Dependency] private readonly IEyeManager _eyeManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IConfigurationManager _cfgMan = default!;
         [Dependency] private readonly InteractionOutlineSystem _outline = default!;
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
         [Dependency] private readonly InputSystem _inputSystem = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
-
-        public static float DragDeadZone = 12f;
 
         // how often to recheck possible targets (prevents calling expensive
         // check logic each update)
@@ -76,7 +77,8 @@ namespace Content.Client.DragDrop
         {
             UpdatesOutsidePrediction = true;
 
-            _dragDropHelper = new DragDropHelper<EntityUid>(OnBeginDrag, OnContinueDrag, OnEndDrag, DragDeadZone);
+            _dragDropHelper = new DragDropHelper<EntityUid>(OnBeginDrag, OnContinueDrag, OnEndDrag);
+            _cfgMan.OnValueChanged(CCVars.DragDropDeadZone, SetDeadZone, true);
 
             _dropTargetInRangeShader = _prototypeManager.Index<ShaderPrototype>(ShaderDropTargetInRange).Instance();
             _dropTargetOutOfRangeShader = _prototypeManager.Index<ShaderPrototype>(ShaderDropTargetOutOfRange).Instance();
@@ -86,8 +88,14 @@ namespace Content.Client.DragDrop
                 .Register<DragDropSystem>();
         }
 
+        private void SetDeadZone(float deadZone)
+        {
+            _dragDropHelper.Deadzone = deadZone;
+        }
+
         public override void Shutdown()
         {
+            _cfgMan.UnsubValueChanged(CCVars.DragDropDeadZone, SetDeadZone);
             _dragDropHelper.EndDrag();
             CommandBinds.Unregister<DragDropSystem>();
             base.Shutdown();

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -869,5 +869,15 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<int> ResourceUploadingStoreDeletionDays =
             CVarDef.Create("netres.store_deletion_days", 30, CVar.SERVER | CVar.SERVERONLY);
+
+        /*
+         * Controls
+         */
+
+        /// <summary>
+        /// Deadzone for drag-drop interactions.
+        /// </summary>
+        public static readonly CVarDef<float> DragDropDeadZone =
+            CVarDef.Create("control.drag_dead_zone", 12f, CVar.CLIENTONLY | CVar.ARCHIVE);
     }
 }


### PR DESCRIPTION
from `2` to `12` (in units of ScreenCoordinates). IMO this feels fine.

cl:
- tweak: Increased dead zone for click-dragging. Should reduce the frequency of accidental drags when trying to click on things.

