### PR TITLE
minibomb beeps again.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -114,7 +114,8 @@
   - type: Appearance
     visuals:
     - type: TimerTriggerVisualizer
-
+      countdown_sound:
+        path: /Audio/Effects/countdown.ogg
 - type: entity
   name: the nuclear option
   description: Please don't throw it, think of the children.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR 
Minibombs now beep again. They're capable of breaching now that explosions are fixed, so they need to be more audible.

:cl: moony
- tweak: Minibombs beep again.

