### PR TITLE
Fixes more noSpawn abstract funnies

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifacts.yml
@@ -3,7 +3,7 @@
   id: BaseXenoArtifact
   name: alien artifact
   description: A strange alien device.
-  abstract: true
+  noSpawn: true
   components:
     - type: Sprite
       sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -2,7 +2,7 @@
   id: BaseShutter
   parent: BaseStructure
   name: shutter
-  abstract: true
+  noSpawn: true
   description: One shudders to think about what might be behind this shutter.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  abstract: true
+  noSpawn: true
   id: ArcadeBase
   description: An arcade cabinet.
   name: arcade

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -12,7 +12,8 @@
     sound:
       path: /Audio/Ambience/Objects/vending_machine_hum.ogg
   - type: Sprite
-    sprite: Structures/Machines/VendingMachines/empty.rsi
+    sprite: Structures/Machines/VendingMachines/snack.rsi
+    state: off
     netsync: false
   - type: Physics
     bodyType: Static

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -3,7 +3,7 @@
   parent: BaseMachinePowered
   name: vending machine
   description: Just add capitalism!
-  abstract: true
+  noSpawn: true
   components:
   - type: AmbientOnPowered
   - type: AmbientSound

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   parent: GasPipeBase
-  abstract: true
+  noSpawn: true
   id: GasBinaryBase
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -1,5 +1,5 @@
 - type: entity
-  abstract: true
+  noSpawn: true
   name: gas miner
   description: Gases mined from the gas giant below (above?) flow out through this massive vent.
   id: GasMinerBase

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  abstract: true
+  noSpawn: true
   id: GasPipeBase
   name: pipe
   description: Holds gas.

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: GasPipeBase
-  abstract: true
+  noSpawn: true
   id: GasTrinaryBase
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: GasPipeBase
-  abstract: true
+  noSpawn: true
   id: GasUnaryBase
   placement:
     mode: SnapgridCenter
@@ -158,7 +158,7 @@
   parent: BaseMachinePowered
   id: BaseGasThermoMachine
   name: thermomachine
-  abstract: true
+  noSpawn: true
   placement:
     mode: SnapgridCenter
   components:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -1,7 +1,7 @@
 # Base Generator
 
 - type: entity
-  abstract: true
+  noSpawn: true
   id: BaseGenerator
   description: A high efficiency thermoelectric generator.
   name: generator
@@ -71,7 +71,7 @@
 # Base Wallmount Generator
 
 - type: entity
-  abstract: true
+  noSpawn: true
   id: BaseGeneratorWallmount
   parent: BaseGenerator
   name: wallmount generator
@@ -166,6 +166,7 @@
   parent: BaseGenerator
   id: GeneratorPlasma
   suffix: Plasma, 5kW
+  description: A high efficiency thermoelectric generator that runs on plasma. 5kW.
   components:
   - type: PowerSupplier
     supplyRate: 5000 # 260 sec / sheet
@@ -185,6 +186,7 @@
   parent: BaseGenerator
   id: GeneratorUranium
   suffix: Uranium, 15kW
+  description: A high efficiency thermoelectric generator that runs on uranium. 15kW.
   components:
   - type: PowerSupplier
     supplyRate: 15000 # 85 sec / sheet

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -1,6 +1,6 @@
 # Base SMES
 - type: entity
-  abstract: true
+  noSpawn: true
   id: BaseSMES
   parent: BaseMachine
   name: SMES

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -1,6 +1,6 @@
 # Base substation
 - type: entity
-  abstract: true
+  noSpawn: true
   id: BaseSubstation
   parent: BaseMachine
   name: substation

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -1,5 +1,5 @@
 - type: entity
-  abstract: true
+  noSpawn: true
   parent: BaseStructureDynamic
   id: GasCanister
   name: gas canister


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #7407

- Also added descriptions to make the types of generator more useful. (Decided against calling them uranium and plasma generator because that may confuse some people that it's a power generator and not a generator of X.
- Fixes shutter abstracts.

Fixes abstract to noSpawn on the following:

- Generators
- Atmos devices / pipes
- Gas Canisters
- Shutters
- Arcades
- Artefacts
- Substations and SMES

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed naming / function of the new generators. They won't have a blank name now. Same for shutters and gas canisters.

