### PR TITLE
Entity Whitelist changes

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -155,19 +155,11 @@ namespace Content.Client.Actions
 
                 act.CopyFrom(serverAct);
                 serverActions.Remove(serverAct);
-
-                if (act is EntityTargetAction entAct)
-                {
-                    entAct.Whitelist?.UpdateRegistrations();
-                }
             }
 
             // Anything that remains is a new action
             foreach (var newAct in serverActions)
             {
-                if (newAct is EntityTargetAction entAct)
-                    entAct.Whitelist?.UpdateRegistrations();
-
                 // We create a new action, not just sorting a reference to the state's action.
                 component.Actions.Add((ActionType) newAct.Clone());
             }

--- a/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
@@ -81,8 +81,8 @@ namespace Content.IntegrationTests.Tests.Utility
                 // Test instantiated on its own
                 var whitelistInst = new EntityWhitelist
                 {
-                    Components = new[] {$"{ValidComponent}"},
-                    Tags = new[] {"ValidTag"}
+                    Components = new[] { $"{ValidComponent}"},
+                    Tags = new() {"ValidTag"}
                 };
                 whitelistInst.UpdateRegistrations();
                 Assert.That(whitelistInst, Is.Not.Null);

--- a/Content.Server/Storage/EntitySystems/ItemMapperSystem.cs
+++ b/Content.Server/Storage/EntitySystems/ItemMapperSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Content.Server.Storage.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
@@ -24,7 +24,7 @@ namespace Content.Server.Storage.EntitySystems
                 {
                     foreach (var entity in containedLayers)
                     {
-                        if (mapLayerData.Whitelist.IsValid(entity))
+                        if (mapLayerData.ServerWhitelist.IsValid(entity))
                         {
                             list.Add(mapLayerData.Layer);
                             break;

--- a/Content.Shared/Storage/Components/SharedMapLayerData.cs
+++ b/Content.Shared/Storage/Components/SharedMapLayerData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Content.Shared.Whitelist;
 using Robust.Shared.Serialization;
@@ -19,8 +19,8 @@ namespace Content.Shared.Storage.Components
     {
         public string Layer = string.Empty;
 
-        [DataField("whitelist", required: true)]
-        public EntityWhitelist Whitelist { get; set; } = new();
+        [DataField("whitelist", required: true, serverOnly: true)]
+        public EntityWhitelist ServerWhitelist { get; set; } = new();
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
- Removes ISerializationHooks from entity whitelists
- Adds type serializer to check for correct tag prototypes
- Add support for whitelists to require an entity to have ALL listed tags & components, instead of only just one of them.
