### PR TITLE
Optimize status effects

### DIFF
--- a/Content.Shared/StatusEffect/StatusEffectsComponent.cs
+++ b/Content.Shared/StatusEffect/StatusEffectsComponent.cs
@@ -24,6 +24,9 @@ namespace Content.Shared.StatusEffect
         public List<string> AllowedEffects = default!;
     }
 
+    [RegisterComponent]
+    public sealed class ActiveStatusEffectsComponent : Component {}
+
     /// <summary>
     ///     Holds information about an active status effect.
     /// </summary>

--- a/Content.Shared/StatusEffect/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffect/StatusEffectsSystem.cs
@@ -32,9 +32,8 @@ namespace Content.Shared.StatusEffect
             base.Update(frameTime);
 
             var curTime = _gameTiming.CurTime;
-            foreach (var status in EntityManager.EntityQuery<StatusEffectsComponent>(false))
+            foreach (var (_, status) in EntityManager.EntityQuery<ActiveStatusEffectsComponent, StatusEffectsComponent>())
             {
-                if (status.ActiveEffects.Count == 0) continue;
                 foreach (var state in status.ActiveEffects.ToArray())
                 {
                     // if we're past the end point of the effect
@@ -190,6 +189,7 @@ namespace Content.Shared.StatusEffect
             else
             {
                 status.ActiveEffects.Add(key, new StatusEffectState(cooldown, refresh, null));
+                EnsureComp<ActiveStatusEffectsComponent>(uid);
             }
 
             if (proto.Alert != null)
@@ -271,6 +271,10 @@ namespace Content.Shared.StatusEffect
             }
 
             status.ActiveEffects.Remove(key);
+            if (status.ActiveEffects.Count == 0)
+            {
+                RemComp<ActiveStatusEffectsComponent>(uid);
+            }
 
             Dirty(status);
             // event?


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

only query over entities with active status effects