### PR TITLE
Reduce movement allocs

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -48,8 +48,14 @@ public partial class InventorySystem : EntitySystem
         if (!_prototypeManager.TryIndex<InventoryTemplatePrototype>(inventory.TemplateId, out var templatePrototype))
             return false;
 
-        slotDefinition = templatePrototype.Slots.FirstOrDefault(x => x.Name == slot);
-        return slotDefinition != default;
+        foreach (var slotDef in templatePrototype.Slots)
+        {
+            if (!slotDef.Name.Equals(slot)) continue;
+            slotDefinition = slotDef;
+            return true;
+        }
+
+        return false;
     }
 
     public bool TryGetContainerSlotEnumerator(EntityUid uid, out ContainerSlotEnumerator containerSlotEnumerator, InventoryComponent? component = null)


### PR DESCRIPTION
Movement should be caching this, but it's a low hanging fruit and no.3 for allocs on server so goodbye LINQ.