### PR TITLE
Remove armor from EVA suit, add base syndie suit to uplink, surplus rifle

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -58,7 +58,7 @@
   parent: ClothingBackpackDuffelSyndicateAmmo
   id: ClothingBackpackDuffelSyndicateFilledRevolver
   name: Predator bundle
-  description: "Go loud and proud with a fully loaded Magnum Predator, bundled with two speed loaders." 
+  description: "Go loud and proud with a fully loaded Magnum Predator, bundled with two speed loaders."
   components:
   - type: StorageFill
     contents:
@@ -162,9 +162,20 @@
       - id: ClothingHeadPyjamaSyndicateBlack
       - id: ClothingHeadPyjamaSyndicatePink
       - id: ClothingShoesSlippers
-        amount: 3   
+        amount: 3
       - id: BedsheetSyndie
-        amount: 3   
+        amount: 3
       - id: PlushieCarp
       - id: PlushieNuke
       - id: PlushieLizard
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicate
+  id: ClothingBackpackDuffelSyndicateHardsuitBundle
+  name: syndicate hardsuit duffel bag
+  description: "Contains the Syndicate's signature blood red hardsuit."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingOuterHardsuitSyndie
+      - id: ClothingHeadHelmetHardsuitSyndie

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -172,7 +172,7 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicate
   id: ClothingBackpackDuffelSyndicateHardsuitBundle
-  name: syndicate hardsuit duffel bag
+  name: syndicate hardsuit bundle
   description: "Contains the Syndicate's signature blood red hardsuit."
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -697,3 +697,14 @@
   - type: Sprite
     layers:
       - state: box
+
+- type: entity
+  name: box of .30 rifle bullets
+  parent: BoxCardboard
+  id: BoxBulletLRifleSmall
+  description: A box full of individual .30 rifle bullets.
+  components:
+  - type: StorageFill
+    contents:
+      - id: CartridgeLRifle
+        amount: 20

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -241,3 +241,26 @@
   - type: Tag
     tags:
       - DroneUsable
+
+- type: entity
+  name: syndicate EVA box
+  parent: BoxCardboard
+  id: BoxSyndicateEVA
+  description: A box containing one Syndicate approved EVA suit.
+  components:
+  - type: Item
+    size: 40
+  - type: Storage
+    capacity: 40
+    size: 10
+    whitelist:
+      components:
+      - Clothing
+  - type: StorageFill
+    contents:
+      - id: ClothingHeadHelmetSyndicate
+      - id: ClothingOuterHardsuitSyndicate
+  - type: Sprite
+    layers:
+      - state: box_of_doom
+      - state: writing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -25,6 +25,15 @@
   description: A rugged, robust operator handgun with inbuilt silencer. Use pistol magazines (.25 caseless).
   price: 8
 
+# Poor accuracy, slow to fire, cheap option
+- type: uplinkListing
+  id: UplinkRifleMosin
+  category: Weapons
+  itemId: SniperBoltGunWood
+  listingName: Surplus Rifle
+  description: A bolt action service rifle that has seen many wars. Not modern by any standard, hand loaded, and terrible recoil, but it is cheap.
+  price: 4
+
 #- type: uplinkListing
 #  id: UplinkCrossbowEnergyMini
 #  category: Weapons
@@ -116,6 +125,15 @@
   price: 2
   icon: /Textures/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_sl.rsi/icon.png
 
+# For the mosin
+- type: uplinkListing
+  id: UplinkMosinAmmo
+  category: Ammo
+  itemId: BoxBulletLRifleSmall
+  description: A box of bullets for the surplus rifle.
+  price: 2
+
+
 #Utility
 
 - type: uplinkListing
@@ -203,7 +221,7 @@
   id: UplinkCarpDehydrated
   category: Tools
   itemId: DehydratedSpaceCarp
-  price: 5
+  price: 3
 
 # Armor
 
@@ -225,14 +243,16 @@
 - type: uplinkListing
   id: UplinkHardsuitSyndie
   category: Armor
-  itemId: ClothingOuterHardsuitSyndie
-  price: 5
+  itemId: ClothingBackpackDuffelSyndicateHardsuitBundle
+  description: The Syndicate's well known armored blood red hardsuit, capable of space walks and bullet resistant.
+  price: 8
 
 - type: uplinkListing
-  id: UplinkHardsuitSyndieHelmet
+  id: UplinkEVASyndie
   category: Armor
-  itemId: ClothingHeadHelmetHardsuitSyndie
-  price: 5
+  itemId: BoxSyndicateEVA
+  description: A simple EVA suit that offers no protection other than what's needed to survive in space.
+  price: 4
 
 # Misc
 
@@ -306,7 +326,7 @@
   listingName: Ultragigacancer Health Analyzer
   description: Works like a normal health analyzer, other than giving everyone it scans ultragigacancer.
   price: 5
-  
+
 - type: uplinkListing
   id: UplinkNocturineChemistryBottle
   category: Misc

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -26,6 +26,26 @@
 - type: entity
   abstract: true
   parent: ClothingHeadBase
+  id: ClothingHeadEVAHelmetBase
+  name: base space helmet
+  components:
+  - type: Clothing
+    size: 10
+  - type: PressureProtection
+    highPressureMultiplier: 0.6
+    lowPressureMultiplier: 10
+  - type: TemperatureProtection
+    coefficient: 0.2
+  - type: IngestionBlocker
+  - type: Tag
+    tags:
+    - HidesHair
+  - type: DiseaseProtection
+    protection: 0.05
+
+- type: entity
+  abstract: true
+  parent: ClothingHeadBase
   id: ClothingHeadHardsuitBase
   name: base hardsuit helmet
   components:

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -13,7 +13,7 @@
     resistance: 0.25 # +0.65 from body -> 90%
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetCosmonaut
   name: cosmonaut helmet
   description: A deceptively well armored space helmet. Ancient design, but advanced manufacturing.
@@ -23,7 +23,7 @@
   - type: Clothing
     sprite: Clothing/Head/Helmets/cosmonaut.rsi
   - type: IngestionBlocker
-  
+
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHelmetCult
@@ -37,7 +37,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetEVA
   name: EVA helmet
   description: A basic helmet designed for extravehicular activies.
@@ -114,7 +114,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetSyndicate
   name: syndicate EVA helmet
   description: A stylish, robust syndicate helmet
@@ -159,7 +159,7 @@
   - type: Clothing
     sprite: Clothing/Head/Helmets/wizardhelm.rsi
   - type: IngestionBlocker
-  
+
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase # hardsuitlight base for light and protection
   id: ClothingHeadHelmetFire
@@ -176,7 +176,7 @@
       startingItem: PowerCellSmallHigh
   - type: TemperatureProtection
     coefficient: 0.01
-    
+
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase # hardsuitlight base for light and protection
   id: ClothingHeadHelmetAtmosFire
@@ -189,7 +189,7 @@
     sprite: Clothing/Head/Helmets/atmos_firehelmet.rsi
   - type: IngestionBlocker
   - type: TemperatureProtection
-    coefficient: 0.005    
+    coefficient: 0.005
 
 - type: entity
   parent: ClothingHeadBase
@@ -208,4 +208,4 @@
         Slash: 0.5
         Piercing: 0.5
         Heat: 0.9
-        
+

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -34,3 +34,21 @@
         Heat: 0.90
         Radiation: 0.25
   - type: DiseaseProtection
+
+- type: entity
+  abstract: true
+  parent: ClothingOuterBase
+  id: ClothingOuterEVASuitBase
+  name: base EVA Suit
+  components:
+  - type: PressureProtection
+    highPressureMultiplier: 1
+    lowPressureMultiplier: 100
+  - type: TemperatureProtection
+    coefficient: 0.01 # Not complete protection from fire
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
+  - type: Clothing
+    size: 30
+  - type: DiseaseProtection

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -92,11 +92,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9 #higher physical protections than atmo but less enviro 
+        Blunt: 0.9 #higher physical protections than atmo but less enviro
         Slash: 0.85
         Piercing: 0.9
         Heat: 0.85
-        Radiation: 0.35 
+        Radiation: 0.35
 
 - type: entity
   parent: ClothingOuterHardsuitBase
@@ -140,7 +140,7 @@
     sprintModifier: 0.8
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: ClothingOuterEVASuitBase
   id:  ClothingOuterHardsuitEVA
   name: EVA suit
   description: A lightweight space suit with the basic ability to protect the wearer from the vacuum of space during emergencies.
@@ -149,17 +149,11 @@
     sprite: Clothing/OuterClothing/Hardsuits/eva.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/eva.rsi
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
-  - type: PressureProtection
-    highPressureMultiplier: 1
-    lowPressureMultiplier: 100
 
 # Moved to hardsuits because this is where EVA capable suits are apparently.
 # Same stats as normal EVA suit.
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: ClothingOuterEVASuitBase
   id: ClothingOuterHardsuitSyndicate
   name: syndicate EVA suit
   description: "Has a tag on it 'Totally not property of an enemy corporation, honest!'"
@@ -168,15 +162,9 @@
     sprite: Clothing/OuterClothing/Suits/syndicate.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/syndicate.rsi
-  - type: PressureProtection
-    highPressureMultiplier: 1
-    lowPressureMultiplier: 100
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: ClothingOuterEVASuitBase
   id:  ClothingOuterHardsuitEVAPrisoner
   name: prisoner EVA suit
   description: A lightweight space suit for prisoners to protect them from the vacuum of space during emergencies.
@@ -185,9 +173,6 @@
     sprite: Clothing/OuterClothing/Hardsuits/evaprisoner.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/evaprisoner.rsi
-  - type: PressureProtection
-    highPressureMultiplier: 1
-    lowPressureMultiplier: 100
 
 - type: entity
   parent: ClothingOuterHardsuitBase
@@ -302,9 +287,9 @@
         Blunt: 0.7 #slightly higher than sec hardsuit
         Slash: 0.75
         Piercing: 0.7
-        Heat: 0.8 
+        Heat: 0.8
         Radiation: 0.25
-        
+
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSyndie


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes EVA suits to not parent from hardsuit and to be slightly lighter, with no armor. They also make a terrible choice if you try to go near the singularity with it.

Added syndie suit as a basic eva suit to the uplink.
Added blood red hardsuit to a duffelbag, now bundled together.
Added Mosin as a basic crappy gun that can be bought, these were available in ss13 as surplus rifle in the uplink so I figured if it's there to just put it in and see how you all felt in PR.
Made dehydrated space carp slightly cheaper (again just another add and see, they seemed really expensive)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![Capture](https://user-images.githubusercontent.com/47410468/161807385-f781c80d-5dec-41e4-bd47-dca6dd122fe7.PNG)

![eva](https://user-images.githubusercontent.com/47410468/161807424-99fc3cca-bd27-41b9-bf4c-20a8c0184aec.PNG)

![duffel](https://user-images.githubusercontent.com/47410468/161807459-0f65dbbc-1e08-4186-865f-8d28add7852d.PNG)

https://user-images.githubusercontent.com/47410468/161806422-256f4dbc-3c67-4c11-99a6-a61ce7f374a9.mp4



:cl:
- add: Added a basic Syndie EVA suit to uplink and hardsuit is now bundled by default.
- add: Syndicate found a bunch of old surplus Mosins which have been added to the uplink.

