### PR TITLE
Fix melee swings on people

### DIFF
--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -258,7 +258,7 @@ namespace Content.Server.Weapon.Melee
                 var castAngle = new Angle(baseAngle + increment * i);
                 var res = Get<SharedPhysicsSystem>().IntersectRay(mapId,
                     new CollisionRay(position, castAngle.ToWorldVec(),
-                        (int) (CollisionGroup.Impassable | CollisionGroup.MobImpassable)), range, ignore).ToList();
+                        (int) (CollisionGroup.MobMask | CollisionGroup.Opaque)), range, ignore).ToList();
 
                 if (res.Count != 0)
                 {


### PR DESCRIPTION
## About the PR 
You can now hit living people and not just walls.

**Changelog**
:cl: moony
- fix: The wide attack (bound to space) now hits people and not just mobs, so you can use it when you don't think you'll hit your target with a click.

