### PR TITLE
Stun baton nerf

### DIFF
--- a/Content.Server/Stunnable/Components/StunbatonComponent.cs
+++ b/Content.Server/Stunnable/Components/StunbatonComponent.cs
@@ -28,7 +28,7 @@ namespace Content.Server.Stunnable.Components
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("energyPerUse")]
-        public float EnergyPerUse { get; set; } = 50;
+        public float EnergyPerUse { get; set; } = 350;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("onThrowStunChance")]


### PR DESCRIPTION
## About the PR 

Right now stun batons only use 50 power per-each stun you do and it holds a medium high-capacity battery that can hold 2880 of power, that means you can stun 57 times without needing a recharge.

Changed the amount of power it uses to 350 so the baton can hold 8 stun charges before needing a recharge.

:cl: Leander
- tweak: Nerfed stun batons, they now hold 8 charges and have to recharge more often.

