### PR TITLE
Mini bomb changes

### DIFF
--- a/Content.Server/Administration/AdminVerbSystem.cs
+++ b/Content.Server/Administration/AdminVerbSystem.cs
@@ -153,7 +153,7 @@ namespace Content.Server.Administration
                 {
                     var coords = Transform(args.Target).MapPosition;
                     Timer.Spawn(_gameTiming.TickPeriod,
-                        () => _explosionSystem.QueueExplosion(coords, ExplosionSystem.DefaultExplosionPrototypeId, 4, 1, 2, maxTileBreak: 0), // it gibs, damage doesn't need to be high.
+                        () => _explosionSystem.QueueExplosion(coords, ExplosionSystem.DefaultExplosionPrototypeId, 4, 1, 2, maxTileBreak: 0, canCreateVacuum: false), // it gibs, damage doesn't need to be high.
                         CancellationToken.None);
 
                     if (TryComp(args.Target, out SharedBodyComponent? body))

--- a/Content.Server/Administration/AdminVerbSystem.cs
+++ b/Content.Server/Administration/AdminVerbSystem.cs
@@ -153,7 +153,7 @@ namespace Content.Server.Administration
                 {
                     var coords = Transform(args.Target).MapPosition;
                     Timer.Spawn(_gameTiming.TickPeriod,
-                        () => _explosionSystem.QueueExplosion(coords, ExplosionSystem.DefaultExplosionPrototypeId, 4, 1, 2, maxTileBreak: 0, canCreateVacuum: false), // it gibs, damage doesn't need to be high.
+                        () => _explosionSystem.QueueExplosion(coords, ExplosionSystem.DefaultExplosionPrototypeId, 4, 1, 2, maxTileBreak: 0), // it gibs, damage doesn't need to be high.
                         CancellationToken.None);
 
                     if (TryComp(args.Target, out SharedBodyComponent? body))

--- a/Content.Server/Explosion/Components/ExplosiveComponent.cs
+++ b/Content.Server/Explosion/Components/ExplosiveComponent.cs
@@ -60,12 +60,19 @@ public sealed class ExplosiveComponent : Component
     public float TileBreakScale = 1f;
 
     /// <summary>
-    ///     Maximum number of times that an explosive can break a tile. Currently, for normal space ships breaking a
-    ///     tile twice will result in a vacuum.
+    ///     Maximum number of times that an explosive can break a tile. Currently, for normal space stations breaking a
+    ///     tile twice will generally result in a vacuum.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("maxTileBreak")]
     public int MaxTileBreak = int.MaxValue;
+
+    /// <summary>
+    ///     Whether this explosive should be able to create a vacuum by breaking tiles.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("canCreateVacuum")]
+    public bool CanCreateVacuum = true;
 
     /// <summary>
     ///     Avoid somehow double-triggering this explosion (e.g. by damaging this entity from its own explosion.

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -122,6 +122,7 @@ public sealed partial class ExplosionSystem : EntitySystem
             explosive.MaxIntensity,
             explosive.TileBreakScale,
             explosive.MaxTileBreak,
+            explosive.CanCreateVacuum,
             user);
 
         if (delete)
@@ -190,13 +191,14 @@ public sealed partial class ExplosionSystem : EntitySystem
         float maxTileIntensity,
         float tileBreakScale = 1f,
         int maxTileBreak = int.MaxValue,
+        bool canCreateVacuum = true,
         EntityUid? user = null,
         bool addLog = false)
     {
         var pos = Transform(uid).MapPosition;
 
 
-        QueueExplosion(pos, typeId, totalIntensity, slope, maxTileIntensity, tileBreakScale, maxTileBreak, addLog: false);
+        QueueExplosion(pos, typeId, totalIntensity, slope, maxTileIntensity, tileBreakScale, maxTileBreak, canCreateVacuum, addLog: false);
 
         if (!addLog)
             return;
@@ -219,6 +221,7 @@ public sealed partial class ExplosionSystem : EntitySystem
         float maxTileIntensity,
         float tileBreakScale = 1f,
         int maxTileBreak = int.MaxValue,
+        bool canCreateVacuum = true,
         bool addLog = false)
     {
         if (totalIntensity <= 0 || slope <= 0)
@@ -234,7 +237,7 @@ public sealed partial class ExplosionSystem : EntitySystem
             _logsSystem.Add(LogType.Explosion, LogImpact.High, $"Explosion spawned at {epicenter:coordinates} with intensity {totalIntensity} slope {slope}");
         
         _explosionQueue.Enqueue(() => SpawnExplosion(epicenter, type, totalIntensity,
-            slope, maxTileIntensity, tileBreakScale, maxTileBreak));
+            slope, maxTileIntensity, tileBreakScale, maxTileBreak, canCreateVacuum));
     }
 
     /// <summary>
@@ -248,7 +251,8 @@ public sealed partial class ExplosionSystem : EntitySystem
         float slope,
         float maxTileIntensity,
         float tileBreakScale,
-        int maxTileBreak)
+        int maxTileBreak,
+        bool canCreateVacuum)
     {
         if (!_mapManager.MapExists(epicenter.MapId))
             return null;
@@ -283,6 +287,7 @@ public sealed partial class ExplosionSystem : EntitySystem
             area,
             tileBreakScale,
             maxTileBreak,
+            canCreateVacuum,
             EntityManager,
             _mapManager);
     }

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -80,7 +80,7 @@
 
 - type: entity
   name: Syndicate minibomb
-  description: Creates a small but powerful explosion that is strong enough to break through reinforced walls.
+  description: Creates a small but powerful explosion that is strong enough to break through walls.
   parent: BaseItem
   id: SyndieMiniBomb
   components:
@@ -100,7 +100,7 @@
     totalIntensity: 492
     intensitySlope: 20.5
     maxIntensity: 41
-    maxTileBreak: 1 # for destroying walls, not spacing the hallway
+    canCreateVacuum: false # for destroying walls, not spacing the hallway
   - type: ExplodeOnTrigger
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -95,8 +95,7 @@
     delay: 5
   - type: Explosive
     explosionType: Default
-    # About a 2.5 tile radius
-    # If placed next to a reinforced wall, can open a 3-wide hole.
+    # About a 2.5 tile radius. If placed next to walls, will destroy a line of 3-normal walls and turn 3 reinforced walls into girders.
     totalIntensity: 492
     intensitySlope: 20.5
     maxIntensity: 41

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -80,7 +80,7 @@
 
 - type: entity
   name: Syndicate minibomb
-  description: A syndicate manufactured explosive used to sow destruction and chaos.
+  description: Creates a small but powerful explosion that is strong enough to break through reinforced walls.
   parent: BaseItem
   id: SyndieMiniBomb
   components:
@@ -95,9 +95,11 @@
     delay: 5
   - type: Explosive
     explosionType: Default
-    # About a 3-3.5 tile radius, strong enough to break reinforced walls near centre.
-    totalIntensity: 800
-    intensitySlope: 15
+    # About a 2.5 tile radius
+    # If placed next to a reinforced wall, can open a 3-wide hole.
+    totalIntensity: 492
+    intensitySlope: 20.5
+    maxIntensity: 41
     maxTileBreak: 1 # for destroying walls, not spacing the hallway
   - type: ExplodeOnTrigger
   - type: Damageable


### PR DESCRIPTION
- Fixes an issue introduced in #7375, where mini bombs became relatively weak with a large area of effect because the `maxIntensity` was accidentally removed, causing to to default to 4.
- Rebalanced minibombs so that they have a small area of effect, but can break walls, and can break reinforced walls down to girders.
- Fixed an issue that meant that tiles could be broken even if there was still a solid object anchored on top of them (e.g., girders spawned due to a wall breaking)
- Instead of limiting the number of tile-breaks, minibombs now just restrict the ability to create a vacuum at all.
  - This was changed because as the tiles under walls are usually just plating, a single tile-break would result in vacuums.

New minibombs cover this area:
![bomb](https://user-images.githubusercontent.com/60421075/162114799-4103b8f7-72aa-4861-aee6-7ad3f84bc756.png)

Strong enough to break a 3-wide hole into walls, or turn 3 reinforced walls into girders (requires intensity of 40+).
![wall_bomb](https://user-images.githubusercontent.com/60421075/162116287-0628a5af-732d-46e7-99f4-b37e06ad19b1.png)

I'm still not sure if this is the role that minibombs should be playing, or whether this is balanced well. This should really be changed by people who actually play the game.

:cl:
- fix: Fixed an issue causing minibombs to have a large but weak explosion. They are now the opposite.

