### PR TITLE
Optimize vent/scrubber

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Grid.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Grid.cs
@@ -926,7 +926,7 @@ namespace Content.Server.Atmos.EntitySystems
         public IEnumerable<GasMixture> GetAdjacentTileMixtures(EntityCoordinates coordinates, bool includeBlocked = false, bool invalidate = false)
         {
             if (TryGetGridAndTile(coordinates, out var tuple))
-                return GetAdjacentTileMixtures(tuple.Value.Grid, tuple.Value.Tile);
+                return GetAdjacentTileMixtures(tuple.Value.Grid, tuple.Value.Tile, includeBlocked, invalidate);
 
             return Enumerable.Empty<GasMixture>();
         }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -216,6 +216,5 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 appearance.SetData(VentPumpVisuals.State, VentPumpState.Welded);
             }
         }
-
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -33,6 +33,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             SubscribeLocalEvent<GasVentPumpComponent, AtmosDeviceUpdateEvent>(OnGasVentPumpUpdated);
             SubscribeLocalEvent<GasVentPumpComponent, AtmosDeviceDisabledEvent>(OnGasVentPumpLeaveAtmosphere);
+            SubscribeLocalEvent<GasVentPumpComponent, AtmosDeviceEnabledEvent>(OnGasVentPumpEnterAtmosphere);
             SubscribeLocalEvent<GasVentPumpComponent, AtmosMonitorAlarmEvent>(OnAtmosAlarm);
             SubscribeLocalEvent<GasVentPumpComponent, PowerChangedEvent>(OnPowerChanged);
             SubscribeLocalEvent<GasVentPumpComponent, PacketSentEvent>(OnPacketRecv);
@@ -40,11 +41,9 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnGasVentPumpUpdated(EntityUid uid, GasVentPumpComponent vent, AtmosDeviceUpdateEvent args)
         {
-            var appearance = EntityManager.GetComponentOrNull<AppearanceComponent>(vent.Owner); //Bingo waz here
-
+            //Bingo waz here
             if (vent.Welded)
             {
-                appearance?.SetData(VentPumpVisuals.State, VentPumpState.Welded);
                 return;
             }
 
@@ -53,8 +52,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 || !TryComp(uid, out NodeContainerComponent? nodeContainer)
                 || !nodeContainer.TryGetNode(vent.InletName, out PipeNode? pipe))
             {
-                appearance?.SetData(VentPumpVisuals.State, VentPumpState.Off);
-                _ambientSoundSystem.SetAmbience(vent.Owner, false);
                 return;
             }
 
@@ -63,8 +60,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             // We're in an air-blocked tile... Do nothing.
             if (environment == null)
             {
-                appearance?.SetData(VentPumpVisuals.State, VentPumpState.Off);
-                _ambientSoundSystem.SetAmbience(vent.Owner, false);
                 return;
             }
 
@@ -73,9 +68,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             if (vent.PumpDirection == VentPumpDirection.Releasing && pipe.Air.Pressure > 0)
             {
-                appearance?.SetData(VentPumpVisuals.State, VentPumpState.Out);
-                _ambientSoundSystem.SetAmbience(vent.Owner, true);
-
                 if (environment.Pressure > vent.MaxPressure)
                     return;
 
@@ -105,8 +97,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             }
             else if (vent.PumpDirection == VentPumpDirection.Siphoning && environment.Pressure > 0)
             {
-                appearance?.SetData(VentPumpVisuals.State, VentPumpState.In);
-
                 if (pipe.Air.Pressure > vent.MaxPressure)
                     return;
 
@@ -139,10 +129,12 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnGasVentPumpLeaveAtmosphere(EntityUid uid, GasVentPumpComponent component, AtmosDeviceDisabledEvent args)
         {
-            if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
-            {
-                appearance.SetData(VentPumpVisuals.State, VentPumpState.Off);
-            }
+            UpdateState(uid, component);
+        }
+
+        private void OnGasVentPumpEnterAtmosphere(EntityUid uid, GasVentPumpComponent component, AtmosDeviceEnabledEvent args)
+        {
+            UpdateState(uid, component);
         }
 
         private void OnAtmosAlarm(EntityUid uid, GasVentPumpComponent component, AtmosMonitorAlarmEvent args)
@@ -155,11 +147,14 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             {
                 component.Enabled = true;
             }
+
+            UpdateState(uid, component);
         }
 
         private void OnPowerChanged(EntityUid uid, GasVentPumpComponent component, PowerChangedEvent args)
         {
             component.Enabled = args.Powered;
+            UpdateState(uid, component);
         }
 
         private void OnPacketRecv(EntityUid uid, GasVentPumpComponent component, PacketSentEvent args)
@@ -185,6 +180,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                         break;
 
                     component.FromAirAlarmData(setData);
+                    UpdateState(uid, component);
                     alarmable.IgnoreAlarms = setData.IgnoreAlarms;
                     payload.Add(DeviceNetworkConstants.Command, AirAlarmSystem.AirAlarmSetDataStatus);
                     payload.Add(AirAlarmSystem.AirAlarmSetDataStatus, true);
@@ -192,6 +188,32 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                     _deviceNetSystem.QueuePacket(uid, string.Empty, AirAlarmSystem.Freq, payload, true);
 
                     return;
+            }
+        }
+
+        private void UpdateState(EntityUid uid, GasVentPumpComponent vent, AppearanceComponent? appearance = null)
+        {
+            if (!Resolve(uid, ref appearance, false))
+                return;
+
+            _ambientSoundSystem.SetAmbience(uid, true);
+            if (!vent.Enabled)
+            {
+                _ambientSoundSystem.SetAmbience(uid, false);
+                appearance.SetData(VentPumpVisuals.State, VentPumpState.Off);
+            }
+            else if (vent.PumpDirection == VentPumpDirection.Releasing)
+            {
+                appearance.SetData(VentPumpVisuals.State, VentPumpState.Out);
+            }
+            else if (vent.PumpDirection == VentPumpDirection.Siphoning)
+            {
+                appearance.SetData(VentPumpVisuals.State, VentPumpState.In);
+            }
+            else if (vent.Welded)
+            {
+                _ambientSoundSystem.SetAmbience(uid, false);
+                appearance.SetData(VentPumpVisuals.State, VentPumpState.Welded);
             }
         }
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -33,6 +33,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             base.Initialize();
 
             SubscribeLocalEvent<GasVentScrubberComponent, AtmosDeviceUpdateEvent>(OnVentScrubberUpdated);
+            SubscribeLocalEvent<GasVentScrubberComponent, AtmosDeviceEnabledEvent>(OnVentScrubberEnterAtmosphere);
             SubscribeLocalEvent<GasVentScrubberComponent, AtmosDeviceDisabledEvent>(OnVentScrubberLeaveAtmosphere);
             SubscribeLocalEvent<GasVentScrubberComponent, AtmosMonitorAlarmEvent>(OnAtmosAlarm);
             SubscribeLocalEvent<GasVentScrubberComponent, PowerChangedEvent>(OnPowerChanged);
@@ -41,12 +42,8 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnVentScrubberUpdated(EntityUid uid, GasVentScrubberComponent scrubber, AtmosDeviceUpdateEvent args)
         {
-            var appearance = EntityManager.GetComponentOrNull<AppearanceComponent>(scrubber.Owner);
-
             if (scrubber.Welded)
             {
-                appearance?.SetData(ScrubberVisuals.State, ScrubberState.Welded);
-                _ambientSoundSystem.SetAmbience(scrubber.Owner, false);
                 return;
             }
 
@@ -59,40 +56,35 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             || !EntityManager.TryGetComponent(uid, out NodeContainerComponent? nodeContainer)
             || !nodeContainer.TryGetNode(scrubber.OutletName, out PipeNode? outlet))
             {
-                appearance?.SetData(ScrubberVisuals.State, ScrubberState.Off);
-                _ambientSoundSystem.SetAmbience(scrubber.Owner, false);
                 return;
             }
-            _ambientSoundSystem.SetAmbience(scrubber.Owner, true);
 
-            var environment = _atmosphereSystem.GetTileMixture(EntityManager.GetComponent<TransformComponent>(scrubber.Owner).Coordinates, true);
+            var xform = Transform(uid);
+            var environment = _atmosphereSystem.GetTileMixture(xform.Coordinates, true);
 
-            Scrub(timeDelta, scrubber, appearance, environment, outlet);
+            Scrub(timeDelta, scrubber, environment, outlet);
 
             if (!scrubber.WideNet) return;
 
             // Scrub adjacent tiles too.
-            foreach (var adjacent in _atmosphereSystem.GetAdjacentTileMixtures(EntityManager.GetComponent<TransformComponent>(scrubber.Owner).Coordinates, false, true))
+            foreach (var adjacent in _atmosphereSystem.GetAdjacentTileMixtures(xform.Coordinates, false, true))
             {
-                Scrub(timeDelta, scrubber, null, adjacent, outlet);
+                Scrub(timeDelta, scrubber, adjacent, outlet);
             }
         }
 
-        private void OnVentScrubberLeaveAtmosphere(EntityUid uid, GasVentScrubberComponent component, AtmosDeviceDisabledEvent args)
-        {
-            if (EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
-            {
-                appearance.SetData(ScrubberVisuals.State, ScrubberState.Off);
-            }
-        }
+        private void OnVentScrubberLeaveAtmosphere(EntityUid uid, GasVentScrubberComponent component,
+            AtmosDeviceDisabledEvent args) => UpdateState(uid, component);
 
-        private void Scrub(float timeDelta, GasVentScrubberComponent scrubber, AppearanceComponent? appearance, GasMixture? tile, PipeNode outlet)
+        private void OnVentScrubberEnterAtmosphere(EntityUid uid, GasVentScrubberComponent component,
+            AtmosDeviceEnabledEvent args) => UpdateState(uid, component);
+
+        private void Scrub(float timeDelta, GasVentScrubberComponent scrubber, GasMixture? tile, PipeNode outlet)
         {
             // Cannot scrub if tile is null or air-blocked.
             if (tile == null
                 || outlet.Air.Pressure >= 50 * Atmospherics.OneAtmosphere) // Cannot scrub if pressure too high.
             {
-                appearance?.SetData(ScrubberVisuals.State, ScrubberState.Off);
                 return;
             }
 
@@ -106,8 +98,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             if (scrubber.PumpDirection == ScrubberPumpDirection.Scrubbing)
             {
-                appearance?.SetData(ScrubberVisuals.State, scrubber.WideNet ? ScrubberState.WideScrub : ScrubberState.Scrub);
-
                 _atmosphereSystem.ScrubInto(removed, outlet.Air, scrubber.FilterGases);
 
                 // Remix the gases.
@@ -115,8 +105,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             }
             else if (scrubber.PumpDirection == ScrubberPumpDirection.Siphoning)
             {
-                appearance?.SetData(ScrubberVisuals.State, ScrubberState.Siphon);
-
                 _atmosphereSystem.Merge(outlet.Air, removed);
             }
         }
@@ -131,10 +119,15 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             {
                 component.Enabled = true;
             }
+
+            UpdateState(uid, component);
         }
 
-        private void OnPowerChanged(EntityUid uid, GasVentScrubberComponent component, PowerChangedEvent args) =>
+        private void OnPowerChanged(EntityUid uid, GasVentScrubberComponent component, PowerChangedEvent args)
+        {
             component.Enabled = args.Powered;
+            UpdateState(uid, component);
+        }
 
         private void OnPacketRecv(EntityUid uid, GasVentScrubberComponent component, PacketSentEvent args)
         {
@@ -159,6 +152,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                         break;
 
                     component.FromAirAlarmData(setData);
+                    UpdateState(uid, component);
                     alarmable.IgnoreAlarms = setData.IgnoreAlarms;
                     payload.Add(DeviceNetworkConstants.Command, AirAlarmSystem.AirAlarmSetDataStatus);
                     payload.Add(AirAlarmSystem.AirAlarmSetDataStatus, true);
@@ -166,6 +160,36 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                     _deviceNetSystem.QueuePacket(uid, string.Empty, AirAlarmSystem.Freq, payload, true);
 
                     return;
+            }
+        }
+
+        /// <summary>
+        ///     Updates a scrubber's appearance and ambience state.
+        /// </summary>
+        private void UpdateState(EntityUid uid, GasVentScrubberComponent scrubber,
+            AppearanceComponent? appearance = null)
+        {
+            if (!Resolve(uid, ref appearance, false))
+                return;
+
+            _ambientSoundSystem.SetAmbience(uid, true);
+            if (!scrubber.Enabled)
+            {
+                _ambientSoundSystem.SetAmbience(uid, false);
+                appearance.SetData(ScrubberVisuals.State, ScrubberState.Off);
+            }
+            else if (scrubber.PumpDirection == ScrubberPumpDirection.Scrubbing)
+            {
+                appearance.SetData(ScrubberVisuals.State, scrubber.WideNet ? ScrubberState.WideScrub : ScrubberState.Scrub);
+            }
+            else if (scrubber.PumpDirection == ScrubberPumpDirection.Siphoning)
+            {
+                appearance.SetData(ScrubberVisuals.State, ScrubberState.Siphon);
+            }
+            else if (scrubber.Welded)
+            {
+                _ambientSoundSystem.SetAmbience(uid, false);
+                appearance.SetData(ScrubberVisuals.State, ScrubberState.Welded);
             }
         }
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

a not-inconsiderable amount of atmos ticktime was updating every single vent and scrubber's appearance and ambience whenever they did anything

this just makes it so the appearance/ambience only updates when it leaves/exits an atmosphere, changes power, or has new data synced from an air alarm