### PR TITLE
Fix decal crash

### DIFF
--- a/Content.Client/Decals/DecalOverlay.cs
+++ b/Content.Client/Decals/DecalOverlay.cs
@@ -56,7 +56,7 @@ namespace Content.Client.Decals
                     {
                         if (!cachedTextures.TryGetValue(decal.Id, out var texture))
                         {
-                            var sprite = _prototypeManager.Index<DecalPrototype>(decal.Id).Sprite;
+                            var sprite = GetDecalSprite(decal.Id);
                             texture = _sprites.Frame0(sprite);
                             cachedTextures[decal.Id] = texture;
                         }
@@ -67,6 +67,17 @@ namespace Content.Client.Decals
                             handle.DrawTexture(texture, decal.Coordinates, decal.Angle, decal.Color);
                     }
                 }
+            }
+        }
+
+        public SpriteSpecifier GetDecalSprite(string id)
+        {
+            if (_prototypeManager.TryIndex<DecalPrototype>(id, out var proto))
+                return proto.Sprite;
+            else
+            {
+                Logger.Error($"Unknown decal prototype: {id}");
+                return new SpriteSpecifier.Texture(new ResourcePath("/Textures/noSprite.png"));
             }
         }
     }

--- a/Resources/Maps/Salvage/medium-pet-hospital.yml
+++ b/Resources/Maps/Salvage/medium-pet-hospital.yml
@@ -129,14 +129,6 @@ entities:
           color: '#FFFFFFFF'
           id: Grasse1
           coordinates: 13.889501,-4.865914
-        10:
-          color: '#FFFFFFFF'
-          id: Rock08
-          coordinates: 3.2020006,-13.537788
-        11:
-          color: '#FFFFFFFF'
-          id: Rock10
-          coordinates: 5.9051256,-13.131538
         12:
           color: '#FFFFFFFF'
           id: Flowersbr2


### PR DESCRIPTION
Fixes a repeat of a previous bug, where a new salvage map (#7326) has decals that were removed sometime after the PR was opened & tested. Also adds some code to make clients not just crash in the future. See also: #7271.