### PR TITLE
Quickfix: Give color to some announcements

### DIFF
--- a/Content.Server/Administration/UI/AdminAnnounceEui.cs
+++ b/Content.Server/Administration/UI/AdminAnnounceEui.cs
@@ -47,7 +47,7 @@ namespace Content.Server.Administration.UI
                             _chatManager.DispatchServerAnnouncement(doAnnounce.Announcement);
                             break;
                         case AdminAnnounceType.Station:
-                            _chatManager.DispatchStationAnnouncement(doAnnounce.Announcement, doAnnounce.Announcer);
+                            _chatManager.DispatchStationAnnouncement(doAnnounce.Announcement, doAnnounce.Announcer, colorOverride: Color.Gold);
                             break;
                     }
 

--- a/Content.Server/Announcements/AnnounceCommand.cs
+++ b/Content.Server/Announcements/AnnounceCommand.cs
@@ -26,12 +26,12 @@ namespace Content.Server.Announcements
 
             if (args.Length == 1)
             {
-                chat.DispatchStationAnnouncement(args[0]);
+                chat.DispatchStationAnnouncement(args[0], colorOverride: Color.Gold);
             }
             else
             {
                 var message = string.Join(' ', new ArraySegment<string>(args, 1, args.Length-1));
-                chat.DispatchStationAnnouncement(message, args[0]);
+                chat.DispatchStationAnnouncement(message, args[0], colorOverride: Color.Gold);
             }
             shell.WriteLine("Sent!");
         }

--- a/Content.Server/Nuke/NukeCodeSystem.cs
+++ b/Content.Server/Nuke/NukeCodeSystem.cs
@@ -76,7 +76,7 @@ namespace Content.Server.Nuke
             if (wasSent)
             {
                 var msg = Loc.GetString("nuke-component-announcement-send-codes");
-                _chat.DispatchStationAnnouncement(msg);
+                _chat.DispatchStationAnnouncement(msg, colorOverride: Color.Red);
             }
 
             return wasSent;

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -113,7 +113,8 @@ namespace Content.Server.RoundEnd
                 _adminLog.Add(LogType.ShuttleRecalled, LogImpact.High, $"Shuttle recalled");
             }
 
-            _chatManager.DispatchStationAnnouncement(Loc.GetString("round-end-system-shuttle-recalled-announcement"), Loc.GetString("Station"), false);
+            _chatManager.DispatchStationAnnouncement(Loc.GetString("round-end-system-shuttle-recalled-announcement"),
+                Loc.GetString("Station"), false, colorOverride: Color.Gold);
 
             SoundSystem.Play(Filter.Broadcast(), "/Audio/Announcements/shuttlerecalled.ogg");
 

--- a/Content.Server/StationEvents/Events/RandomSentience.cs
+++ b/Content.Server/StationEvents/Events/RandomSentience.cs
@@ -53,7 +53,8 @@ public sealed class RandomSentience : StationEvent
             Loc.GetString("station-event-random-sentience-announcement",
                 ("kind1", kind1), ("kind2", kind2), ("kind3", kind3), ("amount", groupList.Count),
                 ("data", Loc.GetString($"random-sentience-event-data-{_random.Next(1, 6)}")),
-                ("strength", Loc.GetString($"random-sentience-event-strength-{_random.Next(1, 8)}")))
+                ("strength", Loc.GetString($"random-sentience-event-strength-{_random.Next(1, 8)}"))), 
+                colorOverride: Color.Gold
         );
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives color to certain announcements to reflect other station announcements

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->
N/A - too small of a change to mention

