### PR TITLE
Removes the default announcement sound from Salvage

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -293,9 +293,9 @@ namespace Content.Server.Salvage
             return true;
         }
         private void Report(string messageKey) =>
-            _chatManager.DispatchStationAnnouncement(Loc.GetString(messageKey), Loc.GetString("salvage-system-announcement-source"), colorOverride: Color.Orange);
+            _chatManager.DispatchStationAnnouncement(Loc.GetString(messageKey), Loc.GetString("salvage-system-announcement-source"), colorOverride: Color.Orange, playDefaultSound: false);
         private void Report(string messageKey, params (string, object)[] args) =>
-            _chatManager.DispatchStationAnnouncement(Loc.GetString(messageKey, args), Loc.GetString("salvage-system-announcement-source"), colorOverride: Color.Orange);
+            _chatManager.DispatchStationAnnouncement(Loc.GetString(messageKey, args), Loc.GetString("salvage-system-announcement-source"), colorOverride: Color.Orange, playDefaultSound: false);
 
         private void Transition(SalvageMagnetComponent magnet, TimeSpan currentTime)
         {


### PR DESCRIPTION
## About the PR 

Text is pretty descriptive! I've chosen to do so since the sound gets pretty spammy during most rounds, and also because there are talks about moving the announcement to department radio when those come out.

**Changelog**


:cl:
- tweak: Removed the sound from Salvage's Announcements.


