### PR TITLE
Fahrenheit451 and other balancings 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -119,3 +119,7 @@
     sprite: Clothing/Eyes/Glasses/thermal.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/thermal.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Heat: 0.5 #matches mesons now but for thermal

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -122,4 +122,4 @@
   - type: Armor
     modifiers:
       coefficients:
-        Heat: 0.5 #matches mesons now but for thermal
+        Heat: 0.95

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -55,7 +55,7 @@
         Heat: 0.2
         Radiation: 0.5
   - type: TemperatureProtection
-    coefficient: 0.01
+    coefficient: 0.005
  
 - type: entity
   parent: ClothingHeadHardsuitBase

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -46,6 +46,16 @@
   - type: PressureProtection
     highPressureMultiplier: 0.40
     lowPressureMultiplier: 100
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.90
+        Slash: 0.90
+        Piercing: 0.95
+        Heat: 0.2
+        Radiation: 0.5
+  - type: TemperatureProtection
+    coefficient: 0.01
  
 - type: entity
   parent: ClothingHeadHardsuitBase

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -11,6 +11,12 @@
   - type: IngestionBlocker
   - type: ExplosionResistance
     resistance: 0.25 # +0.65 from body -> 90%
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.8
+        Piercing: 0.8    
 
 - type: entity
   parent: ClothingHeadEVAHelmetBase
@@ -88,6 +94,12 @@
   - type: Clothing
     sprite: Clothing/Head/Helmets/light_riot.rsi
   - type: IngestionBlocker
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8
 
 - type: entity
   parent: ClothingHeadBase
@@ -100,6 +112,12 @@
   - type: Clothing
     sprite: Clothing/Head/Helmets/scaf.rsi
   - type: IngestionBlocker
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8
 
 - type: entity
   parent: ClothingHeadBase
@@ -176,6 +194,14 @@
       startingItem: PowerCellSmallHigh
   - type: TemperatureProtection
     coefficient: 0.01
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.90
+        Slash: 0.90
+        Piercing: 0.95
+        Heat: 0.5
+        Radiation: 1
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase # hardsuitlight base for light and protection
@@ -190,6 +216,14 @@
   - type: IngestionBlocker
   - type: TemperatureProtection
     coefficient: 0.005
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.90
+        Slash: 0.90
+        Piercing: 0.95
+        Heat: 0.35
+        Radiation: .95
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -200,7 +200,7 @@
         Blunt: 0.90
         Slash: 0.90
         Piercing: 0.95
-        Heat: 0.5
+        Heat: 0.65
         Radiation: 1
 
 - type: entity
@@ -222,7 +222,7 @@
         Blunt: 0.90
         Slash: 0.90
         Piercing: 0.95
-        Heat: 0.35
+        Heat: 0.5
         Radiation: .95
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -22,6 +22,8 @@
         Piercing: 0.9
         Heat: 0.2
         Radiation: 0.25
+  - type: TemperatureProtection
+    coefficient: 0.01
 
 - type: entity
   parent: ClothingOuterHardsuitBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,18 +9,18 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/atmospherics.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.45
+    highPressureMultiplier: 0.2
     lowPressureMultiplier: 100
   - type: ClothingSpeedModifier
     walkModifier: 0.65
-    sprintModifier: 0.7 #less armor than engineering but slightly higher move speed so they can get to breaches a bit faster
+    sprintModifier: 0.7 
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9 #raising these slightly so its a bit more attractive 
+        Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.35
+        Heat: 0.2
         Radiation: 0.25
 
 - type: entity
@@ -44,8 +44,8 @@
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.85
-        Heat: 0.5 #putting higher enviro since the captain's carapace is already super heavy physical
+        Piercing: 0.75
+        Heat: 0.5 
         Radiation: 0.1
 
 - type: entity
@@ -88,14 +88,14 @@
     lowPressureMultiplier: 100
   - type: ClothingSpeedModifier
     walkModifier: 0.65
-    sprintModifier: 0.65 #making this a bit faster than salvages
+    sprintModifier: 0.65 
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9 #higher physical protections than atmo but less enviro
+        Blunt: 0.9 
         Slash: 0.85
-        Piercing: 0.9
-        Heat: 0.85
+        Piercing: 0.85
+        Heat: 0.7
         Radiation: 0.35
 
 - type: entity
@@ -109,18 +109,18 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/engineering-white.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.45
+    highPressureMultiplier: 0.4
     lowPressureMultiplier: 100
   - type: ClothingSpeedModifier
     walkModifier: 0.75
-    sprintModifier: 0.8 #turning this up slightly because CEs have started just wearing firesuits instead and never putting on advanced armor
+    sprintModifier: 0.8 
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.85
         Slash: 0.85
-        Piercing: 0.85
-        Heat: 0.45 #slightly improved stats over last pass
+        Piercing: 0.8
+        Heat: 0.4
         Radiation: 0.25
 
 #The voidsuit and eva suit are not techically 'hardsuits' but this seems to be the place for all EVA-capable outer clothing. This may be worth reevaluating when we have a lot more items.
@@ -190,8 +190,13 @@
   - type: DiseaseProtection
     protection: 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.9 #old movespeed i had was too punishing and this needs to be useable for saving people in medbay
+    walkModifier: 0.9 
     sprintModifier: 0.9
+  - type: Armor
+    modifiers:
+      coefficients:
+        Heat: 0.90
+        Radiation: 0.25 
 
 - type: entity
   parent: ClothingOuterHardsuitBase
@@ -210,12 +215,12 @@
     modifiers:
       coefficients:
         Blunt: 0.6
-        Slash: 0.75 #increasing slash on this because it's a big ass suit
+        Slash: 0.75
         Piercing: 0.95
         Heat: 0.65
         Radiation: 0.25
   - type: ClothingSpeedModifier
-    walkModifier: 0.75 #moving the movespeed on this up, it's a high risk item and traitors shouldnt have to keep this in their bag all round
+    walkModifier: 0.75
     sprintModifier: 0.75
 
 - type: entity
@@ -262,7 +267,7 @@
         Blunt: 0.7
         Slash: 0.7
         Piercing: 0.7
-        Heat: 0.8 #buffed combat stats all round
+        Heat: 0.8 
         Radiation: 0.25
 
 - type: entity
@@ -280,7 +285,7 @@
     lowPressureMultiplier: 100
   - type: ClothingSpeedModifier
     walkModifier: 0.7 
-    sprintModifier: 0.7 #buffing the movespeed slightly so its somewhat feasible to catch up to a felon, this speed is what the cmo's was at. seems a good fit
+    sprintModifier: 0.7
   - type: Armor
     modifiers:
       coefficients:
@@ -337,7 +342,7 @@
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.4
-        Heat: 0.25 #higher heat resist due to spell casting
+        Heat: 0.25 
         Radiation: 0.20
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -19,7 +19,7 @@
     resistance: 0.65 # +0.25 from helmet -> 90%
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterEVASuitBase
   id: ClothingOuterSuitEmergency
   name: emergency suit
   description: An emergency suit in cases of... emergencies.
@@ -28,16 +28,6 @@
     sprite: Clothing/OuterClothing/Suits/emergency.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/emergency.rsi
-  - type: PressureProtection
-    highPressureMultiplier: 0.85
-    lowPressureMultiplier: 25
-  - type: TemperatureProtection
-    coefficient: 0.1
-  - type: Armor
-    modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.85
 
 - type: entity
   parent: ClothingOuterBase
@@ -48,7 +38,7 @@
   - type: Sprite
     sprite: Clothing/OuterClothing/Suits/fire.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.85
+    highPressureMultiplier: 0.65
     lowPressureMultiplier: 25
   - type: TemperatureProtection
     coefficient: 0.03
@@ -58,8 +48,13 @@
     modifiers:
       coefficients:
         Slash: 0.9
-        Heat: 0.7 #makes sense right?
-
+        Heat: 0.5
+  - type: ClothingSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7
+  - type: TemperatureProtection
+    coefficient: 0.01
+    
 - type: entity
   parent: ClothingOuterBase
   id: ClothingOuterSuitRad
@@ -136,7 +131,7 @@
   - type: Sprite
     sprite: Clothing/OuterClothing/Suits/atmos_firesuit.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.65
+    highPressureMultiplier: 0.45
     lowPressureMultiplier: 25
   - type: TemperatureProtection
     coefficient: 0.01
@@ -146,4 +141,7 @@
     modifiers:
       coefficients:
         Slash: 0.9
-        Heat: 0.5
+        Heat: 0.35
+  - type: ClothingSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -40,8 +40,6 @@
   - type: PressureProtection
     highPressureMultiplier: 0.65
     lowPressureMultiplier: 25
-  - type: TemperatureProtection
-    coefficient: 0.03
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/fire.rsi
   - type: Armor

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -44,7 +44,7 @@
         map: ["enum.RangedBarrelVisualLayers.MagUnshaded"]
         shader: unshaded
   - type: Item
-    size: 24
+    size: 12
     sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi
   - type: RangedWeapon
   - type: BatteryBarrel
@@ -94,7 +94,7 @@
         map: ["enum.RangedBarrelVisualLayers.MagUnshaded"]
         shader: unshaded
   - type: Item
-    size: 24
+    size: 12
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
   - type: BatteryBarrel
     fireCost: 25
@@ -115,7 +115,7 @@
         map: ["enum.RangedBarrelVisualLayers.MagUnshaded"]
         shader: unshaded
   - type: Item
-    size: 24
+    size: 12
     sprite: Objects/Weapons/Guns/Battery/pulse_pistol.rsi
   - type: BatteryBarrel
     fireCost: 25

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -17,7 +17,7 @@
   - type: Icon
     state: icon
   - type: Item
-    size: 12
+    size: 10
   - type: MagazineBarrel
     caliber: Pistol
     magazineTypes:
@@ -64,7 +64,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/clarissa.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/clarissa.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -94,7 +94,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/colt.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/colt.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -121,7 +121,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/giskard.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/giskard.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -151,7 +151,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/hm_pistol.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/hm_pistol.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -203,7 +203,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/lamia.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/lamia.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -253,7 +253,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/mandella.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/mandella.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -285,7 +285,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -317,7 +317,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/mk58_wood.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/mk58_wood.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -344,7 +344,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/molly.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/molly.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -374,7 +374,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/gyro_pistol.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/gyro_pistol.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -409,7 +409,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/olivaw_civil.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/olivaw_civil.rsi
   - type: RangedWeapon
   - type: MagazineBarrel
@@ -437,7 +437,7 @@
   - type: Icon
     sprite: Objects/Weapons/Guns/Pistols/paco.rsi
   - type: Item
-    size: 12
+    size: 10
     sprite: Objects/Weapons/Guns/Pistols/paco.rsi
   - type: RangedWeapon
   - type: MagazineBarrel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -26,10 +26,10 @@
       map: ["enum.RangedBarrelVisualLayers.MagUnshaded"]
       shader: unshaded
   - type: Item
-    size: 24
+    size: 10
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
   - type: RangedWeapon
-  - type: BoltActionBarrel
+  - type: RevolverBarrel
     currentSelector: Single
     allSelectors:
     - Single
@@ -60,7 +60,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
   - type: Item
-    size: 24
+    size: 10
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
   - type: RangedWeapon
   - type: RevolverBarrel
@@ -88,7 +88,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
   - type: Item
-    size: 24
+    size: 10
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
   - type: RangedWeapon
   - type: RevolverBarrel
@@ -116,7 +116,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/predator.rsi
   - type: Item
-    size: 24
+    size: 10
     sprite: Objects/Weapons/Guns/Revolvers/predator.rsi
   - type: RangedWeapon
   - type: RevolverBarrel
@@ -144,7 +144,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi
   - type: Item
-    size: 24
+    size: 10
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi
   - type: RangedWeapon
   - type: RevolverBarrel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -26,7 +26,7 @@
       map: ["enum.RangedBarrelVisualLayers.MagUnshaded"]
       shader: unshaded
   - type: Item
-    size: 10
+    size: 12
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
   - type: RangedWeapon
   - type: RevolverBarrel
@@ -60,7 +60,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
   - type: Item
-    size: 10
+    size: 12
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
   - type: RangedWeapon
   - type: RevolverBarrel
@@ -88,7 +88,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
   - type: Item
-    size: 10
+    size: 12
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
   - type: RangedWeapon
   - type: RevolverBarrel
@@ -116,7 +116,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/predator.rsi
   - type: Item
-    size: 10
+    size: 12
     sprite: Objects/Weapons/Guns/Revolvers/predator.rsi
   - type: RangedWeapon
   - type: RevolverBarrel
@@ -144,7 +144,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi
   - type: Item
-    size: 10
+    size: 12
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi
   - type: RangedWeapon
   - type: RevolverBarrel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -228,7 +228,7 @@
     sprite: Objects/Weapons/Guns/Shotguns/sawn.rsi
     state: icon
   - type: Item
-    size: 24
+    size: 15
     sprite: Objects/Weapons/Guns/Shotguns/sawn.rsi
   - type: RangedWeapon
   - type: BoltActionBarrel


### PR DESCRIPTION
changelog
-firesuit and atmos firesuit have both been nerfed movespeed wise but been buffed in the heat and pressure resist departments
-emergency suit is now parented to eva base so itll work now
-atmos hardsuit has had heat and pressure resist buffed
-captains hardsuit isnt meant to be a physical tank but putting the piercing resist up slightly higher
-engineering hardsuit has slightly higher pierce resist and more heat resist
-cmo's hardsuit now has decent rad protection in case of rad storms
-most helmets have proper stats now, besides fun flavor ones (no more regular helmet being the best helmet since none of the others had stats)
-all pistols weigh 10 now (used to weigh 12)
-all revolvers weigh 12 (used to weigh 24)
-sawn off weighs 15 (other shotguns weigh 24)
-retro, svallin, and pulse pistol weigh 12 now
-thermal glasses now match mesons protection but for thermal
-skub
![image](https://user-images.githubusercontent.com/99158783/163011821-e5488759-b659-4d91-9be8-c5a8ad65b42a.png)
