### PR TITLE
Gun accuracy pass

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -22,7 +22,7 @@
     minAngle: 5
     maxAngle: 45
     angleIncrease: 10
-    angleDecay: 15
+    angleDecay: 20
     magNeedsOpenBolt: false
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
@@ -66,7 +66,7 @@
     minAngle: 0
     maxAngle: 15
     angleIncrease: 15
-    angleDecay: 15
+    angleDecay: 20
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -19,10 +19,10 @@
     magazineTypes:
     - Box
     fireRate: 20
-    minAngle: 10
+    minAngle: 5
     maxAngle: 45
     angleIncrease: 10
-    angleDecay: 60
+    angleDecay: 15
     magNeedsOpenBolt: false
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
@@ -66,7 +66,7 @@
     minAngle: 0
     maxAngle: 15
     angleIncrease: 15
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -22,7 +22,7 @@
     minAngle: 5
     maxAngle: 45
     angleIncrease: 10
-    angleDecay: 15
+    angleDecay: 20
     magNeedsOpenBolt: true
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
@@ -68,7 +68,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 15
+    angleDecay: 20
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -104,7 +104,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 15
+    angleDecay: 20
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -19,10 +19,10 @@
     magazineTypes:
     - Box
     fireRate: 8
-    minAngle: 10
+    minAngle: 5
     maxAngle: 45
     angleIncrease: 10
-    angleDecay: 60
+    angleDecay: 15
     magNeedsOpenBolt: true
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
@@ -68,7 +68,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -104,7 +104,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -26,10 +26,10 @@
     allSelectors:
     - Single
     fireRate: 8
-    minAngle: 10
+    minAngle: 5
     maxAngle: 60
     angleIncrease: 10
-    angleDecay: 60
+    angleDecay: 15
     magFillPrototype: MagazinePistol
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/pistol.ogg
@@ -76,7 +76,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
 
 - type: entity
   name: colt M1911
@@ -105,7 +105,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -132,7 +132,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
 
 - type: entity
   name: handmade pistol
@@ -162,10 +162,10 @@
     magazineTypes:
     - Pistol
     fireRate: 8
-    minAngle: 10
+    minAngle: 5
     maxAngle: 60
     angleIncrease: 10
-    angleDecay: 60
+    angleDecay: 15
     magFillPrototype: MagazinePistol
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/pistol.ogg
@@ -216,7 +216,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/hpistol.ogg
     soundEmpty:
@@ -265,7 +265,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/silenced.ogg
 
@@ -296,7 +296,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -328,7 +328,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -361,7 +361,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
 
 - type: entity
   name: basilisk
@@ -391,7 +391,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
 
 - type: entity
   name: olivaw
@@ -421,7 +421,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -449,4 +449,4 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 60
+    angleDecay: 15

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -36,6 +36,10 @@
     fillPrototype: CartridgeMagnum
     caliber: Magnum
     capacity: 5
+    minAngle: 0
+    maxAngle: 60
+    angleIncrease: 20
+    angleDecay: 15
     autoCycle: true
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/revolver.ogg
@@ -70,6 +74,10 @@
     fillPrototype: CartridgeMagnum
     caliber: Magnum
     capacity: 6
+    minAngle: 0
+    maxAngle: 60
+    angleIncrease: 20
+    angleDecay: 15
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
     soundGunshot:
@@ -98,6 +106,10 @@
     fillPrototype: CartridgeMagnum
     caliber: Magnum
     capacity: 7
+    minAngle: 0
+    maxAngle: 60
+    angleIncrease: 20
+    angleDecay: 15
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
     soundGunshot:
@@ -126,6 +138,10 @@
     fillPrototype: CartridgeMagnum
     caliber: Magnum
     capacity: 7
+    minAngle: 0
+    maxAngle: 60
+    angleIncrease: 20
+    angleDecay: 15
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
     soundGunshot:
@@ -155,6 +171,10 @@
     fillPrototype: CartridgePistol
     caliber: Pistol
     capacity: 5
+    minAngle: 0
+    maxAngle: 60
+    angleIncrease: 20
+    angleDecay: 15
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
     soundGunshot:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -21,7 +21,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 15
+    angleDecay: 20
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/batrifle.ogg
     soundEmpty:
@@ -66,7 +66,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 15
+    angleDecay: 20
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
     soundRack:
@@ -112,7 +112,7 @@
     minAngle: 0
     maxAngle: 60
     angleIncrease: 15
-    angleDecay: 15
+    angleDecay: 20
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
     soundRack:
@@ -159,7 +159,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 60
+    angleDecay: 20
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/batrifle.ogg
     soundRack:
@@ -204,7 +204,7 @@
     minAngle: 10
     maxAngle: 60
     angleIncrease: 10
-    angleDecay: 15
+    angleDecay: 20
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/m41.ogg
     soundRack:
@@ -249,7 +249,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 15
+    angleDecay: 20
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
     soundRack:
@@ -296,7 +296,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 15
+    angleDecay: 20
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -336,7 +336,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 15
+    angleDecay: 20
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
     soundRack:
@@ -381,7 +381,7 @@
     minAngle: 0
     maxAngle: 25
     angleIncrease: 15
-    angleDecay: 15
+    angleDecay: 20
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
     soundRack:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -21,7 +21,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 90
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/batrifle.ogg
     soundEmpty:
@@ -66,7 +66,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 20
-    angleDecay: 90
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
     soundRack:
@@ -112,7 +112,7 @@
     minAngle: 0
     maxAngle: 60
     angleIncrease: 15
-    angleDecay: 60
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
     soundRack:
@@ -204,7 +204,7 @@
     minAngle: 10
     maxAngle: 60
     angleIncrease: 10
-    angleDecay: 60
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/m41.ogg
     soundRack:
@@ -249,7 +249,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 60
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
     soundRack:
@@ -296,7 +296,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -336,7 +336,7 @@
     minAngle: 0
     maxAngle: 45
     angleIncrease: 15
-    angleDecay: 60
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
     soundRack:
@@ -381,7 +381,7 @@
     minAngle: 0
     maxAngle: 25
     angleIncrease: 15
-    angleDecay: 25
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
     soundRack:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -20,10 +20,10 @@
     caliber: Pistol
     magazineTypes:
     - Smg
-    minAngle: 5
+    minAngle: 0
     maxAngle: 60
     angleIncrease: 10
-    angleDecay: 60
+    angleDecay: 15
     magFillPrototype: MagazinePistolSmg
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/smg.ogg
@@ -69,10 +69,10 @@
     caliber: Pistol
     magazineTypes:
     - Smg
-    minAngle: 10
+    minAngle: 5
     maxAngle: 60
     angleIncrease: 12
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -111,10 +111,10 @@
     caliber: Pistol
     magazineTypes:
     - Smg
-    minAngle: 5
+    minAngle: 0
     maxAngle: 60
     angleIncrease: 10
-    angleDecay: 60
+    angleDecay: 15
     autoEjectMag: true
   - type: Appearance
     visuals:
@@ -154,10 +154,10 @@
     magazineTypes:
     - Smg
     magFillPrototype: MagazineMagnumSmg
-    minAngle: 5
+    minAngle: 0
     maxAngle: 60
     angleIncrease: 12
-    angleDecay: 60
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -23,7 +23,7 @@
     minAngle: 0
     maxAngle: 60
     angleIncrease: 10
-    angleDecay: 15
+    angleDecay: 20
     magFillPrototype: MagazinePistolSmg
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/smg.ogg
@@ -71,8 +71,8 @@
     - Smg
     minAngle: 5
     maxAngle: 60
-    angleIncrease: 12
-    angleDecay: 15
+    angleIncrease: 10
+    angleDecay: 20
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
@@ -114,7 +114,7 @@
     minAngle: 0
     maxAngle: 60
     angleIncrease: 10
-    angleDecay: 15
+    angleDecay: 20
     autoEjectMag: true
   - type: Appearance
     visuals:
@@ -157,7 +157,7 @@
     minAngle: 0
     maxAngle: 60
     angleIncrease: 12
-    angleDecay: 15
+    angleDecay: 20
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -20,10 +20,10 @@
     caliber: Shotgun
     capacity: 7
     fireRate: 2.0
-    minAngle: 10
+    minAngle: 5
     maxAngle: 60
     angleIncrease: 30
-    angleDecay: 30
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
     soundEmpty:
@@ -111,10 +111,10 @@
     fillPrototype: ShellShotgun
     fireRate: 8.0
     capacity: 2
-    minAngle: 10
+    minAngle: 5
     maxAngle: 60
     angleIncrease: 30
-    angleDecay: 30
+    angleDecay: 15
     ammoSpreadRatio: 0.7
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
@@ -151,8 +151,10 @@
   - type: RangedWeapon
   - type: PumpBarrel
     fireRate: 4.0
-    minAngle: 10
+    minAngle: 5
     maxAngle: 120
+    angleIncrease: 30
+    angleDecay: 15
   - type: Appearance
     visuals:
     - type: MagVisualizer
@@ -176,6 +178,8 @@
   - type: PumpBarrel
     capacity: 9
     ammoSpreadRatio: 0.5
+    angleIncrease: 30
+    angleDecay: 15
 
 - type: entity
   name: Regulator 1000
@@ -193,6 +197,8 @@
   - type: PumpBarrel
     capacity: 7
     ammoSpreadRatio: 0.7
+    angleIncrease: 30
+    angleDecay: 15
 
 - type: entity
   name: Kammerer
@@ -210,6 +216,8 @@
   - type: PumpBarrel
     capacity: 4
     ammoSpreadRatio: 0.7
+    angleIncrease: 30
+    angleDecay: 15
 
 - type: entity
   name: sawn-off shotgun
@@ -239,10 +247,10 @@
     fillPrototype: ShellShotgun
     fireRate: 8.0
     capacity: 2
-    minAngle: 10
+    minAngle: 7
     maxAngle: 90
     angleIncrease: 45
-    angleDecay: 30
+    angleDecay: 15
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
     soundEmpty:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -22,8 +22,8 @@
     caliber: LRifle
     capacity: 10
     fireRate: 1.0
-    minAngle: 5
-    maxAngle: 45
+    minAngle: 0
+    maxAngle: 60
     angleIncrease: 20
     angleDecay: 15
     soundGunshot:
@@ -88,7 +88,7 @@
     caliber: AntiMaterial
     capacity: 1
     fireRate: 1.0
-    minAngle: 25
+    minAngle: 20
     maxAngle: 80
     angleIncrease: 20
     angleDecay: 15
@@ -111,7 +111,7 @@
     caliber: AntiMaterial
     capacity: 1
     fireRate: 1.0
-    minAngle: 15
+    minAngle: 10
     maxAngle: 60
     angleIncrease: 20
     angleDecay: 15


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I reduced the first shot accuracy penalty of most guns by 5, but I set the decay way lower. This means that firing off single shots is much stronger, but tap firing is much weaker. All of the guns should feel better.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/60792108/163025262-ea46c9dc-ed81-47df-8b76-e477f145ce8c.mp4


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
-tweak: Most guns now have a much more accurate first shot.
-tweak: Most guns now take much longer to get back to first-shot accuracy, making tap firing worse.

