### PR TITLE
Adds the ability for electrification to check if the entity is powered by an APC

### DIFF
--- a/Content.Server/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Server/Electrocution/Components/ElectrifiedComponent.cs
@@ -30,6 +30,9 @@ namespace Content.Server.Electrocution
         [DataField("requirePower")]
         public bool RequirePower { get; } = true;
 
+        [DataField("usesApcPower")]
+        public bool UsesApcPower { get; } = false;
+
         [DataField("highVoltageNode")]
         public string? HighVoltageNode { get; }
 

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -189,7 +189,7 @@ namespace Content.Server.Electrocution
                 // attempt an electrocution if all the checks succeed.
 
                 if (electrified.UsesApcPower &&
-                    (!EntityManager.TryGetComponent(uid, out ApcPowerReceiverComponent power)
+                    (!TryComp(uid, out ApcPowerReceiverComponent? power)
                      || !power.Powered))
                 {
                     return false;

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -183,8 +183,18 @@ namespace Content.Server.Electrocution
 
             var targets = new List<(EntityUid entity, int depth)>();
             GetChainedElectrocutionTargets(targetUid, targets);
-            if (!electrified.RequirePower)
+            if (!electrified.RequirePower || electrified.UsesApcPower)
             {
+                // Does it use APC power for its electrification check? Check if it's powered, and then
+                // attempt an electrocution if all the checks succeed.
+
+                if (electrified.UsesApcPower &&
+                    (!EntityManager.TryGetComponent(uid, out ApcPowerReceiverComponent power)
+                     || !power.Powered))
+                {
+                    return false;
+                }
+
                 var lastRet = true;
                 for (var i = targets.Count - 1; i >= 0; i--)
                 {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the ability for electrification to check if the entity it's checking is powered by an APC. If so, and if it's enabled, it will electrocute the user as if RequiresPower was set to false.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Entities that are powered by APCs can now be designed so that they can electrocute you. Shocking!

