### PR TITLE
Fix handcuffed players being able to escape pulls

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -26,7 +26,8 @@ namespace Content.Shared.Cuffs
             SubscribeLocalEvent<SharedCuffableComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, DropAttemptEvent>(OnDropAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, PickupAttemptEvent>(OnPickupAttempt);
-            SubscribeLocalEvent<SharedCuffableComponent, PullMessage>(OnPull);
+            SubscribeLocalEvent<SharedCuffableComponent, PullStartedMessage>(OnPull);
+            SubscribeLocalEvent<SharedCuffableComponent, PullStoppedMessage>(OnPull);
         }
 
         private void OnPull(EntityUid uid, SharedCuffableComponent component, PullMessage args)


### PR DESCRIPTION
Fixes #7529
:cl:
- FIx: Fixed handcuffed players being able to freely move around despite being pulled.

