### PR TITLE
Docking airlocks are now also airtight to their sides.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -44,6 +44,8 @@
   - type: Airtight
     fixVacuum: true
     airBlockedDirection:
+      - East
+      - West
       - South
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows mappers to have multiple docking airlocks in a row without fear of decompression.

