### PR TITLE
Pirate ship and prototypes for admemes

### DIFF
--- a/Resources/Maps/pirate.yml
+++ b/Resources/Maps/pirate.yml
@@ -1,0 +1,6400 @@
+meta:
+  format: 2
+  name: DemoStation
+  author: Space-Wizards
+  postmapinit: false
+tilemap:
+  0: space
+  1: FloorArcadeBlue
+  2: FloorArcadeRed
+  3: FloorAsteroidIronsand1
+  4: FloorAsteroidIronsand2
+  5: FloorAsteroidIronsand3
+  6: FloorAsteroidIronsand4
+  7: FloorEighties
+  8: FloorGrassJungle
+  9: FloorShuttleBlue
+  10: FloorShuttleOrange
+  11: FloorShuttlePurple
+  12: FloorShuttleRed
+  13: FloorShuttleWhite
+  14: floor_asteroid_coarse_sand0
+  15: floor_asteroid_coarse_sand1
+  16: floor_asteroid_coarse_sand2
+  17: floor_asteroid_coarse_sand_dug
+  18: floor_asteroid_sand
+  19: floor_asteroid_tile
+  20: floor_bar
+  21: floor_blue
+  22: floor_blue_circuit
+  23: floor_clown
+  24: floor_dark
+  25: floor_elevator_shaft
+  26: floor_freezer
+  27: floor_glass
+  28: floor_gold
+  29: floor_grass
+  30: floor_green_circuit
+  31: floor_hydro
+  32: floor_kitchen
+  33: floor_laundry
+  34: floor_lino
+  35: floor_mime
+  36: floor_mono
+  37: floor_reinforced
+  38: floor_rglass
+  39: floor_rock_vault
+  40: floor_showroom
+  41: floor_silver
+  42: floor_snow
+  43: floor_steel
+  44: floor_steel_dirty
+  45: floor_techmaint
+  46: floor_white
+  47: floor_wood
+  48: lattice
+  49: plating
+  50: underplating
+grids:
+- settings:
+    chunksize: 16
+    tilesize: 1
+  chunks:
+  - ind: -1,0
+    tiles: AAAAAAAAAAAAAAAAAAAAADEAAAAxAAAAMQAAADEAAAAUAAAAMQAAADEAAAAlAAAAJQAAACUAAAAlAAAAJQAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAMQAAADEAAAArAAAAMQAAACsAAAAxAAAAJQAAACUAAAAlAAAAJQAAACUAAAAAAAAAAAAAAAAAAAAAAAAAMQAAADEAAAAxAAAAKwAAADEAAAArAAAAMQAAACUAAAAlAAAAJQAAACUAAAAlAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAxAAAAMQAAACsAAAAxAAAAKwAAADEAAAAlAAAAJQAAACUAAAAlAAAAJQAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAMQAAADEAAAAxAAAAKwAAADEAAAAxAAAAJQAAACUAAAAlAAAAJQAAACUAAAAAAAAAAAAAAAAAAAAAAAAAMAAAADEAAAArAAAAKwAAACsAAAArAAAAMQAAADEAAAAxAAAAGAAAADEAAAAxAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAxAAAAMQAAADEAAAAxAAAAMQAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMQAAADEAAAAxAAAALwAAADEAAAAxAAAAGAAAABgAAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAMAAAADEAAAAxAAAALwAAAC8AAAAvAAAAMQAAADEAAAAxAAAAGAAAADEAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMQAAADEAAAAxAAAAMQAAADEAAAAYAAAAGAAAABgAAAAYAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMAAAADAAAAAxAAAAGAAAABgAAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAMQAAADEAAAAYAAAAGAAAABgAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAxAAAAMQAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAADAAAAAwAAAAMAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: -1,-1
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAADAAAAAwAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAAAAAAADAAAAAwAAAAAAAAADAAAAAwAAAAMAAAADAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMAAAADAAAAAxAAAAMQAAADEAAAAxAAAAMQAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAADEAAAAxAAAAMQAAABQAAAAxAAAAMQAAAC0AAAAtAAAALQAAAC0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAxAAAALwAAAC8AAAAUAAAAMQAAADEAAAAtAAAALQAAAC0AAAAtAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAxAAAALwAAAC8AAAAvAAAAFAAAADEAAAAxAAAAMQAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMQAAAC8AAAAvAAAALwAAABQAAAAUAAAAMQAAADEAAAAxAAAAMQAAADEAAAAAAAAAAAAAAAAAAAAAAAAAMAAAADEAAAAvAAAALwAAAC8AAAAUAAAAMQAAADEAAAAxAAAAMQAAADEAAAAxAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAxAAAAFAAAABQAAAAUAAAAFAAAADEAAAAxAAAAMQAAADEAAAAxAAAAMQAAAA==
+  - ind: 0,0
+    tiles: MQAAADEAAAArAAAAMQAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAtAAAAKwAAACsAAAAxAAAAMQAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAALQAAACsAAAArAAAAMQAAADEAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAC0AAAArAAAAKwAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAxAAAAKwAAADEAAAAxAAAAMQAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAKAAAACgAAAAoAAAAKAAAADEAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAACgAAAAoAAAAKAAAACgAAAAxAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAoAAAAKAAAACgAAAAoAAAAMQAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAMQAAADEAAAAtAAAAMQAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAADAAAAAxAAAALQAAADEAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAwAAAAMQAAADEAAAAxAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAMAAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAxAAAAMQAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAADEAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: 0,-1
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAADAAAAAAAAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAADEAAAAxAAAAMAAAADAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC0AAAAxAAAAMQAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtAAAAMQAAAC0AAAAtAAAAMQAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAADEAAAAxAAAAMQAAADEAAAAxAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAxAAAAMQAAADEAAAAxAAAAMQAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAMQAAADEAAAAxAAAAJQAAADEAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAADEAAAAxAAAAMQAAACUAAAAxAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+entities:
+- uid: 0
+  type: Grille
+  components:
+  - pos: 0.5,10.5
+    parent: 25
+    type: Transform
+- uid: 1
+  type: ReinforcedWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,12.5
+    parent: 25
+    type: Transform
+- uid: 2
+  type: AirlockExternal
+  components:
+  - pos: 3.5,10.5
+    parent: 25
+    type: Transform
+- uid: 3
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,4.5
+    parent: 25
+    type: Transform
+- uid: 4
+  type: WallShuttle
+  components:
+  - pos: 4.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 5
+  type: WallShuttle
+  components:
+  - pos: 2.5,10.5
+    parent: 25
+    type: Transform
+- uid: 6
+  type: WallShuttle
+  components:
+  - pos: 5.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 7
+  type: WallShuttle
+  components:
+  - pos: -9.5,1.5
+    parent: 25
+    type: Transform
+- uid: 8
+  type: WallShuttle
+  components:
+  - pos: -6.5,0.5
+    parent: 25
+    type: Transform
+- uid: 9
+  type: WallShuttle
+  components:
+  - pos: -7.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 10
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,14.5
+    parent: 25
+    type: Transform
+- uid: 11
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,0.5
+    parent: 25
+    type: Transform
+- uid: 12
+  type: WallReinforced
+  components:
+  - pos: -5.5,4.5
+    parent: 25
+    type: Transform
+- uid: 13
+  type: Grille
+  components:
+  - pos: 0.5,11.5
+    parent: 25
+    type: Transform
+- uid: 14
+  type: Grille
+  components:
+  - pos: -3.5,12.5
+    parent: 25
+    type: Transform
+- uid: 15
+  type: WallReinforced
+  components:
+  - pos: -3.5,5.5
+    parent: 25
+    type: Transform
+- uid: 16
+  type: Grille
+  components:
+  - pos: -0.5,11.5
+    parent: 25
+    type: Transform
+- uid: 17
+  type: Grille
+  components:
+  - pos: -4.5,12.5
+    parent: 25
+    type: Transform
+- uid: 18
+  type: WallShuttleDiagonal
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,-7.5
+    parent: 25
+    type: Transform
+- uid: 19
+  type: Table
+  components:
+  - pos: -1.5,11.5
+    parent: 25
+    type: Transform
+- uid: 20
+  type: ReinforcedWindow
+  components:
+  - pos: 0.5,11.5
+    parent: 25
+    type: Transform
+- uid: 21
+  type: WallShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -6.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 22
+  type: WallShuttle
+  components:
+  - pos: -10.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 23
+  type: WallShuttle
+  components:
+  - pos: -10.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 24
+  type: WallShuttle
+  components:
+  - pos: -10.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 25
+  components:
+  - pos: 2.2710133,-2.4148211
+    parent: null
+    type: Transform
+  - index: 0
+    type: MapGrid
+  - angularDamping: 100
+    linearDamping: 50
+    fixedRotation: False
+    bodyType: Dynamic
+    type: Physics
+  - fixtures: []
+    type: Fixtures
+  - gravityShakeSound: !type:SoundPathSpecifier
+      path: /Audio/Effects/alert.ogg
+    type: Gravity
+  - chunkCollection:
+      -1,0:
+        0:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -7,1
+        1:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -7,2
+        2:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -9,3
+        3:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -7,3
+        4:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -7,3
+        5:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -8,3
+        17:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -9,3
+        18:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -9,2
+        20:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -8,4
+        28:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -1,6
+        29:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -1,7
+        30:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -2,6
+        31:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -1,6
+        32:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -7,6
+        33:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -6,6
+        34:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -10,5
+        35:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -9,8
+        36:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -8,8
+        37:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -5,9
+        38:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -5,10
+        39:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -3,9
+        40:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -3,7
+        41:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -3,7
+        42:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -3,8
+        43:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -2,9
+        44:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -5,6
+        45:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -4,6
+        46:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -5,7
+        47:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -2,7
+        52:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -9,5
+        53:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -8,4
+        54:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -8,5
+        55:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -7,5
+        56:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -7,8
+        57:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -8,6
+        58:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -8,7
+        59:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -4,9
+        60:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -3,9
+        61:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -2,10
+        62:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -10,6
+        63:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -9,6
+        64:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -3,6
+        65:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -4,7
+        66:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -2,7
+        67:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -3,4
+        68:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -4,3
+        72:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -3,10
+        73:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -3,11
+        74:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -2,9
+        79:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -1,0
+        80:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -1,1
+        81:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -5,0
+        82:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -5,0
+        83:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -2,0
+        84:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -3,0
+        85:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -1,2
+        86:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -1,2
+        87:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -1,3
+        88:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -5,2
+        89:
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -9,1
+        90:
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -8,1
+        99:
+          angle: -1.5707963267948966 rad
+          color: '#FFFFFFFF'
+          id: WarningLine
+          coordinates: -9,1
+        100:
+          angle: -1.5707963267948966 rad
+          color: '#FFFFFFFF'
+          id: WarningLine
+          coordinates: -9,2
+        101:
+          angle: -1.5707963267948966 rad
+          color: '#FFFFFFFF'
+          id: WarningLine
+          coordinates: -9,3
+      0,0:
+        6:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 1,1
+        7:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 1,1
+        8:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 2,1
+        9:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 3,3
+        10:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: 3,1
+        11:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: 2,2
+        12:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 1,2
+        13:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 3,2
+        14:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 3,2
+        15:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 1,3
+        16:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 2,1
+        19:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 2,4
+        21:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 3,9
+        22:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 3,9
+        23:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 3,8
+        24:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 1,5
+        25:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 2,4
+        26:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 1,6
+        27:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: 0,6
+        48:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: 2,5
+        49:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: 3,5
+        50:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: 3,7
+        51:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: 2,3
+        69:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 3,6
+        70:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 4,5
+        71:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 1,7
+        75:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 3,7
+        76:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 4,6
+        77:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 4,7
+        78:
+          cleanable: True
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 3,6
+        102:
+          angle: 1.5707963267948966 rad
+          color: '#FFFFFFFF'
+          id: WarningLine
+          coordinates: 3,1
+        103:
+          angle: 1.5707963267948966 rad
+          color: '#FFFFFFFF'
+          id: WarningLine
+          coordinates: 3,2
+        104:
+          angle: 1.5707963267948966 rad
+          color: '#FFFFFFFF'
+          id: WarningLine
+          coordinates: 3,3
+        105:
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 1,7
+        106:
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: 3,6
+      -1,-1:
+        91:
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -7,-2
+        92:
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -7,-1
+        93:
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -9,-1
+        94:
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -8,-1
+        95:
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -7,-6
+        96:
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -10,-1
+        97:
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -7,-3
+        98:
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -6,-3
+        107:
+          color: '#FFFFFFFF'
+          id: DirtHeavy
+          coordinates: -9,-5
+        108:
+          color: '#FFFFFFFF'
+          id: DirtMedium
+          coordinates: -9,-4
+        109:
+          color: '#FFFFFFFF'
+          id: DirtLight
+          coordinates: -9,-3
+    type: DecalGrid
+  - tiles:
+      -5,-2: 0
+      -5,-1: 0
+      -4,-10: 1
+      -4,-4: 1
+      -4,-3: 0
+      -3,-11: 1
+      -3,-8: 0
+      -3,-7: 0
+      -3,-6: 0
+      -2,-11: 1
+      -2,-9: 0
+      -2,-8: 0
+      -2,-7: 0
+      -2,-6: 0
+      -2,-5: 0
+      -2,-4: 0
+      -2,-3: 0
+      -2,-1: 0
+      -1,-11: 1
+      -1,-9: 0
+      -1,-8: 0
+      -1,-7: 0
+      -1,-6: 0
+      -1,-5: 0
+      -1,-4: 0
+      -1,-3: 0
+      -1,-1: 0
+      -5,5: 0
+      -5,6: 0
+      -5,7: 0
+      -4,1: 0
+      -4,2: 0
+      -4,3: 0
+      -4,7: 0
+      -4,8: 0
+      -4,9: 0
+      -3,12: 1
+      -3,13: 1
+      -3,14: 1
+      -2,0: 0
+      -2,1: 0
+      -2,2: 0
+      -2,3: 0
+      -2,4: 0
+      -2,5: 0
+      -2,7: 0
+      -2,8: 0
+      -2,9: 0
+      -2,10: 0
+      -1,0: 0
+      -1,1: 0
+      -1,2: 0
+      -1,3: 0
+      -1,4: 0
+      -1,5: 0
+      -1,7: 0
+      -1,8: 0
+      -1,9: 0
+      -1,10: 0
+      -1,12: 0
+      -1,13: 0
+      -1,14: 0
+      0,-11: 1
+      0,-9: 0
+      0,-8: 0
+      0,-7: 0
+      0,-6: 0
+      0,-5: 0
+      0,-4: 0
+      0,-3: 0
+      1,-11: 1
+      1,-9: 0
+      1,-8: 0
+      1,-7: 0
+      1,-6: 0
+      1,-5: 0
+      1,-4: 0
+      1,-3: 0
+      1,-1: 0
+      2,-11: 1
+      2,-9: 0
+      2,-8: 0
+      2,-7: 0
+      2,-6: 0
+      2,-5: 0
+      2,-4: 0
+      2,-3: 0
+      2,-1: 0
+      3,-11: 1
+      3,-9: 0
+      3,-8: 0
+      3,-7: 0
+      3,-6: 0
+      3,-5: 0
+      3,-4: 0
+      3,-3: 0
+      3,-1: 0
+      4,-11: 1
+      4,-8: 0
+      4,-7: 0
+      4,-6: 0
+      5,-10: 1
+      5,-4: 0
+      5,-3: 0
+      6,-2: 1
+      6,-1: 1
+      0,7: 0
+      0,8: 0
+      0,9: 0
+      0,10: 0
+      0,12: 0
+      0,13: 0
+      0,14: 0
+      0,15: 0
+      1,0: 0
+      1,1: 0
+      1,2: 0
+      1,3: 0
+      1,4: 0
+      1,5: 0
+      1,7: 0
+      1,8: 0
+      1,9: 0
+      1,10: 0
+      1,12: 0
+      1,13: 0
+      1,14: 0
+      1,15: 0
+      2,0: 0
+      2,1: 0
+      2,2: 0
+      2,3: 0
+      2,4: 0
+      2,5: 0
+      2,7: 0
+      2,8: 0
+      2,9: 0
+      2,10: 0
+      2,12: 0
+      2,13: 0
+      2,14: 0
+      3,0: 0
+      3,1: 0
+      3,2: 0
+      3,3: 0
+      3,4: 0
+      3,5: 0
+      3,7: 0
+      3,8: 0
+      3,9: 0
+      3,10: 0
+      4,12: 1
+      4,13: 0
+      4,14: 1
+      5,1: 0
+      5,2: 0
+      5,3: 0
+      5,7: 0
+      5,8: 0
+      5,9: 1
+      6,1: 0
+      6,2: 2
+      6,3: 0
+      6,5: 0
+      6,6: 0
+      6,7: 0
+      0,17: 1
+      1,17: 1
+      2,17: 1
+      3,16: 1
+      -2,16: 1
+      -1,17: 1
+      -4,-9: 0
+      -4,-8: 0
+      -4,-7: 0
+      -4,-6: 0
+      -4,-5: 0
+      -3,-10: 0
+      -3,-9: 0
+      -3,-5: 0
+      -3,-4: 0
+      -3,-3: 0
+      -3,-2: 0
+      -3,-1: 0
+      -2,-10: 0
+      -2,-2: 0
+      -1,-10: 0
+      -1,-2: 0
+      -5,0: 0
+      -5,1: 0
+      -5,2: 0
+      -5,3: 0
+      -5,4: 0
+      -4,0: 0
+      -4,4: 0
+      -3,0: 0
+      -3,1: 0
+      -3,2: 0
+      -3,3: 0
+      -3,4: 0
+      -3,5: 0
+      -3,6: 0
+      -3,7: 0
+      -3,8: 0
+      -3,9: 0
+      -3,10: 0
+      -3,11: 0
+      -2,6: 0
+      -2,11: 0
+      -2,12: 0
+      -2,13: 0
+      -2,14: 0
+      -2,15: 0
+      -1,6: 0
+      -1,11: 0
+      -1,15: 0
+      0,-10: 0
+      0,-2: 0
+      0,-1: 0
+      1,-10: 0
+      1,-2: 0
+      2,-10: 0
+      2,-2: 0
+      3,-10: 0
+      3,-2: 0
+      4,-10: 0
+      4,-9: 0
+      4,-5: 0
+      4,-4: 0
+      4,-3: 0
+      4,-2: 0
+      4,-1: 0
+      5,-9: 0
+      5,-8: 0
+      5,-7: 0
+      5,-6: 0
+      5,-5: 0
+      0,0: 0
+      0,1: 0
+      0,2: 0
+      0,3: 0
+      0,4: 0
+      0,5: 0
+      0,6: 0
+      0,11: 0
+      1,6: 0
+      1,11: 0
+      2,6: 0
+      2,11: 0
+      2,15: 0
+      3,6: 0
+      3,11: 0
+      3,12: 0
+      3,13: 0
+      3,14: 0
+      3,15: 0
+      4,0: 0
+      4,1: 0
+      4,2: 0
+      4,3: 0
+      4,4: 0
+      4,5: 0
+      4,6: 0
+      4,7: 0
+      4,8: 0
+      4,9: 0
+      4,10: 0
+      4,11: 0
+      5,0: 0
+      5,4: 0
+      6,0: 0
+      6,4: 0
+      0,16: 0
+      1,16: 0
+      2,16: 0
+      -1,16: 0
+      -12,0: 0
+      -12,1: 0
+      -12,2: 3
+      -12,3: 0
+      -12,4: 0
+      -12,5: 0
+      -12,6: 0
+      -11,0: 0
+      -11,1: 0
+      -11,2: 0
+      -11,3: 0
+      -11,4: 0
+      -11,5: 0
+      -11,6: 0
+      -11,7: 0
+      -11,8: 0
+      -11,9: 0
+      -10,0: 0
+      -10,1: 0
+      -10,2: 0
+      -10,3: 0
+      -10,4: 0
+      -10,5: 0
+      -10,6: 0
+      -10,7: 0
+      -10,8: 0
+      -10,9: 0
+      -9,0: 0
+      -9,1: 0
+      -9,2: 0
+      -9,3: 0
+      -9,4: 0
+      -9,5: 0
+      -9,6: 0
+      -9,7: 0
+      -9,8: 0
+      -9,9: 0
+      -9,10: 0
+      -8,0: 0
+      -8,1: 0
+      -8,2: 0
+      -8,3: 0
+      -8,4: 0
+      -8,5: 0
+      -8,6: 0
+      -8,7: 0
+      -8,8: 0
+      -8,9: 0
+      -8,10: 0
+      -7,0: 0
+      -7,1: 0
+      -7,2: 0
+      -7,3: 0
+      -7,4: 0
+      -7,5: 0
+      -7,6: 0
+      -7,7: 0
+      -7,8: 0
+      -7,9: 0
+      -7,10: 0
+      -6,0: 0
+      -6,1: 0
+      -6,2: 0
+      -6,3: 0
+      -6,4: 0
+      -6,5: 0
+      -6,6: 0
+      -6,7: 0
+      -6,8: 0
+      -6,9: 0
+      -6,10: 0
+      -6,11: 0
+      -6,12: 0
+      -5,8: 0
+      -5,9: 0
+      -5,10: 0
+      -5,11: 0
+      -5,12: 0
+      -5,13: 0
+      -4,5: 0
+      -4,6: 0
+      -4,10: 0
+      -4,11: 0
+      -4,12: 0
+      -4,13: 0
+      -12,-2: 0
+      -12,-1: 0
+      -11,-9: 0
+      -11,-8: 0
+      -11,-7: 0
+      -11,-6: 0
+      -11,-5: 0
+      -11,-4: 0
+      -11,-3: 0
+      -11,-2: 0
+      -11,-1: 0
+      -10,-7: 0
+      -10,-6: 0
+      -10,-5: 0
+      -10,-4: 0
+      -10,-3: 0
+      -10,-2: 0
+      -10,-1: 0
+      -9,-7: 0
+      -9,-6: 0
+      -9,-5: 0
+      -9,-4: 0
+      -9,-3: 0
+      -9,-2: 0
+      -9,-1: 0
+      -8,-10: 0
+      -8,-9: 0
+      -8,-8: 0
+      -8,-7: 0
+      -8,-6: 0
+      -8,-5: 0
+      -8,-4: 0
+      -8,-3: 0
+      -8,-2: 0
+      -8,-1: 0
+      -7,-8: 0
+      -7,-7: 0
+      -7,-6: 0
+      -7,-5: 0
+      -7,-4: 0
+      -7,-3: 0
+      -7,-2: 0
+      -7,-1: 0
+      -6,-7: 0
+      -6,-6: 0
+      -6,-5: 0
+      -6,-4: 0
+      -6,-3: 0
+      -6,-2: 0
+      -6,-1: 0
+      -5,-8: 0
+      -5,-7: 0
+      -5,-6: 0
+      -5,-5: 0
+      -5,-4: 0
+      -5,-3: 0
+      -4,-2: 0
+      -4,-1: 0
+      -3,-12: 0
+      5,5: 0
+      5,6: 0
+      5,10: 0
+      5,-2: 0
+      5,-1: 0
+      -12,7: 0
+      -12,8: 0
+      -9,11: 0
+      -12,-4: 0
+      -12,-3: 0
+      -8,-11: 0
+      6,-4: 0
+      6,-3: 0
+    uniqueMixes:
+    - volume: 2500
+      temperature: 293.15
+      moles:
+      - 21.824879
+      - 82.10312
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      immutable: True
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 220.5375
+      moles:
+      - 16.36866
+      - 61.57734
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 220.53749
+      moles:
+      - 16.36866
+      - 61.57734
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    type: GridAtmosphere
+- uid: 26
+  type: WallShuttle
+  components:
+  - pos: -8.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 27
+  type: AirlockExternal
+  components:
+  - pos: -9.5,2.5
+    parent: 25
+    type: Transform
+- uid: 28
+  type: ComputerRadar
+  components:
+  - pos: -3.5,11.5
+    parent: 25
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 29
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,13.5
+    parent: 25
+    type: Transform
+- uid: 30
+  type: WallShuttle
+  components:
+  - pos: 0.5,7.5
+    parent: 25
+    type: Transform
+- uid: 31
+  type: Chair
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -1.5,9.5
+    parent: 25
+    type: Transform
+- uid: 32
+  type: WallShuttle
+  components:
+  - pos: -6.5,9.5
+    parent: 25
+    type: Transform
+- uid: 33
+  type: WallShuttleDiagonal
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -0.5,-7.5
+    parent: 25
+    type: Transform
+- uid: 34
+  type: ReinforcedWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,13.5
+    parent: 25
+    type: Transform
+- uid: 35
+  type: WallShuttle
+  components:
+  - pos: 5.5,8.5
+    parent: 25
+    type: Transform
+- uid: 36
+  type: Grille
+  components:
+  - pos: -4.5,11.5
+    parent: 25
+    type: Transform
+- uid: 37
+  type: WallShuttleDiagonal
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -10.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 38
+  type: WallShuttle
+  components:
+  - pos: -9.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 39
+  type: AirlockShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 6.5,2.5
+    parent: 25
+    type: Transform
+  - fixtures:
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 40
+  type: Grille
+  components:
+  - pos: 0.5,9.5
+    parent: 25
+    type: Transform
+- uid: 41
+  type: WallShuttle
+  components:
+  - pos: -6.5,4.5
+    parent: 25
+    type: Transform
+- uid: 42
+  type: WallShuttle
+  components:
+  - pos: -7.5,9.5
+    parent: 25
+    type: Transform
+- uid: 43
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,14.5
+    parent: 25
+    type: Transform
+- uid: 44
+  type: ComputerShuttleSyndie
+  components:
+  - desc: Used to pilot a pirate shuttle. Arrgh.
+    name: pirate shuttle console
+    type: MetaData
+  - pos: -2.5,11.5
+    parent: 25
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 45
+  type: ChairPilotSeat
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,10.5
+    parent: 25
+    type: Transform
+- uid: 46
+  type: ReinforcedWindow
+  components:
+  - pos: -4.5,11.5
+    parent: 25
+    type: Transform
+- uid: 47
+  type: Grille
+  components:
+  - pos: -5.5,11.5
+    parent: 25
+    type: Transform
+- uid: 48
+  type: WallReinforced
+  components:
+  - pos: -4.5,5.5
+    parent: 25
+    type: Transform
+- uid: 49
+  type: WallShuttle
+  components:
+  - pos: 1.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 50
+  type: ReinforcedWindow
+  components:
+  - pos: -4.5,12.5
+    parent: 25
+    type: Transform
+- uid: 51
+  type: ReinforcedWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,12.5
+    parent: 25
+    type: Transform
+- uid: 52
+  type: WallShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -5.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 53
+  type: WallShuttle
+  components:
+  - pos: 4.5,11.5
+    parent: 25
+    type: Transform
+- uid: 54
+  type: WallReinforced
+  components:
+  - pos: -5.5,5.5
+    parent: 25
+    type: Transform
+- uid: 55
+  type: GeneratorUranium
+  components:
+  - pos: 0.5,-1.5
+    parent: 25
+    type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 56
+  type: WallShuttle
+  components:
+  - pos: 3.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 57
+  type: WallShuttle
+  components:
+  - pos: 2.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 58
+  type: ReinforcedWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,14.5
+    parent: 25
+    type: Transform
+- uid: 59
+  type: WallReinforced
+  components:
+  - pos: -5.5,3.5
+    parent: 25
+    type: Transform
+- uid: 60
+  type: Grille
+  components:
+  - pos: -2.5,12.5
+    parent: 25
+    type: Transform
+- uid: 61
+  type: WallShuttle
+  components:
+  - pos: -9.5,9.5
+    parent: 25
+    type: Transform
+- uid: 62
+  type: WallShuttle
+  components:
+  - pos: 2.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 63
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 6.5,0.5
+    parent: 25
+    type: Transform
+- uid: 64
+  type: WallShuttle
+  components:
+  - pos: -9.5,8.5
+    parent: 25
+    type: Transform
+- uid: 65
+  type: WallShuttle
+  components:
+  - pos: -10.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 66
+  type: WallShuttle
+  components:
+  - pos: -9.5,0.5
+    parent: 25
+    type: Transform
+- uid: 67
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 1.5,0.5
+    parent: 25
+    type: Transform
+- uid: 68
+  type: WallReinforced
+  components:
+  - pos: -5.5,2.5
+    parent: 25
+    type: Transform
+- uid: 69
+  type: WallShuttle
+  components:
+  - pos: -5.5,-4.5
+    parent: 25
+    type: Transform
+- uid: 70
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,4.5
+    parent: 25
+    type: Transform
+- uid: 71
+  type: WallShuttle
+  components:
+  - pos: -5.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 72
+  type: WallShuttle
+  components:
+  - pos: -6.5,7.5
+    parent: 25
+    type: Transform
+- uid: 73
+  type: Table
+  components:
+  - pos: -0.5,10.5
+    parent: 25
+    type: Transform
+- uid: 74
+  type: WallShuttle
+  components:
+  - pos: 0.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 75
+  type: ReinforcedWindow
+  components:
+  - pos: 0.5,9.5
+    parent: 25
+    type: Transform
+- uid: 76
+  type: WallShuttle
+  components:
+  - pos: -0.5,8.5
+    parent: 25
+    type: Transform
+- uid: 77
+  type: AirlockShuttle
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -11.5,2.5
+    parent: 25
+    type: Transform
+  - fixtures:
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 78
+  type: WallShuttle
+  components:
+  - pos: -2.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 79
+  type: WallShuttle
+  components:
+  - pos: 5.5,5.5
+    parent: 25
+    type: Transform
+- uid: 80
+  type: WallShuttle
+  components:
+  - pos: -5.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 81
+  type: WallShuttle
+  components:
+  - pos: -0.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 82
+  type: WallShuttle
+  components:
+  - pos: 2.5,9.5
+    parent: 25
+    type: Transform
+- uid: 83
+  type: WallShuttle
+  components:
+  - pos: 5.5,6.5
+    parent: 25
+    type: Transform
+- uid: 84
+  type: WallShuttle
+  components:
+  - pos: 5.5,-3.5
+    parent: 25
+    type: Transform
+- uid: 85
+  type: WallShuttle
+  components:
+  - pos: -1.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 86
+  type: Catwalk
+  components:
+  - pos: 2.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 87
+  type: ReinforcedWindow
+  components:
+  - pos: 0.5,10.5
+    parent: 25
+    type: Transform
+- uid: 88
+  type: ReinforcedWindow
+  components:
+  - pos: -0.5,11.5
+    parent: 25
+    type: Transform
+- uid: 89
+  type: ReinforcedWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,14.5
+    parent: 25
+    type: Transform
+- uid: 90
+  type: WallShuttle
+  components:
+  - pos: -5.5,-3.5
+    parent: 25
+    type: Transform
+- uid: 91
+  type: Rack
+  components:
+  - pos: -0.5,1.5
+    parent: 25
+    type: Transform
+- uid: 92
+  type: Catwalk
+  components:
+  - pos: 2.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 93
+  type: WallShuttle
+  components:
+  - pos: -11.5,0.5
+    parent: 25
+    type: Transform
+- uid: 94
+  type: WallShuttle
+  components:
+  - pos: -11.5,1.5
+    parent: 25
+    type: Transform
+- uid: 95
+  type: WallShuttle
+  components:
+  - pos: -8.5,0.5
+    parent: 25
+    type: Transform
+- uid: 96
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 6.5,4.5
+    parent: 25
+    type: Transform
+- uid: 97
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 5.5,0.5
+    parent: 25
+    type: Transform
+- uid: 98
+  type: WallShuttleDiagonal
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 6.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 99
+  type: WallShuttle
+  components:
+  - pos: -3.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 100
+  type: WallReinforced
+  components:
+  - pos: 0.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 101
+  type: ReinforcedWindow
+  components:
+  - pos: -5.5,11.5
+    parent: 25
+    type: Transform
+- uid: 102
+  type: ReinforcedWindow
+  components:
+  - pos: -5.5,10.5
+    parent: 25
+    type: Transform
+- uid: 103
+  type: WallShuttle
+  components:
+  - pos: -3.5,8.5
+    parent: 25
+    type: Transform
+- uid: 104
+  type: WallReinforced
+  components:
+  - pos: -0.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 105
+  type: ReinforcedWindow
+  components:
+  - pos: -5.5,9.5
+    parent: 25
+    type: Transform
+- uid: 106
+  type: WallReinforced
+  components:
+  - pos: 0.5,0.5
+    parent: 25
+    type: Transform
+- uid: 107
+  type: WallShuttle
+  components:
+  - pos: -8.5,4.5
+    parent: 25
+    type: Transform
+- uid: 108
+  type: CableApcExtension
+  components:
+  - pos: -0.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 109
+  type: WallReinforced
+  components:
+  - pos: -1.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 110
+  type: WallReinforced
+  components:
+  - pos: -3.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 111
+  type: WallReinforced
+  components:
+  - pos: -5.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 112
+  type: WallReinforced
+  components:
+  - pos: -5.5,0.5
+    parent: 25
+    type: Transform
+- uid: 113
+  type: WallShuttle
+  components:
+  - pos: 5.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 114
+  type: WallShuttle
+  components:
+  - pos: -10.5,5.5
+    parent: 25
+    type: Transform
+- uid: 115
+  type: GasPipeStraight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 3.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 116
+  type: WallShuttle
+  components:
+  - pos: -9.5,3.5
+    parent: 25
+    type: Transform
+- uid: 117
+  type: WallShuttle
+  components:
+  - pos: -10.5,4.5
+    parent: 25
+    type: Transform
+- uid: 118
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,1.5
+    parent: 25
+    type: Transform
+- uid: 119
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,12.5
+    parent: 25
+    type: Transform
+- uid: 120
+  type: WallShuttle
+  components:
+  - pos: -10.5,7.5
+    parent: 25
+    type: Transform
+- uid: 121
+  type: WallShuttle
+  components:
+  - pos: -11.5,3.5
+    parent: 25
+    type: Transform
+- uid: 122
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 5.5,4.5
+    parent: 25
+    type: Transform
+- uid: 123
+  type: WallReinforced
+  components:
+  - pos: 0.5,5.5
+    parent: 25
+    type: Transform
+- uid: 124
+  type: WallReinforced
+  components:
+  - pos: -0.5,5.5
+    parent: 25
+    type: Transform
+- uid: 125
+  type: WallReinforced
+  components:
+  - pos: -1.5,5.5
+    parent: 25
+    type: Transform
+- uid: 126
+  type: WallShuttle
+  components:
+  - pos: -1.5,8.5
+    parent: 25
+    type: Transform
+- uid: 127
+  type: WallShuttle
+  components:
+  - pos: -8.5,9.5
+    parent: 25
+    type: Transform
+- uid: 128
+  type: WallShuttle
+  components:
+  - pos: -10.5,8.5
+    parent: 25
+    type: Transform
+- uid: 129
+  type: WallShuttle
+  components:
+  - pos: 4.5,8.5
+    parent: 25
+    type: Transform
+- uid: 130
+  type: WallShuttle
+  components:
+  - pos: 2.5,11.5
+    parent: 25
+    type: Transform
+- uid: 131
+  type: ReinforcedWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,13.5
+    parent: 25
+    type: Transform
+- uid: 132
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,12.5
+    parent: 25
+    type: Transform
+- uid: 133
+  type: WallShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 134
+  type: WallShuttle
+  components:
+  - pos: 0.5,8.5
+    parent: 25
+    type: Transform
+- uid: 135
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,0.5
+    parent: 25
+    type: Transform
+- uid: 136
+  type: WallShuttle
+  components:
+  - pos: -10.5,0.5
+    parent: 25
+    type: Transform
+- uid: 137
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 1.5,4.5
+    parent: 25
+    type: Transform
+- uid: 138
+  type: WallShuttle
+  components:
+  - pos: 4.5,9.5
+    parent: 25
+    type: Transform
+- uid: 139
+  type: WallShuttle
+  components:
+  - pos: -9.5,4.5
+    parent: 25
+    type: Transform
+- uid: 140
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 6.5,3.5
+    parent: 25
+    type: Transform
+- uid: 141
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 4.5,3.5
+    parent: 25
+    type: Transform
+- uid: 142
+  type: WallShuttle
+  components:
+  - pos: 5.5,7.5
+    parent: 25
+    type: Transform
+- uid: 143
+  type: AirlockExternal
+  components:
+  - pos: 4.5,2.5
+    parent: 25
+    type: Transform
+- uid: 144
+  type: WallShuttle
+  components:
+  - pos: -7.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 145
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,13.5
+    parent: 25
+    type: Transform
+- uid: 146
+  type: WallShuttle
+  components:
+  - pos: 2.5,8.5
+    parent: 25
+    type: Transform
+- uid: 147
+  type: ComputerPowerMonitoring
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,9.5
+    parent: 25
+    type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 148
+  type: WallReinforced
+  components:
+  - pos: -4.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 149
+  type: WallShuttle
+  components:
+  - pos: -5.5,8.5
+    parent: 25
+    type: Transform
+- uid: 150
+  type: Grille
+  components:
+  - pos: -5.5,9.5
+    parent: 25
+    type: Transform
+- uid: 151
+  type: ReinforcedWindow
+  components:
+  - pos: -3.5,12.5
+    parent: 25
+    type: Transform
+- uid: 152
+  type: ReinforcedWindow
+  components:
+  - pos: -2.5,12.5
+    parent: 25
+    type: Transform
+- uid: 153
+  type: ReinforcedWindow
+  components:
+  - pos: -1.5,12.5
+    parent: 25
+    type: Transform
+- uid: 154
+  type: WallReinforced
+  components:
+  - pos: 0.5,4.5
+    parent: 25
+    type: Transform
+- uid: 155
+  type: WallReinforced
+  components:
+  - pos: 0.5,3.5
+    parent: 25
+    type: Transform
+- uid: 156
+  type: WallReinforced
+  components:
+  - pos: 0.5,2.5
+    parent: 25
+    type: Transform
+- uid: 157
+  type: WallShuttle
+  components:
+  - pos: -4.5,8.5
+    parent: 25
+    type: Transform
+- uid: 158
+  type: WallShuttle
+  components:
+  - pos: -8.5,7.5
+    parent: 25
+    type: Transform
+- uid: 159
+  type: Grille
+  components:
+  - pos: -5.5,10.5
+    parent: 25
+    type: Transform
+- uid: 160
+  type: Grille
+  components:
+  - pos: -1.5,12.5
+    parent: 25
+    type: Transform
+- uid: 161
+  type: WallReinforced
+  components:
+  - pos: -5.5,1.5
+    parent: 25
+    type: Transform
+- uid: 162
+  type: ReinforcedWindow
+  components:
+  - pos: -0.5,12.5
+    parent: 25
+    type: Transform
+- uid: 163
+  type: WallReinforced
+  components:
+  - pos: 0.5,1.5
+    parent: 25
+    type: Transform
+- uid: 164
+  type: WallShuttle
+  components:
+  - pos: 5.5,-4.5
+    parent: 25
+    type: Transform
+- uid: 165
+  type: WallShuttle
+  components:
+  - pos: 1.5,8.5
+    parent: 25
+    type: Transform
+- uid: 166
+  type: WallShuttle
+  components:
+  - pos: 4.5,10.5
+    parent: 25
+    type: Transform
+- uid: 167
+  type: WallShuttle
+  components:
+  - pos: -10.5,6.5
+    parent: 25
+    type: Transform
+- uid: 168
+  type: WallShuttle
+  components:
+  - pos: -11.5,4.5
+    parent: 25
+    type: Transform
+- uid: 169
+  type: WallReinforced
+  components:
+  - pos: -2.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 170
+  type: WallShuttle
+  components:
+  - pos: -5.5,7.5
+    parent: 25
+    type: Transform
+- uid: 171
+  type: Grille
+  components:
+  - pos: -0.5,12.5
+    parent: 25
+    type: Transform
+- uid: 172
+  type: WallShuttle
+  components:
+  - pos: -10.5,-4.5
+    parent: 25
+    type: Transform
+- uid: 173
+  type: Table
+  components:
+  - pos: -7.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 174
+  type: WallShuttle
+  components:
+  - pos: -10.5,-3.5
+    parent: 25
+    type: Transform
+- uid: 175
+  type: Table
+  components:
+  - pos: -7.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 176
+  type: Table
+  components:
+  - pos: -7.5,-3.5
+    parent: 25
+    type: Transform
+- uid: 177
+  type: Table
+  components:
+  - pos: -7.5,-4.5
+    parent: 25
+    type: Transform
+- uid: 178
+  type: WallShuttle
+  components:
+  - pos: 3.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 179
+  type: WallShuttle
+  components:
+  - pos: 4.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 180
+  type: Thruster
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 181
+  type: WallShuttleDiagonal
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 6.5,7.5
+    parent: 25
+    type: Transform
+- uid: 182
+  type: Thruster
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -8.5,-6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 183
+  type: WallShuttleDiagonal
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -6.5,10.5
+    parent: 25
+    type: Transform
+- uid: 184
+  type: WallShuttleDiagonal
+  components:
+  - pos: -11.5,7.5
+    parent: 25
+    type: Transform
+- uid: 185
+  type: WallShuttleDiagonal
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 6.5,5.5
+    parent: 25
+    type: Transform
+- uid: 186
+  type: WallShuttleDiagonal
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -11.5,5.5
+    parent: 25
+    type: Transform
+- uid: 187
+  type: WallShuttleDiagonal
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -11.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 188
+  type: Thruster
+  components:
+  - pos: 1.5,9.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 189
+  type: Thruster
+  components:
+  - pos: -7.5,10.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 190
+  type: GasPipeBend
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 191
+  type: GasMixerFlipped
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 1.5,-3.5
+    parent: 25
+    type: Transform
+  - inletTwoConcentration: 0.22000003
+    inletOneConcentration: 0.78
+    type: GasMixer
+  - canCollide: False
+    type: Physics
+- uid: 192
+  type: WallShuttle
+  components:
+  - pos: 5.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 193
+  type: WallShuttleDiagonal
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 5.5,-6.5
+    parent: 25
+    type: Transform
+- uid: 194
+  type: ReinforcedPlasmaWindow
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 3.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 195
+  type: ReinforcedPlasmaWindow
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 3.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 196
+  type: GasPipeTJunction
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 197
+  type: GasPipeBend
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 2.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 198
+  type: GasPipeBend
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 199
+  type: GasPipeStraight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 1.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 200
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 6.5,1.5
+    parent: 25
+    type: Transform
+- uid: 201
+  type: GasPassiveVent
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 202
+  type: GasPassiveVent
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 203
+  type: GasPressurePump
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 1.5,-4.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 204
+  type: GasPressurePump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 205
+  type: GasPort
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 206
+  type: GasPort
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 1.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 207
+  type: NitrogenCanister
+  components:
+  - pos: 3.5,-3.5
+    parent: 25
+    type: Transform
+- uid: 208
+  type: OxygenCanister
+  components:
+  - pos: 1.5,-5.5
+    parent: 25
+    type: Transform
+- uid: 209
+  type: WallShuttle
+  components:
+  - pos: 5.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 210
+  type: StorageCanister
+  components:
+  - pos: 3.5,-4.5
+    parent: 25
+    type: Transform
+- uid: 211
+  type: GasPressurePump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 212
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -1.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 213
+  type: GasPipeTJunction
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -2.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 214
+  type: GasPipeBend
+  components:
+  - pos: -2.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 215
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -3.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 216
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -4.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 217
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -5.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 218
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -6.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 219
+  type: GasPipeBend
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -7.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 220
+  type: GasPipeTJunction
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -7.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 221
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -7.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 222
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -7.5,0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 223
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -7.5,1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 224
+  type: GasPipeTJunction
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -7.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 225
+  type: GasPipeStraight
+  components:
+  - pos: -7.5,3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 226
+  type: GasPipeStraight
+  components:
+  - pos: -7.5,4.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 227
+  type: GasPipeStraight
+  components:
+  - pos: -7.5,5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 228
+  type: GasPipeTJunction
+  components:
+  - pos: -7.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 229
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -6.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 230
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -5.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 231
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -4.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 232
+  type: GasPipeStraight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -3.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 233
+  type: GasPipeFourway
+  components:
+  - pos: -2.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 234
+  type: GasPipeTJunction
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,7.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 235
+  type: GasPipeStraight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -1.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 236
+  type: GasPipeStraight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -0.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 237
+  type: GasPipeStraight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 238
+  type: GasPipeStraight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 1.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 239
+  type: GasPipeTJunction
+  components:
+  - pos: 2.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 240
+  type: GasPipeStraight
+  components:
+  - pos: 2.5,5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 241
+  type: GasPipeStraight
+  components:
+  - pos: 2.5,4.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 242
+  type: GasPipeStraight
+  components:
+  - pos: 2.5,3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 243
+  type: GasVentPump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 244
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 245
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 246
+  type: GasPipeBend
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 247
+  type: GasPipeStraight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 3.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 248
+  type: GasPipeStraight
+  components:
+  - pos: -2.5,5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 249
+  type: GasPipeStraight
+  components:
+  - pos: -2.5,4.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 250
+  type: GasPipeStraight
+  components:
+  - pos: -2.5,3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 251
+  type: GasVentPump
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 252
+  type: GasVentPump
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -3.5,7.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 253
+  type: GasVentPump
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -8.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 254
+  type: GasVentPump
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 255
+  type: GasVentPump
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -8.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 256
+  type: Rack
+  components:
+  - pos: -6.5,2.5
+    parent: 25
+    type: Transform
+- uid: 257
+  type: GasVentPump
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -8.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 258
+  type: GasVentPump
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,-4.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 259
+  type: GasPipeStraight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,8.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 260
+  type: GasVentPump
+  components:
+  - pos: -2.5,9.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 261
+  type: SalternAPC
+  components:
+  - pos: -0.5,5.5
+    parent: 25
+    type: Transform
+- uid: 262
+  type: SalternAPC
+  components:
+  - pos: -9.5,0.5
+    parent: 25
+    type: Transform
+- uid: 263
+  type: SalternAPC
+  components:
+  - pos: 4.5,8.5
+    parent: 25
+    type: Transform
+- uid: 264
+  type: GeneratorWallmountAPU
+  components:
+  - pos: 3.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 265
+  type: GeneratorUranium
+  components:
+  - pos: -0.5,-1.5
+    parent: 25
+    type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 266
+  type: GeneratorUranium
+  components:
+  - pos: -1.5,-1.5
+    parent: 25
+    type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 267
+  type: SMESBasic
+  components:
+  - pos: -3.5,-1.5
+    parent: 25
+    type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 268
+  type: CableTerminal
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 269
+  type: CableHV
+  components:
+  - pos: -2.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 270
+  type: CableHV
+  components:
+  - pos: -1.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 271
+  type: CableHV
+  components:
+  - pos: -0.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 272
+  type: CableHV
+  components:
+  - pos: 0.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 273
+  type: CableHV
+  components:
+  - pos: 1.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 274
+  type: CableHV
+  components:
+  - pos: 1.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 275
+  type: CableHV
+  components:
+  - pos: 2.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 276
+  type: CableHV
+  components:
+  - pos: 3.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 277
+  type: SubstationBasic
+  components:
+  - pos: -4.5,-5.5
+    parent: 25
+    type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 278
+  type: SubstationBasic
+  components:
+  - pos: -9.5,7.5
+    parent: 25
+    type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 279
+  type: CableHV
+  components:
+  - pos: -3.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 280
+  type: CableHV
+  components:
+  - pos: -4.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 281
+  type: CableHV
+  components:
+  - pos: -4.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 282
+  type: CableHV
+  components:
+  - pos: -4.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 283
+  type: CableHV
+  components:
+  - pos: -4.5,-4.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 284
+  type: CableHV
+  components:
+  - pos: -4.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 285
+  type: CableHV
+  components:
+  - pos: -5.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 286
+  type: CableHV
+  components:
+  - pos: -6.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 287
+  type: CableHV
+  components:
+  - pos: -7.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 288
+  type: CableHV
+  components:
+  - pos: -7.5,-1.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 289
+  type: CableHV
+  components:
+  - pos: -7.5,-0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 290
+  type: CableHV
+  components:
+  - pos: -7.5,0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 291
+  type: CableHV
+  components:
+  - pos: -7.5,1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 292
+  type: CableHV
+  components:
+  - pos: -7.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 293
+  type: CableHV
+  components:
+  - pos: -7.5,3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 294
+  type: CableHV
+  components:
+  - pos: -7.5,4.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 295
+  type: CableHV
+  components:
+  - pos: -7.5,5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 296
+  type: CableHV
+  components:
+  - pos: -8.5,5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 297
+  type: CableHV
+  components:
+  - pos: -9.5,5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 298
+  type: CableHV
+  components:
+  - pos: -9.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 299
+  type: CableHV
+  components:
+  - pos: -9.5,7.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 300
+  type: CableMV
+  components:
+  - pos: -4.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 301
+  type: CableMV
+  components:
+  - pos: -4.5,-4.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 302
+  type: CableMV
+  components:
+  - pos: -4.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 303
+  type: CableMV
+  components:
+  - pos: -4.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 304
+  type: CableMV
+  components:
+  - pos: -5.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 305
+  type: CableMV
+  components:
+  - pos: -6.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 306
+  type: CableMV
+  components:
+  - pos: -7.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 307
+  type: CableMV
+  components:
+  - pos: -8.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 308
+  type: CableMV
+  components:
+  - pos: -9.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 309
+  type: CableMV
+  components:
+  - pos: -9.5,-1.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 310
+  type: CableMV
+  components:
+  - pos: -9.5,-0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 311
+  type: CableMV
+  components:
+  - pos: -9.5,0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 312
+  type: CableMV
+  components:
+  - pos: -9.5,7.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 313
+  type: CableMV
+  components:
+  - pos: -9.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 314
+  type: CableMV
+  components:
+  - pos: -8.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 315
+  type: CableMV
+  components:
+  - pos: -7.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 316
+  type: CableMV
+  components:
+  - pos: -6.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 317
+  type: CableMV
+  components:
+  - pos: -5.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 318
+  type: CableMV
+  components:
+  - pos: -4.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 319
+  type: CableMV
+  components:
+  - pos: -3.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 320
+  type: CableMV
+  components:
+  - pos: -2.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 321
+  type: CableMV
+  components:
+  - pos: -1.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 322
+  type: CableMV
+  components:
+  - pos: -0.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 323
+  type: CableMV
+  components:
+  - pos: -0.5,5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 324
+  type: CableMV
+  components:
+  - pos: 0.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 325
+  type: CableMV
+  components:
+  - pos: 1.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 326
+  type: CableMV
+  components:
+  - pos: 2.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 327
+  type: CableMV
+  components:
+  - pos: 2.5,7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 328
+  type: CableMV
+  components:
+  - pos: 3.5,7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 329
+  type: CableMV
+  components:
+  - pos: 4.5,7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 330
+  type: CableMV
+  components:
+  - pos: 4.5,8.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 331
+  type: SalternAPC
+  components:
+  - pos: 0.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 332
+  type: CableMV
+  components:
+  - pos: -3.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 333
+  type: CableMV
+  components:
+  - pos: -2.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 334
+  type: CableMV
+  components:
+  - pos: -1.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 335
+  type: CableMV
+  components:
+  - pos: -0.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 336
+  type: CableMV
+  components:
+  - pos: 0.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 337
+  type: CableMV
+  components:
+  - pos: 0.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 338
+  type: CableMV
+  components:
+  - pos: 0.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 339
+  type: CableApcExtension
+  components:
+  - pos: -0.5,5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 340
+  type: CableApcExtension
+  components:
+  - pos: -0.5,4.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 341
+  type: CableApcExtension
+  components:
+  - pos: -1.5,4.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 342
+  type: CableApcExtension
+  components:
+  - pos: -2.5,4.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 343
+  type: CableApcExtension
+  components:
+  - pos: -2.5,3.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 344
+  type: CableApcExtension
+  components:
+  - pos: -2.5,2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 345
+  type: CableApcExtension
+  components:
+  - pos: -2.5,1.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 346
+  type: CableApcExtension
+  components:
+  - pos: -2.5,0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 347
+  type: CableApcExtension
+  components:
+  - pos: -3.5,2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 348
+  type: CableApcExtension
+  components:
+  - pos: -1.5,2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 349
+  type: CableApcExtension
+  components:
+  - pos: -4.5,2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 350
+  type: CableApcExtension
+  components:
+  - pos: -0.5,2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 351
+  type: CableApcExtension
+  components:
+  - pos: 4.5,8.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 352
+  type: CableApcExtension
+  components:
+  - pos: 4.5,7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 353
+  type: CableApcExtension
+  components:
+  - pos: 4.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 354
+  type: CableApcExtension
+  components:
+  - pos: 3.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 355
+  type: CableApcExtension
+  components:
+  - pos: 3.5,8.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 356
+  type: CableApcExtension
+  components:
+  - pos: 3.5,9.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 357
+  type: CableApcExtension
+  components:
+  - pos: 3.5,10.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 358
+  type: CableApcExtension
+  components:
+  - pos: 3.5,11.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 359
+  type: CableApcExtension
+  components:
+  - pos: 3.5,12.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 360
+  type: CableApcExtension
+  components:
+  - pos: 3.5,13.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 361
+  type: AirlockShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,14.5
+    parent: 25
+    type: Transform
+  - fixtures:
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 362
+  type: CableApcExtension
+  components:
+  - pos: 2.5,5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 363
+  type: CableApcExtension
+  components:
+  - pos: 2.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 364
+  type: CableApcExtension
+  components:
+  - pos: 2.5,4.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 365
+  type: CableApcExtension
+  components:
+  - pos: 2.5,3.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 366
+  type: CableApcExtension
+  components:
+  - pos: 2.5,2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 367
+  type: CableApcExtension
+  components:
+  - pos: 3.5,2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 368
+  type: CableApcExtension
+  components:
+  - pos: 5.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 369
+  type: CableApcExtension
+  components:
+  - pos: 4.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 370
+  type: CableApcExtension
+  components:
+  - pos: 2.5,1.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 371
+  type: CableApcExtension
+  components:
+  - pos: -1.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 372
+  type: CableApcExtension
+  components:
+  - pos: -2.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 373
+  type: CableApcExtension
+  components:
+  - pos: -3.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 374
+  type: CableApcExtension
+  components:
+  - pos: -4.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 375
+  type: CableApcExtension
+  components:
+  - pos: -2.5,7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 376
+  type: CableApcExtension
+  components:
+  - pos: -2.5,8.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 377
+  type: CableApcExtension
+  components:
+  - pos: -2.5,9.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 378
+  type: CableApcExtension
+  components:
+  - pos: -2.5,10.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 379
+  type: CableApcExtension
+  components:
+  - pos: -2.5,11.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 380
+  type: CableApcExtension
+  components:
+  - pos: -3.5,9.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 381
+  type: CableApcExtension
+  components:
+  - pos: -4.5,9.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 382
+  type: CableApcExtension
+  components:
+  - pos: -1.5,9.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 383
+  type: CableApcExtension
+  components:
+  - pos: -0.5,9.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 384
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 385
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 386
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 387
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 388
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 389
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 390
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 391
+  type: CableApcExtension
+  components:
+  - pos: -0.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 392
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 393
+  type: CableApcExtension
+  components:
+  - pos: -2.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 394
+  type: CableApcExtension
+  components:
+  - pos: -3.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 395
+  type: CableApcExtension
+  components:
+  - pos: -4.5,-2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 396
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 397
+  type: CableApcExtension
+  components:
+  - pos: -9.5,0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 398
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-4.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 399
+  type: CableApcExtension
+  components:
+  - pos: 0.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 400
+  type: CableApcExtension
+  components:
+  - pos: -0.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 401
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 402
+  type: CableApcExtension
+  components:
+  - pos: -2.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 403
+  type: CableApcExtension
+  components:
+  - pos: -3.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 404
+  type: CableApcExtension
+  components:
+  - pos: -4.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 405
+  type: CableApcExtension
+  components:
+  - pos: 1.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 406
+  type: CableApcExtension
+  components:
+  - pos: -9.5,-0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 407
+  type: CableApcExtension
+  components:
+  - pos: -8.5,-0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 408
+  type: CableApcExtension
+  components:
+  - pos: -7.5,-0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 409
+  type: CableApcExtension
+  components:
+  - pos: -7.5,-1.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 410
+  type: CableApcExtension
+  components:
+  - pos: -7.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 411
+  type: CableApcExtension
+  components:
+  - pos: -7.5,-3.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 412
+  type: CableApcExtension
+  components:
+  - pos: -7.5,-4.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 413
+  type: CableApcExtension
+  components:
+  - pos: -6.5,-2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 414
+  type: CableApcExtension
+  components:
+  - pos: -7.5,0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 415
+  type: CableApcExtension
+  components:
+  - pos: -7.5,1.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 416
+  type: CableApcExtension
+  components:
+  - pos: -7.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 417
+  type: CableApcExtension
+  components:
+  - pos: -7.5,3.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 418
+  type: CableApcExtension
+  components:
+  - pos: -8.5,2.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 419
+  type: CableApcExtension
+  components:
+  - pos: -9.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 420
+  type: CableApcExtension
+  components:
+  - pos: -10.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 421
+  type: CableApcExtension
+  components:
+  - pos: -7.5,4.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 422
+  type: CableApcExtension
+  components:
+  - pos: -7.5,5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 423
+  type: CableApcExtension
+  components:
+  - pos: -7.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 424
+  type: CableApcExtension
+  components:
+  - pos: -6.5,6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 425
+  type: CableApcExtension
+  components:
+  - pos: -7.5,7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 426
+  type: CableApcExtension
+  components:
+  - pos: -7.5,8.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 427
+  type: CableApcExtension
+  components:
+  - pos: -8.5,5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 428
+  type: CableApcExtension
+  components:
+  - pos: -9.5,5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 429
+  type: CableApcExtension
+  components:
+  - pos: 1.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 430
+  type: CableApcExtension
+  components:
+  - pos: 1.5,7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 431
+  type: CableApcExtension
+  components:
+  - pos: 1.5,8.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 432
+  type: CableApcExtension
+  components:
+  - pos: 4.5,5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 433
+  type: CableApcExtension
+  components:
+  - pos: 5.5,5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 434
+  type: CableApcExtension
+  components:
+  - pos: -7.5,9.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 435
+  type: CableApcExtension
+  components:
+  - pos: -10.5,5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 436
+  type: CableApcExtension
+  components:
+  - pos: -10.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 437
+  type: CableApcExtension
+  components:
+  - pos: -7.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 438
+  type: CableApcExtension
+  components:
+  - pos: -8.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 439
+  type: CableApcExtension
+  components:
+  - pos: -9.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 440
+  type: CableApcExtension
+  components:
+  - pos: 2.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 441
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 442
+  type: CableApcExtension
+  components:
+  - pos: 4.5,-5.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 443
+  type: CableApcExtension
+  components:
+  - pos: 3.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 444
+  type: CableApcExtension
+  components:
+  - pos: 4.5,-0.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 445
+  type: CableApcExtension
+  components:
+  - pos: 5.5,-0.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 446
+  type: PoweredSmallLight
+  components:
+  - pos: 0.5,-1.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 447
+  type: PoweredSmallLight
+  components:
+  - pos: -2.5,-1.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 448
+  type: PoweredSmallLight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -9.5,-0.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 449
+  type: PoweredSmallLight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -7.5,-4.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 450
+  type: PoweredSmallLight
+  components:
+  - pos: -10.5,3.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 451
+  type: PoweredSmallLight
+  components:
+  - pos: 5.5,3.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 452
+  type: PoweredSmallLight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,3.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 453
+  type: PoweredSmallLight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -8.5,3.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 454
+  type: PoweredSmallLight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,9.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 455
+  type: PoweredSmallLight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -0.5,9.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 456
+  type: PoweredSmallLight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,2.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 457
+  type: PoweredSmallLight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,2.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 458
+  type: PoweredSmallLight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,0.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 459
+  type: PoweredSmallLight
+  components:
+  - pos: 2.5,7.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 460
+  type: PoweredSmallLight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,6.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 461
+  type: PoweredSmallLight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,11.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 462
+  type: PoweredSmallLight
+  components:
+  - pos: -7.5,8.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 463
+  type: PoweredSmallLight
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -9.5,6.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 464
+  type: PoweredSmallLight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -6.5,5.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 465
+  type: PoweredSmallLight
+  components:
+  - pos: -4.5,7.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 466
+  type: PoweredSmallLight
+  components:
+  - pos: -0.5,7.5
+    parent: 25
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - enabled: False
+    type: AmbientSound
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 467
+  type: Gyroscope
+  components:
+  - pos: -2.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 468
+  type: Gyroscope
+  components:
+  - pos: -1.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 469
+  type: Gyroscope
+  components:
+  - pos: -3.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 470
+  type: Table
+  components:
+  - pos: -9.5,-3.5
+    parent: 25
+    type: Transform
+- uid: 471
+  type: StoolBar
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -6.5,-3.5
+    parent: 25
+    type: Transform
+- uid: 472
+  type: StoolBar
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -6.5,-4.5
+    parent: 25
+    type: Transform
+- uid: 473
+  type: StoolBar
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -6.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 474
+  type: StoolBar
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -6.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 475
+  type: Table
+  components:
+  - pos: -9.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 476
+  type: Table
+  components:
+  - pos: -9.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 477
+  type: soda_dispenser
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -9.5,-2.5
+    parent: 25
+    type: Transform
+  - containers:
+      ReagentDispenser-beaker: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 478
+  type: BoozeDispenser
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -9.5,-3.5
+    parent: 25
+    type: Transform
+  - containers:
+      ReagentDispenser-beaker: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 479
+  type: AirlockEngineering
+  components:
+  - pos: -5.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 480
+  type: AirlockEngineering
+  components:
+  - pos: 2.5,0.5
+    parent: 25
+    type: Transform
+- uid: 481
+  type: AirlockCommand
+  components:
+  - pos: -2.5,8.5
+    parent: 25
+    type: Transform
+- uid: 482
+  type: AirlockCommand
+  components:
+  - pos: -2.5,5.5
+    parent: 25
+    type: Transform
+- uid: 483
+  type: Airlock
+  components:
+  - pos: -7.5,7.5
+    parent: 25
+    type: Transform
+- uid: 484
+  type: AirlockGlass
+  components:
+  - pos: -7.5,0.5
+    parent: 25
+    type: Transform
+- uid: 485
+  type: AirlockMedicalGlass
+  components:
+  - pos: 0.5,6.5
+    parent: 25
+    type: Transform
+- uid: 486
+  type: AirlockMedicalGlass
+  components:
+  - pos: 2.5,4.5
+    parent: 25
+    type: Transform
+- uid: 487
+  type: AirlockGlass
+  components:
+  - pos: -7.5,4.5
+    parent: 25
+    type: Transform
+- uid: 488
+  type: AirlockGlass
+  components:
+  - pos: -5.5,6.5
+    parent: 25
+    type: Transform
+- uid: 489
+  type: Grille
+  components:
+  - pos: 3.5,-1.5
+    parent: 25
+    type: Transform
+- uid: 490
+  type: Grille
+  components:
+  - pos: 3.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 491
+  type: Catwalk
+  components:
+  - pos: 2.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 492
+  type: Catwalk
+  components:
+  - pos: 1.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 493
+  type: Catwalk
+  components:
+  - pos: 0.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 494
+  type: Catwalk
+  components:
+  - pos: -0.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 495
+  type: Catwalk
+  components:
+  - pos: -1.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 496
+  type: Catwalk
+  components:
+  - pos: -2.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 497
+  type: Catwalk
+  components:
+  - pos: -3.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 498
+  type: Catwalk
+  components:
+  - pos: -4.5,-2.5
+    parent: 25
+    type: Transform
+- uid: 499
+  type: Catwalk
+  components:
+  - pos: 3.5,11.5
+    parent: 25
+    type: Transform
+- uid: 500
+  type: Catwalk
+  components:
+  - pos: 3.5,12.5
+    parent: 25
+    type: Transform
+- uid: 501
+  type: Catwalk
+  components:
+  - pos: 3.5,13.5
+    parent: 25
+    type: Transform
+- uid: 502
+  type: Catwalk
+  components:
+  - pos: 5.5,2.5
+    parent: 25
+    type: Transform
+- uid: 503
+  type: Catwalk
+  components:
+  - pos: -10.5,2.5
+    parent: 25
+    type: Transform
+- uid: 504
+  type: Catwalk
+  components:
+  - pos: -7.5,1.5
+    parent: 25
+    type: Transform
+- uid: 505
+  type: GasPipeTJunction
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 2.5,2.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - enabled: False
+    type: AmbientSound
+- uid: 506
+  type: Catwalk
+  components:
+  - pos: -7.5,3.5
+    parent: 25
+    type: Transform
+- uid: 507
+  type: Catwalk
+  components:
+  - pos: -6.5,6.5
+    parent: 25
+    type: Transform
+- uid: 508
+  type: Catwalk
+  components:
+  - pos: -7.5,6.5
+    parent: 25
+    type: Transform
+- uid: 509
+  type: Catwalk
+  components:
+  - pos: -8.5,6.5
+    parent: 25
+    type: Transform
+- uid: 510
+  type: Catwalk
+  components:
+  - pos: -9.5,6.5
+    parent: 25
+    type: Transform
+- uid: 511
+  type: DrinkShaker
+  components:
+  - pos: -9.676509,-1.6372542
+    parent: 25
+    type: Transform
+  - solution: drink
+    type: DrainableSolution
+- uid: 512
+  type: DrinkWineBottleFull
+  components:
+  - pos: -9.720953,-1.2651272
+    parent: 25
+    type: Transform
+- uid: 513
+  type: DrinkCognacBottleFull
+  components:
+  - pos: -9.455328,-1.4370022
+    parent: 25
+    type: Transform
+- uid: 514
+  type: DrinkBottleAle
+  components:
+  - pos: -9.517828,-1.2026272
+    parent: 25
+    type: Transform
+  - solution: drink
+    type: RefillableSolution
+  - solution: drink
+    type: DrainableSolution
+- uid: 515
+  type: Thruster
+  components:
+  - pos: 5.5,9.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 516
+  type: VendingMachineCigs
+  components:
+  - name: cigarette machine
+    type: MetaData
+  - pos: -6.5,-5.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 517
+  type: Sink
+  components:
+  - pos: -9.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 518
+  type: Lighter
+  components:
+  - pos: -7.3640995,-4.4362655
+    parent: 25
+    type: Transform
+- uid: 519
+  type: ClosetEmergencyFilledRandom
+  components:
+  - pos: -10.5,3.5
+    parent: 25
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 520
+  type: ClosetEmergencyFilledRandom
+  components:
+  - pos: 5.5,3.5
+    parent: 25
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 521
+  type: OxygenCanister
+  components:
+  - pos: -10.5,1.5
+    parent: 25
+    type: Transform
+- uid: 522
+  type: OxygenCanister
+  components:
+  - pos: 5.5,1.5
+    parent: 25
+    type: Transform
+- uid: 523
+  type: Rack
+  components:
+  - pos: -4.5,1.5
+    parent: 25
+    type: Transform
+- uid: 524
+  type: Rack
+  components:
+  - pos: -4.5,2.5
+    parent: 25
+    type: Transform
+- uid: 525
+  type: Rack
+  components:
+  - pos: -0.5,2.5
+    parent: 25
+    type: Transform
+- uid: 526
+  type: ClothingOuterHardsuitEVA
+  components:
+  - pos: -4.5551305,1.5432775
+    parent: 25
+    type: Transform
+- uid: 527
+  type: ClothingOuterHardsuitEVA
+  components:
+  - pos: -4.5238805,2.6057775
+    parent: 25
+    type: Transform
+- uid: 528
+  type: ClothingOuterHardsuitEVA
+  components:
+  - pos: -0.49263048,1.5589025
+    parent: 25
+    type: Transform
+- uid: 529
+  type: ClothingOuterHardsuitEVA
+  components:
+  - pos: -0.46138048,2.5589025
+    parent: 25
+    type: Transform
+- uid: 530
+  type: ClothingHeadHelmetEVA
+  components:
+  - pos: -4.6801305,2.4964025
+    parent: 25
+    type: Transform
+- uid: 531
+  type: ClothingHeadHelmetEVA
+  components:
+  - pos: -4.6488805,1.4807775
+    parent: 25
+    type: Transform
+- uid: 532
+  type: ClothingHeadHelmetEVA
+  components:
+  - pos: -0.5707555,1.4339025
+    parent: 25
+    type: Transform
+- uid: 533
+  type: ClothingHeadHelmetEVA
+  components:
+  - pos: -0.5863805,2.4964025
+    parent: 25
+    type: Transform
+- uid: 534
+  type: Table
+  components:
+  - pos: -4.5,3.5
+    parent: 25
+    type: Transform
+- uid: 535
+  type: Table
+  components:
+  - pos: -4.5,4.5
+    parent: 25
+    type: Transform
+- uid: 536
+  type: Table
+  components:
+  - pos: -3.5,4.5
+    parent: 25
+    type: Transform
+- uid: 537
+  type: SpaceCash
+  components:
+  - pos: -4.2487273,4.740372
+    parent: 25
+    type: Transform
+- uid: 538
+  type: SpaceCash
+  components:
+  - pos: -4.3268523,4.521622
+    parent: 25
+    type: Transform
+- uid: 539
+  type: WeaponCapacitorRecharger
+  components:
+  - pos: -3.5,4.5
+    parent: 25
+    type: Transform
+  - fixtures: []
+    type: Fixtures
+  - containers:
+      charger-slot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 540
+  type: Table
+  components:
+  - pos: -0.5,3.5
+    parent: 25
+    type: Transform
+- uid: 541
+  type: ShotgunDB
+  components:
+  - pos: -0.54232633,3.6617234
+    parent: 25
+    type: Transform
+  - containers:
+      Content.Server.Weapon.Ranged.Barrels.Components.BoltActionBarrelComponent-ammo-container: !type:Container
+        ents: []
+      Content.Server.Weapon.Ranged.Barrels.Components.BoltActionBarrelComponent-chamber-container: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 542
+  type: ShellShotgunSlug
+  components:
+  - pos: -0.27670133,3.4585984
+    parent: 25
+    type: Transform
+- uid: 543
+  type: ShellShotgunSlug
+  components:
+  - pos: -0.43295133,3.4898484
+    parent: 25
+    type: Transform
+- uid: 544
+  type: CratePrivateSecure
+  components:
+  - pos: -0.5,4.5
+    parent: 25
+    type: Transform
+  - locked: False
+    type: Lock
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+    - EntityStorageComponent
+    type: Construction
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+      PaperLabel: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 545
+  type: Table
+  components:
+  - pos: -4.5,0.5
+    parent: 25
+    type: Transform
+- uid: 546
+  type: Table
+  components:
+  - pos: -3.5,0.5
+    parent: 25
+    type: Transform
+- uid: 547
+  type: Table
+  components:
+  - pos: -0.5,0.5
+    parent: 25
+    type: Transform
+- uid: 548
+  type: Table
+  components:
+  - pos: -1.5,0.5
+    parent: 25
+    type: Transform
+- uid: 549
+  type: Bed
+  components:
+  - pos: -6.5,8.5
+    parent: 25
+    type: Transform
+- uid: 550
+  type: BedsheetBrown
+  components:
+  - pos: -6.5,8.5
+    parent: 25
+    type: Transform
+- uid: 551
+  type: TableWood
+  components:
+  - pos: -8.5,8.5
+    parent: 25
+    type: Transform
+- uid: 552
+  type: ChairWood
+  components:
+  - pos: -7.5,8.5
+    parent: 25
+    type: Transform
+- uid: 553
+  type: RevolverPirate
+  components:
+  - pos: -1.3154829,0.45411658
+    parent: 25
+    type: Transform
+- uid: 554
+  type: ClothingOuterCoatPirate
+  components:
+  - pos: -8.451058,8.571966
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 555
+  type: ClothingHeadHatPirate
+  components:
+  - pos: -8.482308,8.775091
+    parent: 25
+    type: Transform
+- uid: 556
+  type: LockerSyndicatePersonal
+  components:
+  - desc: A hardy closet for any good pirate.
+    name: pirate closet
+    type: MetaData
+  - pos: -2.5,0.5
+    parent: 25
+    type: Transform
+  - isPlaceable: False
+    type: PlaceableSurface
+  - containers:
+      EntityStorageComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 557
+  type: DrinkWhiskeyBottleFull
+  components:
+  - pos: -7.6487703,-3.1932058
+    parent: 25
+    type: Transform
+- uid: 558
+  type: DrinkGlass
+  components:
+  - pos: -7.3675203,-2.6619558
+    parent: 25
+    type: Transform
+  - solution: drink
+    type: DrainableSolution
+- uid: 559
+  type: DrinkGlass
+  components:
+  - pos: -7.4925203,-2.2557058
+    parent: 25
+    type: Transform
+  - solution: drink
+    type: DrainableSolution
+- uid: 560
+  type: DrinkGlass
+  components:
+  - pos: -7.2581453,-1.2869558
+    parent: 25
+    type: Transform
+  - solution: drink
+    type: DrainableSolution
+- uid: 561
+  type: WeldingFuelTankFull
+  components:
+  - pos: -6.5,1.5
+    parent: 25
+    type: Transform
+- uid: 562
+  type: WaterTankFull
+  components:
+  - pos: 1.5,1.5
+    parent: 25
+    type: Transform
+- uid: 563
+  type: RevolverPirate
+  components:
+  - pos: -0.560128,0.743088
+    parent: 25
+    type: Transform
+- uid: 564
+  type: RevolverPirate
+  components:
+  - pos: -0.560128,0.461838
+    parent: 25
+    type: Transform
+- uid: 565
+  type: SpaceCash
+  components:
+  - pos: -4.3893523,4.255997
+    parent: 25
+    type: Transform
+- uid: 566
+  type: PosterContrabandRedRum
+  components:
+  - pos: -5.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 567
+  type: DrinkBottleRum
+  components:
+  - pos: -3.3236163,0.66330457
+    parent: 25
+    type: Transform
+  - solution: drink
+    type: RefillableSolution
+  - solution: drink
+    type: DrainableSolution
+- uid: 568
+  type: DrinkBottleRum
+  components:
+  - pos: -3.6204913,0.72580457
+    parent: 25
+    type: Transform
+  - solution: drink
+    type: RefillableSolution
+  - solution: drink
+    type: DrainableSolution
+- uid: 569
+  type: DrinkBottleRum
+  components:
+  - pos: -3.4798663,0.83517957
+    parent: 25
+    type: Transform
+  - solution: drink
+    type: RefillableSolution
+  - solution: drink
+    type: DrainableSolution
+- uid: 570
+  type: WeaponCapacitorRecharger
+  components:
+  - pos: -1.4965465,11.554127
+    parent: 25
+    type: Transform
+  - fixtures: []
+    type: Fixtures
+  - containers:
+      charger-slot: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 571
+  type: RollerBed
+  components:
+  - pos: 4.360234,6.581131
+    parent: 25
+    type: Transform
+- uid: 572
+  type: Table
+  components:
+  - pos: 4.5,5.5
+    parent: 25
+    type: Transform
+- uid: 573
+  type: Table
+  components:
+  - pos: 3.5,5.5
+    parent: 25
+    type: Transform
+- uid: 574
+  type: Table
+  components:
+  - pos: 4.5,7.5
+    parent: 25
+    type: Transform
+- uid: 575
+  type: Table
+  components:
+  - pos: -4.5,7.5
+    parent: 25
+    type: Transform
+- uid: 576
+  type: Table
+  components:
+  - pos: -0.5,7.5
+    parent: 25
+    type: Transform
+- uid: 577
+  type: FireExtinguisher
+  components:
+  - pos: -4.625556,7.7085676
+    parent: 25
+    type: Transform
+- uid: 578
+  type: FireExtinguisher
+  components:
+  - pos: -4.391181,7.6616926
+    parent: 25
+    type: Transform
+- uid: 579
+  type: ToolboxEmergencyFilled
+  components:
+  - pos: -0.48493075,7.6148176
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 580
+  type: Pen
+  components:
+  - pos: -1.2349308,11.723301
+    parent: 25
+    type: Transform
+- uid: 581
+  type: CyberPen
+  components:
+  - pos: -3.2974308,4.700146
+    parent: 25
+    type: Transform
+- uid: 582
+  type: Table
+  components:
+  - pos: -8.5,5.5
+    parent: 25
+    type: Transform
+- uid: 583
+  type: ChairOfficeDark
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -9.5,5.5
+    parent: 25
+    type: Transform
+- uid: 584
+  type: ChairOfficeLight
+  components:
+  - pos: -8.5,6.5
+    parent: 25
+    type: Transform
+- uid: 585
+  type: FoodTinBeans
+  components:
+  - pos: -8.617796,5.8602495
+    parent: 25
+    type: Transform
+- uid: 586
+  type: FoodTinMRE
+  components:
+  - pos: -8.367796,5.6102495
+    parent: 25
+    type: Transform
+- uid: 587
+  type: FoodTinPeaches
+  components:
+  - pos: -0.462291,10.781815
+    parent: 25
+    type: Transform
+- uid: 588
+  type: WelderMini
+  components:
+  - pos: -6.391465,2.47309
+    parent: 25
+    type: Transform
+- uid: 589
+  type: Rack
+  components:
+  - pos: -6.5,3.5
+    parent: 25
+    type: Transform
+- uid: 590
+  type: Catwalk
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -7.5,2.5
+    parent: 25
+    type: Transform
+- uid: 591
+  type: Rack
+  components:
+  - pos: 1.5,3.5
+    parent: 25
+    type: Transform
+- uid: 592
+  type: ClothingHeadHatWelding
+  components:
+  - pos: -6.50084,2.62934
+    parent: 25
+    type: Transform
+- uid: 593
+  type: ToolboxMechanicalFilled
+  components:
+  - pos: -6.485215,3.582465
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 594
+  type: MedkitOxygenFilled
+  components:
+  - pos: 4.579829,7.5955043
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 595
+  type: MedkitFilled
+  components:
+  - pos: 4.548579,5.6111293
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 596
+  type: ClothingHandsGlovesLatex
+  components:
+  - pos: 3.8298292,5.5017543
+    parent: 25
+    type: Transform
+- uid: 597
+  type: HandheldHealthAnalyzer
+  components:
+  - pos: 3.4609303,5.7205043
+    parent: 25
+    type: Transform
+- uid: 598
+  type: ClothingShoesBootsJack
+  components:
+  - pos: 1.4085763,7.6423793
+    parent: 25
+    type: Transform
+- uid: 599
+  type: ClothingShoesSlippers
+  components:
+  - pos: -7.1776752,8.294594
+    parent: 25
+    type: Transform
+- uid: 600
+  type: ChairPilotSeat
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,9.5
+    parent: 25
+    type: Transform
+- uid: 601
+  type: ChairPilotSeat
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,10.5
+    parent: 25
+    type: Transform
+- uid: 602
+  type: PosterContrabandRevolver
+  components:
+  - pos: 0.5,3.5
+    parent: 25
+    type: Transform
+- uid: 603
+  type: PosterContrabandShamblersJuice
+  components:
+  - pos: -9.5,-4.5
+    parent: 25
+    type: Transform
+- uid: 604
+  type: PosterContrabandSmoke
+  components:
+  - pos: -8.5,7.5
+    parent: 25
+    type: Transform
+- uid: 605
+  type: PosterBroken
+  components:
+  - pos: 2.5,8.5
+    parent: 25
+    type: Transform
+- uid: 606
+  type: PosterBroken
+  components:
+  - pos: -0.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 607
+  type: PosterContrabandUnreadableAnnouncement
+  components:
+  - pos: -1.4882443,-0.31776285
+    parent: 25
+    type: Transform
+- uid: 608
+  type: WallShuttleDiagonal
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 6.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 609
+  type: PosterLegit12Gauge
+  components:
+  - pos: -4.5,5.5
+    parent: 25
+    type: Transform
+- uid: 610
+  type: PosterLegitUeNo
+  components:
+  - pos: -9.5,3.5
+    parent: 25
+    type: Transform
+- uid: 611
+  type: Chair
+  components:
+  - pos: -1.5,7.5
+    parent: 25
+    type: Transform
+- uid: 612
+  type: Multitool
+  components:
+  - pos: 1.213983,3.589278
+    parent: 25
+    type: Transform
+- uid: 613
+  type: YellowOxygenTankFilled
+  components:
+  - pos: 1.432733,3.558028
+    parent: 25
+    type: Transform
+- uid: 614
+  type: YellowOxygenTankFilled
+  components:
+  - pos: 1.620233,3.495528
+    parent: 25
+    type: Transform
+- uid: 615
+  type: Rack
+  components:
+  - pos: 1.5,2.5
+    parent: 25
+    type: Transform
+- uid: 616
+  type: YellowOxygenTankFilled
+  components:
+  - pos: 1.4021807,2.5500863
+    parent: 25
+    type: Transform
+- uid: 617
+  type: RedOxygenTankFilled
+  components:
+  - pos: 1.6834307,2.5188363
+    parent: 25
+    type: Transform
+- uid: 618
+  type: ClothingBackpackDuffel
+  components:
+  - pos: -1.440954,0.8505888
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 619
+  type: ClothingBackpackDuffel
+  components:
+  - pos: -1.347204,4.569339
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 620
+  type: ClothingShoesBootsMag
+  components:
+  - pos: -1.4924707,1.4130888
+    parent: 25
+    type: Transform
+- uid: 621
+  type: ClothingHandsGlovesLeather
+  components:
+  - pos: 1.513545,-0.51127124
+    parent: 25
+    type: Transform
+- uid: 622
+  type: SpawnPointCaptain
+  components:
+  - pos: -3.5,9.5
+    parent: 25
+    type: Transform
+- uid: 623
+  type: WallShuttleDiagonal
+  components:
+  - pos: -11.5,-0.5
+    parent: 25
+    type: Transform
+- uid: 624
+  type: Thruster
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -11.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 625
+  type: Thruster
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -11.5,-1.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 626
+  type: Thruster
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 6.5,-1.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 627
+  type: Thruster
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 6.5,6.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 628
+  type: Thruster
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -3.5,-7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 629
+  type: Thruster
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,-7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 630
+  type: Thruster
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-7.5
+    parent: 25
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+- uid: 631
+  type: CableApcExtension
+  components:
+  - pos: -1.5,-6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 632
+  type: CableApcExtension
+  components:
+  - pos: -2.5,-6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 633
+  type: CableApcExtension
+  components:
+  - pos: -3.5,-6.5
+    parent: 25
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 634
+  type: Wrench
+  components:
+  - pos: 2.4808617,-4.4780817
+    parent: 25
+    type: Transform
+- uid: 635
+  type: CrowbarRed
+  components:
+  - pos: -8.437552,-4.4587874
+    parent: 25
+    type: Transform
+- uid: 636
+  type: ClothingOuterCoatPirate
+  components:
+  - pos: -8.520257,8.499649
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 637
+  type: ClothingOuterCoatPirate
+  components:
+  - pos: -8.473382,8.499649
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 638
+  type: ClothingOuterCoatPirate
+  components:
+  - pos: -8.442132,8.499649
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 639
+  type: ClothingHeadHatPirate
+  components:
+  - pos: -8.520257,8.780899
+    parent: 25
+    type: Transform
+- uid: 640
+  type: ClothingHeadHatPirate
+  components:
+  - pos: -8.520257,8.765274
+    parent: 25
+    type: Transform
+- uid: 641
+  type: ClothingHeadHatPirate
+  components:
+  - pos: -8.520257,8.765274
+    parent: 25
+    type: Transform
+- uid: 642
+  type: WallShuttleDiagonal
+  components:
+  - pos: -8.5,10.5
+    parent: 25
+    type: Transform
+- uid: 643
+  type: ClothingOuterCoatPirate
+  components:
+  - pos: -0.5223602,7.5450263
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 644
+  type: ClothingOuterCoatPirate
+  components:
+  - pos: -0.4286102,7.5450263
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 645
+  type: ClothingOuterCoatPirate
+  components:
+  - pos: -0.3036102,7.5450263
+    parent: 25
+    type: Transform
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 646
+  type: ClothingHeadHatPirate
+  components:
+  - pos: -0.5848602,7.7950263
+    parent: 25
+    type: Transform
+- uid: 647
+  type: ClothingHeadHatPirate
+  components:
+  - pos: -0.3817352,7.7637763
+    parent: 25
+    type: Transform
+- uid: 648
+  type: ClothingHeadHatPirate
+  components:
+  - pos: -0.2879852,7.7637763
+    parent: 25
+    type: Transform
+- uid: 649
+  type: ClothingShoesBootsMag
+  components:
+  - pos: -3.5011463,9.362282
+    parent: 25
+    type: Transform
+- uid: 650
+  type: ClothingShoesBootsMag
+  components:
+  - pos: -0.565886,6.24822
+    parent: 25
+    type: Transform
+- uid: 651
+  type: ClothingShoesBootsMag
+  components:
+  - pos: -1.253386,6.263845
+    parent: 25
+    type: Transform
+- uid: 652
+  type: ClothingShoesBootsMag
+  components:
+  - pos: -1.503386,1.9256558
+    parent: 25
+    type: Transform
+- uid: 653
+  type: ClothingShoesBootsMag
+  components:
+  - pos: -1.487761,2.4412808
+    parent: 25
+    type: Transform
+- uid: 654
+  type: ClothingShoesBootsMag
+  components:
+  - pos: -6.446637,5.335637
+    parent: 25
+    type: Transform
+...

--- a/Resources/Prototypes/Maps/infiltrator.yml
+++ b/Resources/Prototypes/Maps/infiltrator.yml
@@ -1,0 +1,13 @@
+- type: gameMap
+  id: infiltrator
+  mapName: 'Syndicate Infiltrator'
+  mapNameTemplate: '{0} Infiltrator {1}'
+  nameGenerator:
+    !type:NanotrasenNameGenerator
+    prefixCreator: '14'
+  mapPath: /Maps/infiltrator.yml
+  minPlayers: 0
+  votable: false
+  overflowJobs: []
+  availableJobs:
+    Captain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/pirate.yml
+++ b/Resources/Prototypes/Maps/pirate.yml
@@ -1,0 +1,13 @@
+- type: gameMap
+  id: pirate
+  mapName: 'Pirate Ship'
+  mapNameTemplate: '{0} Pirate {1}'
+  nameGenerator:
+    !type:NanotrasenNameGenerator
+    prefixCreator: '14'
+  mapPath: /Maps/pirate.yml
+  minPlayers: 0
+  votable: false
+  overflowJobs: []
+  availableJobs:
+    Captain: [ 1, 1 ]


### PR DESCRIPTION
Adds the pirate shuttle and prototypes for it and the syndicate infiltrator so they can be spawned for admemes.
![image](https://user-images.githubusercontent.com/99158783/163343239-c98029bb-5196-41ca-b343-cef0ac283a6d.png)
ahoy