### PR TITLE
Rejig pressure protection

### DIFF
--- a/Content.Server/Atmos/Components/BarotraumaComponent.cs
+++ b/Content.Server/Atmos/Components/BarotraumaComponent.cs
@@ -1,8 +1,5 @@
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Server.Atmos.Components
 {
@@ -24,5 +21,11 @@ namespace Content.Server.Atmos.Components
         ///     Used to keep track of when damage starts/stops. Useful for logs.
         /// </summary>
         public bool TakingDamage = false;
+
+        /// <summary>
+        ///     These are the inventory slots that are checked for pressure protection. If a slot is missing protection, no protection is applied.
+        /// </summary>
+        [DataField("protectionSlots")]
+        public List<string> ProtectionSlots = new() { "head", "outerClothing" }; 
     }
 }

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -1,4 +1,3 @@
-using System;
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Shared.Alert;
@@ -6,8 +5,8 @@ using Content.Shared.Atmos;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
+using Content.Shared.Inventory;
+using Robust.Shared.Containers;
 
 namespace Content.Server.Atmos.EntitySystems
 {
@@ -17,6 +16,7 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly DamageableSystem _damageableSystem = default!;
         [Dependency] private readonly AlertsSystem _alertsSystem = default!;
         [Dependency] private readonly AdminLogSystem _logSystem = default!;
+        [Dependency] private readonly InventorySystem _inventorySystem = default!;
 
         private const float UpdateTimer = 1f;
         private float _timer;
@@ -39,27 +39,74 @@ namespace Content.Server.Atmos.EntitySystems
             args.Multiplier *= component.LowPressureMultiplier;
         }
 
-        private float CalculateFeltPressure(float environmentPressure, PressureEvent pressureEvent)
+        public float GetFeltLowPressure(BarotraumaComponent baro, float environmentPressure)
         {
-            environmentPressure += pressureEvent.Modifier;
-            environmentPressure *= pressureEvent.Multiplier;
-            return environmentPressure;
-        }
+            var modifier = float.MaxValue;
+            var multiplier = float.MaxValue;
 
-        public float GetFeltLowPressure(EntityUid uid, float environmentPressure)
-        {
+            TryComp(baro.Owner, out InventoryComponent? inv);
+            TryComp(baro.Owner, out ContainerManagerComponent? contMan);
+
+            // TODO: cache this & update when equipment changes?
+            // This continuously raises events for every player in space.
+
+            // First, check if for protective equipment
+            foreach (var slot in baro.ProtectionSlots)
+            {
+                if (!_inventorySystem.TryGetSlotEntity(baro.Owner, slot, out var equipment, inv, contMan)
+                    || ! TryComp(equipment, out PressureProtectionComponent? protection))
+                {
+                    // Missing protection, skin is exposed.
+                    modifier = 0;
+                    multiplier = 1;
+                    break;
+                }
+
+                modifier = Math.Min(protection.LowPressureModifier, modifier);
+                multiplier = Math.Min(protection.LowPressureMultiplier, multiplier);
+
+            }
+
+            // generic, non-clothing related modifiers.
             var lowPressureEvent = new LowPressureEvent(environmentPressure);
-            RaiseLocalEvent(uid, lowPressureEvent, false);
+            RaiseLocalEvent(baro.Owner, lowPressureEvent, false);
 
-            return CalculateFeltPressure(environmentPressure, lowPressureEvent);
+            return (environmentPressure + modifier + lowPressureEvent.Modifier) * (multiplier * lowPressureEvent.Multiplier);
         }
 
-        public float GetFeltHighPressure(EntityUid uid, float environmentPressure)
+        public float GetFeltHighPressure(BarotraumaComponent baro, float environmentPressure)
         {
-            var highPressureEvent = new HighPressureEvent(environmentPressure);
-            RaiseLocalEvent(uid, highPressureEvent, false);
+            var modifier = float.MinValue;
+            var multiplier = float.MinValue;
 
-            return CalculateFeltPressure(environmentPressure, highPressureEvent);
+            TryComp(baro.Owner, out InventoryComponent? inv);
+            TryComp(baro.Owner, out ContainerManagerComponent? contMan);
+
+            // TODO: cache this & update when equipment changes?
+            // Not as import and as low-pressure, but probably still useful.
+
+            // First, check if for protective equipment
+            foreach (var slot in baro.ProtectionSlots)
+            {
+                if (!_inventorySystem.TryGetSlotEntity(baro.Owner, slot, out var equipment, inv, contMan)
+                    || !TryComp(equipment, out PressureProtectionComponent? protection))
+                {
+                    // Missing protection, skin is exposed.
+                    modifier = 0;
+                    multiplier = 1;
+                    break;
+                }
+
+                modifier = Math.Max(protection.LowPressureModifier, modifier);
+                multiplier = Math.Max(protection.LowPressureMultiplier, multiplier);
+
+            }
+
+            // generic, non-clothing related modifiers.
+            var highPressureEvent = new HighPressureEvent(environmentPressure);
+            RaiseLocalEvent(baro.Owner, highPressureEvent, false);
+
+            return (environmentPressure + modifier + highPressureEvent.Modifier) * (multiplier * highPressureEvent.Multiplier);
         }
 
         public override void Update(float frameTime)
@@ -94,7 +141,7 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     // Low pressure.
                     case <= Atmospherics.WarningLowPressure:
-                        pressure = GetFeltLowPressure(barotrauma.Owner, pressure);
+                        pressure = GetFeltLowPressure(barotrauma, pressure);
 
                         if (pressure > Atmospherics.WarningLowPressure)
                             goto default;
@@ -119,7 +166,7 @@ namespace Content.Server.Atmos.EntitySystems
 
                     // High pressure.
                     case >= Atmospherics.WarningHighPressure:
-                        pressure = GetFeltHighPressure(barotrauma.Owner, pressure);
+                        pressure = GetFeltHighPressure(barotrauma, pressure);
 
                         if(pressure < Atmospherics.WarningHighPressure)
                             goto default;

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -64,10 +64,9 @@ namespace Content.Server.Atmos.EntitySystems
 
                 modifier = Math.Min(protection.LowPressureModifier, modifier);
                 multiplier = Math.Min(protection.LowPressureMultiplier, multiplier);
-
             }
 
-            // generic, non-clothing related modifiers.
+            // Then apply any generic, non-clothing related modifiers.
             var lowPressureEvent = new LowPressureEvent(environmentPressure);
             RaiseLocalEvent(baro.Owner, lowPressureEvent, false);
 
@@ -99,10 +98,9 @@ namespace Content.Server.Atmos.EntitySystems
 
                 modifier = Math.Max(protection.LowPressureModifier, modifier);
                 multiplier = Math.Max(protection.LowPressureMultiplier, multiplier);
-
             }
 
-            // generic, non-clothing related modifiers.
+            // Then apply any generic, non-clothing related modifiers.
             var highPressureEvent = new HighPressureEvent(environmentPressure);
             RaiseLocalEvent(baro.Owner, highPressureEvent, false);
 

--- a/Content.Server/Atmos/PressureEvent.cs
+++ b/Content.Server/Atmos/PressureEvent.cs
@@ -1,9 +1,6 @@
-using Content.Shared.Inventory;
-using Robust.Shared.GameObjects;
-
 namespace Content.Server.Atmos
 {
-    public abstract class PressureEvent : EntityEventArgs, IInventoryRelayEvent
+    public abstract class PressureEvent : EntityEventArgs
     {
         /// <summary>
         ///     The environment pressure.
@@ -28,11 +25,6 @@ namespace Content.Server.Atmos
         ///     Do not set, add to or subtract from this directly. Multiply this by your multiplier only.
         /// </remarks>
         public float Multiplier { get; set; } = 1f;
-
-        /// <summary>
-        ///     The inventory slots that should be checked for pressure protecting equipment.
-        /// </summary>
-        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
 
         protected PressureEvent(float pressure)
         {

--- a/Content.Server/Inventory/ServerInventorySystem.cs
+++ b/Content.Server/Inventory/ServerInventorySystem.cs
@@ -15,8 +15,6 @@ namespace Content.Server.Inventory
         {
             base.Initialize();
 
-            SubscribeLocalEvent<InventoryComponent, HighPressureEvent>(RelayInventoryEvent);
-            SubscribeLocalEvent<InventoryComponent, LowPressureEvent>(RelayInventoryEvent);
             SubscribeLocalEvent<InventoryComponent, ModifyChangedTemperatureEvent>(RelayInventoryEvent);
 
             SubscribeLocalEvent<ClothingComponent, UseInHandEvent>(OnUseInHand);

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -33,7 +33,7 @@
     size: 10
   - type: PressureProtection
     highPressureMultiplier: 0.6
-    lowPressureMultiplier: 10
+    lowPressureMultiplier: 1000
   - type: TemperatureProtection
     coefficient: 0.2
   - type: IngestionBlocker
@@ -52,8 +52,8 @@
   - type: Clothing
     size: 15
   - type: PressureProtection
-    highPressureMultiplier: 0.6
-    lowPressureMultiplier: 10
+    highPressureMultiplier: 0.3
+    lowPressureMultiplier: 1000
   - type: TemperatureProtection
     coefficient: 0.1
   - type: Armor

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -44,8 +44,8 @@
       - state: inhand-right-unshaded
         shader: unshaded
   - type: PressureProtection
-    highPressureMultiplier: 0.40
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.08
+    lowPressureMultiplier: 10000
   - type: Armor
     modifiers:
       coefficients:
@@ -67,6 +67,9 @@
     sprite: Clothing/Head/Hardsuits/capspace.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/capspace.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.3
+    lowPressureMultiplier: 1000
 
 - type: entity
   parent: HatBase
@@ -78,6 +81,9 @@
     sprite: Clothing/Head/Hardsuits/deathsquad.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/deathsquad.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.27
+    lowPressureMultiplier: 1000
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -90,8 +96,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.40
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.26
+    lowPressureMultiplier: 1000
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -103,6 +109,9 @@
     sprite: Clothing/Head/Hardsuits/engineering-white.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering-white.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.24
+    lowPressureMultiplier: 1000
 
 - type: entity
   parent: HatBase
@@ -115,8 +124,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/ihsvoid.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.60
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.3
+    lowPressureMultiplier: 10000
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -129,8 +138,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/medical.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.80
-    lowPressureMultiplier: 55
+    highPressureMultiplier: 0.6
+    lowPressureMultiplier: 5500
   - type: DiseaseProtection
     protection: 0.15
 
@@ -145,8 +154,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/rd.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.80
-    lowPressureMultiplier: 55
+    highPressureMultiplier: 0.60
+    lowPressureMultiplier: 5500
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -159,8 +168,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/salvage.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.70
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 10000
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -173,8 +182,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/security.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.70
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 10000
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -187,8 +196,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/security-red.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.60
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.45
+    lowPressureMultiplier: 10000
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -202,6 +211,9 @@
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: PointLight
     color: green
+  - type: PressureProtection
+    highPressureMultiplier: 0.27
+    lowPressureMultiplier: 1000
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -213,6 +225,9 @@
     sprite: Clothing/Head/Hardsuits/wizard.rsi
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/wizard.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.27
+    lowPressureMultiplier: 1000
 
 - type: entity
   parent: ClothingHeadHardsuitBase
@@ -225,8 +240,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/lingspacehelmet.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.225
+    lowPressureMultiplier: 10000
     
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -274,5 +289,5 @@
       - state: inhand-right-unshaded
         shader: unshaded   
   - type: PressureProtection
-    highPressureMultiplier: 0.8
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.72
+    lowPressureMultiplier: 10000

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -202,6 +202,9 @@
         Piercing: 0.95
         Heat: 0.65
         Radiation: 1
+  - type: PressureProtection
+    highPressureMultiplier: 0.65
+    lowPressureMultiplier: 25
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase # hardsuitlight base for light and protection
@@ -224,6 +227,9 @@
         Piercing: 0.95
         Heat: 0.5
         Radiation: .95
+  - type: PressureProtection
+    highPressureMultiplier: 0.45
+    lowPressureMultiplier: 25
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -16,8 +16,8 @@
   name: base hardsuit
   components:
   - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.3
+    lowPressureMultiplier: 1000
   - type: TemperatureProtection
     coefficient: 0.001 # yes it needs to be this low, fires are fucking deadly apparently!!!!
   - type: ClothingSpeedModifier
@@ -42,8 +42,8 @@
   name: base EVA Suit
   components:
   - type: PressureProtection
-    highPressureMultiplier: 1
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.6
+    lowPressureMultiplier: 1000
   - type: TemperatureProtection
     coefficient: 0.01 # Not complete protection from fire
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,8 +9,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/atmospherics.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.2
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.08
+    lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.7 
@@ -36,8 +36,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/capspace.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.5
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.3
+    lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -61,8 +61,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/deathsquad.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.45
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.27
+    lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -86,8 +86,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/engineering.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.65
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.26
+    lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65 
@@ -111,8 +111,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/engineering-white.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.4
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.24
+    lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.8 
@@ -136,10 +136,12 @@
     sprite: Clothing/OuterClothing/Hardsuits/ihsvoid.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ihsvoid.rsi
-  - type: PressureProtection
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: PressureProtection
+    highPressureMultiplier: 0.3
+    lowPressureMultiplier: 10000
 
 - type: entity
   parent: ClothingOuterEVASuitBase
@@ -187,8 +189,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/medical.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.75
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.6
+    lowPressureMultiplier: 5500
   - type: DiseaseProtection
     protection: 0.2
   - type: ClothingSpeedModifier
@@ -211,8 +213,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.75
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.60
+    lowPressureMultiplier: 5500
   - type: Armor
     modifiers:
       coefficients:
@@ -236,8 +238,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.75
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
     walkModifier: 0.6 #changing these values around so its only a tiny bit faster so less salvages get stuck floating in space
     sprintModifier: 0.65
@@ -261,8 +263,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/security.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.75
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 10000
   - type: Armor
     modifiers:
       coefficients:
@@ -283,8 +285,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/security-red.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.75
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.45
+    lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
     walkModifier: 0.7 
     sprintModifier: 0.7
@@ -308,8 +310,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.45
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.27
+    lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -333,8 +335,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/wizard.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.45
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.27
+    lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -358,8 +360,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/lingspacesuit.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.45
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.225
+    lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
     walkModifier: .8
     sprintModifier: .8
@@ -383,8 +385,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/spatio.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.9
-    lowPressureMultiplier: 100
+    highPressureMultiplier: 0.72
+    lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
     walkModifier: 0.9 #mildly better than eva, might adjust this down if its heavily abused but want to see how it plays out in game first 
     sprintModifier: 0.8


### PR DESCRIPTION
This PR changes how pressure protection works. Previously it would just combine all the multiplicative and additive modifiers from any source of pressure protection. This means that wearing nothing but a helmet would still grant you some amount of pressure protection, even if a player is wearing nothing else.

This PR gives the barotrauma component a list of protection slots (default head+suit). Instead of combining the protective modifiers from all clothing, the protection is now calculated by using the modifiers from the "weakest" piece of protective equipment in those slots. If a slot has no protective equipment, then no equipment protection is applied.

This PR makes a lot of changes to yaml files to account for this change. E.g., the atmos hard suit helmet high/low pressure multiplier used to be 0.4/100, and the suit protection used to be 0.2/100. Now they are both just 0.08/10000. So if you are wearing both of them, the final protection should be the same. 

I think I changed all the suits & helmets properly, so that the protection corresponds to what it used to give when they were paired together. But there is still some odd stuff, like the captain, RD, CE, CM all having lower pressure protection than many other suits, because they used the base-helmet modifier of 10x, while most suit helmets have a 100x multiplier. Though I guess for low-pressure that doesn't really matter al that much, seeing as there's a lower bound on pressure.

This also adds some pressure protection to fire-helmets, so that they can be paired with the fire suit to provide some protection.

:cl:
- tweak: The way pressure protection is calculated has been changed. You now need both a suit and a helmet.

