### PR TITLE
Add flash immunity to welding masks

### DIFF
--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -210,9 +210,12 @@ namespace Content.Server.Flash
 
         private void OnInventoryFlashAttempt(EntityUid uid, InventoryComponent component, FlashAttemptEvent args)
         {
+            // Forward the event to a worn helmet, if one is equipped.
+            if (_inventorySystem.TryGetSlotEntity(uid, "head", out var maskSlotEntity, component))
+                RaiseLocalEvent(maskSlotEntity.Value, args);
             // Forward the event to the glasses, if any.
-            if(_inventorySystem.TryGetSlotEntity(uid, "eyes", out var slotEntity, component))
-                RaiseLocalEvent(slotEntity.Value, args);
+            if(!args.Cancelled && _inventorySystem.TryGetSlotEntity(uid, "eyes", out var eyeSlotEntity, component))
+                RaiseLocalEvent(eyeSlotEntity.Value, args);
         }
 
         private void OnFlashImmunityFlashAttempt(EntityUid uid, FlashImmunityComponent component, FlashAttemptEvent args)

--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -5,6 +5,7 @@
   abstract: true
   components:
   - type: IngestionBlocker
+  - type: FlashImmunity
 
 - type: entity
   parent: WeldingMaskBase


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds flash protection to welding mask.
Ideally welding masks should impair vision a bit but that is out of scope for this PR as we don't have an easy way to apply a shader to the whole screen.

Also this enables head slot clothes to have flash protection.
 
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![2022-4-15_11 40 57](https://user-images.githubusercontent.com/8915246/163556415-f8d47fb4-b0f8-4aea-96b6-1a68b379c445.png)
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for ch

angelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Welding masks actually protect your eyes now! 

