### PR TITLE
make items be able to define itemslots

### DIFF
--- a/Content.Client/Clothing/ClothingSystem.cs
+++ b/Content.Client/Clothing/ClothingSystem.cs
@@ -227,7 +227,7 @@ public sealed class ClothingSystem : EntitySystem
             });
         }
 
-        if (!_inventorySystem.TryGetSlot(equipee, slot, out var slotDef, inventory))
+        if (!_inventorySystem.TryGetSlot(equipee, slot, out var slotDef, out _, inventory))
             return;
 
         // Remove old layers. We could also just set them to invisible, but as items may add arbitrary layers, this
@@ -258,7 +258,7 @@ public sealed class ClothingSystem : EntitySystem
         // temporary, until layer draw depths get added. Basically: a layer with the key "slot" is being used as a
         // bookmark to determine where in the list of layers we should insert the clothing layers.
         bool slotLayerExists = sprite.LayerMapTryGet(slot, out var index);
-        
+
         // add the new layers
         foreach (var (key, layerData) in ev.Layers)
         {

--- a/Content.Client/Clothing/ClothingSystem.cs
+++ b/Content.Client/Clothing/ClothingSystem.cs
@@ -182,14 +182,13 @@ public sealed class ClothingSystem : EntitySystem
 
     public void InitClothing(EntityUid uid, ClientInventoryComponent? component = null, SpriteComponent? sprite = null)
     {
-        if (!_inventorySystem.TryGetSlots(uid, out var slots, component) || !Resolve(uid, ref sprite, ref component)) return;
+        if (!_inventorySystem.TryGetSlotEnumerator(uid, out var enumerator, inventoryComponent: component) || !Resolve(uid, ref sprite, ref component)) return;
 
-        foreach (var slot in slots)
+        while (enumerator.MoveNext(out var slotDefinition))
         {
-            if (!_inventorySystem.TryGetSlotContainer(uid, slot.Name, out var containerSlot, out _, component) ||
-                !containerSlot.ContainedEntity.HasValue) continue;
+            if (!_inventorySystem.TryGetSlotEntity(uid, slotDefinition.Name, out var slotEntity, component)) continue;
 
-            RenderEquipment(uid, containerSlot.ContainedEntity.Value, slot.Name, component, sprite);
+            RenderEquipment(uid, slotEntity.Value, slotDefinition.Name, component, sprite);
         }
     }
 

--- a/Content.Client/Inventory/ClientInventoryComponent.cs
+++ b/Content.Client/Inventory/ClientInventoryComponent.cs
@@ -25,7 +25,7 @@ namespace Content.Client.Inventory
 
         public DefaultWindow InventoryWindow = default!;
 
-        public readonly Dictionary<string, ItemSlotButton> SlotButtons = new();
+        public readonly Dictionary<string, (ItemSlotButton hudButton, ItemSlotButton windowButton)> SlotButtons = new();
 
         [ViewVariables]
         [DataField("speciesId")] public string? SpeciesId { get; set; }

--- a/Content.Client/Inventory/ClientInventoryComponent.cs
+++ b/Content.Client/Inventory/ClientInventoryComponent.cs
@@ -25,7 +25,7 @@ namespace Content.Client.Inventory
 
         public DefaultWindow InventoryWindow = default!;
 
-        public readonly Dictionary<string, List<ItemSlotButton>> SlotButtons = new();
+        public readonly Dictionary<string, ItemSlotButton> SlotButtons = new();
 
         [ViewVariables]
         [DataField("speciesId")] public string? SpeciesId { get; set; }

--- a/Content.Client/Inventory/ClientInventorySlotComponent.cs
+++ b/Content.Client/Inventory/ClientInventorySlotComponent.cs
@@ -1,0 +1,11 @@
+﻿using Content.Client.Items.UI;
+using Content.Shared.Inventory;
+
+namespace Content.Client.Inventory;
+
+[RegisterComponent]
+public sealed class ClientInventorySlotComponent : InventorySlotComponent
+{
+    public readonly Dictionary<string, ItemSlotButton> SlotButtons = new();
+    public readonly Dictionary<string, int> SlotDefIndexes = new();
+}

--- a/Content.Client/Inventory/ClientInventorySlotComponent.cs
+++ b/Content.Client/Inventory/ClientInventorySlotComponent.cs
@@ -4,8 +4,9 @@ using Content.Shared.Inventory;
 namespace Content.Client.Inventory;
 
 [RegisterComponent]
+[ComponentReference(typeof(InventorySlotComponent))]
 public sealed class ClientInventorySlotComponent : InventorySlotComponent
 {
-    public readonly Dictionary<string, ItemSlotButton> SlotButtons = new();
+    public readonly Dictionary<string, (ItemSlotButton hudButton, ItemSlotButton windowButton)> SlotButtons = new();
     public readonly Dictionary<string, int> SlotDefIndexes = new();
 }

--- a/Content.Client/Inventory/ClientInventorySystem.InventorySlots.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.InventorySlots.cs
@@ -1,0 +1,83 @@
+﻿using Content.Client.Items.UI;
+using Content.Shared.Inventory;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Containers;
+
+namespace Content.Client.Inventory;
+
+public partial class ClientInventorySystem
+{
+    void InitializeInventorySlots()
+    {
+        SubscribeLocalEvent<ClientInventorySlotComponent, ComponentInit>(OnInvSlotCompInit);
+        SubscribeLocalEvent<ClientInventorySlotComponent, ComponentAdd>(OnInvSlotCompAdd);
+        SubscribeLocalEvent<ClientInventorySlotComponent, ComponentRemove>(OnInvSlotCompRemove);
+    }
+
+    private void OnInvSlotCompRemove(EntityUid uid, ClientInventorySlotComponent component, ComponentRemove args)
+    {
+        if (TryComp<ClientInventoryComponent>(uid, out var invComp))
+        {
+            foreach (var (id, btn) in component.SlotButtons)
+            {
+                _itemSlotManager.SetItemSlot(btn, null);
+                var slotDef = component.Slots[component.SlotDefIndexes[id]];
+                switch (slotDef.UIContainer)
+                {
+                    case SlotUIContainer.BottomLeft:
+                        invComp.BottomLeftButtons.RemoveChild(btn);
+                        break;
+                    case SlotUIContainer.BottomRight:
+                        invComp.BottomRightButtons.RemoveChild(btn);
+                        break;
+                    case SlotUIContainer.Top:
+                        invComp.TopQuickButtons.RemoveChild(btn);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+                invComp.InventoryWindow.RemoveChild(btn);
+            }
+        }
+    }
+
+    private void OnInvSlotCompAdd(EntityUid uid, ClientInventorySlotComponent component, ComponentAdd args)
+    {
+        if(TryComp<ClientInventoryComponent>(uid, out var invComp))
+        {
+            if (TryComp<ContainerManagerComponent>(uid, out var containerManager))
+                InitSlotButtons(uid, component.SlotButtons, invComp, containerManager);
+
+            foreach (var (id, btn) in component.SlotButtons)
+            {
+                var slotDef = component.Slots[component.SlotDefIndexes[id]];
+                switch (slotDef.UIContainer)
+                {
+                    case SlotUIContainer.BottomLeft:
+                        invComp.BottomLeftButtons.AddChild(btn);
+                        break;
+                    case SlotUIContainer.BottomRight:
+                        invComp.BottomRightButtons.AddChild(btn);
+                        break;
+                    case SlotUIContainer.Top:
+                        invComp.TopQuickButtons.AddChild(btn);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+                invComp.InventoryWindow.AddChild(btn);
+                LayoutContainer.SetPosition(btn, slotDef.UIWindowPosition * (ButtonSize + ButtonSeparation));
+            }
+        }
+    }
+
+    private void OnInvSlotCompInit(EntityUid uid, ClientInventorySlotComponent component, ComponentInit args)
+    {
+        for (var i = 0; i < component.Slots.Length; i++)
+        {
+            var slotDefinition = component.Slots[i];
+            component.SlotButtons.Add(slotDefinition.Name, GenerateButton(uid, slotDefinition));
+            component.SlotDefIndexes.Add(slotDefinition.Name, i);
+        }
+    }
+}

--- a/Content.Client/Inventory/ClientInventorySystem.InventorySlots.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.InventorySlots.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Client.Items.UI;
 using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Containers;
 
@@ -9,75 +10,81 @@ public partial class ClientInventorySystem
 {
     void InitializeInventorySlots()
     {
-        SubscribeLocalEvent<ClientInventorySlotComponent, ComponentInit>(OnInvSlotCompInit);
-        SubscribeLocalEvent<ClientInventorySlotComponent, ComponentAdd>(OnInvSlotCompAdd);
-        SubscribeLocalEvent<ClientInventorySlotComponent, ComponentRemove>(OnInvSlotCompRemove);
+        SubscribeLocalEvent<ClientInventorySlotComponent, GotEquippedEvent>(OnInvSlotEquipped);
+        SubscribeLocalEvent<ClientInventorySlotComponent, GotUnequippedEvent>(OnInvSlotUnequipped);
     }
 
-    private void OnInvSlotCompRemove(EntityUid uid, ClientInventorySlotComponent component, ComponentRemove args)
+    private void OnInvSlotUnequipped(EntityUid uid, ClientInventorySlotComponent component, GotUnequippedEvent args)
     {
-        if (TryComp<ClientInventoryComponent>(uid, out var invComp))
+        if (TryComp<ClientInventoryComponent>(args.Equipee, out var invComp))
         {
-            foreach (var (id, btn) in component.SlotButtons)
-            {
-                _itemSlotManager.SetItemSlot(btn, null);
-                var slotDef = component.Slots[component.SlotDefIndexes[id]];
-                switch (slotDef.UIContainer)
-                {
-                    case SlotUIContainer.BottomLeft:
-                        invComp.BottomLeftButtons.RemoveChild(btn);
-                        break;
-                    case SlotUIContainer.BottomRight:
-                        invComp.BottomRightButtons.RemoveChild(btn);
-                        break;
-                    case SlotUIContainer.Top:
-                        invComp.TopQuickButtons.RemoveChild(btn);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-                invComp.InventoryWindow.RemoveChild(btn);
-            }
-        }
-    }
-
-    private void OnInvSlotCompAdd(EntityUid uid, ClientInventorySlotComponent component, ComponentAdd args)
-    {
-        if(TryComp<ClientInventoryComponent>(uid, out var invComp))
-        {
-            if (TryComp<ContainerManagerComponent>(uid, out var containerManager))
-                InitSlotButtons(uid, component.SlotButtons, invComp, containerManager);
-
             foreach (var (id, btn) in component.SlotButtons)
             {
                 var slotDef = component.Slots[component.SlotDefIndexes[id]];
                 switch (slotDef.UIContainer)
                 {
                     case SlotUIContainer.BottomLeft:
-                        invComp.BottomLeftButtons.AddChild(btn);
+                        invComp.BottomLeftButtons.RemoveChild(btn.hudButton);
                         break;
                     case SlotUIContainer.BottomRight:
-                        invComp.BottomRightButtons.AddChild(btn);
+                        invComp.BottomRightButtons.RemoveChild(btn.hudButton);
                         break;
                     case SlotUIContainer.Top:
-                        invComp.TopQuickButtons.AddChild(btn);
+                        invComp.TopQuickButtons.RemoveChild(btn.hudButton);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
-                invComp.InventoryWindow.AddChild(btn);
-                LayoutContainer.SetPosition(btn, slotDef.UIWindowPosition * (ButtonSize + ButtonSeparation));
+
+                invComp.InventoryWindow.RemoveChild(btn.windowButton);
             }
         }
+
+        foreach (var (_, btn) in component.SlotButtons)
+        {
+            _itemSlotManager.SetItemSlot(btn.hudButton, null);
+            _itemSlotManager.SetItemSlot(btn.windowButton, null);
+        }
+
+        component.SlotButtons.Clear();
+        component.SlotDefIndexes.Clear();
     }
 
-    private void OnInvSlotCompInit(EntityUid uid, ClientInventorySlotComponent component, ComponentInit args)
+    private void OnInvSlotEquipped(EntityUid uid, ClientInventorySlotComponent component, GotEquippedEvent args)
     {
         for (var i = 0; i < component.Slots.Length; i++)
         {
             var slotDefinition = component.Slots[i];
-            component.SlotButtons.Add(slotDefinition.Name, GenerateButton(uid, slotDefinition));
+            component.SlotButtons.Add(slotDefinition.Name, (GenerateButton(args.Equipee, slotDefinition), GenerateButton(args.Equipee, slotDefinition)));
             component.SlotDefIndexes.Add(slotDefinition.Name, i);
+        }
+
+        if(TryComp<ClientInventoryComponent>(args.Equipee, out var invComp))
+        {
+            if (TryComp<ContainerManagerComponent>(args.Equipee, out var containerManager))
+                InitSlotButtons(args.Equipee, component.SlotButtons, invComp, containerManager);
+
+            foreach (var (id, btn) in component.SlotButtons)
+            {
+                var slotDef = component.Slots[component.SlotDefIndexes[id]];
+                switch (slotDef.UIContainer)
+                {
+                    case SlotUIContainer.BottomLeft:
+                        invComp.BottomLeftButtons.AddChild(btn.hudButton);
+                        break;
+                    case SlotUIContainer.BottomRight:
+                        invComp.BottomRightButtons.AddChild(btn.hudButton);
+                        break;
+                    case SlotUIContainer.Top:
+                        invComp.TopQuickButtons.AddChild(btn.hudButton);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                invComp.InventoryWindow.AddChild(btn.windowButton);
+                LayoutContainer.SetPosition(btn.windowButton, slotDef.UIWindowPosition * (ButtonSize + ButtonSeparation));
+            }
         }
     }
 }

--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -95,7 +95,7 @@ namespace Content.Client.Inventory
                 var found = false;
                 foreach (var slotSlot in component.InventorySlotSlots)
                 {
-                    if(TryGetSlotEntity(uid, slotSlot, out var slotEnt, component)) continue;
+                    if(!TryGetSlotEntity(uid, slotSlot, out var slotEnt, component)) continue;
 
                     if(TryComp<ClientInventorySlotComponent>(slotEnt, out var invSlotComp))
                     {

--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -90,10 +90,21 @@ namespace Content.Client.Inventory
             if (!Resolve(uid, ref component))
                 return;
 
-            if (!component.SlotButtons.TryGetValue(slot, out var buttons) &&
-                (!TryComp<ClientInventorySlotComponent>(uid, out var invSlotComp) ||
-                 !invSlotComp.SlotButtons.TryGetValue(slot, out buttons)))
-                return;
+            if (!component.SlotButtons.TryGetValue(slot, out var buttons))
+            {
+                var found = false;
+                foreach (var slotSlot in component.InventorySlotSlots)
+                {
+                    if(TryGetSlotEntity(uid, slotSlot, out var slotEnt, component)) continue;
+
+                    if(TryComp<ClientInventorySlotComponent>(slotEnt, out var invSlotComp))
+                    {
+                        if (invSlotComp.SlotButtons.TryGetValue(slot, out buttons))
+                            found = true;
+                    }
+                }
+                if(!found) return;
+            }
 
             _itemSlotManager.SetItemSlot(buttons.hudButton, item);
             _itemSlotManager.SetItemSlot(buttons.windowButton, item);

--- a/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
+++ b/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.cs
@@ -150,11 +150,11 @@ namespace Content.Client.Lobby.UI
             // ReSharper disable once ConstantNullCoalescingCondition
             var job = protoMan.Index<JobPrototype>(highPriorityJob ?? SharedGameTicker.FallbackOverflowJob);
 
-            if (job.StartingGear != null && invSystem.TryGetSlots(dummy, out var slots))
+            if (job.StartingGear != null && invSystem.TryGetSlotEnumerator(dummy, out var slotEnumerator))
             {
                 var gear = protoMan.Index<StartingGearPrototype>(job.StartingGear);
 
-                foreach (var slot in slots)
+                while (slotEnumerator.MoveNext(out var slot))
                 {
                     var itemType = gear.GetGear(slot.Name, profile);
                     if (invSystem.TryUnequip(dummy, slot.Name, out var unequippedItem, true, true))

--- a/Content.Server/AI/Components/AiControllerComponent.cs
+++ b/Content.Server/AI/Components/AiControllerComponent.cs
@@ -66,11 +66,10 @@ namespace Content.Server.AI.Components
 
             if (StartingGearPrototype != null)
             {
-                var gameTicker = EntitySystem.Get<GameTicker>();
                 var protoManager = IoCManager.Resolve<IPrototypeManager>();
 
                 var startingGear = protoManager.Index<StartingGearPrototype>(StartingGearPrototype);
-                gameTicker.EquipStartingGear(Owner, startingGear, null);
+                startingGear.EquipStartingGear(Owner);
             }
         }
 

--- a/Content.Server/AI/Utility/Considerations/Clothing/ClothingInInventoryCon.cs
+++ b/Content.Server/AI/Utility/Considerations/Clothing/ClothingInInventoryCon.cs
@@ -26,7 +26,7 @@ namespace Content.Server.AI.Utility.Considerations.Clothing
             foreach (var entity in context.GetState<EnumerableInventoryState>().GetValue())
             {
                 if (!IoCManager.Resolve<IEntityManager>().TryGetComponent(entity, out ClothingComponent? clothingComponent) ||
-                    !EntitySystem.Get<InventorySystem>().TryGetSlot(entity, slots, out var slotDef))
+                    !EntitySystem.Get<InventorySystem>().TryGetSlot(entity, slots, out var slotDef, out _))
                 {
                     continue;
                 }

--- a/Content.Server/AI/WorldState/States/Clothing/EquippedClothingState.cs
+++ b/Content.Server/AI/WorldState/States/Clothing/EquippedClothingState.cs
@@ -18,12 +18,12 @@ namespace Content.Server.AI.WorldState.States.Clothing
             var result = new Dictionary<string, EntityUid>();
 
             var invSystem = EntitySystem.Get<InventorySystem>();
-            if (!invSystem.TryGetSlots(Owner, out var slotDefinitions))
+            if (!invSystem.TryGetSlotEnumerator(Owner, out var slotDefinitions))
             {
                 return result;
             }
 
-            foreach (var slot in slotDefinitions)
+            while (slotDefinitions.MoveNext(out var slot))
             {
                 if (!invSystem.HasSlot(Owner, slot.Name)) continue;
 

--- a/Content.Server/Administration/Commands/SetOutfitCommand.cs
+++ b/Content.Server/Administration/Commands/SetOutfitCommand.cs
@@ -88,9 +88,9 @@ namespace Content.Server.Administration.Commands
             }
 
             var invSystem = EntitySystem.Get<InventorySystem>();
-            if (invSystem.TryGetSlots(target, out var slotDefinitions, inventoryComponent))
+            if (invSystem.TryGetSlotEnumerator(target, out var slotDefinitions, inventoryComponent: inventoryComponent))
             {
-                foreach (var slot in slotDefinitions)
+                while (slotDefinitions.MoveNext(out var slot))
                 {
                     invSystem.TryUnequip(target, slot.Name, true, true, inventoryComponent);
                     var gearStr = startingGear.GetGear(slot.Name, profile);

--- a/Content.Server/Administration/Commands/SetOutfitCommand.cs
+++ b/Content.Server/Administration/Commands/SetOutfitCommand.cs
@@ -88,26 +88,13 @@ namespace Content.Server.Administration.Commands
             }
 
             var invSystem = EntitySystem.Get<InventorySystem>();
-            if (invSystem.TryGetSlotEnumerator(target, out var slotDefinitions, inventoryComponent: inventoryComponent))
-            {
-                while (slotDefinitions.MoveNext(out var slot))
-                {
-                    invSystem.TryUnequip(target, slot.Name, true, true, inventoryComponent);
-                    var gearStr = startingGear.GetGear(slot.Name, profile);
-                    if (gearStr == string.Empty)
-                    {
-                        continue;
-                    }
-                    var equipmentEntity = entityManager.SpawnEntity(gearStr, entityManager.GetComponent<TransformComponent>(target).Coordinates);
-                    if (slot.Name == "id" &&
-                        entityManager.TryGetComponent<PDAComponent?>(equipmentEntity, out var pdaComponent) &&
-                        pdaComponent.ContainedID != null)
-                    {
-                        pdaComponent.ContainedID.FullName = entityManager.GetComponent<MetaDataComponent>(target).EntityName;
-                    }
+            startingGear.EquipStartingGear(target, profile, StartingGearPrototype.UnequipMethod.Strip, inventorySystem: invSystem, entityManager: entityManager);
 
-                    invSystem.TryEquip(target, equipmentEntity, slot.Name, true, inventory: inventoryComponent);
-                }
+            if (invSystem.TryGetSlotEntity(target, "id", out var idEntityUid) &&
+                entityManager.TryGetComponent<PDAComponent?>(idEntityUid, out var pdaComponent) &&
+                pdaComponent.ContainedID != null)
+            {
+                pdaComponent.ContainedID.FullName = entityManager.GetComponent<MetaDataComponent>(target).EntityName;
             }
         }
     }

--- a/Content.Server/Chemistry/Components/FoamSolutionAreaEffectComponent.cs
+++ b/Content.Server/Chemistry/Components/FoamSolutionAreaEffectComponent.cs
@@ -42,9 +42,9 @@ namespace Content.Server.Chemistry.Components
             // TODO: Add a permeability property to clothing
             // For now it just adds to protection for each clothing equipped
             var protection = 0f;
-            if (invSystem.TryGetSlots(entity, out var slotDefinitions))
+            if (invSystem.TryGetSlotEnumerator(entity, out var enumerator))
             {
-                foreach (var slot in slotDefinitions)
+                while (enumerator.MoveNext(out var slot))
                 {
                     if (slot.Name == "back" ||
                         slot.Name == "pocket1" ||

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -308,9 +308,9 @@ namespace Content.Server.GameTicking
         #region Equip Helpers
         public void EquipStartingGear(EntityUid entity, StartingGearPrototype startingGear, HumanoidCharacterProfile? profile)
         {
-            if (_inventorySystem.TryGetSlots(entity, out var slotDefinitions))
+            if (_inventorySystem.TryGetSlotEnumerator(entity, out var enumerator))
             {
-                foreach (var slot in slotDefinitions)
+                while (enumerator.MoveNext(out var slot))
                 {
                     var equipmentStr = startingGear.GetGear(slot.Name, profile);
                     if (!string.IsNullOrEmpty(equipmentStr))

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -286,7 +286,7 @@ namespace Content.Server.GameTicking
             if (job.StartingGear != null)
             {
                 var startingGear = _prototypeManager.Index<StartingGearPrototype>(job.StartingGear);
-                EquipStartingGear(entity, startingGear, profile);
+                startingGear.EquipStartingGear(entity, profile, inventorySystem: _inventorySystem, handsSystem: _handsSystem, entityManager: EntityManager);
             }
 
             if (profile != null)
@@ -306,32 +306,6 @@ namespace Content.Server.GameTicking
         #endregion
 
         #region Equip Helpers
-        public void EquipStartingGear(EntityUid entity, StartingGearPrototype startingGear, HumanoidCharacterProfile? profile)
-        {
-            if (_inventorySystem.TryGetSlotEnumerator(entity, out var enumerator))
-            {
-                while (enumerator.MoveNext(out var slot))
-                {
-                    var equipmentStr = startingGear.GetGear(slot.Name, profile);
-                    if (!string.IsNullOrEmpty(equipmentStr))
-                    {
-                        var equipmentEntity = EntityManager.SpawnEntity(equipmentStr, EntityManager.GetComponent<TransformComponent>(entity).Coordinates);
-                        _inventorySystem.TryEquip(entity, equipmentEntity, slot.Name, true);
-                    }
-                }
-            }
-
-            if (!TryComp(entity, out HandsComponent? handsComponent))
-                return;
-
-            var inhand = startingGear.Inhand;
-            var coords = EntityManager.GetComponent<TransformComponent>(entity).Coordinates;
-            foreach (var (hand, prototype) in inhand)
-            {
-                var inhandEntity = EntityManager.SpawnEntity(prototype, coords);
-                _handsSystem.TryPickup(entity, inhandEntity, hand, checkActionBlocker: false, handsComp: handsComponent);
-            }
-        }
 
         public void EquipIdCard(EntityUid entity, string characterName, JobPrototype jobPrototype)
         {

--- a/Content.Server/Inventory/ServerInventorySlotComponent.cs
+++ b/Content.Server/Inventory/ServerInventorySlotComponent.cs
@@ -1,0 +1,7 @@
+﻿using Content.Shared.Inventory;
+
+namespace Content.Server.Inventory;
+
+[RegisterComponent]
+[ComponentReference(typeof(InventorySlotComponent))]
+public sealed class ServerInventorySlotComponent : InventorySlotComponent { }

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -61,9 +61,9 @@ namespace Content.Server.Strip
                 }
             }
 
-            if (_inventorySystem.TryGetSlots(uid, out var slots))
+            if (_inventorySystem.TryGetSlotEnumerator(uid, out var enumerator))
             {
-                foreach (var slot in slots)
+                while (enumerator.MoveNext(out var slot))
                 {
                     var name = "None";
 

--- a/Content.Shared/Inventory/InventoryComponent.cs
+++ b/Content.Shared/Inventory/InventoryComponent.cs
@@ -6,4 +6,6 @@ public abstract class InventoryComponent : Component
 {
     [DataField("templateId", customTypeSerializer: typeof(PrototypeIdSerializer<InventoryTemplatePrototype>))]
     public string TemplateId { get; } = "human";
+
+    public HashSet<string> InventorySlotSlots = new();
 }

--- a/Content.Shared/Inventory/InventorySlotComponent.cs
+++ b/Content.Shared/Inventory/InventorySlotComponent.cs
@@ -1,9 +1,7 @@
 ﻿namespace Content.Shared.Inventory;
 
-[RegisterComponent]
 [Virtual]
 [Friend(typeof(InventorySystem))]
-[ComponentProtoName("InventorySlot")]
 public class InventorySlotComponent : Component
 {
     [DataField("slots")]

--- a/Content.Shared/Inventory/InventorySlotComponent.cs
+++ b/Content.Shared/Inventory/InventorySlotComponent.cs
@@ -1,0 +1,10 @@
+﻿namespace Content.Shared.Inventory;
+
+[Virtual]
+[Friend(typeof(InventorySystem))]
+[ComponentProtoName("InventorySlot")]
+public class InventorySlotComponent : Component
+{
+    [DataField("slots")]
+    public SlotDefinition[] Slots { get; } = Array.Empty<SlotDefinition>();
+}

--- a/Content.Shared/Inventory/InventorySlotComponent.cs
+++ b/Content.Shared/Inventory/InventorySlotComponent.cs
@@ -1,5 +1,6 @@
 ﻿namespace Content.Shared.Inventory;
 
+[RegisterComponent]
 [Virtual]
 [Friend(typeof(InventorySystem))]
 [ComponentProtoName("InventorySlot")]

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -205,6 +205,10 @@ public abstract partial class InventorySystem
         if (_interactionSystem.CanAccessViaStorage(actor, itemUid))
             return true;
 
+        // the item is in an inventoryslotcomponent
+        if (itemUid.TryGetContainer(out var container) && HasComp<InventorySlotComponent>(container.Owner) && _containerSystem.IsInSameOrParentContainer(actor, container.Owner))
+            return true;
+
         // Is the actor currently stripping the target? Here we could check if the actor has the stripping UI open, but
         // that requires server/client specific code. so lets just check if they **could** open the stripping UI.
         // Note that this doesn't check that the item is equipped by the target, as this is done elsewhere.

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -227,9 +227,6 @@ public abstract partial class InventorySystem
         if (slotDefinition == null && !TryGetSlot(target, slot, out slotDefinition, inventory: inventory))
             return false;
 
-        if (slotDefinition.DependsOn != null && !TryGetSlotEntity(target, slotDefinition.DependsOn, out _, inventory))
-            return false;
-
         if(!item.SlotFlags.HasFlag(slotDefinition.SlotFlags) && (!slotDefinition.SlotFlags.HasFlag(SlotFlags.POCKET) || item.Size > (int) ReferenceSizes.Pocket))
         {
             reason = "inventory-component-can-equip-does-not-fit";
@@ -315,15 +312,6 @@ public abstract partial class InventorySystem
         //we need to do this to make sure we are 100% removing this entity, since we are now dropping dependant slots
         if (!force && !slotContainer.CanRemove(removedItem.Value))
             return false;
-
-        foreach (var slotDef in GetSlots(target, inventory))
-        {
-            if (slotDef != slotDefinition && slotDef.DependsOn == slotDefinition.Name)
-            {
-                //this recursive call might be risky
-                TryUnequip(actor, target, slotDef.Name, true, true, inventory);
-            }
-        }
 
         if (force)
         {

--- a/Content.Shared/Inventory/InventorySystem.InventorySlot.cs
+++ b/Content.Shared/Inventory/InventorySystem.InventorySlot.cs
@@ -1,0 +1,63 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Inventory.Events;
+
+namespace Content.Shared.Inventory;
+
+public partial class InventorySystem
+{
+    void InitializeInventorySlot()
+    {
+        SubscribeLocalEvent<InventorySlotComponent, GotEquippedEvent>(OnInvSlotGotEquipped);
+        SubscribeLocalEvent<InventorySlotComponent, GotUnequippedEvent>(OnInvSlotGotUnequipped);
+        SubscribeLocalEvent<InventorySlotComponent, BeingEquippedAttemptEvent>(OnEquipAttempt);
+    }
+
+    private void OnEquipAttempt(EntityUid uid, InventorySlotComponent component, BeingEquippedAttemptEvent args)
+    {
+        if (!TryInvCompWarn(args.Equipee, out var invComp))
+        {
+            args.Cancel();
+            return;
+        }
+
+        foreach (var invSlotSlotDef in component.Slots)
+        {
+            if (!_prototypeManager.TryIndex<InventoryTemplatePrototype>(invComp.TemplateId, out var template))
+                return;
+            foreach (var invSlotDef in template.Slots)
+            {
+                if (invSlotDef.Name == invSlotSlotDef.Name)
+                {
+                    Logger.Error($"Found duplicate slotname {invSlotDef.Name} when trying to equip invslotcomp.");
+                    args.Cancel();
+                    return;
+                }
+            }
+        }
+    }
+
+    private bool TryInvCompWarn(EntityUid uid, [NotNullWhen(true)] out InventoryComponent component)
+    {
+        if (!TryComp(uid, out component!))
+        {
+            Logger.Error("Could not find inventorycomponent on entity that equipped an inventoryslot-entity.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void OnInvSlotGotUnequipped(EntityUid uid, InventorySlotComponent component, GotUnequippedEvent args)
+    {
+        if(!TryInvCompWarn(args.Equipee, out var invComp)) return;
+
+        invComp.InventorySlotSlots.Remove(args.Slot);
+    }
+
+    private void OnInvSlotGotEquipped(EntityUid uid, InventorySlotComponent component, GotEquippedEvent args)
+    {
+        if(!TryInvCompWarn(args.Equipee, out var invComp)) return;
+
+        invComp.InventorySlotSlots.Add(args.Slot);
+    }
+}

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -19,7 +19,7 @@ public partial class InventorySystem
 
     protected void RelayInventoryEvent<T>(EntityUid uid, InventoryComponent component, T args) where T : EntityEventArgs, IInventoryRelayEvent
     {
-        var containerEnumerator = new ContainerSlotEnumerator(uid, component.TemplateId, _prototypeManager, this, args.TargetSlots);
+        var containerEnumerator = new ContainerSlotEnumerator(uid, component, _prototypeManager, this, args.TargetSlots);
         while(containerEnumerator.MoveNext(out var container))
         {
             if(!container.ContainedEntity.HasValue) continue;

--- a/Content.Shared/Inventory/InventorySystem.cs
+++ b/Content.Shared/Inventory/InventorySystem.cs
@@ -11,5 +11,23 @@ public partial class InventorySystem
         InitializeEquip();
         InitializeRelay();
         InitializeInventorySlot();
+
+        SubscribeLocalEvent<InventoryComponent, ComponentInit>(OnInvInit);
+    }
+
+    private void OnInvInit(EntityUid uid, InventoryComponent component, ComponentInit args)
+    {
+        if(!_prototypeManager.TryIndex<InventoryTemplatePrototype>(component.TemplateId, out var template)) return;
+
+        for (int i = 0; i < template.Slots.Length; i++)
+        {
+            for (int j = i+1; j < template.Slots.Length; j++)
+            {
+                if (template.Slots[i].ConflictsWith(template.Slots[j]))
+                {
+                    Logger.Error($"Found slotdef conflict for slots {template.Slots[i].Name} and {template.Slots[j].Name}!");
+                }
+            }
+        }
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.cs
+++ b/Content.Shared/Inventory/InventorySystem.cs
@@ -10,5 +10,6 @@ public partial class InventorySystem
         base.Initialize();
         InitializeEquip();
         InitializeRelay();
+        InitializeInventorySlot();
     }
 }

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using Robust.Shared.Maths;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
-using Robust.Shared.Utility;
+﻿using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Inventory;
 

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -25,9 +25,6 @@ public sealed class SlotDefinition
 
     [DataField("uiWindowPos", required: true)] public Vector2i UIWindowPosition { get; }
 
-    //todo this is supreme shit and ideally slots should be stored in a given equipmentslotscomponent on each equipment
-    [DataField("dependsOn")] public string? DependsOn { get; }
-
     [DataField("displayName", required: true)] public string DisplayName { get; } = string.Empty;
 
     /// <summary>

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -31,6 +31,11 @@ public sealed class SlotDefinition
     ///     Offset for the clothing sprites.
     /// </summary>
     [DataField("offset")] public Vector2 Offset { get; } = Vector2.Zero;
+
+    public bool ConflictsWith(SlotDefinition otherDefinition)
+    {
+        return Name == otherDefinition.Name || UIWindowPosition == otherDefinition.UIWindowPosition;
+    }
 }
 
 public enum SlotUIContainer

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -8,6 +8,14 @@
     - outerClothing
   - type: Sprite
     state: icon
+  - type: InventorySlot
+    slots:
+      - name: suitstorage
+        slotTexture: suit_storage
+        slotFlags: SUITSTORAGE
+        uiContainer: BottomLeft
+        uiWindowPos: 2,0
+        displayName: Suit Storage
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -14,7 +14,7 @@
         slotTexture: suit_storage
         slotFlags: SUITSTORAGE
         uiContainer: BottomLeft
-        uiWindowPos: 2,0
+        uiWindowPos: 2,3
         displayName: Suit Storage
   - type: ContainerContainer
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -16,6 +16,7 @@
         uiContainer: BottomLeft
         uiWindowPos: 2,0
         displayName: Suit Storage
+  - type: ContainerContainer
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -26,6 +26,26 @@
     spawned:
     - id: MaterialCloth1
       amount: 3
+  - type: InventorySlot
+    slots:
+      - name: pocket1
+        slotTexture: pocket
+        slotFlags: POCKET
+        uiContainer: BottomRight
+        uiWindowPos: 0,3
+        displayName: Pocket 1
+      - name: pocket2
+        slotTexture: pocket
+        slotFlags: POCKET
+        uiContainer: BottomRight
+        uiWindowPos: 2,3
+        displayName: Pocket 2
+      - name: id
+        slotTexture: id
+        slotFlags: IDCARD
+        uiContainer: BottomRight
+        uiWindowPos: 2,1
+        displayName: ID
 
 - type: entity
   abstract: true
@@ -44,3 +64,23 @@
     spawned:
     - id: MaterialCloth1
       amount: 3
+  - type: InventorySlot
+    slots:
+      - name: pocket1
+        slotTexture: pocket
+        slotFlags: POCKET
+        uiContainer: BottomRight
+        uiWindowPos: 0,3
+        displayName: Pocket 1
+      - name: pocket2
+        slotTexture: pocket
+        slotFlags: POCKET
+        uiContainer: BottomRight
+        uiWindowPos: 2,3
+        displayName: Pocket 2
+      - name: id
+        slotTexture: id
+        slotFlags: IDCARD
+        uiContainer: BottomRight
+        uiWindowPos: 2,1
+        displayName: ID

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -46,6 +46,7 @@
         uiContainer: BottomRight
         uiWindowPos: 2,1
         displayName: ID
+  - type: ContainerContainer
 
 - type: entity
   abstract: true
@@ -84,3 +85,4 @@
         uiContainer: BottomRight
         uiWindowPos: 2,1
         displayName: ID
+  - type: ContainerContainer

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -55,13 +55,6 @@
       uiContainer: Top
       uiWindowPos: 1,0
       displayName: Head
-    - name: suitstorage
-      slotTexture: suit_storage
-      slotFlags:   SUITSTORAGE
-      uiContainer: BottomLeft
-      uiWindowPos: 2,0
-      dependsOn: outerClothing
-      displayName: Suit Storage
     - name: belt
       slotTexture: belt
       slotFlags: BELT

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -55,20 +55,6 @@
       uiContainer: Top
       uiWindowPos: 1,0
       displayName: Head
-    - name: pocket1
-      slotTexture: pocket
-      slotFlags: POCKET
-      uiContainer: BottomRight
-      uiWindowPos: 0,3
-      dependsOn: jumpsuit
-      displayName: Pocket 1
-    - name: pocket2
-      slotTexture: pocket
-      slotFlags: POCKET
-      uiContainer: BottomRight
-      uiWindowPos: 2,3
-      dependsOn: jumpsuit
-      displayName: Pocket 2
     - name: suitstorage
       slotTexture: suit_storage
       slotFlags:   SUITSTORAGE
@@ -76,13 +62,6 @@
       uiWindowPos: 2,0
       dependsOn: outerClothing
       displayName: Suit Storage
-    - name: id
-      slotTexture: id
-      slotFlags: IDCARD
-      uiContainer: BottomRight
-      uiWindowPos: 2,1
-      dependsOn: jumpsuit
-      displayName: ID
     - name: belt
       slotTexture: belt
       slotFlags: BELT


### PR DESCRIPTION
the itemslots show up when you equip the item, get removed when unequipped

also removes dependsOn bc that was the janky way of doing it before

todo:
- smol writeup for smug
- stripping ui for items that have slots