### PR TITLE
Add extrap Welding steps to reinforced window's deconstruction

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
@@ -59,10 +59,14 @@
               amount: 2
             - !type:DeleteEntity {}
           steps:
+            - tool: Welding
+              doAfter: 5
             - tool: Screwing
               doAfter: 1
             - tool: Prying
               doAfter: 2
+            - tool: Welding
+              doAfter: 5
             - tool: Screwing
               doAfter: 1
             - tool: Anchoring
@@ -116,10 +120,14 @@
               amount: 2
             - !type:DeleteEntity {}
           steps:
+            - tool: Welding
+              doAfter: 5
             - tool: Screwing
               doAfter: 2
             - tool: Prying
               doAfter: 3
+            - tool: Welding
+              doAfter: 5
             - tool: Screwing
               doAfter: 2
             - tool: Anchoring


### PR DESCRIPTION
## About the PR

I currently believe that deconstructing Reinforced Windows is way too fast in comparison to Reinforced Walls. 
I timed it, and RWindow decon takes about 9-10 seconds if you know the steps. Rwalls takes 30 seconds.

Considering RWindows are used to protect high-access areas or cell'd prisoners, they shouldn't be so trivial to decon.
This adds about 10 extra seconds to RWindow decon, taking it up to 20-25 seconds if you don't know the steps or fumble your tools.
**Changelog**

:cl:
- tweak: Due to the recent number of jailbreaks, Nanotrasen has added iron caps to Reinforced Window's screws. You will now need to melt them to deconstruct the window.

