### PR TITLE
Give all hostile salvage mobs + spider ghost role takeover

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1116,6 +1116,10 @@
       behaviorSets:
         - Idle
         - UnarmedAttackHostiles
+    - type: GhostTakeoverAvailable
+      makeSentient: true
+      name: giant spider
+      description: Wreak havoc on the station's inhabitants!
 
 - type: entity
   name: possum

--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -59,3 +59,7 @@
     damage:
       groups:
         Brute: 15
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: space bear
+    description: Wreak havoc on the station's inhabitants, and disrupt salvage!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -56,6 +56,11 @@
     damage:
       groups:
         Brute: 20
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: space carp
+    description: Wreak havoc on the station's inhabitants, and disrupt salvage!
+
 
 - type: entity
   name: magicarp
@@ -69,6 +74,8 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: alive
       sprite: Mobs/Aliens/Carps/magic.rsi
+  - type: GhostTakeoverAvailable
+    name: magicarp
 
 - type: entity
   name: holocarp
@@ -95,3 +102,5 @@
         - SmallImpassable
       layer:
         - Opaque
+  - type: GhostTakeoverAvailable
+    name: holocarp

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -70,3 +70,7 @@
     solution: melee
   - type: SolutionTransfer
     maxTransferAmount: 5
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: space tick
+    description: Wreak havoc on the station's inhabitants, and disrupt salvage!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

reasoning:
- more ghost roles are good, and these are strictly worse than being alive, so no weird incentives
- you aren't likely to be alive for very long, so no issues with persistence or metagrudging likely to happen
- makes fighting these mobs more interesting, as now you can't rely on the fact that you can abuse their dumb AI

:cl:
- add: Giant spiders, space ticks, space bears, and space carp can now be inhabited as ghost roles by default. Have fun!
