### PR TITLE
Hotfix gas tile overlay shading

### DIFF
--- a/Content.Client/Atmos/Overlays/GasTileOverlay.cs
+++ b/Content.Client/Atmos/Overlays/GasTileOverlay.cs
@@ -31,6 +31,8 @@ namespace Content.Client.Atmos.Overlays
             var mapId = args.Viewport.Eye!.Position.MapId;
             var worldBounds = args.WorldBounds;
 
+            drawHandle.UseShader(null);
+
             foreach (var mapGrid in _mapManager.FindGridsIntersecting(mapId, worldBounds))
             {
                 if (!_gasTileOverlaySystem.HasData(mapGrid.Index))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

the actual issue is something not calling UseShader(null) after drawing but w/e this fixes it the same way

fixes #7575 

**Screenshots**
![image](https://user-images.githubusercontent.com/19853115/163655443-7d9a05cb-4708-4889-8710-cf3b2be83bca.png)
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Gas tile overlays should no longer appear unshaded.
