### PR TITLE
Fix #7574 - Lights stay off if taken from the fixture and placed back

### DIFF
--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -250,7 +250,7 @@ namespace Content.Server.Light.EntitySystems
                     case LightBulbState.Normal:
                         if (powerReceiver.Powered && light.On)
                         {
-                            powerReceiver.Load = (light.On && lightBulb.State == LightBulbState.Normal) ? lightBulb.PowerUse : 0;
+                            powerReceiver.Load = lightBulb.PowerUse;
                             SetLight(uid, true, lightBulb.Color, light, lightBulb.LightRadius, lightBulb.LightEnergy, lightBulb.LightSoftness);
                             appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.On);
                             var time = _gameTiming.CurTime;
@@ -263,15 +263,18 @@ namespace Content.Server.Light.EntitySystems
                         else
                         {
                             SetLight(uid, false, light: light);
+                            powerReceiver.Load = lightBulb.PowerUse;
                             appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Off);
                         }
                         break;
                     case LightBulbState.Broken:
                         SetLight(uid, false, light: light);
+                        powerReceiver.Load = lightBulb.PowerUse;
                         appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Broken);
                         break;
                     case LightBulbState.Burned:
                         SetLight(uid, false, light: light);
+                        powerReceiver.Load = lightBulb.PowerUse;
                         appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Burned);
                         break;
                 }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -263,18 +263,18 @@ namespace Content.Server.Light.EntitySystems
                         else
                         {
                             SetLight(uid, false, light: light);
-                            powerReceiver.Load = lightBulb.PowerUse;
+                            powerReceiver.Load = 0;
                             appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Off);
                         }
                         break;
                     case LightBulbState.Broken:
                         SetLight(uid, false, light: light);
-                        powerReceiver.Load = lightBulb.PowerUse;
+                        powerReceiver.Load = 0;
                         appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Broken);
                         break;
                     case LightBulbState.Burned:
                         SetLight(uid, false, light: light);
-                        powerReceiver.Load = lightBulb.PowerUse;
+                        powerReceiver.Load = 0;
                         appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Burned);
                         break;
                 }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -250,7 +250,6 @@ namespace Content.Server.Light.EntitySystems
                     case LightBulbState.Normal:
                         if (powerReceiver.Powered && light.On)
                         {
-                            powerReceiver.Load = lightBulb.PowerUse;
                             SetLight(uid, true, lightBulb.Color, light, lightBulb.LightRadius, lightBulb.LightEnergy, lightBulb.LightSoftness);
                             appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.On);
                             var time = _gameTiming.CurTime;
@@ -263,21 +262,20 @@ namespace Content.Server.Light.EntitySystems
                         else
                         {
                             SetLight(uid, false, light: light);
-                            powerReceiver.Load = 0;
                             appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Off);
                         }
                         break;
                     case LightBulbState.Broken:
                         SetLight(uid, false, light: light);
-                        powerReceiver.Load = 0;
                         appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Broken);
                         break;
                     case LightBulbState.Burned:
                         SetLight(uid, false, light: light);
-                        powerReceiver.Load = 0;
                         appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.Burned);
                         break;
                 }
+
+                powerReceiver.Load = (light.On && lightBulb.State == LightBulbState.Normal) ? lightBulb.PowerUse : 0;
             }
         }
 

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -244,13 +244,13 @@ namespace Content.Server.Light.EntitySystems
             }
             else
             {
-                powerReceiver.Load = (light.On && lightBulb.State == LightBulbState.Normal) ? lightBulb.PowerUse : 0;
 
                 switch (lightBulb.State)
                 {
                     case LightBulbState.Normal:
                         if (powerReceiver.Powered && light.On)
                         {
+                            powerReceiver.Load = (light.On && lightBulb.State == LightBulbState.Normal) ? lightBulb.PowerUse : 0;
                             SetLight(uid, true, lightBulb.Color, light, lightBulb.LightRadius, lightBulb.LightEnergy, lightBulb.LightSoftness);
                             appearance?.SetData(PoweredLightVisuals.BulbState, PoweredLightState.On);
                             var time = _gameTiming.CurTime;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #7574 
Bug was caused due to recent changes in how the ApcPowerReceiverComponent works. PoweredLightSystem would set the load to 60 in the receiver and instantly check if it was powered, not giving the network enough time to return true since the recent changes made it so the event is only fired when Powered switches between true/false, instead of on every Load change.
I also tested during events/power failure and brownouts, everything seems to be working correctly.

Moving the Load setting to after the Powered check fixes the issue, and to my knowledge, doesn't screw up anything else.

**Screenshots**
Sorry, GH's max upload size is 10mb.
https://youtu.be/y5XJEMQFL6Q

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Replaced light bulbs in fixtures will no longer remain off!

