### PR TITLE
Salvage mob tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1116,6 +1116,13 @@
     spawned:
     - id: FoodMeatSpider
       amount: 2
+  - type: CombatMode
+    disarmAction:
+      enabled: false
+      autoPopulate: false
+      name: action-name-disarm
+  - type: ReplacementAccent
+    accent: Xeno
   - type: InteractionPopup
     successChance: 0.5
     interactSuccessString: petting-success-tarantula

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1122,7 +1122,7 @@
       autoPopulate: false
       name: action-name-disarm
   - type: ReplacementAccent
-    accent: Xeno
+    accent: xeno
   - type: InteractionPopup
     successChance: 0.5
     interactSuccessString: petting-success-tarantula

--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -49,6 +49,11 @@
       prob: 0.3
   - type: Bloodstream
     bloodMaxVolume: 500
+  - type: CombatMode
+    disarmAction:
+      enabled: false
+      autoPopulate: false
+      name: action-name-disarm
   - type: Temperature
     heatDamageThreshold: 500
     coldDamageThreshold: 0
@@ -59,7 +64,5 @@
     damage:
       groups:
         Brute: 15
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    name: space bear
-    description: Wreak havoc on the station's inhabitants, and disrupt salvage!
+  - type: ReplacementAccent
+    accent: genericAggressive

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -23,7 +23,7 @@
     - shape:
         !type:PhysShapeCircle
         radius: 0.40
-      mass: 50
+      mass: 20
       mask:
       - Impassable
       - MobImpassable
@@ -55,12 +55,20 @@
       path: /Audio/Effects/bite.ogg
     damage:
       groups:
-        Brute: 20
+        Brute: 16
+  - type: CombatMode
+    disarmAction:
+      enabled: false
+      autoPopulate: false
+      name: action-name-disarm
   - type: GhostTakeoverAvailable
     makeSentient: true
     name: space carp
-    description: Wreak havoc on the station's inhabitants, and disrupt salvage!
-
+    description: |
+      If you're a salvage spawn, defend the loot inside!
+      Otherwise, wreak havoc on the station!
+  - type: ReplacementAccent
+    accent: genericAggressive
 
 - type: entity
   name: magicarp

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -27,7 +27,7 @@
     - shape:
         !type:PhysShapeCircle
         radius: 0.20
-      mass: 5
+      mass: 2.5
       mask:
       - Impassable
       - MobImpassable
@@ -50,6 +50,11 @@
       amount: 1
   - type: Bloodstream
     bloodMaxVolume: 50
+  - type: CombatMode
+    disarmAction:
+      enabled: false
+      autoPopulate: false
+      name: action-name-disarm
   - type: UnarmedCombat
     range: 0.5
     arcwidth: 0
@@ -73,4 +78,8 @@
   - type: GhostTakeoverAvailable
     makeSentient: true
     name: space tick
-    description: Wreak havoc on the station's inhabitants, and disrupt salvage!
+    description: |
+      If you're a salvage spawn, defend the loot inside!
+      Otherwise, wreak havoc on the station!
+  - type: ReplacementAccent
+    accent: genericAggressive

--- a/Resources/Prototypes/accents.yml
+++ b/Resources/Prototypes/accents.yml
@@ -45,5 +45,12 @@
     - Hiss.
     - Hisssss!
     - Hisssuuu...
-    - Sssss~
     - Hiss...!
+
+- type: accent
+  id: genericAggressive
+  words:
+  - Grr!
+  - Rrrr!
+  - Grr...
+  - Grrow!!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

see clog

:cl:
- remove: Space bears are no longer valid ghost roles.
- tweak: Modified the rules slightly for salvage mob ghost roles.
- tweak: Space carps/ticks/etc can no longer disarm, and they're worse at pulling things.
- tweak: Carp, ticks, spiders, and bears now have replacement accents.

