### PR TITLE
Fix flares to last their full intended duration + 1 minute

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -47,6 +47,7 @@
     color: "#FF8080"
     radius: 1.0
     energy: 9.0
+    netsync: false
   - type: LightBehaviour
     behaviours:
       - !type:RandomizeBehaviour # immediately make it bright and flickery
@@ -61,7 +62,7 @@
       - !type:FadeBehaviour # have the radius start small and get larger as it starts to burn
         id: turn_on
         interpolate: Linear
-        maxDuration: 225.0 #duration of light
+        maxDuration: 45.0
         startValue: 2.5
         endValue: 10.0
         property: Radius
@@ -78,6 +79,6 @@
         id: fade_out
         interpolate: Linear
         maxDuration: 15.0
-        startValue: 8.0
+        startValue: 10.0
         endValue: 1.0
         property: Radius

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -13,7 +13,7 @@
   - type: ExpendableLight
     spentName: spent flare
     spentDesc: It looks like this flare has burnt out. What a bummer.
-    glowDuration: 165
+    glowDuration: 225
     fadeOutDuration: 15
     iconStateOn: flare_unlit
     iconStateSpent: flare_spent
@@ -61,7 +61,7 @@
       - !type:FadeBehaviour # have the radius start small and get larger as it starts to burn
         id: turn_on
         interpolate: Linear
-        maxDuration: 45.0 #duration of light
+        maxDuration: 225.0 #duration of light
         startValue: 2.5
         endValue: 10.0
         property: Radius


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This changes flares to actually glow during the time that they are burning for. I changed flares last and I missed where it was actually timing the glow.

this also adds 1 more minute to make it a burn time of 3.75 minutes with the last 15 seconds burning out.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

Now lasts longer than 45 seconds!

![image](https://user-images.githubusercontent.com/47410468/163696377-851017bf-83f1-40c9-996f-6653b8ac47b3.png)

