### PR TITLE
Familiar QOL changes

### DIFF
--- a/Content.Server/Bible/Components/SummonableComponent.cs
+++ b/Content.Server/Bible/Components/SummonableComponent.cs
@@ -1,5 +1,8 @@
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Prototypes;
+using Content.Shared.Actions.ActionTypes;
+using Content.Server.Bible;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Bible.Components
 {
@@ -19,5 +22,13 @@ namespace Content.Server.Bible.Components
         [DataField("requriesBibleUser")]
         public bool RequiresBibleUser = true;
 
+        [DataField("summonAction")]
+        public InstantAction SummonAction = new()
+        {
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("Clothing/Head/Hats/witch.rsi/icon.png")),
+            Name = "bible-summon-verb",
+            Description = "bible-summon-verb-desc",
+            Event = new SummonActionEvent(),
+        };
     }
 }

--- a/Resources/Locale/en-US/chapel/bible.ftl
+++ b/Resources/Locale/en-US/chapel/bible.ftl
@@ -4,6 +4,7 @@ bible-heal-fail-self = You hit {THE($target)} with {THE($bible)}, and it lands w
 bible-heal-fail-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and it lands with a sad thack, dazing {OBJECT($target)}!
 bible-sizzle = The book sizzles in your hands!
 bible-summon-verb = Summon familiar
+bible-summon-verb-desc = Summon a familiar that will aid you and gain humanlike intelligence once inhabited by a soul.
 necro-heal-success-self = You hit {THE($target)} with {THE($bible)}, and {POSS-ADJ($target)} flesh warps as it melts!
 necro-heal-success-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and {POSS-ADJ($target)} flesh warps as it melts!
 necro-heal-fail-self = You hit {THE($target)} with {THE($bible)}, and it lands with a sad thwack, failing to smite {OBJECT($target)}.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -9,7 +9,7 @@
   components:
   - type: MovementSpeedModifier
     baseWalkSpeed : 6
-    baseSprintSpeed : 6
+    baseSprintSpeed : 3
   - type: Sprite
     drawdepth: Mobs
     layers:
@@ -51,6 +51,13 @@
     bloodMaxVolume: 50
   - type: ReplacementAccent
     accent: mouse
+  - type: UnarmedCombat
+    range: 1.5
+    arcwidth: 0
+    arc: bite
+    damage:
+      types:
+        Piercing: 5
 
 - type: entity
   name: bee

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -8,8 +8,8 @@
   description: Some cultures find them terrifying, others crunchy on the teeth.
   components:
   - type: MovementSpeedModifier
-    baseWalkSpeed : 6
-    baseSprintSpeed : 3
+    baseWalkSpeed : 3
+    baseSprintSpeed : 6
   - type: Sprite
     drawdepth: Mobs
     layers:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -154,6 +154,11 @@
   - type: Tag
     tags:
       - Familiar
+      - DoorBumpOpener
+  - type: Access
+    tags:
+    - Chapel
+
 
 - type: entity
   name: Ian
@@ -219,6 +224,10 @@
   - type: Tag
     tags:
       - Familiar
+      - DoorBumpOpener
+  - type: Access
+    tags:
+    - Chapel
 
 - type: entity
   name: Lisa

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -228,6 +228,13 @@
   - type: Access
     tags:
     - Chapel
+  - type: UnarmedCombat
+    range: 1.5
+    arcwidth: 0
+    arc: bite
+    damage:
+      types:
+        Piercing: 5
 
 - type: entity
   name: Lisa

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -114,53 +114,6 @@
         Heat : 1 #per second, scales with temperature & other constants
 
 - type: entity
-  name: Cerberus
-  parent: MobCorgiNarsi
-  id: MobCorgiCerberus
-  description: This pupper is not wholesome.
-  components:
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    name: Cerberus, Evil Familiar
-    description: Obey your master. Spread chaos.
-    rules: You are an intelligent, demonic dog. Try to help the chaplain and any of his flock. As an antagonist, you're otherwise unrestrained.
-  - type: UnarmedCombat
-    range: 1.5
-    arcwidth: 0
-    arc: bite
-    damage:
-      types:
-        Piercing: 8
-        Slash: 7
-  - type: UtilityAI
-    behaviorSets:
-    - Idle
-  - type: AiFactionTag
-    factions:
-    - SimpleNeutral
-  - type: InteractionPopup
-    successChance: 0.5
-    interactSuccessString: petting-success-corrupted-corgi
-    interactFailureString: petting-failure-corrupted-corgi
-  - type: MobState
-    thresholds:
-      0: !type:NormalMobState {}
-      80: !type:CriticalMobState {}
-      160: !type:DeadMobState {}
-  - type: Grammar
-    attributes:
-      gender: male
-      proper: true
-  - type: Tag
-    tags:
-      - Familiar
-      - DoorBumpOpener
-  - type: Access
-    tags:
-    - Chapel
-
-
-- type: entity
   name: Ian
   parent: MobCorgi
   id: MobCorgiOld
@@ -205,36 +158,6 @@
     attributes:
       proper: true
       gender: male
-
-- type: entity
-  name: Remilia
-  parent: MobBat
-  id: MobBatRemilia
-  description: The chaplain's familiar. Likes fruit.
-  components:
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    name: Remilia, the chaplain's familiar
-    description: Obey your master. Eat fruit.
-    rules: Follow the chaplain around. Don't cause any trouble unless the chaplain tells you to.
-  - type: Grammar
-    attributes:
-      gender: female
-      proper: true
-  - type: Tag
-    tags:
-      - Familiar
-      - DoorBumpOpener
-  - type: Access
-    tags:
-    - Chapel
-  - type: UnarmedCombat
-    range: 1.5
-    arcwidth: 0
-    arc: bite
-    damage:
-      types:
-        Piercing: 5
 
 - type: entity
   name: Lisa

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -22,6 +22,7 @@
     - Chapel
   - type: Mind
     showExamineInfo: true
+  - type: Alerts
 
 - type: entity
   name: Cerberus

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -1,0 +1,72 @@
+- type: entity
+  name: Remilia
+  parent: MobBat
+  id: MobBatRemilia
+  description: The chaplain's familiar. Likes fruit.
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: Remilia, the chaplain's familiar
+    description: Obey your master. Eat fruit.
+    rules: You are an intelligent fruit bat. Follow the chaplain around. Don't cause any trouble unless the chaplain tells you to.
+  - type: Grammar
+    attributes:
+      gender: female
+      proper: true
+  - type: Tag
+    tags:
+      - Familiar
+      - DoorBumpOpener
+  - type: Access
+    tags:
+    - Chapel
+  - type: Mind
+    showExamineInfo: true
+
+- type: entity
+  name: Cerberus
+  parent: MobCorgiNarsi
+  id: MobCorgiCerberus
+  description: This pupper is not wholesome.
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: Cerberus, Evil Familiar
+    description: Obey your master. Spread chaos.
+    rules: You are an intelligent, demonic dog. Try to help the chaplain and any of his flock. As an antagonist, you're otherwise unrestrained.
+  - type: UnarmedCombat
+    range: 1.5
+    arcwidth: 0
+    arc: bite
+    damage:
+      types:
+        Piercing: 8
+        Slash: 7
+  - type: UtilityAI
+    behaviorSets:
+    - Idle
+  - type: AiFactionTag
+    factions:
+    - SimpleNeutral
+  - type: InteractionPopup
+    successChance: 0.5
+    interactSuccessString: petting-success-corrupted-corgi
+    interactFailureString: petting-failure-corrupted-corgi
+  - type: MobState
+    thresholds:
+      0: !type:NormalMobState {}
+      80: !type:CriticalMobState {}
+      160: !type:DeadMobState {}
+  - type: Grammar
+    attributes:
+      gender: male
+      proper: true
+  - type: Tag
+    tags:
+      - Familiar
+      - DoorBumpOpener
+  - type: Access
+    tags:
+    - Chapel
+  - type: Mind
+    showExamineInfo: true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Familiars are now DoorBumpOpeners with chapel access, and the summon familiar verb is now an action too.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/60792108/163719610-0d470243-6553-4467-ba6e-c211dc3e477f.mp4



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: The bible's Summon Familiar now appears in the action bar in addition to being an alternative verb.
- tweak: Familiars can now open public and chapel doors by walking into them.
- fix: Familiars now accurately show when they are dead when examined.
