### PR TITLE
fix airlock collision

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -127290,13 +127290,6 @@ entities:
   - pos: 0.5,-81.5
     parent: 61
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
   - containers:
       board: !type:Container
         ents: []
@@ -146801,13 +146794,6 @@ entities:
     pos: 53.5,11.5
     parent: 61
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 13115
   type: TableWood
   components:
@@ -174387,13 +174373,6 @@ entities:
     pos: 53.5,6.5
     parent: 61
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 16226
   type: SignCargoDock
   components:
@@ -195113,13 +195092,6 @@ entities:
     pos: 34.5,42.5
     parent: 61
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 18631
   type: AirlockExternalLocked
   components:
@@ -195133,13 +195105,6 @@ entities:
     pos: 34.5,33.5
     parent: 61
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 18633
   type: AirlockExternalLocked
   components:
@@ -195153,13 +195118,6 @@ entities:
     pos: 42.5,33.5
     parent: 61
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 18635
   type: AirlockExternalShuttleLocked
   components:
@@ -195167,13 +195125,6 @@ entities:
     pos: 42.5,42.5
     parent: 61
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 18636
   type: AirlockExternalLocked
   components:

--- a/Resources/Maps/moose.yml
+++ b/Resources/Maps/moose.yml
@@ -74161,13 +74161,6 @@ entities:
     pos: -55.5,0.5
     parent: 33
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7115
   type: AirlockExternalLocked
   components:
@@ -74187,13 +74180,6 @@ entities:
     pos: -63.5,0.5
     parent: 33
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7118
   type: Poweredlight
   components:

--- a/Resources/Maps/nss_pillar.yml
+++ b/Resources/Maps/nss_pillar.yml
@@ -29565,13 +29565,6 @@ entities:
     pos: -73.5,33.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 1445
   type: AirlockExternalGlassShuttleLocked
   components:
@@ -29579,13 +29572,6 @@ entities:
     pos: -67.5,33.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 1446
   type: AirlockExternalGlassLocked
   components:
@@ -29605,13 +29591,6 @@ entities:
     pos: -61.5,33.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 1449
   type: ReinforcedWindow
   components:
@@ -34981,13 +34960,6 @@ entities:
     pos: -46.5,46.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 2162
   type: PoweredSmallLight
   components:
@@ -99894,13 +99866,6 @@ entities:
     pos: -42.5,46.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 8313
   type: WallReinforced
   components:
@@ -107670,13 +107635,6 @@ entities:
     pos: -83.5,24.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9241
   type: AirlockExternalGlassShuttleLocked
   components:
@@ -107684,13 +107642,6 @@ entities:
     pos: -83.5,25.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9242
   type: ReinforcedWindow
   components:
@@ -107809,13 +107760,6 @@ entities:
     pos: -79.5,29.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9257
   type: AirlockExternalGlassShuttleLocked
   components:
@@ -107823,13 +107767,6 @@ entities:
     pos: -80.5,29.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9258
   type: CableApcExtension
   components:
@@ -110046,13 +109983,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9482
   type: AirlockShuttle
   components:
@@ -110065,13 +109995,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9483
   type: WallReinforced
   components:
@@ -113056,13 +112979,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9801
   type: AirlockShuttle
   components:
@@ -113076,13 +112992,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9802
   type: SignShipDock
   components:
@@ -114596,13 +114505,6 @@ entities:
     pos: -43.5,-29.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9979
   type: FirelockGlass
   components:
@@ -114632,13 +114534,6 @@ entities:
     pos: -43.5,-25.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 9983
   type: ReinforcedWindow
   components:
@@ -114808,13 +114703,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 10009
   type: AirlockShuttle
   components:
@@ -114827,13 +114715,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 10010
   type: CableApcExtension
   components:
@@ -127412,13 +127293,6 @@ entities:
     pos: 65.5,19.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 11270
   type: AirlockShuttle
   components:
@@ -127426,13 +127300,6 @@ entities:
     pos: 66.5,16.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 11271
   type: AirlockExternalGlassShuttleLocked
   components:
@@ -127440,13 +127307,6 @@ entities:
     pos: 66.5,0.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 11272
   type: AirlockExternalGlassShuttleLocked
   components:
@@ -127454,13 +127314,6 @@ entities:
     pos: 66.5,4.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 11273
   type: AirlockExternalGlassShuttleLocked
   components:
@@ -127468,13 +127321,6 @@ entities:
     pos: 66.5,7.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 11274
   type: AirlockExternalGlassShuttleLocked
   components:
@@ -127482,13 +127328,6 @@ entities:
     pos: 66.5,11.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 11275
   type: Catwalk
   components:
@@ -137243,13 +137082,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 12248
   type: AirlockShuttle
   components:
@@ -137264,38 +137096,18 @@ entities:
     state: Opening
     type: Door
   - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 12249
   type: AirlockShuttle
   components:
   - pos: 0.5,-7.5
     parent: 12185
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 12250
   type: AirlockShuttle
   components:
   - pos: 1.5,-7.5
     parent: 12185
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 12251
   type: Thruster
   components:
@@ -139038,13 +138850,6 @@ entities:
     pos: 25.5,36.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 12428
   type: ExtinguisherCabinetFilled
   components:
@@ -142112,13 +141917,6 @@ entities:
     pos: -43.5,-24.5
     parent: 130
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 12723
   type: BoxSterile
   components:

--- a/Resources/Maps/nss_pillar.yml
+++ b/Resources/Maps/nss_pillar.yml
@@ -137095,7 +137095,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
 - uid: 12249
   type: AirlockShuttle
   components:

--- a/Resources/Maps/packedstation.yml
+++ b/Resources/Maps/packedstation.yml
@@ -14552,13 +14552,6 @@ entities:
   - pos: -10.5,-8.5
     parent: 2
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 39
   type: CableApcExtension
   components:
@@ -14970,13 +14963,6 @@ entities:
   - pos: -6.5,-13.5
     parent: 2
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 97
   type: Grille
   components:
@@ -16561,13 +16547,6 @@ entities:
     pos: -1.5,10.5
     parent: 2
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 324
   type: AirlockExternalGlass
   components:
@@ -16587,13 +16566,6 @@ entities:
     pos: -1.5,4.5
     parent: 2
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 327
   type: Chair
   components:
@@ -28644,13 +28616,6 @@ entities:
     pos: 4.5,24.5
     parent: 2
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 2002
   type: AirlockExternalGlass
   components:
@@ -28670,13 +28635,6 @@ entities:
     pos: 4.5,26.5
     parent: 2
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 2005
   type: Grille
   components:
@@ -128259,13 +128217,6 @@ entities:
   - pos: -11.5,-1.5
     parent: 2
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 12126
   type: WallShuttle
   components:

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -6985,13 +6985,6 @@ entities:
     pos: -41.5,8.5
     parent: 857
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
   - containers:
       board: !type:Container
         ents: []
@@ -7042,13 +7035,6 @@ entities:
     pos: -41.5,4.5
     parent: 857
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
   - containers:
       board: !type:Container
         ents: []

--- a/Resources/Maps/splitstation.yml
+++ b/Resources/Maps/splitstation.yml
@@ -24325,13 +24325,6 @@ entities:
     pos: 11.5,14.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 539
   type: WallSolid
   components:
@@ -29334,13 +29327,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 1203
   type: WallReinforced
   components:
@@ -29642,13 +29628,6 @@ entities:
     pos: -21.5,6.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
   - containers:
       board: !type:Container
         ents: []
@@ -35838,13 +35817,6 @@ entities:
     pos: 17.5,14.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 1958
   type: WallSolid
   components:
@@ -36359,13 +36331,6 @@ entities:
     changeAirtight: False
     state: Opening
     type: Door
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 2019
   type: WallReinforced
   components:
@@ -41116,13 +41081,6 @@ entities:
     pos: -51.5,14.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 2556
   type: WallReinforced
   components:
@@ -83079,52 +83037,24 @@ entities:
   - pos: 18.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7403
   type: AirlockExternalGlassShuttleLocked
   components:
   - pos: 17.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7404
   type: AirlockExternalGlassShuttleLocked
   components:
   - pos: 12.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7405
   type: AirlockExternalGlassShuttleLocked
   components:
   - pos: 13.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7406
   type: AirlockCargoGlassLocked
   components:
@@ -83485,26 +83415,12 @@ entities:
   - pos: 2.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7466
   type: AirlockExternalGlassShuttleLocked
   components:
   - pos: 3.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7467
   type: Catwalk
   components:
@@ -84416,52 +84332,24 @@ entities:
   - pos: -11.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7589
   type: AirlockExternalGlassShuttleLocked
   components:
   - pos: -10.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7590
   type: AirlockExternalGlassShuttleLocked
   components:
   - pos: -3.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7591
   type: AirlockExternalGlassShuttleLocked
   components:
   - pos: -2.5,-135.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7592
   type: AirlockExternalGlass
   components:
@@ -84775,13 +84663,6 @@ entities:
     pos: -22.5,-131.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7644
   type: AirlockExternalGlassShuttleLocked
   components:
@@ -84789,13 +84670,6 @@ entities:
     pos: -22.5,-130.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 7645
   type: Catwalk
   components:
@@ -115529,13 +115403,6 @@ entities:
     pos: 45.5,-31.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 11293
   type: AsteroidRock
   components:
@@ -203986,13 +203853,6 @@ entities:
     pos: -45.5,14.5
     parent: 112
     type: Transform
-  - fixtures:
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 20452
   type: Rack
   components:


### PR DESCRIPTION
This just removes the fixtures component from the maps, because the saved fixture overrides the entity prototype's fixtures.

If this causes conflicts for some other map changes, people can just override the changes and remove the fixtures themselves (or just delete & re-add the docking airlocks).

:cl:
- fix: Fixed docking airlocks not having proper collision.

