### PR TITLE
Fix pointing in mapping mode

### DIFF
--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -219,7 +219,7 @@ namespace Content.Server.Pointing.EntitySystems
 
         public override void Update(float frameTime)
         {
-            foreach (var component in EntityManager.EntityQuery<PointingArrowComponent>())
+            foreach (var component in EntityManager.EntityQuery<PointingArrowComponent>(true))
             {
                 component.Update(frameTime);
             }

--- a/Resources/Prototypes/Entities/Markers/pointing.yml
+++ b/Resources/Prototypes/Entities/Markers/pointing.yml
@@ -1,6 +1,7 @@
 ﻿- type: entity
   name: pointing arrow
   id: pointingarrow
+  save: false
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
Fixes #7606

Makes pointing system update even when paused, and sets pointing arrow entities to not be saved to the map. 