### PR TITLE
Make mapping use consistent Entity Uids

### DIFF
--- a/Content.Server/GameTicking/Commands/MappingCommand.cs
+++ b/Content.Server/GameTicking/Commands/MappingCommand.cs
@@ -67,7 +67,7 @@ namespace Content.Server.GameTicking.Commands
             if (args.Length <= 1)
                 shell.ExecuteCommand($"addmap {mapId} false");
             else
-                shell.ExecuteCommand($"loadmap {mapId} \"{CommandParsing.Escape(args[1])}\"");
+                shell.ExecuteCommand($"loadmap {mapId} \"{CommandParsing.Escape(args[1])}\" 0 0 0 true");
 
             // was the map actually created?
             if (!mapManager.MapExists(mapId))


### PR DESCRIPTION
This PR makes the mapping command use the `storeUids` option when loading maps. This ensure that entities loaded from yaml will get written to yaml using the same UID. Requires space-wizards/RobustToolbox/pull/2744.

As to why: for smaller and actually readable map diffs. Map saving tries to save entities using consecutive EntityUids. This means that if you delete entity 100, many entities need their Uids reshuffled (101 -> 100, 102 -> 101, etc). If this impacts a grid-entity, this also leads to changes to the parentUid in the transform component of many entities. So with +30k entities this will often lead to ~+30k changed lines.

The diffs are still a bit ugly due to GridAtmosphereComponent seemingly saving the gas mixtures slightly differently every time, but with this change simple map edits can actually once again be examined by looking at the diffs