### PR TITLE
Fix hardsuit lights not working

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -86,6 +86,7 @@
       map: [ "light" ]
   - type: Clothing
     HeldPrefix: off
+  - type: ToggleableLightVisuals
   - type: PointLight
     netsync: false
     enabled: false


### PR DESCRIPTION
I accidentally broke them for non atmos-variants.

:cl:
- fix: Fixed most hardsuit helmets not having working lights.
