### PR TITLE
Fix lathe completetime

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -558,7 +558,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatcap.rsi
     state: icon
   result: ClothingOuterWinterCap
-  completetime: 800
+  completetime: 3.2
   materials:
     Cloth: 300
     Durathread: 300
@@ -569,7 +569,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatce.rsi
     state: icon
   result: ClothingOuterWinterCE
-  completetime: 800
+  completetime: 3.2
   materials:
     Cloth: 300
     Durathread: 300
@@ -580,7 +580,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatcmo.rsi
     state: icon
   result: ClothingOuterWinterCMO
-  completetime: 800
+  completetime: 3.2
   materials:
     Cloth: 300
     Durathread: 300
@@ -591,7 +591,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coathop.rsi
     state: icon
   result: ClothingOuterWinterHoP
-  completetime: 800
+  completetime: 3.2
   materials:
     Cloth: 300
     Durathread: 300
@@ -602,7 +602,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coathos.rsi
     state: icon
   result: ClothingOuterWinterHoS
-  completetime: 800
+  completetime: 3.2
   materials:
     Cloth: 300
     Durathread: 300
@@ -613,7 +613,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatqm.rsi
     state: icon
   result: ClothingOuterWinterQM
-  completetime: 800
+  completetime: 3.2
   materials:
     Cloth: 300
     Durathread: 300
@@ -624,7 +624,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatrd.rsi
     state: icon
   result: ClothingOuterWinterRD
-  completetime: 800
+  completetime: 3.2
   materials:
     Cloth: 300
     Durathread: 300

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Devices/timer.rsi
     state: timer
   result: TimerTrigger
-  completetime: 500
+  completetime: 2
   materials:
     Steel: 300
     Plastic: 200
@@ -15,7 +15,7 @@
     sprite: Objects/Devices/payload.rsi
     state: payload-empty
   result: ChemicalPayload
-  completetime: 500
+  completetime: 2
   materials:
     Steel: 200
     Plastic: 300

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -189,7 +189,7 @@
   id: StasisBedMachineCircuitboard
   icon: Objects/Misc/module.rsi/id_mod.png
   result: StasisBedMachineCircuitboard
-  completetime: 1000
+  completetime: 4
   materials:
     Steel: 100
     Glass: 900


### PR DESCRIPTION
Some of the lathe recipes weren't updated to seconds when #7238 was merged. Probably because those recipes were added after the PR was created.

fixes #7620.