### PR TITLE
Add an atmos throw velocity cap, adjustible CVars, and fix throw directions

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -9,6 +9,10 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly IConfigurationManager _cfg = default!;
 
         public bool SpaceWind { get; private set; }
+        public float SpaceWindPressureForceDivisorThrow { get; private set; }
+        public float SpaceWindPressureForceDivisorPush { get; private set; }
+        public float SpaceWindMaxVelocity { get; private set; }
+        public float SpaceWindMaxPushForce { get; private set; }
         public bool MonstermosEqualization { get; private set; }
         public bool MonstermosDepressurization { get; private set; }
         public bool MonstermosRipTiles { get; private set; }
@@ -23,6 +27,10 @@ namespace Content.Server.Atmos.EntitySystems
         private void InitializeCVars()
         {
             _cfg.OnValueChanged(CCVars.SpaceWind, value => SpaceWind = value, true);
+            _cfg.OnValueChanged(CCVars.SpaceWindPressureForceDivisorThrow, value => SpaceWindPressureForceDivisorThrow = value, true);
+            _cfg.OnValueChanged(CCVars.SpaceWindPressureForceDivisorPush, value => SpaceWindPressureForceDivisorPush = value, true);
+            _cfg.OnValueChanged(CCVars.SpaceWindMaxVelocity, value => SpaceWindMaxVelocity = value, true);
+            _cfg.OnValueChanged(CCVars.SpaceWindMaxPushForce, value => SpaceWindMaxPushForce = value, true);
             _cfg.OnValueChanged(CCVars.MonstermosEqualization, value => MonstermosEqualization = value, true);
             _cfg.OnValueChanged(CCVars.MonstermosDepressurization, value => MonstermosDepressurization = value, true);
             _cfg.OnValueChanged(CCVars.MonstermosRipTiles, value => MonstermosRipTiles = value, true);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -545,6 +545,32 @@ namespace Content.Shared.CCVar
             CVarDef.Create("atmos.space_wind", true, CVar.SERVERONLY);
 
         /// <summary>
+        ///     Divisor from maxForce (pressureDifference * 2.25f) to force applied on objects.
+        /// </summary>
+        public static readonly CVarDef<float> SpaceWindPressureForceDivisorThrow =
+            CVarDef.Create("atmos.space_wind_pressure_force_divisor_throw", 15f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Divisor from maxForce (pressureDifference * 2.25f) to force applied on objects.
+        /// </summary>
+        public static readonly CVarDef<float> SpaceWindPressureForceDivisorPush =
+            CVarDef.Create("atmos.space_wind_pressure_force_divisor_push", 2500f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     The maximum velocity (not force) that may be applied to an object by atmospheric pressure differences.
+        ///     Useful to prevent clipping through objects.
+        /// </summary>
+        public static readonly CVarDef<float> SpaceWindMaxVelocity =
+            CVarDef.Create("atmos.space_wind_max_velocity", 30f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     The maximum force that may be applied to an object by pushing (i.e. not throwing) atmospheric pressure differences.
+        ///     A "throwing" atmospheric pressure difference ignores this limit, but not the max. velocity limit.
+        /// </summary>
+        public static readonly CVarDef<float> SpaceWindMaxPushForce =
+            CVarDef.Create("atmos.space_wind_max_push_force", 20f, CVar.SERVERONLY);
+
+        /// <summary>
         ///     Whether monstermos tile equalization is enabled.
         /// </summary>
         public static readonly CVarDef<bool> MonstermosEqualization =


### PR DESCRIPTION
## About the PR

This should hopefully either fix the "atmos clipped me through a wall" problem or make it relatively easy to fix in future by simply lowering the default values of some CVars.

**Changelog**

:cl:
- fix: You should be less likely to be phased through walls.
- fix: When pushed by high pressure differences ("space wind") you should be pushed in the direction of the pressure difference again.

