### PR TITLE
Familiars respawn

### DIFF
--- a/Content.Server/Atmos/Components/MovedByPressureComponent.cs
+++ b/Content.Server/Atmos/Components/MovedByPressureComponent.cs
@@ -16,6 +16,7 @@ namespace Content.Server.Atmos.Components
         /// Accumulates time when yeeted by high pressure deltas.
         /// </summary>
         [ViewVariables]
+        [DataField("accumulator")]
         public float Accumulator = 0f;
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -36,6 +36,9 @@ namespace Content.Server.Bible
             SubscribeLocalEvent<SummonableComponent, SummonActionEvent>(OnSummon);
             SubscribeLocalEvent<FamiliarComponent, MobStateChangedEvent>(OnFamiliarDeath);
         }
+        /// <summary>
+        /// This handles familiar respawning.
+        /// </summary>
         public override void Update(float frameTime)
         {
             base.Update(frameTime);
@@ -152,6 +155,10 @@ namespace Content.Server.Bible
             AttemptSummon(component, args.Performer, Transform(args.Performer));
         }
 
+        /// <summary>
+        /// Starts up the respawn stuff when
+        /// the chaplain's familiar dies.
+        /// </summary>
         private void OnFamiliarDeath(EntityUid uid, FamiliarComponent component, MobStateChangedEvent args)
         {
             if (!args.Component.IsDead() || component.Source == null)
@@ -160,10 +167,11 @@ namespace Content.Server.Bible
             var source = component.Source;
             if (source != null && TryComp<SummonableComponent>(source, out var summonable))
             {
-                summonable.ResidentDead = true;
                 AddComp<SummonableRespawningComponent>(summonable.Owner);
             }
         }
+
+
         private void AttemptSummon(SummonableComponent component, EntityUid user, TransformComponent? position)
         {
             if (component.AlreadySummoned || component.SpecialItemPrototype == null)
@@ -179,12 +187,15 @@ namespace Content.Server.Bible
 
             // Make this familiar the component's summon
             var familiar = EntityManager.SpawnEntity(component.SpecialItemPrototype, position.Coordinates);
-            component.Summon = familiar;
+                            component.Summon = familiar;
 
-            /// Make this Summon the familiar's source
-            var familiarComp = AddComp<FamiliarComponent>(familiar);
-            familiarComp.Source = component.Owner;
-
+            /// We only want to add the familiar component to mobs
+            if (HasComp<MobStateComponent>(familiar))
+            {
+                /// Make this Summon the familiar's source
+                var familiarComp = AddComp<FamiliarComponent>(familiar);
+                familiarComp.Source = component.Owner;
+            }
             component.AlreadySummoned = true;
             _actionsSystem.RemoveAction(user, component.SummonAction);
         }

--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -209,7 +209,7 @@ namespace Content.Server.Bible
             if (HasComp<MobStateComponent>(familiar))
             {
                 /// Make this Summon the familiar's source
-                var familiarComp = AddComp<FamiliarComponent>(familiar);
+                var familiarComp = EnsureComp<FamiliarComponent>(familiar);
                 familiarComp.Source = component.Owner;
             }
             component.AlreadySummoned = true;

--- a/Content.Server/Bible/Components/FamiliarComponent.cs
+++ b/Content.Server/Bible/Components/FamiliarComponent.cs
@@ -1,0 +1,17 @@
+namespace Content.Server.Bible.Components
+{
+    /// <summary>
+    /// This component is for the chaplain's familiars, and mostly
+    /// used to track their current state and to give a component to check for
+    /// if any special behavior is needed.
+    /// </summary>
+    [RegisterComponent]
+    public sealed class FamiliarComponent : Component
+    {
+        /// <summary>
+        /// The entity this familiar was summoned from.
+        /// </summary>
+        [ViewVariables]
+        public EntityUid? Source = null;
+    }
+}

--- a/Content.Server/Bible/Components/SummonableComponent.cs
+++ b/Content.Server/Bible/Components/SummonableComponent.cs
@@ -38,6 +38,7 @@ namespace Content.Server.Bible.Components
 
         /// Used for respawning
         [ViewVariables]
+        [DataField("accumulator")]
         public float Accumulator = 0f;
         [ViewVariables]
         [DataField("respawnTime")]

--- a/Content.Server/Bible/Components/SummonableComponent.cs
+++ b/Content.Server/Bible/Components/SummonableComponent.cs
@@ -35,9 +35,8 @@ namespace Content.Server.Bible.Components
             Description = "bible-summon-verb-desc",
             Event = new SummonActionEvent(),
         };
-        /// used for respawning
-        public bool ResidentDead = false;
 
+        /// Used for respawning
         [ViewVariables]
         public float Accumulator = 0f;
         [ViewVariables]

--- a/Content.Server/Bible/Components/SummonableComponent.cs
+++ b/Content.Server/Bible/Components/SummonableComponent.cs
@@ -1,7 +1,6 @@
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Prototypes;
 using Content.Shared.Actions.ActionTypes;
-using Content.Server.Bible;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Bible.Components
@@ -22,6 +21,12 @@ namespace Content.Server.Bible.Components
         [DataField("requriesBibleUser")]
         public bool RequiresBibleUser = true;
 
+        /// <summary>
+        /// The specific creature this summoned, if the SpecialItemPrototype has a mobstate.
+        /// </summary>
+        [ViewVariables]
+        public EntityUid? Summon = null;
+
         [DataField("summonAction")]
         public InstantAction SummonAction = new()
         {
@@ -30,5 +35,13 @@ namespace Content.Server.Bible.Components
             Description = "bible-summon-verb-desc",
             Event = new SummonActionEvent(),
         };
+        /// used for respawning
+        public bool ResidentDead = false;
+
+        [ViewVariables]
+        public float Accumulator = 0f;
+        [ViewVariables]
+        [DataField("respawnTime")]
+        public float RespawnTime = 180f;
     }
 }

--- a/Content.Server/Bible/Components/SummonableRespawningComponent.cs
+++ b/Content.Server/Bible/Components/SummonableRespawningComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.Bible.Components
+{
+    /// <summary>
+    /// EntityQuery Tracking Component for Summonables that are counting up a respawn.
+    /// </summary>
+    [RegisterComponent]
+    public sealed class SummonableRespawningComponent : Component
+    {}
+}

--- a/Content.Server/Cargo/Components/CargoTelepadComponent.cs
+++ b/Content.Server/Cargo/Components/CargoTelepadComponent.cs
@@ -19,6 +19,7 @@ namespace Content.Server.Cargo.Components
         /// How much time we've accumulated until next teleport.
         /// </summary>
         [ViewVariables]
+        [DataField("accumulator")]
         public float Accumulator = 0f;
 
         [ViewVariables]

--- a/Content.Server/Disease/Components/DiseaseMachineComponent.cs
+++ b/Content.Server/Disease/Components/DiseaseMachineComponent.cs
@@ -16,6 +16,7 @@ namespace Content.Server.Disease.Components
         /// How much time we've accumulated processing
         /// </summary>
         [ViewVariables]
+        [DataField("accumulator")]
         public float Accumulator = 0f;
         /// <summary>
         /// The disease prototype currently being diagnosed

--- a/Content.Server/Explosion/Components/TriggerOnProximityComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerOnProximityComponent.cs
@@ -47,6 +47,7 @@ namespace Content.Server.Explosion.Components
         /// <summary>
         /// How much cooldown has elapsed (if relevant).
         /// </summary>
+        [DataField("accumulator")]
         public float Accumulator = 0f;
 
         /// <summary>

--- a/Content.Server/Fluids/Components/EvaporationComponent.cs
+++ b/Content.Server/Fluids/Components/EvaporationComponent.cs
@@ -46,6 +46,7 @@ namespace Content.Server.Fluids.Components
         /// <summary>
         ///     The time accumulated since the start.
         /// </summary>
+        [DataField("accumulator")]
         public float Accumulator = 0f;
     }
 }

--- a/Content.Server/Lathe/Components/LatheComponent.cs
+++ b/Content.Server/Lathe/Components/LatheComponent.cs
@@ -32,11 +32,13 @@ namespace Content.Server.Lathe.Components
         /// <summary>
         /// Update accumulator for the insertion time
         /// </suummary>
+        [DataField("insertionAccumulator")]
         public float InsertionAccumulator = 0f;
         /// <summary>
         /// Production accumulator for the production time.
         /// </summary>
         [ViewVariables]
+        [DataField("producingAccumulator")]
         public float ProducingAccumulator = 0f;
 
         /// <summary>

--- a/Content.Server/Singularity/Components/ServerSingularityComponent.cs
+++ b/Content.Server/Singularity/Components/ServerSingularityComponent.cs
@@ -60,6 +60,7 @@ namespace Content.Server.Singularity.Components
                 _ => 0
             };
 
+        [DataField("moveAccumulator")]
         public float MoveAccumulator;
 
         // This is an interesting little workaround.

--- a/Content.Shared/Emag/Components/EmagComponent.cs
+++ b/Content.Shared/Emag/Components/EmagComponent.cs
@@ -11,6 +11,8 @@ namespace Content.Shared.Emag.Components
 
         [DataField("rechargeTime"), ViewVariables(VVAccess.ReadWrite)]
         public float RechargeTime = 90f;
+
+        [DataField("accumulator")]
         public float Accumulator = 0f;
     }
 }

--- a/Resources/Locale/en-US/chapel/bible.ftl
+++ b/Resources/Locale/en-US/chapel/bible.ftl
@@ -5,6 +5,7 @@ bible-heal-fail-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE(
 bible-sizzle = The book sizzles in your hands!
 bible-summon-verb = Summon familiar
 bible-summon-verb-desc = Summon a familiar that will aid you and gain humanlike intelligence once inhabited by a soul.
+bible-summon-respawn-ready = {CAPITALIZE(THE($book))} surges with ethereal power. {CAPITALIZE(POSS-ADJ($book))} resident is home again.
 necro-heal-success-self = You hit {THE($target)} with {THE($bible)}, and {POSS-ADJ($target)} flesh warps as it melts!
 necro-heal-success-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and {POSS-ADJ($target)} flesh warps as it melts!
 necro-heal-fail-self = You hit {THE($target)} with {THE($bible)}, and it lands with a sad thwack, failing to smite {OBJECT($target)}.

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -15,7 +15,6 @@
       proper: true
   - type: Tag
     tags:
-      - Familiar
       - DoorBumpOpener
   - type: Access
     tags:
@@ -64,7 +63,6 @@
       proper: true
   - type: Tag
     tags:
-      - Familiar
       - DoorBumpOpener
   - type: Access
     tags:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -55,6 +55,7 @@
     cooldownTime: 1.3
   - type: Summonable
     specialItem: MobCorgiCerberus
+    respawnTime: 300
   - type: Sprite
     netsync: false
     sprite: Objects/Specific/Chapel/necronomicon.rsi

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -136,9 +136,6 @@
   id: ExplosivePassable
 
 - type: Tag
-  id: Familiar
-
-- type: Tag
   id: FireAlarmElectronics
 
 - type: Tag


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As suggested during the discussion yesterday about people griefing the chaplain, familiars respawn now, which makes random deaths to atmos or griefers a bit less devastating to their round. 3 minutes for Remilia, 5 minutes for Cerberus.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- add: The chaplain's familiars can be resummoned now after they die. 3 minutes for Remilia, 5 minutes for Cerberus.

