### PR TITLE
Change doors to ignore static entities when closing

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -170,7 +170,7 @@ public abstract class SharedDoorSystem : EntitySystem
     protected virtual void OnActivate(EntityUid uid, DoorComponent door, ActivateInWorldEvent args)
     {
         // avoid client-mispredicts, as the server will definitely handle this event
-        args.Handled = true; 
+        args.Handled = true;
     }
 
     private void OnExamine(EntityUid uid, DoorComponent door, ExaminedEvent args)
@@ -433,7 +433,7 @@ public abstract class SharedDoorSystem : EntitySystem
             if (!otherPhysics.CanCollide)
                 continue;
 
-            if ((physics.CollisionMask & otherPhysics.CollisionLayer) == 0
+            if (otherPhysics.BodyType == BodyType.Static || (physics.CollisionMask & otherPhysics.CollisionLayer) == 0
                 && (otherPhysics.CollisionMask & physics.CollisionLayer) == 0)
                 continue;
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Doors now ignore static entities that are in the way when closing.
Fixes #7032 

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Firelocks and airlocks now close when there are static entities in the way (e.g. anchored tables).
