### PR TITLE
Adds a number identifier to all mobs except players

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -133,6 +133,8 @@
     safe: false
   - type: StandingState
   - type: Alerts
+  - type: NameIdentifier
+    group: GenericNumber
 
 - type: entity
   save: false

--- a/Resources/Prototypes/name_identifier_groups.yml
+++ b/Resources/Prototypes/name_identifier_groups.yml
@@ -13,3 +13,7 @@
   fullName: true
   minValue: 10000
   maxValue: 99999
+
+# Used to suffix a number to any mob to identify player controlled mob griefing.
+- type: nameIdentifierGroup
+  id: GenericNumber


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds a generic number identifier to all mobs so that griefers can be identified.

This is in response to getting reports of carps and ticks not following salvage rules so now we can identify them easier since players can report them by number. Extended it to include all generic passive mobs to identify unruly farm animals etc.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![ident](https://user-images.githubusercontent.com/78795277/164239849-8793286a-46ef-4c95-9dc9-bcaf5860ad5e.PNG)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added a number identifier to all mobs. Now it's easier to report rule breaking ghost roles such as ticks and carp.
