### PR TITLE
splitstation massive update

### DIFF
--- a/Resources/Prototypes/Maps/splitstation.yml
+++ b/Resources/Prototypes/Maps/splitstation.yml
@@ -1,6 +1,6 @@
 - type: gameMap
   id: splitstation
-  mapName: 'Split Station v2.1'
+  mapName: 'Split Station'
   mapNameTemplate: '{0} Split Station {1}'
   nameGenerator:
     !type:NanotrasenNameGenerator


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Totally redid the whole bottom half of the station as well as top right.

Notable changes are:

- Science and Salvage are now in the top right.
- Bar is now in the center as one of the bridges.
- Cargo is now top right of bottom station so it's more central.
- Bridge is now in the lower section overlooking a wide park area.
- There's now more outside rock areas to explore. More to come.

Might be some teething issues or complaints about maint but will likely ask Emisse to do a flavor pass in future.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
Local map renderer borked.
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Split Station massive update!

