### PR TITLE
Prevents suicide if someone is already dead

### DIFF
--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -21,6 +21,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
+using Content.Shared.MobState.Components;
 
 namespace Content.Server.Chat.Commands
 {
@@ -80,6 +81,13 @@ namespace Content.Server.Chat.Commands
             if (mind?.OwnedComponent?.Owner is not {Valid: true} owner)
             {
                 shell.WriteLine("You don't have a mind!");
+                return;
+            }
+
+            //Checks to see if the player is dead.
+            if(_entities.TryGetComponent<MobStateComponent>(owner, out var mobState) && mobState.IsDead())
+            {
+                shell?.WriteLine("You can't suicide, you're dead.");
                 return;
             }
 

--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -87,7 +87,7 @@ namespace Content.Server.Chat.Commands
             //Checks to see if the player is dead.
             if(_entities.TryGetComponent<MobStateComponent>(owner, out var mobState) && mobState.IsDead())
             {
-                shell?.WriteLine("You can't suicide, you're dead.");
+                shell.WriteLine(Loc.GetString("suicide-command-already-dead"));
                 return;
             }
 

--- a/Resources/Locale/en-US/chat/commands/suicide-command.ftl
+++ b/Resources/Locale/en-US/chat/commands/suicide-command.ftl
@@ -5,3 +5,4 @@ suicide-command-help-text = The suicide command gives you a quick way out of a r
                             Finally, if neither of the above worked, you will die by biting your tongue.
 suicide-command-default-text-others = {$name} is attempting to bite their own tongue!
 suicide-command-default-text-self = You attempt to bite your own tongue!
+suicide-command-already-dead = You can't suicide. You're dead.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #7643 

This prevents suicide if you're already dead.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Players can't suicide if they're already dead.

