### PR TITLE
Makes dump_contributors_since.ps1 work on PowerShell 5.1

### DIFF
--- a/Tools/dump_contributors_since.ps1
+++ b/Tools/dump_contributors_since.ps1
@@ -9,9 +9,9 @@ param(
     [Nullable[DateTime]]$until);
 
 $replacements = @{
-    "moonheart08" = "moony",
-    "Elijahrane" = "Rane",
-    "ZeroDayDaemon" = "Daemon",
+    "moonheart08" = "moony"
+    "Elijahrane" = "Rane"
+    "ZeroDayDaemon" = "Daemon"
     "ElectroJr" = "ElectroSR"
 }
 
@@ -25,10 +25,10 @@ $content = & "$PSScriptRoot\dump_commits_since.ps1" -repo space-wizards/space-st
 $contribs = ($content + $engine) `
     | Select-Object -ExpandProperty author `
     | Select-Object -ExpandProperty login -Unique `
-    | Where-Object { -not $ignore[$_] }
-    | ForEach-Object { $replacements[$_] ?? $_ } 
+    | Where-Object { -not $ignore[$_] }`
+    | ForEach-Object { if($replacements[$_] -eq $null){ $_ } else { $replacements[$_] }} `
     | Sort-Object `
-    | Join-String -Separator ", "
 
+$contribs = $contribs -join ", "
 Write-Host $contribs
 Write-Host "Total commit count is $($engine.Length + $content.Length)"


### PR DESCRIPTION
Right now the script only works on newer versions of powershell. Also the script is pretty useless because it doesn't include contributors whose PRs were squash merged, but that's a separate issue. And it counts commits of excluded users for the total commit count.

Test:
```
PS C:\Users\main\Documents\GitHub\SS14\space-station-14\Tools> .\dump_contributors_since.ps1 -since "2022/03/01" -until "2022/03/31"
Acruid, actually-reb, areitpog, asperger-sind, BasedUser, Carou02, CrudeWax, Daemon, Delete69, DogZeroX, DrSmugleaf, DubiousDoggo, ElectroSR, elthundercloud, Emisse, EmoGarbage404, Fishfish458, HoofedEar, ike709, InquisitivePenguin, juliangiebel, KaiShibaa, lapatison, Macoron, metalgearsloth, mirrorcult, Mith-randalf, moony, Morb0, Pangogie, Partmedia, PaulRitter, Peptide90, PJB3005, Radrark, Rane, Rember, retequizzle, ScalyChimp, ShadowCommander, Silvertorch5, Snowni, TaralGit, TimrodDX, Veritius, vulppine, Willhelm53, wrexbe, WTCWR68, Zumorica
Total commit count is 551
```