### PR TITLE
Makes glass external and shuttle airlocks pass light

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -31,15 +31,6 @@
   components:
   - type: Door
     occludes: false
-    crushDamage:
-      types:
-        Blunt: 15
-    openSound:
-      path: /Audio/Machines/airlock_ext_open.ogg
-    closeSound:
-      path: /Audio/Machines/airlock_ext_close.ogg
-    denySound:
-      path: /Audio/Machines/airlock_deny.ogg
   - type: Occluder
     enabled: false
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -29,6 +29,17 @@
   id: AirlockExternalGlass
   suffix: Glass, External
   components:
+  - type: Door
+    occludes: false
+    crushDamage:
+      types:
+        Blunt: 15
+    openSound:
+      path: /Audio/Machines/airlock_ext_open.ogg
+    closeSound:
+      path: /Audio/Machines/airlock_ext_close.ogg
+    denySound:
+      path: /Audio/Machines/airlock_deny.ogg
   - type: Occluder
     enabled: false
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -86,16 +86,3 @@
     group: ShuttleGlass
   - type: Door
     occludes: false
-    bumpOpen: false
-    closeTimeTwo: 0.4
-    openTimeTwo: 0.4
-    board: DoorElectronics
-    crushDamage:
-      types:
-        Blunt: 15
-    openSound:
-      path: /Audio/Effects/docking.ogg
-    closeSound:
-      path: /Audio/Effects/docking.ogg
-    denySound:
-      path: /Audio/Machines/airlock_deny.ogg

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -84,3 +84,18 @@
     enabled: false
   - type: PaintableAirlock
     group: ShuttleGlass
+  - type: Door
+    occludes: false
+    bumpOpen: false
+    closeTimeTwo: 0.4
+    openTimeTwo: 0.4
+    board: DoorElectronics
+    crushDamage:
+      types:
+        Blunt: 15
+    openSound:
+      path: /Audio/Effects/docking.ogg
+    closeSound:
+      path: /Audio/Effects/docking.ogg
+    denySound:
+      path: /Audio/Machines/airlock_deny.ogg


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So when I added glass variants of the external airlock and docking airlock, they had occlusion false so you could see through them but I totally missed that light didn't pass through them.

This fixes that by adding occlusion false to the door components on both. See below.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
Before:
![before](https://user-images.githubusercontent.com/78795277/164428745-41383011-7e3b-4e96-aa56-d995e592fbb3.PNG)
After:
![after](https://user-images.githubusercontent.com/78795277/164428767-e6b602a1-c797-4244-9db5-a65c623ce0a5.gif)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Light now passes through glass external airlocks and glass docking airlocks.

