### PR TITLE
Windoor can be pried by crowbar

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
@@ -115,7 +115,7 @@
       completed:
       - !type:EmptyAllContainers {}
       steps:
-      - tool: Prying
+      - tool: Anchoring
         doAfter: 1
 
   - node: assemblySecure
@@ -215,5 +215,5 @@
       completed:
       - !type:EmptyAllContainers {}
       steps:
-      - tool: Prying
+      - tool: Anchoring
         doAfter: 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #7671

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Any windoor with an open wire panel can be pried open without deconstruction. To start a windoor deconstruction use a wrench first.

