### PR TITLE
Gives Bibles and Necronomicons the ability to worn in the belt slot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -34,8 +34,6 @@
     storageSoundCollection:
       collection: storageRustle
   
-
-
 - type: entity
   parent: Bible
   name: necronomicon
@@ -69,4 +67,3 @@
     prefix: inhand
     Slots:
     - Belt
-  

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -27,10 +27,14 @@
     size: 15
     sprite: Objects/Specific/Chapel/bible.rsi
     prefix: inhand
+    Slots:
+    - Belt
   - type: Storage
     capacity: 10
     storageSoundCollection:
       collection: storageRustle
+  
+
 
 - type: entity
   parent: Bible
@@ -63,3 +67,6 @@
     size: 15
     sprite: Objects/Specific/Chapel/necronomicon.rsi
     prefix: inhand
+    Slots:
+    - Belt
+  


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR gives bibles and necronomicons the ability to be worn in the belt slot.  Simple as

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/31361371/164565398-9b477dcd-2b46-4ce7-8bc1-ada649acd6cd.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Saakra
- add: Bibles and Necronomicons can now be worn in the belt slot

