### PR TITLE
Health hud adjust

### DIFF
--- a/Content.Server/MobState/States/NormalMobState.cs
+++ b/Content.Server/MobState/States/NormalMobState.cs
@@ -28,9 +28,9 @@ namespace Content.Server.MobState.States
 
             if (stateComponent.TryGetEarliestIncapacitatedState(threshold, out _, out var earliestThreshold) && damageable.TotalDamage>0)
             {
-                modifier = (short) (damageable.TotalDamage / (earliestThreshold / 6f));
+                modifier = (short) (damageable.TotalDamage / (earliestThreshold / 6f)); //6 hurt states including the first one and crit state
                 if (modifier < 1)
-                {
+                { //this is here so if this comes up with a decimal between 0 and 1 we just use the first "hurt" state by default
                     modifier = 1;
                 }
             }

--- a/Content.Server/MobState/States/NormalMobState.cs
+++ b/Content.Server/MobState/States/NormalMobState.cs
@@ -26,11 +26,14 @@ namespace Content.Server.MobState.States
 
             short modifier = 0;
 
-            if (stateComponent.TryGetEarliestIncapacitatedState(threshold, out _, out var earliestThreshold))
+            if (stateComponent.TryGetEarliestIncapacitatedState(threshold, out _, out var earliestThreshold) && damageable.TotalDamage>0)
             {
-                modifier = (short) (damageable.TotalDamage / (earliestThreshold / 7f));
+                modifier = (short) (damageable.TotalDamage / (earliestThreshold / 6f));
+                if (modifier < 1)
+                {
+                    modifier = 1;
+                }
             }
-
             EntitySystem.Get<AlertsSystem>().ShowAlert(entity, AlertType.HumanHealth, modifier);
         }
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is a very slight adjustment to the HUD Health Alert which makes the healthiest icon (the one with the "100" on top of the spaceman) only show up if the holder actually is at 100% health and has no damage. I think this makes is more quickly apparent to the player if they begin taking damage from something, and it is more easily communicated if that damage is no longer an issue.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: the health HUD icon for 100% health now only shows if you are actually undamaged and at 100% health

