### PR TITLE
Add use-delay to signal transmitters

### DIFF
--- a/Content.Server/MachineLinking/System/SignalButtonSystem.cs
+++ b/Content.Server/MachineLinking/System/SignalButtonSystem.cs
@@ -14,7 +14,7 @@ namespace Content.Server.MachineLinking.System
         {
             base.Initialize();
             SubscribeLocalEvent<SignalButtonComponent, ComponentInit>(OnInit);
-            SubscribeLocalEvent<SignalButtonComponent, InteractHandEvent>(OnInteractHand);
+            SubscribeLocalEvent<SignalButtonComponent, ActivateInWorldEvent>(OnActivated);
         }
 
         private void OnInit(EntityUid uid, SignalButtonComponent component, ComponentInit args)
@@ -24,7 +24,7 @@ namespace Content.Server.MachineLinking.System
                 transmitter.AddPort("Pressed");
         }
 
-        private void OnInteractHand(EntityUid uid, SignalButtonComponent component, InteractHandEvent args)
+        private void OnActivated(EntityUid uid, SignalButtonComponent component, ActivateInWorldEvent args)
         {
             RaiseLocalEvent(uid, new InvokePortEvent("Pressed"), false);
             args.Handled = true;

--- a/Content.Server/MachineLinking/System/SignalSwitchSystem.cs
+++ b/Content.Server/MachineLinking/System/SignalSwitchSystem.cs
@@ -11,7 +11,7 @@ namespace Content.Server.MachineLinking.System
         {
             base.Initialize();
             SubscribeLocalEvent<SignalSwitchComponent, ComponentInit>(OnInit);
-            SubscribeLocalEvent<SignalSwitchComponent, InteractHandEvent>(OnInteracted);
+            SubscribeLocalEvent<SignalSwitchComponent, ActivateInWorldEvent>(OnActivated);
         }
 
         private void OnInit(EntityUid uid, SignalSwitchComponent component, ComponentInit args)
@@ -23,7 +23,7 @@ namespace Content.Server.MachineLinking.System
 
         }
 
-        private void OnInteracted(EntityUid uid, SignalSwitchComponent component, InteractHandEvent args)
+        private void OnActivated(EntityUid uid, SignalSwitchComponent component, ActivateInWorldEvent args)
         {
             component.State = !component.State;
             RaiseLocalEvent(uid, new InvokePortEvent(component.State ? "On" : "Off"), false);

--- a/Content.Server/MachineLinking/System/TwoWayLeverSystem.cs
+++ b/Content.Server/MachineLinking/System/TwoWayLeverSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Content.Server.MachineLinking.Components;
 using Content.Server.MachineLinking.Events;
 using Content.Shared.Interaction;
@@ -13,7 +13,7 @@ namespace Content.Server.MachineLinking.System
         {
             base.Initialize();
             SubscribeLocalEvent<TwoWayLeverComponent, ComponentInit>(OnInit);
-            SubscribeLocalEvent<TwoWayLeverComponent, InteractHandEvent>(OnInteractHand);
+            SubscribeLocalEvent<TwoWayLeverComponent, ActivateInWorldEvent>(OnActivated);
         }
 
         private void OnInit(EntityUid uid, TwoWayLeverComponent component, ComponentInit args)
@@ -24,7 +24,7 @@ namespace Content.Server.MachineLinking.System
                     transmitter.AddPort(state);
         }
 
-        private void OnInteractHand(EntityUid uid, TwoWayLeverComponent component, InteractHandEvent args)
+        private void OnActivated(EntityUid uid, TwoWayLeverComponent component, ActivateInWorldEvent args)
         {
             component.State = component.State switch
             {

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/signaller.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/signaller.yml
@@ -10,3 +10,4 @@
     sprite: Objects/Devices/signaller.rsi
     state: signaller
   - type: Signaller
+  - type: UseDelay

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -12,6 +12,8 @@
     sprite: Structures/Wallmounts/switch.rsi
     state: on
   - type: SignalSwitch
+  - type: UseDelay
+    delay: 0.5 # prevent light-toggling auto-clickers.
   - type: Rotatable
   placement:
     mode: SnapgridCenter
@@ -32,6 +34,8 @@
     sprite: Structures/Wallmounts/switch.rsi
     state: dead
   - type: SignalButton
+  - type: UseDelay
+    delay: 0.5 # prevent light-toggling auto-clickers.
   - type: Rotatable
   placement:
     mode: SnapgridCenter
@@ -82,6 +86,8 @@
       sprite: Structures/conveyor.rsi
       state: switch-off
     - type: TwoWayLever
+    - type: UseDelay
+      delay: 0.2 # prevent light-toggling auto-clickers.
     - type: Appearance
       visuals:
         - type: TwoWayLeverVisualizer


### PR DESCRIPTION
Also moves some events from interact hand to activate, because interact hand does not work with use delay (otherwise picking up items would trigger potentially lengthy delays).