### PR TITLE
Adds a damage threshold property for DoAfters

### DIFF
--- a/Content.Server/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/DoAfter/DoAfterEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Content.Shared.FixedPoint;
 using Robust.Shared.GameObjects;
 
 namespace Content.Server.DoAfter
@@ -53,7 +54,7 @@ namespace Content.Server.DoAfter
         /// <summary>
         ///     Threshold for user damage
         /// </summary>
-        public float DamageThreshold { get; set; }
+        public FixedPoint2 DamageThreshold { get; set; }
         public bool BreakOnStun { get; set; }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace Content.Server.DoAfter
             CancelToken = cancelToken;
             Target = target;
             MovementThreshold = 0.1f;
-            DamageThreshold = 1.0f;
+            DamageThreshold = 0;
 
             if (Target == null)
             {

--- a/Content.Server/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/DoAfter/DoAfterEventArgs.cs
@@ -49,6 +49,11 @@ namespace Content.Server.DoAfter
         public float MovementThreshold { get; set; }
 
         public bool BreakOnDamage { get; set; }
+
+        /// <summary>
+        ///     Threshold for user damage
+        /// </summary>
+        public float DamageThreshold { get; set; }
         public bool BreakOnStun { get; set; }
 
         /// <summary>
@@ -105,6 +110,7 @@ namespace Content.Server.DoAfter
             CancelToken = cancelToken;
             Target = target;
             MovementThreshold = 0.1f;
+            DamageThreshold = 1.0f;
 
             if (Target == null)
             {

--- a/Content.Server/DoAfter/DoAfterSystem.cs
+++ b/Content.Server/DoAfter/DoAfterSystem.cs
@@ -79,6 +79,7 @@ namespace Content.Server.DoAfter
                     doAfter.EventArgs.BreakOnUserMove,
                     doAfter.EventArgs.BreakOnTargetMove,
                     doAfter.EventArgs.MovementThreshold,
+                    doAfter.EventArgs.DamageThreshold,
                     doAfter.EventArgs.Target);
 
                 toAdd.Add(clientDoAfter);
@@ -98,6 +99,14 @@ namespace Content.Server.DoAfter
             }
         }
 
+        /// <summary>
+        /// Cancels DoAfter if it breaks on damage and it meets the threshold
+        /// </summary>
+        /// <param name="_">
+        /// The EntityUID of the user
+        /// </param>
+        /// <param name="component"></param>
+        /// <param name="args"></param>
         public void OnDamage(EntityUid _, DoAfterComponent component, DamageChangedEvent args)
         {
             if (!args.InterruptsDoAfters || !args.DamageIncreased)
@@ -105,7 +114,7 @@ namespace Content.Server.DoAfter
 
             foreach (var (doAfter, _) in component.DoAfters)
             {
-                if (doAfter.EventArgs.BreakOnDamage)
+                if (doAfter.EventArgs.BreakOnDamage && args.DamageDelta?.Total.Float() > doAfter.EventArgs.DamageThreshold)
                 {
                     doAfter.Cancel();
                 }

--- a/Content.Server/DoAfter/DoAfterSystem.cs
+++ b/Content.Server/DoAfter/DoAfterSystem.cs
@@ -109,7 +109,7 @@ namespace Content.Server.DoAfter
         /// <param name="args"></param>
         public void OnDamage(EntityUid _, DoAfterComponent component, DamageChangedEvent args)
         {
-            if (!args.InterruptsDoAfters || !args.DamageIncreased)
+            if (!args.InterruptsDoAfters || !args.DamageIncreased || args.DamageDelta == null)
                 return;
 
             foreach (var (doAfter, _) in component.DoAfters)

--- a/Content.Shared/DoAfter/SharedDoAfterComponent.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
@@ -59,10 +60,10 @@ namespace Content.Shared.DoAfter
 
         public float MovementThreshold { get; }
 
-        public float UserDamageThreshold { get; }
+        public FixedPoint2 DamageThreshold { get; }
 
         public ClientDoAfter(byte id, EntityCoordinates userGrid, EntityCoordinates targetGrid, TimeSpan startTime,
-            float delay, bool breakOnUserMove, bool breakOnTargetMove, float movementThreshold, float damageThreshold, EntityUid? target = null)
+            float delay, bool breakOnUserMove, bool breakOnTargetMove, float movementThreshold, FixedPoint2 damageThreshold, EntityUid? target = null)
         {
             ID = id;
             UserGrid = userGrid;
@@ -72,7 +73,7 @@ namespace Content.Shared.DoAfter
             BreakOnUserMove = breakOnUserMove;
             BreakOnTargetMove = breakOnTargetMove;
             MovementThreshold = movementThreshold;
-            UserDamageThreshold = damageThreshold;
+            DamageThreshold = damageThreshold;
             Target = target;
         }
     }

--- a/Content.Shared/DoAfter/SharedDoAfterComponent.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterComponent.cs
@@ -59,8 +59,10 @@ namespace Content.Shared.DoAfter
 
         public float MovementThreshold { get; }
 
+        public float UserDamageThreshold { get; }
+
         public ClientDoAfter(byte id, EntityCoordinates userGrid, EntityCoordinates targetGrid, TimeSpan startTime,
-            float delay, bool breakOnUserMove, bool breakOnTargetMove, float movementThreshold, EntityUid? target = null)
+            float delay, bool breakOnUserMove, bool breakOnTargetMove, float movementThreshold, float damageThreshold, EntityUid? target = null)
         {
             ID = id;
             UserGrid = userGrid;
@@ -70,6 +72,7 @@ namespace Content.Shared.DoAfter
             BreakOnUserMove = breakOnUserMove;
             BreakOnTargetMove = breakOnTargetMove;
             MovementThreshold = movementThreshold;
+            UserDamageThreshold = damageThreshold;
             Target = target;
         }
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The PR adds a DamageThreshold property to DoAfters so it doesn't break on too low damages. It can be adjusted as needed but defaults at 0 damage.

I don't think this closes #7264 because it only does one out of the 2-3 requests in that issue. Also when I was going through looking at damage types, I noticed a lot of the requested damage types already had a "don't break a do after" or something similar. So it might be redundant to have both.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Do afters will break after a specific minimum threshold is set

