### PR TITLE
Makes TurfHelpers.IsBlockedTurf use the resolves pattern.

### DIFF
--- a/Content.Shared/Maps/TurfHelpers.cs
+++ b/Content.Shared/Maps/TurfHelpers.cs
@@ -191,9 +191,14 @@ namespace Content.Shared.Maps
         /// <summary>
         /// Checks if a turf has something dense on it.
         /// </summary>
-        public static bool IsBlockedTurf(this TileRef turf, bool filterMobs)
+        public static bool IsBlockedTurf(this TileRef turf, bool filterMobs, SharedPhysicsSystem? physics = null, IEntitySystemManager? entSysMan = null)
         {
-            var physics = EntitySystem.Get<SharedPhysicsSystem>();
+            if (physics == null)
+            {
+                // Slow path, resolve dependencies.
+                IoCManager.Resolve(ref entSysMan);
+                entSysMan.Resolve(ref physics);
+            }
 
             if (!GetWorldTileBox(turf, out var worldBox))
                 return false;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Optional performance good!