### PR TITLE
Adds optional "maxAmount" parameter to EntitySpawnEntry.

### DIFF
--- a/Content.Shared/Storage/EntitySpawnEntry.cs
+++ b/Content.Shared/Storage/EntitySpawnEntry.cs
@@ -45,9 +45,17 @@ public struct EntitySpawnEntry : IPopulateDefaultValues
 
     [DataField("amount")] public int Amount;
 
+    /// <summary>
+    ///     How many of this can be spawned, in total.
+    ///     If this is lesser or equal to <see cref="Amount"/>, it will spawn <see cref="Amount"/> exactly.
+    ///     Otherwise, it chooses a random value between <see cref="Amount"/> and <see cref="MaxAmount"/> on spawn.
+    /// </summary>
+    [DataField("maxAmount")] public int MaxAmount;
+
     public void PopulateDefaultValues()
     {
         Amount = 1;
+        MaxAmount = 1;
         SpawnProbability = 1;
     }
 }
@@ -100,7 +108,12 @@ public static class EntitySpawnCollection
             // ReSharper disable once CompareOfFloatsByEqualityOperator
             if (entry.SpawnProbability != 1f && !random.Prob(entry.SpawnProbability)) continue;
 
-            for (var i = 0; i < entry.Amount; i++)
+            var amount = entry.Amount;
+
+            if (entry.MaxAmount > amount)
+                amount = random.Next(amount, entry.MaxAmount);
+
+            for (var i = 0; i < amount; i++)
             {
                 spawned.Add(entry.PrototypeId);
             }
@@ -118,7 +131,13 @@ public static class EntitySpawnCollection
                 cumulative += entry.SpawnProbability;
                 if (diceRoll > cumulative) continue;
                 // Dice roll succeeded, add item and break loop
-                for (var index = 0; index < entry.Amount; index++)
+
+                var amount = entry.Amount;
+
+                if (entry.MaxAmount > amount)
+                    amount = random.Next(amount, entry.MaxAmount);
+
+                for (var index = 0; index < amount; index++)
                 {
                     spawned.Add(entry.PrototypeId);
                 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basically, when maxAmount is greater than amount, it will choose a random number from amount to maxAmount as the number of things to spawn. This parameter is entirely optional, and behavior for existing spawn entries remains the same.