### PR TITLE
Fix hardsuit helmet unequip

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -71,7 +71,10 @@ public sealed class ToggleableClothingSystem : EntitySystem
     /// </summary>
     private void OnToggleableUnequip(EntityUid uid, ToggleableClothingComponent component, GotUnequippedEvent args)
     {
-        if (component.Container != null && component.Container.ContainedEntity != null && component.ClothingUid != null)
+        // If the attached clothing is not currently in the container, this just assumes that it is currently equipped.
+        // This should maybe double check that the entity currently in the slot is actually the attached clothing, but
+        // if its not, then something else has gone wrong already...
+        if (component.Container != null && component.Container.ContainedEntity == null && component.ClothingUid != null)
             _inventorySystem.TryUnequip(args.Equipee, component.Slot, force: true);
     }
 


### PR DESCRIPTION
replace a `!=` with `==`
Fixes hardsuit helmets not being unequipped when hardsuits are unequipped (bug added in #7559 )

fixes #7727