### PR TITLE
Fixes job-assigned special prototypes not carrying over when cloned

### DIFF
--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -34,6 +34,12 @@ namespace Content.Server.Cloning
                 return;
 
             mind.TransferTo(entity, ghostCheckOverride: true);
+            //if job isn't null then add prototype jobspecials
+            if (mind.CurrentJob != null)
+            foreach (var jobSpecial in mind.CurrentJob.Prototype.Special)
+            {
+                jobSpecial.AfterEquip(entity);
+            }
             mind.UnVisit();
             ClonesWaitingForMind.Remove(mind);
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a body is cloned, jobs such as the chaplain do not receive the special job prototype (Summoning) on the new body. This PR fixes that. This PR only affects crew jobs.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/31361371/164992714-1ae0794c-f820-4324-bb5b-8a0771c4f6c1.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Saakra
- fix: When cloned, special abilities from your job now carry over. (ex. Chaplain summoning)

