### PR TITLE
Fix 1 vehicle exploit, increase price of ATV crate

### DIFF
--- a/Content.Server/Vehicle/RiderSystem.cs
+++ b/Content.Server/Vehicle/RiderSystem.cs
@@ -46,7 +46,7 @@ namespace Content.Server.Vehicle
             }
         }
 
-        private void UnbuckleFromVehicle(EntityUid uid)
+        public void UnbuckleFromVehicle(EntityUid uid)
         {
             if (!TryComp<BuckleComponent>(uid, out var buckle))
                 return;

--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -23,6 +23,7 @@ namespace Content.Server.Vehicle
         [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
         [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
+        [Dependency] private readonly RiderSystem _riderSystem = default!;
 
         public override void Initialize()
         {
@@ -69,6 +70,12 @@ namespace Content.Server.Vehicle
         {
             if (args.Buckling)
             {
+                /// Add a virtual item to rider's hand, unbuckle if we can't.
+                if (!_virtualItemSystem.TrySpawnVirtualItemInHand(uid, args.BuckledEntity))
+                {
+                    _riderSystem.UnbuckleFromVehicle(args.BuckledEntity);
+                    return;
+                }
                 /// Set up the rider and vehicle with each other
                 EnsureComp<SharedPlayerInputMoverComponent>(uid);
                 var rider = EnsureComp<RiderComponent>(args.BuckledEntity);
@@ -79,8 +86,7 @@ namespace Content.Server.Vehicle
                 /// Handle pulling
                 RemComp<SharedPullableComponent>(args.BuckledEntity);
                 RemComp<SharedPullableComponent>(uid);
-                /// Add a virtual item to rider's hand
-                _virtualItemSystem.TrySpawnVirtualItemInHand(uid, args.BuckledEntity);
+
                 /// Let this open doors if it has the key in it
                 if (component.HasKey)
                 {

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -66,6 +66,6 @@
     sprite: Objects/Vehicles/atv.rsi
     state: vehicle
   product: CrateFunATV
-  cost: 2500
+  cost: 6000
   category: Fun
   group: market


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The vehicle buckle event now unbuckles you and exits if it can't place a virtual item in your hand. ATV crate increased from 2500 to 6000 credits.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: You can no longer get on vehicles if your hands are full.
- tweak: ATV crate price from 2500 -> 6000.

