### PR TITLE
Fix capitalization of emotes

### DIFF
--- a/Content.Server/Chat/ChatSystem.cs
+++ b/Content.Server/Chat/ChatSystem.cs
@@ -91,7 +91,9 @@ public sealed class ChatSystem : EntitySystem
         if (!CanSendInGame(message, shell, player))
             return;
 
-        message = SanitizeInGameICMessage(source, message, out var emoteStr);
+        bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
+
+        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize);
 
         // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
@@ -294,10 +296,11 @@ public sealed class ChatSystem : EntitySystem
     }
 
     // ReSharper disable once InconsistentNaming
-    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr)
+    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true)
     {
         var newMessage = message.Trim();
-        newMessage = SanitizeMessageCapital(source, newMessage);
+        if (capitalize)
+            newMessage = SanitizeMessageCapital(source, newMessage);
         newMessage = FormattedMessage.EscapeText(newMessage);
 
         _sanitizer.TrySanitizeOutSmilies(newMessage, source, out newMessage, out emoteStr);

--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -65,6 +65,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "lel", "chatsan-laughs" },
         { "kek", "chatsan-laughs" },
         { "o7", "chatsan-salutes" },
+        { ";_;7", "chatsan-tearfully-salutes"},
         { "idk", "chatsan-shrugs" }
     };
 

--- a/Resources/Locale/en-US/chat/sanitizer-replacements.ftl
+++ b/Resources/Locale/en-US/chat/sanitizer-replacements.ftl
@@ -18,4 +18,5 @@ chatsan-confused = looks confused
 chatsan-unimpressed = seems unimpressed
 chatsan-waves = waves
 chatsan-salutes = salutes
+chatsan-tearfully-salutes = tearfully salutes
 chatsan-shrugs = shrugs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes https://github.com/space-wizards/space-station-14/issues/7765
Also I added another sanitization of a favorite emoticon of mine

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/60792108/165002683-d1f112f9-5a4b-4a02-a804-a6ccad636fcb.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: Emotes will no longer be capitalized when they shouldn't be.

