### PR TITLE
Fix decals (finally)

### DIFF
--- a/Content.Client/Decals/DecalOverlay.cs
+++ b/Content.Client/Decals/DecalOverlay.cs
@@ -45,6 +45,8 @@ namespace Content.Client.Decals
 
             foreach (var (gridId, zIndexDictionary) in _decals.DecalRenderIndex)
             {
+                if (zIndexDictionary.Count == 0) continue;
+
                 var gridUid = _mapManager.GetGridEuid(gridId);
                 var xform = xformQuery.GetComponent(gridUid);
 

--- a/Content.Client/Decals/DecalSystem.cs
+++ b/Content.Client/Decals/DecalSystem.cs
@@ -61,8 +61,6 @@ namespace Content.Client.Decals
         protected override bool RemoveDecalHook(GridId gridId, uint uid)
         {
             RemoveDecalFromRenderIndex(gridId, uid);
-            ChunkIndex[gridId].Remove(uid);
-
             return base.RemoveDecalHook(gridId, uid);
         }
 
@@ -94,7 +92,7 @@ namespace Content.Client.Decals
                         removedUids.ExceptWith(newChunkData.Keys);
                         foreach (var removedUid in removedUids)
                         {
-                            RemoveDecalHook(gridId, removedUid);
+                            RemoveDecalInternal(gridId, removedUid);
                         }
 
                         chunkCollection[indices] = newChunkData;
@@ -135,7 +133,7 @@ namespace Content.Client.Decals
 
                     foreach (var (uid, _) in chunk)
                     {
-                        RemoveDecalHook(gridId, uid);
+                        RemoveDecalInternal(gridId, uid);
                     }
 
                     chunkCollection.Remove(index);

--- a/Content.Client/Decals/DecalSystem.cs
+++ b/Content.Client/Decals/DecalSystem.cs
@@ -85,6 +85,7 @@ namespace Content.Client.Decals
 
                 var chunkCollection = ChunkCollection(gridId);
 
+                // Update any existing data / remove decals we didn't receive data for.
                 foreach (var (indices, newChunkData) in gridChunks)
                 {
                     if (chunkCollection.TryGetValue(indices, out var chunk))

--- a/Content.Client/Decals/DecalSystem.cs
+++ b/Content.Client/Decals/DecalSystem.cs
@@ -81,6 +81,8 @@ namespace Content.Client.Decals
         {
             foreach (var (gridId, gridChunks) in ev.Data)
             {
+                if (gridChunks.Count == 0) continue;
+
                 var chunkCollection = ChunkCollection(gridId);
 
                 foreach (var (indices, newChunkData) in gridChunks)
@@ -122,6 +124,8 @@ namespace Content.Client.Decals
             // Now we'll cull old chunks out of range as the server will send them to us anyway.
             foreach (var (gridId, chunks) in ev.RemovedChunks)
             {
+                if (chunks.Count == 0) continue;
+
                 var chunkCollection = ChunkCollection(gridId);
 
                 foreach (var index in chunks)

--- a/Content.Server/Chemistry/TileReactions/CleanTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/CleanTileReaction.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Chemistry.TileReactions
             }
 
             var decalSystem = EntitySystem.Get<DecalSystem>();
-            foreach (var uid in decalSystem.GetDecalsInRange(tile.GridIndex, tile.GridIndices+new Vector2(0.5f, 0.5f), validDelegate: x => x.Cleanable))
+            foreach (var (uid, _) in decalSystem.GetDecalsInRange(tile.GridIndex, tile.GridIndices+new Vector2(0.5f, 0.5f), validDelegate: x => x.Cleanable))
             {
                 decalSystem.RemoveDecal(tile.GridIndex, uid);
             }

--- a/Content.Server/Decals/DecalSystem.cs
+++ b/Content.Server/Decals/DecalSystem.cs
@@ -178,7 +178,6 @@ namespace Content.Server.Decals
             {
                 var chunkIndices = GetChunkIndices(decal.Coordinates);
                 RemoveDecal(gridId, uid);
-                DirtyChunk(gridId, chunkIndices);
             }
         }
 

--- a/Content.Server/Decals/DecalSystem.cs
+++ b/Content.Server/Decals/DecalSystem.cs
@@ -52,16 +52,15 @@ namespace Content.Server.Decals
             var enumerator = MapManager.GetGrid(ev.Grid).GetAllTilesEnumerator();
             var oldChunkCollection = DecalGridChunkCollection(ev.OldGrid);
             var chunkCollection = DecalGridChunkCollection(ev.Grid);
-            var chunksSeen = new HashSet<Vector2i>();
 
             while (enumerator.MoveNext(out var tile))
             {
-                var chunkIndices = GetChunkIndices(tile.Value.GridIndices);
+                var tilePos = (Vector2) tile.Value.GridIndices;
+                var chunkIndices = GetChunkIndices(tilePos);
 
-                if (!chunksSeen.Add(chunkIndices) ||
-                    !oldChunkCollection.ChunkCollection.TryGetValue(chunkIndices, out var oldChunk)) continue;
+                if (!oldChunkCollection.ChunkCollection.TryGetValue(chunkIndices, out var oldChunk)) continue;
 
-                var bounds = new Box2(tile.Value.GridIndices, tile.Value.GridIndices + 1);
+                var bounds = new Box2(tilePos - 0.01f, tilePos + 1.01f);
                 var toRemove = new RemQueue<uint>();
 
                 foreach (var (oldUid, decal) in oldChunk)

--- a/Content.Shared/Decals/DecalChunkUpdateEvent.cs
+++ b/Content.Shared/Decals/DecalChunkUpdateEvent.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
-using Robust.Shared.Maths;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Decals
@@ -11,5 +7,6 @@ namespace Content.Shared.Decals
     public sealed class DecalChunkUpdateEvent : EntityEventArgs
     {
         public Dictionary<GridId, Dictionary<Vector2i, Dictionary<uint, Decal>>> Data = new();
+        public Dictionary<GridId, HashSet<Vector2i>> RemovedChunks = new();
     }
 }

--- a/Content.Shared/Decals/SharedDecalSystem.cs
+++ b/Content.Shared/Decals/SharedDecalSystem.cs
@@ -79,7 +79,7 @@ namespace Content.Shared.Decals
             if (chunkCollection[indices].Count == 0)
                 chunkCollection.Remove(indices);
 
-            ChunkIndex[gridId]?.Remove(uid);
+            ChunkIndex[gridId].Remove(uid);
             DirtyChunk(gridId, indices);
             return true;
         }


### PR DESCRIPTION
:cl:
- fix: Decals (e.g. tile paint) should now be removed correctly.

@PaulRitter 

Originally I had it as separate messages but the subscriptions seemed to be done out of order so this way just guarantees the decals get cleaned up for the overlay.

Edit: Requires https://github.com/space-wizards/RobustToolbox/pull/2774 as I also merged in my grid split fix branch.

Fixes https://github.com/space-wizards/RobustToolbox/issues/2772