### PR TITLE
Add a garbage collection component for grid movement

### DIFF
--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -66,6 +66,7 @@ namespace Content.Client.Entry
             "Drain",
             "Food",
             "DeployableBarrier",
+            "SpaceGarbage",
             "MagicMirror",
             "DiseaseSwab",
             "FloorTile",

--- a/Content.Server/Shuttles/Components/SpaceGarbageComponent.cs
+++ b/Content.Server/Shuttles/Components/SpaceGarbageComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Server.Shuttles.Components;
+
+/// <summary>
+///     Cleanup component that deletes the entity if it has a cross-grid collision.
+///     Useful for small, unimportant items like bullets to avoid generating many contacts.
+/// </summary>
+[RegisterComponent]
+public sealed class SpaceGarbageComponent : Component {}

--- a/Content.Server/Shuttles/EntitySystems/SpaceGarbageSystem.cs
+++ b/Content.Server/Shuttles/EntitySystems/SpaceGarbageSystem.cs
@@ -1,0 +1,28 @@
+using Content.Server.Shuttles.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Dynamics;
+
+namespace Content.Server.Shuttles.EntitySystems;
+
+/// <summary>
+///     Deletes anything with <see cref="SpaceGarbageComponent"/> that has a cross-grid collision with a static body.
+/// </summary>
+public sealed class SpaceGarbageSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SpaceGarbageComponent, StartCollideEvent>(OnCollide);
+    }
+
+    private void OnCollide(EntityUid uid, SpaceGarbageComponent component, StartCollideEvent args)
+    {
+        var ourXform = Transform(args.OurFixture.Body.Owner);
+        var otherXform = Transform(args.OtherFixture.Body.Owner);
+
+        if (ourXform.GridID == otherXform.GridID ||
+            args.OtherFixture.Body.BodyType != BodyType.Static) return;
+
+        QueueDel(uid);
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -2103,9 +2103,9 @@
     sprite: Objects/Consumable/Drinks/ramen.rsi
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   parent: DrinkRamen

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -36,10 +36,10 @@
       stateOpen: icon_open
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: ItemCooldown
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   parent: DrinkCanBaseFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/trash_drinks.yml
@@ -52,9 +52,9 @@
         acts: [ "Destruction" ]
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 # Containers
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
@@ -59,9 +59,9 @@
     netsync: false
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   name: bowl

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
@@ -44,9 +44,9 @@
         acts: [ "Destruction" ]
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   name: broken plate
@@ -60,9 +60,9 @@
     netsync: false
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 # Small Plate
 
@@ -142,3 +142,4 @@
     tags:
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -110,6 +110,7 @@
     - Egg
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 # Egg
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
@@ -8,6 +8,7 @@
   components:
   - type: Food
   - type: Recyclable
+  - type: SpaceGarbage
   - type: Sprite
     netsync: false
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -259,3 +259,4 @@
     tags:
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -211,6 +211,7 @@
   - type: Extractable
     grindableSolutionName: food
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   name: carrot

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -206,9 +206,9 @@
     HeldPrefix: packet
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cartons.yml
@@ -23,9 +23,9 @@
         openIcon: open
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   id: CigCartonRed

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -14,9 +14,9 @@
   - type: Tag
     tags:
       - Cigarette
-      - Recyclable
       - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigarettes/cigarette.rsi
     Slots: [ mask ]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
@@ -11,9 +11,9 @@
   - type: Tag
     tags:
       - Cigarette
-      - Recyclable
       - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigarettes/blunt.rsi
     Slots: [ mask ]
@@ -43,9 +43,9 @@
   - type: Tag
     tags:
       - Cigarette
-      - Recyclable
       - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigarettes/blunt.rsi
     Slots: [ mask ]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -7,9 +7,9 @@
   - type: Tag
     tags:
     - CigPack
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: Storage
     capacity: 6
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/rolling_paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/rolling_paper.yml
@@ -57,10 +57,10 @@
     size: 2
   - type: Tag
     tags:
-    - Recyclable
     - RollingPaper
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   id: CigaretteFilter
@@ -81,6 +81,5 @@
   - type: Tag
     tags:
     - CigFilter
-    - Recyclable
     - Trash
   - type: Recyclable

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -12,9 +12,9 @@
       - type: BurnStateVisualizer
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 # Base for all cigars and cigarettes.
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -9,9 +9,9 @@
     tags:
     - Write
     - Crayon
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: UserInterface
     interfaces:
     - key: enum.CrayonUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -25,9 +25,9 @@
         Slash: 2
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Glass

--- a/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
@@ -20,7 +20,7 @@
         Slash: 2
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -9,9 +9,9 @@
     sprite: Objects/Misc/utensils.rsi
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   parent: UtensilBase

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -54,9 +54,9 @@
     - type: LightBulbVisualizer
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 # Lighting color values gathered from
 # https://andi-siess.de/rgb-to-color-temperature/

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -51,9 +51,9 @@
       emptySpriteName: medipen_empty
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
 
 - type: entity
   name: emergency medipen
@@ -114,4 +114,4 @@
   - type: Tag
     tags:
     - Write
-    
+

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -8,9 +8,9 @@
   - type: Tag
     tags:
     - Bottle
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: Sprite
     sprite: Objects/Specific/Chemistry/bottle.rsi
     netsync: false
@@ -139,7 +139,7 @@
         reagents:
         - ReagentId: RobustHarvest
           Quantity: 30
-          
+
 - type: entity
   id: NocturineChemistryBottle
   name: nocturine bottle

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -7,9 +7,9 @@
   - type: Tag
     tags:
     - Flare
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: ExpendableLight
     spentName: spent flare
     spentDesc: It looks like this flare has burnt out. What a bummer.

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -6,9 +6,9 @@
   components:
     - type: Tag
       tags:
-      - Recyclable
       - Trash
     - type: Recyclable
+    - type: SpaceGarbage
     - type: ExpendableLight
       spentName: spent green glowstick
       spentDesc: It looks like this glowstick has stopped glowing. How tragic.

--- a/Resources/Prototypes/Entities/Objects/Tools/matches.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/matches.yml
@@ -17,9 +17,9 @@
   - type: Tag
     tags:
     - Matchstick
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage
   - type: Sprite
     netsync: false
     sprite: Objects/Tools/matches.rsi
@@ -81,6 +81,6 @@
           - matchbox3
   - type: Tag
     tags:
-    - Recyclable
     - Trash
   - type: Recyclable
+  - type: SpaceGarbage

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/BaseCartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/BaseCartridge.yml
@@ -6,7 +6,7 @@
   - type: Tag
     tags:
     - Cartridge
-    - Recyclable
   - type: Item
     size: 1
   - type: Recyclable
+  - type: SpaceGarbage


### PR DESCRIPTION
If we move a station and there's thousands of bullets in the way we shouldn't just indefinitely lag the server as a result.

Addresses most of https://github.com/space-wizards/space-station-14/issues/7775
