### PR TITLE
Drone blocker ignores dead ghost roles

### DIFF
--- a/Content.Server/Drone/DroneSystem.cs
+++ b/Content.Server/Drone/DroneSystem.cs
@@ -176,13 +176,12 @@ namespace Content.Server.Drone
             var xform = Comp<TransformComponent>(uid);
             foreach (var entity in _lookup.GetEntitiesInRange(xform.MapPosition, component.InteractionBlockRange))
             {
-                // Filter out dead ghost roles. Dead normal players are intended to block.
-                if ((TryComp<MobStateComponent>(entity, out var entityMobState) && HasComp<GhostTakeoverAvailableComponent>(entity) && entityMobState.IsDead()))
-                    continue;
-
                 // Return true if the entity is/was controlled by a player and is not a drone or ghost.
                 if (HasComp<MindComponent>(entity) && !HasComp<DroneComponent>(entity) && !HasComp<GhostComponent>(entity))
                 {
+                    // Filter out dead ghost roles. Dead normal players are intended to block.
+                    if ((TryComp<MobStateComponent>(entity, out var entityMobState) && HasComp<GhostTakeoverAvailableComponent>(entity) && entityMobState.IsDead()))
+                        continue;
                     if (_gameTiming.IsFirstTimePredicted)
                         _popupSystem.PopupEntity(Loc.GetString("drone-too-close", ("being", entity)), uid, Filter.Entities(uid));
                     return true;

--- a/Content.Server/Drone/DroneSystem.cs
+++ b/Content.Server/Drone/DroneSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Drone.Components;
 using Content.Shared.Actions;
 using Content.Server.Light.Components;
 using Content.Shared.MobState;
+using Content.Shared.MobState.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Examine;
@@ -175,6 +176,11 @@ namespace Content.Server.Drone
             var xform = Comp<TransformComponent>(uid);
             foreach (var entity in _lookup.GetEntitiesInRange(xform.MapPosition, component.InteractionBlockRange))
             {
+                // Filter out dead ghost roles. Dead normal players are intended to block.
+                if ((TryComp<MobStateComponent>(entity, out var entityMobState) && HasComp<GhostTakeoverAvailableComponent>(entity) && entityMobState.IsDead()))
+                    continue;
+
+                // Return true if the entity is/was controlled by a player and is not a drone or ghost.
                 if (HasComp<MindComponent>(entity) && !HasComp<DroneComponent>(entity) && !HasComp<GhostComponent>(entity))
                 {
                     if (_gameTiming.IsFirstTimePredicted)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The blocker ignoring bodies is intentional, but only ones that might be cloned. We don't really care if they clean up a dead mouse or something. 
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
We're gonna prevent this
![image](https://user-images.githubusercontent.com/60792108/165156247-de0756a9-bfef-4c79-84a7-fe47512ead86.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: Drones will no longer be blocked from acting near dead ghost roles.

