### PR TITLE
Vehicle camera lurching fix + drawdepth fix

### DIFF
--- a/Content.Client/Vehicle/VehicleSystem.cs
+++ b/Content.Client/Vehicle/VehicleSystem.cs
@@ -27,7 +27,6 @@ namespace Content.Client.Vehicle
             // Reset if we get unbuckled.
             if (!TryComp<EyeComponent>(args.Rider, out var component) || component.Eye == null)
                 return; // This probably will never happen but in this strange new world we probably want to maintain our old vision
-            Logger.Error("Resetting our eye back to our eye..");
             _eyeManager.CurrentEye = component.Eye;
         }
 

--- a/Content.Client/Vehicle/VehicleSystem.cs
+++ b/Content.Client/Vehicle/VehicleSystem.cs
@@ -16,14 +16,11 @@ namespace Content.Client.Vehicle
 
         private void OnBuckle(BuckledToVehicleEvent args)
         {
-            Logger.Error("Received event...");
             // Use the vehicle's eye if we get buckled
             if (args.Buckling)
             {
-                Logger.Error("Args are buckling...");
                 if (!TryComp<EyeComponent>(args.Vehicle, out var vehicleEye) || vehicleEye.Eye == null)
                     return;
-                Logger.Error("Setting current eye to vehicle's eye...");
                 _eyeManager.CurrentEye = vehicleEye.Eye;
                 return;
             }

--- a/Content.Client/Vehicle/VehicleSystem.cs
+++ b/Content.Client/Vehicle/VehicleSystem.cs
@@ -1,32 +1,38 @@
-using Robust.Client.GameObjects;
 using Content.Shared.Vehicle;
+using Robust.Client.Graphics;
+using Robust.Client.GameObjects;
 
 namespace Content.Client.Vehicle
 {
-    /// <summary>
-    /// Controls client-side visuals for
-    /// vehicles
-    /// </summary>
-    public sealed class VehicleSystem : VisualizerSystem<VehicleVisualsComponent>
+    public sealed class VehicleSystem : EntitySystem
     {
-        protected override void OnAppearanceChange(EntityUid uid, VehicleVisualsComponent component, ref AppearanceChangeEvent args)
+        [Dependency] private readonly IEyeManager _eyeManager = default!;
+
+        public override void Initialize()
         {
-            /// First check is for the sprite itself
-            if (TryComp(uid, out SpriteComponent? sprite)
-                && args.Component.TryGetData(VehicleVisuals.DrawDepth, out int drawDepth) && sprite != null)
-            {
-                sprite.DrawDepth = drawDepth;
-            }
-            /// Set vehicle layer to animated or not (i.e. are the wheels turning or not)
-            if (args.Component.TryGetData(VehicleVisuals.AutoAnimate, out bool autoAnimate))
-            {
-                sprite?.LayerSetAutoAnimated(VehicleVisualLayers.AutoAnimate, autoAnimate);
-            }
+            base.Initialize();
+            SubscribeNetworkEvent<BuckledToVehicleEvent>(OnBuckle);
         }
+
+        private void OnBuckle(BuckledToVehicleEvent args)
+        {
+            Logger.Error("Received event...");
+            // Use the vehicle's eye if we get buckled
+            if (args.Buckling)
+            {
+                Logger.Error("Args are buckling...");
+                if (!TryComp<EyeComponent>(args.Vehicle, out var vehicleEye) || vehicleEye.Eye == null)
+                    return;
+                Logger.Error("Setting current eye to vehicle's eye...");
+                _eyeManager.CurrentEye = vehicleEye.Eye;
+                return;
+            }
+            // Reset if we get unbuckled.
+            if (!TryComp<EyeComponent>(args.Rider, out var component) || component.Eye == null)
+                return; // This probably will never happen but in this strange new world we probably want to maintain our old vision
+            Logger.Error("Resetting our eye back to our eye..");
+            _eyeManager.CurrentEye = component.Eye;
+        }
+
     }
-}
-public enum VehicleVisualLayers : byte
-{
-    /// Layer for the vehicle's wheels
-    AutoAnimate,
 }

--- a/Content.Client/Vehicle/VehicleVisualsSystem.cs
+++ b/Content.Client/Vehicle/VehicleVisualsSystem.cs
@@ -1,0 +1,32 @@
+using Robust.Client.GameObjects;
+using Content.Shared.Vehicle;
+
+namespace Content.Client.Vehicle
+{
+    /// <summary>
+    /// Controls client-side visuals for
+    /// vehicles
+    /// </summary>
+    public sealed class VehicleVisualsSystem : VisualizerSystem<VehicleVisualsComponent>
+    {
+        protected override void OnAppearanceChange(EntityUid uid, VehicleVisualsComponent component, ref AppearanceChangeEvent args)
+        {
+            /// First check is for the sprite itself
+            if (TryComp(uid, out SpriteComponent? sprite)
+                && args.Component.TryGetData(VehicleVisuals.DrawDepth, out int drawDepth) && sprite != null)
+            {
+                sprite.DrawDepth = drawDepth;
+            }
+            /// Set vehicle layer to animated or not (i.e. are the wheels turning or not)
+            if (args.Component.TryGetData(VehicleVisuals.AutoAnimate, out bool autoAnimate))
+            {
+                sprite?.LayerSetAutoAnimated(VehicleVisualLayers.AutoAnimate, autoAnimate);
+            }
+        }
+    }
+}
+public enum VehicleVisualLayers : byte
+{
+    /// Layer for the vehicle's wheels
+    AutoAnimate,
+}

--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -81,7 +81,6 @@ namespace Content.Server.Vehicle
                     _riderSystem.UnbuckleFromVehicle(args.BuckledEntity);
                     return;
                 }
-
                 // Set up the rider and vehicle with each other
                 EnsureComp<SharedPlayerInputMoverComponent>(uid);
                 var rider = EnsureComp<RiderComponent>(args.BuckledEntity);

--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -205,16 +205,16 @@ namespace Content.Server.Vehicle
             {
                 return xform.LocalRotation.Degrees switch
                 {
-                    < 135f => 10,
+                    < 135f => 5,
                     <= 225f => 2,
-                    _ => 10
+                    _ => 5
                 };
             }
             return xform.LocalRotation.Degrees switch
             {
-                < 45f => 10,
+                < 45f => 5,
                 <= 315f => 2,
-                _ => 10
+                _ => 5
             };
         }
 

--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -10,8 +10,10 @@ using Content.Server.Light.Components;
 using Content.Server.Buckle.Components;
 using Content.Server.Hands.Systems;
 using Content.Shared.Tag;
+using Content.Server.Mind.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Containers;
+using Robust.Shared.Player;
 
 namespace Content.Server.Vehicle
 {
@@ -24,7 +26,6 @@ namespace Content.Server.Vehicle
         [Dependency] private readonly TagSystem _tagSystem = default!;
         [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
         [Dependency] private readonly RiderSystem _riderSystem = default!;
-
         public override void Initialize()
         {
             base.Initialize();
@@ -68,6 +69,10 @@ namespace Content.Server.Vehicle
         /// </summary>
         private void OnBuckleChange(EntityUid uid, VehicleComponent component, BuckleChangeEvent args)
         {
+            // Send an event that our vehicle buckle changed
+            if (TryComp<MindComponent>(args.BuckledEntity, out var mind) && mind.Mind != null && mind.Mind.TryGetSession(out var session))
+                RaiseNetworkEvent(new BuckledToVehicleEvent(uid, args.BuckledEntity, args.Buckling), Filter.SinglePlayer(session));
+
             if (args.Buckling)
             {
                 // Add a virtual item to rider's hand, unbuckle if we can't.
@@ -76,6 +81,7 @@ namespace Content.Server.Vehicle
                     _riderSystem.UnbuckleFromVehicle(args.BuckledEntity);
                     return;
                 }
+
                 // Set up the rider and vehicle with each other
                 EnsureComp<SharedPlayerInputMoverComponent>(uid);
                 var rider = EnsureComp<RiderComponent>(args.BuckledEntity);

--- a/Content.Shared/Vehicle/SharedVehicleSystem.cs
+++ b/Content.Shared/Vehicle/SharedVehicleSystem.cs
@@ -48,4 +48,26 @@ namespace Content.Shared.Vehicle
     /// Raised when someone honks a vehicle horn
     /// </summary>
     public sealed class HonkActionEvent : InstantActionEvent { }
+
+    /// <summary>
+    /// Raised on the rider when someone is buckled to a vehicle.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed class BuckledToVehicleEvent : EntityEventArgs
+    {
+        public EntityUid Vehicle;
+
+        public EntityUid Rider;
+
+        /// <summary>
+        /// Whether they were buckled or unbuckled
+        /// </summary>
+        public bool Buckling;
+        public BuckledToVehicleEvent(EntityUid vehicle, EntityUid rider, bool buckling)
+        {
+            Vehicle = vehicle;
+            Rider = rider;
+            Buckling = buckling;
+        }
+    }
 }

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -17,6 +17,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 7
     baseSprintSpeed : 7
+  - type: Eye
   - type: Tag
   - type: Pullable
   - type: Physics


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes https://github.com/space-wizards/space-station-14/issues/7803.
Makes you use the vehicle's eye when riding one, preventing camera lurching when you turn. Helps a lot no matter what amount of lag you have. Also changes their highest drawdepth to the "doors" layer.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
https://user-images.githubusercontent.com/60792108/165177237-455a3965-754a-4bfe-b6ce-b422f37f08e1.mp4


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Your camera now follows the vehicle rather than you when you are riding one.
- fix: Vehicles no longer render above kudzu.

