### PR TITLE
Verb tooltip tweaks

### DIFF
--- a/Resources/Locale/en-US/atmos/gas-analyzable-system.ftl
+++ b/Resources/Locale/en-US/atmos/gas-analyzable-system.ftl
@@ -1,7 +1,7 @@
 gas-analyzable-system-internal-error-missing-component = Your gas analyzer whirrs for a while, then stops.
 gas-anlayzable-system-internal-error-no-gas-node = Your gas analyzer reads, "NO GAS FOUND".
 gas-analyzable-system-verb-name = Analyze
-gas-analyzable-system-verb-tooltip = Analyze Contents
+gas-analyzable-system-verb-tooltip = Use a gas analyzer to examine the contents of this device.
 gas-analyzable-system-header = Your gas analyzer shows a list of statistics:
 gas-analyzable-system-statistics = Pressure: {PRESSURE($pressure)}
                                    Temperature: {$tempK}K ({$tempC}°C)

--- a/Resources/Locale/en-US/cable/cable-multitool-system.ftl
+++ b/Resources/Locale/en-US/cable/cable-multitool-system.ftl
@@ -1,7 +1,7 @@
 cable-multitool-system-internal-error-no-power-node = Your multitool reads, "INTERNAL ERROR: NOT A POWER CABLE".
 cable-multitool-system-internal-error-missing-component = Your multitool reads, "INTERNAL ERROR: CABLE ABNORMAL".
 cable-multitool-system-verb-name = Power
-cable-multitool-system-verb-tooltip = Requires multitool
+cable-multitool-system-verb-tooltip = Use a multitool to examine power statistics.
 
 cable-multitool-system-statistics = Your multitool shows a list of statistics:
                                     Current Supply: { POWERWATTS($supplyc) }

--- a/Resources/Locale/en-US/health-examinable/health-examinable-comp.ftl
+++ b/Resources/Locale/en-US/health-examinable/health-examinable-comp.ftl
@@ -1,2 +1,2 @@
 ﻿health-examinable-verb-text = Health
-health-examinable-verb-disabled = Need to be in close range
+health-examinable-verb-disabled = Perform a basic health examination in close range.

--- a/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
@@ -1,4 +1,4 @@
 ﻿butcherable-knife-butchered-success = You butcher { THE($target) } with { THE($knife) }.
-butcherable-need-knife = Need something sharp.
+butcherable-need-knife = Use a sharp object to butcher this creature.
 butcherable-mob-isnt-dead = Needs to be dead.
 butcherable-verb-name = Butcher

--- a/Resources/Locale/en-US/machine-linking/components/signal-linker-component.ftl
+++ b/Resources/Locale/en-US/machine-linking/components/signal-linker-component.ftl
@@ -13,5 +13,5 @@ signal-linker-component-out-of-range = Connection is out of range!
 signal-linking-verb-text-link-default = Link default ports
 signal-linking-verb-success = Connected all default {$machine} links.
 signal-linking-verb-fail = Failed to connect all default {$machine} links.
-signal-linking-verb-disabled-no-transmitter = You first need to interact with a transmitter.
-signal-linking-verb-disabled-no-receiver = You first need to interact with a receiver.
+signal-linking-verb-disabled-no-transmitter = First interact with a transmitter, then link default ports.
+signal-linking-verb-disabled-no-receiver = First interact with a receiver, then link default ports.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

IMO these tooltips should
- be one sentence
- explain exactly what will occur
- explain the preconditions for it to be available

so this modifies all current verb tooltips to read as such.

