### PR TITLE
Make Disarm opt-in

### DIFF
--- a/Content.Shared/CombatMode/SharedCombatModeComponent.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeComponent.cs
@@ -30,6 +30,9 @@ namespace Content.Shared.CombatMode
         [DataField("disarmActionId", customTypeSerializer:typeof(PrototypeIdSerializer<EntityTargetActionPrototype>))]
         public readonly string DisarmActionId = "Disarm";
 
+        [DataField("canDisarm")]
+        public bool CanDisarm;
+
         [DataField("disarmAction")] // must be a data-field to properly save cooldown when saving game state.
         public EntityTargetAction? DisarmAction;
 

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -33,12 +33,13 @@ namespace Content.Shared.CombatMode
                 _actionsSystem.AddAction(uid, component.CombatToggleAction, null);
 
             if (component.DisarmAction == null
+                && component.CanDisarm
                 && _protoMan.TryIndex(component.DisarmActionId, out EntityTargetActionPrototype? disarmProto))
             {
                 component.DisarmAction = new(disarmProto);
             }
 
-            if (component.DisarmAction != null)
+            if (component.DisarmAction != null && component.CanDisarm)
                 _actionsSystem.AddAction(uid, component.DisarmAction, null);
         }
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -612,6 +612,8 @@
   parent: SimpleMobBase
   description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
   components:
+  - type: CombatMode
+    canDisarm: true
   - type: NameIdentifier
     group: Monkey
   - type: SentienceTarget

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -580,6 +580,8 @@
   id: MobKangarooBoxer
   description: A large marsupial herbivore. It has powerful hind legs and... boxing gloves?
   components:
+  - type: CombatMode
+    canDisarm: true
   - type: Sprite
     drawdepth: Mobs
     layers:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -5,6 +5,8 @@
   parent: SimpleSpaceMobBase
   description: They mostly come at night. Mostly.
   components:
+  - type: CombatMode
+    canDisarm: true
   - type: UtilityAI
     behaviorSets:
     - Idle

--- a/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
@@ -5,6 +5,8 @@
   id: MobDwarf
   description: A miserable pile of secrets.
   components:
+    - type: CombatMode
+      canDisarm: true
     - type: InteractionPopup
       successChance: 1
       interactSuccessString: hugging-success-generic

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -5,6 +5,8 @@
   id: MobHuman
   description: A miserable pile of secrets.
   components:
+  - type: CombatMode
+    canDisarm: true
   - type: InteractionPopup
     successChance: 1
     interactSuccessString: hugging-success-generic

--- a/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
@@ -5,6 +5,8 @@
   id: MobReptilian
   description: A miserable pile of scales.
   components:
+    - type: CombatMode
+      canDisarm: true
     - type: InteractionPopup
       successChance: 1
       interactSuccessString: hugging-success-generic

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -3,6 +3,8 @@
   abstract: true
   id: PlayerSiliconBase #for player controlled silicons
   components:
+  - type: CombatMode
+    canDisarm: true
   - type: Reactive
     groups:
       Acidic: [Touch]

--- a/Resources/Prototypes/Entities/Mobs/Player/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/slime.yml
@@ -3,6 +3,8 @@
   parent: MobSlimePersonBase
   id: MobSlimePerson
   components:
+    - type: CombatMode
+      canDisarm: true
     - type: InteractionPopup
       successChance: 1
       interactSuccessString: hugging-success-generic

--- a/Resources/Prototypes/Entities/Mobs/Player/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vox.yml
@@ -4,6 +4,8 @@
   parent: BaseVox
   id: Vox
   components:
+    - type: CombatMode
+      canDisarm: true
     - type: InteractionPopup
       successChance: 1
       interactSuccessString: hugging-success-generic


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a bool to CombatMode to switch Disarm opt-out to opt-in.
It's a saner way of dealing with instead of adding new mobs/species and getting an issue on github saying "Bee's should disarm" then having to retroactively remove the function.

That being said, I'm unsure if this is a sane way of implementing it. I'm still very much in the "if it works, it works" stages of coding, so feel free to scrutinize, thank you!

