### PR TITLE
Allow self-cuffing and appropriate text changes

### DIFF
--- a/Content.Server/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Server/Cuffs/Components/HandcuffComponent.cs
@@ -154,11 +154,11 @@ namespace Content.Server.Cuffs.Components
                 return false;
             }
 
-            if (eventArgs.Target == eventArgs.User)
+            /*if (eventArgs.Target == eventArgs.User)
             {
                 eventArgs.User.PopupMessage(Loc.GetString("handcuff-component-target-self-error"));
                 return true;
-            }
+            }*/
 
             if (Broken)
             {
@@ -184,9 +184,15 @@ namespace Content.Server.Cuffs.Components
                 return true;
             }
 
-            eventArgs.User.PopupMessage(Loc.GetString("handcuff-component-start-cuffing-target-message",("targetName", eventArgs.Target)));
-            eventArgs.User.PopupMessage(target, Loc.GetString("handcuff-component-start-cuffing-by-other-message",("otherName", eventArgs.User)));
-
+            if (eventArgs.Target == eventArgs.User)
+            {
+                eventArgs.User.PopupMessage(Loc.GetString("handcuff-component-target-self"));
+            }
+            else
+            {
+                eventArgs.User.PopupMessage(Loc.GetString("handcuff-component-start-cuffing-target-message",("targetName", eventArgs.Target)));
+                eventArgs.User.PopupMessage(target, Loc.GetString("handcuff-component-start-cuffing-by-other-message",("otherName", eventArgs.User)));
+            }
             SoundSystem.Play(Filter.Pvs(Owner), StartCuffSound.GetSound(), Owner);
 
             TryUpdateCuff(eventArgs.User, target, cuffed);
@@ -225,15 +231,28 @@ namespace Content.Server.Cuffs.Components
                 if (cuffs.TryAddNewCuffs(user, Owner))
                 {
                     SoundSystem.Play(Filter.Pvs(Owner), EndCuffSound.GetSound(), Owner);
-
-                    user.PopupMessage(Loc.GetString("handcuff-component-cuff-other-success-message",("otherName", target)));
-                    target.PopupMessage(Loc.GetString("handcuff-component-cuff-by-other-success-message", ("otherName", user)));
+                    if (target == user)
+                    {
+                        user.PopupMessage(Loc.GetString("handcuff-component-cuff-self-success-message"));
+                    }
+                    else
+                    {
+                        user.PopupMessage(Loc.GetString("handcuff-component-cuff-other-success-message",("otherName", target)));
+                        target.PopupMessage(Loc.GetString("handcuff-component-cuff-by-other-success-message", ("otherName", user)));
+                    }
                 }
             }
             else
             {
-                user.PopupMessage(Loc.GetString("handcuff-component-cuff-interrupt-message",("targetName", target)));
-                target.PopupMessage(Loc.GetString("handcuff-component-cuff-interrupt-other-message",("otherName", user)));
+                if (target == user)
+                {
+                    user.PopupMessage(Loc.GetString("handcuff-component-cuff-interrupt-self-message"));
+                }
+                else
+                {
+                    user.PopupMessage(Loc.GetString("handcuff-component-cuff-interrupt-message",("targetName", target)));
+                    target.PopupMessage(Loc.GetString("handcuff-component-cuff-interrupt-other-message",("otherName", user)));
+                }
             }
         }
     }

--- a/Content.Server/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Server/Cuffs/Components/HandcuffComponent.cs
@@ -154,12 +154,6 @@ namespace Content.Server.Cuffs.Components
                 return false;
             }
 
-            /*if (eventArgs.Target == eventArgs.User)
-            {
-                eventArgs.User.PopupMessage(Loc.GetString("handcuff-component-target-self-error"));
-                return true;
-            }*/
-
             if (Broken)
             {
                 eventArgs.User.PopupMessage(Loc.GetString("handcuff-component-cuffs-broken-error"));

--- a/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/handcuff-component.ftl
@@ -1,11 +1,13 @@
-handcuff-component-target-self-error = You can't cuff yourself!
+handcuff-component-target-self = You start cuffing yourself.
 handcuff-component-cuffs-broken-error = The cuffs are broken!
 handcuff-component-target-has-no-hands-error = {$targetName} has no hands!
 handcuff-component-target-has-no-free-hands-error = {$targetName} has no free hands!
 handcuff-component-too-far-away-error = You are too far away to use the cuffs!
-handcuff-component-start-cuffing-target-message = You start cuffing {$targetName}.  
+handcuff-component-start-cuffing-target-message = You start cuffing {$targetName}.
 handcuff-component-start-cuffing-by-other-message = {$otherName} starts cuffing you!
 handcuff-component-cuff-other-success-message = You successfully cuff {$otherName}.
 handcuff-component-cuff-by-other-success-message = You have been cuffed by {$otherName}!
+handcuff-component-cuff-self-success-message = You cuff yourself.
 handcuff-component-cuff-interrupt-message = You were interrupted while cuffing {$targetName}!
 handcuff-component-cuff-interrupt-other-message = You interrupt {$otherName} while they are cuffing you!
+handcuff-component-cuff-interrupt-self-message = You were interrupted while cuffing yourself.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This simple PR allows a mob to cuff themselves by using a pair of handcuffs or restraints on their own person instead of explicitly stopping it from being possible. This also makes appropriate changes to messaging displayed to the user when they start/stop/succeed in cuffing themselves.

While it may be beneficial to prevent self-cuffing as to avoid people accidentally cuffing themselves (especially those new to the game), I find the inability for someone to willingly restrain themselves (either at request or as part of a ruse) to be lacking. Particularly as Security, it can be useful to help defuse situations by telling an offender to cuff themselves as an act of goodwill, thereby ensuring the safety of both parties. The alternative to this scenario is security has no way of knowing if the offender will try to resist last moment and usually, to ensure their safety, end up going in guns blazing by default since there is no other way to guarantee their own safety. 

I think allowing this mechanic may help expand some RP opportunities and also it may be funny when someone accidentally cuffs themselves. 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/104049107/165679379-174a05e9-04da-41bd-ad31-13b6abae25bb.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: tweaks to handcuffs and restraints so they can now be used to restrain yourself