### PR TITLE
Rebalance small-a-1 for salvage ore mining

### DIFF
--- a/Resources/Maps/Salvage/small-a-1.yml
+++ b/Resources/Maps/Salvage/small-a-1.yml
@@ -72,214 +72,22 @@ entities:
 - uid: 0
   type: AsteroidRock
   components:
-  - pos: 0.5,-0.5
-    parent: 35
+  - pos: -2.5,-2.5
+    parent: 3
     type: Transform
 - uid: 1
-  type: AsteroidRock
+  type: AtmosFixInstantPlasmaFireMarker
   components:
-  - pos: -0.5,-0.5
-    parent: 35
+  - pos: 1.5,0.5
+    parent: 3
     type: Transform
 - uid: 2
-  type: AsteroidRock
-  components:
-  - pos: -1.5,0.5
-    parent: 35
-    type: Transform
-- uid: 3
-  type: AsteroidRock
-  components:
-  - pos: -0.5,-3.5
-    parent: 35
-    type: Transform
-- uid: 4
-  type: AsteroidRock
-  components:
-  - pos: -1.5,-3.5
-    parent: 35
-    type: Transform
-- uid: 5
-  type: AsteroidRock
-  components:
-  - pos: -2.5,-3.5
-    parent: 35
-    type: Transform
-- uid: 6
-  type: AsteroidRock
-  components:
-  - pos: 2.5,-1.5
-    parent: 35
-    type: Transform
-- uid: 7
-  type: AsteroidRock
-  components:
-  - pos: 2.5,-0.5
-    parent: 35
-    type: Transform
-- uid: 8
-  type: AsteroidRock
-  components:
-  - pos: 2.5,0.5
-    parent: 35
-    type: Transform
-- uid: 9
-  type: AsteroidRock
-  components:
-  - pos: 1.5,-1.5
-    parent: 35
-    type: Transform
-- uid: 10
-  type: AsteroidRock
-  components:
-  - pos: 1.5,-0.5
-    parent: 35
-    type: Transform
-- uid: 11
-  type: AsteroidRock
-  components:
-  - pos: 1.5,1.5
-    parent: 35
-    type: Transform
-- uid: 12
-  type: AsteroidRock
-  components:
-  - pos: -3.5,-1.5
-    parent: 35
-    type: Transform
-- uid: 13
-  type: AsteroidRock
-  components:
-  - pos: -3.5,-0.5
-    parent: 35
-    type: Transform
-- uid: 14
-  type: AsteroidRock
-  components:
-  - pos: -3.5,0.5
-    parent: 35
-    type: Transform
-- uid: 15
-  type: AsteroidRock
-  components:
-  - pos: -3.5,1.5
-    parent: 35
-    type: Transform
-- uid: 16
-  type: AsteroidRock
-  components:
-  - pos: 0.5,-2.5
-    parent: 35
-    type: Transform
-- uid: 17
-  type: AsteroidRock
-  components:
-  - pos: 0.5,-1.5
-    parent: 35
-    type: Transform
-- uid: 18
-  type: AsteroidRock
-  components:
-  - pos: 0.5,0.5
-    parent: 35
-    type: Transform
-- uid: 19
-  type: AsteroidRock
-  components:
-  - pos: 0.5,1.5
-    parent: 35
-    type: Transform
-- uid: 20
-  type: AsteroidRock
-  components:
-  - pos: 0.5,2.5
-    parent: 35
-    type: Transform
-- uid: 21
-  type: AsteroidRock
-  components:
-  - pos: -0.5,-2.5
-    parent: 35
-    type: Transform
-- uid: 22
-  type: AsteroidRock
-  components:
-  - pos: -0.5,-1.5
-    parent: 35
-    type: Transform
-- uid: 23
-  type: AsteroidRock
-  components:
-  - pos: -1.5,-0.5
-    parent: 35
-    type: Transform
-- uid: 24
-  type: AsteroidRock
-  components:
-  - pos: -0.5,1.5
-    parent: 35
-    type: Transform
-- uid: 25
-  type: AsteroidRock
-  components:
-  - pos: -0.5,2.5
-    parent: 35
-    type: Transform
-- uid: 26
-  type: AsteroidRock
-  components:
-  - pos: -1.5,-2.5
-    parent: 35
-    type: Transform
-- uid: 27
-  type: AsteroidRock
-  components:
-  - pos: -1.5,-1.5
-    parent: 35
-    type: Transform
-- uid: 28
-  type: AsteroidRock
-  components:
-  - pos: -0.5,0.5
-    parent: 35
-    type: Transform
-- uid: 29
-  type: AsteroidRock
-  components:
-  - pos: -1.5,2.5
-    parent: 35
-    type: Transform
-- uid: 30
-  type: AsteroidRock
-  components:
-  - pos: -2.5,-1.5
-    parent: 35
-    type: Transform
-- uid: 31
-  type: AsteroidRock
+  type: AtmosFixInstantPlasmaFireMarker
   components:
   - pos: -2.5,-0.5
-    parent: 35
+    parent: 3
     type: Transform
-- uid: 32
-  type: AsteroidRock
-  components:
-  - pos: -2.5,0.5
-    parent: 35
-    type: Transform
-- uid: 33
-  type: AsteroidRock
-  components:
-  - pos: -2.5,1.5
-    parent: 35
-    type: Transform
-- uid: 34
-  type: AsteroidRock
-  components:
-  - pos: -2.5,2.5
-    parent: 35
-    type: Transform
-- uid: 35
+- uid: 3
   components:
   - pos: 0.5,0.5
     parent: null
@@ -302,13 +110,13 @@ entities:
       -3,-4: 0
       -3,-3: 0
       -3,-2: 0
-      -3,-1: 0
+      -3,-1: 1
       -2,-4: 0
       -2,-3: 0
       -2,-2: 0
       -2,-1: 0
       -1,-4: 0
-      -1,-3: 0
+      -1,-3: 1
       -1,-2: 0
       -1,-1: 0
       0,-3: 0
@@ -324,7 +132,7 @@ entities:
       -3,1: 0
       -3,2: 0
       -2,0: 0
-      -2,1: 0
+      -2,1: 1
       -2,2: 0
       -1,0: 0
       -1,1: 0
@@ -332,7 +140,7 @@ entities:
       0,0: 0
       0,1: 0
       0,2: 0
-      1,0: 0
+      1,0: 1
       1,1: 0
       2,0: 0
     uniqueMixes:
@@ -347,25 +155,228 @@ entities:
       - 0
       - 0
       - 0
+    - volume: 2500
+      temperature: 5000
+      moles:
+      - 6666.982
+      - 0
+      - 0
+      - 6666.982
+      - 0
+      - 0
+      - 0
+      - 0
     type: GridAtmosphere
   - chunkCollection: {}
     type: DecalGrid
+- uid: 4
+  type: AsteroidRock
+  components:
+  - pos: -2.5,2.5
+    parent: 3
+    type: Transform
+- uid: 5
+  type: AsteroidRock
+  components:
+  - pos: -2.5,1.5
+    parent: 3
+    type: Transform
+- uid: 6
+  type: AsteroidRock
+  components:
+  - pos: -2.5,0.5
+    parent: 3
+    type: Transform
+- uid: 7
+  type: AtmosFixInstantPlasmaFireMarker
+  components:
+  - pos: -0.5,-2.5
+    parent: 3
+    type: Transform
+- uid: 8
+  type: AsteroidRock
+  components:
+  - pos: -2.5,-1.5
+    parent: 3
+    type: Transform
+- uid: 9
+  type: AsteroidRock
+  components:
+  - pos: -1.5,2.5
+    parent: 3
+    type: Transform
+- uid: 10
+  type: AsteroidRock
+  components:
+  - pos: -0.5,0.5
+    parent: 3
+    type: Transform
+- uid: 11
+  type: AsteroidRock
+  components:
+  - pos: -1.5,-1.5
+    parent: 3
+    type: Transform
+- uid: 12
+  type: AsteroidRock
+  components:
+  - pos: -1.5,-2.5
+    parent: 3
+    type: Transform
+- uid: 13
+  type: AsteroidRock
+  components:
+  - pos: -0.5,1.5
+    parent: 3
+    type: Transform
+- uid: 14
+  type: AsteroidRock
+  components:
+  - pos: -0.5,-1.5
+    parent: 3
+    type: Transform
+- uid: 15
+  type: AsteroidRock
+  components:
+  - pos: 0.5,2.5
+    parent: 3
+    type: Transform
+- uid: 16
+  type: AsteroidRock
+  components:
+  - pos: 0.5,0.5
+    parent: 3
+    type: Transform
+- uid: 17
+  type: AsteroidRock
+  components:
+  - pos: 0.5,-2.5
+    parent: 3
+    type: Transform
+- uid: 18
+  type: AsteroidRock
+  components:
+  - pos: -3.5,0.5
+    parent: 3
+    type: Transform
+- uid: 19
+  type: AsteroidRock
+  components:
+  - pos: -3.5,-0.5
+    parent: 3
+    type: Transform
+- uid: 20
+  type: AsteroidRock
+  components:
+  - pos: -3.5,-1.5
+    parent: 3
+    type: Transform
+- uid: 21
+  type: AsteroidRock
+  components:
+  - pos: 1.5,1.5
+    parent: 3
+    type: Transform
+- uid: 22
+  type: AsteroidRock
+  components:
+  - pos: 1.5,-0.5
+    parent: 3
+    type: Transform
+- uid: 23
+  type: AsteroidRock
+  components:
+  - pos: 1.5,-1.5
+    parent: 3
+    type: Transform
+- uid: 24
+  type: AsteroidRock
+  components:
+  - pos: 2.5,0.5
+    parent: 3
+    type: Transform
+- uid: 25
+  type: AsteroidRock
+  components:
+  - pos: 2.5,-1.5
+    parent: 3
+    type: Transform
+- uid: 26
+  type: AsteroidRock
+  components:
+  - pos: -1.5,-3.5
+    parent: 3
+    type: Transform
+- uid: 27
+  type: AsteroidRock
+  components:
+  - pos: -0.5,-3.5
+    parent: 3
+    type: Transform
+- uid: 28
+  type: AsteroidRock
+  components:
+  - pos: -1.5,0.5
+    parent: 3
+    type: Transform
+- uid: 29
+  type: AsteroidRock
+  components:
+  - pos: -0.5,-0.5
+    parent: 3
+    type: Transform
+- uid: 30
+  type: AsteroidRock
+  components:
+  - pos: 0.5,-0.5
+    parent: 3
+    type: Transform
+- uid: 31
+  type: AsteroidRock
+  components:
+  - pos: -0.5,2.5
+    parent: 3
+    type: Transform
+- uid: 32
+  type: AsteroidRock
+  components:
+  - pos: -1.5,-0.5
+    parent: 3
+    type: Transform
+- uid: 33
+  type: AtmosFixInstantPlasmaFireMarker
+  components:
+  - pos: -1.5,1.5
+    parent: 3
+    type: Transform
+- uid: 34
+  type: AsteroidRock
+  components:
+  - pos: 0.5,1.5
+    parent: 3
+    type: Transform
+- uid: 35
+  type: AsteroidRock
+  components:
+  - pos: 0.5,-1.5
+    parent: 3
+    type: Transform
 - uid: 36
   type: AsteroidRock
   components:
-  - pos: 1.5,0.5
-    parent: 35
+  - pos: -3.5,1.5
+    parent: 3
     type: Transform
 - uid: 37
   type: AsteroidRock
   components:
-  - pos: -1.5,1.5
-    parent: 35
+  - pos: 2.5,-0.5
+    parent: 3
     type: Transform
 - uid: 38
   type: AsteroidRock
   components:
-  - pos: -2.5,-2.5
-    parent: 35
+  - pos: -2.5,-3.5
+    parent: 3
     type: Transform
 ...

--- a/Resources/Maps/Salvage/small-a-1.yml
+++ b/Resources/Maps/Salvage/small-a-1.yml
@@ -5,180 +5,293 @@ meta:
   postmapinit: false
 tilemap:
   0: space
-  1: floor_asteroid_coarse_sand0
-  2: floor_asteroid_coarse_sand1
-  3: floor_asteroid_coarse_sand2
-  4: floor_asteroid_coarse_sand_dug
-  5: floor_asteroid_sand
-  6: floor_asteroid_tile
-  7: floor_blue
-  8: floor_blue_circuit
-  9: floor_dark
-  10: floor_elevator_shaft
-  11: floor_freezer
-  12: floor_glass
-  13: floor_gold
-  14: floor_green_circuit
-  15: floor_hydro
-  16: floor_lino
-  17: floor_mono
-  18: floor_reinforced
-  19: floor_rglass
-  20: floor_rock_vault
-  21: floor_showroom
-  22: floor_silver
-  23: floor_snow
-  24: floor_steel
-  25: floor_steel_dirty
-  26: floor_techmaint
-  27: floor_white
-  28: floor_wood
-  29: lattice
-  30: plating
-  31: underplating
+  1: FloorArcadeBlue
+  2: FloorArcadeRed
+  3: FloorAsteroidIronsand1
+  4: FloorAsteroidIronsand2
+  5: FloorAsteroidIronsand3
+  6: FloorAsteroidIronsand4
+  7: FloorEighties
+  8: FloorGrassJungle
+  9: FloorShuttleBlue
+  10: FloorShuttleOrange
+  11: FloorShuttlePurple
+  12: FloorShuttleRed
+  13: FloorShuttleWhite
+  14: floor_asteroid_coarse_sand0
+  15: floor_asteroid_coarse_sand1
+  16: floor_asteroid_coarse_sand2
+  17: floor_asteroid_coarse_sand_dug
+  18: floor_asteroid_sand
+  19: floor_asteroid_tile
+  20: floor_bar
+  21: floor_blue
+  22: floor_blue_circuit
+  23: floor_clown
+  24: floor_dark
+  25: floor_elevator_shaft
+  26: floor_freezer
+  27: floor_glass
+  28: floor_gold
+  29: floor_grass
+  30: floor_green_circuit
+  31: floor_hydro
+  32: floor_kitchen
+  33: floor_laundry
+  34: floor_lino
+  35: floor_mime
+  36: floor_mono
+  37: floor_reinforced
+  38: floor_rglass
+  39: floor_rock_vault
+  40: floor_showroom
+  41: floor_silver
+  42: floor_snow
+  43: floor_steel
+  44: floor_steel_dirty
+  45: floor_techmaint
+  46: floor_white
+  47: floor_wood
+  48: lattice
+  49: plating
+  50: underplating
 grids:
 - settings:
     chunksize: 16
     tilesize: 1
   chunks:
-  - ind: "-1,-1"
-    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAFAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAABQAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAABQAAAAUAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAUAAAAFAAAABQAAAA==
-  - ind: "0,-1"
-    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAABQAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAUAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-  - ind: "-1,0"
-    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAUAAAAFAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAFAAAABQAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAUAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-  - ind: "0,0"
-    tiles: BQAAAAUAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: -1,-1
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABIAAAASAAAAEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAEgAAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAEgAAABIAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgAAABIAAAASAAAAEgAAAA==
+  - ind: 0,-1
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAEgAAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgAAABIAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: -1,0
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgAAABIAAAASAAAAEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABIAAAASAAAAEgAAABIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgAAABIAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: 0,0
+    tiles: EgAAABIAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABIAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
 entities:
 - uid: 0
+  type: AsteroidRock
+  components:
+  - pos: 0.5,-0.5
+    parent: 35
+    type: Transform
+- uid: 1
+  type: AsteroidRock
+  components:
+  - pos: -0.5,-0.5
+    parent: 35
+    type: Transform
+- uid: 2
+  type: AsteroidRock
+  components:
+  - pos: -1.5,0.5
+    parent: 35
+    type: Transform
+- uid: 3
+  type: AsteroidRock
+  components:
+  - pos: -0.5,-3.5
+    parent: 35
+    type: Transform
+- uid: 4
+  type: AsteroidRock
+  components:
+  - pos: -1.5,-3.5
+    parent: 35
+    type: Transform
+- uid: 5
+  type: AsteroidRock
+  components:
+  - pos: -2.5,-3.5
+    parent: 35
+    type: Transform
+- uid: 6
+  type: AsteroidRock
+  components:
+  - pos: 2.5,-1.5
+    parent: 35
+    type: Transform
+- uid: 7
+  type: AsteroidRock
+  components:
+  - pos: 2.5,-0.5
+    parent: 35
+    type: Transform
+- uid: 8
+  type: AsteroidRock
+  components:
+  - pos: 2.5,0.5
+    parent: 35
+    type: Transform
+- uid: 9
+  type: AsteroidRock
+  components:
+  - pos: 1.5,-1.5
+    parent: 35
+    type: Transform
+- uid: 10
+  type: AsteroidRock
+  components:
+  - pos: 1.5,-0.5
+    parent: 35
+    type: Transform
+- uid: 11
+  type: AsteroidRock
+  components:
+  - pos: 1.5,1.5
+    parent: 35
+    type: Transform
+- uid: 12
+  type: AsteroidRock
+  components:
+  - pos: -3.5,-1.5
+    parent: 35
+    type: Transform
+- uid: 13
+  type: AsteroidRock
+  components:
+  - pos: -3.5,-0.5
+    parent: 35
+    type: Transform
+- uid: 14
+  type: AsteroidRock
+  components:
+  - pos: -3.5,0.5
+    parent: 35
+    type: Transform
+- uid: 15
+  type: AsteroidRock
+  components:
+  - pos: -3.5,1.5
+    parent: 35
+    type: Transform
+- uid: 16
+  type: AsteroidRock
+  components:
+  - pos: 0.5,-2.5
+    parent: 35
+    type: Transform
+- uid: 17
+  type: AsteroidRock
+  components:
+  - pos: 0.5,-1.5
+    parent: 35
+    type: Transform
+- uid: 18
+  type: AsteroidRock
+  components:
+  - pos: 0.5,0.5
+    parent: 35
+    type: Transform
+- uid: 19
+  type: AsteroidRock
+  components:
+  - pos: 0.5,1.5
+    parent: 35
+    type: Transform
+- uid: 20
+  type: AsteroidRock
+  components:
+  - pos: 0.5,2.5
+    parent: 35
+    type: Transform
+- uid: 21
+  type: AsteroidRock
+  components:
+  - pos: -0.5,-2.5
+    parent: 35
+    type: Transform
+- uid: 22
+  type: AsteroidRock
+  components:
+  - pos: -0.5,-1.5
+    parent: 35
+    type: Transform
+- uid: 23
+  type: AsteroidRock
+  components:
+  - pos: -1.5,-0.5
+    parent: 35
+    type: Transform
+- uid: 24
+  type: AsteroidRock
+  components:
+  - pos: -0.5,1.5
+    parent: 35
+    type: Transform
+- uid: 25
+  type: AsteroidRock
+  components:
+  - pos: -0.5,2.5
+    parent: 35
+    type: Transform
+- uid: 26
+  type: AsteroidRock
+  components:
+  - pos: -1.5,-2.5
+    parent: 35
+    type: Transform
+- uid: 27
+  type: AsteroidRock
+  components:
+  - pos: -1.5,-1.5
+    parent: 35
+    type: Transform
+- uid: 28
+  type: AsteroidRock
+  components:
+  - pos: -0.5,0.5
+    parent: 35
+    type: Transform
+- uid: 29
+  type: AsteroidRock
+  components:
+  - pos: -1.5,2.5
+    parent: 35
+    type: Transform
+- uid: 30
+  type: AsteroidRock
+  components:
+  - pos: -2.5,-1.5
+    parent: 35
+    type: Transform
+- uid: 31
+  type: AsteroidRock
+  components:
+  - pos: -2.5,-0.5
+    parent: 35
+    type: Transform
+- uid: 32
+  type: AsteroidRock
+  components:
+  - pos: -2.5,0.5
+    parent: 35
+    type: Transform
+- uid: 33
+  type: AsteroidRock
+  components:
+  - pos: -2.5,1.5
+    parent: 35
+    type: Transform
+- uid: 34
+  type: AsteroidRock
+  components:
+  - pos: -2.5,2.5
+    parent: 35
+    type: Transform
+- uid: 35
   components:
   - pos: 0.5,0.5
     parent: null
     type: Transform
   - index: 0
     type: MapGrid
-  - angularDamping: 0.3
+  - angularDamping: 100
+    linearDamping: 50
     fixedRotation: False
     bodyType: Dynamic
     type: Physics
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 3,0
-        - 3,1
-        - 0,1
-        - 0,0
-      id: grid_chunk-0-0
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 12
-      restitution: 0.1
-    - shape: !type:PolygonShape
-        vertices:
-        - 1,-3
-        - 1,-2
-        - 0,-2
-        - 0,-3
-      id: grid_chunk-0--3
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 4
-      restitution: 0.1
-    - shape: !type:PolygonShape
-        vertices:
-        - 3,-2
-        - 3,0
-        - 0,0
-        - 0,-2
-      id: grid_chunk-0--2
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 24
-      restitution: 0.1
-    - shape: !type:PolygonShape
-        vertices:
-        - 2,1
-        - 2,2
-        - 0,2
-        - 0,1
-      id: grid_chunk-0-1
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 8
-      restitution: 0.1
-    - shape: !type:PolygonShape
-        vertices:
-        - 1,2
-        - 1,3
-        - 0,3
-        - 0,2
-      id: grid_chunk-0-2
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 4
-      restitution: 0.1
-    - shape: !type:PolygonShape
-        vertices:
-        - 0,0
-        - 0,2
-        - -4,2
-        - -4,0
-      id: grid_chunk--4-0
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 32
-      restitution: 0.1
-    - shape: !type:PolygonShape
-        vertices:
-        - 0,-4
-        - 0,-2
-        - -3,-2
-        - -3,-4
-      id: grid_chunk--3--4
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 24
-      restitution: 0.1
-    - shape: !type:PolygonShape
-        vertices:
-        - 0,-2
-        - 0,0
-        - -4,0
-        - -4,-2
-      id: grid_chunk--4--2
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 32
-      restitution: 0.1
-    - shape: !type:PolygonShape
-        vertices:
-        - 0,2
-        - 0,3
-        - -3,3
-        - -3,2
-      id: grid_chunk--3-2
-      mask:
-      - MapGrid
-      layer:
-      - MapGrid
-      mass: 12
-      restitution: 0.1
+  - fixtures: []
     type: Fixtures
   - gravityShakeSound: !type:SoundPathSpecifier
       path: /Audio/Effects/alert.ogg
@@ -193,14 +306,14 @@ entities:
       -2,-4: 0
       -2,-3: 0
       -2,-2: 0
-      -2,-1: 1
+      -2,-1: 0
       -1,-4: 0
       -1,-3: 0
-      -1,-2: 1
-      -1,-1: 2
+      -1,-2: 0
+      -1,-1: 0
       0,-3: 0
       0,-2: 0
-      0,-1: 1
+      0,-1: 0
       1,-2: 0
       1,-1: 0
       2,-2: 0
@@ -210,10 +323,10 @@ entities:
       -3,0: 0
       -3,1: 0
       -3,2: 0
-      -2,0: 3
+      -2,0: 0
       -2,1: 0
       -2,2: 0
-      -1,0: 1
+      -1,0: 0
       -1,1: 0
       -1,2: 0
       0,0: 0
@@ -234,330 +347,25 @@ entities:
       - 0
       - 0
       - 0
-    - volume: 2500
-      temperature: 293.15
-      moles:
-      - 0
-      - 0
-      - 0
-      - 6666.982
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 9000
-      moles:
-      - 0
-      - 0
-      - 0
-      - 6666.982
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 293.15
-      moles:
-      - 6666.982
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
     type: GridAtmosphere
-- uid: 1
-  type: AsteroidRock
-  components:
-  - pos: -2.5,2.5
-    parent: 0
-    type: Transform
-- uid: 2
-  type: AsteroidRock
-  components:
-  - pos: -2.5,1.5
-    parent: 0
-    type: Transform
-- uid: 3
-  type: AsteroidRock
-  components:
-  - pos: -2.5,0.5
-    parent: 0
-    type: Transform
-- uid: 4
-  type: AsteroidRock
-  components:
-  - pos: -2.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 5
-  type: AsteroidRock
-  components:
-  - pos: -2.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 6
-  type: AsteroidRock
-  components:
-  - pos: -2.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 7
-  type: AsteroidRock
-  components:
-  - pos: -1.5,2.5
-    parent: 0
-    type: Transform
-- uid: 8
-  type: AsteroidRock
-  components:
-  - pos: -1.5,1.5
-    parent: 0
-    type: Transform
-- uid: 9
-  type: SalvageMobSpawner
-  components:
-  - pos: -1.5,0.5
-    parent: 0
-    type: Transform
-- uid: 10
-  type: CrateMaterialPlasteel
-  components:
-  - pos: -1.5,-0.5
-    parent: 0
-    type: Transform
-  - isPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent: !type:Container
-        ents: []
-      PaperLabel: !type:ContainerSlot {}
-    type: ContainerContainer
-- uid: 11
-  type: AsteroidRock
-  components:
-  - pos: -1.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 12
-  type: AsteroidRock
-  components:
-  - pos: -1.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 13
-  type: AsteroidRock
-  components:
-  - pos: -0.5,2.5
-    parent: 0
-    type: Transform
-- uid: 14
-  type: AsteroidRock
-  components:
-  - pos: -0.5,1.5
-    parent: 0
-    type: Transform
-- uid: 15
-  type: CrateMaterialPlastic
-  components:
-  - pos: -0.5,0.5
-    parent: 0
-    type: Transform
-  - isPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent: !type:Container
-        ents: []
-      PaperLabel: !type:ContainerSlot {}
-    type: ContainerContainer
-- uid: 16
-  type: CrateMaterialGlass
-  components:
-  - pos: 0.5,-0.5
-    parent: 0
-    type: Transform
-  - isPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent: !type:Container
-        ents: []
-      PaperLabel: !type:ContainerSlot {}
-    type: ContainerContainer
-- uid: 17
-  type: SalvageMaterialCrateSpawner
-  components:
-  - pos: -0.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 18
-  type: AsteroidRock
-  components:
-  - pos: -0.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 19
-  type: AsteroidRock
-  components:
-  - pos: 0.5,2.5
-    parent: 0
-    type: Transform
-- uid: 20
-  type: AsteroidRock
-  components:
-  - pos: 0.5,1.5
-    parent: 0
-    type: Transform
-- uid: 21
-  type: AsteroidRock
-  components:
-  - pos: 0.5,0.5
-    parent: 0
-    type: Transform
-- uid: 22
-  type: CrateMaterialSteel
-  components:
-  - pos: -0.5,-0.5
-    parent: 0
-    type: Transform
-  - isPlaceable: False
-    type: PlaceableSurface
-  - containers:
-      EntityStorageComponent: !type:Container
-        ents: []
-      PaperLabel: !type:ContainerSlot {}
-    type: ContainerContainer
-- uid: 23
-  type: AsteroidRock
-  components:
-  - pos: 0.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 24
-  type: AsteroidRock
-  components:
-  - pos: 0.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 25
-  type: AsteroidRock
-  components:
-  - pos: -3.5,1.5
-    parent: 0
-    type: Transform
-- uid: 26
-  type: AsteroidRock
-  components:
-  - pos: -3.5,0.5
-    parent: 0
-    type: Transform
-- uid: 27
-  type: AsteroidRock
-  components:
-  - pos: -3.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 28
-  type: AsteroidRock
-  components:
-  - pos: -3.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 29
-  type: AsteroidRock
-  components:
-  - pos: 1.5,1.5
-    parent: 0
-    type: Transform
-- uid: 30
-  type: AsteroidRock
-  components:
-  - pos: 1.5,0.5
-    parent: 0
-    type: Transform
-- uid: 31
-  type: AsteroidRock
-  components:
-  - pos: 1.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 32
-  type: AsteroidRock
-  components:
-  - pos: 1.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 33
-  type: AsteroidRock
-  components:
-  - pos: 2.5,0.5
-    parent: 0
-    type: Transform
-- uid: 34
-  type: AsteroidRock
-  components:
-  - pos: 2.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 35
-  type: AsteroidRock
-  components:
-  - pos: 2.5,-1.5
-    parent: 0
-    type: Transform
+  - chunkCollection: {}
+    type: DecalGrid
 - uid: 36
   type: AsteroidRock
   components:
-  - pos: -2.5,-3.5
-    parent: 0
+  - pos: 1.5,0.5
+    parent: 35
     type: Transform
 - uid: 37
   type: AsteroidRock
   components:
-  - pos: -1.5,-3.5
-    parent: 0
+  - pos: -1.5,1.5
+    parent: 35
     type: Transform
 - uid: 38
   type: AsteroidRock
   components:
-  - pos: -0.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 39
-  type: AtmosFixOxygenMarker
-  components:
-  - pos: -1.5,0.5
-    parent: 0
-    type: Transform
-- uid: 40
-  type: AtmosFixPlasmaMarker
-  components:
-  - pos: -0.5,0.5
-    parent: 0
-    type: Transform
-- uid: 41
-  type: AtmosFixPlasmaMarker
-  components:
-  - pos: -0.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 42
-  type: AtmosFixPlasmaMarker
-  components:
-  - pos: -1.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 43
-  type: AtmosFixPlasmaMarker
-  components:
-  - pos: 0.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 44
-  type: AtmosFixPlasmaMarker
-  components:
-  - pos: -0.5,-1.5
-    parent: 0
+  - pos: -2.5,-2.5
+    parent: 35
     type: Transform
 ...


### PR DESCRIPTION
## About the PR

The crates in `small-a-1` were always intended as a holdover until mining dropped ores.
Also removes a known "noob trap" (the plasmafire) since the salvage teams have just learned it.

**Screenshots**
![image](https://user-images.githubusercontent.com/22304167/165740883-5cb9ba91-12c6-4e01-8d18-d0a805d303b4.png)

**Changelog**

:cl:
- tweak: A certain sealed small asteroid will no longer contain plasmafire or crates.
