### PR TITLE
controversial backpack pr

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -30,6 +30,9 @@
     sprite: Clothing/Back/Backpacks/clown.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/clown.rsi
+  - type: Storage
+    storageOpenSound:
+      collection: BikeHorn  
 
 - type: entity
   parent: ClothingBackpack
@@ -85,7 +88,9 @@
     sprite: Clothing/Back/Backpacks/mime.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/mime.rsi
-
+    storageOpenSound:
+      collection: null
+      
 - type: entity
   parent: ClothingBackpack
   id: ClothingBackpackChemistry

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -90,6 +90,8 @@
     sprite: Clothing/Back/Backpacks/mime.rsi
     storageOpenSound:
       collection: null
+    storageInsertSound:
+      collection: null      
       
 - type: entity
   parent: ClothingBackpack

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -66,6 +66,8 @@
     sprite: Clothing/Back/Duffels/clown.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/clown.rsi
+    storageOpenSound:
+      collection: BikeHorn
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -99,6 +101,8 @@
     sprite: Clothing/Back/Duffels/mime.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/mime.rsi
+    storageOpenSound:
+      collection: null    
 
 - type: entity
   parent: ClothingBackpackDuffel

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -14,7 +14,10 @@
     Slots:
     - back
   - type: Storage
-    capacity: 100
+    capacity: 120
+  - type: ClothingSpeedModifier
+    walkModifier: 1
+    sprintModifier: 0.9
   - type: UserInterface
     interfaces:
     - key: enum.StorageUiKey.Key

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -103,6 +103,8 @@
     sprite: Clothing/Back/Duffels/mime.rsi
     storageOpenSound:
       collection: null    
+    storageInsertSound:
+      collection: null      
 
 - type: entity
   parent: ClothingBackpackDuffel


### PR DESCRIPTION
changelog
-duffelbags hold 120 and slow for 10% of movespeed
-clown bags honk and mime bags are silent

