### PR TITLE
Cleanup of Vox + make them breathe nitrogen

### DIFF
--- a/Resources/Prototypes/Body/Mechanisms/vox.yml
+++ b/Resources/Prototypes/Body/Mechanisms/vox.yml
@@ -1,1 +1,8 @@
-﻿
+- type: entity
+  id: OrganVoxLungs
+  parent: OrganHumanLungs
+  suffix: "vox"
+  components:
+  - type: Metabolizer
+    metabolizerTypes: [ Vox ]
+

--- a/Resources/Prototypes/Body/Parts/vox.yml
+++ b/Resources/Prototypes/Body/Parts/vox.yml
@@ -27,7 +27,7 @@
       compatibility: Biological
       mechanisms:
         - OrganHumanHeart
-        - OrganHumanLungs
+        - OrganVoxLungs
         - OrganHumanStomach
         - OrganHumanLiver
         - OrganHumanKidneys

--- a/Resources/Prototypes/Chemistry/metabolizer_types.yml
+++ b/Resources/Prototypes/Chemistry/metabolizer_types.yml
@@ -9,3 +9,7 @@
 
 - type: metabolizerType
   id: Slime
+
+- type: metabolizerType
+  id: Vox
+

--- a/Resources/Prototypes/Entities/Mobs/Player/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vox.yml
@@ -1,8 +1,8 @@
 ﻿- type: entity
   save: false
   name: Vox
-  parent: BaseVox
-  id: Vox
+  parent: MobVoxBase
+  id: MobVox
   components:
     - type: InteractionPopup
       successChance: 1
@@ -13,14 +13,24 @@
       showExamineInfo: true
     - type: Input
       context: "human"
-    - type: Alerts
-    - type: Actions
-    - type: Eye
-    - type: CameraRecoil
-    - type: Examiner
+    - type: PlayerMobMover
+    - type: PlayerInputMover
     - type: Vocal
       maleScream: /Audio/Voice/Vox/shriek1.ogg
       femaleScream: /Audio/Voice/Vox/shriek1.ogg
+    - type: Alerts
+    - type: Eye
+    - type: CameraRecoil
+    - type: Examiner
+    - type: CanHostGuardian
     - type: AiFactionTag
       factions:
         - NanoTrasen
+    - type: Respirator
+      damage:
+       types:
+        Asphyxiation: 1.5
+      damageRecovery:
+        types:
+          Asphyxiation: -1.5
+

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
-  parent: MobHuman
-  abstract: true
-  id: BaseVox
+  parent: MobHumanBase
+  id: MobVoxBase
+  noSpawn: true
   components:
   - type: Icon
     sprite: Mobs/Species/Vox/parts.rsi
@@ -83,7 +83,7 @@
   - type: Body
     template: HumanoidTemplate
     preset: VoxPreset
-  # TODO Vox nitrogen
+  # Vox nitrogen stuff is handled in their metabolism
   - type: Respirator
     damage:
       types:
@@ -91,17 +91,6 @@
     damageRecovery:
       types:
         Asphyxiation: -1.5
-#  - type: Appearance
-#    visuals:
-#      - type: RotationVisualizer
-#      - type: BuckleVisualizer
-#      - type: FireVisualizer
-#        sprite: Mobs/Effects/onfire.rsi
-#        normalState: Generic_mob_burning
-#        alternateState: Standing
-#        fireStackAlternateState: 3
-#      - type: CreamPiedVisualizer
-#        state: creampie_human
   - type: HumanoidAppearance
     canColorHair: false
     canColorFacialHair: false
@@ -114,3 +103,92 @@
     spawned:
     - id: FoodMeatChicken
       amount: 5
+
+- type: entity
+  id: MobVoxDummy
+  parent: MobHumanDummy
+  noSpawn: true
+  components:
+  - type: Sprite
+    netsync: false
+    noRot: true
+    drawdepth: Mobs
+    layers:
+      - map: [ "enum.HumanoidVisualLayers.Chest" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: torso_m
+      - map: [ "enum.HumanoidVisualLayers.Head" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: head_m
+      - map: [ "enum.HumanoidVisualLayers.Eyes" ]
+        color: "#008800"
+        sprite: Mobs/Customization/eyes.rsi
+        state: vox_eyes_s
+      - map: [ "enum.HumanoidVisualLayers.RArm" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: r_arm
+      - map: [ "enum.HumanoidVisualLayers.LArm" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: l_arm
+      - map: [ "enum.HumanoidVisualLayers.RLeg" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: r_leg
+      - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: l_leg
+      # Vox don't have female clothing masks.
+      #- shader: StencilClear
+      #  sprite: Mobs/Species/Vox/parts.rsi
+      #  state: l_leg
+      #- shader: StencilMask
+      #  map: [ "enum.HumanoidVisualLayers.StencilMask" ]
+      #  sprite: Mobs/Customization/masking_helpers.rsi
+      #  state: female_full
+      #  visible: false
+      #- map: [ "jumpsuit" ]
+      #  shader: StencilDraw
+      - map: [ "enum.HumanoidVisualLayers.LHand" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: l_hand
+      - map: [ "enum.HumanoidVisualLayers.RHand" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: r_hand
+      - map: [ "enum.HumanoidVisualLayers.LFoot" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: l_foot
+      - map: [ "enum.HumanoidVisualLayers.RFoot" ]
+        sprite: Mobs/Species/Vox/parts.rsi
+        state: r_foot
+      - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
+        color: "#ffffff"
+        sprite: Objects/Misc/handcuffs.rsi
+        state: body-overlay-2
+        visible: false
+      - map: [ "id" ]
+      - map: [ "gloves" ]
+      - map: [ "shoes" ]
+      - map: [ "ears" ]
+      - map: [ "outerClothing" ]
+      - map: [ "eyes" ]
+      - map: [ "belt" ]
+      - map: [ "neck" ]
+      - map: [ "back" ]
+      - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
+        state: shaved
+        sprite: Mobs/Customization/human_facial_hair.rsi
+      - map: [ "enum.HumanoidVisualLayers.Hair" ]
+        state: bald
+        sprite: Mobs/Customization/human_hair.rsi
+      - map: [ "mask" ]
+      - map: [ "head" ]
+      - map: [ "pocket1" ]
+      - map: [ "pocket2" ]
+  - type: HumanoidAppearance
+    canColorHair: false
+    canColorFacialHair: false
+    categoriesHair: VoxHair
+    categoriesFacialHair: VoxFacialHair
+  - type: Body
+    template: HumanoidTemplate
+    preset: VoxPreset
+

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -19,6 +19,10 @@
           type: Animal
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
+        conditions:
+        - !type:OrganType
+          type: Vox
+          shouldHave: false
         ratios:
           CarbonDioxide: 1.0
           Oxygen: -1.0
@@ -124,3 +128,19 @@
   color: "#808080"
   boilingPoint: -195.8
   meltingPoint: -210.0
+  metabolisms:
+    Gas:
+      effects:
+      - !type:Oxygenate
+        conditions:
+        - !type:OrganType
+          type: Vox
+      # Converts Nitrogen into CO2
+      - !type:ModifyLungGas
+        conditions:
+        - !type:OrganType
+          type: Vox
+        ratios:
+          CarbonDioxide: 1.0
+          Nitrogen: -1.0
+

--- a/Resources/Prototypes/species.yml
+++ b/Resources/Prototypes/species.yml
@@ -29,3 +29,12 @@
   prototype: MobSlimePerson
   dollPrototype: MobSlimePersonDummy
   skinColoration: Hues
+
+#- type: species
+#  id: Vox
+#  name: Vox
+#  roundStart: true
+#  prototype: MobVox
+#  dollPrototype: MobVoxDummy
+#  skinColoration: Hues
+


### PR DESCRIPTION
## About the PR

No oxygen poisoning, but that opens the can of worms of required equipment for Vox to not-die (which could involve C# changes).

Kinda thinking that maybe the metabolism groups for these should be changed a bit? "Oxygen-breathing" seems common.

But that's out of scope for this PR.

No changelog as Vox do not appear in-game, though this makes them decently easy to patch into the lobby screen if you want to test stuff.
