### PR TITLE
Plant clippers for botanical belt

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -288,7 +288,7 @@
       tags:
         - BotanyHoe
         # - PlantAnalyzer
-        - BotanyHoe
+        - PlantSampleTaker
         - BotanyShovel
         - PlantBGone
         - Bottle


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Changelog**
For some reason, `BotanyHoe` was whitelisted twice and `PlantSampleTaker` (tag for `plant clippers`) was not whitelisted at all for a botanical belt.
Its now possible to put plant clippers into botanical belt.
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: lapatison
- add: plant clippers strap for botanical belt

