### PR TITLE
Tile and Bola throwing nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
@@ -27,7 +27,7 @@
         damage: 20
       behaviors:
       - !type:PlaySoundBehavior
-        sound: metalbreak.ogg
+        sound: /Audio/Effects/metalbreak.ogg
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: DamageOnLand

--- a/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
@@ -12,7 +12,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Blunt: 10
+        Blunt: 5
   - type: Stack
     count: 1
   - type: Tag
@@ -24,10 +24,16 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 20
       behaviors:
+      - !type:PlaySoundBehavior
+        sound: metalbreak.ogg
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: DamageOnLand
+    damage:
+      types:
+        Blunt: 5
 
 - type: entity
   name: steel tile

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -28,7 +28,7 @@
         damage: 15
       behaviors:
       - !type:PlaySoundBehavior
-        sound: metalbreak.ogg
+        sound: /Audio/Effects/metalbreak.ogg
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: DamageOnLand

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -19,3 +19,19 @@
   - type: Construction
     graph: Bola
     node: bola
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound: metalbreak.ogg
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: DamageOnLand
+    damage:
+      types:
+        Blunt: 5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Adds DamageOnLand to bolas and tiles so they break in 3 throws and 4 throws respectively.
- Reduced thrown damage of tiles from 10 to 5 to reduce their abuse when used on windows.

In future maybe their damage should be based on velocity so throwing is bad and pneumatic cannon is good.

Currently neither thing breaks into a resource either because they should be expendable in my eyes. Their component parts are abundant and it's unnecessary.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Bolas and tiles now break after 3 and 4 throws respectively. Reduced tile damage from 10 to 5. No more tile abuse.
