### PR TITLE
Fix helmet toggle bug

### DIFF
--- a/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
@@ -48,6 +48,7 @@ public sealed class ToggleableClothingComponent : Component
     [DataField("containerId")]
     public string ContainerId = DefaultClothingContainerId;
 
+    [ViewVariables]
     public ContainerSlot? Container;
 
     /// <summary>

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -26,7 +26,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ToggleableClothingComponent, ComponentAdd>(OnAdd);
+        SubscribeLocalEvent<ToggleableClothingComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<ToggleableClothingComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<ToggleableClothingComponent, ToggleClothingEvent>(OnToggleClothing);
         SubscribeLocalEvent<ToggleableClothingComponent, GetItemActionsEvent>(OnGetActions);
@@ -163,7 +163,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
             args.Actions.Add(component.ToggleAction);
     }
 
-    private void OnAdd(EntityUid uid, ToggleableClothingComponent component, ComponentAdd args)
+    private void OnInit(EntityUid uid, ToggleableClothingComponent component, ComponentInit args)
     {
         component.Container = _containerSystem.EnsureContainer<ContainerSlot>(uid, component.ContainerId);
     }


### PR DESCRIPTION
Fixes #7762. The problem was about using `EnsureContainer` before the container component was deserialized & added, which caused problems for hard suits that were saved to map files, while storage-fill and manually spawned hard suits worked fine.

:cl:
- fix: Fixed a bug causing hard-suit helmets to get stuck on heads.