### PR TITLE
[Quickfix] Remove overriding plastic sheet tag

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -107,6 +107,10 @@
   name: plastic
   suffix: Full
   components:
+  - type: Tag
+    tags:
+    - Plastic
+    - Sheet
   - type: Material
     materials:
       Plastic: 100

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -107,9 +107,6 @@
   name: plastic
   suffix: Full
   components:
-  - type: Tag
-    tags:
-    - Plastic
   - type: Material
     materials:
       Plastic: 100

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -111,6 +111,7 @@
     tags:
     - Plastic
     - Sheet
+    - DroneUsable
   - type: Material
     materials:
       Plastic: 100


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Plastic sheets were overriding their tags, thus being rejected by the lathe's whitelists

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->


