### PR TITLE
Stop mapping command from unsetting it's own settings if used repeatedly

### DIFF
--- a/Content.Client/Commands/MappingClientSideSetupCommand.cs
+++ b/Content.Client/Commands/MappingClientSideSetupCommand.cs
@@ -1,0 +1,34 @@
+using JetBrains.Annotations;
+using System;
+using Content.Client.Markers;
+using Robust.Client.Graphics;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+
+namespace Content.Client.Commands;
+
+/// <summary>
+/// Sent by mapping command to client.
+/// This is because the debug commands for some of these options are on toggles.
+/// </summary>
+[UsedImplicitly]
+internal sealed class MappingClientSideSetupCommand : IConsoleCommand
+{
+    // ReSharper disable once StringLiteralTypo
+    public string Command => "mappingclientsidesetup";
+    public string Description => "Sets up the lighting control and such settings client-side. Sent by 'mapping' to client.";
+    public string Help => "";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var mgr = IoCManager.Resolve<ILightManager>();
+        if (!mgr.LockConsoleAccess)
+        {
+            EntitySystem.Get<MarkerSystem>().MarkersVisible = true;
+            mgr.Enabled = false;
+            shell.ExecuteCommand("showsubfloorforever");
+            shell.ExecuteCommand("loadmapacts");
+        }
+    }
+}
+

--- a/Content.Server/GameTicking/Commands/MappingCommand.cs
+++ b/Content.Server/GameTicking/Commands/MappingCommand.cs
@@ -85,10 +85,7 @@ namespace Content.Server.GameTicking.Commands
 
             shell.ExecuteCommand("sudo cvar events.enabled false");
             shell.ExecuteCommand($"tp 0 0 {mapId}");
-            shell.RemoteExecuteCommand("showmarkers");
-            shell.RemoteExecuteCommand("togglelight");
-            shell.RemoteExecuteCommand("showsubfloorforever");
-            shell.RemoteExecuteCommand("loadmapacts");
+            shell.RemoteExecuteCommand("mappingclientsidesetup");
             mapManager.SetMapPaused(mapId, true);
 
             if (args.Length == 2)


### PR DESCRIPTION
## About the PR
The `mapping` command will, if used repeatedly, unset the lighting and markers settings it's supposed to have.

This is because it uses the "toggle" commands remotely for those settings.

This PR replaces it all with a single sent command which does all the client-side setup.

No meaningful visual changes and nothing for players, so no changelog.
