### PR TITLE
Players are propelled forward when slipping

### DIFF
--- a/Content.Shared/Slippery/SharedSlipperySystem.cs
+++ b/Content.Shared/Slippery/SharedSlipperySystem.cs
@@ -91,6 +91,11 @@ namespace Content.Shared.Slippery
                 return false;
             }
 
+            if (EntityManager.HasComponent<KnockedDownComponent>(otherBody.Owner))
+            {
+                return false;
+            }
+
             var ev = new SlipAttemptEvent();
             RaiseLocalEvent(otherBody.Owner, ev, false);
             if (ev.Cancelled)

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -15,6 +15,7 @@
   - type: Clickable
   - type: Evaporation
   - type: Slippery
+    launchForwardsMultiplier: 2.0
   - type: Physics
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -178,6 +178,7 @@
     HeldPrefix: peel
   - type: Slippery
     intersectPercentage: 0.2
+    launchForwardsMultiplier: 6.0
   - type: CollisionWake
     enabled: false
   - type: Physics

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -132,6 +132,7 @@
     state: pda-clown
   - type: Slippery
     paralyzeTime: 4
+    launchForwardsMultiplier: 9.0
   - type: CollisionWake
     enabled: false
   - type: Physics
@@ -520,4 +521,4 @@
         state: pda-atmos
   - type: Icon
     state: pda-atmos
-        
+

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -521,4 +521,3 @@
         state: pda-atmos
   - type: Icon
     state: pda-atmos
-

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -15,6 +15,7 @@
   - type: Slippery
     paralyzeTime: 2
     intersectPercentage: 0.2
+    launchForwardsMultiplier: 6.0
   - type: CollisionWake
     enabled: false
   - type: Physics
@@ -67,6 +68,7 @@
     state: syndie
   - type: Slippery
     paralyzeTime: 5
+    launchForwardsMultiplier: 9.0
   - type: Item
     HeldPrefix: syndie
 
@@ -93,5 +95,6 @@
     state: omega
   - type: Slippery
     paralyzeTime: 7
+    launchForwardsMultiplier: 9.0
   - type: Item
     HeldPrefix: omega


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
All slippery components in prototypes use the previously unused launchForwardsMultiplier datafield now. TrySlip in SlipSystem also checks if a player is already knocked down before slipping them. This prevents infinite velocity generation through lined up banana peels.

The slip multipliers and distances when players are at full healtth are based on the SS13 distances:
puddle: 2 - less than a tile.
foam: 2 - less than a tile.
peel: 6 - 1.5 tiles at full speed.
soap: 6 - 1.5 tiles at full speed.
syndie/omega soap: 9 - 3 tiles at full speed.
clown pda: 9 - 3 tiles at full speed.

**Changelog**

:cl:
- fix: Players properly slide forward when slipping on things. Some liquids or objects are more slippery than others.

