### PR TITLE
NanoTrasen Resequencer

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
@@ -43,6 +43,10 @@ namespace Content.Server.Atmos.Monitor.Systems
 
         private void OnEmagged(EntityUid uid, FireAlarmComponent component, GotEmaggedEvent args)
         {
+            // TODO: Allow fixing of emagged fire alarms.
+            if (args.Fixing)
+                return;
+
             if (TryComp<AtmosMonitorComponent>(uid, out var atmosMonitor))
             {
                 if (atmosMonitor?.MonitorFire == true)

--- a/Content.Server/Bed/BedSystem.cs
+++ b/Content.Server/Bed/BedSystem.cs
@@ -90,6 +90,10 @@ namespace Content.Server.Bed
 
         private void OnEmagged(EntityUid uid, StasisBedComponent component, GotEmaggedEvent args)
         {
+            // Only the emag can do this one neat trick.
+            if (args.Fixing)
+                return;
+
             ///Repeatable
             ///Reset any metabolisms first so they receive the multiplier correctly
             UpdateMetabolisms(uid, component, false);

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -23,6 +23,10 @@ namespace Content.Server.Chemistry.EntitySystems
 
         private void OnEmagged(EntityUid uid, ReagentDispenserComponent comp, GotEmaggedEvent args)
         {
+            // TODO: Allow fixing of emagged ReagentDispensers.
+            if (args.Fixing)
+                return;
+
             if (!comp.AlreadyEmagged)
             {
                 comp.AddFromPrototype(comp.EmagPackPrototypeId);

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Doors;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
 using Content.Shared.Emag.Systems;
-using Content.Shared.EmagFixer.Systems;
 using Content.Shared.Interaction;
 using Content.Shared.Tag;
 using Robust.Shared.Audio;
@@ -43,7 +42,6 @@ public sealed class DoorSystem : SharedDoorSystem
         SubscribeLocalEvent<DoorComponent, WeldFinishedEvent>(OnWeldFinished);
         SubscribeLocalEvent<DoorComponent, WeldCancelledEvent>(OnWeldCancelled);
         SubscribeLocalEvent<DoorComponent, GotEmaggedEvent>(OnEmagged);
-        SubscribeLocalEvent<DoorComponent, GotEmagFixedEvent>(OnEmagFixed);
     }
 
     protected override void OnActivate(EntityUid uid, DoorComponent door, ActivateInWorldEvent args)
@@ -331,30 +329,6 @@ public sealed class DoorSystem : SharedDoorSystem
                     PlaySound(uid, door.SparkSound.GetSound(), AudioParams.Default.WithVolume(8), args.UserUid, false);
                     args.Handled = true;
                 }
-            }
-        }
-    }
-
-    private void OnEmagFixed(EntityUid uid, DoorComponent door, GotEmagFixedEvent args)
-    {
-        if (TryComp<AirlockComponent>(uid, out var airlockComponent))
-        {
-            if (!airlockComponent.IsPowered())
-                return;
-
-            if (airlockComponent.BoltsDown && (door.State == DoorState.Open || door.State == DoorState.Opening))
-            {
-                // The door is bolted and open. Emags do this and it can be disruptive, so undo it.
-                airlockComponent.BoltsDown = false;
-                SetState(uid, DoorState.Closing, door);
-                args.Handled = true;
-            }
-            else if (door.State == DoorState.Emagging)
-            {
-                // The door was JUST emagged and is playing the zap animation.
-                // If it's allowed to finish then the door will be opened and bolted. Simply interrupt this.
-                SetState(uid, DoorState.Closing, door);
-                args.Handled = true;
             }
         }
     }

--- a/Content.Server/Emag/EmagSystem.cs
+++ b/Content.Server/Emag/EmagSystem.cs
@@ -61,7 +61,7 @@ namespace Content.Server.Emag
                 return;
             }
 
-            var emaggedEvent = new GotEmaggedEvent(args.User);
+            var emaggedEvent = new GotEmaggedEvent(args.User, shouldFix: false);
             RaiseLocalEvent(args.Target.Value, emaggedEvent, false);
             if (emaggedEvent.Handled)
             {

--- a/Content.Server/EmagFixer/EmagFixerSystem.cs
+++ b/Content.Server/EmagFixer/EmagFixerSystem.cs
@@ -1,0 +1,51 @@
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
+using Content.Shared.Emag.Components;
+using Content.Shared.Emag.Systems;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Tag;
+using Robust.Shared.Player;
+
+namespace Content.Server.Emag
+{
+    public sealed class EmagFixerSystem : EntitySystem
+    {
+        [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+        [Dependency] private readonly SharedAdminLogSystem _adminLog = default!;
+
+        [Dependency] private readonly TagSystem _tagSystem = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<EmagFixerComponent, AfterInteractEvent>(OnAfterInteract);
+        }
+
+        private void OnAfterInteract(EntityUid uid, EmagFixerComponent component, AfterInteractEvent args)
+        {
+            if (!args.CanReach || args.Target == null)
+                return;
+
+            if (_tagSystem.HasTag(args.Target.Value, "EmagImmune"))
+                return;
+
+            if (component.Charges <= 0)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("emag-no-charges"), args.User, Filter.Entities(args.User));
+                return;
+            }
+
+            var fixedEvent = new GotEmaggedEvent(args.User, shouldFix: true);
+            RaiseLocalEvent(args.Target.Value, fixedEvent, false);
+            if (fixedEvent.Handled)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("emag-fix-success", ("target", args.Target)), args.User, Filter.Entities(args.User));
+                _adminLog.Add(LogType.Emag, LogImpact.High, $"{ToPrettyString(args.User):player} fixed emag on {ToPrettyString(args.Target.Value):target}");
+                component.Charges--;
+                return;
+            }
+        }
+    }
+}

--- a/Content.Server/Lock/LockSystem.cs
+++ b/Content.Server/Lock/LockSystem.cs
@@ -188,6 +188,10 @@ namespace Content.Server.Lock
 
         private void OnEmagged(EntityUid uid, LockComponent component, GotEmaggedEvent args)
         {
+            // The lock is too broken to be properly fixed.
+            if (args.Fixing)
+                return;
+
             if (component.Locked == true)
             {
                 if (component.UnlockSound != null)
@@ -197,8 +201,11 @@ namespace Content.Server.Lock
 
                 if (EntityManager.TryGetComponent(component.Owner, out AppearanceComponent? appearanceComp))
                 {
+                    // BUG: Broken locks don't appear as broken.
                     appearanceComp.SetData(StorageVisuals.Locked, false);
                 }
+
+                // TODO: Track broken locks so they can be fixed. Ex: BrokenLockComponent
                 EntityManager.RemoveComponent<LockComponent>(uid); //Literally destroys the lock as a tell it was emagged
                 args.Handled = true;
             }

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -73,16 +73,29 @@ namespace Content.Server.Power.EntitySystems
 
         private void OnEmagged(EntityUid uid, ApcComponent comp, GotEmaggedEvent args)
         {
-            if(!comp.Emagged)
+            if (args.Fixing)
             {
-                comp.Emagged = true;
-                args.Handled = true;
+                // Re-enable ID checking.
+                if (comp.Emagged)
+                {
+                    comp.Emagged = false;
+                    args.Handled = true;
+                }
+            }
+            else
+            {
+                // Disable ID checking.
+                if (!comp.Emagged)
+                {
+                    comp.Emagged = true;
+                    args.Handled = true;
+                }
             }
         }
 
         public void UpdateApcState(EntityUid uid,
-            ApcComponent? apc=null,
-            BatteryComponent? battery=null)
+            ApcComponent? apc = null,
+            BatteryComponent? battery = null)
         {
             if (!Resolve(uid, ref apc, ref battery))
                 return;
@@ -124,8 +137,8 @@ namespace Content.Server.Power.EntitySystems
         }
 
         public ApcChargeState CalcChargeState(EntityUid uid,
-            ApcComponent? apc=null,
-            BatteryComponent? battery=null)
+            ApcComponent? apc = null,
+            BatteryComponent? battery = null)
         {
             if (apc != null && apc.Emagged)
                 return ApcChargeState.Emag;
@@ -147,8 +160,8 @@ namespace Content.Server.Power.EntitySystems
         }
 
         public ApcExternalPowerState CalcExtPowerState(EntityUid uid,
-            ApcComponent? apc=null,
-            BatteryComponent? battery=null)
+            ApcComponent? apc = null,
+            BatteryComponent? battery = null)
         {
             if (!Resolve(uid, ref apc, ref battery))
                 return ApcExternalPowerState.None;

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.APC;
 using Content.Shared.Emag.Systems;
-using Content.Shared.EmagFixer.Systems;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -31,7 +30,6 @@ namespace Content.Server.Power.EntitySystems
             SubscribeLocalEvent<ApcComponent, ChargeChangedEvent>(OnBatteryChargeChanged);
             SubscribeLocalEvent<ApcComponent, ApcToggleMainBreakerMessage>(OnToggleMainBreaker);
             SubscribeLocalEvent<ApcComponent, GotEmaggedEvent>(OnEmagged);
-            SubscribeLocalEvent<ApcComponent, GotEmagFixedEvent>(OnEmagFixed);
         }
 
         // Change the APC's state only when the battery state changes, or when it's first created.
@@ -92,15 +90,6 @@ namespace Content.Server.Power.EntitySystems
                     comp.Emagged = true;
                     args.Handled = true;
                 }
-            }
-        }
-
-        private void OnEmagFixed(EntityUid uid, ApcComponent comp, GotEmagFixedEvent args)
-        {
-            if(comp.Emagged)
-            {
-                comp.Emagged = false;
-                args.Handled = true;
             }
         }
 

--- a/Content.Server/Recycling/RecyclerSystem.cs
+++ b/Content.Server/Recycling/RecyclerSystem.cs
@@ -115,9 +115,20 @@ namespace Content.Server.Recycling
 
         private void OnEmagged(EntityUid uid, RecyclerComponent component, GotEmaggedEvent args)
         {
-            if (!component.Safe) return;
-            component.Safe = false;
-            args.Handled = true;
+            if (args.Fixing)
+            {
+                // It's once against safe to ride down a chute of used needles and toxic waste.
+                if (component.Safe) return;
+                component.Safe = true;
+                args.Handled = true;
+            }
+            else
+            {
+                // One man is trash. This feature is a treasure.
+                if (!component.Safe) return;
+                component.Safe = false;
+                args.Handled = true;
+            }
         }
     }
 }

--- a/Content.Server/Recycling/RecyclerSystem.cs
+++ b/Content.Server/Recycling/RecyclerSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Recycling.Components;
 using Content.Shared.Audio;
 using Content.Shared.Body.Components;
 using Content.Shared.Emag.Systems;
-using Content.Shared.EmagFixer.Systems;
 using Content.Shared.Recycling;
 using Content.Shared.Tag;
 using Robust.Shared.Audio;
@@ -26,7 +25,6 @@ namespace Content.Server.Recycling
         {
             SubscribeLocalEvent<RecyclerComponent, StartCollideEvent>(OnCollide);
             SubscribeLocalEvent<RecyclerComponent, GotEmaggedEvent>(OnEmagged);
-            SubscribeLocalEvent<RecyclerComponent, GotEmagFixedEvent>(OnEmagFixed);
         }
 
         public void EnableRecycler(RecyclerComponent component)
@@ -131,13 +129,6 @@ namespace Content.Server.Recycling
                 component.Safe = false;
                 args.Handled = true;
             }
-        }
-
-        private void OnEmagFixed(EntityUid uid, RecyclerComponent component, GotEmagFixedEvent args)
-        {
-            if (component.Safe) return;
-            component.Safe = true;
-            args.Handled = true;
         }
     }
 }

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -44,10 +44,23 @@ namespace Content.Shared.Access.Systems
 
         private void OnEmagged(EntityUid uid, AccessReaderComponent reader, GotEmaggedEvent args)
         {
-            if (reader.Enabled == true)
+            if (args.Fixing)
             {
-                reader.Enabled = false;
-                args.Handled = true;
+                // Enable ID access checks.
+                if (reader.Enabled == false)
+                {
+                    reader.Enabled = true;
+                    args.Handled = true;
+                }
+            }
+            else
+            {
+                // Disable ID access checks.
+                if (reader.Enabled == true)
+                {
+                    reader.Enabled = false;
+                    args.Handled = true;
+                }
             }
         }
 
@@ -153,7 +166,7 @@ namespace Content.Shared.Access.Systems
             }
 
             if (EntityManager.TryGetComponent(uid, out PDAComponent? pda) &&
-                pda.ContainedID?.Owner is {Valid: true} id)
+                pda.ContainedID?.Owner is { Valid: true } id)
             {
                 tags = EntityManager.GetComponent<AccessComponent>(id).Tags;
                 return true;

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared.Inventory;
 using Content.Shared.Emag.Systems;
-using Content.Shared.EmagFixer.Systems;
 using Content.Shared.PDA;
 using Content.Shared.Access.Components;
 using Robust.Shared.Prototypes;
@@ -22,7 +21,6 @@ namespace Content.Shared.Access.Systems
             base.Initialize();
             SubscribeLocalEvent<AccessReaderComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<AccessReaderComponent, GotEmaggedEvent>(OnEmagged);
-            SubscribeLocalEvent<AccessReaderComponent, GotEmagFixedEvent>(OnEmagFixed);
             SubscribeLocalEvent<AccessReaderComponent, LinkAttemptEvent>(OnLinkAttempt);
         }
 
@@ -63,15 +61,6 @@ namespace Content.Shared.Access.Systems
                     reader.Enabled = false;
                     args.Handled = true;
                 }
-            }
-        }
-
-        private void OnEmagFixed(EntityUid uid, AccessReaderComponent reader, GotEmagFixedEvent args)
-        {
-            if (reader.Enabled == false)
-            {
-                reader.Enabled = true;
-                args.Handled = true;
             }
         }
 

--- a/Content.Shared/Emag/Systems/SharedEmagSystem.cs
+++ b/Content.Shared/Emag/Systems/SharedEmagSystem.cs
@@ -6,8 +6,9 @@ namespace Content.Shared.Emag.Systems
     /// How to add an emag interaction:
     /// 1. Go to the system for the component you want the interaction with
     /// 2. Subscribe to the GotEmaggedEvent
-    /// 3. Have some check for if this actually needs to be emagged or is already emagged (to stop charge waste)
-    /// 4. Past the check, add all the effects you desire and HANDLE THE EVENT ARGUMENT so a charge is spent
+    /// 3. Check if you're trying to fix or sabotage the object ('args.Fixing')
+    /// 4. Have some check for if this actually needs to be emagged or is already emagged (to stop charge waste)
+    /// 5. Past the check, add all the effects you desire and HANDLE THE EVENT ARGUMENT so a charge is spent
     public sealed class SharedEmagSystem : EntitySystem
     {
         public override void Initialize()
@@ -29,13 +30,18 @@ namespace Content.Shared.Emag.Systems
         }
     }
 
+    /// <summary>
+    /// Handle the interact event for both emags and emag-fixer.
+    /// </summary>
     public sealed class GotEmaggedEvent : HandledEntityEventArgs
     {
         public readonly EntityUid UserUid;
+        public readonly bool Fixing;
 
-        public GotEmaggedEvent(EntityUid userUid)
+        public GotEmaggedEvent(EntityUid userUid, bool shouldFix = false)
         {
             UserUid = userUid;
+            Fixing = shouldFix;
         }
     }
 }

--- a/Content.Shared/EmagFixer/Components/EmagFixerComponent.cs
+++ b/Content.Shared/EmagFixer/Components/EmagFixerComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared.Emag.Components
+{
+    [RegisterComponent]
+    public sealed class EmagFixerComponent : Component
+    {
+        [DataField("maxCharges"), ViewVariables(VVAccess.ReadWrite)]
+        public int MaxCharges = 4;
+
+        [DataField("charges"), ViewVariables(VVAccess.ReadWrite)]
+        public int Charges = 4;
+    }
+}

--- a/Content.Shared/EmagFixer/Systems/SharedEmagFixerSystem.cs
+++ b/Content.Shared/EmagFixer/Systems/SharedEmagFixerSystem.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Emag.Components;
+using Content.Shared.Examine;
+
+namespace Content.Shared.Emag.Systems
+{
+    public sealed class SharedEmagFixerSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<EmagFixerComponent, ExaminedEvent>(OnExamine);
+        }
+
+        private void OnExamine(EntityUid uid, EmagFixerComponent component, ExaminedEvent args)
+        {
+            args.PushMarkup(Loc.GetString("emag-charges-remaining", ("charges", component.Charges)));
+            if (component.Charges == component.MaxCharges)
+            {
+                args.PushMarkup(Loc.GetString("emag-max-charges"));
+                return;
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/emag/emag.ftl
+++ b/Resources/Locale/en-US/emag/emag.ftl
@@ -3,3 +3,4 @@ emag-no-charges = No charges left!
 emag-charges-remaining = It has [color=fuchsia]{$charges}[/color] charges remaining.
 emag-max-charges = It's at [color=green]maximum[/color] charges.
 emag-recharging = There are [color=yellow]{$seconds}[/color] seconds left until the next charge.
+emag-fix-success = You reformatted {THE($target)}.

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -102,6 +102,7 @@
       - id: CigarCase
         prob: 0.15
       - id: DoorRemoteEngineering
+      - id: EmagFixer
 
 - type: entity
   id: LockerChiefMedicalOfficerFilled

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -155,7 +155,7 @@
   itemId: Emag
   description: The business card of the syndicate, this sequencer is able to break open airlocks and tamper with a variety of station devices. Recharges automatically.
   icon: /Textures/Objects/Tools/emag.rsi/icon.png
-  price: 8
+  price: 7
 
 - type: uplinkListing
   id: UplinkAgentIDCard

--- a/Resources/Prototypes/Entities/Objects/Tools/emag_fixer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag_fixer.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: BaseItem
+  id: EmagFixer
+  name: nanotrasen resequencer
+  description: A portable formatter for fixing corrupted NanoTrasen systems.
+  components:
+  - type: EmagFixer
+  - type: Sprite
+    netsync: false
+    sprite: Objects/Misc/stock_parts.rsi
+    state: card_reader


### PR DESCRIPTION
Adds a way to "reformat" objects that have been sabotaged by emags.
- Has 4 charges which do not recharge over time.
- Limited use is to keep it somewhat strategic and not completely counter the emag.
- You can find it in any CE's starting locker unless the map has a custom-stocked one.

Supported Firmware (for now):
- Access ID Readers (of any kind)
- Airlocks
- APCs
- Recyclers (grinder)

Also: the cryptographic sequencer now only costs 7, down from 8. A modest change to test the waters.

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/100040020/166165561-ff31c63c-cb03-4f28-b149-792cf4c63184.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: ShuttleEnjoyer
- add: Added a new NanoTrasen Resequencer to the CE's locker which resets emagged objects. It has 4 charges that do not recharge.
- tweak: The emag costs 7 TC, down from 8.

