### PR TITLE
Only capitalise first S in lizard accent

### DIFF
--- a/Content.Server/Speech/EntitySystems/LizardAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/LizardAccentSystem.cs
@@ -18,7 +18,7 @@ public sealed class LizardAccentSystem : EntitySystem
         // hissss
         message = Regex.Replace(message, "s+", "sss");
         // hiSSS
-        message = Regex.Replace(message, "S+", "SSS");
+        message = Regex.Replace(message, "S+", "Sss");
         // ekssit
         message = Regex.Replace(message, @"(\w)x", "$1kss");
         // ecks


### PR DESCRIPTION
It annoys me @DogZeroX @vulppine 

:cl:
- tweak: Lizard accent only capitalises the first "S" so "SSS" now becomes "Sss".
