### PR TITLE
hardsuit, hardsuit helmets, web vests pass

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -87,7 +87,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/deathsquad.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.27
+    highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
 
 - type: entity
@@ -102,7 +102,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.26
+    highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000
 
 - type: entity
@@ -117,7 +117,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering-white.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.24
+    highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
 
 - type: entity
@@ -181,6 +181,15 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 10000
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8 
+  - type: PointLight
+    radius: 7
+    energy: 3
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -196,7 +205,13 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 10000
-
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8
+        
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
   id: ClothingHeadHelmetHardsuitSecurityRed
@@ -211,6 +226,12 @@
   - type: PressureProtection
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 10000
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase
@@ -226,8 +247,16 @@
   - type: PointLight
     color: green
   - type: PressureProtection
-    highPressureMultiplier: 0.27
+    highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8
+        Heat: 0.8
+        Radiation: 0.5
 
 - type: entity
   parent: ClothingHeadHardsuitWithLightBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,7 +9,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/atmospherics.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.08
+    highPressureMultiplier: 0.02
     lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
     walkModifier: 0.65
@@ -23,7 +23,7 @@
         Heat: 0.2
         Radiation: 0.25
   - type: TemperatureProtection
-    coefficient: 0.01
+    coefficient: 0.001
   - type: ExplosionResistance
     resistance: 0.8
   - type: ToggleableClothing
@@ -40,7 +40,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/capspace.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.3
+    highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 0.8
@@ -51,7 +51,7 @@
         Blunt: 0.8
         Slash: 0.8
         Piercing: 0.75
-        Heat: 0.5 
+        Heat: 0.3 
         Radiation: 0.1
   - type: ExplosionResistance
     resistance: 0.5
@@ -69,7 +69,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/deathsquad.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.27
+    highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 1.0
@@ -98,7 +98,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/engineering.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.26
+    highPressureMultiplier: 0.04
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 0.65
@@ -127,7 +127,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/engineering-white.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.24
+    highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 0.75
@@ -211,7 +211,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/medical.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.6
+    highPressureMultiplier: 0.3
     lowPressureMultiplier: 5500
   - type: DiseaseProtection
     protection: 0.2
@@ -237,7 +237,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.60
+    highPressureMultiplier: 0.05
     lowPressureMultiplier: 5500
   - type: Armor
     modifiers:
@@ -269,18 +269,18 @@
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
-    walkModifier: 0.6 #changing these values around so its only a tiny bit faster so less salvages get stuck floating in space
+    walkModifier: 0.6
     sprintModifier: 0.65
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8 #buffed up due to introduction of spationaut suit 
-        Slash: 0.75
-        Piercing: 0.75
+        Blunt: 0.75
+        Slash: 0.7
+        Piercing: 0.7
         Heat: 0.85
         Radiation: 0.5
   - type: ExplosionResistance
-    resistance: 0.8
+    resistance: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
 
@@ -350,7 +350,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.27
+    highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 1.0
@@ -379,7 +379,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/wizard.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.27
+    highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
     walkModifier: 0.8
@@ -440,7 +440,7 @@
     highPressureMultiplier: 0.72
     lowPressureMultiplier: 10000
   - type: ClothingSpeedModifier
-    walkModifier: 0.9 #mildly better than eva, might adjust this down if its heavily abused but want to see how it plays out in game first 
+    walkModifier: 0.9 
     sprintModifier: 0.8
   - type: Armor
     modifiers:
@@ -449,7 +449,7 @@
         Slash: 0.9
         Piercing: 0.95
         Heat: 0.9
-        Radiation: 0.5 #low physical but gave some rad protection in case of rad artifacts/rad storms
+        Radiation: 0.5 
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpatio
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterStorageBase #web vest so it should have some pockets for ammo
   id: ClothingOuterVestWebMerc
   name: merc web vest
   description: A high-quality armored vest made from a hard synthetic material. It's surprisingly flexible and light, despite formidable armor plating.
@@ -19,7 +19,7 @@
     resistance: 0.9
     
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterStorageBase
   id: ClothingOuterVestWeb
   name: web vest
   description: A synthetic armor vest. This one has added webbing and ballistic plates.
@@ -73,7 +73,7 @@
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.85
+        Piercing: 0.75
         Heat: 0.9
   - type: ExplosionResistance
     resistance: 0.9


### PR DESCRIPTION
changelog
-massively increases hardsuits high pressure band (atmos, engi, CE, RD, cap, deathsquad, wizard, and syndi specifically)
-buffs the armor on mining hardsuit for salvagers so its slightly more attractive compared to spatios speed
-web vests all now hold 10 storage, properly webbed now
-security helmet, hos helmet, syndi helmet, mining helmet all have slightly higher over base stats against physical damage now
-mining helmet has a better headlamp now


