### PR TITLE
Fix health state thresholds

### DIFF
--- a/Content.Server/MobState/States/NormalMobState.cs
+++ b/Content.Server/MobState/States/NormalMobState.cs
@@ -26,10 +26,9 @@ namespace Content.Server.MobState.States
 
             short modifier = 0;
 
-            if (stateComponent.TryGetEarliestIncapacitatedState(threshold, out _, out var earliestThreshold) && damageable.TotalDamage > 0)
+            if (stateComponent.TryGetEarliestIncapacitatedState(threshold, out _, out var earliestThreshold) && damageable.TotalDamage != 0)
             {
-                modifier = (short) MathF.Max((float) (damageable.TotalDamage / (earliestThreshold / 6f)),1);
-                 //if hurt at all we skip to the first hurt state with Max(), anything else will end up falling to 5 at maximum before crit
+                modifier = (short)(damageable.TotalDamage / (earliestThreshold / 5) + 1);
             }
             EntitySystem.Get<AlertsSystem>().ShowAlert(entity, AlertType.HumanHealth, modifier);
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes health state to be 1, 19, 20, 20, 20, 20 thresholds
Previous thresholds were 1, 33, 16, 17, 17, 16

Example testing:
https://rextester.com/GODLK87878
