### PR TITLE
PTech Vending Machine Fill (no its not cartridges)

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -8,3 +8,4 @@
     AssistantIDCard: 5
     RubberStampApproved: 1
     RubberStampDenied: 1
+    Paper: 10

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -2,3 +2,9 @@
   id: PTechInventory
   name: PTech
   spriteName: cart
+  startingInventory:
+    AssistantPDA: 5
+    ClearPDA: 5
+    AssistantIDCard: 5
+    RubberStampApproved: 1
+    RubberStampDenied: 1

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -521,3 +521,14 @@
         state: pda-atmos
   - type: Icon
     state: pda-atmos
+
+- type: entity
+  parent: BasePDA
+  id: ClearPDA
+  name: clear PDA
+  description: 99 and 44/100ths percent pure plastic. 
+  components:
+  - type: PDA
+    id: AssistantIDCard
+ - type: Icon
+    state: pda-clear    

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -530,5 +530,5 @@
   components:
   - type: PDA
     id: AssistantIDCard
- - type: Icon
+  - type: Icon
     state: pda-clear    

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -125,7 +125,7 @@
   parent: VendingMachine
   id: VendingMachineCart
   name: PTech
-  description: PTech vending! Providing a ROBUST selection of PDA cartridges.
+  description: PTech vending! Providing a ROBUST selection of PDAs, cartridges, and anything else a dull paper pusher needs!
   components:
   - type: VendingMachine
     pack: PTechInventory
@@ -151,6 +151,8 @@
     radius: 1
     energy: 1.3
     color: "#ffb0b0"
+  - type: AccessReader
+    access: [["HeadOfPersonnel"]]    
 
 - type: entity
   parent: VendingMachine


### PR DESCRIPTION
PTech machine is in almost every HoP office but it sits unused since we have no cartridges. This gives it fills useful to the HoP and provides stuff they won't have access to on every map, as well as functioning as backups in case their locker gets taken.

changelog
-adds assistant PDAs to the PTech machine
-adds clear PDAs to the PTech machine (pda we have a texture for but no prototype file, they look like those old clear gameboys)
-adds 5 assistant ID cards to the PTech machine
-adds both the approved and denied rubber stamps
-adds 10 pieces of paper to it