### PR TITLE
Make alerts background transparent

### DIFF
--- a/Content.Client/Alerts/UI/AlertsUI.xaml
+++ b/Content.Client/Alerts/UI/AlertsUI.xaml
@@ -1,7 +1,6 @@
 ﻿<Control xmlns="https://spacestation14.io"
          MinSize="64 64">
-    <PanelContainer StyleClasses="TransparentBorderedWindowPanel"
-                    HorizontalAlignment="Right"
+    <PanelContainer HorizontalAlignment="Right"
                     VerticalAlignment="Top">
         <GridContainer Name="AlertContainer" Access="Public" MaxGridHeight="64" ExpandBackwards="True">
 


### PR DESCRIPTION
Looks cleaner with the animated health.

![image](https://user-images.githubusercontent.com/31366439/166619713-e4c20e87-28bd-4f45-965d-94008249ae25.png)

:cl:
- tweak: Removed the background from alerts.