### PR TITLE
Atlas Update 1.3

### DIFF
--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -7,7 +7,7 @@
     prefixCreator: 'R4' # R4407/Goon. GS isn't as cool sounding.
   mapPath: /Maps/atlas.yml
   minPlayers: 0
-  maxPlayers: 29
+  maxPlayers: 25
   overflowJobs:
     - Assistant
   availableJobs:
@@ -22,19 +22,18 @@
     Captain: [ 1, 1 ]
     HeadOfPersonnel: [ 1, 1 ]
     ChiefEngineer: [ 1, 1 ]
-    StationEngineer: [ 3, 4 ]
+    StationEngineer: [ 3, 3 ]
     ChiefMedicalOfficer: [ 1, 1 ]
     MedicalDoctor: [ 2, 2 ]
     Chemist: [ 2, 2 ]
     ResearchDirector: [ 1, 1 ]
     Scientist: [ 1, 3 ]
     HeadOfSecurity: [ 1, 1 ]
-    SecurityOfficer: [ 2, 2 ]
+    SecurityOfficer: [ 3, 3 ]
     Chaplain: [ 1, 1 ]
-    Warden: [ 1, 1 ]
     Librarian: [ 1, 1 ]
     Lawyer: [ 1, 1 ]
     Quartermaster: [ 1, 1 ]
     SalvageSpecialist: [ 2, 2 ]
     Musician: [ 1, 1 ]
-    AtmosphericTechnician: [ 1, 2 ]
+    AtmosphericTechnician: [ 1, 1 ]


### PR DESCRIPTION
changelog
-lowered required players to 25
-removed warden and added 1 extra secoff
-lowered atmo techs from 2 to 1
-lowered engineers from 4 to 3
-medbay has been redesigned
-engineering has been shuffled
-many small qol fixes
-skub

