### PR TITLE
Implement count estimate query for postgresdb

### DIFF
--- a/Content.Server.Database/Model.cs
+++ b/Content.Server.Database/Model.cs
@@ -2,14 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Data.Common;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
 using Content.Shared.Database;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
-using Npgsql;
 
 namespace Content.Server.Database
 {

--- a/Content.Server.Database/Model.cs
+++ b/Content.Server.Database/Model.cs
@@ -2,11 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Common;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
 using Content.Shared.Database;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
 
 namespace Content.Server.Database
 {
@@ -174,6 +177,8 @@ namespace Content.Server.Database
         {
             return query.Where(log => EF.Functions.Like(log.Message, "%" + searchText + "%"));
         }
+
+        public abstract int CountAdminLogs();
     }
 
     public class Preference

--- a/Content.Server.Database/ModelPostgres.cs
+++ b/Content.Server.Database/ModelPostgres.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql;
-using NpgsqlTypes;
 
 namespace Content.Server.Database
 {

--- a/Content.Server.Database/ModelPostgres.cs
+++ b/Content.Server.Database/ModelPostgres.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
 using NpgsqlTypes;
 
 namespace Content.Server.Database
@@ -79,6 +80,15 @@ namespace Content.Server.Database
         public override IQueryable<AdminLog> SearchLogs(IQueryable<AdminLog> query, string searchText)
         {
             return query.Where(log => EF.Functions.ToTsVector("english", log.Message).Matches(searchText));
+        }
+
+        public override int CountAdminLogs()
+        {
+            var command = new NpgsqlCommand("SELECT reltuples FROM pg_class WHERE relname = 'admin_log';", (NpgsqlConnection?) Database.GetDbConnection());
+            Database.GetDbConnection().Open();
+            var count = Convert.ToInt32((float) (command.ExecuteScalar() ?? 0));
+            Database.GetDbConnection().Close();
+            return count;
         }
     }
 }

--- a/Content.Server.Database/ModelSqlite.cs
+++ b/Content.Server.Database/ModelSqlite.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -79,6 +80,11 @@ namespace Content.Server.Database
             modelBuilder.Entity<Profile>()
                 .Property(log => log.Markings)
                 .HasConversion(jsonByteArrayConverter);
+        }
+
+        public override int CountAdminLogs()
+        {
+            return AdminLog.Count();
         }
 
         private static string InetToString(IPAddress address, int mask) {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements the abstract `CountAdminLogs` method. The postgresql implementation of that method uses a query to estimate the amount of admin logs instead of doing a `count(*)` query. 