### PR TITLE
Remove combat mode from drones again

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -3,8 +3,6 @@
   abstract: true
   id: PlayerSiliconBase #for player controlled silicons
   components:
-  - type: CombatMode
-    canDisarm: true
   - type: Reactive
     groups:
       Acidic: [Touch]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#7811 gave drones combat mode for some unknown reason. This removes it. Closes #7953 


:cl: Rane
- fix: Drones no longer have combat mode or disarms again.

