### PR TITLE
Slippery stuff has a crawl duration as well as paralysis

### DIFF
--- a/Content.Shared/Slippery/SharedSlipperySystem.cs
+++ b/Content.Shared/Slippery/SharedSlipperySystem.cs
@@ -105,12 +105,22 @@ namespace Content.Shared.Slippery
 
             bool playSound = !_statusEffectsSystem.HasStatusEffect(otherBody.Owner, "KnockedDown");
 
-            _stunSystem.TryParalyze(otherBody.Owner, TimeSpan.FromSeconds(component.ParalyzeTime), true);
+            // Duration of full paralysis.
+            if (component.ParalyzeTime > 0f)
+                _stunSystem.TryParalyze(otherBody.Owner, TimeSpan.FromSeconds(component.ParalyzeTime), true);
+
+            // Duration of knockdown with slowed movement.
+            if (component.KnockdownTime > 0f)
+            {
+                _stunSystem.TryKnockdown(otherBody.Owner, TimeSpan.FromSeconds(component.KnockdownTime), true);
+                _stunSystem.TrySlowdown(otherBody.Owner, TimeSpan.FromSeconds(component.KnockdownTime), true);
+            }
+
             component.Slipped.Add(otherBody.Owner);
             component.Dirty();
 
             //Preventing from playing the slip sound when you are already knocked down.
-            if(playSound)
+            if (playSound)
             {
                 PlaySound(component);
             }

--- a/Content.Shared/Slippery/SlipperyComponent.cs
+++ b/Content.Shared/Slippery/SlipperyComponent.cs
@@ -17,6 +17,7 @@ namespace Content.Shared.Slippery
     public sealed class SlipperyComponent : Component
     {
         private float _paralyzeTime = 5f;
+        private float _knockdownTime = 5f;
         private float _intersectPercentage = 0.3f;
         private float _requiredSlipSpeed = 3.5f;
         private float _launchForwardsMultiplier = 1f;
@@ -64,6 +65,23 @@ namespace Content.Shared.Slippery
                 if (MathHelper.CloseToPercent(_paralyzeTime, value)) return;
 
                 _paralyzeTime = value;
+                Dirty();
+            }
+        }
+
+        /// <summary>
+        ///     How many seconds the mob will be forced to crawl.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("knockdownTime")]
+        public float KnockdownTime
+        {
+            get => _knockdownTime;
+            set
+            {
+                if (MathHelper.CloseToPercent(_knockdownTime, value)) return;
+
+                _knockdownTime = value;
                 Dirty();
             }
         }
@@ -138,7 +156,7 @@ namespace Content.Shared.Slippery
 
         public override ComponentState GetComponentState()
         {
-            return new SlipperyComponentState(ParalyzeTime, IntersectPercentage, RequiredSlipSpeed, LaunchForwardsMultiplier, Slippery, SlipSound.GetSound(), Slipped.ToArray());
+            return new SlipperyComponentState(ParalyzeTime, KnockdownTime, IntersectPercentage, RequiredSlipSpeed, LaunchForwardsMultiplier, Slippery, SlipSound.GetSound(), Slipped.ToArray());
         }
 
         public override void HandleComponentState(ComponentState? curState, ComponentState? nextState)
@@ -148,6 +166,7 @@ namespace Content.Shared.Slippery
             _slippery = state.Slippery;
             _intersectPercentage = state.IntersectPercentage;
             _paralyzeTime = state.ParalyzeTime;
+            _knockdownTime = state.KnockdownTime;
             _requiredSlipSpeed = state.RequiredSlipSpeed;
             _launchForwardsMultiplier = state.LaunchForwardsMultiplier;
             _slipSound = new SoundPathSpecifier(state.SlipSound);
@@ -164,6 +183,7 @@ namespace Content.Shared.Slippery
     public sealed class SlipperyComponentState : ComponentState
     {
         public float ParalyzeTime { get; }
+        public float KnockdownTime { get; }
         public float IntersectPercentage { get; }
         public float RequiredSlipSpeed { get; }
         public float LaunchForwardsMultiplier { get; }
@@ -171,9 +191,10 @@ namespace Content.Shared.Slippery
         public string SlipSound { get; }
         public readonly EntityUid[] Slipped;
 
-        public SlipperyComponentState(float paralyzeTime, float intersectPercentage, float requiredSlipSpeed, float launchForwardsMultiplier, bool slippery, string slipSound, EntityUid[] slipped)
+        public SlipperyComponentState(float paralyzeTime, float knockdownTime, float intersectPercentage, float requiredSlipSpeed, float launchForwardsMultiplier, bool slippery, string slipSound, EntityUid[] slipped)
         {
             ParalyzeTime = paralyzeTime;
+            KnockdownTime = knockdownTime;
             IntersectPercentage = intersectPercentage;
             RequiredSlipSpeed = requiredSlipSpeed;
             LaunchForwardsMultiplier = launchForwardsMultiplier;

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -58,6 +58,8 @@
         maxVol: 600
         canReact: false
   - type: Slippery
+    paralyzeTime: 5.0
+    knockdownTime: 5.5
 
 - type: entity
   id: IronMetalFoam

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -16,6 +16,8 @@
   - type: Evaporation
   - type: Slippery
     launchForwardsMultiplier: 2.0
+    paralyzeTime: 2.0
+    knockdownTime: 4.0
   - type: Physics
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -179,6 +179,8 @@
   - type: Slippery
     intersectPercentage: 0.2
     launchForwardsMultiplier: 6.0
+    paralyzeTime: 4.5
+    knockdownTime: 5.5
   - type: CollisionWake
     enabled: false
   - type: Physics

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -131,7 +131,8 @@
   - type: Icon
     state: pda-clown
   - type: Slippery
-    paralyzeTime: 4
+    paralyzeTime: 4.0
+    knockdownTime: 4.5
     launchForwardsMultiplier: 9.0
   - type: CollisionWake
     enabled: false
@@ -526,9 +527,9 @@
   parent: BasePDA
   id: ClearPDA
   name: clear PDA
-  description: 99 and 44/100ths percent pure plastic. 
+  description: 99 and 44/100ths percent pure plastic.
   components:
   - type: PDA
     id: AssistantIDCard
   - type: Icon
-    state: pda-clear    
+    state: pda-clear

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -13,7 +13,8 @@
   - type: Item
     sprite: Objects/Specific/Janitorial/soap.rsi
   - type: Slippery
-    paralyzeTime: 2
+    paralyzeTime: 1.5
+    knockdownTime: 2.5
     intersectPercentage: 0.2
     launchForwardsMultiplier: 6.0
   - type: CollisionWake
@@ -67,7 +68,8 @@
   - type: Sprite
     state: syndie
   - type: Slippery
-    paralyzeTime: 5
+    paralyzeTime: 5.0
+    knockdownTime: 5.5
     launchForwardsMultiplier: 9.0
   - type: Item
     HeldPrefix: syndie
@@ -81,7 +83,8 @@
   - type: Sprite
     state: gibs
   - type: Slippery
-    paralyzeTime: 2
+    paralyzeTime: 1.5
+    knockdownTime: 2.5
   - type: Item
     HeldPrefix: gibs
 
@@ -94,7 +97,8 @@
   - type: Sprite
     state: omega
   - type: Slippery
-    paralyzeTime: 7
+    paralyzeTime: 7.0
+    knockdownTime: 7.5
     launchForwardsMultiplier: 9.0
   - type: Item
     HeldPrefix: omega


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This adds a `knockdownTime` field to the `Slippery` component that lets you specify how long the mob should be forced to crawl on the floor.

This does not replace the existing `paralyzeTime` field and is meant to complement it, though you could set it to 0 and then the object would only force you to crawl.

Most importantly: slippery liquids(except lube/chemical foam) now only paralyze you for half the time(2 seconds) and force you to crawl for the rest of the time (2 more seconds). This makes them a lot less annoying

Other existing slippery stuff(as defined in the yml) has been given some trailing knockdown crawl as a kind of wake-up animation. Feels good and consistent to me.

YAML example of 50/50 paralyze/crawl:
```yml
  - type: Slippery
    paralyzeTime: 2.0
    knockdownTime: 4.0
```

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: ShuttleEnjoyer
- add: Slippery stuff (puddles, soap) can optionally give you slow knockdown (like the bola) as well as full paralysis.
- tweak: Puddles now only paralyze you for 2secs and afterwards let you crawl for 2secs.

