### PR TITLE
New Medium Salvage Map- Cult Hideout

### DIFF
--- a/Med-Cult-Vault.yml
+++ b/Med-Cult-Vault.yml
@@ -1,0 +1,2434 @@
+meta:
+  format: 2
+  name: DemoStation
+  author: Space-Wizards
+  postmapinit: false
+tilemap:
+  0: space
+  1: FloorArcadeBlue
+  2: FloorArcadeRed
+  3: FloorAsteroidIronsand1
+  4: FloorAsteroidIronsand2
+  5: FloorAsteroidIronsand3
+  6: FloorAsteroidIronsand4
+  7: FloorEighties
+  8: FloorGrassJungle
+  9: FloorShuttleBlue
+  10: FloorShuttleOrange
+  11: FloorShuttlePurple
+  12: FloorShuttleRed
+  13: FloorShuttleWhite
+  14: floor_asteroid_coarse_sand0
+  15: floor_asteroid_coarse_sand1
+  16: floor_asteroid_coarse_sand2
+  17: floor_asteroid_coarse_sand_dug
+  18: floor_asteroid_sand
+  19: floor_asteroid_tile
+  20: floor_bar
+  21: floor_blue
+  22: floor_blue_circuit
+  23: floor_clown
+  24: floor_dark
+  25: floor_elevator_shaft
+  26: floor_freezer
+  27: floor_glass
+  28: floor_gold
+  29: floor_grass
+  30: floor_green_circuit
+  31: floor_hydro
+  32: floor_kitchen
+  33: floor_laundry
+  34: floor_lino
+  35: floor_mime
+  36: floor_mono
+  37: floor_reinforced
+  38: floor_rglass
+  39: floor_rock_vault
+  40: floor_showroom
+  41: floor_silver
+  42: floor_snow
+  43: floor_steel
+  44: floor_steel_dirty
+  45: floor_techmaint
+  46: floor_white
+  47: floor_wood
+  48: lattice
+  49: plating
+  50: underplating
+grids:
+- settings:
+    chunksize: 16
+    tilesize: 1
+  chunks:
+  - ind: -1,0
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAADAAAAAwAAAAMQAAADEAAAAZAAAAMQAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABkAAAAZAAAAMQAAADEAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAMQAAADEAAAAxAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAADEAAAAZAAAAGQAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAGQAAADEAAAAZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMQAAADEAAAAZAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMAAAADAAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  - ind: 0,0
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAxAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMQAAADAAAAAxAAAAMQAAADAAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAADEAAAAxAAAAGQAAABkAAAAxAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAxAAAAMQAAADEAAAAxAAAAMQAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAMQAAADEAAAAxAAAAMQAAADEAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGQAAABkAAAAZAAAAMQAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAZAAAAGQAAADEAAAAAAAAAAAAAADAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAMQAAADEAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAwAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+- settings:
+    chunksize: 16
+    tilesize: 1
+  chunks:
+  - ind: -1,0
+    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+entities:
+- uid: 0
+  type: CableApcExtension
+  components:
+  - pos: 0.5,6.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 1
+  type: CableApcExtension
+  components:
+  - pos: -0.5,6.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 2
+  type: CableApcExtension
+  components:
+  - pos: -0.5,5.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 3
+  type: CableApcExtension
+  components:
+  - pos: -1.5,5.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 4
+  type: CableApcExtension
+  components:
+  - pos: 2.5,7.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 5
+  type: CableApcExtension
+  components:
+  - pos: 2.5,3.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 6
+  type: CableApcExtension
+  components:
+  - pos: 1.5,3.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 7
+  type: CableApcExtension
+  components:
+  - pos: 0.5,3.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 8
+  type: CableApcExtension
+  components:
+  - pos: 5.5,3.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 9
+  type: CableApcExtension
+  components:
+  - pos: -0.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 10
+  type: CableApcExtension
+  components:
+  - pos: -0.5,3.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 11
+  type: CableApcExtension
+  components:
+  - pos: -4.5,2.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 12
+  type: CableApcExtension
+  components:
+  - pos: 4.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 13
+  type: WallCult
+  components:
+  - pos: 2.5,8.5
+    parent: 74
+    type: Transform
+- uid: 14
+  type: CableApcExtension
+  components:
+  - pos: -2.5,1.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 15
+  type: CableApcExtension
+  components:
+  - pos: 2.5,6.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 16
+  type: SalvageMobSpawner
+  components:
+  - pos: -2.5,4.5
+    parent: 74
+    type: Transform
+- uid: 17
+  type: SalvageMaterialCrateSpawner
+  components:
+  - pos: 4.5,3.5
+    parent: 74
+    type: Transform
+- uid: 18
+  type: SpaceTickSpawner
+  components:
+  - pos: -2.5,2.5
+    parent: 74
+    type: Transform
+- uid: 19
+  type: SpawnMobBear
+  components:
+  - pos: 1.5,7.5
+    parent: 74
+    type: Transform
+- uid: 20
+  type: RandomArtifactSpawner
+  components:
+  - pos: 2.5,7.5
+    parent: 74
+    type: Transform
+- uid: 21
+  type: CableApcExtension
+  components:
+  - pos: -3.5,1.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 22
+  type: SalvageMobSpawner
+  components:
+  - pos: 3.5,2.5
+    parent: 74
+    type: Transform
+- uid: 23
+  type: CableApcExtension
+  components:
+  - pos: -1.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 24
+  type: CableApcExtension
+  components:
+  - pos: -2.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 25
+  type: CableApcExtension
+  components:
+  - pos: -2.5,4.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 26
+  type: CableApcExtension
+  components:
+  - pos: -2.5,5.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 27
+  type: CableApcExtension
+  components:
+  - pos: -3.5,5.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 28
+  type: SalternAPC
+  components:
+  - pos: -3.5,5.5
+    parent: 74
+    type: Transform
+- uid: 29
+  type: BlastDoor
+  components:
+  - pos: 0.5,6.5
+    parent: 74
+    type: Transform
+  - inputs:
+      Open: []
+      Close: []
+      Toggle: []
+    type: SignalReceiver
+- uid: 30
+  type: CableMV
+  components:
+  - pos: 1.5,6.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 31
+  type: CableMV
+  components:
+  - pos: -0.5,6.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 32
+  type: CableMV
+  components:
+  - pos: -0.5,5.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 33
+  type: CableMV
+  components:
+  - pos: -0.5,4.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 34
+  type: CableMV
+  components:
+  - pos: -1.5,4.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 35
+  type: CableMV
+  components:
+  - pos: -2.5,4.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 36
+  type: CableMV
+  components:
+  - pos: -2.5,1.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 37
+  type: CableMV
+  components:
+  - pos: -4.5,2.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 38
+  type: CableMV
+  components:
+  - pos: -3.5,2.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 39
+  type: CableMV
+  components:
+  - pos: -2.5,3.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 40
+  type: CableMV
+  components:
+  - pos: -2.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 41
+  type: CableMV
+  components:
+  - pos: -1.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 42
+  type: CableMV
+  components:
+  - pos: -0.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 43
+  type: SalternSubstation
+  components:
+  - pos: -0.5,2.5
+    parent: 74
+    type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 44
+  type: GeneratorUranium
+  components:
+  - pos: -2.5,6.5
+    parent: 74
+    type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 45
+  type: CableHV
+  components:
+  - pos: -2.5,6.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 46
+  type: CableHV
+  components:
+  - pos: -1.5,5.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 47
+  type: CableHV
+  components:
+  - pos: -2.5,5.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 48
+  type: CableHV
+  components:
+  - pos: -0.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 49
+  type: CableHV
+  components:
+  - pos: -1.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 50
+  type: CableHV
+  components:
+  - pos: -2.5,4.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 51
+  type: CableHV
+  components:
+  - pos: -2.5,3.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 52
+  type: CableHV
+  components:
+  - pos: -2.5,2.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 53
+  type: CableHV
+  components:
+  - pos: -3.5,2.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 54
+  type: WallReinforced
+  components:
+  - pos: -2.5,8.5
+    parent: 74
+    type: Transform
+- uid: 55
+  type: WallReinforced
+  components:
+  - pos: 3.5,4.5
+    parent: 74
+    type: Transform
+- uid: 56
+  type: WallReinforced
+  components:
+  - pos: 1.5,4.5
+    parent: 74
+    type: Transform
+- uid: 57
+  type: WallReinforced
+  components:
+  - pos: 2.5,4.5
+    parent: 74
+    type: Transform
+- uid: 58
+  type: WallReinforced
+  components:
+  - pos: 3.5,5.5
+    parent: 74
+    type: Transform
+- uid: 59
+  type: WallReinforced
+  components:
+  - pos: -1.5,1.5
+    parent: 74
+    type: Transform
+- uid: 60
+  type: WallReinforced
+  components:
+  - pos: 0.5,1.5
+    parent: 74
+    type: Transform
+- uid: 61
+  type: WallReinforced
+  components:
+  - pos: 0.5,1.5
+    parent: 74
+    type: Transform
+- uid: 62
+  type: WallReinforced
+  components:
+  - pos: 2.5,1.5
+    parent: 74
+    type: Transform
+- uid: 63
+  type: WallCult
+  components:
+  - pos: 0.5,4.5
+    parent: 74
+    type: Transform
+- uid: 64
+  type: WallCult
+  components:
+  - pos: -4.5,3.5
+    parent: 74
+    type: Transform
+- uid: 65
+  type: WallCult
+  components:
+  - pos: -3.5,5.5
+    parent: 74
+    type: Transform
+- uid: 66
+  type: WallCult
+  components:
+  - pos: -3.5,7.5
+    parent: 74
+    type: Transform
+- uid: 67
+  type: WallCult
+  components:
+  - pos: -3.5,8.5
+    parent: 74
+    type: Transform
+- uid: 68
+  type: WallCult
+  components:
+  - pos: 0.5,5.5
+    parent: 74
+    type: Transform
+- uid: 69
+  type: WallCult
+  components:
+  - pos: 1.5,5.5
+    parent: 74
+    type: Transform
+- uid: 70
+  type: WallCult
+  components:
+  - pos: 2.5,5.5
+    parent: 74
+    type: Transform
+- uid: 71
+  type: WallCult
+  components:
+  - pos: 3.5,6.5
+    parent: 74
+    type: Transform
+- uid: 72
+  type: WallCult
+  components:
+  - pos: 3.5,7.5
+    parent: 74
+    type: Transform
+- uid: 73
+  type: WallCult
+  components:
+  - pos: 0.5,7.5
+    parent: 74
+    type: Transform
+- uid: 74
+  components:
+  - pos: 2.2710133,-2.4148211
+    parent: null
+    type: Transform
+  - index: 0
+    type: MapGrid
+  - angularDamping: 100
+    linearDamping: 50
+    fixedRotation: False
+    bodyType: Dynamic
+    type: Physics
+  - fixtures: []
+    type: Fixtures
+  - gravityShakeSound: !type:SoundPathSpecifier
+      path: /Audio/Effects/alert.ogg
+    type: Gravity
+  - chunkCollection: {}
+    type: DecalGrid
+  - tiles:
+      -5,-2: 0
+      -5,-1: 0
+      -4,-10: 0
+      -4,-4: 0
+      -4,-3: 0
+      -3,-11: 0
+      -3,-8: 1
+      -3,-7: 2
+      -3,-6: 3
+      -2,-11: 0
+      -2,-9: 4
+      -2,-8: 5
+      -2,-7: 5
+      -2,-6: 5
+      -2,-5: 5
+      -2,-4: 5
+      -2,-3: 5
+      -2,-1: 5
+      -1,-11: 0
+      -1,-9: 5
+      -1,-8: 5
+      -1,-7: 5
+      -1,-6: 5
+      -1,-5: 5
+      -1,-4: 5
+      -1,-3: 5
+      -1,-1: 5
+      -5,5: 0
+      -5,6: 0
+      -5,7: 0
+      -4,1: 5
+      -4,2: 5
+      -4,3: 5
+      -4,7: 0
+      -4,8: 0
+      -4,9: 0
+      -3,12: 0
+      -3,13: 0
+      -3,14: 0
+      -2,0: 5
+      -2,1: 5
+      -2,2: 5
+      -2,3: 6
+      -2,4: 5
+      -2,5: 5
+      -2,7: 5
+      -2,8: 5
+      -2,9: 5
+      -2,10: 5
+      -1,0: 5
+      -1,1: 5
+      -1,2: 5
+      -1,3: 7
+      -1,4: 5
+      -1,5: 5
+      -1,7: 5
+      -1,8: 5
+      -1,9: 5
+      -1,10: 5
+      -1,12: 5
+      -1,13: 5
+      -1,14: 5
+      0,-11: 0
+      0,-9: 5
+      0,-8: 5
+      0,-7: 5
+      0,-6: 5
+      0,-5: 5
+      0,-4: 5
+      0,-3: 5
+      1,-11: 0
+      1,-9: 5
+      1,-8: 5
+      1,-7: 5
+      1,-6: 8
+      1,-5: 5
+      1,-4: 5
+      1,-3: 5
+      1,-1: 5
+      2,-11: 0
+      2,-9: 5
+      2,-8: 5
+      2,-7: 5
+      2,-6: 9
+      2,-5: 5
+      2,-4: 5
+      2,-3: 5
+      2,-1: 5
+      3,-11: 0
+      3,-9: 5
+      3,-8: 5
+      3,-7: 5
+      3,-6: 10
+      3,-5: 5
+      3,-4: 5
+      3,-3: 5
+      3,-1: 5
+      4,-11: 0
+      4,-8: 5
+      4,-7: 5
+      4,-6: 11
+      5,-10: 0
+      5,-4: 0
+      5,-3: 0
+      6,-2: 0
+      6,-1: 0
+      0,7: 5
+      0,8: 5
+      0,9: 5
+      0,10: 5
+      0,12: 5
+      0,13: 5
+      0,14: 5
+      0,15: 5
+      1,0: 5
+      1,1: 5
+      1,2: 5
+      1,3: 5
+      1,4: 5
+      1,5: 5
+      1,7: 5
+      1,8: 5
+      1,9: 5
+      1,10: 5
+      1,12: 5
+      1,13: 5
+      1,14: 5
+      1,15: 5
+      2,0: 5
+      2,1: 5
+      2,2: 5
+      2,3: 5
+      2,4: 5
+      2,5: 5
+      2,7: 5
+      2,8: 5
+      2,9: 5
+      2,10: 5
+      2,12: 5
+      2,13: 5
+      2,14: 5
+      3,0: 5
+      3,1: 5
+      3,2: 5
+      3,3: 5
+      3,4: 5
+      3,5: 5
+      3,7: 5
+      3,8: 5
+      3,9: 5
+      3,10: 5
+      4,12: 0
+      4,13: 0
+      4,14: 0
+      5,1: 5
+      5,2: 5
+      5,3: 5
+      5,7: 0
+      5,8: 0
+      5,9: 0
+      6,1: 12
+      6,2: 13
+      6,3: 14
+      6,5: 0
+      6,6: 0
+      6,7: 0
+      0,17: 0
+      1,17: 0
+      2,17: 0
+      3,16: 0
+      -2,16: 0
+      -1,17: 0
+      -4,-9: 15
+      -4,-8: 16
+      -4,-7: 17
+      -4,-6: 18
+      -4,-5: 19
+      -3,-10: 15
+      -3,-9: 5
+      -3,-5: 20
+      -3,-4: 21
+      -3,-3: 22
+      -3,-2: 23
+      -3,-1: 24
+      -2,-10: 16
+      -2,-2: 25
+      -1,-10: 17
+      -1,-2: 5
+      -5,0: 26
+      -5,1: 27
+      -5,2: 28
+      -5,3: 29
+      -5,4: 30
+      -4,0: 31
+      -4,4: 32
+      -3,0: 33
+      -3,1: 34
+      -3,2: 35
+      -3,3: 36
+      -3,4: 37
+      -3,5: 38
+      -3,6: 39
+      -3,7: 40
+      -3,8: 41
+      -3,9: 42
+      -3,10: 43
+      -3,11: 44
+      -2,6: 45
+      -2,11: 46
+      -2,12: 47
+      -2,13: 48
+      -2,14: 49
+      -2,15: 50
+      -1,6: 5
+      -1,11: 5
+      -1,15: 51
+      0,-10: 18
+      0,-2: 5
+      0,-1: 5
+      1,-10: 52
+      1,-2: 5
+      2,-10: 53
+      2,-2: 5
+      3,-10: 54
+      3,-2: 5
+      4,-10: 55
+      4,-9: 5
+      4,-5: 56
+      4,-4: 57
+      4,-3: 54
+      4,-2: 5
+      4,-1: 58
+      5,-9: 15
+      5,-8: 59
+      5,-7: 17
+      5,-6: 60
+      5,-5: 61
+      0,0: 5
+      0,1: 5
+      0,2: 5
+      0,3: 5
+      0,4: 5
+      0,5: 5
+      0,6: 5
+      0,11: 5
+      1,6: 5
+      1,11: 5
+      2,6: 5
+      2,11: 62
+      2,15: 4
+      3,6: 63
+      3,11: 64
+      3,12: 65
+      3,13: 53
+      3,14: 54
+      3,15: 66
+      4,0: 67
+      4,1: 68
+      4,2: 5
+      4,3: 69
+      4,4: 70
+      4,5: 71
+      4,6: 72
+      4,7: 73
+      4,8: 60
+      4,9: 17
+      4,10: 59
+      4,11: 15
+      5,0: 74
+      5,4: 75
+      6,0: 76
+      6,4: 77
+      0,16: 17
+      1,16: 59
+      2,16: 15
+      -1,16: 78
+      -8,1: 5
+      -7,1: 5
+      -7,8: 5
+      -6,1: 5
+      -6,8: 5
+      -5,8: 5
+      -4,5: 5
+      -4,6: 5
+      5,5: 5
+      7,7: 5
+    uniqueMixes:
+    - volume: 2500
+      immutable: True
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 265.9203
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 253.77684
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 262.7293
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 256.84375
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 293.15
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 291.63702
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 292.77173
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 292.6032
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 290.96286
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 284.4014
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 258.15558
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 195.26967
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 192.07867
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 179.31473
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 147.925
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 184.23125
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 193.30782
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 195.57695
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 117.50431
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 269.04028
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 196.71117
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 197.84462
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 202.37846
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 220.51387
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 270.4571
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 129.76598
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 179.69148
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 192.17287
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 195.29323
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 103.794716
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 220.51385
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 214.48563
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 293.05545
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 292.77176
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 291.63705
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 287.09814
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 268.9425
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 196.32002
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 196.2801
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 196.12038
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 195.48149
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 192.92601
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 182.70409
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 141.8163
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 268.93253
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 268.71518
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 195.41075
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 192.64302
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 181.5721
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 137.2884
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 250.6036
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 173.45284
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 202.38437
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 220.5375
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 129.77188
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 250.74542
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 191.78323
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 213.34772
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 184.23126
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 195.57697
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 123.53174
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 278.11694
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 268.93402
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 233.01776
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 197.8461
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 120.69531
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 264.39093
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 285.96024
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 287.09824
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 268.94287
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 196.32152
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 196.28607
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 196.14424
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 178.11374
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 214.48572
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 123.45491
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 128.25894
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 122.96446
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    type: GridAtmosphere
+- uid: 75
+  type: WallCult
+  components:
+  - pos: 1.5,8.5
+    parent: 74
+    type: Transform
+- uid: 76
+  type: CableApcExtension
+  components:
+  - pos: -2.5,3.5
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 77
+  type: WallReinforced
+  components:
+  - pos: -4.5,1.5
+    parent: 74
+    type: Transform
+- uid: 78
+  type: WallReinforced
+  components:
+  - pos: 1.5,1.5
+    parent: 74
+    type: Transform
+- uid: 79
+  type: CableApcExtension
+  components:
+  - pos: -3.5,2.5
+    parent: 74
+    type: Transform
+  - enabled: False
+    type: AmbientSound
+  - canCollide: False
+    type: Physics
+- uid: 80
+  type: Airlock
+  components:
+  - pos: -4.5,2.5
+    parent: 74
+    type: Transform
+- uid: 81
+  type: WallCult
+  components:
+  - pos: -3.5,4.5
+    parent: 74
+    type: Transform
+- uid: 82
+  type: WallCult
+  components:
+  - pos: -3.5,6.5
+    parent: 74
+    type: Transform
+- uid: 83
+  type: WallCult
+  components:
+  - pos: 3.5,8.5
+    parent: 74
+    type: Transform
+- uid: 84
+  type: SalvageMaterialCrateSpawner
+  components:
+  - pos: -4.5,8.5
+    parent: 74
+    type: Transform
+- uid: 85
+  type: HeadHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents:
+        - 123
+        - 122
+    type: ContainerContainer
+- uid: 86
+  type: WoodDoor
+  components:
+  - pos: 1.5,3.5
+    parent: 74
+    type: Transform
+- uid: 87
+  type: WallMetal
+  components:
+  - pos: 4.5,2.5
+    parent: 74
+    type: Transform
+- uid: 88
+  type: WallMetal
+  components:
+  - pos: 5.5,4.5
+    parent: 74
+    type: Transform
+- uid: 89
+  type: WallLight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,5.5
+    parent: 74
+    type: Transform
+- uid: 90
+  type: WallLight
+  components:
+  - pos: 3.5,3.5
+    parent: 74
+    type: Transform
+- uid: 91
+  type: WallLight
+  components:
+  - pos: 1.5,7.5
+    parent: 74
+    type: Transform
+- uid: 92
+  type: BannerRed
+  components:
+  - pos: 4.5,4.5
+    parent: 74
+    type: Transform
+- uid: 93
+  type: Carpet
+  components:
+  - pos: 0.5,3.5
+    parent: 74
+    type: Transform
+- uid: 94
+  type: Carpet
+  components:
+  - pos: 2.5,3.5
+    parent: 74
+    type: Transform
+- uid: 95
+  type: Carpet
+  components:
+  - pos: 3.5,3.5
+    parent: 74
+    type: Transform
+- uid: 96
+  type: Carpet
+  components:
+  - pos: 1.5,3.5
+    parent: 74
+    type: Transform
+- uid: 97
+  type: DrinkDevilsKiss
+  components:
+  - pos: -3.7782707,1.8155499
+    parent: 74
+    type: Transform
+  - solution: drink
+    type: DrainableSolution
+- uid: 98
+  type: PlushieNar
+  components:
+  - pos: -0.5438957,4.487425
+    parent: 74
+    type: Transform
+- uid: 99
+  components:
+  - pos: 2.2710133,-2.4148211
+    parent: null
+    type: Transform
+  - index: 1
+    type: MapGrid
+  - angularDamping: 100
+    linearDamping: 50
+    fixedRotation: False
+    bodyType: Dynamic
+    type: Physics
+  - fixtures: []
+    type: Fixtures
+  - gravityShakeSound: !type:SoundPathSpecifier
+      path: /Audio/Effects/alert.ogg
+    type: Gravity
+  - chunkCollection: {}
+    type: DecalGrid
+  - tiles:
+      -1,8: 0
+    uniqueMixes:
+    - volume: 2500
+      temperature: 293.15
+      moles:
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    type: GridAtmosphere
+- uid: 100
+  type: WallMetal
+  components:
+  - pos: 1.5,2.5
+    parent: 74
+    type: Transform
+- uid: 101
+  type: PillSpaceDrugs
+  components:
+  - pos: -1.2313957,3.4092999
+    parent: 74
+    type: Transform
+- uid: 102
+  type: TableStone
+  components:
+  - pos: 6.5,7.5
+    parent: 74
+    type: Transform
+- uid: 103
+  type: ClothingOuterRobesCult
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -3.1836758,1.3183668
+    parent: 74
+    type: Transform
+- uid: 104
+  type: ClothingHeadHatHoodCulthood
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -3.7149258,1.3652418
+    parent: 74
+    type: Transform
+- uid: 105
+  type: ClothingShoesCult
+  components:
+  - pos: 2.550733,3.7419677
+    parent: 74
+    type: Transform
+- uid: 106
+  type: ClothingHeadHelmetCult
+  components:
+  - pos: -0.4979365,6.71418
+    parent: 74
+    type: Transform
+- uid: 107
+  type: ClothingOuterArmorCult
+  components:
+  - pos: 1.4064612,6.845893
+    parent: 74
+    type: Transform
+- uid: 108
+  type: OrganHumanBrain
+  components:
+  - pos: 1.7350073,6.546685
+    parent: 74
+    type: Transform
+- uid: 109
+  type: PuddleBlood
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 1.453757,6.56231
+    parent: 74
+    type: Transform
+  - solutions:
+      puddle:
+        reagents: []
+    type: SolutionContainerManager
+- uid: 110
+  type: LeftArmHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 111
+  type: LeftFootHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 112
+  type: LeftLegHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 113
+  type: RightHandHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 114
+  type: RightArmHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 115
+  type: LeftHandHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 116
+  type: OrganHumanKidneys
+  components:
+  - parent: 121
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 117
+  type: OrganHumanLiver
+  components:
+  - parent: 121
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 118
+  type: OrganHumanStomach
+  components:
+  - parent: 121
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 119
+  type: OrganHumanLungs
+  components:
+  - parent: 121
+    type: Transform
+  - solutions:
+      organ:
+        reagents:
+        - Quantity: 10
+          ReagentId: Nutriment
+      Lung:
+        canReact: False
+        reagents: []
+    type: SolutionContainerManager
+  - canCollide: False
+    type: Physics
+- uid: 120
+  type: OrganHumanHeart
+  components:
+  - parent: 121
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 121
+  type: TorsoHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents:
+        - 120
+        - 119
+        - 118
+        - 117
+        - 116
+    type: ContainerContainer
+- uid: 122
+  type: OrganHumanEyes
+  components:
+  - parent: 85
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 123
+  type: OrganHumanBrain
+  components:
+  - parent: 85
+    type: Transform
+  - canCollide: False
+    type: Physics
+- uid: 124
+  type: PlushieRGBee
+  components:
+  - pos: 6.4644976,7.5701184
+    parent: 74
+    type: Transform
+- uid: 125
+  type: SalvageHumanCorpse
+  components:
+  - pos: -3.3459435,1.5874257
+    parent: 74
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - fixtures:
+    - shape: !type:PhysShapeCircle
+        radius: 0.35
+      mask:
+      - Impassable
+      - MobImpassable
+      - SmallImpassable
+      layer:
+      - Opaque
+      mass: 70
+    type: Fixtures
+  - combatToggleAction:
+      popupToggleSuffix: -disabling
+      icon: Interface/Actions/harmOff.png
+      iconOn: Interface/Actions/harm.png
+      name: action-name-combat
+      description: action-description-combat
+      keywords: []
+      userPopup: action-popup-combat
+      event: !type:ToggleCombatActionEvent {}
+    type: CombatMode
+  - action:
+      checkCanInteract: False
+      icon: Interface/Actions/scream.png
+      name: action-name-scream
+      description: AAAAAAAAAAAAAAAAAAAAAAAAA
+      keywords: []
+      useDelay: 10
+      event: !type:ScreamActionEvent {}
+    type: Vocal
+  - standing: False
+    vaultImpassableFixtures:
+    - fixture_1
+    type: StandingState
+  - solutions:
+      chemicals:
+        reagents: []
+      bloodstream:
+        reagents:
+        - Quantity: 300
+          ReagentId: Blood
+      bloodstreamTemporary:
+        reagents: []
+    type: SolutionContainerManager
+  - containers:
+      Body-BodyComponent: !type:Container
+        ents:
+        - 85
+        - 121
+        - 110
+        - 115
+        - 114
+        - 113
+        - 112
+        - 111
+        - 132
+        - 131
+      left hand: !type:ContainerSlot
+        occludes: False
+      right hand: !type:ContainerSlot
+        occludes: False
+      Cuffable: !type:Container
+        ents: []
+      shoes: !type:ContainerSlot
+        occludes: False
+      jumpsuit: !type:ContainerSlot
+        occludes: False
+      outerClothing: !type:ContainerSlot
+        occludes: False
+      gloves: !type:ContainerSlot
+        occludes: False
+      neck: !type:ContainerSlot
+        occludes: False
+      mask: !type:ContainerSlot
+        occludes: False
+      eyes: !type:ContainerSlot
+        occludes: False
+      ears: !type:ContainerSlot
+        occludes: False
+      head: !type:ContainerSlot
+        occludes: False
+      pocket1: !type:ContainerSlot
+        occludes: False
+      pocket2: !type:ContainerSlot
+        occludes: False
+      suitstorage: !type:ContainerSlot
+        occludes: False
+      id: !type:ContainerSlot
+        occludes: False
+      belt: !type:ContainerSlot
+        occludes: False
+      back: !type:ContainerSlot
+        occludes: False
+    type: ContainerContainer
+  - mustBeDead: True
+    type: GhostOnMove
+- uid: 126
+  type: OrganHumanEyes
+  components:
+  - pos: 2.3912573,6.59356
+    parent: 74
+    type: Transform
+- uid: 127
+  type: RightLegHuman
+  components:
+  - pos: 2.8127112,6.252143
+    parent: 74
+    type: Transform
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 128
+  type: PuddleBlood
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 1.688132,6.49981
+    parent: 74
+    type: Transform
+  - solutions:
+      puddle:
+        reagents: []
+    type: SolutionContainerManager
+- uid: 129
+  type: PuddleBlood
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 2.5475073,6.452935
+    parent: 74
+    type: Transform
+  - solutions:
+      puddle:
+        reagents: []
+    type: SolutionContainerManager
+- uid: 130
+  type: PuddleBlood
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 2.2818823,6.37481
+    parent: 74
+    type: Transform
+  - solutions:
+      puddle:
+        reagents: []
+    type: SolutionContainerManager
+- uid: 131
+  type: RightFootHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+- uid: 132
+  type: RightLegHuman
+  components:
+  - parent: 125
+    type: Transform
+  - canCollide: False
+    type: Physics
+  - containers:
+      BodyPart-BodyPartComponent: !type:Container
+        ents: []
+    type: ContainerContainer
+...


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wanted to try to design a few small salvage maps, this is my second attempt as I bungled the first one with saving.

**Screenshots**
![20220505220421_1](https://user-images.githubusercontent.com/104950325/167065195-7cfa7a4b-b368-4526-8e30-73a7df755990.jpg)

**Changelog**
This map is based around the idea of a cultist hideout being separated from the station, it includes;

Persistent Items:
1x Uranium Generator
1x Substation
Assorted Wires
1x RGB Plushie
Some Cult clothes/gear
1x Devil's Kiss drink
1x Space Drug pill
1x Nar 'Sie Plushie

Spawners:
2x 75% Salvage Mob
1x Space Bear
1x Space tick 
2x Salvage Material crate
1x Random Artifact

I feel that this salvage map will be good because there is not one like it, and it adds some power gen items for Salvage/Cargo/Engi. This should encourage salvagers to look for power for their shuttle/dept/station, and help spread the cult cheer depending on the round.
:cl:
- add: New Medium Salvage Map 

