### PR TITLE
Fix storage interactions not preventing afterinteract for the item

### DIFF
--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -185,6 +185,9 @@ namespace Content.Server.Storage.EntitySystems
         /// <returns>true if inserted, false otherwise</returns>
         private void OnInteractUsing(EntityUid uid, ServerStorageComponent storageComp, InteractUsingEvent args)
         {
+            if (args.Handled)
+                return;
+
             if (!storageComp.ClickInsert)
                 return;
 
@@ -193,7 +196,8 @@ namespace Content.Server.Storage.EntitySystems
             if (HasComp<PlaceableSurfaceComponent>(uid))
                 return;
 
-            PlayerInsertHeldEntity(uid, args.User, storageComp);
+            if (PlayerInsertHeldEntity(uid, args.User, storageComp))
+                args.Handled = true;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #7970 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Trying to insert items into storage will no longer cause those items to be used on the tile below you.