### PR TITLE
no submodule update in prs workflow

### DIFF
--- a/.github/workflows/no-submodule-update.yml
+++ b/.github/workflows/no-submodule-update.yml
@@ -1,0 +1,14 @@
+name: No submodule update checker
+
+on:
+  pull_request:
+    paths:
+      - 'RobustToolbox'
+
+jobs:
+  this_aint_right:
+    name: Submodule update in pr found
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail
+        run: exit 1


### PR DESCRIPTION
alternatively we could run this on all prs & use `git diff --exit-code RobustToolbox`