### PR TITLE
Make inventory slot interact properly go through unequip

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -123,11 +123,13 @@ public abstract partial class InventorySystem
             return;
         }
 
-        // interact with an empty hand (usually just unequips the item).
+        // unequip the item.
         if (itemUid != null)
         {
-            if (_actionBlockerSystem.CanInteract(actor, itemUid.Value))
-                _interactionSystem.InteractHand(actor, itemUid.Value);
+            if (!TryUnequip(actor, ev.Slot, out var item, predicted: true, inventory: inventory))
+                return;
+
+            _handsSystem.PickupOrDrop(actor, item.Value);
             return;
         }
 
@@ -145,7 +147,7 @@ public abstract partial class InventorySystem
 
         if (_handsSystem.TryDrop(actor, hands.ActiveHand!, doDropInteraction: false, handsComp: hands))
             TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory);
-        }
+    }
 
     public bool TryEquip(EntityUid uid, EntityUid itemUid, string slot, bool silent = false, bool force = false, bool predicted = false,
         InventoryComponent? inventory = null, SharedItemComponent? item = null) =>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #7995
Previously it just called `InteractHand` which "would usually unequip the item", except that it doesn't actually call the `TryUnequip` method on `InventorySystem` because it just picks it up. This undoubtedly fucked other stuff up and probably meant that unequip sounds didn't work for these (though only hardsuit helmets use those right now). I just made it directly call `TryUnequip` instead of detouring through interaction system. This way it's more consistent and it has identical behavior to before otherwise (and I can't think of a situation right now where you would want to click on an inventory item and -not- unequip it?)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Unequipping clothing now properly resets any movespeed modifiers they gave you.

