### PR TITLE
Add checks missing in the current half-implementation of lockable sto…

### DIFF
--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -191,6 +191,9 @@ namespace Content.Server.Storage.EntitySystems
             if (!storageComp.ClickInsert)
                 return;
 
+            if (TryComp(uid, out LockComponent? lockComponent) && lockComponent.Locked)
+                return;
+
             Logger.DebugS(storageComp.LoggerName, $"Storage (UID {uid}) attacked by user (UID {args.User}) with entity (UID {args.Used}).");
 
             if (HasComp<PlaceableSurfaceComponent>(uid))
@@ -207,6 +210,9 @@ namespace Content.Server.Storage.EntitySystems
         private void OnActivate(EntityUid uid, ServerStorageComponent storageComp, ActivateInWorldEvent args)
         {
             if (!TryComp<ActorComponent>(args.User, out var actor))
+                return;
+
+            if (TryComp(uid, out LockComponent? lockComponent) && lockComponent.Locked)
                 return;
 
             OpenStorageUI(uid, args.User, storageComp);


### PR DESCRIPTION
…rage

<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lockable storage is actually half-implemented already, the only reason it doesn't work right is for some reason only a fraction of the things that should stop if it's locked. This prevents you from inserting stuff in it or opening its ui when it's locked

