### PR TITLE
Taser Nerf and Blood No Longer Slips

### DIFF
--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -13,8 +13,6 @@
       path: /Audio/Effects/Fluids/splat.ogg
     recolor: true
   - type: Clickable  
-  - type: Slippery
-    launchForwardsMultiplier: 2.0
   - type: Evaporation
   - type: Physics
   - type: Fixtures
@@ -57,6 +55,8 @@
   - type: Appearance
     visuals:
     - type: PuddleVisualizer
+  - type: Slippery
+    launchForwardsMultiplier: 2.0
 
 - type: entity
   name: puddle
@@ -73,7 +73,9 @@
     visuals:
     - type: PuddleVisualizer
       recolor: true
-
+  - type: Slippery
+    launchForwardsMultiplier: 2.0
+    
 - type: entity
   name: puddle
   id: PuddleSplatter
@@ -88,7 +90,9 @@
   - type: Appearance
     visuals:
     - type: PuddleVisualizer
-
+  - type: Slippery
+    launchForwardsMultiplier: 2.0
+    
 - type: entity
   id: PuddleBlood
   name: blood
@@ -131,7 +135,9 @@
   - type: Appearance
     visuals:
     - type: PuddleVisualizer
-
+  - type: Slippery
+    launchForwardsMultiplier: 2.0
+    
 - type: entity
   name: toxins vomit
   id: PuddleVomitToxin
@@ -154,7 +160,9 @@
   - type: Appearance
     visuals:
     - type: PuddleVisualizer
-
+  - type: Slippery
+    launchForwardsMultiplier: 2.0
+    
 - type: entity
   name: writing
   id: PuddleWriting
@@ -170,4 +178,6 @@
   - type: Appearance
     visuals:
     - type: PuddleVisualizer
-
+  - type: Slippery
+    launchForwardsMultiplier: 2.0
+    

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -355,7 +355,7 @@
   - type: BatteryBarrel
     minAngle: 5
     angleIncrease: 20
-    fireCost: 80
+    fireCost: 360
     ammoPrototype: BulletTaser
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser.ogg


### PR DESCRIPTION
changelog
-taser only fires 1 shot before needing recharge now. ss14 realistic game????
-blood puddles no longer slip
-puddles parent has had slippable remove and its now opt in for children puddles

:cl: emisse
- add: tasers can only fire 1 shot
- add: blood no longer slips