### PR TITLE
Fix lathe visuals exception

### DIFF
--- a/Content.Client/Lathe/LatheSystem.cs
+++ b/Content.Client/Lathe/LatheSystem.cs
@@ -11,30 +11,39 @@ namespace Content.Client.Lathe
     {
         protected override void OnAppearanceChange(EntityUid uid, LatheVisualsComponent component, ref AppearanceChangeEvent args)
         {
-            if (TryComp(uid, out SpriteComponent? sprite))
+            if (!TryComp(uid, out SpriteComponent? sprite)) return;
+
+            if (args.Component.TryGetData(PowerDeviceVisuals.Powered, out bool powered) &&
+                sprite.LayerMapTryGet(PowerDeviceVisualLayers.Powered, out _))
             {
-                if (args.Component.TryGetData(PowerDeviceVisuals.Powered, out bool powered))
-                    sprite.LayerSetVisible(PowerDeviceVisualLayers.Powered, powered);
-                if (args.Component.TryGetData(WiresVisuals.MaintenancePanelState, out bool panel)
-                    && sprite.LayerMapTryGet(WiresVisualizer.WiresVisualLayers.MaintenancePanel, out var panelLayer))
-                    sprite.LayerSetVisible(WiresVisualizer.WiresVisualLayers.MaintenancePanel, panel);
-                // Lathe specific stuff
-                if (args.Component.TryGetData(LatheVisuals.IsRunning, out bool isRunning))
+                sprite.LayerSetVisible(PowerDeviceVisualLayers.Powered, powered);
+            }
+
+            if (args.Component.TryGetData(WiresVisuals.MaintenancePanelState, out bool panel)
+                && sprite.LayerMapTryGet(WiresVisualizer.WiresVisualLayers.MaintenancePanel, out _))
+            {
+                sprite.LayerSetVisible(WiresVisualizer.WiresVisualLayers.MaintenancePanel, panel);
+            }
+
+            // Lathe specific stuff
+            if (args.Component.TryGetData(LatheVisuals.IsRunning, out bool isRunning))
+            {
+                var state = isRunning ? component.RunningState : component.IdleState;
+                sprite.LayerSetAnimationTime(LatheVisualLayers.IsRunning, 0f);
+                sprite.LayerSetState(LatheVisualLayers.IsRunning, state);
+            }
+
+            if (args.Component.TryGetData(LatheVisuals.IsInserting, out bool isInserting)
+                && sprite.LayerMapTryGet(LatheVisualLayers.IsInserting, out var isInsertingLayer))
+            {
+                if (args.Component.TryGetData(LatheVisuals.InsertingColor, out Color color)
+                    && !component.IgnoreColor)
                 {
-                    var state = isRunning ? component.RunningState : component.IdleState;
-                    sprite.LayerSetAnimationTime(LatheVisualLayers.IsRunning, 0f);
-                    sprite.LayerSetState(LatheVisualLayers.IsRunning, state);
+                    sprite.LayerSetColor(isInsertingLayer, color);
                 }
-                if (args.Component.TryGetData(LatheVisuals.IsInserting, out bool isInserting)
-                    && sprite.LayerMapTryGet(LatheVisualLayers.IsInserting, out var isInsertingLayer))
-                {
-                    if (args.Component.TryGetData(LatheVisuals.InsertingColor, out Color color)
-                        && !component.IgnoreColor)
-                        sprite.LayerSetColor(isInsertingLayer, color);
-                        
-                    sprite.LayerSetAnimationTime(isInsertingLayer, 0f);
-                    sprite.LayerSetVisible(isInsertingLayer, isInserting);
-                }
+
+                sprite.LayerSetAnimationTime(isInsertingLayer, 0f);
+                sprite.LayerSetVisible(isInsertingLayer, isInserting);
             }
         }
     }


### PR DESCRIPTION
Uniform printer moment. Formatting was pretty annoying but the actual change was layermaptryget for the powered layer because the uniform printer only has 2.