### PR TITLE
Optionally deserialize `AudioParams` in `SoundSpecifier`

### DIFF
--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -369,7 +369,7 @@ namespace Content.Server.Storage.EntitySystems
                 UpdateStorageVisualization(uid, storageComp);
 
                 if (storageComp.StorageCloseSound is not null)
-                    SoundSystem.Play(Filter.Pvs(uid, entityManager: EntityManager), storageComp.StorageCloseSound.GetSound(), uid, AudioParams.Default);
+                    SoundSystem.Play(Filter.Pvs(uid, entityManager: EntityManager), storageComp.StorageCloseSound.GetSound(), uid, storageComp.StorageCloseSound.Params);
             }
         }
 
@@ -578,7 +578,7 @@ namespace Content.Server.Storage.EntitySystems
                 return;
 
             if (storageComp.StorageOpenSound is not null)
-                SoundSystem.Play(Filter.Pvs(uid, entityManager: EntityManager), storageComp.StorageOpenSound.GetSound(), uid, AudioParams.Default);
+                SoundSystem.Play(Filter.Pvs(uid, entityManager: EntityManager), storageComp.StorageOpenSound.GetSound(), uid, storageComp.StorageOpenSound.Params);
 
             Logger.DebugS(storageComp.LoggerName, $"Storage (UID {uid}) \"used\" by player session (UID {player.PlayerSession.AttachedEntity}).");
 

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -197,7 +197,7 @@ public abstract partial class InventorySystem
                     filter.RemoveWhereAttachedEntity(entity => entity == actor);
             }
 
-            SoundSystem.Play(filter, item.EquipSound.GetSound(), target, AudioParams.Default.WithVolume(-2f));
+            SoundSystem.Play(filter, item.EquipSound.GetSound(), target, item.EquipSound.Params.WithVolume(-2f));
         }
 
         inventory.Dirty();
@@ -376,7 +376,7 @@ public abstract partial class InventorySystem
                     filter.RemoveWhereAttachedEntity(entity => entity == actor);
             }
 
-            SoundSystem.Play(filter, item.UnequipSound.GetSound(), target, AudioParams.Default.WithVolume(-2f));
+            SoundSystem.Play(filter, item.UnequipSound.GetSound(), target, item.UnequipSound.Params.WithVolume(-2f));
         }
 
         inventory.Dirty();

--- a/Content.Shared/Sound/SoundSpecifier.cs
+++ b/Content.Shared/Sound/SoundSpecifier.cs
@@ -1,4 +1,6 @@
 using Content.Shared.Audio;
+using JetBrains.Annotations;
+using Robust.Shared.Audio;
 using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -9,6 +11,9 @@ namespace Content.Shared.Sound
     [ImplicitDataDefinitionForInheritors]
     public abstract class SoundSpecifier
     {
+        [DataField("params")]
+        public AudioParams Params = AudioParams.Default;
+
         public abstract string GetSound();
     }
 
@@ -19,6 +24,7 @@ namespace Content.Shared.Sound
         [DataField(Node, customTypeSerializer: typeof(ResourcePathSerializer), required: true)]
         public ResourcePath? Path { get; }
 
+        [UsedImplicitly]
         public SoundPathSpecifier()
         {
         }
@@ -46,6 +52,7 @@ namespace Content.Shared.Sound
         [DataField(Node, customTypeSerializer: typeof(PrototypeIdSerializer<SoundCollectionPrototype>), required: true)]
         public string? Collection { get; }
 
+        [UsedImplicitly]
         public SoundCollectionSpecifier()
         {
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

A lot of stuff that uses soundspecifiers deserializes volume or pitch variation etc manually which is annoying

This lets you do stuff like this:

![image](https://user-images.githubusercontent.com/19853115/167533203-27e31776-7bd3-43d7-a3c3-21b8090b2870.png)

Things that would now be nice to have:
- Change all current usages of soundspecifiers to use the field instead of `AudioParams.Default`
- OR add a content API for `SoundSystem` so that we can have a method that takes in `SoundSpecifier` and uses `GetSound()` and `Params` itself