### PR TITLE
Allow do_afters to be spammed

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
@@ -108,8 +108,6 @@ public sealed partial class ChemistrySystem
 
         if (component.CancelToken != null)
         {
-            component.CancelToken.Cancel();
-            component.CancelToken = null;
             args.Handled = true;
             return;
         }

--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -92,7 +92,10 @@ public sealed class HealingSystem : EntitySystem
 
     private bool TryHeal(EntityUid uid, EntityUid user, EntityUid target, HealingComponent component)
     {
-        if (component.CancelToken != null) return false;
+        if (component.CancelToken != null)
+        {
+            return false;
+        }
 
         if (TryComp<MobStateComponent>(target, out var state) && state.IsDead())
             return false;

--- a/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/DrinkSystem.cs
@@ -194,8 +194,6 @@ namespace Content.Server.Nutrition.EntitySystems
             // cannot stack do-afters
             if (drink.CancelToken != null)
             {
-                drink.CancelToken.Cancel();
-                drink.CancelToken = null;
                 return true;
             }
 

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -79,8 +79,6 @@ namespace Content.Server.Nutrition.EntitySystems
             // if currently being used to feed, cancel that action.
             if (food.CancelToken != null)
             {
-                food.CancelToken.Cancel();
-                food.CancelToken = null;
                 return true;
             }
 

--- a/Content.Server/Tools/ToolSystem.TilePrying.cs
+++ b/Content.Server/Tools/ToolSystem.TilePrying.cs
@@ -18,6 +18,12 @@ public sealed partial class ToolSystem
     {
         SubscribeLocalEvent<TilePryingComponent, AfterInteractEvent>(OnTilePryingAfterInteract);
         SubscribeLocalEvent<TilePryingComponent, TilePryingCompleteEvent>(OnTilePryComplete);
+        SubscribeLocalEvent<TilePryingComponent, TilePryingCancelledEvent>(OnTilePryCancelled);
+    }
+
+    private void OnTilePryCancelled(EntityUid uid, TilePryingComponent component, TilePryingCancelledEvent args)
+    {
+        component.CancelToken = null;
     }
 
     private void OnTilePryComplete(EntityUid uid, TilePryingComponent component, TilePryingCompleteEvent args)
@@ -38,9 +44,7 @@ public sealed partial class ToolSystem
     {
         if (component.CancelToken != null)
         {
-            component.CancelToken.Cancel();
-            component.CancelToken = null;
-            return false;
+            return true;
         }
 
         if (!TryComp<ToolComponent?>(component.Owner, out var tool) && component.ToolComponentNeeded)
@@ -75,6 +79,7 @@ public sealed partial class ToolSystem
             {
                 Coordinates = clickLocation,
             },
+            new TilePryingCancelledEvent(),
             toolComponent: tool,
             doAfterEventTarget: component.Owner,
             cancelToken: token.Token);
@@ -85,5 +90,10 @@ public sealed partial class ToolSystem
     private sealed class TilePryingCompleteEvent : EntityEventArgs
     {
         public EntityCoordinates Coordinates { get; init; }
+    }
+
+    private sealed class TilePryingCancelledEvent : EntityEventArgs
+    {
+
     }
 }


### PR DESCRIPTION
Doesn't stack but won't cancel either. Also fixes tile prying cancel bug I think.
