### PR TITLE
Atmos high pressure movements cleanup

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -150,7 +150,7 @@ namespace Content.Server.Atmos.EntitySystems
         }
 
         // Called from AtmosphereSystem.LINDA.cs with SpaceWind CVar check handled there.
-        private void ConsiderPressureDifference(GridAtmosphereComponent gridAtmosphere, TileAtmosphere tile, AtmosDirection otherDirection, float difference)
+        private void ConsiderPressureDifference(GridAtmosphereComponent gridAtmosphere, TileAtmosphere tile, AtmosDirection differenceDirection, float difference)
         {
             gridAtmosphere.HighPressureDelta.Add(tile);
 
@@ -158,7 +158,7 @@ namespace Content.Server.Atmos.EntitySystems
                 return;
 
             tile.PressureDifference = difference;
-            tile.PressureDirection = otherDirection;
+            tile.PressureDirection = differenceDirection;
         }
 
         public void ExperiencePressureDifference(

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -104,6 +104,19 @@ namespace Content.Server.Atmos.EntitySystems
                 }
             }
 
+
+            if (tile.PressureDifference > 100)
+            {
+                // TODO ATMOS Do space wind graphics here!
+            }
+
+            if (_spaceWindSoundCooldown++ > SpaceWindSoundCooldownCycles)
+                _spaceWindSoundCooldown = 0;
+
+            // No atmos yeets, return early.
+            if (!SpaceWind)
+                return;
+
             // Used by ExperiencePressureDifference to correct push/throw directions from tile-relative to physics world.
             var gridWorldRotation = xforms.GetComponent(gridAtmosphere.Owner).WorldRotation;
 
@@ -134,14 +147,6 @@ namespace Content.Server.Atmos.EntitySystems
                 }
 
             }
-
-            if (tile.PressureDifference > 100)
-            {
-                // TODO ATMOS Do space wind graphics here!
-            }
-
-            if (_spaceWindSoundCooldown++ > SpaceWindSoundCooldownCycles)
-                _spaceWindSoundCooldown = 0;
         }
 
         // Called from AtmosphereSystem.LINDA.cs with SpaceWind CVar check handled there.

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -145,14 +145,15 @@ namespace Content.Server.Atmos.EntitySystems
         }
 
         // Called from AtmosphereSystem.LINDA.cs with SpaceWind CVar check handled there.
-        private void ConsiderPressureDifference(GridAtmosphereComponent gridAtmosphere, TileAtmosphere tile, TileAtmosphere other, float difference)
+        private void ConsiderPressureDifference(GridAtmosphereComponent gridAtmosphere, TileAtmosphere tile, AtmosDirection otherDirection, float difference)
         {
             gridAtmosphere.HighPressureDelta.Add(tile);
-            if (difference > tile.PressureDifference)
-            {
-                tile.PressureDifference = difference;
-                tile.PressureDirection = (tile.GridIndices - other.GridIndices).GetDir().ToAtmosDirection();
-            }
+
+            if (difference <= tile.PressureDifference)
+                return;
+
+            tile.PressureDifference = difference;
+            tile.PressureDirection = otherDirection;
         }
 
         public void ExperiencePressureDifference(

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -81,7 +81,7 @@ namespace Content.Server.Atmos.EntitySystems
                     var difference = Share(tile.Air!, enemyTile.Air!, adjacentTileLength);
 
                     // Monstermos already handles this, so let's not handle it ourselves.
-                    if (SpaceWind && !MonstermosEqualization)
+                    if (!MonstermosEqualization)
                     {
                         if (difference >= 0)
                         {

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -80,15 +80,16 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     var difference = Share(tile.Air!, enemyTile.Air!, adjacentTileLength);
 
-                    if (SpaceWind)
+                    // Monstermos already handles this, so let's not handle it ourselves.
+                    if (SpaceWind && !MonstermosEqualization)
                     {
-                        if (difference > 0)
+                        if (difference >= 0)
                         {
-                            ConsiderPressureDifference(gridAtmosphere, tile, enemyTile, difference);
+                            ConsiderPressureDifference(gridAtmosphere, tile, direction, difference);
                         }
                         else
                         {
-                            ConsiderPressureDifference(gridAtmosphere, enemyTile, tile, -difference);
+                            ConsiderPressureDifference(gridAtmosphere, enemyTile, direction.GetOpposite(), -difference);
                         }
                     }
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -547,18 +547,17 @@ namespace Content.Server.Atmos.EntitySystems
                 var amount = transferDirections[i];
                 var otherTile = tile.AdjacentTiles[i];
                 if (otherTile?.Air == null) continue;
-                if (amount > 0)
-                {
-                    // Everything that calls this method already ensures that Air will not be null.
-                    if (tile.Air!.TotalMoles < amount)
-                        FinalizeEqNeighbors(gridAtmosphere, tile, transferDirections);
+                if (amount <= 0) continue;
 
-                    otherTile.MonstermosInfo[direction.GetOpposite()] = 0;
-                    Merge(otherTile.Air, tile.Air.Remove(amount));
-                    InvalidateVisuals(tile.GridIndex, tile.GridIndices);
-                    InvalidateVisuals(otherTile.GridIndex, otherTile.GridIndices);
-                    ConsiderPressureDifference(gridAtmosphere, tile, otherTile, amount);
-                }
+                // Everything that calls this method already ensures that Air will not be null.
+                if (tile.Air!.TotalMoles < amount)
+                    FinalizeEqNeighbors(gridAtmosphere, tile, transferDirections);
+
+                otherTile.MonstermosInfo[direction.GetOpposite()] = 0;
+                Merge(otherTile.Air, tile.Air.Remove(amount));
+                InvalidateVisuals(tile.GridIndex, tile.GridIndices);
+                InvalidateVisuals(otherTile.GridIndex, otherTile.GridIndices);
+                ConsiderPressureDifference(gridAtmosphere, tile, direction, amount);
             }
         }
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -219,6 +219,8 @@ namespace Content.Server.Atmos.EntitySystems
             if(!atmosphere.ProcessingPaused)
                 atmosphere.CurrentRunTiles = new Queue<TileAtmosphere>(atmosphere.HighPressureDelta);
 
+            // Note: This is still processed even if space wind is turned off since this handles playing the sounds.
+
             var number = 0;
             var bodies = EntityManager.GetEntityQuery<PhysicsComponent>();
             var xforms = EntityManager.GetEntityQuery<TransformComponent>();


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Fixes LINDA and Monstermos both setting the pressure difference direction, meaning that it ended up being incorrect in the end.
- Fixes space wind CVar not actually disabling atmos movements.
- Cleans up code involving high pressure movements and pressure differences, should be slightly faster now too.