### PR TITLE
Fix pressure direction not being reset after high pressure movements happen.

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -231,6 +231,7 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 HighPressureMovements(atmosphere, tile, bodies, xforms, pressureQuery, metas);
                 tile.PressureDifference = 0f;
+                tile.PressureDirection = AtmosDirection.Invalid;
                 tile.PressureSpecificTarget = null;
                 atmosphere.HighPressureDelta.Remove(tile);
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mostly helps when debugging with the `showatmos` command, so it only shows the high pressure movement directions when they happen, and cleans them up afterwards.