### PR TITLE
Salvage mob restrictions

### DIFF
--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -173,6 +173,8 @@ namespace Content.Client.Entry
             "ExaminableSolution",
             "DrawableSolution",
             "InjectableSolution",
+            "SalvageMobRestrictions",
+            "SalvageMobRestrictionsGrid",
             "Barotrauma",
             "GasVentPump",
             "GasPassiveVent",

--- a/Content.Server/Salvage/SalvageMobRestrictionsComponent.cs
+++ b/Content.Server/Salvage/SalvageMobRestrictionsComponent.cs
@@ -10,7 +10,8 @@ namespace Content.Server.Salvage;
 ///     This component exists as a sort of stateful marker for a
 ///     killswitch meant to keep salvage mobs from doing stuff they
 ///     really shouldn't (attacking station).
-///     The main thing is that this component receives critical events that alert SalvageMobRestrictionsSystem to the presence of a 
+///     The main thing is that adding this component ties the mob to
+///     whatever it's currently parented to.
 /// </summary>
 [RegisterComponent]
 public sealed class SalvageMobRestrictionsComponent : Component

--- a/Content.Server/Salvage/SalvageMobRestrictionsComponent.cs
+++ b/Content.Server/Salvage/SalvageMobRestrictionsComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.ViewVariables;
+using System;
+
+namespace Content.Server.Salvage;
+
+/// <summary>
+///     This component exists as a sort of stateful marker for a
+///     killswitch meant to keep salvage mobs from doing stuff they
+///     really shouldn't (attacking station).
+///     The main thing is that this component receives critical events that alert SalvageMobRestrictionsSystem to the presence of a 
+/// </summary>
+[RegisterComponent]
+public sealed class SalvageMobRestrictionsComponent : Component
+{
+    [ViewVariables(VVAccess.ReadOnly)]
+    [DataField("linkedGridEntity")]
+    public EntityUid LinkedGridEntity = EntityUid.Invalid;
+}
+

--- a/Content.Server/Salvage/SalvageMobRestrictionsGridComponent.cs
+++ b/Content.Server/Salvage/SalvageMobRestrictionsGridComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.ViewVariables;
+using System;
+
+namespace Content.Server.Salvage;
+
+/// <summary>
+///     This component is attached to grids when a salvage mob is
+///     spawned on them.
+///     This attachment is done by SalvageMobRestrictionsSystem.
+///     *Simply put, when this component is removed, the mobs die.*
+///     *This applies even if the mobs are off-grid at the time.*
+/// </summary>
+[RegisterComponent]
+public sealed class SalvageMobRestrictionsGridComponent : Component
+{
+    [ViewVariables(VVAccess.ReadOnly)]
+    [DataField("mobsToKill")]
+    public List<EntityUid> MobsToKill = new();
+}
+

--- a/Content.Server/Salvage/SalvageMobRestrictionsSystem.cs
+++ b/Content.Server/Salvage/SalvageMobRestrictionsSystem.cs
@@ -1,0 +1,74 @@
+using Content.Shared.CCVar;
+using Content.Shared.Examine;
+using Content.Shared.Interaction;
+using Content.Shared.Damage;
+using Content.Shared.Damage;
+using Robust.Server.Maps;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Localization;
+using Robust.Shared.Log;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Content.Server.Salvage;
+
+public sealed class SalvageMobRestrictionsSystem : EntitySystem
+{
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SalvageMobRestrictionsComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<SalvageMobRestrictionsComponent, ComponentRemove>(OnRemove);
+        SubscribeLocalEvent<SalvageMobRestrictionsGridComponent, ComponentRemove>(OnRemoveGrid);
+    }
+
+    private void OnInit(EntityUid uid, SalvageMobRestrictionsComponent component, ComponentInit args)
+    {
+        var gridUid = Transform(uid).ParentUid;
+        if (!EntityManager.EntityExists(gridUid))
+        {
+            // Give up, we were spawned improperly
+            return;
+        }
+        // When this code runs, the salvage magnet hasn't actually gotten ahold of the entity yet.
+        // So it therefore isn't in a position to do this.
+        if (!TryComp(gridUid, out SalvageMobRestrictionsGridComponent? rg))
+        {
+            rg = AddComp<SalvageMobRestrictionsGridComponent>(gridUid);
+        }
+        rg!.MobsToKill.Add(uid);
+        component.LinkedGridEntity = gridUid;
+    }
+
+    private void OnRemove(EntityUid uid, SalvageMobRestrictionsComponent component, ComponentRemove args)
+    {
+        if (TryComp(component.LinkedGridEntity, out SalvageMobRestrictionsGridComponent? rg))
+        {
+            rg.MobsToKill.Remove(uid);
+        }
+    }
+
+    private void OnRemoveGrid(EntityUid uid, SalvageMobRestrictionsGridComponent component, ComponentRemove args)
+    {
+        foreach (EntityUid target in component.MobsToKill)
+        {
+            if (TryComp(target, out DamageableComponent? dc))
+            {
+                _damageableSystem.SetAllDamage(dc, 200);
+            }
+        }
+    }
+}
+

--- a/Content.Server/Salvage/SalvageMobRestrictionsSystem.cs
+++ b/Content.Server/Salvage/SalvageMobRestrictionsSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Damage;
 using Content.Shared.Damage;
+using Content.Server.Body.Components;
 using Robust.Server.Maps;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
@@ -64,7 +65,12 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
     {
         foreach (EntityUid target in component.MobsToKill)
         {
-            if (TryComp(target, out DamageableComponent? dc))
+            if (TryComp(target, out BodyComponent? body))
+            {
+                // Just because.
+                body.Gib();
+            }
+            else if (TryComp(target, out DamageableComponent? dc))
             {
                 _damageableSystem.SetAllDamage(dc, 200);
             }

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -198,8 +198,13 @@ namespace Content.Server.Salvage
             {
                 if (player.AttachedEntity.HasValue)
                 {
-                    var playerTransform = EntityManager.GetComponent<TransformComponent>(player.AttachedEntity.Value);
-                    playerTransform.AttachParent(parentTransform);
+                    var playerEntityUid = player.AttachedEntity.Value;
+                    if (HasComp<SalvageMobRestrictionsComponent>(playerEntityUid))
+                    {
+                        // Salvage mobs are NEVER immune (even if they're from a different salvage, they shouldn't be here)
+                        continue;
+                    }
+                    Transform(playerEntityUid).AttachParent(parentTransform);
                 }
             }
             EntityManager.QueueDeleteEntity(salvage);

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
@@ -1,3 +1,6 @@
+# NOTE! All mobs that come out of this should have Salvage rulesets.
+# These rulesets exist because Salvage mobs kept harassing the station and going out of control.
+
 - type: entity
   name: Salvage Material Crate Spawner
   id: SalvageMaterialCrateSpawner
@@ -56,21 +59,21 @@
         - texture: Mobs/Aliens/Carps/space.rsi/icon.png
     - type: RandomSpawner
       prototypes:
-        - MobCarp
-        - MobCarp
-        - MobCarp
-        - MobCarp
-        - MobCarp
-        - MobTick
-        - MobTick
-        - MobTick
+        - MobCarpSalvage
+        - MobCarpSalvage
+        - MobCarpSalvage
+        - MobCarpSalvage
+        - MobCarpSalvage
+        - MobTickSalvage
+        - MobTickSalvage
+        - MobTickSalvage
         - PlushieCarp
         - DehydratedSpaceCarp
       chance: 0.25
       offset: 0.2
 
 - type: entity #I made this in case someone decided to make a terrifying space tick swarm for salvage. that someone may be me -EG404
-  name: Space Tick Spawner
+  name: Salvage Space Tick Spawner
   id: SpaceTickSpawner
   parent: MarkerBase
   suffix: 100
@@ -81,7 +84,7 @@
         - texture: Mobs/Aliens/Xenos/spacetick.rsi/icon.png
     - type: ConditionalSpawner
       prototypes:
-        - MobTick
+        - MobTickSalvage
 
 - type: entity
   id: SalvageMobSpawner75
@@ -90,14 +93,14 @@
   components:
   - type: RandomSpawner
     prototypes:
-    - MobCarp
-    - MobCarp
-    - MobCarp
-    - MobCarp
-    - MobCarp
-    - MobTick
-    - MobTick
-    - MobTick
+    - MobCarpSalvage
+    - MobCarpSalvage
+    - MobCarpSalvage
+    - MobCarpSalvage
+    - MobCarpSalvage
+    - MobTickSalvage
+    - MobTickSalvage
+    - MobTickSalvage
     - PlushieCarp
     - DehydratedSpaceCarp
     chance: 0.75

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -110,3 +110,15 @@
       - Opaque
   - type: GhostTakeoverAvailable
     name: holocarp
+
+- type: entity
+  id: MobCarpSalvage
+  parent: MobCarp
+  suffix: "Salvage Ruleset"
+  components:
+  - type: GhostTakeoverAvailable
+    name: space carp on salvage wreck
+    description: |
+      Defend the loot inside the salvage wreck!
+  - type: SalvageMobRestrictions
+

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -190,3 +190,5 @@
         Heat : 1 #per second, scales with temperature & other constants
   - type: Bloodstream
     bloodMaxVolume: 150
+  - type: Puller
+

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -190,5 +190,3 @@
         Heat : 1 #per second, scales with temperature & other constants
   - type: Bloodstream
     bloodMaxVolume: 150
-  - type: Puller
-

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -77,7 +77,18 @@
     makeSentient: true
     name: space tick
     description: |
-      If you're a salvage spawn, defend the loot inside!
-      Otherwise, wreak havoc on the station!
+      Wreak havoc on the station!
   - type: ReplacementAccent
     accent: genericAggressive
+
+- type: entity
+  id: MobTickSalvage
+  parent: MobTick
+  suffix: "Salvage Ruleset"
+  components:
+  - type: GhostTakeoverAvailable
+    name: space tick on salvage wreck
+    description: |
+      Defend the loot inside the salvage wreck!
+  - type: SalvageMobRestrictions
+


### PR DESCRIPTION
## About the PR

Written due to popular administrative demand, this:

+ Kills salvage-spawned mobs when the salvage despawns
+ Makes salvage-spawned mobs eligible for deletion when the salvage despawns even if player-occupied
+ Tweaks salvage mob ghost role stuff so that they don't have any of this weird business about "well if you're NOT part of a salvage wreck then go wreak havoc".

This should hopefully keep them from causing too much trouble that the administration decide to flat out remove them.

**Changelog**

:cl:
- tweak: Salvage mobs will now die if they're off the salvage wreck when it despawns.
