### PR TITLE
Adds last pressure direction to atmos debug overlay.

### DIFF
--- a/Content.Client/Atmos/Overlays/AtmosDebugOverlay.cs
+++ b/Content.Client/Atmos/Overlays/AtmosDebugOverlay.cs
@@ -115,17 +115,32 @@ namespace Content.Client.Atmos.Overlays
                                 CheckAndShowBlockDir(AtmosDirection.South);
                                 CheckAndShowBlockDir(AtmosDirection.East);
                                 CheckAndShowBlockDir(AtmosDirection.West);
+
+                                void DrawPressureDirection(
+                                    DrawingHandleWorld handle,
+                                    AtmosDirection d,
+                                    TileRef t,
+                                    Color color)
+                                {
+                                    // Account for South being 0.
+                                    var atmosAngle = d.ToAngle() - Angle.FromDegrees(90);
+                                    var atmosAngleOfs = atmosAngle.ToVec() * 0.4f;
+                                    var tileCentre = new Vector2(t.X + 0.5f, t.Y + 0.5f);
+                                    var basisA = tileCentre;
+                                    var basisB = tileCentre + atmosAngleOfs;
+                                    handle.DrawLine(basisA, basisB, color);
+                                }
+
                                 // -- Pressure Direction --
                                 if (data.PressureDirection != AtmosDirection.Invalid)
                                 {
-                                    // Account for South being 0.
-                                    var atmosAngle = data.PressureDirection.ToAngle() - Angle.FromDegrees(90);
-                                    var atmosAngleOfs = atmosAngle.ToVec() * 0.4f;
-                                    var tileCentre = new Vector2(tile.X + 0.5f, tile.Y + 0.5f);
-                                    var basisA = tileCentre;
-                                    var basisB = tileCentre + atmosAngleOfs;
-                                    drawHandle.DrawLine(basisA, basisB, Color.Blue);
+                                    DrawPressureDirection(drawHandle, data.PressureDirection, tile, Color.Blue);
                                 }
+                                else if (data.LastPressureDirection != AtmosDirection.Invalid)
+                                {
+                                    DrawPressureDirection(drawHandle, data.LastPressureDirection, tile, Color.LightGray);
+                                }
+
                                 // -- Excited Groups --
                                 if (data.InExcitedGroup)
                                 {

--- a/Content.Server/Atmos/EntitySystems/AtmosDebugOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosDebugOverlaySystem.cs
@@ -99,9 +99,10 @@ namespace Content.Server.Atmos.EntitySystems
         private AtmosDebugOverlayData ConvertTileToData(TileAtmosphere? tile)
         {
             var gases = new float[Atmospherics.TotalNumberOfGases];
+
             if (tile?.Air == null)
             {
-                return new AtmosDebugOverlayData(0, gases, AtmosDirection.Invalid, false, tile?.BlockedAirflow ?? AtmosDirection.Invalid);
+                return new AtmosDebugOverlayData(0, gases, AtmosDirection.Invalid, tile?.LastPressureDirection ?? AtmosDirection.Invalid, false, tile?.BlockedAirflow ?? AtmosDirection.Invalid);
             }
             else
             {
@@ -109,7 +110,7 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     gases[i] = tile.Air.GetMoles(i);
                 }
-                return new AtmosDebugOverlayData(tile.Air.Temperature, gases, tile.PressureDirection, tile.ExcitedGroup != null, tile.BlockedAirflow);
+                return new AtmosDebugOverlayData(tile.Air.Temperature, gases, tile.PressureDirection, tile.LastPressureDirection, tile.ExcitedGroup != null, tile.BlockedAirflow);
             }
         }
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -231,6 +231,8 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 HighPressureMovements(atmosphere, tile, bodies, xforms, pressureQuery, metas);
                 tile.PressureDifference = 0f;
+                tile.LastPressureDirection = tile.PressureDirection;
+                tile.PressureDirection = AtmosDirection.Invalid;
                 tile.PressureSpecificTarget = null;
                 atmosphere.HighPressureDelta.Remove(tile);
 

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -59,6 +59,10 @@ namespace Content.Server.Atmos
         [ViewVariables]
         public AtmosDirection PressureDirection;
 
+        // For debug purposes.
+        [ViewVariables]
+        public AtmosDirection LastPressureDirection;
+
         [ViewVariables]
         public GridId GridIndex { get; }
 

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosDebugOverlaySystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosDebugOverlaySystem.cs
@@ -18,14 +18,16 @@ namespace Content.Shared.Atmos.EntitySystems
             public readonly float Temperature;
             public readonly float[] Moles;
             public readonly AtmosDirection PressureDirection;
+            public readonly AtmosDirection LastPressureDirection;
             public readonly bool InExcitedGroup;
             public readonly AtmosDirection BlockDirection;
 
-            public AtmosDebugOverlayData(float temperature, float[] moles, AtmosDirection pressureDirection, bool inExcited, AtmosDirection blockDirection)
+            public AtmosDebugOverlayData(float temperature, float[] moles, AtmosDirection pressureDirection, AtmosDirection lastPressureDirection, bool inExcited, AtmosDirection blockDirection)
             {
                 Temperature = temperature;
                 Moles = moles;
                 PressureDirection = pressureDirection;
+                LastPressureDirection = lastPressureDirection;
                 InExcitedGroup = inExcited;
                 BlockDirection = blockDirection;
             }


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Atmos debug overlay now shows last pressure direction as a grey line.

**Screenshots**
Blue = active pressure difference
Gray = last pressure difference

![Peek 10-05-2022 15-20](https://user-images.githubusercontent.com/6766154/167637987-2ef0bf81-1dd0-4a28-bff9-8c7be8d9a81d.gif)

