### PR TITLE
Delta Decal Update 2

### DIFF
--- a/Resources/Prototypes/Maps/delta.yml
+++ b/Resources/Prototypes/Maps/delta.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/delta.yml
   minPlayers: 60
   stations:
-    Station: Delta
+    Delta:
       mapNameTemplate: '{0} Delta Station {1}'
       nameGenerator:
         !type:NanotrasenNameGenerator

--- a/Resources/Prototypes/Maps/delta.yml
+++ b/Resources/Prototypes/Maps/delta.yml
@@ -4,11 +4,11 @@
   mapPath: /Maps/delta.yml
   minPlayers: 60
   stations:
-    Station: #TODO: Mapper, add a BecomesStation component to the primary grid of the map.
+    Station: Delta
       mapNameTemplate: '{0} Delta Station {1}'
       nameGenerator:
         !type:NanotrasenNameGenerator
-        prefixCreator: '14'
+        prefixCreator: 'TG'
       overflowJobs:
         - Passenger
       availableJobs:
@@ -39,3 +39,8 @@
         SalvageSpecialist: [ 3, 3 ]
         Musician: [ 2, 2 ]
         AtmosphericTechnician: [ 1, 2 ]
+        TechnicalAssistant: [ 1, 2 ]
+        MedicalIntern: [ 1, 2 ]
+        ServiceWorker: [ 1, 2 ]
+        SecurityCadet: [ 1, 2 ]
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR does a number of things to Delta:

- Decals the entire medical wing, plus virology.
- Names all the airlocks in virology.
- Does a basic decal run of Engineering (but not Atmos as 75% of Atmos is plating). I still need decals that aren't available yet.
- Fixes a wiring issue in Delta's escape wing.
- Does a decal run of the hallway outside Engineering, including Tool Storage.
- Adds the new intern roles to Delta.
- Makes Delta compliant with the new BecomesStationComponent requirements.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/7907891/167751253-f69a8202-4818-41e1-ae62-186540158a2b.png)

![image](https://user-images.githubusercontent.com/7907891/167751279-f28e63fe-c579-462f-bf9d-21af0212eee7.png)

![image](https://user-images.githubusercontent.com/7907891/167751331-5ed87f98-d3a0-4a80-a965-403414e9ad68.png)

![image](https://user-images.githubusercontent.com/7907891/167751351-3f841939-902a-4412-bc85-dfeefde215ae.png)

![image](https://user-images.githubusercontent.com/7907891/167751382-7d4834f8-cf2f-4dd4-a109-c0f66e2930b5.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Several areas on Delta Station now have decals.
- add: Interns can now spawn on Delta Station.
- tweak: Delta Station's wiring should be more stable than before.
