### PR TITLE
Adjust EnteringRange for EntityStorage

### DIFF
--- a/Content.Server/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Server/Storage/Components/EntityStorageComponent.cs
@@ -61,7 +61,7 @@ namespace Content.Server.Storage.Components
 
         [ViewVariables]
         [DataField("EnteringRange")]
-        private float _enteringRange = -0.4f;
+        private float _enteringRange = -0.18f;
 
         [DataField("showContents")]
         private bool _showContents;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Simply adjusts the EnteringRange for EntityStorage from -0.4 to -0.18
This is to help make it so the "accidentally putting yourself in a closet/crate" happens less likely

Below is demonstrating the difference between -0.4 and -0.18.

_inb4 why not -0.2_

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
https://user-images.githubusercontent.com/1261392/167761172-c5908a60-edce-4e25-888a-2ec7fe5955ac.mp4


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: You are now less likely to accidentally stuff yourself in a closet or crate.

