### PR TITLE
Suicide2

### DIFF
--- a/Content.Server/Chat/Commands/SuicideCommand.cs
+++ b/Content.Server/Chat/Commands/SuicideCommand.cs
@@ -1,35 +1,15 @@
-using System.Linq;
-using Content.Server.Act;
-using Content.Server.Administration.Logs;
-using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
-using Content.Server.Hands.Components;
 using Content.Server.Players;
-using Content.Server.Popups;
 using Content.Shared.Administration;
-using Content.Shared.Damage;
-using Content.Shared.Damage.Prototypes;
-using Content.Shared.Database;
-using Content.Shared.Item;
-using Content.Shared.Popups;
-using Content.Shared.Tag;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
-using Content.Shared.MobState.Components;
 
 namespace Content.Server.Chat.Commands
 {
     [AnyCommand]
     internal sealed class SuicideCommand : IConsoleCommand
     {
-        [Dependency] private readonly IEntityManager _entities = default!;
-
         public string Command => "suicide";
 
         public string Description => Loc.GetString("suicide-command-description");
@@ -38,7 +18,37 @@ namespace Content.Server.Chat.Commands
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            EntitySystem.Get<SuicideSystem>().Suicide(shell);
+            if (shell.Player is not IPlayerSession player)
+            {
+                shell.WriteLine(Loc.GetString("shell-cannot-run-command-from-server"));
+                return;
+            }
+
+            if (player.Status != SessionStatus.InGame || player.AttachedEntity == null)
+                return;
+            var mind = player.ContentData()?.Mind;
+
+            // This check also proves mind not-null for at the end when the mob is ghosted.
+            if (mind?.OwnedComponent?.Owner is not { Valid: true } victim)
+            {
+                shell.WriteLine("You don't have a mind!");
+                return;
+            }
+            var gameTicker = EntitySystem.Get<GameTicker>();
+            var suicideSystem = EntitySystem.Get<SuicideSystem>();
+            if (suicideSystem.Suicide(victim))
+            {
+                // Prevent the player from returning to the body.
+                // Note that mind cannot be null because otherwise victim would be null.
+                gameTicker.OnGhostAttempt(mind!, false);
+                return;
+            }
+
+            if (gameTicker.OnGhostAttempt(mind, true))
+                return;
+
+            shell?.WriteLine("You can't ghost right now.");
+
         }
     }
 }

--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -154,7 +154,7 @@ namespace Content.Server.GameTicking
             if (handleEv.Handled)
                 return handleEv.Result;
 
-            var playerEntity = mind.OwnedEntity;
+            var playerEntity = mind.CurrentEntity;
 
             var entities = IoCManager.Resolve<IEntityManager>();
             if (entities.HasComponent<GhostComponent>(playerEntity))


### PR DESCRIPTION
## About the PR
I fixed toilet suicides, which I broke.
I fixed a bug with OnGhostAttempt, it was looking at the OwnedEntity to find the ghost component, which is the dead thing, not the CurrentEntity, which is the ghost.
I changed how suicide works a little bit
- If the suicide command can't kill you, it will always try to ghost you, instead of just sometimes.
- The suicide system can try to suicide anything now, it doesn't need to be a player with a mind.
- If the mob is critical, suicide will use the default suicide, because I figure if your laying on the ground, you probably shouldn't be able to use the environment to die. This won't fix stunning, or things like that, but I already had the mob state, and it's better then nothing.