### PR TITLE
Added the TechFabCircuitboards and made them spawn in the head's lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -128,6 +128,7 @@
       - id: HandheldCrewMonitor
       - id: DoorRemoteMedical
       - id: RubberStampCMO
+      - id: MedicalTechFabCircuitboard
 
 - type: entity
   id: LockerResearchDirectorFilled
@@ -185,3 +186,4 @@
       - id: ClothingUniformJumpskirtHosFormal
       - id: ClothingUniformJumpsuitHosFormal
       - id: RubberStampHos
+      - id: SecurityTechFabCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -30,6 +30,40 @@
           ExamineName: Glass Beaker
 
 - type: entity
+  id: SecurityTechFabCircuitboard
+  parent: BaseMachineCircuitboard
+  name: security techfab machine board
+  description: A machine printed circuit board for a security techfab
+  components:
+    - type: MachineBoard
+      prototype: SecurityTechFab
+      requirements:
+        MatterBin: 2
+        Manipulator: 2
+      tagRequirements:
+        GlassBeaker:
+          Amount: 2
+          DefaultPrototype: Beaker
+          ExamineName: Glass Beaker
+
+- type: entity
+  id: MedicalTechFabCircuitboard
+  parent: BaseMachineCircuitboard
+  name: medical techfab machine board
+  description: A machine printed circuit board for a medical techfab
+  components:
+    - type: MachineBoard
+      prototype: MedicalTechFab
+      requirements:
+        MatterBin: 2
+        Manipulator: 2
+      tagRequirements:
+        GlassBeaker:
+          Amount: 2
+          DefaultPrototype: Beaker
+          ExamineName: Glass Beaker
+
+- type: entity
   id: CircuitImprinterMachineCircuitboard
   parent: BaseMachineCircuitboard
   name: circuit imprinter machine board

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -319,6 +319,8 @@
       - TimerTrigger
       - Signaller
       - SignalTrigger
+  - type: Machine
+    board: SecurityTechFabCircuitboard
   - type: Lathe
     whitelist:
       tags:
@@ -384,6 +386,8 @@
       - CableStack
       - CableMVStack
       - CableHVStack
+  - type: Machine
+    board: MedicalTechFabCircuitboard
 
 - type: entity
   parent: Autolathe


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
After deconstructing the tech fabs you will get their circuit boards , and now they will spawn in head's lockers in case the original one is destoryed or the map doesn't spawn with one
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:

