### PR TITLE
Airlocks now trap air in their tile.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -69,6 +69,7 @@
       type: WiresBoundUserInterface
   - type: Airtight
     fixVacuum: true
+    noAirWhenFullyAirBlocked: false
   - type: Occluder
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -88,6 +88,7 @@
           type: WiresBoundUserInterface
     - type: Airtight
       fixVacuum: true
+      noAirWhenFullyAirBlocked: true
     - type: Occluder
     - type: Construction
       graph: Firelock


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #8135, but at what cost.....
This means that airlocks can now also trap plasma/a fire in their tile, even when they're closed. Oops!
Firelock behavior remains the same, for obvious reasons.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![Peek_13-05-2022_13-32](https://user-images.githubusercontent.com/6766154/168275141-a801ff4d-f97f-4a95-98d7-66d16390b817.gif)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Closed airlocks now trap air in their tile, meaning mice can now go under airlocks safely.

