### PR TITLE
Add a redial button

### DIFF
--- a/Content.Client/Launcher/LauncherConnecting.cs
+++ b/Content.Client/Launcher/LauncherConnecting.cs
@@ -88,6 +88,14 @@ namespace Content.Client.Launcher
             }
         }
 
+        public void Redial()
+        {
+            if (_gameController.LaunchState.Ss14Address != null)
+            {
+                _gameController.Redial(_gameController.LaunchState.Ss14Address, Loc.GetString("connecting-redial-reason-user"));
+            }
+        }
+
         public void Exit()
         {
             _gameController.Shutdown("Exit button pressed");

--- a/Content.Client/Launcher/LauncherConnectingGui.xaml
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml
@@ -23,16 +23,18 @@
                     </BoxContainer>
                     <BoxContainer Orientation="Vertical" Name="ConnectFail" Visible="False">
                         <Label Name="ConnectFailReason" Align="Center" />
-                        <Button Name="RetryButton" Text="{Loc 'connecting-retry'}"
-                                HorizontalAlignment="Center"
-                                VerticalExpand="True" VerticalAlignment="Bottom" />
+                        <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" VerticalExpand="True" VerticalAlignment="Bottom">
+                            <Button Name="RetryButton" Text="{Loc 'connecting-retry'}"/>
+                            <Button Name="RedialButton" Text="{Loc 'connecting-redial'}"/>
+                        </BoxContainer>
                     </BoxContainer>
                     <BoxContainer Orientation="Vertical" Name="Disconnected">
                         <Label Text="{Loc 'connecting-disconnected'}" Align="Center" />
                         <Label Name="DisconnectReason" Align="Center" />
-                        <Button Name="ReconnectButton" Text="{Loc 'connecting-reconnect'}"
-                                HorizontalAlignment="Center"
-                                VerticalExpand="True" VerticalAlignment="Bottom" />
+                        <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" VerticalExpand="True" VerticalAlignment="Bottom">
+                            <Button Name="ReconnectButton" Text="{Loc 'connecting-reconnect'}"/>
+                            <Button Name="Redial2Button" Text="{Loc 'connecting-redial'}"/>
+                        </BoxContainer>
                     </BoxContainer>
                 </Control>
                 <Label Name="ConnectingAddress" StyleClasses="LabelSubText" HorizontalAlignment="Center" />

--- a/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
@@ -26,6 +26,8 @@ namespace Content.Client.Launcher
 
             ReconnectButton.OnPressed += _ => _state.RetryConnect();
             RetryButton.OnPressed += _ => _state.RetryConnect();
+            RedialButton.OnPressed += _ => _state.Redial();
+            Redial2Button.OnPressed += _ => _state.Redial();
             ExitButton.OnPressed += _ => _state.Exit();
 
             var addr = state.Address;

--- a/Resources/Locale/en-US/launcher/launcher-connecting.ftl
+++ b/Resources/Locale/en-US/launcher/launcher-connecting.ftl
@@ -3,6 +3,7 @@
 connecting-title = Space Station 14
 connecting-exit = Exit
 connecting-retry = Retry
+connecting-redial = Redial
 connecting-reconnect = Reconnect
 connecting-in-progress = Connecting to server...
 connecting-disconnected = Disconnected from server:
@@ -15,3 +16,6 @@ connecting-state-ResolvingHost = Resolving host
 connecting-state-EstablishingConnection = Establishing connection
 connecting-state-Handshake = Handshake
 connecting-state-Connected = Connected
+
+connecting-redial-reason-user = Redialling by user request...
+

--- a/Resources/Locale/en-US/launcher/launcher-connecting.ftl
+++ b/Resources/Locale/en-US/launcher/launcher-connecting.ftl
@@ -3,7 +3,7 @@
 connecting-title = Space Station 14
 connecting-exit = Exit
 connecting-retry = Retry
-connecting-redial = Redial
+connecting-redial = Reload
 connecting-reconnect = Reconnect
 connecting-in-progress = Connecting to server...
 connecting-disconnected = Disconnected from server:
@@ -17,5 +17,5 @@ connecting-state-EstablishingConnection = Establishing connection
 connecting-state-Handshake = Handshake
 connecting-state-Connected = Connected
 
-connecting-redial-reason-user = Redialling by user request...
+connecting-redial-reason-user = Restarting client by user request...
 

--- a/Resources/Locale/en-US/launcher/launcher-connecting.ftl
+++ b/Resources/Locale/en-US/launcher/launcher-connecting.ftl
@@ -3,7 +3,7 @@
 connecting-title = Space Station 14
 connecting-exit = Exit
 connecting-retry = Retry
-connecting-redial = Reload
+connecting-redial = Relaunch
 connecting-reconnect = Reconnect
 connecting-in-progress = Connecting to server...
 connecting-disconnected = Disconnected from server:


### PR DESCRIPTION
## About the PR

Adds a redial button. Name subject to change, and it might even be an idea to just use this as the reconnect button depending on the disconnect reason.
(It very much depends on if RT can be made to divine if a disconnect is "redial-worthy" like a server shutdown or a key failure... Or if it doesn't matter.)

**Screenshots**
![image](https://user-images.githubusercontent.com/22304167/168347033-c2622f7d-89df-4c6f-8bc0-de359aae3b33.png)

**Changelog**

:cl:
- add: "Redial" button to cause a reconnect-from-launcher without you having to go to the launcher yourself.
