### PR TITLE
Splitstation update and fixes

### DIFF
--- a/Resources/Prototypes/Maps/splitstation.yml
+++ b/Resources/Prototypes/Maps/splitstation.yml
@@ -1,11 +1,10 @@
 - type: gameMap
-  id: splitstation
+  id: SplitStation
   mapName: 'Split Station'
   mapPath: /Maps/splitstation.yml
   minPlayers: 40
-  votable: false
   stations:
-    Dart: #TODO: Mapper, fix this name in your map file. (just change the name for every grid with a BecomesStation or PartOfStation component.)
+    Split:
       mapNameTemplate: '{0} Split Station {1}'
       nameGenerator:
         !type:NanotrasenNameGenerator
@@ -13,7 +12,6 @@
       overflowJobs:
         - Passenger
       availableJobs:
-        CargoTechnician: [ 3, 6 ]
         Passenger: [ -1, -1 ]
         Bartender: [ 2, 3 ]
         Botanist: [ 3, 6]
@@ -21,26 +19,27 @@
         Clown: [ 1, 2 ]
         Janitor: [ 2, 4 ]
         Mime: [ 1, 2 ]
+        Chaplain: [ 1, 1 ]
+        Librarian: [ 1, 1 ]
+        Musician: [ 1, 1 ]
+        ServiceWorker: [ 2, 2 ]
         Captain: [ 1, 1 ]
         HeadOfPersonnel: [ 1, 1 ]
         ChiefEngineer: [ 1, 1 ]
         StationEngineer: [ 6, 8 ]
+        AtmosphericTechnician: [ 1, 2 ]
+        TechnicalAssistant: [ 2, 2 ]
         ChiefMedicalOfficer: [ 1, 1 ]
         MedicalDoctor: [ 3, 8 ]
         Chemist: [ 2, 3 ]
+        MedicalIntern: [ 2, 2 ]
         ResearchDirector: [ 1, 1 ]
         Scientist: [ 3, 6 ]
         HeadOfSecurity: [ 1, 1 ]
-        SecurityOfficer: [ 8, 10 ]
-        Chaplain: [ 1, 1 ]
         Warden: [ 1, 1 ]
-        Librarian: [ 1, 1 ]
+        SecurityOfficer: [ 8, 10 ]
+        SecurityCadet: [ 2, 2 ]
         Lawyer: [ 2, 2 ]
         Quartermaster: [ 1, 1 ]
+        CargoTechnician: [ 3, 6 ]
         SalvageSpecialist: [ 4, 6 ]
-        Musician: [ 1, 1 ]
-        AtmosphericTechnician: [ 1, 2 ]
-        TechnicalAssistant: [ 2, 2 ]
-        MedicalIntern: [ 2, 2 ]
-        ServiceWorker: [ 2, 2 ]
-        SecurityCadet: [ 2, 2 ]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixed roundstart atmos issue which affected the last version I pushed out in a rush (and connected the spawn shuttle to the stations atmos and power so no more issues there). Tested locally and checked against my QC checklist, no issues found.

Also fleshed out a bunch of maint rooms and done some big changes to the left side of the station maint. See changelog below:

- Fixed the spawn shuttle with connected atmos and lighting.
- Fixed disconnected APC below bridge.
- Added more lighting to darker areas of maint and in various places across the map.
- **Moved the left maint connection further into the center and redesigned the maint around those areas (new shop and hangar to explore).**
- Swapped cloning and staff room in medbay so things are closer together. Paramedic void suit and added a sign to further make the point of NOT using the top entrance outside of events.
- **Modified HV grid so now top station has a HV cable for the generation - this means top station has a 3 SMES battery bank on the same circuit as the lower SMES battery bank (on the same circuit). Thus splitting the station will mean top station has it's own power storage. Power outage time will take longer now with the extra SMES.**
- Added a derelict boxing ring to maint.
- Added more fluff stuff and changs vendors.
- Added another secret firefighter shrine to the rocks.
- 1st stab at a highlander room.
- Rat man hideout.
- More flavour rooms in maint in general.
- Added station map posters and random painting spawners.
- Some minor decal grime added throughout, some glass tiles in bar and other misc bits and pieces.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
Not spoiling all the surprises so just some of the changes:
**Medbay switcheroo**
![medbay](https://user-images.githubusercontent.com/78795277/168364909-ff5e5bb5-8ac6-454b-9ff7-1c282e29a375.JPG)
Top station SMES bank. Low left is the new derelict hangar.
![substation](https://user-images.githubusercontent.com/78795277/168365660-5c50152e-53ef-4d35-b000-4cdd308e7f5b.JPG)
Left maint connection and new shop.
![left maint](https://user-images.githubusercontent.com/78795277/168366044-2220757c-cb33-4520-9c8c-6c2a5d22aeea.JPG)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Splitstation big update. Lots of minor fixes, lots of new maint rooms and a new hidden area in the rocks. More drip, medbay changes and redesign of west station maint.
