### PR TITLE
From 500 to 2000u

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -15,7 +15,7 @@
   - type: SolutionContainerManager
     solutions:
       tank:
-        maxVol: 500
+        maxVol: 2000
   - type: DrainableSolution
     solution: tank
   - type: ReagentTank
@@ -31,7 +31,7 @@
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 500
+          Quantity: 2000
 
 - type: entity
   name: wide sink


### PR DESCRIPTION
I made this PR because I noticed botany ran out of water one fifth into the round and with the help of the kitchen bros they lasted one third. The remaining time was supplemented with mobile water tanks.
I suggest we increase the capacity of sinks fourfold without having to make anything more complicated. Alternatively, tweak large sinks to 2000u and regular sinks to 1000u.

If there is any mechanic planned to tackle the issue, please bring me up to speed! Thanks