### PR TITLE
Harmbaton rework + remove `MeleeInteractEvent`

### DIFF
--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -30,7 +30,6 @@ namespace Content.Server.Flash
         {
             base.Initialize();
             SubscribeLocalEvent<FlashComponent, MeleeHitEvent>(OnFlashMeleeHit);
-            SubscribeLocalEvent<FlashComponent, MeleeInteractEvent>(OnFlashMeleeInteract);
             SubscribeLocalEvent<FlashComponent, UseInHandEvent>(OnFlashUseInHand);
             SubscribeLocalEvent<FlashComponent, ExaminedEvent>(OnFlashExamined);
 
@@ -76,20 +75,6 @@ namespace Content.Server.Flash
             foreach (var e in args.HitEntities)
             {
                 Flash(e, args.User, uid, comp.FlashDuration, comp.SlowTo);
-            }
-        }
-
-        private void OnFlashMeleeInteract(EntityUid uid, FlashComponent comp, MeleeInteractEvent args)
-        {
-            if (!UseFlash(comp, args.User))
-            {
-                return;
-            }
-
-            if (EntityManager.HasComponent<FlashableComponent>(args.Entity))
-            {
-                args.CanInteract = true;
-                Flash(args.Entity, args.User, uid, comp.FlashDuration, comp.SlowTo);
             }
         }
 

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -38,7 +38,6 @@ namespace Content.Server.Weapon.Melee
             SubscribeLocalEvent<MeleeWeaponComponent, HandSelectedEvent>(OnHandSelected);
             SubscribeLocalEvent<MeleeWeaponComponent, ClickAttackEvent>(OnClickAttack);
             SubscribeLocalEvent<MeleeWeaponComponent, WideAttackEvent>(OnWideAttack);
-            SubscribeLocalEvent<MeleeWeaponComponent, AfterInteractEvent>(OnAfterInteract);
             SubscribeLocalEvent<MeleeChemicalInjectorComponent, MeleeHitEvent>(OnChemicalInjectorHit);
         }
 
@@ -204,41 +203,6 @@ namespace Content.Server.Weapon.Melee
             RaiseLocalEvent(owner, new RefreshItemCooldownEvent(comp.LastAttackTime, comp.CooldownEnd), false);
         }
 
-        /// <summary>
-        ///     Used for melee weapons that want some behavior on AfterInteract,
-        ///     but also want the cooldown (stun batons, flashes)
-        /// </summary>
-        private void OnAfterInteract(EntityUid owner, MeleeWeaponComponent comp, AfterInteractEvent args)
-        {
-            if (args.Handled || !args.CanReach)
-                return;
-
-            var curTime = _gameTiming.CurTime;
-
-            if (curTime < comp.CooldownEnd)
-            {
-                return;
-            }
-
-            if (!args.Target.HasValue)
-                return;
-
-            var location = EntityManager.GetComponent<TransformComponent>(args.User).Coordinates;
-            var diff = args.ClickLocation.ToMapPos(EntityManager) - location.ToMapPos(EntityManager);
-            var angle = Angle.FromWorldVec(diff);
-
-            var hitEvent = new MeleeInteractEvent(args.Target.Value, args.User);
-            RaiseLocalEvent(owner, hitEvent, false);
-
-            if (!hitEvent.CanInteract) return;
-            SendAnimation(comp.ClickArc, angle, args.User, owner, new List<EntityUid>() { args.Target.Value }, comp.ClickAttackEffect, false);
-
-            comp.LastAttackTime = curTime;
-            comp.CooldownEnd = comp.LastAttackTime + TimeSpan.FromSeconds(comp.CooldownTime);
-
-            RaiseLocalEvent(owner, new RefreshItemCooldownEvent(comp.LastAttackTime, comp.CooldownEnd), false);
-        }
-
         private HashSet<EntityUid> ArcRayCast(Vector2 position, Angle angle, float arcWidth, float range, MapId mapId, EntityUid ignore)
         {
             var widthRad = Angle.FromDegrees(arcWidth);
@@ -345,35 +309,6 @@ namespace Content.Server.Weapon.Melee
         public MeleeHitEvent(List<EntityUid> hitEntities, EntityUid user)
         {
             HitEntities = hitEntities;
-            User = user;
-        }
-    }
-
-    /// <summary>
-    ///     Raised directed on the melee weapon entity used to attack something in combat mode,
-    ///     whether through a click attack or wide attack.
-    /// </summary>
-    public sealed class MeleeInteractEvent : EntityEventArgs
-    {
-        /// <summary>
-        ///     The entity interacted with.
-        /// </summary>
-        public EntityUid Entity { get; }
-
-        /// <summary>
-        ///     The user who interacted using the melee weapon.
-        /// </summary>
-        public EntityUid User { get; }
-
-        /// <summary>
-        ///     Modified by the event handler to specify whether they could successfully interact with the entity.
-        ///     Used to know whether to send the hit animation or not.
-        /// </summary>
-        public bool CanInteract { get; set; } = false;
-
-        public MeleeInteractEvent(EntityUid entity, EntityUid user)
-        {
-            Entity = entity;
             User = user;
         }
     }

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -11,7 +11,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 5
     range: 1.5
     arcwidth: 60
     arc: default


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Motivation:
- Some melee weapons retaining effect even in non combat-mode is unintuitive
    - This leads to harmbatoning, as new players (rightly) assume that the item will only have effect in combat mode and end up beating someone with it
- Harmbatoning is overly strong, considering the baton's damage and its stunlock + damage combo

Solution:
- Remove melee weapons having effect on interact entirely, including stunbatons and flashes. Makes it clearer that you -need- to be in combat mode for special interactions to take place.
- If a stunbaton succeeds to stun someone, it will not deal any damage. This allows you to still use it for harm, but only if you want to forgo the stun.
- Reduce the stunbaton harm damage.

:cl:
- tweak: Flashes and stunbatons now only have effect in combat mode.
- tweak: Stunbatons will no longer hurt people in combat mode, if they successfully stun them. Harmbatoning is no longer possible while stunning at the same time.
- tweak: Stunbaton damage reduced.

