### PR TITLE
Individual bar sign entities

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -2,7 +2,7 @@
   id: BarSign
   parent: BaseStructure
   name: bar sign
-  suffix: [Random]
+  suffix: Random
   components:
   - type: WallMount
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -2,6 +2,7 @@
   id: BarSign
   parent: BaseStructure
   name: bar sign
+  suffix: [Random]
   components:
   - type: WallMount
   - type: Sprite
@@ -34,11 +35,201 @@
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
   - type: BarSign
+   
+- type: entity
+  id: BarSignComboCafe
+  name: Combo Cafe
+  description: Renowned system-wide for their utterly uncreative drink combinations.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: ComboCafe
+   
+- type: entity
+  id: BarSignEmergencyRumParty
+  name: Emergency Rum Party
+  description: Recently relicensed after a long closure.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: EmergencyRumParty
 
+- type: entity
+  id: BarSignLV426
+  name: LV426
+  description: Drinking with fancy facemasks is clearly more important than going to medbay.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: LV426
+
+- type: entity
+  id: BarSignMaidCafe
+  name: Maid Cafe
+  description: Welcome back, master!
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: MaidCafe
+    
+- type: entity
+  id: BarSignMalteseFalcon
+  name: Maltese Falcon
+  description: Play it again, sam.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: MalteseFalcon
+
+- type: entity
+  id: BarSignOfficerBeersky
+  name: Officer Beersky
+  description: Man eat a dong, these drinks are great.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: OfficerBeersky
+
+- type: entity
+  id: BarSignRobustaCafe
+  name: Robusta Cafe
+  description: Holder of the 'Most Lethal Barfights' record 5 years uncontested.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: RobustaCafe
+
+- type: entity
+  id: BarSignTheAleNath
+  name: The Ale Nath
+  description: All right, buddy. I think you've had EI NATH. Time to get a cab.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheAleNath
+
+- type: entity
+  id: BarSignTheBirdCage
+  name: The Bird Cage
+  description: Caw caw!
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheBirdCage
+
+- type: entity
+  id: BarSignTheCoderbus
+  name: The Coderbus
+  description: A very controversial bar known for its wide variety of constantly-changing drinks.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheCoderbus
+    
+- type: entity
+  id: BarSignTheDrunkCarp
+  name: The Drunk Carp
+  description: Don't drink and swim.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheDrunkCarp
+    
 - type: entity
   id: BarSignEngineChange
   name: The Engine Change
+  description: Still waiting.
   parent: BarSign
   components:
   - type: BarSign
     current: EngineChange
+    
+- type: entity
+  id: BarSignTheHarmbaton
+  name: The Harmbaton
+  description: A great dining experience for both security members and passengers.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: Harmbaton
+    
+- type: entity
+  id: BarSignTheLightbulb
+  name: The Lightbulb
+  description: A cafe popular among moths and moffs. Once shut down for a week after the bartender used mothballs to protect her spare uniforms.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheLightbulb
+    
+- type: entity
+  id: BarSignTheLooseGoose
+  name: The Loose Goose
+  description: Drink till you puke and/or break the laws of reality!
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheLooseGoose
+
+- type: entity
+  id: BarSignTheNet
+  name: The Net
+  description: You just seem to get caught up in it for hours.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheNet
+ 
+- type: entity
+  id: BarSignTheOuterSpess
+  name: The Outer Spess
+  description: This bar isn't actually located in outer space.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheOuterSpess
+    
+- type: entity
+  id: BarSignTheSingulo
+  name: The Singulo
+  description: Where people go that'd rather not be called by their name.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheSingulo
+    
+- type: entity
+  id: BarSignTheSun
+  name: The Sun
+  description: Ironically bright for such a shady bar.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: TheSun
+   
+- type: entity
+  id: BarSignWiggleRoom
+  name: Wiggle Room
+  description: MoMMIs got moves.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: WiggleRoom
+   
+- type: entity
+  id: BarSignZocalo
+  name: Zocalo
+  description: Anteriormente ubicado en Spessmerica.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: Zocalo
+    
+- type: entity
+  id: BarSignEmprah
+  name: 4 The Emprah
+  description: Enjoyed by fanatics, heretics, and brain-damaged patrons alike.
+  parent: BarSign
+  components:
+  - type: BarSign
+    current: Emprah

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/bar_sign.yml
@@ -169,7 +169,7 @@
   parent: BarSign
   components:
   - type: BarSign
-    current: TheLooseGoose
+    current: Goose
 
 - type: entity
   id: BarSignTheNet

--- a/Resources/Prototypes/bar_signs.yml
+++ b/Resources/Prototypes/bar_signs.yml
@@ -113,7 +113,7 @@
   description: barsign-prototype-description-the-lightbulb
 
 - type: barSign
-  id: TheLooseGoose
+  id: Goose
   name: barsign-prototype-name-goose
   icon: "goose"
   description: barsign-prototype-description-goose

--- a/Resources/Prototypes/bar_signs.yml
+++ b/Resources/Prototypes/bar_signs.yml
@@ -113,7 +113,7 @@
   description: barsign-prototype-description-the-lightbulb
 
 - type: barSign
-  id: Goose
+  id: TheLooseGoose
   name: barsign-prototype-name-goose
   icon: "goose"
   description: barsign-prototype-description-goose


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Noticed we had a choice of The Engine Change or a random bar sign spawner.

Made it so every bar sign now has it's own entity so people can make themed salvages and bars that are consistent.

The barsign component for some reason does not pull the localised name and description so these have been manually filled out. Probably affects the desciptions for it being off and EMP'd too.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![bar signs](https://user-images.githubusercontent.com/78795277/168418230-dc827a0c-82da-44d4-8e7f-60a93a1a5601.JPG)
