### PR TITLE
Make Lobby Background Not Stretch

### DIFF
--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -13,7 +13,7 @@
     <Control>
         <!-- Parallax background -->
         <parallax:ParallaxControl />
-        <TextureRect Access="Public" Name = "Background" Stretch="Scale"/>
+        <TextureRect Access="Public" Name = "Background" Stretch="KeepAspectCentered"/>
         <Control Margin="10 10 10 10" >
             <!-- Left Top Panel -->
                 <PanelContainer StyleClasses="AngleRect" HorizontalAlignment="Left" Name = "LeftSideTop" VerticalExpand="True"  VerticalAlignment="Top" >

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -11,9 +11,8 @@
          xmlns:lobbyUi="clr-namespace:Content.Client.Lobby.UI"
          xmlns:info="clr-namespace:Content.Client.Info">
     <Control>
-        <!-- Parallax background -->
-        <parallax:ParallaxControl />
-        <TextureRect Access="Public" Name = "Background" Stretch="KeepAspectCentered"/>
+        <!-- Background -->
+        <TextureRect Access="Public" Name = "Background" Stretch="KeepAspectCovered"/>
         <Control Margin="10 10 10 10" >
             <!-- Left Top Panel -->
                 <PanelContainer StyleClasses="AngleRect" HorizontalAlignment="Left" Name = "LeftSideTop" VerticalExpand="True"  VerticalAlignment="Top" >


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> 
Fixes #7558
Simple attribute change to tweak how the background is stretch on the lobby.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

Default window size:
<img width="1321" alt="Screen Shot 2022-05-14 at 11 23 44 AM" src="https://user-images.githubusercontent.com/8183999/168440395-b067667d-c7e2-45c0-bdbd-94c07f0268c4.png">


Squished window size:
<img width="1321" alt="Screen Shot 2022-05-14 at 11 24 02 AM" src="https://user-images.githubusercontent.com/8183999/168440402-2751e02d-cf6a-4aae-9bc2-cd40270c60f0.png">


Smaller but sane window dimensions
<img width="916" alt="Screen Shot 2022-05-14 at 11 28 22 AM" src="https://user-images.githubusercontent.com/8183999/168440520-36ac7dc0-b7fe-426c-80a2-e5d6822b1dd6.png">



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->


:cl:
- tweak: made lobby background keep aspect when stretching

