### PR TITLE
Asteroid buff

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -7,6 +7,7 @@
     Shock: 1.2
   flatReductions:
     Blunt: 5
+    Heat: 5
 
 # Like metallic, but without flat reduction so it can be damaged with fists.
 - type: damageModifierSet

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -15,11 +15,12 @@
     state: full
   - type: Damageable
     damageContainer: Inorganic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 150
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title. People are cutting their way through asteroids with a lit welder.

Personally I think this is jank and detracts from trying to guide people through a map. They can use a pickaxe if they want to mine rather than obscure tools that do high damage.

Solution: Buffed asteroid health up by 50 points but more importantly set the damage modifier set to Metallic and gave it a base reduction of 5 to heat so welders should be far less effective.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Asteroids are now more robust. Use a pickaxe to break them instead of a welder...please.
