### PR TITLE
Cleanup WeightlessSystem

### DIFF
--- a/Content.Server/Gravity/EntitySystems/WeightlessSystem.cs
+++ b/Content.Server/Gravity/EntitySystems/WeightlessSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Gravity.EntitySystems
 
             SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<GravityChangedMessage>(GravityChanged);
-            SubscribeLocalEvent<EntParentChangedMessage>(EntParentChanged);
+            SubscribeLocalEvent<AlertsComponent, EntParentChangedMessage>(EntParentChanged);
             SubscribeLocalEvent<AlertsComponent, AlertSyncEvent>(HandleAlertSyncEvent);
         }
 
@@ -94,13 +94,8 @@ namespace Content.Server.Gravity.EntitySystems
             _alertsSystem.ClearAlert(euid, AlertType.Weightless);
         }
 
-        private void EntParentChanged(ref EntParentChangedMessage ev)
+        private void EntParentChanged(EntityUid uid, AlertsComponent status, ref EntParentChangedMessage ev)
         {
-            if (!EntityManager.TryGetComponent(ev.Entity, out AlertsComponent? status))
-            {
-                return;
-            }
-
             if (ev.OldParent is {Valid: true} old &&
                 EntityManager.TryGetComponent(old, out IMapGridComponent? mapGrid))
             {

--- a/Content.Server/Gravity/EntitySystems/WeightlessSystem.cs
+++ b/Content.Server/Gravity/EntitySystems/WeightlessSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Alert;
 using Content.Shared.GameTicking;
 using Content.Shared.Gravity;
+using Content.Shared.Movement.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Map;
 using Robust.Shared.Utility;
@@ -113,13 +114,15 @@ namespace Content.Server.Gravity.EntitySystems
 
             newStatuses.Add(status);
 
-            // then update the actual alert.
-            // only showing the alert is the user is on a grid that is explicitly missing gravity.
-            if (!_mapManager.TryGetGrid(newGrid, out var grid)
-                || !TryComp(grid.GridEntityId, out GravityComponent? gravity)
-                || gravity.Enabled)
+            // then update the actual alert. The alert is only removed if either the player is on a grid with gravity,
+            // or if they ignore gravity-based movement altogether.
+            // TODO: update this when planets and the like are added.
+            // TODO: update alert when the ignore-gravity component is added or removed.
+            if (_mapManager.TryGetGrid(newGrid, out var grid)
+                && TryComp(grid.GridEntityId, out GravityComponent? gravity)
+                && gravity.Enabled)
                 RemoveWeightless(status.Owner);
-            else
+            else if (!HasComp<MovementIgnoreGravityComponent>(uid))
                 AddWeightless(status.Owner);
         }
 


### PR DESCRIPTION
- Stops every entity that enters or leaves PVS from doing an unnecessary `TryComp<AlertsComponent>()`.
- Updates the alert when moving on or off grids.