### PR TITLE
Restart vote is now actually passable

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -50,12 +50,13 @@ namespace Content.Server.Voting.Managers
                 Options =
                 {
                     (Loc.GetString("ui-vote-restart-yes"), true),
-                    (Loc.GetString("ui-vote-restart-no"), false)
+                    (Loc.GetString("ui-vote-restart-no"), false),
+                    (Loc.GetString("ui-vote-restart-abstain"), false)
                 },
                 Duration = alone
                     ? TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerAlone))
                     : TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerRestart)),
-                InitiatorTimeout = TimeSpan.FromMinutes(3)
+                InitiatorTimeout = TimeSpan.FromMinutes(5)
             };
 
             if (alone)
@@ -92,10 +93,10 @@ namespace Content.Server.Voting.Managers
 
             foreach (var player in _playerManager.ServerSessions)
             {
-                if (player != initiator && !_afkManager.IsAfk(player))
+                if (player != initiator)
                 {
-                    // Everybody else defaults to a no vote.
-                    vote.CastVote(player, 1);
+                    // Everybody else defaults to an abstain vote to say they don't mind.
+                    vote.CastVote(player, 2);
                 }
             }
         }

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -49,9 +49,9 @@ namespace Content.Server.Voting.Managers
                 Title = Loc.GetString("ui-vote-restart-title"),
                 Options =
                 {
-                    (Loc.GetString("ui-vote-restart-yes"), true),
-                    (Loc.GetString("ui-vote-restart-no"), false),
-                    (Loc.GetString("ui-vote-restart-abstain"), false)
+                    (Loc.GetString("ui-vote-restart-yes"), "yes"),
+                    (Loc.GetString("ui-vote-restart-no"), "no"),
+                    (Loc.GetString("ui-vote-restart-abstain"), "abstain")
                 },
                 Duration = alone
                     ? TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerAlone))
@@ -68,12 +68,12 @@ namespace Content.Server.Voting.Managers
 
             vote.OnFinished += (_, _) =>
             {
-                var votesYes = vote.VotesPerOption[true];
-                var votesNo = vote.VotesPerOption[false];
+                var votesYes = vote.VotesPerOption["yes"];
+                var votesNo = vote.VotesPerOption["no"];
                 var total = votesYes + votesNo;
 
                 var ratioRequired = _cfg.GetCVar(CCVars.VoteRestartRequiredRatio);
-                if (votesYes / (float) total >= ratioRequired)
+                if (total > 0 && votesYes / (float) total >= ratioRequired)
                 {
                     _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-restart-succeeded"));
                     EntitySystem.Get<RoundEndSystem>().EndRound();

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -31,7 +31,6 @@ namespace Content.Server.Voting.Managers
         [Dependency] private readonly IChatManager _chatManager = default!;
         [Dependency] private readonly IAdminManager _adminMgr = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] private readonly IAfkManager _afkManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IGameMapManager _gameMapManager = default!;
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -727,7 +727,7 @@ namespace Content.Shared.CCVar
         ///     The required ratio of the server that must agree for a restart round vote to go through.
         /// </summary>
         public static readonly CVarDef<float> VoteRestartRequiredRatio =
-            CVarDef.Create("vote.restart_required_ratio", 0.8f, CVar.SERVERONLY);
+            CVarDef.Create("vote.restart_required_ratio", 0.7f, CVar.SERVERONLY);
 
         /// <summary>
         ///     The delay which two votes of the same type are allowed to be made by separate people, in seconds.

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -746,7 +746,7 @@ namespace Content.Shared.CCVar
         ///     Sets the duration of the restart vote timer.
         /// </summary>
         public static readonly CVarDef<int>
-            VoteTimerRestart = CVarDef.Create("vote.timerrestart", 30, CVar.SERVERONLY);
+            VoteTimerRestart = CVarDef.Create("vote.timerrestart", 60, CVar.SERVERONLY);
 
         /// <summary>
         ///     Sets the duration of the gamemode/preset vote timer.

--- a/Resources/Locale/en-US/voting/managers/vote-manager.ftl
+++ b/Resources/Locale/en-US/voting/managers/vote-manager.ftl
@@ -8,6 +8,7 @@ ui-vote-restart-succeeded = Restart vote succeeded.
 ui-vote-restart-failed = Restart vote failed (need { TOSTRING($ratio, "P0") }).
 ui-vote-restart-yes = Yes
 ui-vote-restart-no = No
+ui-vote-restart-abstain = Abstain
 
 ui-vote-gamemode-title = Next gamemode
 ui-vote-gamemode-tie = Tie for gamemode vote! Picking... { $picked }


### PR DESCRIPTION
It may now be possible for a restart vote to actually pass. This has been a bugbear for me for ages but I forgot about it until I started playing the game.
I've never seen a restart vote pass. I've run plenty of custom restart round votes that won in landslides, e.g.

![image](https://user-images.githubusercontent.com/31366439/168496637-0f4a0b82-18aa-424c-a61a-75398333a641.png)

I don't know if AFK detection is bugged or I get trolled 10/10 times or what.

The only issue I foresee is a bunch of people spamming the vote out but if votemanager stops that then no issue (and even then just bump the timer to 2 minutes or something). Still requires 80% of active players.

:cl:
- tweak: Restart round votes now default to abstain and 60 second timer. Cooldown is also set to 5 minutes.
