### PR TITLE
Don't show sandbox in vote menu

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -13,7 +13,7 @@
     - sandbox
   name: sandbox-title
   description: sandbox-description
-  showInVote: true
+  showInVote: false
   rules:
     - Sandbox
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

people keep voting sandbox on USW for no discernible reason

actual solution is #8219 and a max player count of 5 or so

:cl:
- tweak: Sandbox can no longer be voted as a game preset.
