### PR TITLE
Add Light Replacer to the Janibelt whitelist

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -193,6 +193,8 @@
         - Soap
         - Flashlight
         - CigPack
+      components:
+        - LightReplacer
   - type: ItemMapper
     mapLayers:
       bottle:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Added the light replacer to the janibelt whitelist
- Resolves [#8176](https://github.com/space-wizards/space-station-14/issues/8176)

:cl:
- tweak: The Light Replacer can now be placed in the Janibelt.

