### PR TITLE
Minor lobby fixes

### DIFF
--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -40,7 +40,7 @@
                 <BoxContainer Orientation="Vertical">
                 <!-- Top row -->
                 <BoxContainer Orientation="Horizontal" MinSize="0 40" Name="HeaderContainer" Access="Public">
-                    <Label Margin="8 0 0 0" StyleClasses="LabelHeadingBigger" VAlign="Center" Text="{Loc 'ui-lobby-title'}" />
+                    <Label Margin="8 0 0 0" StyleClasses="LabelHeadingBigger" VAlign="Center" Text="{Loc 'ui-lobby-title'} " />
                     <Label Name="ServerName" Access="Public" StyleClasses="LabelHeadingBigger" VAlign="Center" />
                 </BoxContainer>
                 <!-- Gold line -->

--- a/Resources/Locale/en-US/lobby/ui/lobby-character-preview-panel.ftl
+++ b/Resources/Locale/en-US/lobby/ui/lobby-character-preview-panel.ftl
@@ -1,3 +1,3 @@
-lobby-character-preview-panel-header = character
+lobby-character-preview-panel-header = Character
 lobby-character-preview-panel-character-setup-button = Customize
 lobby-character-preview-panel-unloaded-preferences-label = Your character preferences have not yet loaded, please stand by.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The lobby right now:
![image](https://user-images.githubusercontent.com/5714543/168726979-51141954-0fbe-4b5c-9aad-607fcfec3356.png)

Note the lack of whitespace after `Lobby` and the lowercase `character`. This fixes those.