### PR TITLE
Make combat feel 100x better with this one simple trick

### DIFF
--- a/Content.Client/EscapeMenu/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/EscapeMenu/UI/Tabs/KeyRebindTab.xaml.cs
@@ -107,7 +107,6 @@ namespace Content.Client.EscapeMenu.UI.Tabs
 
             AddHeader("ui-options-header-interaction-basic");
             AddButton(EngineKeyFunctions.Use);
-            AddButton(ContentKeyFunctions.WideAttack);
             AddButton(ContentKeyFunctions.UseItemInHand);
             AddButton(ContentKeyFunctions.AltUseItemInHand);
             AddButton(ContentKeyFunctions.ActivateItemInWorld);

--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -46,7 +46,6 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);
-            human.AddFunction(ContentKeyFunctions.WideAttack);
             human.AddFunction(ContentKeyFunctions.ArcadeUp);
             human.AddFunction(ContentKeyFunctions.ArcadeDown);
             human.AddFunction(ContentKeyFunctions.ArcadeLeft);

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -39,8 +39,6 @@ namespace Content.Server.Interaction
             SubscribeNetworkEvent<DragDropRequestEvent>(HandleDragDropRequestEvent);
 
             CommandBinds.Builder
-                .Bind(ContentKeyFunctions.WideAttack,
-                    new PointerInputCmdHandler(HandleWideAttack))
                 .Bind(ContentKeyFunctions.TryPullObject,
                     new PointerInputCmdHandler(HandleTryPullObject))
                 .Register<InteractionSystem>();
@@ -127,21 +125,6 @@ namespace Content.Server.Interaction
             }
         }
         #endregion
-
-        private bool HandleWideAttack(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
-        {
-            // client sanitization
-            if (!ValidateClientInput(session, coords, uid, out var userEntity))
-            {
-                Logger.InfoS("system.interaction", $"WideAttack input validation failed");
-                return true;
-            }
-
-            if (TryComp(userEntity, out CombatModeComponent? combatMode) && combatMode.IsInCombatMode)
-                DoAttack(userEntity.Value, coords, true);
-
-            return true;
-        }
 
         /// <summary>
         /// Entity will try and use their active hand at the target location.

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -5,7 +5,6 @@ namespace Content.Shared.Input
     [KeyFunctions]
     public static class ContentKeyFunctions
     {
-        public static readonly BoundKeyFunction WideAttack = "WideAttack";
         public static readonly BoundKeyFunction UseItemInHand = "ActivateItemInHand";
         public static readonly BoundKeyFunction AltUseItemInHand = "AltActivateItemInHand";
         public static readonly BoundKeyFunction ActivateItemInWorld = "ActivateItemInWorld";

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -192,7 +192,9 @@ namespace Content.Shared.Interaction
             // TODO COMBAT Consider using alt-interact for advanced combat? maybe alt-interact disarms?
             if (!altInteract && TryComp(user, out SharedCombatModeComponent? combatMode) && combatMode.IsInCombatMode)
             {
-                DoAttack(user, coordinates, false, target);
+                // Wide attack if there isn't a target, click attack otherwise.
+                var shouldWideAttack = target == null;
+                DoAttack(user, coordinates, shouldWideAttack, target);
                 return;
             }
 

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -192,8 +192,8 @@ namespace Content.Shared.Interaction
             // TODO COMBAT Consider using alt-interact for advanced combat? maybe alt-interact disarms?
             if (!altInteract && TryComp(user, out SharedCombatModeComponent? combatMode) && combatMode.IsInCombatMode)
             {
-                // Wide attack if there isn't a target, click attack otherwise.
-                var shouldWideAttack = target == null;
+                // Wide attack if there isn't a target or the target is out of range, click attack otherwise.
+                var shouldWideAttack = target == null || !InRangeUnobstructed(user, target.Value);
                 DoAttack(user, coordinates, shouldWideAttack, target);
                 return;
             }

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -17,9 +17,6 @@ binds:
   type: State
   key: MouseLeft
   canFocus: true
-- function: WideAttack
-  type: State
-  key: Space
 - function: ShowDebugMonitors
   type: Toggle
   key: F3


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is the "wideattack/clickattack rework" part of https://hackmd.io/@rQ2pYSFtRl20YDfmkEtgzA/Hy96U4lIq

Motivation (although its also laid out in that doc):
- You always attack even if you miss, so intent is clear in fights
- Even if you miss a clickattack, the arc of your weapon means you might still hit a wideattack
- No snowflake keybind for 'wide attack' (that people seem to not know exists a lot of the time)
- Should make combat in laggy situations better as it should feel a lot better than having to directly click on an entity

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/19853115/168733894-7929c658-023e-4bed-b4f8-9604908cfdb1.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- remove: The wide attack keybind has been removed.
- tweak: Combat has been slightly reworked. Click on an entity to directly attack it. Click anywhere else (or on an entity out of range), and you'll do a wide attack instead.

