### PR TITLE
Fix cream pie crash due to client deletion

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
@@ -27,6 +27,8 @@ namespace Content.Server.Nutrition.EntitySystems
             {
                 _spillableSystem.SpillAt(creamPie.Owner, solution, "PuddleSmear", false);
             }
+
+            EntityManager.QueueDeleteEntity(uid);
         }
 
         protected override void CreamedEntity(EntityUid uid, CreamPiedComponent creamPied, ThrowHitByEvent args)

--- a/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
@@ -28,8 +28,6 @@ namespace Content.Shared.Nutrition.EntitySystems
             creamPie.Splatted = true;
 
             SplattedCreamPie(uid, creamPie);
-
-            EntityManager.QueueDeleteEntity(uid);
         }
 
         protected virtual void SplattedCreamPie(EntityUid uid, CreamPieComponent creamPie) {}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Client deleted pie then tried to rollback state, which caused the game to crash.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed client crash when someone was cream pied.
