### PR TITLE
Removed the ability for flying mobs to pass through airlocks

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -56,7 +56,7 @@ public enum CollisionGroup
     TabletopMachineLayer = Opaque | HighImpassable | BulletImpassable,
 
     // Airlocks, windoors, firelocks
-    GlassAirlockLayer = HighImpassable | MidImpassable | BulletImpassable | InteractImpassable,
+    GlassAirlockLayer = Impassable | HighImpassable | MidImpassable | BulletImpassable | InteractImpassable,
     AirlockLayer = Opaque | GlassAirlockLayer,
 
     // Airlock assembly

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -35,7 +35,7 @@ public enum CollisionGroup
     SmallMobMask = Impassable | LowImpassable,
     SmallMobLayer = Opaque | BulletImpassable,
     // Birds/other small flyers
-    FlyingMobMask = Impassable,
+    FlyingMobMask = Impassable | HighImpassable,
     FlyingMobLayer = Opaque | BulletImpassable,
 
     // Mechs
@@ -56,7 +56,7 @@ public enum CollisionGroup
     TabletopMachineLayer = Opaque | HighImpassable | BulletImpassable,
 
     // Airlocks, windoors, firelocks
-    GlassAirlockLayer = Impassable | HighImpassable | MidImpassable | BulletImpassable | InteractImpassable,
+    GlassAirlockLayer = HighImpassable | MidImpassable | BulletImpassable | InteractImpassable,
     AirlockLayer = Opaque | GlassAirlockLayer,
 
     // Airlock assembly


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removed Flying mobs ability to anger physicist by phasing through doors. 


**Changelog**

:cl: Ian “Rinzii” Pike
- fix: Fixed FlyingMob’s ability to phase through doors.

