### PR TITLE
Render small mobs at an appropriate layer

### DIFF
--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -23,18 +23,23 @@ namespace Content.Shared.DrawDepth
         /// <summary>
         ///     Things that are beneath regular floors.
         /// </summary>
-        BelowFloor = DrawDepthTag.Default - 5,
+        BelowFloor = DrawDepthTag.Default - 6,
 
         /// <summary>
         ///     Used for entities like carpets.
         /// </summary>
-        FloorTiles = DrawDepthTag.Default - 4,
+        FloorTiles = DrawDepthTag.Default - 5,
 
         /// <summary>
         ///     Things that are actually right on the floor, like puddles. This does not mean objects like
         ///     tables, even though they are technically "on the floor".
         /// </summary>
-        FloorObjects = DrawDepthTag.Default - 3,
+        FloorObjects = DrawDepthTag.Default - 4,
+
+        /// <summary>
+        ///     Allows small mobs like mice and drones to render under tables and chairs but above puddles and vents
+        /// </summary>
+        SmallMobs = DrawDepthTag.Default - 3,
 
         Walls = DrawDepthTag.Default - 2,
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -656,7 +656,7 @@
   - type: Speech
     speechSounds: Squeak
   - type: Sprite
-    drawdepth: FloorObjects
+    drawdepth: SmallMobs
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: mouse-0
@@ -755,7 +755,7 @@
   id: MobMouse1
   components:
   - type: Sprite
-    drawdepth: Mobs
+    drawdepth: SmallMobs
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: mouse-1
@@ -778,7 +778,7 @@
   id: MobMouse2
   components:
   - type: Sprite
-    drawdepth: Mobs
+    drawdepth: SmallMobs
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: mouse-2

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -119,7 +119,7 @@
       types:
         Heat : 1 #per second, scales with temperature & other constants
   - type: Sprite
-    drawdepth: Mobs
+    drawdepth: SmallMobs
     netsync: false
     layers:
     - state: shell


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Creates a new drawdepth SmallMobs between FloorObjects and Walls
- MobMouse, MobMouse1, MobMouse2, and Drone are set to this new drawdepth
- These mobs are rendered above FloorObjects like floor vents and puddles
- These mobs are rendered below things like furniture (much more natural looking for tiny mouse)
- Collision unaffected 
- Resolves [#8198](https://github.com/space-wizards/space-station-14/issues/8198)

The original bug was that the default MobMouse (but not 1 and 2) was set as FloorObjects drawdepth.
It looked like the intention was for small mobs to appear under furniture and items, but was tie-breaking with
things like floor vents, which doesn't make sense.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

Mouse above a vent
![render1](https://user-images.githubusercontent.com/89101928/168868224-da1f9510-f8f4-43cc-b921-5d3e80a1b6b4.PNG)
Mouse below a chair
![render2](https://user-images.githubusercontent.com/89101928/168868259-786367ed-1003-4918-a6fd-b572f49101af.PNG)
Drone above a vent
![render3](https://user-images.githubusercontent.com/89101928/168868284-6c1e4416-bf69-42fc-bec1-144e07e3231d.PNG)
Drone below a table
![render4](https://user-images.githubusercontent.com/89101928/168868302-03f9f9d7-4902-4993-976e-502fcbe12281.PNG)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Small mobs like mice and drones are rendered at the correct layer.

