### PR TITLE
Update bartender gear

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -5,8 +5,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterArmorBulletproof
-      - id: ShotgunSawn
+      - id: ClothingOuterVestKevlar
+      - id: ShotgunDB
       - id: DrinkShaker
       - id: ClothingEyesGlassesBeer
       - id: DrinkBottleBeer

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
@@ -10,7 +10,7 @@
     ClothingUniformJumpskirtBartender: 2
     ClothingUniformJumpsuitBartenderPurple: 2
     ClothingShoesColorBlack: 2
-    ClothingOuterVestKevlar: 1
-    ClothingBeltBandolier: 1
-    ClothingEyesGlassesSunglasses: 1
-    BoxBeanbag: 1
+    ClothingOuterVestKevlar: 2
+    ClothingBeltBandolier: 2
+    ClothingEyesGlassesSunglasses: 2
+    BoxBeanbag: 2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -222,7 +222,8 @@
 - type: entity
   name: sawn-off shotgun
   parent: LauncherBase
-  id: ShotgunSawn
+  id: ShotgunSawnEmpty
+  suffix: Empty
   description: Omar's coming!
   components:
   - type: Sprite
@@ -244,7 +245,6 @@
     currentSelector: Single
     allSelectors:
     - Single
-    fillPrototype: ShellShotgun
     fireRate: 8.0
     capacity: 2
     minAngle: 7
@@ -264,3 +264,16 @@
   - type: Appearance
     visuals:
     - type: BarrelBoltVisualizer
+  - type: Construction
+    graph: ShotgunSawn
+    node: shotgunsawn
+
+- type: entity
+  name: sawn-off shotgun
+  parent: ShotgunSawnEmpty
+  id: ShotgunSawn
+  suffix:
+  description: Omar's coming!
+  components:
+  - type: BoltActionBarrel
+    fillPrototype: ShellShotgun

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/shotgunsawn.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/shotgunsawn.yml
@@ -1,0 +1,21 @@
+- type: constructionGraph
+  id: ShotgunSawn
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: shotgunsawn
+          steps:
+            - prototype: ShotgunDB
+              icon:
+                sprite: Objects/Weapons/Guns/Shotguns/db_shotgun.rsi
+                state: icon
+              name: double-barreled shotgun
+            - prototype: SawElectric
+              icon:
+                sprite: Objects/Specific/Medical/Surgery/saw.rsi
+                state: electric
+              name: circular saw
+              doAfter: 5
+    - node: shotgunsawn
+      entity: ShotgunSawnEmpty

--- a/Resources/Prototypes/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/Recipes/Crafting/improvised.yml
@@ -47,3 +47,16 @@
   icon:
     sprite: Objects/Specific/Medical/medical.rsi
     state: gauze
+
+- type: construction
+  name: sawn-off shotgun
+  id: ShotgunSawn
+  graph: ShotgunSawn
+  startNode: start
+  targetNode: shotgunsawn
+  category: Weapons
+  objectType: Item
+  description: Make sure to unload the gun.
+  icon:
+    sprite: Objects/Weapons/Guns/Shotguns/sawn.rsi
+    state: icon


### PR DESCRIPTION
## About the PR 
Bartender now spawns with a DB Shotgun.
DB Shotgun can be crafted into a sawn off shotgun with a circular saw.
Some maps have two bartenders, tweaked fills to compensate for that

todo:
[ ] - Should be able to use any circular saw, including advanced one
[ ] - Saw should not be consumed upon crafting.

**Screenshots**
![image](https://user-images.githubusercontent.com/60460608/168870437-51bb71c1-db2c-48ca-835f-9656fae0b7f6.png)

**Changelog**
:cl: Daemon
- add: Added craft-able sawn off shotgun.
- tweak: Tweaked bartender vendors and inventory fills.

