### PR TITLE
Reset ghost rotation to zero on follow

### DIFF
--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -72,6 +72,7 @@ public sealed class FollowerSystem : EntitySystem
         var xform = Transform(follower);
         xform.AttachParent(entity);
         xform.LocalPosition = Vector2.Zero;
+        xform.LocalRotation = Angle.Zero;
 
         EnsureComp<OrbitVisualsComponent>(follower);
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

:cl:
- tweak: Ghosts now always have a consistent directional sprite while orbiting an entity
