### PR TITLE
Fix hard hat lights

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -4,7 +4,7 @@
   abstract: true
   components:
   - type: Sprite
-    netsync: true
+    netsync: false
     layers:
     - state: icon
     - state: light-icon
@@ -14,13 +14,29 @@
   - type: Clothing
     HeldPrefix: off
   - type: PointLight
+    netsync: false
     enabled: false
+    mask: /Textures/Effects/LightMasks/cone.png
+    autoRot: true
     radius: 3
   - type: Appearance
     visuals:
       - type: FlashLightVisualizer
   - type: HandheldLight
-    addPrefix: true
+    addPrefix: false
+  - type: ToggleableLightVisuals
+    spriteLayer: light
+    inhandVisuals:
+      left:
+      - state: on-inhand-left
+        shader: unshaded
+      right:
+      - state: on-inhand-right
+        shader: unshaded
+    clothingVisuals:
+      head:
+      - state: on-equipped-HELMET
+        shader: unshaded
   - type: PowerCellSlot
     cellSlot:
       startingItem: PowerCellSmallHigh


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Activating hard hat lights now works properly. 
- Works when carried, worn, or on the floor.
- Resolves [#8178](https://github.com/space-wizards/space-station-14/issues/8178)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

Holding a hard hat
![hardhatheld](https://user-images.githubusercontent.com/89101928/169100899-a4ce45f0-e37f-402a-bc47-308ed51fa834.PNG)

Wearing a hard hat
![hardhatworn](https://user-images.githubusercontent.com/89101928/169100960-53fbee8a-183d-47da-8ce4-9d979d3491b8.PNG)

Hard hat on the floor
![hardhatfloor](https://user-images.githubusercontent.com/89101928/169100996-60f4c2b3-7197-4111-836c-6f5ac09bbf92.PNG)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Hard hat lights now function properly.

