### PR TITLE
Useful bowls

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -40,5 +40,7 @@
       amount: 1
     - id: FoodCondimentBottleEnzyme
       amount: 1
-    - id: LargeBeaker
+    - id: FoodBowlBig
+      amount: 3
+    - id: KitchenKnife
       amount: 1

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
@@ -29,6 +29,12 @@
     solution: food
   - type: Damageable
     damageContainer: Inorganic
+  - type: SolutionTransfer
+    canChangeTransferAmount: true
+  - type: UserInterface
+    interfaces:
+      - key: enum.TransferAmountUiKey.Key
+        type: TransferAmountBoundUserInterface
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
## About the PR 
Added the SolutionTransfer component to FoodBowlBig so that the kitchen staff will stop stealing beakers.

Replaced Beaker that was in the CrateFoodCooking with three large bowls.

**Changelog**
:cl:
- add: allow players to configure the amount of material to add to a regular bowl.
- updated: kitchen crate comes with a kitchen knife in case there is no vending machine in the kitchen.
- change: Kitchen crates from cargo now come with bowls instead of beakers.

