### PR TITLE
Broadly eliminate underplating tiles in various maps

### DIFF
--- a/Resources/Maps/Salvage/asteroid-base.yml
+++ b/Resources/Maps/Salvage/asteroid-base.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/cargo-1.yml
+++ b/Resources/Maps/Salvage/cargo-1.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-1.yml
+++ b/Resources/Maps/Salvage/medium-1.yml
@@ -35,7 +35,7 @@ tilemap:
   28: floor_wood
   29: lattice
   30: plating
-  31: underplating
+  31: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-crashed-shuttle.yml
+++ b/Resources/Maps/Salvage/medium-crashed-shuttle.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-dock.yml
+++ b/Resources/Maps/Salvage/medium-dock.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-library.yml
+++ b/Resources/Maps/Salvage/medium-library.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-pet-hospital.yml
+++ b/Resources/Maps/Salvage/medium-pet-hospital.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-pirate.yml
+++ b/Resources/Maps/Salvage/medium-pirate.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-ruined-emergency-shuttle.yml
+++ b/Resources/Maps/Salvage/medium-ruined-emergency-shuttle.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-silent-orchestra.yml
+++ b/Resources/Maps/Salvage/medium-silent-orchestra.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-template.yml
+++ b/Resources/Maps/Salvage/medium-template.yml
@@ -35,7 +35,7 @@ tilemap:
   28: floor_wood
   29: lattice
   30: plating
-  31: underplating
+  31: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/medium-vault-1.yml
+++ b/Resources/Maps/Salvage/medium-vault-1.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/ruin-cargo-salvage.yml
+++ b/Resources/Maps/Salvage/ruin-cargo-salvage.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/small-1.yml
+++ b/Resources/Maps/Salvage/small-1.yml
@@ -35,7 +35,7 @@ tilemap:
   28: floor_wood
   29: lattice
   30: plating
-  31: underplating
+  31: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/small-2.yml
+++ b/Resources/Maps/Salvage/small-2.yml
@@ -35,7 +35,7 @@ tilemap:
   28: floor_wood
   29: lattice
   30: plating
-  31: underplating
+  31: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/small-3.yml
+++ b/Resources/Maps/Salvage/small-3.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/small-4.yml
+++ b/Resources/Maps/Salvage/small-4.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/small-a-1.yml
+++ b/Resources/Maps/Salvage/small-a-1.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/small-ai-survey-drone.yml
+++ b/Resources/Maps/Salvage/small-ai-survey-drone.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/small-ship-1.yml
+++ b/Resources/Maps/Salvage/small-ship-1.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/small-template.yml
+++ b/Resources/Maps/Salvage/small-template.yml
@@ -35,7 +35,7 @@ tilemap:
   28: floor_wood
   29: lattice
   30: plating
-  31: underplating
+  31: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/stationstation.yml
+++ b/Resources/Maps/Salvage/stationstation.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/tick-colony.yml
+++ b/Resources/Maps/Salvage/tick-colony.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Salvage/wh-salvage.yml
+++ b/Resources/Maps/Salvage/wh-salvage.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Test/Breathing/3by3-20oxy-80nit.yml
+++ b/Resources/Maps/Test/Breathing/3by3-20oxy-80nit.yml
@@ -37,7 +37,7 @@ tilemap:
   30: floor_wood
   31: lattice
   32: plating
-  33: underplating
+  33: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Test/empty.yml
+++ b/Resources/Maps/Test/empty.yml
@@ -37,7 +37,7 @@ tilemap:
   30: floor_wood
   31: lattice
   32: plating
-  33: underplating
+  33: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Test/floor3x3.yml
+++ b/Resources/Maps/Test/floor3x3.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/Test/singularity.yml
+++ b/Resources/Maps/Test/singularity.yml
@@ -30,7 +30,7 @@ tilemap:
   23: floor_wood
   24: lattice
   25: plating
-  26: underplating
+  26: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/barratry.yml
+++ b/Resources/Maps/barratry.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/dart.yml
+++ b/Resources/Maps/dart.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/knightshuttle.yml
+++ b/Resources/Maps/knightshuttle.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/moonrise.yml
+++ b/Resources/Maps/moonrise.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/mothership.yml
+++ b/Resources/Maps/mothership.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/packedstation.yml
+++ b/Resources/Maps/packedstation.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/packedstationxmas.yml
+++ b/Resources/Maps/packedstationxmas.yml
@@ -41,7 +41,7 @@ tilemap:
   34: floor_wood
   35: lattice
   36: plating
-  37: underplating
+  37: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/pirate.yml
+++ b/Resources/Maps/pirate.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16

--- a/Resources/Maps/syndiepuddle.yml
+++ b/Resources/Maps/syndiepuddle.yml
@@ -54,7 +54,7 @@ tilemap:
   47: floor_wood
   48: lattice
   49: plating
-  50: underplating
+  50: plating
 grids:
 - settings:
     chunksize: 16


### PR DESCRIPTION
## About the PR

Absolutely guarantees the removal of underplating from Salvage and Test maps via tile index aliasing.
Also targets a few regular maps, but these have been chosen to try and avoid conflicts.

*NOTE TO ABSOLUTELY ALL MAPPERS: IF YOUR MAP IS MENTIONED IN THIS PR, AND YOU'RE WORKING ON IT, COMMENT!!!*

Also comment if a map isn't mentioned and you want it to be handled here.

**Changelog**

:cl:
- fix: Some maps should no longer contain any of those pesky mouse-tiles.
