### PR TITLE
Techfabcircuits

### DIFF
--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -125,6 +125,7 @@
     - VaccinatorMachineCircuitboard
     - DiagnoserMachineCircuitboard
     - HandheldCrewMonitor
+    - MedicalTechFabMachineCircuitboard
 
 - type: technology
   name: "advanced life support systems"
@@ -159,6 +160,7 @@
     - Handcuffs
     - Stunbaton
     - FlashPayload
+    - SecurityTechFabMachineCircuitboard
 
 - type: technology
   name: "non-lethal technology"

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -80,6 +80,38 @@
         ExamineName: Glass Beaker
 
 - type: entity
+  id: SecurityTechFabMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: security techfab machine board
+  components:
+    - type: MachineBoard
+      prototype: SecurityTechFab
+      requirements:
+        MatterBin: 1
+        Manipulator: 1
+      tagRequirements:
+        GlassBeaker:
+          Amount: 2
+          DefaultPrototype: Beaker
+          ExamineName: Glass Beaker
+
+- type: entity
+  id: MedicalTechFabMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: medical techfab machine board
+  components:
+    - type: MachineBoard
+      prototype: MedicalTechFab
+      requirements:
+        MatterBin: 1
+        Manipulator: 1
+      tagRequirements:
+        GlassBeaker:
+          Amount: 2
+          DefaultPrototype: Beaker
+          ExamineName: Glass Beaker
+
+- type: entity
   id: UniformPrinterMachineCircuitboard
   parent: BaseMachineCircuitboard
   name: uniform printer machine board

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -262,6 +262,8 @@
       - DawInstrumentMachineCircuitboard
       - StasisBedMachineCircuitboard
       - OreProcessorMachineCircuitboard
+      - MedicalTechFabMachineCircuitboard
+      - SecurityTechFabMachineCircuitboard
   - type: Machine
     board: CircuitImprinterMachineCircuitboard
   - type: Lathe

--- a/Resources/Prototypes/Objectives/traitorObjectives..yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives..yml
@@ -170,4 +170,31 @@
   conditions:
     - !type:StealCondition
       prototype: AntiqueLaserGun
-      
+
+- type: objective
+  id: MedicalTechFabStealObjective
+  issuer: syndicate
+  difficultyOverride: 2.75
+  prob: 0.1
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+  conditions:
+    - !type:StealCondition
+      prototype: MedicalTechFabMachineCircuitboard
+
+- type: objective
+  id: SecurityTechFabStealObjective
+  issuer: syndicate
+  difficultyOverride: 2.75
+  prob: 0.1
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+  conditions:
+    - !type:StealCondition
+      prototype: SecurityTechFabMachineCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -119,6 +119,24 @@
      Glass: 900
 
 - type: latheRecipe
+  id: SecurityTechFabMachineCircuitboard
+  icon: Objects/Misc/module.rsi/id_mod.png
+  result: SecurityTechFabMachineCircuitboard
+  completetime: 4
+  materials:
+    Steel: 100
+    Glass: 900
+
+- type: latheRecipe
+  id: MedicalTechFabMachineCircuitboard
+  icon: Objects/Misc/module.rsi/id_mod.png
+  result: MedicalTechFabMachineCircuitboard
+  completetime: 4
+  materials:
+    Steel: 100
+    Glass: 900
+
+- type: latheRecipe
   id: UniformPrinterMachineCircuitboard
   icon: Objects/Misc/module.rsi/id_mod.png
   result: UniformPrinterMachineCircuitboard


### PR DESCRIPTION
## About the PR 
The techfab machines were added a while ago but it seems the circuit board item prototypes were missing despite being referenced.

Ive added the board item prototypes, a recipe for them and added that recipe to the circuit printer and technology database. The items were also added to the traitor objectives.

Ive placed the techfab boards in the technology database as early as possible. As soon as you unlock a recipe that is unique to a given techfab, you also unlock the corresponding circuitboard.

**Changelog**
:cl:
- add: Circuit boards for Medical and Security techfabs.
- add: Recipes in the Circuit printer for Medical and Security techfab circuit boards.
- add: techfab boards can be traitor objectives.
- add: techfab boards are unlocked via research
- tweak: Techfabs drop their respective boards instead of protolathe boards when deconstructed.

