### PR TITLE
Two small bugfixes

### DIFF
--- a/Content.Server/Hands/Systems/HandVirtualItemSystem.cs
+++ b/Content.Server/Hands/Systems/HandVirtualItemSystem.cs
@@ -34,7 +34,6 @@ namespace Content.Server.Hands.Systems
                 if (TryComp(hand.HeldEntity, out HandVirtualItemComponent? virt) && virt.BlockingEntity == matching)
                 {
                     Delete(virt, user);
-                    return;
                 }
             }
         }

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Player;
 using Content.Shared.Storage;
 using Content.Shared.Inventory;
 using Content.Shared.Hands.Components;
+using Content.Shared.ActionBlocker;
 
 namespace Content.Server.Resist;
 
@@ -15,6 +16,7 @@ public sealed class EscapeInventorySystem : EntitySystem
     [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
 
     public override void Initialize()
     {
@@ -35,7 +37,8 @@ public sealed class EscapeInventorySystem : EntitySystem
         if (_containerSystem.TryGetContainingContainer(uid, out var container)
             && (HasComp<SharedStorageComponent>(container.Owner) || HasComp<InventoryComponent>(container.Owner) || HasComp<SharedHandsComponent>(container.Owner)))
         {
-            AttemptEscape(uid, container.Owner, component);
+            if (_actionBlockerSystem.CanInteract(uid, container.Owner))
+                AttemptEscape(uid, container.Owner, component);
         }
     }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
1. DeleteInHandsMatching said it would delete all virtual hand items, but it returns after the first one.
2. Mobs that are dead, stunned, etc. could escape inventory.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: Mice can no longer escape inventory while they are dead, stunned, or similar. The invincible mouse revenant that could break men's hands even after death is no more.

