### PR TITLE
Cargo telepads should not have collision when anchored (#8284)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
+++ b/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
@@ -49,3 +49,4 @@
   - type: ExtensionCableReceiver
   - type: CargoTelepad
   - type: Appearance
+  - type: CollideOnAnchor


### PR DESCRIPTION
## About the PR 
Cargo telepads should not have collision when anchored. Added missing CollideOnAnchor component.

**Changelog**
:cl:
- fix: telepads will no longer collide when anchored

