### PR TITLE
Fix NukeOps rule adding text to roundend even when disabled. 

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -49,7 +49,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     private void OnNukeExploded(NukeExplodedEvent ev)
     {
-    	if (!Enabled) return;
+    	if (!Enabled)
+            return;
 
         _opsWon = true;
         _roundEndSystem.EndRound();
@@ -57,6 +58,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     private void OnRoundEndText(RoundEndTextAppendEvent ev)
     {
+        if (!Enabled)
+            return;
+
         ev.AddLine(_opsWon ? Loc.GetString("nukeops-ops-won") : Loc.GetString("nukeops-crew-won"));
         ev.AddLine(Loc.GetString("nukeops-list-start"));
         foreach (var nukeop in _aliveNukeops)
@@ -67,6 +71,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     private void OnMobStateChanged(MobStateChangedEvent ev)
     {
+        if (!Enabled)
+            return;
+
         if (!_aliveNukeops.TryFirstOrNull(x => x.Key.OwnedEntity == ev.Entity, out var op)) return;
 
         _aliveNukeops[op.Value.Key] = op.Value.Key.CharacterDeadIC;
@@ -79,7 +86,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     private void OnPlayersSpawning(RulePlayerSpawningEvent ev)
     {
-        if (!Enabled) return;
+        if (!Enabled)
+            return;
 
         _aliveNukeops.Clear();
 
@@ -197,7 +205,10 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
     }
 
 
-    public override void Started(){ _opsWon = false; }
+    public override void Started()
+    {
+        _opsWon = false;
+    }
 
-    public override void Ended(){ }
+    public override void Ended() { }
 }


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It was missing an "enabled" check.