### PR TITLE
Include nospawn in tests

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -68,7 +68,7 @@ namespace Content.IntegrationTests.Tests
                 //Generate list of non-abstract prototypes to test
                 foreach (var prototype in prototypeMan.EnumeratePrototypes<EntityPrototype>())
                 {
-                    if (prototype.NoSpawn || prototype.Abstract)
+                    if (prototype.Abstract)
                     {
                         continue;
                     }


### PR DESCRIPTION
Include no-spawn (hidden in spawn-menu) entities in the entity spawning test.