### PR TITLE
Fix strippable text var

### DIFF
--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -261,13 +261,13 @@ namespace Content.Server.Strip
 
                 if (_inventorySystem.TryGetSlotEntity(component.Owner, slot, out _))
                 {
-                    user.PopupMessageCursor(Loc.GetString("strippable-component-item-slot-occupied",("uid", component.Owner)));
+                    user.PopupMessageCursor(Loc.GetString("strippable-component-item-slot-occupied",("owner", component.Owner)));
                     return false;
                 }
 
                 if (!_inventorySystem.CanEquip(user, component.Owner, held, slot, out _))
                 {
-                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-equip-message",("uid", component.Owner)));
+                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-equip-message",("owner", component.Owner)));
                     return false;
                 }
 
@@ -321,7 +321,7 @@ namespace Content.Server.Strip
                 if (!hands.Hands.TryGetValue(handName, out var hand)
                     || !_handsSystem.CanPickupToHand(component.Owner, userHands.ActiveHandEntity.Value, hand, checkActionBlocker: false, hands))
                 {
-                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-put-message",("uid", component.Owner)));
+                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-put-message",("owner", component.Owner)));
                     return false;
                 }
 
@@ -361,13 +361,13 @@ namespace Content.Server.Strip
 
                 if (!_inventorySystem.TryGetSlotEntity(component.Owner, slot, out _))
                 {
-                    user.PopupMessageCursor(Loc.GetString("strippable-component-item-slot-free-message", ("uid", component.Owner)));
+                    user.PopupMessageCursor(Loc.GetString("strippable-component-item-slot-free-message", ("owner", component.Owner)));
                     return false;
                 }
 
                 if (!_inventorySystem.CanUnequip(user, component.Owner, slot, out _))
                 {
-                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-unequip-message", ("uid", component.Owner)));
+                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-unequip-message", ("owner", component.Owner)));
                     return false;
                 }
 
@@ -409,7 +409,7 @@ namespace Content.Server.Strip
             {
                 if (!hands.Hands.TryGetValue(handName, out var hand) || hand.HeldEntity == null)
                 {
-                    user.PopupMessageCursor(Loc.GetString("strippable-component-item-slot-free-message",("uid", component.Owner)));
+                    user.PopupMessageCursor(Loc.GetString("strippable-component-item-slot-free-message",("owner", component.Owner)));
                     return false;
                 }
 
@@ -418,7 +418,7 @@ namespace Content.Server.Strip
 
                 if (!_handsSystem.CanDropHeld(component.Owner, hand, false))
                 {
-                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-drop-message",("uid", component.Owner)));
+                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-drop-message",("owner", component.Owner)));
                     return false;
                 }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Code pass `uid` named var but [fluent text](https://github.com/space-wizards/space-station-14/blob/master/Resources/Locale/en-US/strip/strippable-component.ftl) expect `$owner`.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

