### PR TITLE
Fix GasThermoMachine upgrading

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
@@ -1,43 +1,82 @@
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Piping.Unary.Components;
-using Robust.Shared.Serialization;
 
 namespace Content.Server.Atmos.Piping.Unary.Components
 {
     [RegisterComponent]
-    public sealed class GasThermoMachineComponent : Component, ISerializationHooks
+    public sealed class GasThermoMachineComponent : Component
     {
         [DataField("inlet")]
         public string InletName { get; set; } = "pipe";
 
         [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("enabled")]
         public bool Enabled { get; set; } = true;
 
+        /// <summary>
+        ///     Current maximum temperature, calculated from <see cref="BaseHeatCapacity"/> and the quality of matter
+        ///     bins. The heat capacity effectively determines the rate at which the thermo machine can add or remove
+        ///     heat from a pipenet.
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float HeatCapacity { get; set; } = 0;
+        public float HeatCapacity = 10000;
 
+        /// <summary>
+        ///     Base heat capacity of the device. Actual heat capacity is calculated by taking this number and doubling
+        ///     it for every matter bin quality tier above one.
+        /// </summary>
+        [DataField("baseHeatCapacity ")]
+        public float BaseHeatCapacity = 5000;
+
+        [DataField("targetTemperature")]
         [ViewVariables(VVAccess.ReadWrite)]
         public float TargetTemperature { get; set; } = Atmospherics.T20C;
 
         [DataField("mode")]
-        [ViewVariables(VVAccess.ReadWrite)]
         public ThermoMachineMode Mode { get; set; } = ThermoMachineMode.Freezer;
 
-        [DataField("minTemperature")]
+        /// <summary>
+        ///     Current minimum temperature, calculated from <see cref="InitialMinTemperature"/> and <see
+        ///     cref="MinTemperatureDelta"/>.
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MinTemperature { get; set; } = Atmospherics.T20C;
+        public float MinTemperature = 88.15f;
 
-        [DataField("maxTemperature")]
+        /// <summary>
+        ///     Current maximum temperature, calculated from <see cref="InitialMaxTemperature"/> and <see
+        ///     cref="MaxTemperatureDelta"/>.
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxTemperature { get; set; } = Atmospherics.T20C;
+        public float MaxTemperature = Atmospherics.T20C;
 
-        public float InitialMinTemperature { get; private set; }
-        public float InitialMaxTemperature { get; private set; }
+        /// <summary>
+        ///     Minimum temperature the device can reach with a 0 total laser quality. Usually the quality will be at
+        ///     least 1.
+        /// </summary>
+        [DataField("baseMinTemperature")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float BaseMinTemperature = 259.85f;
 
-        void ISerializationHooks.AfterDeserialization()
-        {
-            InitialMinTemperature = MinTemperature;
-            InitialMaxTemperature = MaxTemperature;
-        }
+        /// <summary>
+        ///     Maximum temperature the device can reach with a 0 total laser quality. Usually the quality will be at
+        ///     least 1.
+        /// </summary>
+        [DataField("baseMaxTemperature")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float BaseMaxTemperature = Atmospherics.T20C;
+
+        /// <summary>
+        ///     Decrease in minimum temperature, per unit machine part quality.
+        /// </summary>
+        [DataField("minTemperatureDelta")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float MinTemperatureDelta = 66.7f;
+
+        /// <summary>
+        ///     Change in maximum temperature, per unit machine part quality.
+        /// </summary>
+        [DataField("maxTemperatureDelta")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float MaxTemperatureDelta = 3 * Atmospherics.T20C;
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
@@ -40,14 +40,14 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         ///     cref="MinTemperatureDelta"/>.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MinTemperature = 88.15f;
+        public float MinTemperature;
 
         /// <summary>
         ///     Current maximum temperature, calculated from <see cref="InitialMaxTemperature"/> and <see
         ///     cref="MaxTemperatureDelta"/>.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxTemperature = Atmospherics.T20C;
+        public float MaxTemperature;
 
         /// <summary>
         ///     Minimum temperature the device can reach with a 0 total laser quality. Usually the quality will be at
@@ -55,7 +55,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// </summary>
         [DataField("baseMinTemperature")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float BaseMinTemperature = 259.85f;
+        public float BaseMinTemperature = 96.625f; // Selected so that tier-1 parts can reach 73.15k 
 
         /// <summary>
         ///     Maximum temperature the device can reach with a 0 total laser quality. Usually the quality will be at
@@ -70,13 +70,13 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// </summary>
         [DataField("minTemperatureDelta")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MinTemperatureDelta = 66.7f;
+        public float MinTemperatureDelta = 23.475f; // selected so that tier-4 parts can reach TCMB
 
         /// <summary>
         ///     Change in maximum temperature, per unit machine part quality.
         /// </summary>
         [DataField("maxTemperatureDelta")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxTemperatureDelta = 3 * Atmospherics.T20C;
+        public float MaxTemperatureDelta = 300;
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasThermoMachineComponent.cs
@@ -7,11 +7,11 @@ namespace Content.Server.Atmos.Piping.Unary.Components
     public sealed class GasThermoMachineComponent : Component
     {
         [DataField("inlet")]
-        public string InletName { get; set; } = "pipe";
+        public string InletName = "pipe";
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("enabled")]
-        public bool Enabled { get; set; } = true;
+        public bool Enabled = true;
 
         /// <summary>
         ///     Current maximum temperature, calculated from <see cref="BaseHeatCapacity"/> and the quality of matter
@@ -25,15 +25,15 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         ///     Base heat capacity of the device. Actual heat capacity is calculated by taking this number and doubling
         ///     it for every matter bin quality tier above one.
         /// </summary>
-        [DataField("baseHeatCapacity ")]
+        [DataField("baseHeatCapacity")]
         public float BaseHeatCapacity = 5000;
 
         [DataField("targetTemperature")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public float TargetTemperature { get; set; } = Atmospherics.T20C;
+        public float TargetTemperature = Atmospherics.T20C;
 
         [DataField("mode")]
-        public ThermoMachineMode Mode { get; set; } = ThermoMachineMode.Freezer;
+        public ThermoMachineMode Mode = ThermoMachineMode.Freezer;
 
         /// <summary>
         ///     Current minimum temperature, calculated from <see cref="InitialMinTemperature"/> and <see

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -96,12 +96,12 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             switch (component.Mode)
             {
-                // 1172.6K with stock parts.
+                // 593.15K with stock parts.
                 case ThermoMachineMode.Heater:
                     component.MaxTemperature = component.BaseMaxTemperature + component.MaxTemperatureDelta * laserRating;
                     component.MinTemperature = Atmospherics.T20C;
                     break;
-                // 193.15K / -100C with stock parts.
+                // 73.15 with stock parts.
                 case ThermoMachineMode.Freezer:
                     component.MinTemperature = MathF.Max(
                         component.BaseMinTemperature - component.MinTemperatureDelta * laserRating, Atmospherics.TCMB);

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -46,7 +46,6 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             var airHeatCapacity = _atmosphereSystem.GetHeatCapacity(inlet.Air);
             var combinedHeatCapacity = airHeatCapacity + thermoMachine.HeatCapacity;
-            var oldTemperature = inlet.Air.Temperature;
 
             if (!MathHelper.CloseTo(combinedHeatCapacity, 0, 0.001f))
             {
@@ -70,6 +69,9 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnGasThermoRefreshParts(EntityUid uid, GasThermoMachineComponent component, RefreshPartsEvent args)
         {
+            // Here we evaluate the average quality of relevant machine parts. 
+            var nLasers = 0;
+            var nBins= 0;
             var matterBinRating = 0;
             var laserRating = 0;
 
@@ -78,25 +80,32 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 switch (part.PartType)
                 {
                     case MachinePart.MatterBin:
+                        nBins += 1;
                         matterBinRating += part.Rating;
                         break;
                     case MachinePart.Laser:
+                        nLasers += 1;
                         laserRating += part.Rating;
                         break;
                 }
             }
+            laserRating /= nLasers;
+            matterBinRating /= nBins;
 
-            component.HeatCapacity = 5000 * MathF.Pow((matterBinRating - 1), 2);
+            component.HeatCapacity = 5000 * MathF.Pow(matterBinRating, 2);
 
             switch (component.Mode)
             {
-                // 573.15K with stock parts.
+                // 1172.6K with stock parts.
                 case ThermoMachineMode.Heater:
-                    component.MaxTemperature = Atmospherics.T20C + (component.InitialMaxTemperature * laserRating);
+                    component.MaxTemperature = component.BaseMaxTemperature + component.MaxTemperatureDelta * laserRating;
+                    component.MinTemperature = Atmospherics.T20C;
                     break;
-                // 73.15K with stock parts.
+                // 193.15K / -100C with stock parts.
                 case ThermoMachineMode.Freezer:
-                    component.MinTemperature = MathF.Max(Atmospherics.T0C - component.InitialMinTemperature + laserRating * 15f, Atmospherics.TCMB);
+                    component.MinTemperature = MathF.Max(
+                        component.BaseMinTemperature - component.MinTemperatureDelta * laserRating, Atmospherics.TCMB);
+                    component.MaxTemperature = Atmospherics.T20C;
                     break;
             }
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasThermoMachineSystem.cs
@@ -101,7 +101,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                     component.MaxTemperature = component.BaseMaxTemperature + component.MaxTemperatureDelta * laserRating;
                     component.MinTemperature = Atmospherics.T20C;
                     break;
-                // 73.15 with stock parts.
+                // 73.15K with stock parts.
                 case ThermoMachineMode.Freezer:
                     component.MinTemperature = MathF.Max(
                         component.BaseMinTemperature - component.MinTemperatureDelta * laserRating, Atmospherics.TCMB);

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -218,7 +218,6 @@
           enabledState: freezer_on
     - type: GasThermoMachine
       mode: Freezer
-      minTemperature: 73.15
     - type: Machine
       board: ThermomachineFreezerMachineCircuitBoard
 
@@ -244,6 +243,5 @@
           enabledState: heater_on
     - type: GasThermoMachine
       mode: Heater
-      maxTemperature: 573.15 # This is changed when parts are refreshed.
     - type: Machine
       board: ThermomachineHeaterMachineCircuitBoard


### PR DESCRIPTION
Currently upgrading the laser to a higher quality actually makes the minimum temperature of a freezer go up (i.e., get worse).
This fixes that, adds more data-fields, and makes minor changes to the stats.

:cl:
- tweak: Tweaked gas heater & freezer stats. Better lasers now actually improve minimum temperatures.

