### PR TITLE
Fix github action test output spam

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,31 +39,31 @@ jobs:
     - name: Setup Submodule
       run: |
         git submodule update --init --recursive
-    
+
     - name: Pull engine updates
       uses: space-wizards/submodule-dependency@v0.1.5
-    
+
     - name: Update Engine Submodules
       run: |
         cd RobustToolbox/
         git submodule update --init --recursive
-    
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
-    
+
     - name: Install dependencies
       run: dotnet restore
-    
+
     - name: Build Project
       run: dotnet build --configuration Release --no-restore /p:WarningsAsErrors=nullable /m
-    
+
     - name: Run Content.Tests
-      run: dotnet test --no-build Content.Tests/Content.Tests.csproj -v n
-    
+      run: dotnet test --no-build Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0
+
     - name: Run Content.IntegrationTests
       shell: pwsh
       run: |
         $env:DOTNET_gcServer=1
-        dotnet test --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -v n
+        dotnet test --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0


### PR DESCRIPTION
Will probably fix the spam of the tests output in github actions by replacing the old argument with the new equivalent. 
https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#consoleout

> In earlier versions you had to use -v n, but that is no longer required. In order to silence it in dotnet test you have to do:
>
> dotnet test -- NUnit.ConsoleOut=0
