### PR TITLE
Gun tweaks

### DIFF
--- a/Content.Client/DragDrop/DragDropSystem.cs
+++ b/Content.Client/DragDrop/DragDropSystem.cs
@@ -1,7 +1,9 @@
+using Content.Client.CombatMode;
 using Content.Client.Outline;
 using Content.Client.Viewport;
 using Content.Shared.ActionBlocker;
 using Content.Shared.CCVar;
+using Content.Shared.CombatMode;
 using Content.Shared.DragDrop;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
@@ -35,6 +37,7 @@ namespace Content.Client.DragDrop
         [Dependency] private readonly IConfigurationManager _cfgMan = default!;
         [Dependency] private readonly InteractionOutlineSystem _outline = default!;
         [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+        [Dependency] private readonly CombatModeSystem _combatMode = default!;
         [Dependency] private readonly InputSystem _inputSystem = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
 
@@ -124,7 +127,8 @@ namespace Content.Client.DragDrop
 
         private bool OnUseMouseDown(in PointerInputCmdHandler.PointerInputCmdArgs args)
         {
-            if (args.Session?.AttachedEntity is not {Valid: true} dragger)
+            if (args.Session?.AttachedEntity is not {Valid: true} dragger ||
+                _combatMode.IsInCombatMode())
             {
                 return false;
             }
@@ -218,7 +222,8 @@ namespace Content.Client.DragDrop
 
         private bool OnContinueDrag(float frameTime)
         {
-            if (_dragDropHelper.Dragged == default || Deleted(_dragDropHelper.Dragged))
+            if (_dragDropHelper.Dragged == default || Deleted(_dragDropHelper.Dragged) ||
+                _combatMode.IsInCombatMode())
             {
                 return false;
             }
@@ -231,8 +236,6 @@ namespace Content.Client.DragDrop
                 return false;
             }
 
-            // keep dragged entity under mouse
-            var mousePos = _eyeManager.ScreenToMap(_dragDropHelper.MouseScreenPosition);
             // TODO: would use MapPosition instead if it had a setter, but it has no setter.
             // is that intentional, or should we add a setter for Transform.MapPosition?
             if (_dragShadow == default)

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Database;
 using Content.Shared.DragDrop;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Pulling.Components;
 using Content.Shared.Weapons.Melee;
@@ -204,10 +205,13 @@ namespace Content.Server.Interaction
             {
                 var item = hands.ActiveHandEntity;
 
-                if (HasComp<ServerRangedBarrelComponent>(item)) return;
-
-                if (item != null && !Deleted(item.Value))
+                if (!Deleted(item))
                 {
+                    var meleeVee = new MeleeAttackAttemptEvent();
+                    RaiseLocalEvent(item.Value, ref meleeVee);
+
+                    if (meleeVee.Cancelled) return;
+
                     if (wideAttack)
                     {
                         var ev = new WideAttackEvent(item.Value, user, coordinates);

--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.CombatMode;
 using Content.Server.Hands.Components;
 using Content.Server.Pulling;
 using Content.Server.Storage.Components;
+using Content.Server.Weapon.Ranged.Barrels.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Database;
 using Content.Shared.DragDrop;
@@ -11,6 +12,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Pulling.Components;
 using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Ranged.Components;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
@@ -201,6 +203,8 @@ namespace Content.Server.Interaction
             if (TryComp(user, out HandsComponent? hands))
             {
                 var item = hands.ActiveHandEntity;
+
+                if (HasComp<ServerRangedBarrelComponent>(item)) return;
 
                 if (item != null && !Deleted(item.Value))
                 {

--- a/Content.Server/Weapon/Ranged/GunSystem.Guns.cs
+++ b/Content.Server/Weapon/Ranged/GunSystem.Guns.cs
@@ -7,6 +7,7 @@ using Content.Server.Weapon.Ranged.Ammunition.Components;
 using Content.Server.Weapon.Ranged.Barrels.Components;
 using Content.Shared.Camera;
 using Content.Shared.Database;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Robust.Shared.Audio;
 using Robust.Shared.Map;
@@ -18,6 +19,11 @@ namespace Content.Server.Weapon.Ranged;
 
 public sealed partial class GunSystem
 {
+    private void OnMeleeAttempt(EntityUid uid, ServerRangedWeaponComponent component, ref MeleeAttackAttemptEvent args)
+    {
+        args.Cancelled = true;
+    }
+
     /// <summary>
     /// Tries to fire a round of ammo out of the weapon.
     /// </summary>
@@ -138,6 +144,7 @@ public sealed partial class GunSystem
     }
 
     #region Firing
+
     /// <summary>
     /// Handles firing one or many projectiles
     /// </summary>
@@ -242,5 +249,6 @@ public sealed partial class GunSystem
             hitscan.FireEffects(shooter, hitscan.MaxLength, angle);
         }
     }
+
     #endregion
 }

--- a/Content.Server/Weapon/Ranged/GunSystem.cs
+++ b/Content.Server/Weapon/Ranged/GunSystem.cs
@@ -123,6 +123,7 @@ public sealed partial class GunSystem : EntitySystem
 
         // SubscribeLocalEvent<ServerRangedWeaponComponent, ExaminedEvent>(OnGunExamine);
         SubscribeNetworkEvent<FirePosEvent>(OnFirePos);
+        SubscribeLocalEvent<ServerRangedWeaponComponent, MeleeAttackAttemptEvent>(OnMeleeAttempt);
     }
 
     private void OnFirePos(FirePosEvent msg, EntitySessionEventArgs args)

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -65,10 +65,8 @@ namespace Content.Shared.CombatMode
         {
             var entity = eventArgs.SenderSession.AttachedEntity;
 
-            if (entity == default || !EntityManager.TryGetComponent(entity, out SharedCombatModeComponent? combatModeComponent))
-            {
+            if (entity == null || !EntityManager.TryGetComponent(entity, out SharedCombatModeComponent? combatModeComponent))
                 return;
-            }
 
             combatModeComponent.IsInCombatMode = ev.Active;
         }

--- a/Content.Shared/Interaction/Events/MeleeAttackAttemptEvent.cs
+++ b/Content.Shared/Interaction/Events/MeleeAttackAttemptEvent.cs
@@ -1,0 +1,16 @@
+namespace Content.Shared.Interaction.Events;
+
+/// <summary>
+/// Raised on directed a weapon when being used in a melee attack.
+/// </summary>
+[ByRefEvent]
+public struct MeleeAttackAttemptEvent
+{
+    public bool Cancelled = false;
+    public readonly EntityUid User;
+
+    public MeleeAttackAttemptEvent(EntityUid user)
+    {
+        User = user;
+    }
+}


### PR DESCRIPTION
- Dragdrop no longer usable in combat mode
- Can't melee with guns anymore (at least for now, so it doesn't happen during shooting).

:cl:
- tweak: Melee combat no longer possible with guns (for now).
- tweak: Drag-drop no longer possible in combat mode.
