### PR TITLE
Allow game presets to have min/max players

### DIFF
--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -25,6 +25,12 @@ namespace Content.Server.GameTicking.Presets
         [DataField("showInVote")]
         public bool ShowInVote { get; } = false;
 
+        [DataField("minPlayers")]
+        public int? MinPlayers { get; } = null;
+
+        [DataField("maxPlayers")]
+        public int? MaxPlayers { get; } = null;
+
         [DataField("rules", customTypeSerializer:typeof(PrototypeIdListSerializer<GameRulePrototype>))]
         public IReadOnlyList<string> Rules { get; } = Array.Empty<string>();
     }

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -110,10 +110,10 @@ namespace Content.Server.Voting.Managers
                 if(!preset.ShowInVote)
                     continue;
 
-                if(_playerManager.PlayerCount < (preset.MinPlayers ?? Int32.MinValue))
+                if(_playerManager.PlayerCount < (preset.MinPlayers ?? int.MinValue))
                     continue;
 
-                if(_playerManager.PlayerCount > (preset.MaxPlayers ?? Int32.MaxValue))
+                if(_playerManager.PlayerCount > (preset.MaxPlayers ?? int.MaxValue))
                     continue;
 
                 presets[preset.ID] = preset.ModeTitle;

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -110,6 +110,12 @@ namespace Content.Server.Voting.Managers
                 if(!preset.ShowInVote)
                     continue;
 
+                if(_playerManager.PlayerCount < (preset.MinPlayers ?? Int32.MinValue))
+                    continue;
+
+                if(_playerManager.PlayerCount > (preset.MaxPlayers ?? Int32.MaxValue))
+                    continue;
+
                 presets[preset.ID] = preset.ModeTitle;
             }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As title. minPlayers and maxPlayers can be assigned to game presets. I didn't actually assign them to any, but it's an option now.

I dunno if the nullable int as data thing even works? If it doesn't, I'll just make the default some dummy value (-1).

I wanted to add holiday stuff, too, but I'm not familiar enough with the codebase to figure out how to grab holidays.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Putnam
- add: Game presets can now be limited by player count (both min and max)

