### PR TITLE
Unrestrict device net ids

### DIFF
--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
@@ -8,25 +8,21 @@ namespace Content.Server.DeviceNetwork.Components
     [Friend(typeof(DeviceNetworkSystem), typeof(DeviceNet))]
     public sealed class DeviceNetworkComponent : Component
     {
-        /// <summary>
-        ///     Valid device network NetIDs. The netID is used to separate device networks that shouldn't interact with
-        ///     each other e.g. wireless and wired.
-        /// </summary>
-        [Serializable]
-        public enum ConnectionType
+        public enum DeviceNetIdDefaults
         {
             Private,
             Wired,
             Wireless,
-            Apc
+            Apc,
+            Reserved = 100,
+            // Ids outside this enum may exist
+            // This exists to let yml use nice names instead of numbers
         }
-        // TODO allow devices to join more than one network?
-
-        // TODO if wireless/wired is determined by ConnectionType, what is the point of WirelessNetworkComponent & the
-        // other network-type-specific components? Shouldn't DeviceNetId determine conectivity checks?
 
         [DataField("deviceNetId")]
-        public ConnectionType DeviceNetId { get; set; } = ConnectionType.Private;
+        public DeviceNetIdDefaults NetIdEnum { get; set; }
+
+        public int DeviceNetId => (int) NetIdEnum;
 
         /// <summary>
         ///     The frequency that this device is listening on.

--- a/Content.Server/DeviceNetwork/DeviceNet.cs
+++ b/Content.Server/DeviceNetwork/DeviceNet.cs
@@ -31,12 +31,12 @@ public sealed class DeviceNet
     public readonly Dictionary<uint, HashSet<DeviceNetworkComponent>> ReceiveAllDevices = new();
 
     private readonly IRobustRandom _random;
-    public readonly ConnectionType Type;
+    public readonly int NetId;
 
-    public DeviceNet(ConnectionType netType, IRobustRandom random)
+    public DeviceNet(int netId, IRobustRandom random)
     {
         _random = random;
-        Type = netType;
+        NetId = netId;
     }
 
     /// <summary>


### PR DESCRIPTION
Changes it so NetIds can be any integer, rather then 4 presets.