### PR TITLE
Before equipping, check if item can be dropped, but don't do it

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -144,7 +144,7 @@ public abstract partial class InventorySystem
             return;
         }
 
-        if (_handsSystem.TryDrop(actor, hands.ActiveHand!, doDropInteraction: false, handsComp: hands))
+        if (_handsSystem.CanDropHeld(actor, hands.ActiveHand!, checkActionBlocker: false))
             TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory);
     }
 


### PR DESCRIPTION
This fixes equipping an item inside a locker. Previously, the item was dropped. Now it actually gets equipped.

Fixes #8179.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Changelog**
Fixed equipping items inside a locker.

<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed equipping items inside a locker.

