### PR TITLE
Fix dropping held items inside of lockers.

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -66,17 +66,24 @@ public abstract partial class SharedHandsSystem : EntitySystem
         var entity = hand.HeldEntity!.Value;
         DoDrop(uid, hand, doDropInteraction: doDropInteraction, handsComp);
 
-        var xform = Transform(uid);
+        var userXform = Transform(uid);
+        var itemXform = Transform(entity);
+        var isInContainer = _containerSystem.IsEntityInContainer(uid);
 
-        if (targetDropLocation == null)
+        if (targetDropLocation == null || isInContainer)
         {
+            // If user is in a container, drop item into that container. Otherwise, attach to grid or map.\
             // TODO recursively check upwards for containers
-            Transform(entity).AttachParentToContainerOrGrid(EntityManager);
+
+            if (!isInContainer
+                || !_containerSystem.TryGetContainingContainer(userXform.ParentUid, uid, out var container, skipExistCheck: true)
+                || !container.Insert(entity, EntityManager, itemXform))
+                itemXform.AttachToGridOrMap();
             return true;
         }
 
         var target = targetDropLocation.Value.ToMap(EntityManager);
-        Transform(entity).WorldPosition = GetFinalDropCoordinates(uid, xform.MapPosition, target);
+        itemXform.WorldPosition = GetFinalDropCoordinates(uid, userXform.MapPosition, target);
         return true;
     }
 

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Clothing.Components;
+using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -144,8 +145,16 @@ public abstract partial class InventorySystem
             return;
         }
 
-        if (_handsSystem.CanDropHeld(actor, hands.ActiveHand!, checkActionBlocker: false))
-            TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory);
+        if (!_handsSystem.CanDropHeld(actor, hands.ActiveHand!, checkActionBlocker: false))
+            return;
+
+        var gotUnequipped = new GotUnequippedHandEvent(actor, held.Value, hands.ActiveHand!);
+        var didUnequip = new DidUnequipHandEvent(actor, held.Value, hands.ActiveHand!);
+        RaiseLocalEvent(held.Value, gotUnequipped, false);
+        RaiseLocalEvent(actor, didUnequip);
+        RaiseLocalEvent(held.Value, new HandDeselectedEvent(actor), false);
+
+        TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory, force: true);
     }
 
     public bool TryEquip(EntityUid uid, EntityUid itemUid, string slot, bool silent = false, bool force = false, bool predicted = false,


### PR DESCRIPTION
Currently dropping held items while inside of lockers will sometimes place them on the floor, rather than inside of the locker. 

This caused the bug that #8333 tried to address, but in doing so also causes unequip events to not get fired. So this also fixes that.