### PR TITLE
Fix bug where being eaten as a mouse tethers your ghost to who ate you

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -90,9 +90,14 @@ public sealed class MindSystem : EntitySystem
 
                     // Async this so that we don't throw if the grid we're on is being deleted.
                     var gridId = spawnPosition.GetGridId(EntityManager);
-                    if (!spawnPosition.IsValid(EntityManager) || gridId == GridId.Invalid || !_mapManager.GridExists(gridId) || spawnPosition.Position == Vector2.Zero)
+                    if (!spawnPosition.IsValid(EntityManager) || gridId == GridId.Invalid || !_mapManager.GridExists(gridId))
                     {
                         spawnPosition = _gameTicker.GetObserverSpawnPoint();
+                    }
+                    else if (spawnPosition.Position == Vector2.Zero)
+                    {
+                        Transform(spawnPosition.EntityId).AttachToGridOrMap();
+                        spawnPosition = Transform(spawnPosition.EntityId).Coordinates;
                     }
 
                     var ghost = Spawn("MobObserver", spawnPosition);

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -90,7 +90,7 @@ public sealed class MindSystem : EntitySystem
 
                     // Async this so that we don't throw if the grid we're on is being deleted.
                     var gridId = spawnPosition.GetGridId(EntityManager);
-                    if (!spawnPosition.IsValid(EntityManager) || gridId == GridId.Invalid || !_mapManager.GridExists(gridId))
+                    if (!spawnPosition.IsValid(EntityManager) || gridId == GridId.Invalid || !_mapManager.GridExists(gridId) || spawnPosition.Position == Vector2.Zero)
                     {
                         spawnPosition = _gameTicker.GetObserverSpawnPoint();
                     }

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -80,6 +80,7 @@ public sealed class MindSystem : EntitySystem
             }
             else if (mind.GhostOnShutdown)
             {
+                Transform(uid).AttachToGridOrMap();
                 var spawnPosition = Transform(uid).Coordinates;
                 // Use a regular timer here because the entity has probably been deleted.
                 Timer.Spawn(0, () =>
@@ -93,11 +94,6 @@ public sealed class MindSystem : EntitySystem
                     if (!spawnPosition.IsValid(EntityManager) || gridId == GridId.Invalid || !_mapManager.GridExists(gridId))
                     {
                         spawnPosition = _gameTicker.GetObserverSpawnPoint();
-                    }
-                    else if (spawnPosition.Position == Vector2.Zero)
-                    {
-                        Transform(spawnPosition.EntityId).AttachToGridOrMap();
-                        spawnPosition = Transform(spawnPosition.EntityId).Coordinates;
                     }
 
                     var ghost = Spawn("MobObserver", spawnPosition);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If someone holds your mouse corpse in their inventory and eats you, your ghost will spawn at their relative coordinates, as if you were still in their inventory. This drags your ghost around as if your position is offset by their movement.

I've simply added a check to spawn the ghost in the observer spawn point if in this situation.

Resolves #8269

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed an issue where mouse ghosts would be tethered to who ate them

