### PR TITLE
Switch voting from plurality to approval

### DIFF
--- a/Content.Client/Voting/UI/VotePopup.xaml.cs
+++ b/Content.Client/Voting/UI/VotePopup.xaml.cs
@@ -41,7 +41,7 @@ namespace Content.Client.Voting.UI
                 };
                 _voteButtons[i] = button;
                 VoteOptionsContainer.AddChild(button);
-                var i1 = i;
+                var i1 = (byte)i;
                 button.OnPressed += _ => _voteManager.SendCastVote(vote.Id, i1);
             }
         }
@@ -56,7 +56,7 @@ namespace Content.Client.Voting.UI
                 var entry = _vote.Entries[i];
                 _voteButtons[i].Text = Loc.GetString("ui-vote-button", ("text", entry.Text), ("votes", entry.Votes));
 
-                if (_vote.OurVote == i)
+                if (_vote.OurVote?.Contains((byte)i) ?? false)
                     _voteButtons[i].Pressed = true;
             }
         }

--- a/Content.Server/Voting/IVoteHandle.cs
+++ b/Content.Server/Voting/IVoteHandle.cs
@@ -63,19 +63,19 @@ namespace Content.Server.Voting
         /// </summary>
         /// <param name="optionId">The integer ID of the option.</param>
         /// <returns>True if the option ID is valid, false otherwise.</returns>
-        bool IsValidOption(int optionId);
+        bool IsValidOption(byte optionId);
 
         /// <summary>
         /// Cast a vote for a specific player.
         /// </summary>
         /// <param name="session">The player session to vote for.</param>
         /// <param name="optionId">
-        /// The integer option ID to vote for. If null, "no vote" is selected (abstaining).
+        /// The integer option ID to vote for. If this entry has already been voted for, that vote is retracted.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="optionId"/> is not a valid option ID.
         /// </exception>
-        void CastVote(IPlayerSession session, int? optionId);
+        void CastVote(IPlayerSession session, byte optionId);
 
         /// <summary>
         /// Cancel this vote.

--- a/Content.Server/Voting/VoteCommands.cs
+++ b/Content.Server/Voting/VoteCommands.cs
@@ -120,7 +120,7 @@ namespace Content.Server.Voting
                 return;
             }
 
-            if (!int.TryParse(args[1], out var voteOption))
+            if (!byte.TryParse(args[1], out var voteOption))
             {
                 shell.WriteError(Loc.GetString("vote-command-on-execute-error-invalid-vote-options"));
                 return;
@@ -133,22 +133,13 @@ namespace Content.Server.Voting
                 return;
             }
 
-            int? optionN;
-            if (voteOption == -1)
-            {
-                optionN = null;
-            }
-            else if (vote.IsValidOption(voteOption))
-            {
-                optionN = voteOption;
-            }
-            else
+            if (!vote.IsValidOption(voteOption))
             {
                 shell.WriteError(Loc.GetString("vote-command-on-execute-error-invalid-option"));
                 return;
             }
 
-            vote.CastVote((IPlayerSession) shell.Player!, optionN);
+            vote.CastVote((IPlayerSession) shell.Player!, voteOption);
         }
     }
 

--- a/Content.Shared/Voting/MsgVoteData.cs
+++ b/Content.Shared/Voting/MsgVoteData.cs
@@ -15,7 +15,8 @@ namespace Content.Shared.Voting
         public TimeSpan EndTime; // Server RealTime.
         public (ushort votes, string name)[] Options = default!;
         public bool IsYourVoteDirty;
-        public byte? YourVote;
+        public int voteCount;
+        public byte[]? YourVote;
 
         public override void ReadFromBuffer(NetIncomingMessage buffer)
         {
@@ -40,7 +41,12 @@ namespace Content.Shared.Voting
             IsYourVoteDirty = buffer.ReadBoolean();
             if (IsYourVoteDirty)
             {
-                YourVote = buffer.ReadBoolean() ? buffer.ReadByte() : null;
+                if(buffer.ReadBoolean()) {
+                    int count = buffer.ReadInt32();
+                    YourVote = buffer.ReadBytes(count);
+                } else {
+                    YourVote = null;
+                }
             }
         }
 
@@ -68,10 +74,11 @@ namespace Content.Shared.Voting
             buffer.Write(IsYourVoteDirty);
             if (IsYourVoteDirty)
             {
-                buffer.Write(YourVote.HasValue);
-                if (YourVote.HasValue)
+                buffer.Write(YourVote != null);
+                if (YourVote != null)
                 {
-                    buffer.Write(YourVote.Value);
+                    buffer.Write(YourVote.Length);
+                    buffer.Write(YourVote);
                 }
             }
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This switches the voting system from [plurality voting](https://en.wikipedia.org/wiki/Plurality_voting), the worst one, to [approval voting](https://en.wikipedia.org/wiki/Approval_voting), one of the better ones, actually. 

Approval voting is exactly as easy to implement as plurality voting and leads to significantly better results for the kinds of polls done in this kind of game. It's significantly better that players be able to say "yeah, I'm fine with these 4 maps" than to have to pick one in particular, for example, and the same is true of game rules and similar things.

Eventually I could allow multiple voting systems, but I'm still new to this whole SS14 thing (and C# too, to a lesser extent), so, like, not right now. This would entail adding new UIs for ranked systems and score-based systems. Plurality itself could probably be implemented separately, but, frankly, I think that's kinda pointless, since it's essentially strictly worse approval (if everyone bullet votes their favorite, it has identical results).

This is a draft because I don't have a proper testing setup yet and thus haven't actually tested it (I can run unit tests, and did for my last PR, but no proper testing). Once I get that all squared away I'll open it properly. 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added fun!
- remove: Removed fun!

