### PR TITLE
Adds a reoccurrence delay to station events

### DIFF
--- a/Content.Server/StationEvents/Events/StationEvent.cs
+++ b/Content.Server/StationEvents/Events/StationEvent.cs
@@ -71,7 +71,7 @@ namespace Content.Server.StationEvents.Events
         /// <summary>
         ///     In minutes, the amount of time before the same event can occur again
         /// </summary>
-        public virtual int ReoccurenceDelay { get; } = 30;
+        public virtual int ReoccurrenceDelay { get; } = 30;
 
         /// <summary>
         ///     When in the lifetime to call Start().

--- a/Content.Server/StationEvents/Events/StationEvent.cs
+++ b/Content.Server/StationEvents/Events/StationEvent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chat.Managers;
+using Content.Server.GameTicking;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Database;
@@ -24,6 +25,11 @@ namespace Content.Server.StationEvents.Events
         ///     If the event has started and is currently running.
         /// </summary>
         public bool Running { get; set; }
+
+        /// <summary>
+        ///     The time when this event last ran.
+        /// </summary>
+        public TimeSpan LastRun { get; set; } = TimeSpan.Zero;
 
         /// <summary>
         ///     Human-readable name for the event.
@@ -61,6 +67,11 @@ namespace Content.Server.StationEvents.Events
         ///     In minutes, when is the first round time this event can start
         /// </summary>
         public virtual int EarliestStart { get; } = 5;
+
+        /// <summary>
+        ///     In minutes, the amount of time before the same event can occur again
+        /// </summary>
+        public virtual int ReoccurenceDelay { get; } = 30;
 
         /// <summary>
         ///     When in the lifetime to call Start().
@@ -112,6 +123,7 @@ namespace Content.Server.StationEvents.Events
         {
             Started = true;
             Occurrences += 1;
+            LastRun = IoCManager.Resolve<GameTicker>().RoundDuration();
 
             EntitySystem.Get<AdminLogSystem>()
                 .Add(LogType.EventStarted, LogImpact.High, $"Event startup: {Name}");

--- a/Content.Server/StationEvents/StationEventSystem.cs
+++ b/Content.Server/StationEvents/StationEventSystem.cs
@@ -352,6 +352,12 @@ namespace Content.Server.StationEvents
                 return false;
             }
 
+            if (stationEvent.LastRun != TimeSpan.Zero && currentTime.TotalMinutes <
+                stationEvent.ReoccurenceDelay + stationEvent.LastRun.Minutes)
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/Content.Server/StationEvents/StationEventSystem.cs
+++ b/Content.Server/StationEvents/StationEventSystem.cs
@@ -353,7 +353,7 @@ namespace Content.Server.StationEvents
             }
 
             if (stationEvent.LastRun != TimeSpan.Zero && currentTime.TotalMinutes <
-                stationEvent.ReoccurenceDelay + stationEvent.LastRun.Minutes)
+                stationEvent.ReoccurrenceDelay + stationEvent.LastRun.Minutes)
             {
                 return false;
             }

--- a/Content.Server/StationEvents/StationEventSystem.cs
+++ b/Content.Server/StationEvents/StationEventSystem.cs
@@ -353,7 +353,7 @@ namespace Content.Server.StationEvents
             }
 
             if (stationEvent.LastRun != TimeSpan.Zero && currentTime.TotalMinutes <
-                stationEvent.ReoccurrenceDelay + stationEvent.LastRun.Minutes)
+                stationEvent.ReoccurrenceDelay + stationEvent.LastRun.TotalMinutes)
             {
                 return false;
             }

--- a/Content.Server/StationEvents/StationEventSystem.cs
+++ b/Content.Server/StationEvents/StationEventSystem.cs
@@ -378,6 +378,7 @@ namespace Content.Server.StationEvents
             foreach (var stationEvent in _stationEvents)
             {
                 stationEvent.Occurrences = 0;
+                stationEvent.LastRun = TimeSpan.Zero;
             }
 
             _timeUntilNextEvent = MinimumTimeUntilFirstEvent;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Regardless of any other inhibitors on when a station event will fire, having the same event occur multiple times in a brief timespan is cringe.

This adds a delay of, by default, 30 minutes before the same event can occur again. Obviously people can tweak this as they see fit for the various event types.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Added a reoccurrence delay to station events. By default no event will reoccur twice within 30 minutes.

