### PR TITLE
Sandbox on no lobby

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -70,7 +70,7 @@ namespace Content.Server.GameTicking
 
         private void InitializeGamePreset()
         {
-            SetGamePreset(_configurationManager.GetCVar(CCVars.GameLobbyDefaultPreset));
+            SetGamePreset(LobbyEnabled ? _configurationManager.GetCVar(CCVars.GameLobbyDefaultPreset) : "sandbox");
         }
 
         public void SetGamePreset(GamePresetPrototype preset, bool force = false)


### PR DESCRIPTION
On Startup
Game preset
Lobby Enabled -> CCVars.GameLobbyDefaultPreset-> traitor
Lobby Not Enabled -> sandbox

Makes local development easier