### PR TITLE
Fixes some high speed item issues

### DIFF
--- a/Content.Server/Damage/Components/DamageOnHighSpeedImpactComponent.cs
+++ b/Content.Server/Damage/Components/DamageOnHighSpeedImpactComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Damage.Components
         [DataField("minimumSpeed")]
         public float MinimumSpeed { get; set; } = 20f;
         [DataField("factor")]
-        public float Factor { get; set; } = 1f;
+        public float Factor { get; set; } = 0.5f;
         [DataField("soundHit", required: true)]
         public SoundSpecifier SoundHit { get; set; } = default!;
         [DataField("stunChance")]

--- a/Content.Shared/Slippery/SharedSlipperySystem.cs
+++ b/Content.Shared/Slippery/SharedSlipperySystem.cs
@@ -1,8 +1,6 @@
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
-using Content.Shared.DragDrop;
 using Content.Shared.Inventory;
-using Content.Shared.Standing;
 using Content.Shared.StatusEffect;
 using Content.Shared.StepTrigger;
 using Content.Shared.Stunnable;
@@ -60,9 +58,7 @@ namespace Content.Shared.Slippery
             var ev = new SlipAttemptEvent();
             RaiseLocalEvent(other, ev, false);
             if (ev.Cancelled)
-            {
                 return;
-            }
 
             if (TryComp(other, out PhysicsComponent? physics))
                 physics.LinearVelocity *= component.LaunchForwardsMultiplier;

--- a/Content.Shared/Slippery/SharedSlipperySystem.cs
+++ b/Content.Shared/Slippery/SharedSlipperySystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.DragDrop;
 using Content.Shared.Inventory;
+using Content.Shared.Standing;
 using Content.Shared.StatusEffect;
 using Content.Shared.StepTrigger;
 using Content.Shared.Stunnable;
@@ -58,7 +60,9 @@ namespace Content.Shared.Slippery
             var ev = new SlipAttemptEvent();
             RaiseLocalEvent(other, ev, false);
             if (ev.Cancelled)
+            {
                 return;
+            }
 
             if (TryComp(other, out PhysicsComponent? physics))
                 physics.LinearVelocity *= component.LaunchForwardsMultiplier;

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -177,7 +177,7 @@
     sprite: Objects/Specific/Hydroponics/banana.rsi
     HeldPrefix: peel
   - type: Slippery
-    launchForwardsMultiplier: 6.0
+    launchForwardsMultiplier: 1.5
   - type: StepTrigger
     intersectRatio: 0.2
   - type: CollisionWake

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -192,7 +192,7 @@
     state: pda-clown
   - type: Slippery
     paralyzeTime: 4
-    launchForwardsMultiplier: 9.0
+    launchForwardsMultiplier: 1.5
   - type: StepTrigger
   - type: CollisionWake
     enabled: false

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -14,7 +14,7 @@
     sprite: Objects/Specific/Janitorial/soap.rsi
   - type: Slippery
     paralyzeTime: 2
-    launchForwardsMultiplier: 6.0
+    launchForwardsMultiplier: 1.5
   - type: StepTrigger
     intersectRatio: 0.2
   - type: CollisionWake

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -36,7 +36,7 @@
   physicalDesc: reagent-physical-desc-shiny
   color: "#77b58e"
   boilingPoint: 290.0 # Glycerin
-  meltingPoint: 18.2 
+  meltingPoint: 18.2
   tileReactions:
     - !type:SpillTileReaction
       paralyzeTime: 3


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

fixes #8262
fixes #7907 
fixes #7936 
(also I'm not sure if it fixes the third one but just in case)

The basic here is that anything that wasn't a puddle was at 6F velocity or higher, which means items flung out of your hands at mach speed. The only things that weren't 6F were lube and puddles. Hilariously the clown PDA was at 9F.

So to fix this I've just balanced it so the velocities are at 2F or below for most everything except:

Space Lube - I know lube is usually considered the funny slip item so I buffed it to 5F
Traitor Soap - I was 50/50 about lowering this from 9F to match with the other regular soaps, but I'll let the maintainer(s) decide that.
Omega Soap - I wasn't sure if this was admin spawn only so I left it alone.

I also lowered the damage factor by half for DamageOnHighSpeedImpact so maybe nothing super funny should happen anymore with that? At least with testing out slipped items at high speed it was less destructive too.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Balanced slipping speed so items don't go mach 5.

