### PR TITLE
Microwave was stuck in busy state on some BeingMicrowavedEvents

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -212,6 +212,7 @@ namespace Content.Server.Kitchen.Components
 
                 if (ev.Handled)
                 {
+                    _busy = false;
                     UIDirty = true;
                     return;
                 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If a microwaved entity has a BeingMicrowavedEvent and the event is marked as handled=true when called, the method exits and is stuck in a permanent 'busy' state.

If the event doesn't break/unpower the microwave, then the OnUpdate() logic doesn't reset it, like in the case of gibbing.

(The microwave can still be set to Broken if an event wants to break it.)

Fixes #8356 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Gibbing an entity in the microwave no longer locks its UI

