### PR TITLE
Fix stack overflow on rigged power cell explosion.

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -85,7 +85,6 @@ public sealed class PowerCellSystem : SharedPowerCellSystem
             return;
 
         var radius = MathF.Min(5, MathF.Ceiling(MathF.Sqrt(battery.CurrentCharge) / 30));
-        battery.CurrentCharge = 0;
 
         _explosionSystem.TriggerExplosive(uid, radius: radius);
         QueueDel(uid);


### PR DESCRIPTION
Remove the set to cell charge from explosion code. I assume the cell won't see much use since it's about to be deleted anyways.