### PR TITLE
Kudzu nerf and electric kudzu

### DIFF
--- a/Content.Server/StationEvents/Events/KudzuGrowthPower.cs
+++ b/Content.Server/StationEvents/Events/KudzuGrowthPower.cs
@@ -1,0 +1,51 @@
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Server.StationEvents.Events;
+
+public sealed class KudzuGrowthPower : StationEvent
+{
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    public override string Name => "KudzuGrowthPower";
+
+    public override string? StartAnnouncement =>
+        Loc.GetString("station-event-kudzupower-growth-start-announcement");
+
+    public override int EarliestStart => 50;
+
+    public override int MinimumPlayers => 15;
+
+    public override float Weight => WeightLow / 2;
+
+    public override int? MaxOccurrences => 2;
+
+    // Get players to scatter a bit looking for it.
+    protected override float StartAfter => 50f;
+
+    // Give crew at least 9 minutes to either have it gone, or to suffer another event. Kudzu is not actually required to be dead for another event to roll.
+    protected override float EndAfter => 60*4;
+
+    private EntityUid _targetGrid;
+
+    private Vector2i _targetTile;
+
+    private EntityCoordinates _targetCoords;
+
+    public override void Startup()
+    {
+        base.Startup();
+
+        // Pick a place to plant the kudzu.
+        if (TryFindRandomTile(out _targetTile, out _, out _targetGrid, out _targetCoords, _robustRandom, _entityManager))
+        {
+            _entityManager.SpawnEntity("KudzuPower", _targetCoords);
+            Logger.InfoS("stationevents", $"Spawning a KudzuPower at {_targetTile} on {_targetGrid}");
+        }
+
+        // If the kudzu tile selection fails we just let the announcement happen anyways because it's funny and people
+        // will be hunting the non-existent, dangerous plant.
+    }
+
+}

--- a/Resources/Locale/en-US/station-events/events/kudzu-growth.ftl
+++ b/Resources/Locale/en-US/station-events/events/kudzu-growth.ftl
@@ -1,1 +1,2 @@
 station-event-kudzu-growth-start-announcement = Attention crew, we have detected a Type 2 Biological Invader on-station, that poses potentially serious threat to crew productivity. We advise you to exterminate it.
+station-event-kudzupower-growth-start-announcement = Attention crew, we have detected a special Type 2 Biological Invader on-station, that poses potentially serious threat to crew productivity. We advise you to exterminate it. Don't get too close.

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -74,7 +74,38 @@
       growthResult: Kudzu
       chance: 1
     - type: GrowingKudzu
-      growthTickSkipChance: 0.1666
+      growthTickSkipChance: 0.6
     - type: SlowContacts
       walkSpeedModifier: 0.2
       sprintSpeedModifier: 0.2
+
+- type: entity
+  id: KudzuPower
+  parent: Kudzu
+  name: kudzu
+  suffix: Power
+  description: A rapidly growing, dangerous plant. WHY ARE YOU STOPPING TO LOOK AT IT?!
+  components:
+    - type: Electrified
+      onHandInteract: false
+      onInteractUsing: false
+      onBump: true
+      requirePower: true
+      highVoltageNode: power
+      mediumVoltageNode: power
+      lowVoltageNode: power
+    - type: ApcPowerReceiver
+    - type: ExtensionCableReceiver
+    - type: Battery
+      maxCharge: 50000
+    - type: PowerConsumer
+      voltage: Apc
+      drawRate: 5000
+    - type: NodeContainer
+      nodes:
+        power:
+          !type:CableNode
+          nodeGroupID: Apc
+    - type: Spreader
+      growthResult: KudzuPower
+      chance: 0.25


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Nerfs kudzu spread speed by increasing the chance it won't spread from 16% to 60% (this mainly affects singular tiles of Kudzu and doesn't do much once it's already took off).
- Adds KudzuPower, an electrified Kudzu as a late game (after 50 minutes, low chance) event. Looks the same except drains APC networks rather fast causing brownouts then blackouts. Will shock if you bump it.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![ContentClient-8JcDb2r83e](https://user-images.githubusercontent.com/78795277/169892476-3b8723d3-e07b-4bf5-a3ba-545fac253625.gif)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added a new Kudzu variant that's utterly shocking! It's rare so look out for the unique announcement late game.
- tweak: Made the normal Kudzu spread less often so it should be easier to manage when it's smaller.

