### PR TITLE
Markings tweaks

### DIFF
--- a/Content.Client/Markings/MarkingPicker.xaml.cs
+++ b/Content.Client/Markings/MarkingPicker.xaml.cs
@@ -349,9 +349,9 @@ namespace Content.Client.Markings
                 );
                 colorSelector.Color = currentColor;
                 _currentMarkingColors.Add(currentColor);
-                int colorIndex = _currentMarkingColors.IndexOf(currentColor);
+                var colorIndex = _currentMarkingColors.Count - 1;
 
-                Action<Color> colorChanged = delegate(Color color)
+                Action<Color> colorChanged = _ =>
                 {
                     _currentMarkingColors[colorIndex] = colorSelector.Color;
 

--- a/Content.Client/Markings/MarkingPicker.xaml.cs
+++ b/Content.Client/Markings/MarkingPicker.xaml.cs
@@ -47,11 +47,13 @@ namespace Content.Client.Markings
         private List<MarkingCategories> _markingCategories = Enum.GetValues<MarkingCategories>().ToList();
 
         private string _currentSpecies = SpeciesManager.DefaultSpecies;
+        public Color CurrentSkinColor = Color.White;
 
-        public void SetData(MarkingsSet newMarkings, string species)
+        public void SetData(MarkingsSet newMarkings, string species, Color skinColor)
         {
             _currentMarkings = newMarkings;
             _currentSpecies = species;
+            CurrentSkinColor = skinColor;
 
             // Should marking limits be dependent on species prototypes,
             // or should it be dependent on the entity the
@@ -71,6 +73,8 @@ namespace Content.Client.Markings
             Populate();
             PopulateUsed();
         }
+
+        public void SetSkinColor(Color color) => CurrentSkinColor = color;
 
         public MarkingPicker()
         {
@@ -394,7 +398,13 @@ namespace Content.Client.Markings
 
             UpdatePoints();
 
-            _currentMarkings.AddBack(marking.AsMarking());
+            var markingObject = marking.AsMarking();
+            for (var i = 0; i < markingObject.MarkingColors.Count; i++)
+            {
+                markingObject.SetColor(i, CurrentSkinColor);
+            }
+
+            _currentMarkings.AddBack(markingObject);
 
             CMarkingsUnused.Remove(_selectedUnusedMarking);
             var item = new ItemList.Item(CMarkingsUsed)

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -568,6 +568,8 @@ namespace Content.Client.Preferences.UI
                     }
 
                     var color = new Color(_rgbSkinColorSelector.Color.R, _rgbSkinColorSelector.Color.G, _rgbSkinColorSelector.Color.B);
+
+                    CMarkings.CurrentSkinColor = color;
                     Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
                     break;
                 }

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -555,6 +555,7 @@ namespace Content.Client.Preferences.UI
 
                     var color = Color.FromHsv(new Vector4(hue / 360, sat / 100, val / 100, 1.0f));
 
+                    CMarkings.CurrentSkinColor = color;
                     Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
                     break;
                 }
@@ -584,6 +585,7 @@ namespace Content.Client.Preferences.UI
                     newColor.Y = .1f;
                     color = Color.FromHsv(newColor);
 
+                    CMarkings.CurrentSkinColor = color;
                     Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
                     break;
                 }
@@ -834,7 +836,7 @@ namespace Content.Client.Preferences.UI
                 return;
             }
 
-            CMarkings.SetData(Profile.Appearance.Markings, Profile.Species);
+            CMarkings.SetData(Profile.Appearance.Markings, Profile.Species, Profile.Appearance.SkinColor);
         }
 
         private void UpdateSpecies()

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -945,7 +945,7 @@ namespace Content.Client.Preferences.UI
             UpdateAntagPreferences();
             UpdateMarkings();
 
-            _needUpdatePreview = true;
+            NeedsDummyRebuild = true;
 
             _preferenceUnavailableButton.SelectId((int) Profile.PreferenceUnavailable);
         }

--- a/Content.Shared/Markings/MarkingsComponent.cs
+++ b/Content.Shared/Markings/MarkingsComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.CharacterAppearance;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Markings
 {
@@ -32,7 +33,7 @@ namespace Content.Shared.Markings
         [DataField("required", required: true)]
         public bool Required = false;
         // Default markings for this layer.
-        [DataField("defaultMarkings")]
+        [DataField("defaultMarkings", customTypeSerializer:typeof(PrototypeIdSerializer<MarkingPrototype>))]
         public List<string> DefaultMarkings = new();
 
         public static Dictionary<MarkingCategories, MarkingPoints> CloneMarkingPointDictionary(Dictionary<MarkingCategories, MarkingPoints> self)

--- a/Content.Shared/Markings/MarkingsComponent.cs
+++ b/Content.Shared/Markings/MarkingsComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.CharacterAppearance;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Shared.Markings
 {
@@ -33,7 +34,7 @@ namespace Content.Shared.Markings
         [DataField("required", required: true)]
         public bool Required = false;
         // Default markings for this layer.
-        [DataField("defaultMarkings", customTypeSerializer:typeof(PrototypeIdSerializer<MarkingPrototype>))]
+        [DataField("defaultMarkings", customTypeSerializer:typeof(PrototypeIdListSerializer<MarkingPrototype>))]
         public List<string> DefaultMarkings = new();
 
         public static Dictionary<MarkingCategories, MarkingPoints> CloneMarkingPointDictionary(Dictionary<MarkingCategories, MarkingPoints> self)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Selecting a marking will now default to it being the current skin color.
- MarkingPoints now has a type serializer, making it so that default markings are verified upon load.
- Markings will now properly disappear when character profiles are switched.