### PR TITLE
Allow ghosts to ignore obstructions

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CombatMode;
 using Content.Shared.Database;
+using Content.Shared.Ghost;
 using Content.Shared.Hands.Components;
 using Content.Shared.Input;
 using Content.Shared.Interaction.Components;
@@ -149,7 +150,7 @@ namespace Content.Shared.Interaction
                 return true;
             }
 
-            UserInteraction(user.Value, coords, uid, altInteract: true);
+            UserInteraction(user.Value, coords, uid, altInteract: true, checkAccess: ShouldCheckAccess(user.Value));
 
             return false;
         }
@@ -163,9 +164,16 @@ namespace Content.Shared.Interaction
                 return true;
             }
 
-            UserInteraction(userEntity.Value, coords, !Deleted(uid) ? uid : null);
+            UserInteraction(userEntity.Value, coords, !Deleted(uid) ? uid : null, checkAccess: ShouldCheckAccess(userEntity.Value));
 
             return false;
+        }
+
+        private bool ShouldCheckAccess(EntityUid user)
+        {
+            // This is for Admin/mapping convenience. If ever there are other ghosts that can still interact, this check
+            // might need to be more selective.
+            return !HasComp<SharedGhostComponent>(user);
         }
 
         /// <summary>
@@ -669,7 +677,7 @@ namespace Content.Shared.Interaction
             if (Deleted(uid))
                 return false;
 
-            InteractionActivate(user.Value, uid);
+            InteractionActivate(user.Value, uid, checkAccess: ShouldCheckAccess(user.Value));
             return false;
         }
 


### PR DESCRIPTION
For admins & mapping, seeing as normal ghosts cant interact in the first place.

Doesn't change the interaction outline. Due to laziness, but might even be a good thing, as it makes it easy for mappers to check if something is in range & unobstructed without controlling a mob.

:cl:
- tweak: Ghosts now ignore obstructions for some interactions. Useful for admins and mappers.

