### PR TITLE
Inflatable wall fix

### DIFF
--- a/Content.Server/Engineering/Components/SpawnAfterInteractComponent.cs
+++ b/Content.Server/Engineering/Components/SpawnAfterInteractComponent.cs
@@ -11,6 +11,10 @@ namespace Content.Server.Engineering.Components
         public string? Prototype { get; }
 
         [ViewVariables]
+        [DataField("ignoreDistance")]
+        public bool IgnoreDistance { get; }
+
+        [ViewVariables]
         [DataField("doAfter")]
         public float DoAfterTime = 0;
 

--- a/Content.Server/Engineering/EntitySystems/SpawnAfterInteractSystem.cs
+++ b/Content.Server/Engineering/EntitySystems/SpawnAfterInteractSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Server.Engineering.EntitySystems
 
         private async void HandleAfterInteract(EntityUid uid, SpawnAfterInteractComponent component, AfterInteractEvent args)
         {
-            if (!args.CanReach)
+            if (!args.CanReach && !component.IgnoreDistance)
                 return;
             if (string.IsNullOrEmpty(component.Prototype))
                 return;

--- a/Content.Server/Engineering/EntitySystems/SpawnAfterInteractSystem.cs
+++ b/Content.Server/Engineering/EntitySystems/SpawnAfterInteractSystem.cs
@@ -25,6 +25,8 @@ namespace Content.Server.Engineering.EntitySystems
 
         private async void HandleAfterInteract(EntityUid uid, SpawnAfterInteractComponent component, AfterInteractEvent args)
         {
+            if (!args.CanReach)
+                return;
             if (string.IsNullOrEmpty(component.Prototype))
                 return;
             if (!_mapManager.TryGetGrid(args.ClickLocation.GetGridId(EntityManager), out var grid))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the fact that inflatable walls (and anything that uses SpawnAfterInteract) ignore distance from the player... by default. This behavior can be toggled with a new flag, `ignoreDistance` in YAML.