### PR TITLE
Adds seven new smites, moves the explosion smite to the verb category.

### DIFF
--- a/Content.Client/Entry/IgnoredComponents.cs
+++ b/Content.Client/Entry/IgnoredComponents.cs
@@ -132,6 +132,7 @@ namespace Content.Client.Entry
             "IntrinsicUI",
             "PowerProvider",
             "ApcPowerReceiver",
+            "Smiteable",
             "Cable",
             "StressTestMovement",
             "EmitSoundOnThrow",

--- a/Content.Server/Administration/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/AdminVerbSystem.Smites.cs
@@ -1,0 +1,227 @@
+﻿using System.Linq;
+using System.Threading;
+using Content.Server.Administration.Commands;
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Clothing.Components;
+using Content.Server.Damage.Systems;
+using Content.Server.Disease;
+using Content.Server.Disease.Components;
+using Content.Server.Electrocution;
+using Content.Server.Explosion.EntitySystems;
+using Content.Server.Nutrition.EntitySystems;
+using Content.Server.Polymorph.Systems;
+using Content.Server.Tabletop;
+using Content.Server.Tabletop.Components;
+using Content.Shared.Administration;
+using Content.Shared.Body.Components;
+using Content.Shared.Damage;
+using Content.Shared.Database;
+using Content.Shared.Disease;
+using Content.Shared.Electrocution;
+using Content.Shared.Interaction.Components;
+using Content.Shared.Inventory;
+using Content.Shared.MobState.Components;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Tabletop.Components;
+using Content.Shared.Verbs;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Utility;
+using Timer = Robust.Shared.Timing.Timer;
+
+namespace Content.Server.Administration;
+
+public sealed partial class AdminVerbSystem
+{
+    [Dependency] private readonly PolymorphableSystem _polymorphableSystem = default!;
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
+    [Dependency] private readonly ElectrocutionSystem _electrocutionSystem = default!;
+    [Dependency] private readonly CreamPieSystem _creamPieSystem = default!;
+    [Dependency] private readonly DiseaseSystem _diseaseSystem = default!;
+    [Dependency] private readonly TabletopSystem _tabletopSystem = default!;
+    [Dependency] private readonly ExplosionSystem _explosionSystem = default!;
+    [Dependency] private readonly FlammableSystem _flammableSystem = default!;
+    [Dependency] private readonly GodmodeSystem _godmodeSystem = default!;
+
+    private void AddSmiteVerbs(GetVerbsEvent<Verb> args)
+    {
+        if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
+            return;
+
+        var player = actor.PlayerSession;
+
+        if (!_adminManager.HasAdminFlag(player, AdminFlags.Fun))
+            return;
+
+        Verb explode = new()
+        {
+            Category = VerbCategory.Smite,
+            IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png",
+            Act = () =>
+            {
+                var coords = Transform(args.Target).MapPosition;
+                Timer.Spawn(_gameTiming.TickPeriod,
+                    () => _explosionSystem.QueueExplosion(coords, ExplosionSystem.DefaultExplosionPrototypeId,
+                        4, 1, 2, maxTileBreak: 0), // it gibs, damage doesn't need to be high.
+                    CancellationToken.None);
+
+                if (TryComp(args.Target, out SharedBodyComponent? body))
+                {
+                    body.Gib();
+                }
+            },
+            Impact = LogImpact.Extreme,
+            Message = "Explode them.",
+        };
+        args.Verbs.Add(explode);
+
+        // TODO: Port cluwne outfit.
+        Verb clown = new()
+        {
+            Category = VerbCategory.Smite,
+            IconTexture = "/Textures/Objects/Fun/bikehorn.rsi/icon.png",
+            Act = () =>
+            {
+                SetOutfitCommand.SetOutfit(args.Target, "ClownGear", EntityManager, (target, clothing) =>
+                {
+                    if (HasComp<ClothingComponent>(clothing))
+                        EnsureComp<UnremoveableComponent>(clothing);
+                });
+            },
+            Impact = LogImpact.Extreme,
+            Message = "Clowns them. The suit cannot be removed.",
+        };
+        args.Verbs.Add(clown);
+
+        Verb chess = new()
+        {
+            Category = VerbCategory.Smite,
+            IconTexture = "/Textures/Objects/Fun/Tabletop/chessboard.rsi/chessboard.png",
+            Act = () =>
+            {
+                _godmodeSystem.EnableGodmode(args.Target); // So they don't suffocate.
+                EnsureComp<TabletopDraggableComponent>(args.Target);
+                RemComp<PhysicsComponent>(args.Target); // So they can be dragged around.
+                var xform = Transform(args.Target);
+                var board = Spawn("ChessBoard", xform.Coordinates);
+                var session = _tabletopSystem.EnsureSession(Comp<TabletopGameComponent>(board));
+                xform.Coordinates = EntityCoordinates.FromMap(_mapManager, session.Position);
+            },
+            Impact = LogImpact.Extreme,
+            Message = "Chess dimension.",
+        };
+        args.Verbs.Add(chess);
+
+        if (TryComp<FlammableComponent>(args.Target, out var flammable))
+        {
+            Verb flames = new()
+            {
+                Category = VerbCategory.Smite,
+                IconTexture = "/Textures/Interface/Alerts/Fire/fire.png",
+                Act = () =>
+                {
+                    // Fuck you. Burn Forever.
+                    flammable.FireStacks = 99999.9f;
+                    _flammableSystem.Ignite(args.Target);
+                },
+                Impact = LogImpact.Extreme,
+                Message = "Makes them burn.",
+            };
+            args.Verbs.Add(flames);
+        }
+
+        Verb monkey = new()
+        {
+            Category = VerbCategory.Smite,
+            IconTexture = "/Textures/Mobs/Animals/monkey.rsi/dead.png",
+            Act = () =>
+            {
+                _polymorphableSystem.PolymorphEntity(args.Target, "AdminMonkeySmite");
+            },
+            Impact = LogImpact.Extreme,
+            Message = "Monkey mode.",
+        };
+        args.Verbs.Add(monkey);
+
+        if (TryComp<DiseaseCarrierComponent>(args.Target, out var carrier))
+        {
+            Verb lungCancer = new()
+            {
+                Category = VerbCategory.Smite,
+                IconTexture = "/Textures/Mobs/Species/Human/organs.rsi/lung-l.png",
+                Act = () =>
+                {
+                    _diseaseSystem.TryInfect(carrier, _prototypeManager.Index<DiseasePrototype>("StageIIIALungCancer"));
+                },
+                Impact = LogImpact.Extreme,
+                Message = "Stage IIIA Lung Cancer, for when they really like the hit show Breaking Bad.",
+            };
+            args.Verbs.Add(lungCancer);
+        }
+
+        if (TryComp<DamageableComponent>(args.Target, out var damageable) &&
+            TryComp<MobStateComponent>(args.Target, out var mobState))
+        {
+            Verb hardElectrocute = new()
+            {
+                Category = VerbCategory.Smite,
+                IconTexture = "/Textures/Clothing/Hands/Gloves/Color/yellow.rsi/icon.png",
+                Act = () =>
+                {
+                    int damageToDeal = 0;
+                    var critState = mobState._highestToLowestStates.Where(x => x.Value.IsCritical()).FirstOrNull();
+                    if (critState is null)
+                    {
+                        // We can't crit them so try killing them.
+                        var deadState = mobState._highestToLowestStates.Where(x => x.Value.IsDead()).FirstOrNull();
+                        if (deadState is null)
+                            return; // welp.
+
+                        damageToDeal = deadState.Value.Key - (int) damageable.TotalDamage;
+                    }
+                    else
+                    {
+                        damageToDeal = critState.Value.Key - (int) damageable.TotalDamage;
+                    }
+
+                    if (damageToDeal <= 0)
+                        damageToDeal = 100; // murder time.
+
+                    if (_inventorySystem.TryGetSlots(args.Target, out var slotDefinitions))
+                    {
+                        foreach (var slot in slotDefinitions)
+                        {
+                            if (!_inventorySystem.TryGetSlotEntity(args.Target, slot.Name, out var slotEnt))
+                                continue;
+
+                            RemComp<InsulatedComponent>(slotEnt.Value); // Fry the gloves.
+                        }
+                    }
+
+                    _electrocutionSystem.TryDoElectrocution(args.Target, null, damageToDeal,
+                        TimeSpan.FromSeconds(30), true);
+                },
+                Impact = LogImpact.Extreme,
+                Message = "Electrocutes them, rendering anything they were wearing useless.",
+            };
+            args.Verbs.Add(hardElectrocute);
+        }
+
+        if (TryComp<CreamPiedComponent>(args.Target, out var creamPied))
+        {
+            Verb creamPie = new()
+            {
+                Category = VerbCategory.Smite,
+                IconTexture = "/Textures/Objects/Consumable/Food/Baked/pie.rsi/plain-slice.png",
+                Act = () =>
+                {
+                    _creamPieSystem.SetCreamPied(args.Target, creamPied, true);
+                },
+                Impact = LogImpact.Extreme,
+                Message = "A cream pie, condensed into a button.",
+            };
+            args.Verbs.Add(creamPie);
+        }
+    }
+}

--- a/Content.Server/Administration/AdminVerbSystem.cs
+++ b/Content.Server/Administration/AdminVerbSystem.cs
@@ -1,21 +1,26 @@
-using System.Threading;
 using Content.Server.Administration.Commands;
 using Content.Server.Administration.Managers;
 using Content.Server.Administration.UI;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chemistry.Components.SolutionManager;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Configurable;
+using Content.Server.Damage.Systems;
+using Content.Server.Disease;
 using Content.Server.Disposal.Tube.Components;
+using Content.Server.Electrocution;
 using Content.Server.EUI;
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Ghost.Roles;
 using Content.Server.Mind.Commands;
 using Content.Server.Mind.Components;
+using Content.Server.Nutrition.EntitySystems;
 using Content.Server.Players;
+using Content.Server.Polymorph.Systems;
+using Content.Server.Tabletop;
 using Content.Server.Xenoarchaeology.XenoArtifacts;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Triggers.Components;
 using Content.Shared.Administration;
-using Content.Shared.Body.Components;
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
 using Content.Shared.Interaction.Helpers;
@@ -26,23 +31,25 @@ using Robust.Server.Console;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Console;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using static Content.Shared.Configurable.SharedConfigurationComponent;
-using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.Administration
 {
     /// <summary>
     ///     System to provide various global admin/debug verbs
     /// </summary>
-    public sealed class AdminVerbSystem : EntitySystem
+    public sealed partial class AdminVerbSystem : EntitySystem
     {
         [Dependency] private readonly IConGroupController _groupController = default!;
         [Dependency] private readonly IConsoleHost _console = default!;
         [Dependency] private readonly IAdminManager _adminManager = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
+        [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly EuiManager _euiManager = default!;
-        [Dependency] private readonly ExplosionSystem _explosionSystem = default!;
         [Dependency] private readonly GhostRoleSystem _ghostRoleSystem = default!;
         [Dependency] private readonly ArtifactSystem _artifactSystem = default!;
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
@@ -53,6 +60,7 @@ namespace Content.Server.Administration
         {
             SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddAdminVerbs);
             SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddDebugVerbs);
+            SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddSmiteVerbs);
             SubscribeLocalEvent<RoundRestartCleanupEvent>(Reset);
             SubscribeLocalEvent<SolutionContainerManagerComponent, SolutionChangedEvent>(OnSolutionChanged);
         }
@@ -141,29 +149,6 @@ namespace Content.Server.Administration
                     Act = () => _console.ExecuteCommand(player, $"tpto {args.Target} {args.User}"),
                     Impact = LogImpact.Low
                 });
-            }
-
-            // Artillery
-            if (_adminManager.HasAdminFlag(player, AdminFlags.Fun))
-            {
-                Verb verb = new();
-                verb.Text = Loc.GetString("explode-verb-get-data-text");
-                verb.Category = VerbCategory.Admin;
-                verb.Act = () =>
-                {
-                    var coords = Transform(args.Target).MapPosition;
-                    Timer.Spawn(_gameTiming.TickPeriod,
-                        () => _explosionSystem.QueueExplosion(coords, ExplosionSystem.DefaultExplosionPrototypeId, 4, 1, 2, maxTileBreak: 0), // it gibs, damage doesn't need to be high.
-                        CancellationToken.None);
-
-                    if (TryComp(args.Target, out SharedBodyComponent? body))
-                    {
-                        body.Gib();
-                    }
-                };
-                verb.Impact = LogImpact.Extreme; // if you're just outright killing a person, I guess that deserves to be extreme?
-                verb.ConfirmationPopup = true;
-                args.Verbs.Add(verb);
             }
         }
 

--- a/Content.Server/Administration/Commands/SetOutfitCommand.cs
+++ b/Content.Server/Administration/Commands/SetOutfitCommand.cs
@@ -47,7 +47,7 @@ namespace Content.Server.Administration.Commands
                 return;
             }
 
-            if (!entityManager.TryGetComponent<InventoryComponent?>(target, out var inventoryComponent))
+            if (!entityManager.HasComponent<InventoryComponent?>(target))
             {
                 shell.WriteLine(Loc.GetString("shell-target-entity-does-not-have-message",("missing", "inventory")));
                 return;
@@ -67,12 +67,18 @@ namespace Content.Server.Administration.Commands
                 return;
             }
 
-            var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            if (!prototypeManager.TryIndex<StartingGearPrototype>(args[1], out var startingGear))
-            {
+            if (!SetOutfit(target, args[1], entityManager))
                 shell.WriteLine(Loc.GetString("set-outfit-command-invalid-outfit-id-error"));
-                return;
-            }
+        }
+
+        public static bool SetOutfit(EntityUid target, string gear, IEntityManager entityManager, Action<EntityUid, EntityUid>? onEquipped = null)
+        {
+            if (!entityManager.TryGetComponent<InventoryComponent?>(target, out var inventoryComponent))
+                return false;
+
+            var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+            if (!prototypeManager.TryIndex<StartingGearPrototype>(gear, out var startingGear))
+                return false;
 
             HumanoidCharacterProfile? profile = null;
             // Check if we are setting the outfit of a player to respect the preferences
@@ -104,8 +110,12 @@ namespace Content.Server.Administration.Commands
                     }
 
                     invSystem.TryEquip(target, equipmentEntity, slot.Name, true, inventory: inventoryComponent);
+
+                    onEquipped?.Invoke(target, equipmentEntity);
                 }
             }
+
+            return true;
         }
     }
 }

--- a/Content.Server/Administration/Components/SmiteableComponent.cs
+++ b/Content.Server/Administration/Components/SmiteableComponent.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Server.Administration.Components;
+
+[RegisterComponent]
+public sealed class SmiteableComponent : Component
+{
+
+}

--- a/Content.Server/Administration/SmiteableSystem.cs
+++ b/Content.Server/Administration/SmiteableSystem.cs
@@ -1,0 +1,23 @@
+﻿using Content.Shared.Verbs;
+
+namespace Content.Server.Administration.Components;
+
+public sealed class SmiteableSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<SmiteableComponent, GetVerbsEvent<Verb>>(AddSmites);
+    }
+
+    private void AddSmites(EntityUid uid, SmiteableComponent component, GetVerbsEvent<Verb> args)
+    {
+        var explode = new Verb()
+        {
+            ConfirmationPopup = true,
+            Category = VerbCategory.Smite,
+            IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png",
+            Priority = 0,
+
+        };
+    }
+}

--- a/Content.Server/Electrocution/RandomInsulationComponent.cs
+++ b/Content.Server/Electrocution/RandomInsulationComponent.cs
@@ -1,7 +1,8 @@
 namespace Content.Server.Electrocution
 {
     [RegisterComponent]
-    public sealed class RandomInsulationComponent : Component
+    public sealed class
+    RandomInsulationComponent : Component
     {
         [DataField("list")]
         public readonly float[] List = { 0f };

--- a/Content.Server/Tabletop/TabletopSystem.Session.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Session.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Tabletop
         /// </summary>
         /// <param name="tabletop">The tabletop game in question.</param>
         /// <returns>The session for the given tabletop game.</returns>
-        private TabletopSession EnsureSession(TabletopGameComponent tabletop)
+        public TabletopSession EnsureSession(TabletopGameComponent tabletop)
         {
             // We already have a session, return it
             // TODO: if tables are connected, treat them as a single entity. This can be done by sharing the session.

--- a/Content.Shared/Verbs/VerbCategory.cs
+++ b/Content.Shared/Verbs/VerbCategory.cs
@@ -53,6 +53,9 @@ namespace Content.Shared.Verbs
         public static readonly VerbCategory Rotate =
             new("verb-categories-rotate", "/Textures/Interface/VerbIcons/refresh.svg.192dpi.png", iconsOnly: true);
 
+        public static readonly VerbCategory Smite =
+            new("verb-categories-smite", "/Textures/Interface/VerbIcons/smite.svg.192dpi.png", iconsOnly: true);
+
         public static readonly VerbCategory SetTransferAmount =
             new("verb-categories-transfer", "/Textures/Interface/VerbIcons/spill.svg.192dpi.png");
 

--- a/Resources/Locale/en-US/verbs/verb-system.ftl
+++ b/Resources/Locale/en-US/verbs/verb-system.ftl
@@ -17,6 +17,7 @@ verb-categories-insert = Insert
 verb-categories-buckle = Buckle
 verb-categories-unbuckle = Unbuckle
 verb-categories-rotate = Rotate
+verb-categories-smite = Smite
 verb-categories-transfer = Set Transfer Amount
 verb-categories-split = Split
 verb-categories-set-sensor = Sensor

--- a/Resources/Prototypes/Diseases/noninfectious.yml
+++ b/Resources/Prototypes/Diseases/noninfectious.yml
@@ -18,6 +18,29 @@
       reagent: Phalanximine
       min: 15
 
+
+- type: disease
+  id: StageIIIALungCancer
+  name: Stage IIIA Lung Cancer
+  infectious: false
+  cureResist: 0.0
+  effects:
+    - !type:DiseaseHealthChange
+      probability: 0.3
+      damage:
+        types:
+          Cellular: 1
+    - !type:DiseaseVomit
+      probability: 0.01
+    - !type:DiseaseSnough
+      probability: 0.10
+      snoughMessage: disease-cough
+      snoughSound:
+        collection: Coughs
+    - !type:DiseasePopUp
+      probability: 0.03
+
+
 ### Once radiation is refactored I want it to have a small chance of giving you regular cancer
 
 - type: disease

--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -17,3 +17,9 @@
   dropInventory: true
   revertOnCrit: true
   revertOnDeath: true
+
+- type: polymorph
+  id: AdminMonkeySmite
+  entity: MobMonkey
+  forced: true
+  dropInventory: true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

- Better electrocute.
  Also destroys any insulated clothing they may be wearing to be useless.
  Does exactly enough damage to crit, unless they are crit in which case it'll do 100.
- Fire.
  It lights them on fire. If they spam stopdroproll they might live but for most people they'll get crit or worse.
- Explode.
  entirely unchanged. Bang.
- Monkey.
  Polymorphs the target into a monkey.
- Stage IIIA Lung Cancer.
  Perfect for chemists.
- Cream Pie.
  It cream pies them. what do you expect.
- Clown.
  Forcibly clowns the target, and makes the clown suit irremovable.
- Chess dimension.
  Banishes the target to the chess dimension, leaving nothing but a lowly chessboard in their place.

**Screenshots**
:cl: moony
- add: Admins have a whole bunch more smites.

