### PR TITLE
Verb icon tiling

### DIFF
--- a/Content.Client/ContextMenu/UI/ContextMenuPopup.xaml.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuPopup.xaml.cs
@@ -29,7 +29,7 @@ namespace Content.Client.ContextMenu.UI
         /// <summary>
         ///     This is the main body of the menu. The menu entries should be added to this object.
         /// </summary>
-        public BoxContainer MenuBody = new() { Orientation = LayoutOrientation.Vertical };
+        public GridContainer MenuBody = new();
 
         private ContextMenuPresenter _presenter;
 
@@ -41,6 +41,7 @@ namespace Content.Client.ContextMenu.UI
             _presenter = presenter;
             ParentElement = parentElement;
 
+            // TODO xaml controls now have the access options -> re-xamlify all this.
             //XAML controls are private. So defining and adding MenuBody here instead.
             Scroll.AddChild(MenuBody);
 

--- a/Content.Client/Verbs/UI/VerbMenuPresenter.cs
+++ b/Content.Client/Verbs/UI/VerbMenuPresenter.cs
@@ -129,8 +129,7 @@ namespace Content.Client.Verbs.UI
                 AddElement(element.SubMenu, subElement);
             }
 
-            if (category.IconsOnly)
-                element.SubMenu.MenuBody.Orientation = LayoutOrientation.Horizontal;
+            element.SubMenu.MenuBody.Columns = category.Columns;
         }
 
         /// <summary>

--- a/Content.Shared/Verbs/VerbCategory.cs
+++ b/Content.Shared/Verbs/VerbCategory.cs
@@ -14,6 +14,12 @@ namespace Content.Shared.Verbs
         public readonly SpriteSpecifier? Icon;
 
         /// <summary>
+        ///     Columns for the grid layout that shows the verbs in this category. If <see cref="IconsOnly"/> is false,
+        ///     this should very likely be set to 1.
+        /// </summary>
+        public int Columns = 1;
+
+        /// <summary>
         ///     If true, the members of this verb category will be shown in the context menu as a row of icons without
         ///     any text.
         /// </summary>
@@ -51,7 +57,7 @@ namespace Content.Shared.Verbs
             new("verb-categories-unbuckle", "/Textures/Interface/VerbIcons/unbuckle.svg.192dpi.png");
 
         public static readonly VerbCategory Rotate =
-            new("verb-categories-rotate", "/Textures/Interface/VerbIcons/refresh.svg.192dpi.png", iconsOnly: true);
+            new("verb-categories-rotate", "/Textures/Interface/VerbIcons/refresh.svg.192dpi.png", iconsOnly: true) { Columns = 5};
 
         public static readonly VerbCategory SetTransferAmount =
             new("verb-categories-transfer", "/Textures/Interface/VerbIcons/spill.svg.192dpi.png");


### PR DESCRIPTION
Context menu now uses a `GridContainer`. Adds support for verb categories to specify the number of columns. Usefull for #8456.

Example image (actual rotate verb is still all 1 row)
![a](https://user-images.githubusercontent.com/60421075/170390478-5bfe4acb-3f91-45d3-9b03-d0f389741b64.png)
