### PR TITLE
Fix inaccessible ready button in lobby

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -179,7 +179,6 @@ namespace Content.Client.Lobby
 
         }
 
-
         private void LobbyStatusUpdated()
         {
             UpdateLobbyBackground();

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -10,12 +10,12 @@
          xmlns:chatUi="clr-namespace:Content.Client.Chat.UI"
          xmlns:lobbyUi="clr-namespace:Content.Client.Lobby.UI"
          xmlns:info="clr-namespace:Content.Client.Info">
-    <Control>
-        <!-- Background -->
-        <TextureRect Access="Public" Name = "Background" Stretch="KeepAspectCovered"/>
-        <BoxContainer Orientation="Horizontal" Margin="10 10 10 10" SeparationOverride="2">
+    <!-- Background -->
+    <TextureRect Access="Public" Name = "Background" Stretch="KeepAspectCovered"/>
+    <BoxContainer Orientation="Horizontal" Margin="10 10 10 10" SeparationOverride="2">
+        <SplitContainer State="Auto" HorizontalExpand="True">
             <!-- LHS Controls -->
-            <BoxContainer Orientation="Vertical" SeparationOverride="4">
+            <BoxContainer Orientation="Vertical" SeparationOverride="4" HorizontalExpand="True">
                 <!-- Left Top Panel -->
                 <PanelContainer StyleClasses="AngleRect" HorizontalAlignment="Left" Name = "LeftSideTop" VerticalAlignment="Top" >
                     <BoxContainer Orientation="Vertical" HorizontalAlignment="Center" MaxWidth="620">
@@ -43,11 +43,9 @@
                     <info:DevInfoBanner Name="DevInfoBanner" VerticalExpand="false" Margin="3 3 3 3"/>
                 </BoxContainer>
             </BoxContainer>
-            <!-- Horizontal Padding -->
-            <Control HorizontalExpand="True"/>
-            <!-- RightPanel Panel -->
-            <PanelContainer Name="RightSide" StyleClasses="AngleRect" HorizontalAlignment= "Right" VerticalExpand="True" VerticalAlignment="Stretch">
-                <BoxContainer Orientation="Vertical">
+            <!-- Right Panel -->
+            <PanelContainer Name="RightSide" StyleClasses="AngleRect" VerticalExpand="True" VerticalAlignment="Stretch">
+                <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                     <!-- Top row -->
                     <BoxContainer Orientation="Horizontal" MinSize="0 40" Name="HeaderContainer" Access="Public" SeparationOverride="4">
                         <Label Margin="8 0 0 0" StyleClasses="LabelHeadingBigger" VAlign="Center" Text="{Loc 'ui-lobby-title'} " />
@@ -77,6 +75,6 @@
                     <chatUi:ChatBox Name="Chat" Access="Public" VerticalExpand="True" Margin="3 3 3 3" MinHeight="50"/>
                 </BoxContainer>
             </PanelContainer>
-        </BoxContainer>
-    </Control>
+        </SplitContainer>
+    </BoxContainer>
 </Control>

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -1,4 +1,4 @@
-﻿<Control xmlns="https://spacestation14.io"
+<Control xmlns="https://spacestation14.io"
          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
          xmlns:maths="clr-namespace:Robust.Shared.Maths;assembly=Robust.Shared.Maths"
          xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
@@ -13,8 +13,9 @@
     <Control>
         <!-- Background -->
         <TextureRect Access="Public" Name = "Background" Stretch="KeepAspectCovered"/>
-        <Control Margin="10 10 10 10" >
-            <!-- Left Top Panel -->
+        <BoxContainer Orientation="Horizontal" Margin="10 10 10 10" SeparationOverride="2">
+            <Control>
+                <!-- Left Top Panel -->
                 <PanelContainer StyleClasses="AngleRect" HorizontalAlignment="Left" Name = "LeftSideTop" VerticalExpand="True"  VerticalAlignment="Top" >
                     <BoxContainer Orientation="Vertical" HorizontalAlignment="Center" MaxWidth="620">
                         <info:LinkBanner Name="LinkBanner" VerticalExpand="false" HorizontalAlignment="Center" Margin="3 3 3 3"/>
@@ -28,13 +29,17 @@
                                        StyleClasses="LabelBig" HorizontalExpand="True" />
                                 <Button Name="ReadyButton" Access="Public" ToggleMode="True" Text="{Loc 'ui-lobby-ready-up-button'}"
                                         StyleClasses="ButtonBig" />
-                            </BoxContainer></hudUi:StripeBack>
+                            </BoxContainer>
+                        </hudUi:StripeBack>
                     </BoxContainer>
                 </PanelContainer>
-            <!-- Left Bot Panel -->
-            <BoxContainer Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Bottom" MaxWidth="620">
-                <info:DevInfoBanner Name="DevInfoBanner" VerticalExpand="false" Margin="3 3 3 3"/>
-            </BoxContainer>
+                <!-- Left Bot Panel -->
+                <BoxContainer Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Bottom" MaxWidth="620">
+                    <info:DevInfoBanner Name="DevInfoBanner" VerticalExpand="false" Margin="3 3 3 3"/>
+                </BoxContainer>
+            </Control>
+            <!-- Padding -->
+            <Control HorizontalExpand="True"/>
             <!-- RightPanel Panel -->
             <PanelContainer Name="RightSide" StyleClasses="AngleRect" HorizontalAlignment= "Right" VerticalExpand="True" VerticalAlignment="Stretch">
                 <BoxContainer Orientation="Vertical">
@@ -67,6 +72,6 @@
                 <chatUi:ChatBox Name="Chat" Access="Public" VerticalExpand="True" Margin="3 3 3 3" MinHeight="50"/>
                 </BoxContainer>
             </PanelContainer>
-        </Control>
+        </BoxContainer>
     </Control>
 </Control>

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -14,7 +14,8 @@
         <!-- Background -->
         <TextureRect Access="Public" Name = "Background" Stretch="KeepAspectCovered"/>
         <BoxContainer Orientation="Horizontal" Margin="10 10 10 10" SeparationOverride="2">
-            <Control>
+            <!-- LHS controls -->
+            <BoxContainer>
                 <!-- Left Top Panel -->
                 <PanelContainer StyleClasses="AngleRect" HorizontalAlignment="Left" Name = "LeftSideTop" VerticalExpand="True"  VerticalAlignment="Top" >
                     <BoxContainer Orientation="Vertical" HorizontalAlignment="Center" MaxWidth="620">
@@ -33,43 +34,45 @@
                         </hudUi:StripeBack>
                     </BoxContainer>
                 </PanelContainer>
+                <!-- This is were the actual voting UI appears when a vote gets called-->
+                <BoxContainer Orientation="Horizontal" Name="VoteContainer" Access="Public" HorizontalAlignment="Left" VerticalAlignment="Top"/>
                 <!-- Left Bot Panel -->
                 <BoxContainer Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Bottom" MaxWidth="620">
                     <info:DevInfoBanner Name="DevInfoBanner" VerticalExpand="false" Margin="3 3 3 3"/>
                 </BoxContainer>
-            </Control>
-            <!-- Padding -->
+            </BoxContainer>
+            <!-- Horizontal Padding -->
             <Control HorizontalExpand="True"/>
-            <!-- RightPanel Panel -->
+            <!-- Right Panel -->
             <PanelContainer Name="RightSide" StyleClasses="AngleRect" HorizontalAlignment= "Right" VerticalExpand="True" VerticalAlignment="Stretch">
                 <BoxContainer Orientation="Vertical">
-                <!-- Top row -->
-                <BoxContainer Orientation="Horizontal" MinSize="0 40" Name="HeaderContainer" Access="Public">
-                    <Label Margin="8 0 0 0" StyleClasses="LabelHeadingBigger" VAlign="Center" Text="{Loc 'ui-lobby-title'} " />
-                    <Label Name="ServerName" Access="Public" StyleClasses="LabelHeadingBigger" VAlign="Center" />
-                </BoxContainer>
-                <!-- Gold line -->
-                <ui:HLine Color="{x:Static style:StyleNano.NanoGold}" Thickness="2"/>
-                <ui:HSpacer Spacing="10"/>
-                <!-- Voting bar -->
-                <BoxContainer Orientation="Horizontal" MinSize="0 40" Name="VoteContainer" Access="Public" HorizontalAlignment="Right">
-                    <cc:CommandButton Name = "AHelpButton" Command="openahelp" Access="Public" Text = "{Loc 'ui-lobby-ahelp-button'}" StyleClasses="ButtonBig"/>
-                    <vote:VoteCallMenuButton Name="CallVoteButton" StyleClasses="ButtonBig" />
-                    <Button Name="OptionsButton" Access="Public" StyleClasses="ButtonBig" Text="{Loc 'ui-lobby-options-button'}" />
-                    <Button Name="LeaveButton" Access="Public" StyleClasses="ButtonBig" Text="{Loc 'ui-lobby-leave-button'}" />
-                </BoxContainer>
-                <ui:HSpacer Spacing="10"/>
-                <!-- Server info -->
-                <hudUi:NanoHeading Text="{Loc 'ui-lobby-server-info-block'}" />
-                <info:ServerInfo Name="ServerInfo" Access="Public" MinSize="0 30" VerticalExpand="false" Margin="3 3 3 3" MaxWidth="400"/>
-                <ui:HSpacer Spacing="5"/>
-                <lobbyUi:LobbyCharacterPreviewPanel Name="CharacterPreview" Access="Public"></lobbyUi:LobbyCharacterPreviewPanel>
-                <ui:HSpacer Spacing="5"/>
-                <BoxContainer MinHeight="10"/>
-                <!-- Gold line -->
-                <ui:HLine Color="{x:Static style:StyleNano.NanoGold}" Thickness="2" Access="Public"/>
-                <ui:HSpacer Spacing="10"/>
-                <chatUi:ChatBox Name="Chat" Access="Public" VerticalExpand="True" Margin="3 3 3 3" MinHeight="50"/>
+                    <!-- Top row -->
+                    <BoxContainer Orientation="Horizontal" MinSize="0 40" Name="HeaderContainer" Access="Public" SeparationOverride="4">
+                        <Label Margin="8 0 0 0" StyleClasses="LabelHeadingBigger" VAlign="Center" Text="{Loc 'ui-lobby-title'} " />
+                        <Label Name="ServerName" Access="Public" StyleClasses="LabelHeadingBigger" VAlign="Center" />
+                    </BoxContainer>
+                    <!-- Gold line -->
+                    <ui:HLine Color="{x:Static style:StyleNano.NanoGold}" Thickness="2"/>
+                    <ui:HSpacer Spacing="10"/>
+                    <!-- Voting & misc button bar -->
+                    <BoxContainer Orientation="Horizontal" MinSize="0 40" HorizontalAlignment="Right">
+                        <cc:CommandButton Name = "AHelpButton" Command="openahelp" Access="Public" Text = "{Loc 'ui-lobby-ahelp-button'}" StyleClasses="ButtonBig"/>
+                        <vote:VoteCallMenuButton Name="CallVoteButton" StyleClasses="ButtonBig" />
+                        <Button Name="OptionsButton" Access="Public" StyleClasses="ButtonBig" Text="{Loc 'ui-lobby-options-button'}" />
+                        <Button Name="LeaveButton" Access="Public" StyleClasses="ButtonBig" Text="{Loc 'ui-lobby-leave-button'}" />
+                    </BoxContainer>
+                    <ui:HSpacer Spacing="10"/>
+                    <!-- Server info -->
+                    <hudUi:NanoHeading Text="{Loc 'ui-lobby-server-info-block'}" />
+                    <info:ServerInfo Name="ServerInfo" Access="Public" MinSize="0 30" VerticalExpand="false" Margin="3 3 3 3" MaxWidth="400"  HorizontalAlignment="Left"/>
+                    <ui:HSpacer Spacing="5"/>
+                    <lobbyUi:LobbyCharacterPreviewPanel Name="CharacterPreview" Access="Public"></lobbyUi:LobbyCharacterPreviewPanel>
+                    <ui:HSpacer Spacing="5"/>
+                    <BoxContainer MinHeight="10"/>
+                    <!-- Gold line -->
+                    <ui:HLine Color="{x:Static style:StyleNano.NanoGold}" Thickness="2" Access="Public"/>
+                    <ui:HSpacer Spacing="10"/>
+                    <chatUi:ChatBox Name="Chat" Access="Public" VerticalExpand="True" Margin="3 3 3 3" MinHeight="50"/>
                 </BoxContainer>
             </PanelContainer>
         </BoxContainer>

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -14,10 +14,10 @@
         <!-- Background -->
         <TextureRect Access="Public" Name = "Background" Stretch="KeepAspectCovered"/>
         <BoxContainer Orientation="Horizontal" Margin="10 10 10 10" SeparationOverride="2">
-            <!-- LHS controls -->
-            <BoxContainer>
+            <!-- LHS Controls -->
+            <BoxContainer Orientation="Vertical" SeparationOverride="4">
                 <!-- Left Top Panel -->
-                <PanelContainer StyleClasses="AngleRect" HorizontalAlignment="Left" Name = "LeftSideTop" VerticalExpand="True"  VerticalAlignment="Top" >
+                <PanelContainer StyleClasses="AngleRect" HorizontalAlignment="Left" Name = "LeftSideTop" VerticalAlignment="Top" >
                     <BoxContainer Orientation="Vertical" HorizontalAlignment="Center" MaxWidth="620">
                         <info:LinkBanner Name="LinkBanner" VerticalExpand="false" HorizontalAlignment="Center" Margin="3 3 3 3"/>
                         <hudUi:StripeBack>
@@ -34,8 +34,10 @@
                         </hudUi:StripeBack>
                     </BoxContainer>
                 </PanelContainer>
-                <!-- This is were the actual voting UI appears when a vote gets called-->
-                <BoxContainer Orientation="Horizontal" Name="VoteContainer" Access="Public" HorizontalAlignment="Left" VerticalAlignment="Top"/>
+                <!-- Voting Popups -->
+                <BoxContainer Orientation="Vertical" SeparationOverride="4" Name="VoteContainer" Access="Public" HorizontalAlignment="Left" VerticalAlignment="Top"/>
+                <!-- Vertical Padding-->
+                <Control VerticalExpand="True"/>
                 <!-- Left Bot Panel -->
                 <BoxContainer Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Bottom" MaxWidth="620">
                     <info:DevInfoBanner Name="DevInfoBanner" VerticalExpand="false" Margin="3 3 3 3"/>
@@ -43,7 +45,7 @@
             </BoxContainer>
             <!-- Horizontal Padding -->
             <Control HorizontalExpand="True"/>
-            <!-- Right Panel -->
+            <!-- RightPanel Panel -->
             <PanelContainer Name="RightSide" StyleClasses="AngleRect" HorizontalAlignment= "Right" VerticalExpand="True" VerticalAlignment="Stretch">
                 <BoxContainer Orientation="Vertical">
                     <!-- Top row -->


### PR DESCRIPTION
- Makes the left-hand side and right-hand side UI elements not overlap. 
  - If there is insufficient space, the RHS panel will now shrink
  - This can mess up some of the UI, but at least all the critical buttons are generally accessible 
  - Fixes #8245
- Moves the voting UI that appears when a vote gets called to the LHS of the screen
  - Fixes #8177
- Make the RHS panel resizable, so people can expand the chat a bit if they want.
 

https://user-images.githubusercontent.com/60421075/170563489-60824824-c700-4b4b-8dc4-9c3c9ebf6dd2.mp4



:cl:
- fix: Fixed some buttons in the lobby not being accessible on some resolutions.
