### PR TITLE
Fix StepTrigger error

### DIFF
--- a/Content.Shared/StepTrigger/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/StepTriggerSystem.cs
@@ -48,8 +48,7 @@ public sealed class StepTriggerSystem : EntitySystem
 
     private bool UpdateColliding(StepTriggerComponent component, TransformComponent ownerTransform, EntityUid otherUid)
     {
-        if (!otherUid.IsValid() ||
-            !TryComp(otherUid, out PhysicsComponent? otherPhysics))
+        if (!TryComp(otherUid, out PhysicsComponent? otherPhysics))
             return true;
 
         if (component.CurrentlySteppedOn.Contains(otherUid) ||

--- a/Content.Shared/StepTrigger/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/StepTriggerSystem.cs
@@ -29,8 +29,7 @@ public sealed class StepTriggerSystem : EntitySystem
 
     private bool Update(StepTriggerComponent component, TransformComponent transform)
     {
-        if (component.Deleted ||
-            !component.Active ||
+        if (!component.Active ||
             component.Colliding.Count == 0)
             return true;
 

--- a/Content.Shared/StepTrigger/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/StepTriggerSystem.cs
@@ -29,12 +29,16 @@ public sealed class StepTriggerSystem : EntitySystem
 
     private bool Update(StepTriggerComponent component)
     {
-        if (component.Deleted || !component.Active || component.Colliding.Count == 0)
+        if (component.Deleted ||
+            !component.Active ||
+            component.Colliding.Count == 0 ||
+            !TryComp<TransformComponent>(component.Owner, out var ownerTransform))
             return true;
+
 
         foreach (var otherUid in component.Colliding.ToArray())
         {
-            if (!otherUid.IsValid())
+            if (!otherUid.IsValid() || !TryComp<TransformComponent>(otherUid, out var otherTransform))
             {
                 component.Colliding.Remove(otherUid);
                 component.CurrentlySteppedOn.Remove(otherUid);
@@ -43,8 +47,8 @@ public sealed class StepTriggerSystem : EntitySystem
             }
 
             // TODO: This shouldn't be calculating based on world AABBs.
-            var ourAabb = _entityLookup.GetWorldAABB(component.Owner);
-            var otherAabb = _entityLookup.GetWorldAABB(otherUid);
+            var ourAabb = _entityLookup.GetWorldAABB(component.Owner, ownerTransform);
+            var otherAabb = _entityLookup.GetWorldAABB(otherUid, otherTransform);
 
             if (!TryComp(otherUid, out PhysicsComponent? otherPhysics) || !ourAabb.Intersects(otherAabb))
             {

--- a/Content.Shared/StepTrigger/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/StepTriggerSystem.cs
@@ -18,66 +18,62 @@ public sealed class StepTriggerSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
-        foreach (var (_, trigger) in EntityQuery<StepTriggerActiveComponent, StepTriggerComponent>())
+        foreach (var (_, trigger, transform) in EntityQuery<StepTriggerActiveComponent, StepTriggerComponent, TransformComponent>())
         {
-            if (!Update(trigger))
+            if (!Update(trigger, transform))
                 continue;
 
             RemComp<StepTriggerActiveComponent>(trigger.Owner);
         }
     }
 
-    private bool Update(StepTriggerComponent component)
+    private bool Update(StepTriggerComponent component, TransformComponent transform)
     {
         if (component.Deleted ||
             !component.Active ||
-            component.Colliding.Count == 0 ||
-            !TryComp<TransformComponent>(component.Owner, out var ownerTransform))
+            component.Colliding.Count == 0)
             return true;
 
 
         foreach (var otherUid in component.Colliding.ToArray())
         {
-            if (!otherUid.IsValid() || !TryComp<TransformComponent>(otherUid, out var otherTransform))
-            {
-                component.Colliding.Remove(otherUid);
-                component.CurrentlySteppedOn.Remove(otherUid);
-                component.Dirty();
-                continue;
-            }
+            var shouldRemoveFromColliding = UpdateColliding(component, transform, otherUid);
+            if (!shouldRemoveFromColliding) continue;
 
-            // TODO: This shouldn't be calculating based on world AABBs.
-            var ourAabb = _entityLookup.GetWorldAABB(component.Owner, ownerTransform);
-            var otherAabb = _entityLookup.GetWorldAABB(otherUid, otherTransform);
-
-            if (!TryComp(otherUid, out PhysicsComponent? otherPhysics) || !ourAabb.Intersects(otherAabb))
-            {
-                component.Colliding.Remove(otherUid);
-                component.CurrentlySteppedOn.Remove(otherUid);
-                component.Dirty();
-                continue;
-            }
-
-            if (component.CurrentlySteppedOn.Contains(otherUid))
-                continue;
-
-            if (!CanTrigger(component.Owner, otherUid, component))
-                continue;
-
-            if (otherPhysics.LinearVelocity.Length < component.RequiredTriggerSpeed)
-                continue;
-
-            var percentage = otherAabb.IntersectPercentage(ourAabb);
-            if (percentage < component.IntersectRatio)
-                continue;
-
-            var ev = new StepTriggeredEvent { Source = component.Owner, Tripper = otherUid };
-            RaiseLocalEvent(component.Owner, ref ev);
-
-            component.CurrentlySteppedOn.Add(otherUid);
+            component.Colliding.Remove(otherUid);
+            component.CurrentlySteppedOn.Remove(otherUid);
             component.Dirty();
         }
+        return false;
+    }
 
+    private bool UpdateColliding(StepTriggerComponent component, TransformComponent ownerTransform, EntityUid otherUid)
+    {
+        if (!otherUid.IsValid() ||
+            !TryComp(otherUid, out PhysicsComponent? otherPhysics))
+            return true;
+
+        if (component.CurrentlySteppedOn.Contains(otherUid) ||
+            !CanTrigger(component.Owner, otherUid, component) ||
+            otherPhysics.LinearVelocity.Length < component.RequiredTriggerSpeed)
+            return false;
+
+        // TODO: This shouldn't be calculating based on world AABBs.
+        var ourAabb = _entityLookup.GetWorldAABB(component.Owner, ownerTransform);
+        var otherAabb = _entityLookup.GetWorldAABB(otherUid);
+
+        if (!ourAabb.Intersects(otherAabb))
+            return true;
+
+        var percentage = otherAabb.IntersectPercentage(ourAabb);
+        if (percentage < component.IntersectRatio)
+            return false;
+
+        var ev = new StepTriggeredEvent { Source = component.Owner, Tripper = otherUid };
+        RaiseLocalEvent(component.Owner, ref ev);
+
+        component.CurrentlySteppedOn.Add(otherUid);
+        component.Dirty();
         return false;
     }
 

--- a/Content.Shared/StepTrigger/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/StepTriggerSystem.cs
@@ -73,7 +73,7 @@ public sealed class StepTriggerSystem : EntitySystem
         RaiseLocalEvent(component.Owner, ref ev);
 
         component.CurrentlySteppedOn.Add(otherUid);
-        component.Dirty();
+        Dirty(component);
         return false;
     }
 

--- a/Content.Shared/StepTrigger/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/StepTriggerSystem.cs
@@ -42,7 +42,7 @@ public sealed class StepTriggerSystem : EntitySystem
 
             component.Colliding.Remove(otherUid);
             component.CurrentlySteppedOn.Remove(otherUid);
-            component.Dirty();
+            Dirty(component);
         }
         return false;
     }


### PR DESCRIPTION
Saw a ton of these errors earlier on lizard

```
Caught exception in entsys
System.Collections.Generic.KeyNotFoundException: Entity 51786 does not have a component of type Robust.Shared.GameObjects.TransformComponent
   at Robust.Shared.GameObjects.EntityQuery`1.GetComponent(EntityUid uid) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 1101
   at Content.Shared.StepTrigger.StepTriggerSystem.Update(StepTriggerComponent component) in /home/runner/work/space-station-14/space-station-14/Content.Shared/StepTrigger/StepTriggerSystem.cs:line 47
   at Content.Shared.StepTrigger.StepTriggerSystem.Update(Single frameTime) in /home/runner/work/space-station-14/space-station-14/Content.Shared/StepTrigger/StepTriggerSystem.cs:line 23
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 317
 Catcher=entsys Sawmill=runtime
```
![errors](https://user-images.githubusercontent.com/81056464/170690870-a7c372e6-ee8d-49b6-a7da-57f5ccfb4804.PNG)

I added checks for a transform component to the guard at the beginning, and one to the remove check. I did not reproduce this bug locally, but I think it'll work.