### PR TITLE
Underplating Must Die (The Movie) (The Video Game)

### DIFF
--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -25,14 +25,8 @@
   thermalConductivity: 0.04
   heatCapacity: 10000
 
-# TODO kill underplating and all its usages since it is deprecated
-- type: tile
+# The final step in underplating's deprecation before it gets completely wiped from the codebase.
+- type: tileAlias
   id: underplating
-  name: haqrecyngvat [DO NOT USE]
-  texture: deprecated
-  base_turfs:
-  - lattice
-  is_subfloor: true
-  footstep_sounds:
-    collection: footstep_plating
-  friction: 0.5
+  target: plating
+


### PR DESCRIPTION
## About the PR

Turns underplating into a tile alias, which means:

+ It no longer has a tile ID and can no longer be selected in the tile picker.
+ It will no longer be written into new map files.
+ It will magically change into plating in existing map files.

No user-visible effects.
