### PR TITLE
step trigger fix + optimization

### DIFF
--- a/Content.Shared/StepTrigger/StepTriggerComponent.cs
+++ b/Content.Shared/StepTrigger/StepTriggerComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.StepTrigger;
@@ -11,12 +11,14 @@ public sealed class StepTriggerComponent : Component
     /// <summary>
     ///     List of entities that are currently colliding with the entity.
     /// </summary>
+    [ViewVariables]
     public readonly HashSet<EntityUid> Colliding = new();
 
     /// <summary>
     ///     The list of entities that are standing on this entity,
     /// which shouldn't be able to trigger it again until stepping off.
     /// </summary>
+    [ViewVariables]
     public readonly HashSet<EntityUid> CurrentlySteppedOn = new();
 
     /// <summary>
@@ -50,13 +52,17 @@ public sealed class StepTriggerComponentState : ComponentState
 {
     public float IntersectRatio { get; }
     public float RequiredTriggerSpeed { get; }
-    public readonly EntityUid[] CurrentlySteppedOn;
+    public readonly HashSet<EntityUid> CurrentlySteppedOn;
+    public readonly HashSet<EntityUid> Colliding;
+    public readonly bool Active;
 
-    public StepTriggerComponentState(float intersectRatio, EntityUid[] currentlySteppedOn, float requiredTriggerSpeed)
+    public StepTriggerComponentState(float intersectRatio, HashSet<EntityUid> currentlySteppedOn, HashSet<EntityUid> colliding, float requiredTriggerSpeed, bool active)
     {
         IntersectRatio = intersectRatio;
         CurrentlySteppedOn = currentlySteppedOn;
         RequiredTriggerSpeed = requiredTriggerSpeed;
+        Active = active;
+        Colliding = colliding;
     }
 }
 


### PR DESCRIPTION
- Fix entities never being removed from `StepTriggerComponent.Colliding`. Probably the cause for bad performance.
- Fix state handling / prediction problems
- Change order of checks to reduce `CanTrigger()` calls
- xform query
- Make the `Update()` entity query use the "Active" component return value for removal.