### PR TITLE
Add basic department access to security jobs

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -18,6 +18,12 @@
   - Armory
   - Maintenance
   - Service
+  - Cargo
+  - Salvage
+  - Engineering
+  - Atmospherics
+  - Research
+  - Medical
 
 - type: startingGear
   id: HoSGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -12,6 +12,12 @@
   - Brig
   - Maintenance
   - Service
+  - Cargo
+  - Salvage
+  - Engineering
+  - Atmospherics
+  - Research
+  - Medical
 
 - type: startingGear
   id: SecurityOfficerGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -13,6 +13,12 @@
   - Maintenance
   - Service
   - Brig
+  - Cargo
+  - Salvage
+  - Engineering
+  - Atmospherics
+  - Research
+  - Medical
 
 - type: startingGear
   id: WardenGear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There was some brief back-and-forth about this idea as a whole on the Discord and I wanted to put this PR up more as a discussion on how security might be able to reach areas with trouble more effectively. Opinion on this issue seemed divided at best, so I thought a PR could be a good way to get further feedback.

This adds the following accesses to Security Officer, Warden, and Head of Security roles:
Cargo, Salvage, Engineering, Atmospherics, Research, Medical

The reasoning behind this is to allow security as a whole better reach and visibility inside departments which normally stay closed to only those in the department. Areas like Cargo, for instance, can typically order whatever they want unopposed because all of cargo will benefit from getting weapons and security has no way (without ID changes, breaking in, or getting someone inside to cooperate) to actually enter Cargo and prevent them from doing so. This also allows security to more reliably respond to emergencies within departments without needing to rely on someone inside to come answer the door.

The downsides I can see with this is it makes Security IDs quite valuable, and seeing as they already get killed on the regular for little reason, it could have a negative effect as a whole. Poor security players could also abuse the access, but I feel this is true of any job with extended access. I think there are potentially better ways this could be done besides a flat access increase (maybe the extended access system that was recently merged?) but those are probably currently beyond my ability. 

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Security roles now have basic access to most departments.

