### PR TITLE
Fix map rendering

### DIFF
--- a/Content.MapRenderer/Painters/GridPainter.cs
+++ b/Content.MapRenderer/Painters/GridPainter.cs
@@ -138,8 +138,8 @@ namespace Content.MapRenderer.Painters
 
         private (float x, float y) TransformLocalPosition(Vector2 position, IMapGrid grid)
         {
-            var xOffset = (int) Math.Abs(grid.LocalAABB.Left);
-            var yOffset = (int) Math.Abs(grid.LocalAABB.Bottom);
+            var xOffset = (int) -grid.LocalAABB.Left;
+            var yOffset = (int) -grid.LocalAABB.Bottom;
             var tileSize = grid.TileSize;
 
             var x = ((float) Math.Floor(position.X) + xOffset) * tileSize * TilePainter.TileImageSize;

--- a/Content.MapRenderer/Painters/MapPainter.cs
+++ b/Content.MapRenderer/Painters/MapPainter.cs
@@ -111,6 +111,13 @@ namespace Content.MapRenderer.Painters
 
             foreach (var grid in grids)
             {
+                // Skip empty grids
+                if (grid.LocalAABB.IsEmpty())
+                {
+                    Console.WriteLine($"Warning: Grid {grid.Index} was empty. Skipping image rendering.");
+                    continue;;
+                }
+
                 var tileXSize = grid.TileSize * TilePainter.TileImageSize;
                 var tileYSize = grid.TileSize * TilePainter.TileImageSize;
 

--- a/Content.MapRenderer/Painters/TilePainter.cs
+++ b/Content.MapRenderer/Painters/TilePainter.cs
@@ -32,8 +32,8 @@ namespace Content.MapRenderer.Painters
             stopwatch.Start();
 
             var bounds = grid.LocalAABB;
-            var xOffset = Math.Abs(bounds.Left);
-            var yOffset = Math.Abs(bounds.Bottom);
+            var xOffset = -bounds.Left;
+            var yOffset = -bounds.Bottom;
             var tileSize = grid.TileSize * TileImageSize;
 
             var images = GetTileImages(_sTileDefinitionManager, _cResourceCache, tileSize);


### PR DESCRIPTION
Fixes: 
- Boxstation PR https://github.com/space-wizards/space-station-14/pull/6887: Had a grid that was below (0, 0), which caused the map render to crash.
- Moose, Bagel: Had an empty grid that crashed the renderer
- SplitStation: crashed because TransformLocalPosition gave the wrong value when grid bounds had a negative

All the maps in the prototypes now render without crashing