### PR TITLE
Grinder dispenser bb fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -16,7 +16,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.4,-0.3,0.4,0.3"
+        bounds: "-0.4,-0.3,0.4,0.2"
       mass: 25
       mask:
       - TabletopMachineMask

--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -3,6 +3,8 @@
   name: booze dispenser
   description: A booze dispenser with a single slot for a container to be filled.
   parent: ReagentDispenserBase
+  placement:
+    mode: PlaceFree
   components:
   - type: Rotatable
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -3,6 +3,8 @@
   name: soda dispenser
   parent: ReagentDispenserBase
   description: A beverage dispenser with a selection of soda and several other common beverages. Has a single fill slot for containers.
+  placement:
+    mode: PlaceFree
   components:
   - type: Rotatable
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -4,6 +4,8 @@
   name: reagent grinder
   description: From BlenderTech. Will It Blend? Let's find out!
   suffix: grinder/juicer
+  placement:
+    mode: PlaceFree
   components:
   - type: Transform
     anchored: true
@@ -30,7 +32,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.08,-0.35,0.15,0.25"
+        bounds: "-0.08,-0.35,0.15,0.20"
       mask:
       - TabletopMachineMask
       layer:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces the collision bb for all dispensers so they fit on tables better. This is an issue when mapping as even free placed they push themselves off of walls.

Also changed the placement type to free so they don't default to snap grid however anchorable currently snaps them to center regardless if snap is set to false so not much I can do about that.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Reduced bounding boxes for reagent grinder, soda and beer dispensers so they sit closer to the wall.
