### PR TITLE
Fix pipe net conservation laws

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -109,6 +109,52 @@ namespace Content.Server.Atmos.EntitySystems
         }
 
         /// <summary>
+        ///     Divides a source gas mixture into several recipient mixtures, scaled by their relative volumes. Does not
+        ///     modify the source gas mixture. Used for pipe network splitting. Note that the total destination volume
+        ///     may be larger or smaller than the source mixture.
+        /// </summary>
+        public void DivideInto(GasMixture source, List<GasMixture> receivers)
+        {
+            var totalVolume = 0f;
+            foreach (var receiver in receivers)
+            {
+                if (!receiver.Immutable)
+                    totalVolume += receiver.Volume;
+            }
+
+            float? sourceHeatCapacity = null;
+            var buffer = new float[Atmospherics.AdjustedNumberOfGases];
+
+            foreach (var receiver in receivers)
+            {
+                if (receiver.Immutable)
+                    continue;
+
+                var fraction = receiver.Volume / totalVolume;
+
+                // Set temperature, if necessary.
+                if (MathF.Abs(receiver.Temperature - source.Temperature) > Atmospherics.MinimumTemperatureDeltaToConsider)
+                {
+                    // Often this divides a pipe net into new and completely empty pipe nets
+                    if (receiver.TotalMoles == 0) 
+                        receiver.Temperature = source.Temperature;
+                    else
+                    {
+                        sourceHeatCapacity ??= GetHeatCapacity(source);
+                        var receiverHeatCapacity = GetHeatCapacity(receiver);
+                        var combinedHeatCapacity = receiverHeatCapacity + sourceHeatCapacity.Value * fraction;
+                        if (combinedHeatCapacity > 0f)
+                            receiver.Temperature = (GetThermalEnergy(source, sourceHeatCapacity.Value * fraction) + GetThermalEnergy(receiver, receiverHeatCapacity)) / combinedHeatCapacity;
+                    }
+                }
+
+                // transfer moles
+                NumericsHelpers.Multiply(source.Moles, fraction, buffer);
+                NumericsHelpers.Add(receiver.Moles, buffer);
+            }
+        }
+
+        /// <summary>
         ///     Shares gas between two gas mixtures. Part of LINDA.
         /// </summary>
         public float Share(GasMixture receiver, GasMixture sharer, int atmosAdjacentTurfs)

--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -30,7 +30,9 @@ namespace Content.Server.Rotatable
 
         private void AddRotateVerbs(EntityUid uid, RotatableComponent component, GetVerbsEvent<Verb> args)
         {
-            if (!args.CanAccess || !args.CanInteract)
+            if (!args.CanAccess
+                || !args.CanInteract
+                || Transform(uid).NoLocalRotation) // Good ol prototype inheritance, eh?
                 return;
 
             // Check if the object is anchored, and whether we are still allowed to rotate it.


### PR DESCRIPTION
Currently, whenever a pipe network is split up due to a node being removed, they will modify their volumes before dividing their gasses into the new pipe nets. The end result was that total moles were not being conserved.

This fixes that, as well as some other pipe net dividing bugs. Fixes #8532

:cl:
- fix: Fixed a bug that caused gas quantity to not be conserved when anchoring and unanchoring atmos devices.

