### PR TITLE
Adds max pressure to gas miners

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -29,6 +29,7 @@
     - type: AtmosDevice
     - type: GasMiner
       maxExternalPressure: 300
+      spawnAmount: 200
 
 - type: entity
   name: O2 gas miner


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Draft PR till I can get home to test it.

Limits gas miners to 300 kPa instead of 4500 kPa so should help make them drastically less deadly in the event they get released onto the stations pipenet.

Also had to reduce the amount of gas that spawns as this apparently made the miners not work unless they were under this amount of gas.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Gas miners are now capped at 300 kPa instead of 4500 kPa. Less pressure bombing.

