### PR TITLE
Add ContainerContainer to airlocks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -51,6 +51,9 @@
       path: /Audio/Machines/airlock_close.ogg
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
   - type: Weldable
     fuel: 3
     time: 3


### PR DESCRIPTION
Avoids serializing the empty board containers.

When I saved saltern it saved around 260 lines.