### PR TITLE
Prune most yml ambientsound entries

### DIFF
--- a/Content.Client/Audio/AmbientOverlayCommand.cs
+++ b/Content.Client/Audio/AmbientOverlayCommand.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Console;
+
+namespace Content.Client.Audio;
+
+public sealed class AmbientOverlayCommand : IConsoleCommand
+{
+    public string Command => "showambient";
+    public string Description => "Shows all AmbientSoundComponents in the viewport";
+    public string Help => $"{Command}";
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var system = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<AmbientSoundSystem>();
+        system.OverlayEnabled ^= true;
+
+        shell.WriteLine($"Ambient sound overlay set to {system.OverlayEnabled}");
+    }
+}

--- a/Content.Client/Audio/AmbientSoundOverlay.cs
+++ b/Content.Client/Audio/AmbientSoundOverlay.cs
@@ -1,0 +1,56 @@
+using Content.Shared.Audio;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+
+namespace Content.Client.Audio;
+
+/// <summary>
+/// Debug overlay that shows all ambientsound sources in range
+/// </summary>
+public sealed class AmbientSoundOverlay : Overlay
+{
+    private IEntityManager _entManager;
+    private AmbientSoundSystem _ambient;
+    private EntityLookupSystem _lookup;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public AmbientSoundOverlay(IEntityManager entManager, AmbientSoundSystem ambient, EntityLookupSystem lookup)
+    {
+        _entManager = entManager;
+        _ambient = ambient;
+        _lookup = lookup;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var worldHandle = args.WorldHandle;
+        var ambientQuery = _entManager.GetEntityQuery<AmbientSoundComponent>();
+        var xformQuery = _entManager.GetEntityQuery<TransformComponent>();
+
+        const float Size = 0.25f;
+        const float Alpha = 0.25f;
+
+        foreach (var ent in _lookup.GetEntitiesIntersecting(args.MapId, args.WorldBounds))
+        {
+            if (!ambientQuery.TryGetComponent(ent, out var ambientSound) ||
+                !xformQuery.TryGetComponent(ent, out var xform)) continue;
+
+            if (ambientSound.Enabled)
+            {
+                if (_ambient.IsActive(ambientSound))
+                {
+                    worldHandle.DrawCircle(xform.WorldPosition, Size, Color.LightGreen.WithAlpha(Alpha * 2f));
+                }
+                else
+                {
+                    worldHandle.DrawCircle(xform.WorldPosition, Size, Color.Orange.WithAlpha(Alpha));
+                }
+            }
+            else
+            {
+                worldHandle.DrawCircle(xform.WorldPosition, Size, Color.Red.WithAlpha(Alpha));
+            }
+        }
+    }
+}

--- a/Content.Client/Audio/AmbientSoundSystem.cs
+++ b/Content.Client/Audio/AmbientSoundSystem.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.Audio;
 using Content.Shared.CCVar;
+using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Configuration;
@@ -29,8 +30,9 @@ namespace Content.Client.Audio
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
 
+        private AmbientSoundOverlay? _overlay;
         private int _maxAmbientCount;
-
+        private bool _overlayEnabled;
         private float _maxAmbientRange;
         private float _cooldown;
         private float _accumulator;
@@ -45,7 +47,37 @@ namespace Content.Client.Audio
 
         private const float RangeBuffer = 3f;
 
+        public bool OverlayEnabled
+        {
+            get => _overlayEnabled;
+            set
+            {
+                if (_overlayEnabled == value) return;
+                _overlayEnabled = value;
+                var overlayManager = IoCManager.Resolve<IOverlayManager>();
 
+                if (_overlayEnabled)
+                {
+                    _overlay = new AmbientSoundOverlay(EntityManager, this, Get<EntityLookupSystem>());
+                    overlayManager.AddOverlay(_overlay);
+                }
+                else
+                {
+                    overlayManager.RemoveOverlay(_overlay!);
+                    _overlay = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Is this AmbientSound actively playing right now?
+        /// </summary>
+        /// <param name="component"></param>
+        /// <returns></returns>
+        public bool IsActive(AmbientSoundComponent component)
+        {
+            return _playingSounds.ContainsKey(component);
+        }
 
         public override void Initialize()
         {

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -23,6 +23,8 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: SubFloorHide
+  - type: AmbientSound
+    enabled: false  # Leaving as false because 90% of them are set to this.
   - type: Appearance
   - type: Electrified
     onHandInteract: false
@@ -78,7 +80,6 @@
   - type: CableVisualizer
     statePrefix: hvcable_
   - type: AmbientSound
-    enabled: true
     volume: -15
     range: 2
     sound:
@@ -128,7 +129,6 @@
   - type: CableVisualizer
     statePrefix: mvcable_
   - type: AmbientSound
-    enabled: true
     volume: -16
     range: 2
     sound:
@@ -181,7 +181,6 @@
   - type: CableVisualizer
     statePrefix: lvcable_
   - type: AmbientSound
-    enabled: true
     volume: -17
     range: 2
     sound:

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -14,6 +14,7 @@
     - toggledecals
     - nodevis
     - nodevisfilter
+    - showambient
 
 - Flags: MAPPING
   Commands:


### PR DESCRIPTION
Cables were set to true but most of these were hidden by subfloor so we can save several thousand lines of yml again.

I also added a debug overlay for showing ambientsound sources.