### PR TITLE
Fix issue with Musician PDA music not being heard by other players

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -37,6 +37,7 @@
   - type: Ringer
   - type: ActivatableUI
     key: enum.PDAUiKey.Key
+    singleUser: true
   - type: UserInterface
     interfaces:
     - key: enum.PDAUiKey.Key


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows the CurrentSingleUser of the PDA to be set to allow it to work the same as other instruments.

The only other behavior change I saw in testing is that two players can't activate the same PDA on the ground at the same time, but that behavior seemed unintentional.  (Players can still swipe it off the ground if someone is using it.)

(The music comes through as a standard piano instead of the synth type that the musician hears. The personal ai has this issue as well, so this is an existing issue. I can open that separately from this.)

Fixes #8088

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Other players can now hear the Musician's PDA music

