### PR TITLE
Nerf SMG accuracy

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -11,6 +11,8 @@
     size: 24
   - type: AmmoCounter
   - type: Gun
+    minAngle: 2
+    maxAngle: 8
     fireRate: 8
     selectedMode: FullAuto
     availableModes:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31366439/171569091-a07c0859-3abb-4cc9-9af0-7efac2cc8932.png)

Need to writeup a doc on my thoughts but rifles should be accurate to kill a player for the full length of a screen but smg should have a chance to miss.

:cl:
- tweak: SMGs have had their maximum spread angle increased (i.e. accuracy reduced).