### PR TITLE
Shotgun nerfs

### DIFF
--- a/Content.Server/Weapon/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapon/Ranged/Systems/GunSystem.cs
@@ -54,8 +54,8 @@ public sealed partial class GunSystem : SharedGunSystem
                     {
                         if (cartridge.Count > 1)
                         {
-                            var angles = LinearSpread(mapAngle - Angle.FromDegrees(cartridge.Spread / 2f),
-                                mapAngle + Angle.FromDegrees(cartridge.Spread / 2f), cartridge.Count);
+                            var angles = LinearSpread(mapAngle - cartridge.Spread / 2,
+                                mapAngle + cartridge.Spread / 2, cartridge.Count);
 
                             for (var i = 0; i < cartridge.Count; i++)
                             {

--- a/Content.Shared/Weapons/Ranged/Components/AmmoComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/AmmoComponent.cs
@@ -35,7 +35,7 @@ public sealed class CartridgeAmmoComponent : AmmoComponent
     /// How much the ammo spreads when shot, in degrees. Does nothing if count is 0.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("spread")]
-    public float Spread = 10f;
+    public Angle Spread = Angle.FromDegrees(5);
 
     /// <summary>
     /// How many prototypes are spawned when shot.

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -44,7 +44,7 @@ public class GunComponent : Component
     /// <summary>
     /// How much the spread increases every time the gun fires.
     /// </summary>
-    [ViewVariables, DataField("angleIncrease")]
+    [ViewVariables(VVAccess.ReadWrite), DataField("angleIncrease")]
     public Angle AngleIncrease = Angle.FromDegrees(0.5);
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -10,6 +10,7 @@
     - ShellShotgun
   - type: CartridgeAmmo
     count: 6
+    spread: 15
     soundEject:
       collection: ShellEject
   - type: Sprite
@@ -46,7 +47,7 @@
   - type: CartridgeAmmo
     proto: PelletShotgunSlug
     count: 4
-    spread: 2.5
+    spread: 5
 
 - type: entity
   id: ShellShotgunFlare

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -10,7 +10,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 13
+        Piercing: 8  # Should have the same or less damage than a regular pellet
 
 - type: entity
   id: PelletShotgunBeanbag
@@ -41,7 +41,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 13
+        Piercing: 8
 
 - type: entity
   id: PelletShotgunFlash

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -51,7 +51,7 @@
     sprite: Objects/Weapons/Guns/Shotguns/bojevic.rsi
     size: 24
   - type: Gun
-    fireRate: 3
+    fireRate: 2
     selectedMode: FullAuto
     availableModes:
     - FullAuto


### PR DESCRIPTION
:cl:
- tweak: Bojevic firerate dropped from 3 to 2
- tweak: Shotgun pellet damage from 13 to 8 (3 shotting players instead of 2 shot assuming all pellets hit).
- tweak: Spread changed from 10 degrees to 15.
