### PR TITLE
Fix thruster shutdown

### DIFF
--- a/Content.Server/Shuttles/EntitySystems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/EntitySystems/ThrusterSystem.cs
@@ -365,6 +365,7 @@ namespace Content.Server.Shuttles.EntitySystems
         public bool CanEnable(EntityUid uid, ThrusterComponent component)
         {
             if (!component.Enabled) return false;
+            if (component.LifeStage > ComponentLifeStage.Running) return false;
 
             var xform = Transform(uid);
 


### PR DESCRIPTION
> Switching map to moose
> Old map (Atlas) cleans up
> Power disconnect events go off
> Thruster tries to enable
> Thruster tries to make fixture
> Boom, the shutdown procedure crashes, but everything keeps going anyways
> Id card still has a reference to old station
> Job Assignment
> Boom, server is dead

This fixes that