### PR TITLE
Ghost movement no longer causes dragged corpse to be dropped

### DIFF
--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -6,6 +6,7 @@ using Content.Shared.Pulling.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
+using Content.Shared.MobState.Components;
 
 namespace Content.Shared.Pulling
 {
@@ -73,7 +74,8 @@ namespace Content.Shared.Pulling
 
         public bool TryStopPull(SharedPullableComponent pullable, EntityUid? user = null)
         {
-            if (!pullable.BeingPulled)
+            if (!pullable.BeingPulled ||
+                (TryComp<MobStateComponent>(pullable.Owner, out var mobState) && mobState.IsDead()))
             {
                 return false;
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check if the pullable is dead before going ahead with the TryStopPull.

The check is after the pullable.BeingPulled to avoid spamming the entity lookup.
I don't think that the check can be done in OnRelayMoveInput. CanMove should return true for ghosts, so there needs to be some kind of check on the PullableComponent itself.

Fixes #8042 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Ghosting no longer causes a dragged corpse to be dropped
