### PR TITLE
Emitter 1984 - cargo and construction

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -58,17 +58,17 @@
   category: Engineering
   group: market
 
-- type: cargoProduct
-  name: "emitter crate"
-  id: EngineSingularityEmitter
-  description: "Contains an emitter. Used only for dangerous applications."
-  icon:
-    sprite: Structures/Power/Generation/Singularity/emitter.rsi
-    state: emitter2
-  product: CrateEngineeringSingularityEmitter
-  cost: 3000
-  category: Engineering
-  group: market
+#- type: cargoProduct
+#  name: "emitter crate"
+#  id: EngineSingularityEmitter
+#  description: "Contains an emitter. Used only for dangerous applications."
+#  icon:
+#    sprite: Structures/Power/Generation/Singularity/emitter.rsi
+#    state: emitter2
+#  product: CrateEngineeringSingularityEmitter
+#  cost: 3000
+#  category: Engineering
+#  group: market
 
 - type: cargoProduct
   name: "radiation collector crate"

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -273,6 +273,7 @@
     - FlashlightLantern
     - FireExtinguisher
     - AutolatheMachineCircuitboard
+    - EmitterCircuitboard
     - ProtolatheMachineCircuitboard
     - OreProcessorMachineCircuitboard
     - CircuitImprinterMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -396,6 +396,21 @@
       materialRequirements:
         Glass: 2
         Cable: 2
+        
+- type: entity
+  id: EmitterCircuitboard
+  parent: BaseMachineCircuitboard
+  name: emitter machine board
+  components:
+    - type: MachineBoard
+      prototype: Emitter
+      requirements:
+        Capacitor: 1
+        Laser: 1
+      materialRequirements:
+        CableHV: 5
+        Glass: 2
+        Cable: 2
 
 - type: entity
   id: SurveillanceCameraRouterCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -410,7 +410,6 @@
       materialRequirements:
         CableHV: 5
         Glass: 2
-        Cable: 2
 
 - type: entity
   id: SurveillanceCameraRouterCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -71,3 +71,8 @@
     locked: false
   - type: AccessReader
     access: [[ "Engineering" ]]
+  - type: Construction
+    graph: Machine
+    node: machine
+  - type: Machine
+    board: EmitterCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -357,3 +357,12 @@
   materials:
     Steel: 100
     Glass: 900
+    
+- type: latheRecipe
+  id: EmitterCircuitboard
+  icon: Objects/Misc/module.rsi/id_mod.png
+  result: EmitterCircuitboard
+  completetime: 4
+  materials:
+    Steel: 100
+    Glass: 900


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Emitters have been removed from the cargo computer.
- Added a machine board / construction for emitters.
- Added the board to basic engineering technology.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Emitters have been removed from cargo ordering. You now have to research a machine board for them and build them from machine frames.

