### PR TITLE
Fix debug tests with engine change

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -29,18 +29,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
+      - name: Checkout Master
+        uses: actions/checkout@v2
+
+      - name: Setup Submodule
+        run: |
+          git submodule update --init --recursive
+
+      - name: Pull engine updates
+        uses: space-wizards/submodule-dependency@v0.1.5
+
+      - name: Update Engine Submodules
+        run: |
+          cd RobustToolbox/
+          git submodule update --init --recursive
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 6.0.x
 
-      - name: Get Engine Tag
-        run: |
-          cd RobustToolbox
-          git fetch --depth=1
+      - name: Install dependencies
+        run: dotnet restore
 
       - name: Package client
         run: |

--- a/BuildChecker/git_helper.py
+++ b/BuildChecker/git_helper.py
@@ -42,6 +42,9 @@ def update_submodules():
     Updates all submodules.
     """
 
+    if ('GITHUB_ACTIONS' in os.environ):
+        return
+
     if os.path.isfile("DISABLE_SUBMODULE_AUTOUPDATE"):
         return
 


### PR DESCRIPTION
I added github action tests earlier for debug, and building the package, but they don't work with engine changes. This stops the python script from messing up the submodule checkout, and makes the test package script get the engine like the other scripts.