### PR TITLE
Re-enable sandbox for <5 players

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -24,7 +24,8 @@
     - sandbox
   name: sandbox-title
   description: sandbox-description
-  showInVote: false
+  showInVote: true
+  maxPlayers: 5
   rules:
     - Sandbox
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

was always intended but preset max/min wasnt implemented for a bit

:cl:
- tweak: Sandbox is now votable again as long as there are less than 5 players in the server.
