### PR TITLE
Don't cancel pulling a corpse because the player ghosted

### DIFF
--- a/Content.Shared/Pulling/Systems/SharedPullableSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullableSystem.cs
@@ -20,7 +20,7 @@ namespace Content.Shared.Pulling.Systems
         {
             var entity = args.Session.AttachedEntity;
             if (entity == null || !_blocker.CanMove(entity.Value)) return;
-            if (!component.BeingPulled || (TryComp<MobStateComponent>(component.Owner, out var mobState) && mobState.IsDead())) return;
+            if (TryComp<MobStateComponent>(component.Owner, out var mobState) && mobState.IsIncapacitated()) return;
             _pullSystem.TryStopPull(component);
         }
     }

--- a/Content.Shared/Pulling/Systems/SharedPullableSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullableSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.Movement.EntitySystems;
 using Content.Shared.Pulling.Components;
+using Content.Shared.MobState.Components;
 
 namespace Content.Shared.Pulling.Systems
 {
@@ -19,6 +20,7 @@ namespace Content.Shared.Pulling.Systems
         {
             var entity = args.Session.AttachedEntity;
             if (entity == null || !_blocker.CanMove(entity.Value)) return;
+            if (!component.BeingPulled || (TryComp<MobStateComponent>(component.Owner, out var mobState) && mobState.IsDead())) return;
             _pullSystem.TryStopPull(component);
         }
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check that the moving pullable isn't dead.

The existing logic checks that the entity can move, which is just a ghost in this case. Since the ghost can move, the dead body stops the current pull. It's the one case where there is a disconnect between the PullableComponent and the Entity.

Checks if it is being dragged first to avoid entity lookup spam.  (Not great to repeat that code from TryStopPull, but the check kind of needs to be here since TryStopPull is called from many places and the OnRelayMoveInput is invoked from SharedMoverSystem)

Fixes #8042 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Ghosting no longer causes dragged corpses to be dropped

