### PR TITLE
Makes ERT roles not show up on role select

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/emergencyresponseteam.yml
@@ -50,6 +50,7 @@
 - type: job
   id: ERTEngineer
   name: "ERT engineer"
+  setPreference: false
   startingGear: ERTEngineerGearEVA
   departments:
   - Command
@@ -94,6 +95,7 @@
 - type: job
   id: ERTSecurity
   name: "ERT security"
+  setPreference: false
   startingGear: ERTEngineerGearEVA
   departments:
   - Command
@@ -138,6 +140,7 @@
 - type: job
   id: ERTMedical
   name: "ERT medic"
+  setPreference: false
   startingGear: ERTMedicalGearEVA
   departments:
   - Command
@@ -183,6 +186,7 @@
 - type: job
   id: ERTJanitor
   name: "ERT janitor"
+  setPreference: false
   startingGear: ERTJanitorGearEVA
   departments:
   - Command


### PR DESCRIPTION
Fixes issues where ERT roles showed up on the role selectiob screen.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: ERT roles no longer show up on the role select screen.

