### PR TITLE
Make HeatCapacity use FixturesMass

### DIFF
--- a/Content.Server/Temperature/Components/TemperatureComponent.cs
+++ b/Content.Server/Temperature/Components/TemperatureComponent.cs
@@ -39,9 +39,9 @@ namespace Content.Server.Temperature.Components
         {
             get
             {
-                if (IoCManager.Resolve<IEntityManager>().TryGetComponent<IPhysBody?>(Owner, out var physics) && physics.Mass != 0)
+                if (IoCManager.Resolve<IEntityManager>().TryGetComponent<IPhysBody?>(Owner, out var physics) && physics.FixturesMass != 0)
                 {
-                    return SpecificHeat * physics.Mass;
+                    return SpecificHeat * physics.FixturesMass;
                 }
 
                 return Atmospherics.MinimumHeatCapacity;


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/2908

Makes the HeatCapacity calculation work regardless of the physics body type.