### PR TITLE
Remove Shuttle Powering Crate from cargo catalogue

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
@@ -22,15 +22,15 @@
   category: Shuttle
   group: market
 
-- type: cargoProduct
-  name: shuttle powering crate
-  id: ShuttlePowerKit
-  description: Contains boards for wallmounted power utilities.
-  icon:
-    sprite: Structures/Machines/computers.rsi
-    state: avionics-systems
-  product: CrateEngineeringShuttle
-  cost: 3000
-  category: Shuttle
-  group: market
+# - type: cargoProduct
+  # name: shuttle powering crate
+  # id: ShuttlePowerKit
+  # description: Contains boards for wallmounted power utilities.
+  # icon:
+    # sprite: Structures/Machines/computers.rsi
+    # state: avionics-systems
+  # product: CrateEngineeringShuttle
+  # cost: 3000
+  # category: Shuttle
+  # group: market
 #  locked: true   # only the QM has permission to order by default

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -139,7 +139,7 @@
 
 - type: entity
   id: CrateEngineeringShuttle
-  name: shuttle power crate
+  name: shuttle powering crate
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill


### PR DESCRIPTION
Goodnight, sweet prince.

## Description
This makes the shuttle powering crate unavailable to order.
Building shuttles does distract salvagers from their job, but much more importantly it can be a significant drain on resources for the rest of the station depending on the complexity.

I've left the crate itself in for admeme purposes and for experimental mapping.
I think this product should be given another chance once permission locking has been added so that the QM or CE needs to approve the order first.

People love building shuttles. This let them build shuttles easier which led to a lot more of that kind of fun. If something is so fun that it's all anyone wants to do then I personally would try to make it more a part of the game that complements the whole.

**Changelog**
:cl:
- remove: Removed the shuttle powering crate from the cargo ordering console.

