### PR TITLE
Make following not use parenting

### DIFF
--- a/Content.Client/Follower/FollowerUpdateSystem.cs
+++ b/Content.Client/Follower/FollowerUpdateSystem.cs
@@ -1,0 +1,18 @@
+﻿using Content.Shared.Follower.Components;
+
+namespace Content.Client.Follower;
+
+/// <summary>
+/// This handles updating the position of every following entity, as it no longer uses parenting.
+/// </summary>
+public sealed class FollowerUpdateSystem : EntitySystem
+{
+    /// <inheritdoc/>
+    public override void FrameUpdate(float frameTime)
+    {
+        foreach (var (follow, xform) in EntityQuery<FollowerComponent, TransformComponent>())
+        {
+            xform.WorldPosition = Transform(follow.Following).WorldPosition;
+        }
+    }
+}

--- a/Content.Client/Follower/FollowerUpdateSystem.cs
+++ b/Content.Client/Follower/FollowerUpdateSystem.cs
@@ -12,6 +12,10 @@ public sealed class FollowerUpdateSystem : EntitySystem
     {
         foreach (var (follow, xform) in EntityQuery<FollowerComponent, TransformComponent>())
         {
+            // pvs shenanigans
+            if (!Exists(follow.Following))
+                continue;
+
             xform.WorldPosition = Transform(follow.Following).WorldPosition;
         }
     }

--- a/Content.Server/Follower/FollowerUpdateSystem.cs
+++ b/Content.Server/Follower/FollowerUpdateSystem.cs
@@ -1,0 +1,18 @@
+﻿using Content.Shared.Follower.Components;
+
+namespace Content.Server.Follower;
+
+/// <summary>
+/// This handles updating the position of every following entity, as it no longer uses parenting.
+/// </summary>
+public sealed class FollowerUpdateSystem : EntitySystem
+{
+    /// <inheritdoc/>
+    public override void Update(float frameTime)
+    {
+        foreach (var (follow, xform) in EntityQuery<FollowerComponent, TransformComponent>())
+        {
+            xform.WorldPosition = Transform(follow.Following).WorldPosition;
+        }
+    }
+}

--- a/Content.Shared/Follower/Components/FollowedComponent.cs
+++ b/Content.Shared/Follower/Components/FollowedComponent.cs
@@ -1,8 +1,8 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Follower.Components;
 
-// TODO properly network this and followercomp.
 /// <summary>
 ///     Attached to entities that are currently being followed by a ghost.
 /// </summary>
@@ -10,5 +10,16 @@ namespace Content.Shared.Follower.Components;
 [NetworkedComponent]
 public sealed class FollowedComponent : Component
 {
-    public HashSet<EntityUid> Following = new();
+    public HashSet<EntityUid> Followers = new();
+}
+
+[Serializable, NetSerializable]
+public sealed class FollowedComponentState : ComponentState
+{
+    public HashSet<EntityUid> Followers;
+
+    public FollowedComponentState(HashSet<EntityUid> followers)
+    {
+        Followers = followers;
+    }
 }

--- a/Content.Shared/Follower/Components/FollowerComponent.cs
+++ b/Content.Shared/Follower/Components/FollowerComponent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Follower.Components;
 
@@ -8,4 +9,15 @@ namespace Content.Shared.Follower.Components;
 public sealed class FollowerComponent : Component
 {
     public EntityUid Following;
+}
+
+[Serializable, NetSerializable]
+public sealed class FollowerComponentState : ComponentState
+{
+    public EntityUid Following;
+
+    public FollowerComponentState(EntityUid following)
+    {
+        Following = following;
+    }
 }

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -14,7 +14,7 @@ public sealed class FollowerSystem : EntitySystem
 
         SubscribeLocalEvent<GetVerbsEvent<AlternativeVerb>>(OnGetAlternativeVerbs);
         SubscribeLocalEvent<FollowerComponent, RelayMoveInputEvent>(OnFollowerMove);
-        SubscribeLocalEvent<FollowedComponent, EntityTerminatingEvent>(OnFollowedTerminating);
+        SubscribeLocalEvent<FollowedComponent, ComponentRemove>(OnFollowedRemoved);
     }
 
     private void OnGetAlternativeVerbs(GetVerbsEvent<AlternativeVerb> ev)
@@ -45,9 +45,10 @@ public sealed class FollowerSystem : EntitySystem
         StopFollowingEntity(uid, component.Following);
     }
 
-    // Since we parent our observer to the followed entity, we need to detach
-    // before they get deleted so that we don't get recursively deleted too.
-    private void OnFollowedTerminating(EntityUid uid, FollowedComponent component, ref EntityTerminatingEvent args)
+    /// <summary>
+    ///     Detach all followers if the followed entity is deleted.
+    /// </summary>
+    private void OnFollowedRemoved(EntityUid uid, FollowedComponent component, ComponentRemove args)
     {
         StopAllFollowers(uid, component);
     }
@@ -70,8 +71,6 @@ public sealed class FollowerSystem : EntitySystem
         followedComp.Following.Add(follower);
 
         var xform = Transform(follower);
-        xform.AttachParent(entity);
-        xform.LocalPosition = Vector2.Zero;
         xform.LocalRotation = Angle.Zero;
 
         EnsureComp<OrbitVisualsComponent>(follower);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This fixes:
- the bug where following an entity inside of a container would make you invisible forever
- the bug where your ghost would rotate with the entity as it moves (though this was solvable anyway with `NoLocalRotation`)
- all of the deletion ordering bugs that occurred (though they have been bandaided since)
- the bug where followed entities that came out of disposals would delete all of their followers :death:
- unforeseen bugs that almost surely would have arisen as a result of this

and still looks clean/smooth because the client one uses `FrameUpdate`

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Many problems related to following/orbiting have been fixed.
