### PR TITLE
Spread items when dumping contents out of a bag

### DIFF
--- a/Content.Server/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Server/Storage/EntitySystems/DumpableSystem.cs
@@ -148,9 +148,10 @@ namespace Content.Server.Storage.EntitySystems
 
             foreach (var entity in dumpQueue)
             {
-                Transform(entity).AttachParentToContainerOrGrid(EntityManager);
-                Transform(entity).LocalPosition = Transform(entity).LocalPosition + _random.NextVector2Box() / 2;
-                Transform(entity).LocalRotation = _random.NextAngle();
+                var transform = Transform(entity);
+                transform.AttachParentToContainerOrGrid(EntityManager);
+                transform.LocalPosition = transform.LocalPosition + _random.NextVector2Box() / 2;
+                transform.LocalRotation = _random.NextAngle();
             }
 
             if (HasComp<PlaceableSurfaceComponent>(args.Target))

--- a/Content.Server/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Server/Storage/EntitySystems/DumpableSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Disposal.Unit.EntitySystems;
 using Content.Server.DoAfter;
 using Content.Shared.Placeable;
 using Robust.Shared.Containers;
+using Robust.Shared.Random;
 
 namespace Content.Server.Storage.EntitySystems
 {
@@ -15,6 +16,7 @@ namespace Content.Server.Storage.EntitySystems
     {
         [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
         [Dependency] private readonly DisposalUnitSystem _disposalUnitSystem = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
 
         public override void Initialize()
         {
@@ -147,13 +149,15 @@ namespace Content.Server.Storage.EntitySystems
             foreach (var entity in dumpQueue)
             {
                 Transform(entity).AttachParentToContainerOrGrid(EntityManager);
+                Transform(entity).LocalPosition = Transform(entity).LocalPosition + _random.NextVector2Box() / 2;
+                Transform(entity).LocalRotation = _random.NextAngle();
             }
 
             if (HasComp<PlaceableSurfaceComponent>(args.Target))
             {
                 foreach (var entity in dumpQueue)
                 {
-                    Transform(entity).LocalPosition = Transform(args.Target.Value).LocalPosition;
+                    Transform(entity).LocalPosition = Transform(args.Target.Value).LocalPosition + _random.NextVector2Box() / 4;
                 }
                 return;
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When you dump items out of a bag, the items will be spread out randomly over the tile instead of all being dumped into the same exact spot. Just a minor visual change that makes it look more like you've dumped stuff out of a bag rather than put a bunch of stuff in the same place.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/70368805/172076455-577827c4-396e-4aeb-b5de-a5b263a79bf6.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: When dumping contents out of a bag, items will now be spread out randomly instead of all being dumped into the same exact spot.

