### PR TITLE
Makes asteroids low yield, adds normal yield variant for mining

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -2,14 +2,14 @@
   id: AsteroidRock
   parent: BaseStructure
   name: asteroid rock
-  description: An asteroid.
+  description: A rocky asteroid.
   components:
   - type: Gatherable
     whitelist:
       tags:
         - Pickaxe
     loot:
-      Pickaxe: MiningLootTable
+      Pickaxe: MiningLootTableLowYield
   - type: Sprite
     sprite: Structures/Walls/asteroid_rock.rsi
     state: full
@@ -41,3 +41,16 @@
   - type: IconSmooth
     key: walls
     base: rock_
+
+- type: entity
+  id: AsteroidRockMining
+  parent: BaseStructure
+  name: asteroid rock
+  description: An asteroid.
+  components:
+  - type: Gatherable
+    whitelist:
+      tags:
+        - Pickaxe
+    loot:
+      Pickaxe: MiningLootTable

--- a/Resources/Prototypes/LootTables/mining_loot_table.yml
+++ b/Resources/Prototypes/LootTables/mining_loot_table.yml
@@ -19,3 +19,25 @@
   - id: UraniumOre1
     prob: 0.025
     orGroup: Asteroid
+    
+- type: entityLootTable
+  id: MiningLootTableLowYield
+  entries:
+  - id: SteelOre1
+    prob: 0.05
+    orGroup: Asteroid
+  - id: GoldOre1
+    prob: 0.01
+    orGroup: Asteroid
+  - id: SpaceQuartz1
+    prob: 0.05
+    orGroup: Asteroid
+  - id: PlasmaOre1
+    prob: 0.025
+    orGroup: Asteroid
+  - id: SilverOre1
+    prob: 0.02
+    orGroup: Asteroid
+  - id: UraniumOre1
+    prob: 0.02
+    orGroup: Asteroid


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Created a low yield loot table for mining and applied it to the default asteroid wall (so we don't need to edit maps).
- Made a mining variant of the asteroid wall with the standard loot table, to be used in asteroid salvage or specifically mapped mines on maps.

Only difference is in the description, in the hopes people don't ruin the aesthetics on maps in the hopes for loot. Maybe we can get a mining analyser or something in future (let's say a competent miner can tell a rock with veins vs a slab of stone).

@moonheart08 not sure if you had an opinion on reducing the basic yields, can incorporate it if so.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Asteroid walls now have reduced ore yield. Look out for designated mining areas and salvage asteroids.
