### PR TITLE
Fix an issue where Omnitools and Jaws of Life sometimes don't pry floor tiles

### DIFF
--- a/Content.Server/Tools/ToolSystem.TilePrying.cs
+++ b/Content.Server/Tools/ToolSystem.TilePrying.cs
@@ -65,7 +65,7 @@ public sealed partial class ToolSystem
         var token = new CancellationTokenSource();
         component.CancelToken = token;
 
-        UseTool(
+        bool success = UseTool(
             component.Owner,
             user,
             null,
@@ -80,6 +80,9 @@ public sealed partial class ToolSystem
             toolComponent: tool,
             doAfterEventTarget: component.Owner,
             cancelToken: token.Token);
+
+        if (!success)
+            component.CancelToken = null;
 
         return true;
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- The TilePryingComponents of Omnitools and Jaws of Life weren't getting their cancel tokens cleared when you try to pry a tile with the wrong tool mode set.
- This doesn't change the spam handling since it only clears the token on failed UseTool()
- Put it in a separate if statement there just for readability

Fixes #8255 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed an issue where Omnitools and Jaws of Life sometimes don't pry floor tiles
