### PR TITLE
Opened airlock maint. panel now red on examine

### DIFF
--- a/Resources/Locale/en-US/wires/components/wires-component.ftl
+++ b/Resources/Locale/en-US/wires/components/wires-component.ftl
@@ -3,7 +3,7 @@ wires-component-ui-on-receive-message-cannot-reach = You can't reach there!
 wires-component-ui-on-receive-message-need-wirecutters = You need to hold a wirecutter in your hand!
 wires-component-ui-on-receive-message-need-multitool = You need to hold a multitool in your hand!
 wires-component-ui-on-receive-message-cannot-pulse-cut-wire = You can't pulse a wire that's been cut!
-wires-component-on-examine-panel-open = The [color=lightgray]maintenance panel[/color] is [color=darkgreen]open[/color].
+wires-component-on-examine-panel-open = The [color=lightgray]maintenance panel[/color] is [color=red]open[/color].
 wires-component-on-examine-panel-closed = The [color=lightgray]maintenance panel[/color] is [color=darkgreen]closed[/color].
 
 ## UI


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

For some reason it was green, just like closed panel. Now its red.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
add: changed color of opened airlock maint. panel
