### PR TITLE
Gathering tweaks

### DIFF
--- a/Content.Server/Gatherable/Components/GatheringToolComponent.cs
+++ b/Content.Server/Gatherable/Components/GatheringToolComponent.cs
@@ -18,15 +18,9 @@ namespace Content.Server.Gatherable.Components
         public SoundSpecifier GatheringSound { get; set; } = new SoundPathSpecifier("/Audio/Items/Mining/pickaxe.ogg");
 
         /// <summary>
-        ///     This directly plugs into the time delay for gathering.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("gatheringTime")]
-        public float GatheringTime { get; set; } = 1f;
-
-        /// <summary>
         ///     What damage should be given to objects when
         ///     gathered using this tool? (0 for infinite gathering)
+        ///     This is used to determine the gathering rate as this is applied per second.
         /// </summary>
         [DataField("damage", required: true)]
         public DamageSpecifier Damage { get; set; } = default!;
@@ -36,7 +30,7 @@ namespace Content.Server.Gatherable.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("maxEntities")]
-        public int MaxGatheringEntities = 1;
+        public int MaxGatheringEntities = 3;
 
         [ViewVariables]
         public readonly Dictionary<EntityUid, CancellationTokenSource> GatheringEntities = new();

--- a/Content.Server/Gatherable/GatherableSystem.cs
+++ b/Content.Server/Gatherable/GatherableSystem.cs
@@ -47,9 +47,10 @@ public sealed class GatherableSystem : EntitySystem
         tool.GatheringEntities[uid] = cancelToken;
         var multiplier = FixedPoint2.New(1f);
 
-        if (TryComp<DestructibleComponent>(uid, out var destructible))
+        if (TryComp<DestructibleComponent>(uid, out var destructible) &&
+            _destructible.TryGetDestroyedAt(uid, out var destroyAt, destructible))
         {
-            multiplier = _destructible.DestroyedAt(uid, destructible) / tool.Damage.Total;
+            multiplier = destroyAt.Value / tool.Damage.Total;
         }
 
         var doAfter = new DoAfterEventArgs(args.User, multiplier.Float(), cancelToken.Token, uid)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -41,8 +41,7 @@
   - type: GatheringTool
     damage:
       types:
-        Piercing: 25
-    gatheringTime: 0.75
+        Piercing: 35
   - type: ItemCooldown
   - type: MeleeWeapon
     damage:


### PR DESCRIPTION
- Resources only dropped at the end.
- Can now mine 3 by default but mining time is slower due to damage being used as a rate.

Overall it's a mining nerf.

:cl:
- tweak: Gathering now only drops resources at the end. Overall time to mine is the same but resource count is reduced as it's only dropped at the end.

