### PR TITLE
Don't electrocute when using remote on electrified door

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -6,12 +6,12 @@ using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Power.NodeGroups;
-using Content.Server.Remotes;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Database;
 using Content.Shared.Electrocution;
 using Content.Shared.Interaction;
+using Content.Shared.Item;
 using Content.Shared.Jittering;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
@@ -141,7 +141,7 @@ namespace Content.Server.Electrocution
 
         private void OnElectrifiedInteractUsing(EntityUid uid, ElectrifiedComponent electrified, InteractUsingEvent args)
         {
-            if (!electrified.OnInteractUsing || TryComp<DoorRemoteComponent>(args.Used, out var remote))
+            if (!electrified.OnInteractUsing || (TryComp<SharedItemComponent>(args.Used, out var item) && item.InteractsRemotely))
                 return;
 
             var siemens = TryComp(args.Used, out InsulatedComponent? insulation)

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Power.NodeGroups;
+using Content.Server.Remotes;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Database;
@@ -140,7 +141,7 @@ namespace Content.Server.Electrocution
 
         private void OnElectrifiedInteractUsing(EntityUid uid, ElectrifiedComponent electrified, InteractUsingEvent args)
         {
-            if (!electrified.OnInteractUsing)
+            if (!electrified.OnInteractUsing || TryComp<DoorRemoteComponent>(args.Used, out var remote))
                 return;
 
             var siemens = TryComp(args.Used, out InsulatedComponent? insulation)

--- a/Content.Shared/Item/SharedItemComponent.cs
+++ b/Content.Shared/Item/SharedItemComponent.cs
@@ -88,6 +88,15 @@ namespace Content.Shared.Item
         [DataField("sprite")]
         public readonly string? RsiPath;
 
+        /// <summary>
+        ///     Defines if this item is used remotely when interacting, like a remote control.
+        /// </summary>
+        /// <remarks>
+        ///     Currently just used to determine electrocution on use.
+        /// </remarks>
+        [DataField("interactsRemotely")]
+        public bool InteractsRemotely = false;
+
         public void RemovedFromSlot()
         {
             if (_entMan.TryGetComponent(Owner, out SharedSpriteComponent? component))

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -10,6 +10,8 @@
     netsync: false
   - type: Access
   - type: DoorRemote
+  - type: Item
+    interactsRemotely: true
 
 - type: entity
   parent: DoorRemoteDefault


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an item property interactsRemotely to determine if it is a special type of item like a remote control that does not physically touch when it interacts. Currently used for electrocution, but could be used for other physical contact things in the future like germ spread, etc.

Fixes #8651 

I went back and tested, and interacting with a door with _any_ item can electrocute you, even a banana. Don't know if we want to check if the item being used to interact is conductive/metal in the future.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Electrified doors no longer shock you when using a remote opener

