### PR TITLE
Fix crayons

### DIFF
--- a/Content.Client/Crayon/CrayonComponent.cs
+++ b/Content.Client/Crayon/CrayonComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Client.Crayon
 {
-    [RegisterComponent, Access(typeof(SharedCrayonSystem), Other = AccessPermissions.ReadExecute)]
+    [RegisterComponent, Access(typeof(CrayonSystem), typeof(CrayonSystem.StatusControl))]
     public sealed class CrayonComponent : SharedCrayonComponent
     {
         [ViewVariables(VVAccess.ReadWrite)] public bool UIUpdateNeeded;

--- a/Content.Client/Crayon/CrayonComponent.cs
+++ b/Content.Client/Crayon/CrayonComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.ViewVariables;
 
 namespace Content.Client.Crayon
 {
-    [RegisterComponent]
+    [RegisterComponent, Access(typeof(SharedCrayonSystem), Other = AccessPermissions.ReadExecute)]
     public sealed class CrayonComponent : SharedCrayonComponent
     {
         [ViewVariables(VVAccess.ReadWrite)] public bool UIUpdateNeeded;

--- a/Content.Client/Crayon/CrayonSystem.cs
+++ b/Content.Client/Crayon/CrayonSystem.cs
@@ -38,7 +38,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
         args.Controls.Add(new StatusControl(component));
     }
 
-    private sealed class StatusControl : Control
+    public sealed class StatusControl : Control
     {
         private readonly CrayonComponent _parent;
         private readonly RichTextLabel _label;

--- a/Content.Client/Crayon/CrayonSystem.cs
+++ b/Content.Client/Crayon/CrayonSystem.cs
@@ -63,7 +63,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
 
             _parent.UIUpdateNeeded = false;
             _label.SetMarkup(Loc.GetString("crayon-drawing-label",
-                ("color",_parent.Color),
+                ("color",_parent.Color.ToHex()),
                 ("state",_parent.SelectedState),
                 ("charges", _parent.Charges),
                 ("capacity",_parent.Capacity)));

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -30,7 +30,7 @@ public sealed class CrayonSystem : SharedCrayonSystem
         SubscribeLocalEvent<CrayonComponent, ComponentInit>(OnCrayonInit);
         SubscribeLocalEvent<CrayonComponent, CrayonSelectMessage>(OnCrayonBoundUI);
         SubscribeLocalEvent<CrayonComponent, CrayonColorMessage>(OnCrayonBoundUIColor);
-        SubscribeLocalEvent<CrayonComponent, UseInHandEvent>(OnCrayonUse);
+        SubscribeLocalEvent<CrayonComponent, UseInHandEvent>(OnCrayonUse, before: new[] { typeof(FoodSystem) } );
         SubscribeLocalEvent<CrayonComponent, AfterInteractEvent>(OnCrayonAfterInteract, after: new []{ typeof(FoodSystem) });
         SubscribeLocalEvent<CrayonComponent, DroppedEvent>(OnCrayonDropped);
         SubscribeLocalEvent<CrayonComponent, ComponentGetState>(OnCrayonGetState);


### PR DESCRIPTION
Status control was erroring due to invalid color tag. Also using `z` would eat the crayon, instead of opening the selection UI.

Currently waiting on changes to the access attribute.

Fixes #8796

:cl:
- fix: Crayons are for drawing, not eating. Using `z` will open the drawing UI, instead of eating them. But if you really want you can still eat them.