### PR TITLE
Add priorities to items slots

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -198,5 +198,11 @@ namespace Content.Shared.Containers.ItemSlots
         // Convenience properties
         public bool HasItem => ContainerSlot?.ContainedEntity != null;
         public EntityUid? Item => ContainerSlot?.ContainedEntity;
+
+        /// <summary>
+        ///     Priority for use with the eject & insert verbs for this slot.
+        /// </summary>
+        [DataField("priority")]
+        public int Priority = 0;
     }
 }

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -431,6 +431,7 @@ namespace Content.Shared.Containers.ItemSlots
                     verb.Text = Loc.GetString(slot.EjectVerbText);
                 }
 
+                verb.Priority = slot.Priority;
                 args.Verbs.Add(verb);
             }
         }
@@ -462,6 +463,7 @@ namespace Content.Shared.Containers.ItemSlots
                 else
                     takeVerb.Text = Loc.GetString(slot.EjectVerbText);
 
+                takeVerb.Priority = slot.Priority;
                 args.Verbs.Add(takeVerb);
             }
 
@@ -500,6 +502,7 @@ namespace Content.Shared.Containers.ItemSlots
                     insertVerb.Text = verbSubject;
                 }
 
+                insertVerb.Priority = slot.Priority;
                 args.Verbs.Add(insertVerb);
             }
         }

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -53,6 +53,7 @@
   - type: PDA
     penSlot:
       startingItem: Pen
+      priority: -1
       whitelist:
         tags:
         - Write
@@ -177,11 +178,10 @@
   - type: PDA
     id: ClownIDCard
     penSlot:
-      startingItem: CrayonOrange # no pink crayon?!?
-      # Maybe this is a bad idea.
-      # At least they can't just spam alt-click it.
-      # You need to remove the ID & alternate between inserting and ejecting
+      startingItem: CrayonOrange # no pink crayon?!? 
+      # ^ Still unacceptable.
       ejectSound: /Audio/Items/bikehorn.ogg
+      priority: -1
       whitelist:
         tags:
         - Write
@@ -365,6 +365,10 @@
     id: CaptainIDCard
     penSlot:
       startingItem: PenCap
+      priority: -1
+      whitelist:
+        tags:
+        - Write
   - type: Appearance
     visuals:
       - type: PDAVisualizer
@@ -382,6 +386,10 @@
     id: HoPIDCard
     penSlot:
       startingItem: PenHop
+      priority: -1
+      whitelist:
+        tags:
+        - Write
   - type: Appearance
     visuals:
       - type: PDAVisualizer
@@ -403,7 +411,6 @@
         state: pda-ce
   - type: Icon
     state: pda-ce
-
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
Ensures that alt-clicking a pda will eject the id card first, and then the pen.