### PR TITLE
Syndicate gas mask flash protection

### DIFF
--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -195,15 +195,16 @@ namespace Content.Server.Flash
 
         private void OnInventoryFlashAttempt(EntityUid uid, InventoryComponent component, FlashAttemptEvent args)
         {
-            // Forward the event to a worn helmet, if one is equipped.
-            if (_inventorySystem.TryGetSlotEntity(uid, "head", out var headSlotEntity, component))
-                RaiseLocalEvent(headSlotEntity.Value, args);
-            // Forward the event to the glasses, if any.
-            if(!args.Cancelled && _inventorySystem.TryGetSlotEntity(uid, "eyes", out var eyeSlotEntity, component))
-                RaiseLocalEvent(eyeSlotEntity.Value, args);
-            // Forward the event to the mask, if any.
-            if (!args.Cancelled && _inventorySystem.TryGetSlotEntity(uid, "mask", out var maskSlotEntity, component))
-                RaiseLocalEvent(maskSlotEntity.Value, args);
+            if(_inventorySystem.TryGetSlots(uid, out var slots))
+            {
+                foreach(var slot in slots)
+                {
+                    if (args.Cancelled)
+                        break;
+                    if (_inventorySystem.TryGetSlotEntity(uid, slot.Name, out var item))
+                        RaiseLocalEvent(item.Value, args);
+                }
+            }
         }
 
         private void OnFlashImmunityFlashAttempt(EntityUid uid, FlashImmunityComponent component, FlashAttemptEvent args)

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -201,6 +201,9 @@ namespace Content.Server.Flash
             // Forward the event to the glasses, if any.
             if(!args.Cancelled && _inventorySystem.TryGetSlotEntity(uid, "eyes", out var eyeSlotEntity, component))
                 RaiseLocalEvent(eyeSlotEntity.Value, args);
+            // Forward the event to the mask, if any.
+            if (!args.Cancelled && _inventorySystem.TryGetSlotEntity(uid, "mask", out var maskSlotEntity, component))
+                RaiseLocalEvent(maskSlotEntity.Value, args);
         }
 
         private void OnFlashImmunityFlashAttempt(EntityUid uid, FlashImmunityComponent component, FlashAttemptEvent args)

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -195,15 +195,12 @@ namespace Content.Server.Flash
 
         private void OnInventoryFlashAttempt(EntityUid uid, InventoryComponent component, FlashAttemptEvent args)
         {
-            if(_inventorySystem.TryGetSlots(uid, out var slots))
+            foreach (var slot in new string[]{"head", "eyes", "mask"})
             {
-                foreach(var slot in slots)
-                {
-                    if (args.Cancelled)
-                        break;
-                    if (_inventorySystem.TryGetSlotEntity(uid, slot.Name, out var item))
-                        RaiseLocalEvent(item.Value, args);
-                }
+                if (args.Cancelled)
+                    break;
+                if (_inventorySystem.TryGetSlotEntity(uid, slot, out var item, component))
+                    RaiseLocalEvent(item.Value, args);
             }
         }
 

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -196,8 +196,8 @@ namespace Content.Server.Flash
         private void OnInventoryFlashAttempt(EntityUid uid, InventoryComponent component, FlashAttemptEvent args)
         {
             // Forward the event to a worn helmet, if one is equipped.
-            if (_inventorySystem.TryGetSlotEntity(uid, "head", out var maskSlotEntity, component))
-                RaiseLocalEvent(maskSlotEntity.Value, args);
+            if (_inventorySystem.TryGetSlotEntity(uid, "head", out var headSlotEntity, component))
+                RaiseLocalEvent(headSlotEntity.Value, args);
             // Forward the event to the glasses, if any.
             if(!args.Cancelled && _inventorySystem.TryGetSlotEntity(uid, "eyes", out var eyeSlotEntity, component))
                 RaiseLocalEvent(eyeSlotEntity.Value, args);

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -42,6 +42,7 @@
   - type: IngestionBlocker
   - type: DiseaseProtection
     protection: 0.05
+  - type: FlashImmunity
 
 - type: entity
   parent: ClothingMaskBase


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Syndicate gas masks protect the wearer from flashing.

I agree with TimrodDX that it seems weird that syndie operators can get flashbanged by the always be-sunglassed security.
From a lore and balance perspective, syndies should have good gear.

Closes #8770

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Syndie gas masks now provide protection from flashbangs

