### PR TITLE
Guns will now eject magazines first instead of chamber

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -31,12 +31,14 @@
         startingItem: MagazineLightRifleBox
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazineLightRifleBox
       gun_chamber:
         name: Chamber
         startingItem: CartridgeLightRifle
+        priority: 1
         whitelist:
           tags:
             - CartridgeLightRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -29,12 +29,14 @@
         startingItem: MagazinePistol
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazinePistol
       gun_chamber:
         name: Chamber
         startingItem: CartridgePistol
+        priority: 1
         whitelist:
           tags:
             - CartridgePistol
@@ -65,6 +67,7 @@
         startingItem: MagazinePistol
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazinePistol
@@ -72,6 +75,7 @@
       gun_chamber:
         name: Chamber
         startingItem: CartridgePistol
+        priority: 1
         whitelist:
           tags:
             - CartridgePistol
@@ -123,12 +127,14 @@
         startingItem: MagazinePistolCaselessRifle
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazinePistolCaselessRifle
       gun_chamber:
         name: Chamber
         startingItem: CartridgeCaselessRifle
+        priority: 1
         whitelist:
           tags:
             - CartridgeCaselessRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -25,12 +25,14 @@
         startingItem: MagazineLightRifle
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazineLightRifle
       gun_chamber:
         name: Chamber
         startingItem: CartridgeLightRifle
+        priority: 1
         whitelist:
           tags:
             - CartridgeLightRifle
@@ -66,12 +68,14 @@
         startingItem: MagazineLightRifle
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazineLightRifle
       gun_chamber:
         name: Chamber
         startingItem: CartridgeLightRifle
+        priority: 1
         whitelist:
           tags:
             - CartridgeLightRifle
@@ -107,12 +111,14 @@
         startingItem: MagazineRifle
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazineRifle
       gun_chamber:
         name: Chamber
         startingItem: CartridgeRifle
+        priority: 1
         whitelist:
           tags:
             - CartridgeRifle
@@ -151,12 +157,14 @@
         startingItem: MagazineRifle
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazineRifle
       gun_chamber:
         name: Chamber
         startingItem: CartridgeRifle
+        priority: 1
         whitelist:
           tags:
             - CartridgeRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -28,12 +28,14 @@
         startingItem: MagazinePistolSubMachineGun
         insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazinePistolSubMachineGun
       gun_chamber:
         name: Chamber
         startingItem: CartridgePistol
+        priority: 1
         whitelist:
           tags:
             - CartridgePistol
@@ -116,12 +118,14 @@
         startingItem: MagazineMagnumSubMachineGun
         insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazineMagnumSubMachineGun
       gun_chamber:
         name: Chamber
         startingItem: CartridgeMagnum
+        priority: 1
         whitelist:
           tags:
             - CartridgeMagnum
@@ -168,12 +172,14 @@
         startingItem: MagazinePistolSubMachineGunTopMounted
         insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazinePistolSubMachineGunTopMounted
       gun_chamber:
         name: Chamber
         startingItem: CartridgePistol
+        priority: 1
         whitelist:
           tags:
             - CartridgePistol
@@ -197,12 +203,14 @@
         startingItem: MagazineMagnumSubMachineGunRubber
         insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
         whitelist:
           tags:
             - MagazineMagnumSubMachineGun
       gun_chamber:
         name: Chamber
         startingItem: CartridgeMagnumRubber
+        priority: 1
         whitelist:
           tags:
             - CartridgeMagnum

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -63,6 +63,7 @@
       gun_magazine:
         name: Magazine
         startingItem: MagazineShotgun
+        priority: 2
         whitelist:
           tags:
           - MagazineShotgun


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

closes #8760

Changes the priority around so alt-click removes the mag first then the round in the chamber.

