### PR TITLE
Clean up door remote

### DIFF
--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -1,5 +1,4 @@
 using Robust.Shared.Player;
-using Robust.Shared.Audio;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Doors.Components;
@@ -9,6 +8,7 @@ using Content.Shared.Access.Components;
 using Content.Server.Doors.Systems;
 using Content.Server.Doors.Components;
 using Content.Shared.Interaction.Events;
+using static Content.Server.Remotes.DoorRemoteComponent;
 
 namespace Content.Server.Remotes
 {
@@ -21,80 +21,81 @@ namespace Content.Server.Remotes
 
         public override void Initialize()
         {
-            base.Initialize();
-
             SubscribeLocalEvent<DoorRemoteComponent, UseInHandEvent>(OnInHandActivation);
             SubscribeLocalEvent<DoorRemoteComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
         }
 
         public void OnInHandActivation(EntityUid user, DoorRemoteComponent component, UseInHandEvent args)
         {
+            string switchMessageId;
             switch (component.Mode)
             {
-                case DoorRemoteComponent.OperatingMode.OpenClose:
-                    component.Mode = DoorRemoteComponent.OperatingMode.ToggleBolts;
-                    _popupSystem.PopupEntity(Loc.GetString("door-remote-switch-state-toggle-bolts"), args.User, Filter.Entities(args.User));
+                case OperatingMode.OpenClose:
+                    component.Mode = OperatingMode.ToggleBolts;
+                    switchMessageId = "door-remote-switch-state-toggle-bolts";
                     break;
-                case DoorRemoteComponent.OperatingMode.ToggleBolts:
-                    component.Mode = DoorRemoteComponent.OperatingMode.ToggleEmergencyAccess;
-                    _popupSystem.PopupEntity(Loc.GetString("door-remote-switch-state-toggle-emergency-access"), args.User, Filter.Entities(args.User));
+                case OperatingMode.ToggleBolts:
+                    component.Mode = OperatingMode.ToggleEmergencyAccess;
+                    switchMessageId = "door-remote-switch-state-toggle-emergency-access";
                     break;
-                case DoorRemoteComponent.OperatingMode.ToggleEmergencyAccess:
-                    component.Mode = DoorRemoteComponent.OperatingMode.OpenClose;
-                    _popupSystem.PopupEntity(Loc.GetString("door-remote-switch-state-open-close"), args.User, Filter.Entities(args.User));
+                case OperatingMode.ToggleEmergencyAccess:
+                    component.Mode = OperatingMode.OpenClose;
+                    switchMessageId = "door-remote-switch-state-open-close";
                     break;
+                default:
+                    throw new InvalidOperationException(
+                        $"{nameof(DoorRemoteComponent)} had invalid mode {component.Mode}");
             }
+            ShowPopupToUser(switchMessageId, args.User);
         }
 
         private void OnBeforeInteract(EntityUid uid, DoorRemoteComponent component, BeforeRangedInteractEvent args)
         {
-            if (!args.CanReach ||
-                args.Handled
+            if (
+                   args.Handled
                 || args.Target == null
-                || !TryComp<DoorComponent>(args.Target, out var doorComponent) // If it isn't a door we don't use it
-                || !HasComp<AccessReaderComponent>(args.Target) // Remotes do not work on doors without access requirements
-                || !TryComp<AirlockComponent>(args.Target, out var airlockComponent) // Remotes only work on airlocks
-                // TODO: Why the fuck is this -1f
-                || !_interactionSystem.InRangeUnobstructed(args.User, doorComponent.Owner, -1f, CollisionGroup.Opaque))
+                || !TryComp<DoorComponent>(args.Target, out var doorComp) // If it isn't a door we don't use it
+                || !TryComp<AirlockComponent>(args.Target, out var airlockComp) // Remotes only work on airlocks
+                // The remote can be used anywhere the user can see the door.
+                // This doesn't work that well, but I don't know of an alternative
+                   || !_interactionSystem.InRangeUnobstructed(args.User, args.Target.Value,
+                    SharedInteractionSystem.MaxRaycastRange, CollisionGroup.Opaque))
+                return;
+
+            args.Handled = true;
+            if (!airlockComp.IsPowered())
             {
+                ShowPopupToUser("door-remote-no-power", args.User);
                 return;
             }
 
-            args.Handled = true;
-
-            if (component.Mode == DoorRemoteComponent.OperatingMode.OpenClose)
+            if (TryComp<AccessReaderComponent>(args.Target, out var accessComponent) &&
+                !_doorSystem.HasAccess(doorComp.Owner, args.Used, accessComponent))
             {
-                _doorSystem.TryToggleDoor(doorComponent.Owner, user: args.Used);
+                _doorSystem.Deny(airlockComp.Owner, doorComp, args.User);
+                ShowPopupToUser("door-remote-denied", args.User);
+                return;
             }
 
-            if (component.Mode == DoorRemoteComponent.OperatingMode.ToggleBolts
-                && airlockComponent.IsPowered())
+            switch (component.Mode)
             {
-                if (_doorSystem.HasAccess(doorComponent.Owner, args.Used))
-                {
-                    airlockComponent.SetBoltsWithAudio(!airlockComponent.IsBolted());
-                }
-                else
-                {
-                    if (doorComponent.State != DoorState.Open)
-                    {
-                        _doorSystem.Deny(airlockComponent.Owner, user: args.User);
-                    }
-                    else if (doorComponent.DenySound != null)
-                    {
-                        SoundSystem.Play(doorComponent.DenySound.GetSound(), Filter.Pvs(args.Target.Value, entityManager: EntityManager), args.Target.Value);
-                    }
-                }
-            }
-
-            if (component.Mode == DoorRemoteComponent.OperatingMode.ToggleEmergencyAccess
-                && airlockComponent.IsPowered())
-            {
-                if (_doorSystem.HasAccess(doorComponent.Owner, args.Used))
-                {
-                    _sharedAirlockSystem.ToggleEmergencyAccess(airlockComponent);
-                }
+                case OperatingMode.OpenClose:
+                    _doorSystem.TryToggleDoor(doorComp.Owner, doorComp, args.Used);
+                    break;
+                case OperatingMode.ToggleBolts:
+                    //TODO: What about cut wires...?
+                    airlockComp.SetBoltsWithAudio(!airlockComp.IsBolted());
+                    break;
+                case OperatingMode.ToggleEmergencyAccess:
+                    _sharedAirlockSystem.ToggleEmergencyAccess(airlockComp);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"{nameof(DoorRemoteComponent)} had invalid mode {component.Mode}");
             }
         }
+
+        private void ShowPopupToUser(string messageId, EntityUid user) =>
+            _popupSystem.PopupEntity(Loc.GetString(messageId), user, Filter.Entities(user));
     }
 }

--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Physics;
 using Content.Shared.Access.Components;
 using Content.Server.Doors.Systems;
 using Content.Server.Doors.Components;
+using Content.Server.Power.EntitySystems;
 using Content.Shared.Interaction.Events;
 using static Content.Server.Remotes.DoorRemoteComponent;
 
@@ -51,19 +52,19 @@ namespace Content.Server.Remotes
 
         private void OnBeforeInteract(EntityUid uid, DoorRemoteComponent component, BeforeRangedInteractEvent args)
         {
-            if (
-                   args.Handled
+            if (args.Handled
                 || args.Target == null
                 || !TryComp<DoorComponent>(args.Target, out var doorComp) // If it isn't a door we don't use it
                 || !TryComp<AirlockComponent>(args.Target, out var airlockComp) // Remotes only work on airlocks
                 // The remote can be used anywhere the user can see the door.
                 // This doesn't work that well, but I don't know of an alternative
-                   || !_interactionSystem.InRangeUnobstructed(args.User, args.Target.Value,
+                || !_interactionSystem.InRangeUnobstructed(args.User, args.Target.Value,
                     SharedInteractionSystem.MaxRaycastRange, CollisionGroup.Opaque))
                 return;
 
             args.Handled = true;
-            if (!airlockComp.IsPowered())
+
+            if (!this.IsPowered(args.Target.Value, EntityManager))
             {
                 ShowPopupToUser("door-remote-no-power", args.User);
                 return;

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -52,10 +52,10 @@ namespace Content.Shared.Interaction
         private const CollisionGroup InRangeUnobstructedMask
             = CollisionGroup.Impassable | CollisionGroup.InteractImpassable;
 
-        public const float InteractionRange = 2;
+        public const float InteractionRange = 2f;
         public const float InteractionRangeSquared = InteractionRange * InteractionRange;
 
-        public const float MaxRaycastRange = 100;
+        public const float MaxRaycastRange = 100f;
 
         public delegate bool Ignored(EntityUid entity);
 

--- a/Resources/Locale/en-US/door-remote/door-remote.ftl
+++ b/Resources/Locale/en-US/door-remote/door-remote.ftl
@@ -1,3 +1,6 @@
 door-remote-switch-state-open-close = You switch the remote to open and close doors
 door-remote-switch-state-toggle-bolts = You switch the remote to toggle bolts
 door-remote-switch-state-toggle-emergency-access = You switch the remote to toggle emergency access
+door-remote-no-power = The door is not powered
+door-remote-denied = Access denied
+


### PR DESCRIPTION
1. Fixed a bug with needing to be close to the door
2. Made all door remote commands require the door to be powered
3. Made access component optional. Debatable, but I like it requiring less things to work.
4. Added failure popups for power, and access.
5. Made some int's assigned to floats, into floats.
6. I think the code looks a little nicer.