### PR TITLE
Add a Wiki Button to the escape menu

### DIFF
--- a/Content.Client/EscapeMenu/UI/EscapeMenu.xaml
+++ b/Content.Client/EscapeMenu/UI/EscapeMenu.xaml
@@ -9,6 +9,7 @@
         <ui:VoteCallMenuButton />
         <Button Name="OptionsButton" Text="{Loc 'ui-escape-options'}" />
         <Button Name="RulesButton" Text="{Loc 'ui-escape-rules'}" />
+        <Button Name="WikiButton" Text="{Loc 'ui-escape-wiki'}" />
         <Button Name="DisconnectButton" Text="{Loc 'ui-escape-disconnect'}" />
         <Button Name="QuitButton" Text="{Loc 'ui-escape-quit'}" />
     </BoxContainer>

--- a/Content.Client/EscapeMenu/UI/EscapeMenu.xaml.cs
+++ b/Content.Client/EscapeMenu/UI/EscapeMenu.xaml.cs
@@ -5,6 +5,8 @@ using Robust.Client.Console;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Client.UserInterface.XAML;
+using Robust.Client.UserInterface;
+using Content.Client.Links;
 using Robust.Shared.GameObjects;
 
 namespace Content.Client.EscapeMenu.UI
@@ -28,6 +30,7 @@ namespace Content.Client.EscapeMenu.UI
             QuitButton.OnPressed += OnQuitButtonClicked;
             RulesButton.OnPressed += _ => new RulesAndInfoWindow().Open();
             DisconnectButton.OnPressed += OnDisconnectButtonClicked;
+            QuitButton.OnPressed += OnWikiButtonClicked;
         }
 
         private void OnQuitButtonClicked(BaseButton.ButtonEventArgs args)
@@ -45,6 +48,12 @@ namespace Content.Client.EscapeMenu.UI
         private void OnOptionsButtonClicked(BaseButton.ButtonEventArgs args)
         {
             _optionsMenu.OpenCentered();
+        }
+
+        private void OnWikiButtonClicked(BaseButton.ButtonEventArgs args)
+        {
+            var uriOpener = IoCManager.Resolve<IUriOpener>();
+            uriOpener.OpenUri(UILinks.Wiki);
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Client/EscapeMenu/UI/EscapeMenu.xaml.cs
+++ b/Content.Client/EscapeMenu/UI/EscapeMenu.xaml.cs
@@ -30,7 +30,7 @@ namespace Content.Client.EscapeMenu.UI
             QuitButton.OnPressed += OnQuitButtonClicked;
             RulesButton.OnPressed += _ => new RulesAndInfoWindow().Open();
             DisconnectButton.OnPressed += OnDisconnectButtonClicked;
-            QuitButton.OnPressed += OnWikiButtonClicked;
+            WikiButton.OnPressed += OnWikiButtonClicked;
         }
 
         private void OnQuitButtonClicked(BaseButton.ButtonEventArgs args)

--- a/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
@@ -3,6 +3,7 @@
 ui-escape-title = Esc Menu
 ui-escape-options = Options
 ui-escape-rules = Rules
+ui-escape-wiki = Wiki
 ui-escape-disconnect = Disconnect
 ui-escape-quit = Quit
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
at last, a wiki button for the escape menu. pancake will like this
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/67359748/173565695-d2ed725f-a61e-41da-9a04-d2762295da33.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: eclips_e
- add: Added a wiki button to the escape menu

