### PR TITLE
Basic Medication Overdoses (Chemistry 1984)

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -152,6 +152,7 @@
         damage:
           types:
             Asphyxiation: 1
+        group:
             Brute: 0.5
       - !type:Jitter
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -273,7 +273,7 @@
           types:
             Radiation: -1
       - !type:ChemVomit
-        probability: 0.05
+        probability: 0.02
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -152,7 +152,7 @@
         damage:
           types:
             Asphyxiation: 1
-        group:
+        groups:
             Brute: 0.5
       - !type:Jitter
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -76,6 +76,18 @@
         damage:
           groups:
             Brute: -2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          types:
+            Asphyxiation: 1
+            Poison: 0.5
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
 
 - type: reagent
   id: Cryoxadone
@@ -133,6 +145,18 @@
         damage:
           groups:
             Burn: -3
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          types:
+            Asphyxiation: 1
+            Brute: 0.5
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
 
 - type: reagent
   id: Dexalin
@@ -248,6 +272,19 @@
         damage:
           types:
             Radiation: -1
+      - !type:ChemVomit
+        probability: 0.05
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+        damage:
+          types:
+           Heat: 0.5
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
 
 - type: reagent
   id: Ipecac


### PR DESCRIPTION
This adds overdoses to 3 of the basic medications. Bicaridine, dermaline, and hyronalin. The overdose threshold is 30u. You will jitter when you OD as visual indication of it. Bicaridine overdose will make you have trouble breathing and mildly poison you. Dermaline overdose will make you have trouble breathing and deal brute damage to you. Hyronalin now has a low (2% per unit) base chance of making you vomit and it's overdose will cause burn damage. This helps make arithrazine a more appealing option for experienced chemists. 
For the elephant in the room. This will make cloning an even more appealing option for medical. I do not like this and this is not my intention with this PR. This PRs goals is to add basic OD functionality to meds that had it in 13 to add more depth to the chem making experience (balancing out pill mixes to counteract ODs, giving doctors a reason to use vomit inducing drugs, etc). Please leave your thoughts below. Thank you.

🆑 Emisse
- add: Bicaridine, Dermaline, and Hyronalin all OD at 30u. Hyronalin has a low base chance to induce vomiting. 

