### PR TITLE
Fixes static not appearing inbetween camera changes client-side

### DIFF
--- a/Content.Client/SurveillanceCamera/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Client/SurveillanceCamera/SurveillanceCameraMonitorSystem.cs
@@ -4,8 +4,6 @@ namespace Content.Client.SurveillanceCamera;
 
 public sealed class SurveillanceCameraMonitorSystem : EntitySystem
 {
-    private readonly RemQueue<EntityUid> _toRemove = new();
-
     public override void Update(float frameTime)
     {
         foreach (var comp in EntityQuery<ActiveSurveillanceCameraMonitorVisualsComponent>())
@@ -24,16 +22,9 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
                     comp.OnFinish();
                 }
 
-                _toRemove.Add(comp.Owner);
+                EntityManager.RemoveComponentDeferred<ActiveSurveillanceCameraMonitorVisualsComponent>(comp.Owner);
             }
         }
-
-        foreach (var uid in _toRemove)
-        {
-            EntityManager.RemoveComponent<ActiveSurveillanceCameraMonitorVisualsComponent>(uid);
-        }
-
-        _toRemove.List?.Clear();
     }
 
     public void AddTimer(EntityUid uid, Action onFinish)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The static that was meant to hide some visual issues related to camera switching should now appear when switching cameras.