### PR TITLE
Nerf gun damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimaterial.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimaterial.yml
@@ -7,4 +7,4 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 70
+        Piercing: 49

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 27
+        Piercing: 19
 
 - type: entity
   id: BulletCaselessRifleFlash
@@ -29,7 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 32
+        Piercing: 22
 
 - type: entity
   id: BulletCaselessRiflePractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 28
+        Piercing: 19
 
 - type: entity
   id: BulletMinigun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 28
+        Piercing: 19
 
 - type: entity
   id: BulletLightRifleFlash
@@ -29,7 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
+        Piercing: 21
 
 - type: entity
   id: BulletLightRiflePractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 32
+        Piercing: 22
 
 - type: entity
   id: BulletMagnumFlash
@@ -29,7 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 24
 
 - type: entity
   id: BulletMagnumPractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 24
+        Piercing: 16
 
 - type: entity
   id: BulletPistolFlash
@@ -29,7 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 28
+        Piercing: 19
 
 - type: entity
   id: BulletPistolPractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 25
+        Piercing: 17
 
 - type: entity
   id: BulletRifleFlash
@@ -29,7 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
+        Piercing: 21
 
 - type: entity
   id: BulletRiflePractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -10,7 +10,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 8  # Should have the same or less damage than a regular pellet
+        Piercing: 5  # Should have the same or less damage than a regular pellet
 
 - type: entity
   id: PelletShotgunBeanbag
@@ -41,7 +41,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 8
+        Piercing: 5
 
 - type: entity
   id: PelletShotgunFlash
@@ -55,7 +55,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
+        Blunt: 2
 
 - type: entity
   id: PelletShotgunIncendiary
@@ -69,7 +69,7 @@
   - type: Projectile
     damage:
       groups:
-        Burn: 10
+        Burn: 7
   - type: PointLight
     enabled: true
     color: "#ff4300"
@@ -130,7 +130,7 @@
   - type: Projectile
     damage:
       groups:
-        Burn: 20
+        Burn: 14
   - type: PointLight
     enabled: true
     color: "#FF8080"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -16,7 +16,7 @@
   id: RedLaser
   damage:
     types:
-      Heat: 20
+      Heat: 14
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -31,7 +31,7 @@
   id: RedMediumLaser
   damage:
     types:
-      Heat: 25
+      Heat: 17
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -46,7 +46,7 @@
   id: OmniLaser
   damage:
     types:
-      Heat: 30
+      Heat: 21
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_omni
@@ -61,8 +61,8 @@
   id: XrayLaser
   damage:
     types:
-      Heat: 15
-      Radiation: 15
+      Heat: 10
+      Radiation: 10
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_xray
@@ -77,7 +77,7 @@
   id: RedHeavyLaser
   damage:
     types:
-      Heat: 40
+      Heat: 28
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy
@@ -92,7 +92,7 @@
   id: Pulse
   damage:
     types:
-      Heat: 50
+      Heat: 35
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_blue

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -31,7 +31,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 20
+        Piercing: 14
     soundHit:
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
 
@@ -81,7 +81,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12
+        Piercing: 17
 
 - type: entity
   id: BaseBulletPractice
@@ -179,7 +179,7 @@
   - type: Projectile
     damage:
       types:
-        Heat: 20
+        Heat: 14
   - type: Tag
     tags:
     - EmitterBolt


### PR DESCRIPTION
Accuracy is in a decent spot I feel, and size will be okay when exoslots work. A few people have said gun TTK is too low so this reduces damage 30% (rounded down) to see how it goes. May need further damage nerf but I'd rather do that after exoslot is in.

The values were taken from ss13 but that game plays much slower and much laggier so our TTK is much lower.

:cl:
- tweak: Nerfed gun damage by 30% across the board.