### PR TITLE
High Sec Door Armory Locked

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -666,3 +666,11 @@
   components:
   - type: AccessReader
     access: [["Captain"]]
+
+- type: entity
+  parent: HighSecDoor
+  id: HighSecArmoryLocked
+  suffix: Armory, Locked
+  components:
+  - type: AccessReader
+    access: [["Armory"]]


### PR DESCRIPTION
changelog
-adds a armory access locked high sec door for mapping. good for enclosed armories.

