### PR TITLE
Can't break other people's drags on cuffed people

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Item;
 using Content.Shared.Movement;
 using Content.Shared.Physics.Pull;
 using Content.Shared.Pulling.Components;
+using Content.Shared.Pulling.Events;
 
 namespace Content.Shared.Cuffs
 {
@@ -25,10 +26,20 @@ namespace Content.Shared.Cuffs
             SubscribeLocalEvent<SharedCuffableComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, DropAttemptEvent>(OnDropAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, PickupAttemptEvent>(OnPickupAttempt);
+            SubscribeLocalEvent<SharedCuffableComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
             SubscribeLocalEvent<SharedCuffableComponent, PullStartedMessage>(OnPull);
             SubscribeLocalEvent<SharedCuffableComponent, PullStoppedMessage>(OnPull);
         }
 
+
+        private void OnBeingPulledAttempt(EntityUid uid, SharedCuffableComponent component, BeingPulledAttemptEvent args)
+        {
+            if (!TryComp<SharedPullableComponent>(uid, out var pullable))
+                return;
+
+            if (pullable.Puller != null && !component.CanStillInteract) // If we are being pulled already and cuffed, we can't get pulled again.
+                args.Cancel();
+        }
         private void OnPull(EntityUid uid, SharedCuffableComponent component, PullMessage args)
         {
             if (!component.CanStillInteract)

--- a/Content.Shared/Pulling/Events/BeingPulledAttemptEvent.cs
+++ b/Content.Shared/Pulling/Events/BeingPulledAttemptEvent.cs
@@ -1,0 +1,17 @@
+namespace Content.Shared.Pulling.Events
+{
+    /// <summary>
+    ///     Directed event raised on the pulled to see if it can be pulled.
+    /// </summary>
+    public sealed class BeingPulledAttemptEvent : CancellableEntityEventArgs
+    {
+        public BeingPulledAttemptEvent(EntityUid puller, EntityUid pulled)
+        {
+            Puller = puller;
+            Pulled = pulled;
+        }
+
+        public EntityUid Puller { get; }
+        public EntityUid Pulled { get; }
+    }
+}

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -3,6 +3,7 @@ using Content.Shared.Buckle.Components;
 using Content.Shared.Physics.Pull;
 using Content.Shared.Pulling.Components;
 using Content.Shared.Pulling.Events;
+using Content.Shared.Cuffs.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
@@ -54,6 +55,12 @@ namespace Content.Shared.Pulling
                     return false;
                 }
             }
+            // Can't pull people who are cuffed if someone else is pulling them.
+            // You have to stun the puller or something first.
+            // Throwing sec a bone.
+            if (TryComp<SharedPullableComponent>(pulled, out var pullable) && pullable.Puller != null // Are they being pulled by someone else?
+            && TryComp<SharedCuffableComponent>(pulled, out var cuffable) && !cuffable.CanStillInteract) // Are they cuffed?
+                return false;
 
             var startPull = new StartPullAttemptEvent(puller, pulled);
             RaiseLocalEvent(puller, startPull);

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -3,7 +3,6 @@ using Content.Shared.Buckle.Components;
 using Content.Shared.Physics.Pull;
 using Content.Shared.Pulling.Components;
 using Content.Shared.Pulling.Events;
-using Content.Shared.Cuffs.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
@@ -55,16 +54,12 @@ namespace Content.Shared.Pulling
                     return false;
                 }
             }
-            // Can't pull people who are cuffed if someone else is pulling them.
-            // You have to stun the puller or something first.
-            // Throwing sec a bone.
-            if (TryComp<SharedPullableComponent>(pulled, out var pullable) && pullable.Puller != null // Are they being pulled by someone else?
-            && TryComp<SharedCuffableComponent>(pulled, out var cuffable) && !cuffable.CanStillInteract) // Are they cuffed?
-                return false;
 
+            var getPulled = new BeingPulledAttemptEvent(puller, pulled);
+            RaiseLocalEvent(pulled, getPulled);
             var startPull = new StartPullAttemptEvent(puller, pulled);
             RaiseLocalEvent(puller, startPull);
-            return !startPull.Cancelled;
+            return (!startPull.Cancelled && !getPulled.Cancelled);
         }
 
         public bool TogglePull(EntityUid puller, SharedPullableComponent pullable)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes it so that if someone else is dragging a handcuffed person, you cannot drag them away without breaking the puller's drag through other methods, like stunning. This came up on discord when discussing ways to make sec more tolerable to play in a healthy way, and was pretty popular.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: You can no longer break pulls on cuffed people if someone else is pulling. Sorry griefers, maybe sec will be tolerable to play now.
