### PR TITLE
Disarm 1984

### DIFF
--- a/Content.Server/CombatMode/CombatModeSystem.cs
+++ b/Content.Server/CombatMode/CombatModeSystem.cs
@@ -108,8 +108,6 @@ namespace Content.Server.CombatMode
 
         private float CalculateDisarmChance(EntityUid disarmer, EntityUid disarmed, EntityUid? inTargetHand, SharedCombatModeComponent disarmerComp)
         {
-            Logger.Error("inTargetHand is: " + inTargetHand);
-
             float healthMod = 0;
             if (TryComp<DamageableComponent>(disarmer, out var disarmerDamage) && TryComp<DamageableComponent>(disarmed, out var disarmedDamage))
             {

--- a/Content.Server/CombatMode/CombatModeSystem.cs
+++ b/Content.Server/CombatMode/CombatModeSystem.cs
@@ -142,10 +142,10 @@ namespace Content.Server.CombatMode
             }
 
             float chance = (disarmerComp.BaseDisarmFailChance - healthMod - massMod);
-            if (HasComp<SlowedDownComponent>(disarmer))
-                chance += 0.2f;
+            if (HasComp<SlowedDownComponent>(disarmer)) // might need to revisit this part after stamina damage, right now this is basically "pre-stun"
+                chance += 0.35f;
             if (HasComp<SlowedDownComponent>(disarmed))
-                chance -= 0.2f;
+                chance -= 0.35f;
 
             if (chance <= 0)
                 return 0f;

--- a/Content.Server/CombatMode/CombatModeSystem.cs
+++ b/Content.Server/CombatMode/CombatModeSystem.cs
@@ -50,6 +50,14 @@ namespace Content.Server.CombatMode
                 inTargetHand = targetHandsComponent.ActiveHand.HeldEntity!.Value;
             }
 
+            if (TryComp<HandsComponent>(args.Performer, out var hands)
+            && hands.ActiveHand != null
+            && !hands.ActiveHand.IsEmpty)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("disarm-action-free-hand"), args.Performer, Filter.Entities(args.Performer));
+                return;
+            }
+
             var attemptEvent = new DisarmAttemptEvent(args.Target, args.Performer,inTargetHand);
 
             if (inTargetHand != null)

--- a/Content.Server/CombatMode/CombatModeSystem.cs
+++ b/Content.Server/CombatMode/CombatModeSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Audio;
 using Content.Shared.CombatMode;
 using Content.Shared.Damage;
 using Content.Shared.Database;
+using Content.Shared.Stunnable;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
@@ -136,6 +137,12 @@ namespace Content.Server.CombatMode
             Logger.Error("Mass mod is: " + massMod);
 
             float chance = (disarmerComp.BaseDisarmFailChance - healthMod - massMod);
+            if (HasComp<SlowedDownComponent>(disarmer))
+                chance += 0.2f;
+            if (HasComp<SlowedDownComponent>(disarmed))
+                chance -= -0.2f;
+
+
             if (chance <= 0)
                 return 0f;
             if (chance >= 1)

--- a/Content.Server/CombatMode/CombatModeSystem.cs
+++ b/Content.Server/CombatMode/CombatModeSystem.cs
@@ -145,7 +145,7 @@ namespace Content.Server.CombatMode
             if (HasComp<SlowedDownComponent>(disarmer))
                 chance += 0.2f;
             if (HasComp<SlowedDownComponent>(disarmed))
-                chance -= -0.2f;
+                chance -= 0.2f;
 
             if (chance <= 0)
                 return 0f;

--- a/Content.Server/CombatMode/CombatModeSystem.cs
+++ b/Content.Server/CombatMode/CombatModeSystem.cs
@@ -68,7 +68,6 @@ namespace Content.Server.CombatMode
 
             args.Handled = true;
             var chance = CalculateDisarmChance(args.Performer, args.Target, component);
-            Logger.Error("Chance is: " + chance);
             if (_random.Prob(chance))
             {
                 SoundSystem.Play(component.DisarmFailSound.GetSound(), Filter.Pvs(args.Performer), args.Performer, AudioHelpers.WithVariation(0.025f));
@@ -111,7 +110,6 @@ namespace Content.Server.CombatMode
                 // I wanted this to consider their mob state thresholds too but I'm not touching that shitcode after having a go at this.
                 healthMod = (((float) disarmedDamage.TotalDamage - (float) disarmerDamage.TotalDamage) / 200); // Ex. You have 0 damage, they have 90, you get a 45% chance increase
             }
-            Logger.Error("Health mod is: " + healthMod);
 
             float massMod = 0;
             float disarmerMass = 0;
@@ -134,14 +132,12 @@ namespace Content.Server.CombatMode
 
                 massMod = (((disarmedMass / disarmerMass - 1 ) / 2)); // Ex, you weigh 120, they weigh 70, you get a 29% bonus
             }
-            Logger.Error("Mass mod is: " + massMod);
 
             float chance = (disarmerComp.BaseDisarmFailChance - healthMod - massMod);
             if (HasComp<SlowedDownComponent>(disarmer))
                 chance += 0.2f;
             if (HasComp<SlowedDownComponent>(disarmed))
                 chance -= -0.2f;
-
 
             if (chance <= 0)
                 return 0f;

--- a/Content.Server/CombatMode/CombatModeSystem.cs
+++ b/Content.Server/CombatMode/CombatModeSystem.cs
@@ -41,21 +41,21 @@ namespace Content.Server.CombatMode
             if (!_actionBlockerSystem.CanAttack(args.Performer))
                 return;
 
-            EntityUid? inTargetHand = null;
-
-            if (EntityManager.TryGetComponent<HandsComponent>(args.Target, out HandsComponent? targetHandsComponent)
-                && targetHandsComponent.ActiveHand != null
-                && !targetHandsComponent.ActiveHand.IsEmpty)
-            {
-                inTargetHand = targetHandsComponent.ActiveHand.HeldEntity!.Value;
-            }
-
             if (TryComp<HandsComponent>(args.Performer, out var hands)
             && hands.ActiveHand != null
             && !hands.ActiveHand.IsEmpty)
             {
                 _popupSystem.PopupEntity(Loc.GetString("disarm-action-free-hand"), args.Performer, Filter.Entities(args.Performer));
                 return;
+            }
+
+            EntityUid? inTargetHand = null;
+
+            if (TryComp<HandsComponent>(args.Target, out HandsComponent? targetHandsComponent)
+                && targetHandsComponent.ActiveHand != null
+                && !targetHandsComponent.ActiveHand.IsEmpty)
+            {
+                inTargetHand = targetHandsComponent.ActiveHand.HeldEntity!.Value;
             }
 
             var attemptEvent = new DisarmAttemptEvent(args.Target, args.Performer,inTargetHand);

--- a/Content.Server/CombatMode/Disarm/DisarmMalusComponent.cs
+++ b/Content.Server/CombatMode/Disarm/DisarmMalusComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server.CombatMode.Disarm
+{
+    [RegisterComponent]
+    /// <summary>
+    /// Applies a malus to disarm attempts against this item.
+    /// </summary>
+    public sealed class DisarmMalusComponent : Component
+    {
+        [DataField("malus")]
+        public float Malus = 0.3f;
+    }
+}

--- a/Content.Server/CombatMode/Disarm/DisarmMalusComponent.cs
+++ b/Content.Server/CombatMode/Disarm/DisarmMalusComponent.cs
@@ -1,11 +1,15 @@
 namespace Content.Server.CombatMode.Disarm
 {
-    [RegisterComponent]
     /// <summary>
     /// Applies a malus to disarm attempts against this item.
     /// </summary>
+    [RegisterComponent]
     public sealed class DisarmMalusComponent : Component
     {
+        /// <summary>
+        /// So, disarm chances are a % chance represented as a value between 0 and 1.
+        /// This default would be a 30% penalty to that.
+        /// </summary>
         [DataField("malus")]
         public float Malus = 0.3f;
     }

--- a/Content.Server/Weapon/Melee/EnergySword/Components/EnergySwordComponent.cs
+++ b/Content.Server/Weapon/Melee/EnergySword/Components/EnergySwordComponent.cs
@@ -36,5 +36,8 @@ namespace Content.Server.Weapon.Melee.EnergySword
 
         [DataField("litDamageBonus", required: true)]
         public DamageSpecifier LitDamageBonus = default!;
+
+        [DataField("litDisarmMalus", required: true)]
+        public float litDisarmMalus = 0.6f;
     }
 }

--- a/Content.Server/Weapon/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Server/Weapon/Melee/EnergySword/EnergySwordSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Light;
 using Content.Shared.Light.Component;
 using Content.Shared.Toggleable;
 using Content.Shared.Tools.Components;
+using Content.Server.CombatMode.Disarm;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
@@ -68,6 +69,11 @@ namespace Content.Server.Weapon.Melee.EnergySword
                 item.Size = 5;
             }
 
+            if (TryComp<DisarmMalusComponent>(comp.Owner, out var malus))
+            {
+                malus.Malus -= comp.litDisarmMalus;
+            }
+
             SoundSystem.Play(comp.DeActivateSound.GetSound(), Filter.Pvs(comp.Owner, entityManager: EntityManager), comp.Owner);
 
             comp.Activated = false;
@@ -84,6 +90,11 @@ namespace Content.Server.Weapon.Melee.EnergySword
             }
 
             SoundSystem.Play(comp.ActivateSound.GetSound(), Filter.Pvs(comp.Owner, entityManager: EntityManager), comp.Owner);
+
+            if (TryComp<DisarmMalusComponent>(comp.Owner, out var malus))
+            {
+                malus.Malus += comp.litDisarmMalus;
+            }
 
             comp.Activated = true;
         }

--- a/Content.Shared/CombatMode/SharedCombatModeComponent.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeComponent.cs
@@ -15,10 +15,10 @@ namespace Content.Shared.CombatMode
         private TargetingZone _activeZone;
 
         [DataField("disarmFailChance")]
-        public readonly float DisarmFailChance = 0.4f;
+        public readonly float BaseDisarmFailChance = 0.4f;
 
         [DataField("pushChance")]
-        public readonly float DisarmPushChance = 0.4f;
+        public readonly float BasePushFailChance = 0.4f;
 
         [DataField("disarmFailSound")]
         public readonly SoundSpecifier DisarmFailSound = new SoundPathSpecifier("/Audio/Weapons/punchmiss.ogg");

--- a/Resources/Locale/en-US/actions/actions/disarm-action.ftl
+++ b/Resources/Locale/en-US/actions/actions/disarm-action.ftl
@@ -1,3 +1,5 @@
+disarm-action-free-hand = You need to use a free hand to disarm!
+
 disarm-action-popup-message-other-clients = {$performerName} fails to disarm {$targetName}!
 disarm-action-popup-message-cursor = You fail to disarm {$targetName}!
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -10,6 +10,7 @@
             Slash: 12.5
             Heat: 12.5
             Blunt: -7
+    litDisarmMalus: 0.6
   - type: Sharp
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_sword.rsi
@@ -47,6 +48,8 @@
       right:
       - state: inhand-right-blade
         shader: unshaded
+  - type: DisarmMalus
+    malus: 0
 
 - type: entity
   name: pen
@@ -61,6 +64,7 @@
             Slash: 7.5
             Heat: 7.5
             Blunt: -1
+    litDisarmMalus: 0.225
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_dagger.rsi
     layers:
@@ -98,3 +102,5 @@
   - type: Tag
     tags:
     - Write
+  - type: DisarmMalus
+    malus: 0

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -64,7 +64,7 @@
             Slash: 7.5
             Heat: 7.5
             Blunt: -1
-    litDisarmMalus: 0.225
+    litDisarmMalus: 0.3
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_dagger.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -64,7 +64,7 @@
             Slash: 7.5
             Heat: 7.5
             Blunt: -1
-    litDisarmMalus: 0.3
+    litDisarmMalus: 0.4
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_dagger.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -89,6 +89,8 @@
     size: 10
     sprite: Objects/Weapons/Melee/combat_knife.rsi
     prefix: inhand
+  - type: DisarmMalus
+    malus: 0.225
 
 - type: entity
   name: survival knife

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -18,6 +18,7 @@
   - type: Tag
     tags:
     - CaptainSabre
+  - type: DisarmMalus
 
 - type: entity
   name: katana
@@ -39,6 +40,7 @@
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/katana.rsi
+  - type: DisarmMalus
 
 - type: entity
   name: machete
@@ -60,6 +62,7 @@
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/machete.rsi
+  - type: DisarmMalus
 
 - type: entity
   name: claymore
@@ -80,3 +83,4 @@
     sprite: Objects/Weapons/Melee/claymore.rsi
     Slots:
     - back
+  - type: DisarmMalus

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -27,6 +27,8 @@
     size: 20
     Slots:
     - Belt
+  - type: DisarmMalus
+    malus: 0.225
 
 - type: entity
   name: flash


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disarm fail chance is now modified by relative health, relative mass, and whether either party has the "slowed down" component.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Disarm chance now scales with relative health, relative mass, and status effects. It's now a much, much worse tool to instantly win a fight you're losing.
- tweak: You now need to use an empty hand to perform disarms.
- add: Purpose-built single-handed melee weapons now have a disarm malus, making them much harder to disarm.
