### PR TITLE
Fix wide attacking in containers

### DIFF
--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -197,6 +197,12 @@ namespace Content.Server.Interaction
                 if (!unobstructed)
                     return;
             }
+            else if (ContainerSystem.IsEntityInContainer(user))
+            {
+                // No wide attacking while in containers (holos, lockers, etc).
+                // Can't think of a valid case where you would want this.
+                return;
+            }
 
             // Verify user has a hand, and find what object they are currently holding in their active hand
             if (TryComp(user, out HandsComponent? hands))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

:cl:
- fix: Holoparasites can no longer attack their owner while recalled using wide attacks.
- fix: You can no longer wide attack inside of lockers, crates, etc.

