### PR TITLE
Item strip delay dependant on slot.

### DIFF
--- a/Content.Server/Strip/StrippableComponent.cs
+++ b/Content.Server/Strip/StrippableComponent.cs
@@ -9,9 +9,14 @@ namespace Content.Server.Strip
     [Access(typeof(StrippableSystem))]
     public sealed class StrippableComponent : SharedStrippableComponent
     {
+        /// <summary>
+        /// How long it takes to open the strip menu.
+        /// This should be relatively short so it's not a hassle
+        /// but so it also doesn't open immediately during melee combat
+        /// </summary>
         [ViewVariables]
         [DataField("openDelay")]
-        public float OpenDelay = 1f;
+        public float OpenDelay = 0.8f;
 
         /// <summary>
         /// The default strip delay to default to if it doesn't meet params or not specified.

--- a/Content.Server/Strip/StrippableComponent.cs
+++ b/Content.Server/Strip/StrippableComponent.cs
@@ -19,30 +19,14 @@ namespace Content.Server.Strip
         public float OpenDelay = 0.8f;
 
         /// <summary>
-        /// The default strip delay to default to if it doesn't meet params or not specified.
+        /// The strip delay for hands.
         /// </summary>
         [ViewVariables]
-        [DataField("defaultDelay")]
-        public float DefaultStripDelay = 3f;
+        [DataField("handDelay")]
+        public float HandStripDelay = 3f;
 
         /// <summary>
-        /// Delay for important objects that should take awhile to steal
-        /// Jumpsuit, suit, back, belt and ID
-        /// </summary>
-        [ViewVariables]
-        [DataField("importantDelay")]
-        public float ImportantDelay = 5f;
-
-        /// <summary>
-        /// Delay for not so important objects that shouldn't take too long to steal
-        /// Pockets, ears, eyes, shoes and suit storage.
-        /// </summary>
-        [ViewVariables]
-        [DataField("lowPriorityDelay")]
-        public float LowPriorityDelay = 2f;
-
-        /// <summary>
-        /// Store the value for the strip delay
+        /// Store the value for the inventory strip time
         /// </summary>
         [ViewVariables]
         public float StripDelay;

--- a/Content.Server/Strip/StrippableComponent.cs
+++ b/Content.Server/Strip/StrippableComponent.cs
@@ -16,7 +16,7 @@ namespace Content.Server.Strip
         /// </summary>
         [ViewVariables]
         [DataField("openDelay")]
-        public float OpenDelay = 0.8f;
+        public float OpenDelay = 1f;
 
         /// <summary>
         /// The strip delay for hands.

--- a/Content.Server/Strip/StrippableComponent.cs
+++ b/Content.Server/Strip/StrippableComponent.cs
@@ -11,11 +11,36 @@ namespace Content.Server.Strip
     {
         [ViewVariables]
         [DataField("openDelay")]
-        public float OpenDelay = 4f;
+        public float OpenDelay = 1f;
 
+        /// <summary>
+        /// The default strip delay to default to if it doesn't meet params or not specified.
+        /// </summary>
         [ViewVariables]
-        [DataField("delay")]
-        public float StripDelay = 2f;
+        [DataField("defaultDelay")]
+        public float DefaultStripDelay = 3f;
+
+        /// <summary>
+        /// Delay for important objects that should take awhile to steal
+        /// Jumpsuit, suit, back, belt and ID
+        /// </summary>
+        [ViewVariables]
+        [DataField("importantDelay")]
+        public float ImportantDelay = 5f;
+
+        /// <summary>
+        /// Delay for not so important objects that shouldn't take too long to steal
+        /// Pockets, ears, eyes, shoes and suit storage.
+        /// </summary>
+        [ViewVariables]
+        [DataField("lowPriorityDelay")]
+        public float LowPriorityDelay = 2f;
+
+        /// <summary>
+        /// Store the value for the strip delay
+        /// </summary>
+        [ViewVariables]
+        public float StripDelay;
 
         public override bool Drop(DragDropEvent args)
         {

--- a/Content.Server/Strip/StrippableComponent.cs
+++ b/Content.Server/Strip/StrippableComponent.cs
@@ -25,12 +25,6 @@ namespace Content.Server.Strip
         [DataField("handDelay")]
         public float HandStripDelay = 3f;
 
-        /// <summary>
-        /// Store the value for the inventory strip time
-        /// </summary>
-        [ViewVariables]
-        public float StripDelay;
-
         public override bool Drop(DragDropEvent args)
         {
             IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<StrippableSystem>().StartOpeningStripper(args.User, this);

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -276,6 +276,7 @@ namespace Content.Server.Strip
 
             if (!_inventorySystem.TryGetSlot(component.Owner, slot, out var slotDef))
             {
+                Logger.Error("The slot didn't exist.");
                 return;
             }
 

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -276,7 +276,7 @@ namespace Content.Server.Strip
 
             if (!_inventorySystem.TryGetSlot(component.Owner, slot, out var slotDef))
             {
-                Logger.Error("The slot didn't exist.");
+                Logger.Error($"{ToPrettyString(user)} attempted to place an item in a non-existent inventory slot ({slot}) on {ToPrettyString(component.Owner)}");
                 return;
             }
 
@@ -382,7 +382,7 @@ namespace Content.Server.Strip
 
             if (!_inventorySystem.TryGetSlot(component.Owner, slot, out var slotDef))
             {
-                Logger.Error("The slot didn't exist.");
+                Logger.Error($"{ToPrettyString(user)} attempted to place an item in a non-existent inventory slot ({slot}) on {ToPrettyString(component.Owner)}");
                 return;
             }
 

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -81,6 +81,8 @@ namespace Content.Server.Strip
 
             var placingItem = userHands.ActiveHandEntity != null;
 
+            //here from hands
+
             if (TryComp<HandsComponent>(component.Owner, out var hands))
             {
                 if (hands.Hands.TryGetValue(args.Hand, out var hand) && !hand.IsEmpty)
@@ -105,6 +107,8 @@ namespace Content.Server.Strip
             {
                 if (_inventorySystem.TryGetSlotEntity(component.Owner, args.Slot, out _, inventory))
                     placingItem = false;
+
+                //place switch here
 
                 if (placingItem)
                     PlaceActiveHandItemInInventory(user, args.Slot, component);
@@ -274,6 +278,8 @@ namespace Content.Server.Strip
                 return true;
             }
 
+            component.StripDelay = SlotSwitch(slot, component);
+
             var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
             {
                 ExtraCheck = Check,
@@ -328,6 +334,8 @@ namespace Content.Server.Strip
                 return true;
             }
 
+            component.StripDelay = SlotSwitch(handName, component);
+
             var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
             {
                 ExtraCheck = Check,
@@ -373,6 +381,8 @@ namespace Content.Server.Strip
 
                 return true;
             }
+
+            component.StripDelay = SlotSwitch(slot, component);
 
             var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
             {
@@ -425,6 +435,8 @@ namespace Content.Server.Strip
                 return true;
             }
 
+            component.StripDelay = SlotSwitch(handName, component);
+
             var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
             {
                 ExtraCheck = Check,
@@ -443,6 +455,35 @@ namespace Content.Server.Strip
             _handsSystem.TryDrop(component.Owner, hand, checkActionBlocker: false, handsComp: hands);
             _handsSystem.PickupOrDrop(user, held, handsComp: userHands);
             // hand update will trigger strippable update
+        }
+
+        private float SlotSwitch(string slot, StrippableComponent component)
+        {
+            switch (slot)
+            {
+                case "jumpsuit":
+                case "outerClothing":
+                case "back":
+                case "belt":
+                case "id":
+                {
+                    return component.ImportantDelay;
+                }
+                case "pocket1":
+                case "pocket2":
+                case "ears":
+                case "eyes":
+                case "shoes":
+                case "suitstorage":
+                {
+                    return component.LowPriorityDelay;
+                }
+
+                default:
+                {
+                    return component.DefaultStripDelay;
+                }
+            }
         }
 
         private sealed class OpenStrippingCompleteEvent

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -274,7 +274,12 @@ namespace Content.Server.Strip
                 return true;
             }
 
-            component.StripDelay = SlotSwitch(slot, component);
+            if (!_inventorySystem.TryGetSlot(component.Owner, slot, out var slotDef))
+            {
+                return;
+            }
+
+            component.StripDelay = slotDef.StripTime;
 
             var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
             {
@@ -330,9 +335,7 @@ namespace Content.Server.Strip
                 return true;
             }
 
-            component.StripDelay = SlotSwitch(handName, component);
-
-            var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
+            var doAfterArgs = new DoAfterEventArgs(user, component.HandStripDelay, CancellationToken.None, component.Owner)
             {
                 ExtraCheck = Check,
                 BreakOnStun = true,
@@ -378,7 +381,12 @@ namespace Content.Server.Strip
                 return true;
             }
 
-            component.StripDelay = SlotSwitch(slot, component);
+            if (!_inventorySystem.TryGetSlot(component.Owner, slot, out var slotDef))
+            {
+                return;
+            }
+
+            component.StripDelay = slotDef.StripTime;
 
             var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
             {
@@ -431,9 +439,7 @@ namespace Content.Server.Strip
                 return true;
             }
 
-            component.StripDelay = SlotSwitch(handName, component);
-
-            var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
+            var doAfterArgs = new DoAfterEventArgs(user, component.HandStripDelay, CancellationToken.None, component.Owner)
             {
                 ExtraCheck = Check,
                 BreakOnStun = true,
@@ -451,35 +457,6 @@ namespace Content.Server.Strip
             _handsSystem.TryDrop(component.Owner, hand, checkActionBlocker: false, handsComp: hands);
             _handsSystem.PickupOrDrop(user, held, handsComp: userHands);
             // hand update will trigger strippable update
-        }
-
-        private float SlotSwitch(string slot, StrippableComponent component)
-        {
-            switch (slot)
-            {
-                case "jumpsuit":
-                case "outerClothing":
-                case "back":
-                case "belt":
-                case "id":
-                {
-                    return component.ImportantDelay;
-                }
-                case "pocket1":
-                case "pocket2":
-                case "ears":
-                case "eyes":
-                case "shoes":
-                case "suitstorage":
-                {
-                    return component.LowPriorityDelay;
-                }
-
-                default:
-                {
-                    return component.DefaultStripDelay;
-                }
-            }
         }
 
         private sealed class OpenStrippingCompleteEvent

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -81,8 +81,6 @@ namespace Content.Server.Strip
 
             var placingItem = userHands.ActiveHandEntity != null;
 
-            //here from hands
-
             if (TryComp<HandsComponent>(component.Owner, out var hands))
             {
                 if (hands.Hands.TryGetValue(args.Hand, out var hand) && !hand.IsEmpty)
@@ -107,8 +105,6 @@ namespace Content.Server.Strip
             {
                 if (_inventorySystem.TryGetSlotEntity(component.Owner, args.Slot, out _, inventory))
                     placingItem = false;
-
-                //place switch here
 
                 if (placingItem)
                     PlaceActiveHandItemInInventory(user, args.Slot, component);

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -279,9 +279,7 @@ namespace Content.Server.Strip
                 return;
             }
 
-            component.StripDelay = slotDef.StripTime;
-
-            var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
+            var doAfterArgs = new DoAfterEventArgs(user, slotDef.StripTime, CancellationToken.None, component.Owner)
             {
                 ExtraCheck = Check,
                 BreakOnStun = true,
@@ -383,12 +381,11 @@ namespace Content.Server.Strip
 
             if (!_inventorySystem.TryGetSlot(component.Owner, slot, out var slotDef))
             {
+                Logger.Error("The slot didn't exist.");
                 return;
             }
 
-            component.StripDelay = slotDef.StripTime;
-
-            var doAfterArgs = new DoAfterEventArgs(user, component.StripDelay, CancellationToken.None, component.Owner)
+            var doAfterArgs = new DoAfterEventArgs(user, slotDef.StripTime, CancellationToken.None, component.Owner)
             {
                 ExtraCheck = Check,
                 BreakOnStun = true,

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -21,6 +21,8 @@ public sealed class SlotDefinition
 
     [DataField("slotFlags")] public SlotFlags SlotFlags { get; } = SlotFlags.PREVENTEQUIP;
 
+    [DataField("stripTime")] public float StripTime { get; } = 3f;
+
     [DataField("uiContainer")] public SlotUIContainer UIContainer { get; } = SlotUIContainer.None;
 
     [DataField("uiWindowPos", required: true)] public Vector2i UIWindowPosition { get; }

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -4,18 +4,21 @@
     - name: shoes
       slotTexture: shoes
       slotFlags: FEET
+      stripTime: 2
       uiContainer: Top
       uiWindowPos: 1,3
       displayName: Shoes
     - name: jumpsuit
       slotTexture: uniform
       slotFlags: INNERCLOTHING
+      stripTime: 5
       uiContainer: Top
       uiWindowPos: 0,2
       displayName: Jumpsuit
     - name: outerClothing
       slotTexture: suit
       slotFlags: OUTERCLOTHING
+      stripTime: 5
       uiContainer: Top
       uiWindowPos: 1,2
       displayName: Suit
@@ -40,12 +43,14 @@
     - name: eyes
       slotTexture: glasses
       slotFlags: EYES
+      stripTime: 2
       uiContainer: Top
       uiWindowPos: 0,0
       displayName: Eyes
     - name: ears
       slotTexture: ears
       slotFlags: EARS
+      stripTime: 2
       uiContainer: Top
       uiWindowPos: 2,0
       displayName: Ears
@@ -58,6 +63,7 @@
     - name: pocket1
       slotTexture: pocket
       slotFlags: POCKET
+      stripTime: 2
       uiContainer: BottomRight
       uiWindowPos: 0,3
       dependsOn: jumpsuit
@@ -65,6 +71,7 @@
     - name: pocket2
       slotTexture: pocket
       slotFlags: POCKET
+      stripTime: 2
       uiContainer: BottomRight
       uiWindowPos: 2,3
       dependsOn: jumpsuit
@@ -72,6 +79,7 @@
     - name: suitstorage
       slotTexture: suit_storage
       slotFlags:   SUITSTORAGE
+      stripTime: 2
       uiContainer: BottomLeft
       uiWindowPos: 2,0
       dependsOn: outerClothing
@@ -79,6 +87,7 @@
     - name: id
       slotTexture: id
       slotFlags: IDCARD
+      stripTime: 5
       uiContainer: BottomRight
       uiWindowPos: 2,1
       dependsOn: jumpsuit
@@ -86,12 +95,14 @@
     - name: belt
       slotTexture: belt
       slotFlags: BELT
+      stripTime: 5
       uiContainer: BottomLeft
       uiWindowPos: 3,1
       displayName: Belt
     - name: back
       slotTexture: back
       slotFlags: BACK
+      stripTime: 5
       uiContainer: BottomLeft
       uiWindowPos: 3,0
       displayName: Back


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

closes #7899

Certain inventory slots will take longer than others when stripping now. 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: When stripping other players, the delay now depends on the targeted slot.