### PR TITLE
Add BreakOnDistance to DoAfterEventArgs

### DIFF
--- a/Content.Server/DoAfter/DoAfter.cs
+++ b/Content.Server/DoAfter/DoAfter.cs
@@ -165,20 +165,20 @@ namespace Content.Server.DoAfter
             }
 
             //Allow movement but enforce distance
-            if (EventArgs.DistanceThreshold != null)
+            if (EventArgs.BreakOnDistance != null)
             {
                 if(EventArgs.Target != null && !EventArgs.User.Equals(EventArgs.Target))
                 {
                     //recalculate Target location in case Target has also moved
                     TargetGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Target!.Value).Coordinates;
-                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, TargetGrid, EventArgs.DistanceThreshold!.Value))
+                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, TargetGrid, EventArgs.BreakOnDistance!.Value))
                         return true;
                 }
                 if (EventArgs.Used != null && !EventArgs.User.Equals(EventArgs.Used))
                 {
                     //recalculate Used location in case Used has also moved
                     UsedGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Used!.Value).Coordinates;
-                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, UsedGrid, EventArgs.DistanceThreshold!.Value))
+                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, UsedGrid, EventArgs.BreakOnDistance!.Value))
                         return true;
                 }
             }

--- a/Content.Server/DoAfter/DoAfter.cs
+++ b/Content.Server/DoAfter/DoAfter.cs
@@ -162,20 +162,26 @@ namespace Content.Server.DoAfter
                 }
             }
 
-            if (EventArgs.BreakOnDistance != null)
+            if (EventArgs.DistanceThreshold != null)
             {
-                if (!EventArgs.User.Equals(EventArgs.Target))
+                var xformQuery = entityManager.GetEntityQuery<TransformComponent>();
+                TransformComponent? userXform = null;
+
+                // Check user distance to target AND used entities.
+                if (EventArgs.Target != null && !EventArgs.User.Equals(EventArgs.Target))
                 {
                     //recalculate Target location in case Target has also moved
-                    EntityCoordinates CurrentTargetGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Target!.Value).Coordinates;
-                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, CurrentTargetGrid, EventArgs.BreakOnDistance!.Value))
+                    var targetCoordinates = xformQuery.GetComponent(EventArgs.Target.Value).Coordinates;
+                    userXform ??= xformQuery.GetComponent(EventArgs.User);
+                    if (userXform.Coordinates.InRange(entityManager, targetCoordinates, EventArgs.DistanceThreshold.Value))
                         return true;
                 }
+
                 if (EventArgs.Used != null)
                 {
-                    //recalculate Used location in case Used has also moved
-                    EntityCoordinates CurrentUsedGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Used!.Value).Coordinates;
-                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, CurrentUsedGrid, EventArgs.BreakOnDistance!.Value))
+                    var targetCoordinates = xformQuery.GetComponent(EventArgs.Used.Value).Coordinates;
+                    userXform ??= xformQuery.GetComponent(EventArgs.User);
+                    if (!userXform.Coordinates.InRange(entityManager, targetCoordinates, EventArgs.DistanceThreshold.Value))
                         return true;
                 }
             }

--- a/Content.Server/DoAfter/DoAfter.cs
+++ b/Content.Server/DoAfter/DoAfter.cs
@@ -20,7 +20,9 @@ namespace Content.Server.DoAfter
 
         public EntityCoordinates UserGrid { get; }
 
-        public EntityCoordinates TargetGrid { get; }
+        public EntityCoordinates TargetGrid { get; set; }
+
+        public EntityCoordinates UsedGrid { get; set; }
 
         public DoAfterStatus Status => AsTask.IsCompletedSuccessfully ? AsTask.Result : DoAfterStatus.Running;
 
@@ -159,6 +161,25 @@ namespace Content.Server.DoAfter
                     {
                         return true;
                     }
+                }
+            }
+
+            //Allow movement but enforce distance
+            if (EventArgs.DistanceThreshold != null)
+            {
+                if(EventArgs.Target != null && !EventArgs.User.Equals(EventArgs.Target))
+                {
+                    //recalculate Target location in case Target has also moved
+                    TargetGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Target!.Value).Coordinates;
+                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, TargetGrid, EventArgs.DistanceThreshold!.Value))
+                        return true;
+                }
+                if (EventArgs.Used != null && !EventArgs.User.Equals(EventArgs.Used))
+                {
+                    //recalculate Used location in case Used has also moved
+                    UsedGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Used!.Value).Coordinates;
+                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, UsedGrid, EventArgs.DistanceThreshold!.Value))
+                        return true;
                 }
             }
 

--- a/Content.Server/DoAfter/DoAfter.cs
+++ b/Content.Server/DoAfter/DoAfter.cs
@@ -20,9 +20,7 @@ namespace Content.Server.DoAfter
 
         public EntityCoordinates UserGrid { get; }
 
-        public EntityCoordinates TargetGrid { get; set; }
-
-        public EntityCoordinates UsedGrid { get; set; }
+        public EntityCoordinates TargetGrid { get; }
 
         public DoAfterStatus Status => AsTask.IsCompletedSuccessfully ? AsTask.Result : DoAfterStatus.Running;
 
@@ -164,21 +162,20 @@ namespace Content.Server.DoAfter
                 }
             }
 
-            //Allow movement but enforce distance
             if (EventArgs.BreakOnDistance != null)
             {
-                if(EventArgs.Target != null && !EventArgs.User.Equals(EventArgs.Target))
+                if (!EventArgs.User.Equals(EventArgs.Target))
                 {
                     //recalculate Target location in case Target has also moved
-                    TargetGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Target!.Value).Coordinates;
-                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, TargetGrid, EventArgs.BreakOnDistance!.Value))
+                    EntityCoordinates CurrentTargetGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Target!.Value).Coordinates;
+                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, CurrentTargetGrid, EventArgs.BreakOnDistance!.Value))
                         return true;
                 }
-                if (EventArgs.Used != null && !EventArgs.User.Equals(EventArgs.Used))
+                if (EventArgs.Used != null)
                 {
                     //recalculate Used location in case Used has also moved
-                    UsedGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Used!.Value).Coordinates;
-                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, UsedGrid, EventArgs.BreakOnDistance!.Value))
+                    EntityCoordinates CurrentUsedGrid = entityManager.GetComponent<TransformComponent>(EventArgs.Used!.Value).Coordinates;
+                    if (!entityManager.GetComponent<TransformComponent>(EventArgs.User).Coordinates.InRange(entityManager, CurrentUsedGrid, EventArgs.BreakOnDistance!.Value))
                         return true;
                 }
             }

--- a/Content.Server/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/DoAfter/DoAfterEventArgs.cs
@@ -63,7 +63,7 @@ namespace Content.Server.DoAfter
         /// <summary>
         ///     Threshold for distance user is allowed to get from the target
         /// </summary>
-        public float? DistanceThreshold { get; set; }
+        public float? BreakOnDistance { get; set; }
 
         /// <summary>
         ///     Requires a function call once at the end (like InRangeUnobstructed).

--- a/Content.Server/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/DoAfter/DoAfterEventArgs.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+﻿using System.Threading;
 using Content.Shared.FixedPoint;
 
 namespace Content.Server.DoAfter
@@ -21,7 +21,7 @@ namespace Content.Server.DoAfter
         public EntityUid? Target { get; }
 
         /// <summary>
-        ///     Entity used in a User A used B on target C interaction
+        ///     Entity used by the User on the Target.
         /// </summary>
         public EntityUid? Used { get; set; }
 
@@ -61,9 +61,9 @@ namespace Content.Server.DoAfter
         public bool BreakOnStun { get; set; }
 
         /// <summary>
-        ///     Threshold for distance user is allowed to get from the target
+        ///     Threshold for distance user from the used OR target entities.
         /// </summary>
-        public float? BreakOnDistance { get; set; }
+        public float? DistanceThreshold { get; set; }
 
         /// <summary>
         ///     Requires a function call once at the end (like InRangeUnobstructed).

--- a/Content.Server/DoAfter/DoAfterEventArgs.cs
+++ b/Content.Server/DoAfter/DoAfterEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using Content.Shared.FixedPoint;
 
 namespace Content.Server.DoAfter
@@ -19,6 +19,11 @@ namespace Content.Server.DoAfter
         ///     Applicable target (if relevant)
         /// </summary>
         public EntityUid? Target { get; }
+
+        /// <summary>
+        ///     Entity used in a User A used B on target C interaction
+        /// </summary>
+        public EntityUid? Used { get; set; }
 
         /// <summary>
         ///     Manually cancel the do_after so it no longer runs
@@ -54,6 +59,11 @@ namespace Content.Server.DoAfter
         /// </summary>
         public FixedPoint2 DamageThreshold { get; set; }
         public bool BreakOnStun { get; set; }
+
+        /// <summary>
+        ///     Threshold for distance user is allowed to get from the target
+        /// </summary>
+        public float? DistanceThreshold { get; set; }
 
         /// <summary>
         ///     Requires a function call once at the end (like InRangeUnobstructed).
@@ -102,12 +112,14 @@ namespace Content.Server.DoAfter
             EntityUid user,
             float delay,
             CancellationToken cancelToken = default,
-            EntityUid? target = null)
+            EntityUid? target = null,
+            EntityUid? used = null)
         {
             User = user;
             Delay = delay;
             CancelToken = cancelToken;
             Target = target;
+            Used = used;
             MovementThreshold = 0.1f;
             DamageThreshold = 1.0;
 

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -126,13 +126,14 @@ namespace Content.Server.Nutrition.EntitySystems
 
             var moveBreak = user != target;
 
-            _doAfterSystem.DoAfter(new DoAfterEventArgs(user, forceFeed ? food.ForceFeedDelay : food.Delay, food.CancelToken.Token, target)
+            _doAfterSystem.DoAfter(new DoAfterEventArgs(user, forceFeed ? food.ForceFeedDelay : food.Delay, food.CancelToken.Token, target, food.Owner)
             {
                 BreakOnUserMove = moveBreak,
                 BreakOnDamage = true,
                 BreakOnStun = true,
                 BreakOnTargetMove = moveBreak,
                 MovementThreshold = 0.01f,
+                DistanceThreshold = 2.0f,
                 TargetFinishedEvent = new FeedEvent(user, food, foodSolution, utensils),
                 BroadcastCancelledEvent = new ForceFeedCancelledEvent(food),
                 NeedHand = true,

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -133,7 +133,7 @@ namespace Content.Server.Nutrition.EntitySystems
                 BreakOnStun = true,
                 BreakOnTargetMove = moveBreak,
                 MovementThreshold = 0.01f,
-                DistanceThreshold = 2.0f,
+                BreakOnDistance = 2.0f,
                 TargetFinishedEvent = new FeedEvent(user, food, foodSolution, utensils),
                 BroadcastCancelledEvent = new ForceFeedCancelledEvent(food),
                 NeedHand = true,

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -133,7 +133,7 @@ namespace Content.Server.Nutrition.EntitySystems
                 BreakOnStun = true,
                 BreakOnTargetMove = moveBreak,
                 MovementThreshold = 0.01f,
-                BreakOnDistance = 2.0f,
+                DistanceThreshold = 2.0f,
                 TargetFinishedEvent = new FeedEvent(user, food, foodSolution, utensils),
                 BroadcastCancelledEvent = new ForceFeedCancelledEvent(food),
                 NeedHand = true,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

There are some interactions where we want to allow movement, but we still want to enforce a distance.
We want people to be able to eat food and move, but want to enforce a maximum distance, to avoid eating food and finishing it while far away.

- BreakOnDistance nullable float to define maximum distance between user and target
- Added optional Used entity in the case of a separate entity being involved between user and target (feeding yourself makes you the user and target. The food is the Used in this case.)
- Coordinates need to be updated in case the target/used has moved. (might be better way of doing this? hopefully not too expensive doing it this way.)
- Need to account for target/used movement for cases like walking while eating food in your hand. Otherwise, BreakOnMove would cancel this.

Fixes #8297

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

1. Eating without moving ✔️ 
2. Eating while moving within range ✔️ 
3. Eating and moving out of range ❌ 
4. Eating held food while walking ✔️ 

<video src=https://user-images.githubusercontent.com/89101928/174168802-ad1c9fde-97c1-459c-8310-73d67ed14834.mp4></video>

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: No more Dine and Dash (alt clicking food and running away)

