### PR TITLE
Fix ERT

### DIFF
--- a/Content.Server/RandomMetadata/RandomMetadataComponent.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Dataset;
+using Content.Shared.Dataset;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.RandomMetadata;
@@ -14,4 +14,7 @@ public sealed class RandomMetadataComponent : Component
 
     [DataField("nameSet", customTypeSerializer:typeof(PrototypeIdSerializer<DatasetPrototype>))]
     public string? NameSet;
+
+    [DataField("nameSet2", customTypeSerializer: typeof(PrototypeIdSerializer<DatasetPrototype>))]
+    public string? NameSet2;
 }

--- a/Content.Server/RandomMetadata/RandomMetadataSystem.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Dataset;
+using Content.Shared.Dataset;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -25,6 +25,12 @@ public sealed class RandomMetadataSystem : EntitySystem
         {
             var nameProto = _prototype.Index<DatasetPrototype>(component.NameSet);
             meta.EntityName = _random.Pick(nameProto.Values);
+        }
+
+        if (component.NameSet2 != null && component.NameSet != null)
+        {
+            var nameProto = _prototype.Index<DatasetPrototype>(component.NameSet2);
+            meta.EntityName = meta.EntityName + " " + _random.Pick(nameProto.Values);
         }
 
         if (component.DescriptionSet != null)

--- a/Content.Shared/Species/SpeciesPrototype.cs
+++ b/Content.Shared/Species/SpeciesPrototype.cs
@@ -49,7 +49,7 @@ public sealed class SpeciesPrototype : IPrototype
     public string FemaleFirstNames { get; } = "names_first_female";
 
     [DataField("lastNames")]
-    public string LastNames { get; } = "names_last";
+    public string LastNames { get; } = "NamesLast";
 
     [DataField("naming")]
     public SpeciesNaming Naming { get; } = SpeciesNaming.FirstLast;

--- a/Content.Tests/Server/Preferences/ServerDbSqliteTests.cs
+++ b/Content.Tests/Server/Preferences/ServerDbSqliteTests.cs
@@ -35,7 +35,7 @@ namespace Content.Tests.Server.Preferences
   - Aaliyah
 
 - type: dataset
-  id: names_last
+  id: NamesLast
   values:
   - Ackerley";
 

--- a/Resources/Prototypes/Datasets/Names/last.yml
+++ b/Resources/Prototypes/Datasets/Names/last.yml
@@ -1,5 +1,5 @@
 ﻿- type: dataset
-  id: names_last
+  id: NamesLast
   values:
   - Ackerley
   - Adams

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -62,9 +62,7 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertleader
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTLeader
-    deleteOnSpawn: true
+  - type: GhostTakeoverAvailable
     makeSentient: true
     name: ERT Leader
     description: Lead a team of specialists to resolve the stations issues.
@@ -72,6 +70,7 @@
     prototype: ERTLeaderGear
   - type: RandomMetadata
     nameSet: NamesFirstMilitaryLeader
+    nameSet2: NamesLast
   - type: RandomHumanoidAppearance
     randomizeName: false
     
@@ -84,10 +83,6 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertleadereva
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTLeaderEVA
-    deleteOnSpawn: true
-    makeSentient: true
   - type: Loadout
     prototype: ERTLeaderGearEVA
 
@@ -100,9 +95,7 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertengineer
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTEngineer
-    deleteOnSpawn: true
+  - type: GhostTakeoverAvailable
     makeSentient: true
     name: ERT Engineer
     description: Assist with engineering efforts to resolve the stations issues.
@@ -110,6 +103,7 @@
     prototype: ERTEngineerGear
   - type: RandomMetadata
     nameSet: NamesFirstMilitary
+    nameSet2: NamesLast
     
 - type: entity
   name: ERT engineer
@@ -120,12 +114,6 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertengineereva
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTEngineerEVA
-    deleteOnSpawn: true
-    makeSentient: true
-    name: ERT Engineer
-    description: Assist with engineering efforts to resolve the stations issues.
   - type: Loadout
     prototype: ERTEngineerGearEVA
     
@@ -138,9 +126,7 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertsecurity
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTSecurity
-    deleteOnSpawn: true
+  - type: GhostTakeoverAvailable
     makeSentient: true
     name: ERT Security
     description: Assist with security efforts to resolve the stations issues.
@@ -148,6 +134,7 @@
     prototype: ERTSecurityGear
   - type: RandomMetadata
     nameSet: NamesFirstMilitary
+    nameSet2: NamesLast
     
 - type: entity
   name: ERT security
@@ -158,12 +145,6 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertsecurityeva
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTSecurityEVA
-    deleteOnSpawn: true
-    makeSentient: true
-    name: ERT Security
-    description: Assist with security efforts to resolve the stations issues.
   - type: Loadout
     prototype: ERTSecurityGearEVA
     
@@ -176,9 +157,7 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertmedical
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTMedical
-    deleteOnSpawn: true
+  - type: GhostTakeoverAvailable
     makeSentient: true
     name: ERT Medic
     description: Assist with medical efforts to resolve the stations issues.
@@ -186,6 +165,7 @@
     prototype: ERTMedicalGear
   - type: RandomMetadata
     nameSet: NamesFirstMilitary
+    nameSet2: NamesLast
     
 - type: entity
   name: ERT medic
@@ -196,12 +176,6 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertmedicaleva
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTMedicalEVA
-    deleteOnSpawn: true
-    makeSentient: true
-    name: ERT Medic
-    description: Assist with medical efforts to resolve the stations issues.
   - type: Loadout
     prototype: ERTMedicalGearEVA
     
@@ -214,16 +188,15 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertjanitor
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTJanitor
-    deleteOnSpawn: true
+  - type: GhostTakeoverAvailable
     makeSentient: true
     name: ERT Janitor
-    description: Assist with custodial efforts to resolve the stations issues.
+    description: Assist with janitorial efforts to resolve the stations issues.
   - type: Loadout
     prototype: ERTJanitorGear
   - type: RandomMetadata
     nameSet: NamesFirstMilitary
+    nameSet2: NamesLast
     
 - type: entity
   name: ERT janitor
@@ -234,11 +207,5 @@
   - type: Icon
     sprite: Markers/jobs.rsi
     state: ertjanitoreva
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanERTJanitorEVA
-    deleteOnSpawn: true
-    makeSentient: true
-    name: ERT Janitor
-    description: Assist with custodial efforts to resolve the stations issues.
   - type: Loadout
     prototype: ERTJanitorGearEVA


### PR DESCRIPTION
Fix ERT ghost roles.
Give ERT a last name.

RandomMetaData can have 2 nameSets so there can be random first + last names.
Renamed names_last to NamesLast since I was in there and touching it.

:cl: Pancake
- tweak: ERT squads have decided to start using name badges.

