### PR TITLE
Prioritize anchor before insert

### DIFF
--- a/Content.Shared/Construction/EntitySystems/SharedAnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/SharedAnchorableSystem.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Content.Shared.Construction.Components;
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Interaction;
 using Content.Shared.Pulling.Components;
 using Content.Shared.Tools.Components;
@@ -12,7 +13,8 @@ public abstract class SharedAnchorableSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<AnchorableComponent, InteractUsingEvent>(OnInteractUsing, after: new[] { typeof(SharedConstructionSystem) });
+        SubscribeLocalEvent<AnchorableComponent, InteractUsingEvent>(OnInteractUsing,
+            before: new[] { typeof(ItemSlotsSystem) }, after: new[] { typeof(SharedConstructionSystem) });
     }
 
     private void OnInteractUsing(EntityUid uid, AnchorableComponent anchorable, InteractUsingEvent args)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Prioritizes anchoring/unanchoring on an AnchorableComponent before inserting the tool into a slot.

(I tried instead setting ItemSlotsSystem to be after SharedAnchorableSystem, but I think there is something with the inheritance that since the (server) AnchorarbleSystem is the one first receiving the interaction, the priority doesn't seem to work.)

The only thing that anchoring tools are inserted into currently are StorageComponents like bags, toolboxes, belts, etc.
I haven't found any situation where we want to insert a wrench into an anchorable component before wrenching it.

Fixes #8908 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

No changelog needed