### PR TITLE
Botany + engi belt whitelist update 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -19,12 +19,12 @@
         - Screwdriver
         - Flashlight
         - Wrench
-#        - Painter
 #        - GeigerCounter
         - Flare
         - CableCoil
         - CigPack
       components:
+        - AirlockPainter
         - SignalLinker
         - RCD
         - RCDAmmo
@@ -82,7 +82,6 @@
         - Screwdriver
         - Flashlight
         - Wrench
-#        - Painter
 #        - GeigerCounter
         - Flare
         - CableCoil
@@ -90,6 +89,7 @@
         - JawsOfLife
         - CigPack
       components:
+        - AirlockPainter
         - SignalLinker
         - RCD
         - RCDAmmo
@@ -193,6 +193,7 @@
         - Soap
         - Flashlight
         - CigPack
+        - TrashBag
       components:
         - LightReplacer
   - type: ItemMapper
@@ -292,6 +293,9 @@
         # - PlantAnalyzer
         - PlantSampleTaker
         - BotanyShovel
+        - BotanyHoe
+        - BotanyHatchet
+        - PlantSampleTaker
         - PlantBGone
         - Bottle
         - CigPack


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the airlock painter to the engineering belt whitelist.

Adds the botany tools to the botany belt whitelist.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Botany tools now fit on the botany belt.
- tweak: Airlock Painters now fit on utility belts.

