### PR TITLE
Obfuscates pocket slots from the Strip Menu

### DIFF
--- a/Content.Client/Inventory/StrippableBoundUserInterface.cs
+++ b/Content.Client/Inventory/StrippableBoundUserInterface.cs
@@ -16,7 +16,7 @@ namespace Content.Client.Inventory
         public Dictionary<(string ID, string Name), string>? Inventory { get; private set; }
         public Dictionary<string, string>? Hands { get; private set; }
         public Dictionary<EntityUid, string>? Handcuffs { get; private set; }
-        public string Occupied { get; } = "Occupied";
+        public string Occupied { get; } = Loc.GetString("strippable-bound-user-interface-stripping-menu-obfuscate");
 
         [ViewVariables]
         private StrippingMenu? _strippingMenu;

--- a/Content.Client/Inventory/StrippableBoundUserInterface.cs
+++ b/Content.Client/Inventory/StrippableBoundUserInterface.cs
@@ -16,7 +16,6 @@ namespace Content.Client.Inventory
         public Dictionary<(string ID, string Name), string>? Inventory { get; private set; }
         public Dictionary<string, string>? Hands { get; private set; }
         public Dictionary<EntityUid, string>? Handcuffs { get; private set; }
-        public string Occupied { get; } = Loc.GetString("strippable-bound-user-interface-stripping-menu-obfuscate");
 
         [ViewVariables]
         private StrippingMenu? _strippingMenu;
@@ -55,20 +54,10 @@ namespace Content.Client.Inventory
             {
                 foreach (var (slot, name) in Inventory)
                 {
-                    if (slot.ID == "pocket1" && name != "None" || slot.ID == "pocket2" && name != "None")
+                    _strippingMenu.AddButton(slot.Name, name, (ev) =>
                     {
-                        _strippingMenu.AddButton(slot.Name, Occupied, (ev) =>
-                        {
-                            SendMessage(new StrippingInventoryButtonPressed(slot.ID));
-                        });
-                    }
-                    else
-                    {
-                        _strippingMenu.AddButton(slot.Name, name, (ev) =>
-                        {
-                            SendMessage(new StrippingInventoryButtonPressed(slot.ID));
-                        });
-                    }
+                        SendMessage(new StrippingInventoryButtonPressed(slot.ID));
+                    });
                 }
             }
 

--- a/Content.Client/Inventory/StrippableBoundUserInterface.cs
+++ b/Content.Client/Inventory/StrippableBoundUserInterface.cs
@@ -16,6 +16,7 @@ namespace Content.Client.Inventory
         public Dictionary<(string ID, string Name), string>? Inventory { get; private set; }
         public Dictionary<string, string>? Hands { get; private set; }
         public Dictionary<EntityUid, string>? Handcuffs { get; private set; }
+        public string Occupied { get; } = "Occupied";
 
         [ViewVariables]
         private StrippingMenu? _strippingMenu;
@@ -54,10 +55,20 @@ namespace Content.Client.Inventory
             {
                 foreach (var (slot, name) in Inventory)
                 {
-                    _strippingMenu.AddButton(slot.Name, name, (ev) =>
+                    if (slot.ID == "pocket1" && name != "None" || slot.ID == "pocket2" && name != "None")
                     {
-                        SendMessage(new StrippingInventoryButtonPressed(slot.ID));
-                    });
+                        _strippingMenu.AddButton(slot.Name, Occupied, (ev) =>
+                        {
+                            SendMessage(new StrippingInventoryButtonPressed(slot.ID));
+                        });
+                    }
+                    else
+                    {
+                        _strippingMenu.AddButton(slot.Name, name, (ev) =>
+                        {
+                            SendMessage(new StrippingInventoryButtonPressed(slot.ID));
+                        });
+                    }
                 }
             }
 

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -190,7 +190,17 @@ namespace Content.Server.Strip
                     var name = "None";
 
                     if (_inventorySystem.TryGetSlotEntity(uid, slot.Name, out var item))
-                        name = Name(item.Value);
+                    {
+                        if (!slot.StripHidden)
+                        {
+                            name = Name(item.Value);
+                        }
+
+                        else
+                        {
+                            name = Loc.GetString("strippable-bound-user-interface-stripping-menu-obfuscate");
+                        }
+                    }
 
                     inventory[(slot.Name, slot.DisplayName)] = name;
                 }

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -30,6 +30,8 @@ public sealed class SlotDefinition
 
     [DataField("displayName", required: true)] public string DisplayName { get; } = string.Empty;
 
+    [DataField("stripHidden")] public bool StripHidden { get; }
+
     /// <summary>
     ///     Offset for the clothing sprites.
     /// </summary>

--- a/Resources/Locale/en-US/strip/strippable-component.ftl
+++ b/Resources/Locale/en-US/strip/strippable-component.ftl
@@ -14,3 +14,4 @@ strip-verb-get-data-text = Strip
 
 strippable-bound-user-interface-stripping-menu-title = {$ownerName}'s inventory
 strippable-bound-user-interface-stripping-menu-handcuffs-button = Restraints
+strippable-bound-user-interface-stripping-menu-obfuscate = Occupied

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -62,6 +62,7 @@
       uiWindowPos: 0,3
       dependsOn: jumpsuit
       displayName: Pocket 1
+      stripHidden: true
     - name: pocket2
       slotTexture: pocket
       slotFlags: POCKET
@@ -69,6 +70,7 @@
       uiWindowPos: 2,3
       dependsOn: jumpsuit
       displayName: Pocket 2
+      stripHidden: true
     - name: suitstorage
       slotTexture: suit_storage
       slotFlags:   SUITSTORAGE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Hides pocket items from strip menu changes.

It is a bit hardcoded right now and the only other example of this in code hardcodes it something similar. I'd like to try to not hardcode it, but I'm having issues getting to that point.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/54602815/174460121-6669c3a2-ce97-4c39-8e48-3d5745fa83ed.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Adds obfuscation to pocket items so players can't check the strip menu to see what they have.

