### PR TITLE
Add a penalty to self-repair

### DIFF
--- a/Content.Server/Repairable/RepairableComponent.cs
+++ b/Content.Server/Repairable/RepairableComponent.cs
@@ -25,5 +25,11 @@ namespace Content.Server.Repairable
 
         [ViewVariables(VVAccess.ReadWrite)] [DataField("doAfterDelay")]
         public int DoAfterDelay = 1;
+
+        /// <summary>
+        /// A multiplier that will be applied to the above if an entity is repairing themselves.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("selfRepairPenalty")]
+        public float SelfRepairPenalty = 3f;
     }
 }

--- a/Content.Server/Repairable/RepairableSystem.cs
+++ b/Content.Server/Repairable/RepairableSystem.cs
@@ -24,8 +24,14 @@ namespace Content.Server.Repairable
             if (!EntityManager.TryGetComponent(component.Owner, out DamageableComponent? damageable) || damageable.TotalDamage == 0)
                 return;
 
+            float delay = component.DoAfterDelay;
+
+            // Add a penalty to how long it takes if the user it repairing itself
+            if (args.User == args.Target)
+                delay *= component.SelfRepairPenalty;
+
             // Can the tool actually repair this, does it have enough fuel?
-            if (!await _toolSystem.UseTool(args.Used, args.User, uid, component.FuelCost, component.DoAfterDelay, component.QualityNeeded))
+            if (!await _toolSystem.UseTool(args.Used, args.User, uid, component.FuelCost, delay, component.QualityNeeded))
                 return;
 
             if (component.Damage != null)

--- a/Content.Server/Repairable/RepairableSystem.cs
+++ b/Content.Server/Repairable/RepairableSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Repairable
 
             float delay = component.DoAfterDelay;
 
-            // Add a penalty to how long it takes if the user it repairing itself
+            // Add a penalty to how long it takes if the user is repairing itself
             if (args.User == args.Target)
                 delay *= component.SelfRepairPenalty;
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Entities repairing themselves (which here, drones can do) had the same speed as other entities repairing them. This adds a pretty simple multiplier to discourage that sort of self-sufficiency.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Repairing yourself now takes 3 times as long as letting someone else do it.

