### PR TITLE
Updated GasAnalyzerMenu.cs (Window adjustment)

### DIFF
--- a/Content.Client/Atmos/UI/GasAnalyzerMenu.cs
+++ b/Content.Client/Atmos/UI/GasAnalyzerMenu.cs
@@ -145,7 +145,7 @@ namespace Content.Client.Atmos.UI
                 PanelOverride = new StyleBoxFlat { BackgroundColor = Color.FromHex("#525252ff") }
             });
             CloseButton.OnPressed += _ => Close();
-            SetSize = (300, 200);
+            SetSize = (300, 420);
         }
 
 


### PR DESCRIPTION
Not really the most elegant solution to the issue but it will make due for the time being, that is making it readable when multiple gasses are on display.

:cl:
- change:  Window size from **300x200 to 300x420** (funny gamer number)