### PR TITLE
Update GasVentScrubberComponent.cs (Faster settings for scrubbers)

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentScrubberComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentScrubberComponent.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("maxTransferRate")]
-        public float MaxTransferRate = Atmospherics.MaxTransferRate;
+        public float MaxTransferRate = 900;
 
         /// <summary>
         ///     As pressure difference approaches this number, the effective volume rate may be smaller than <see


### PR DESCRIPTION
**About the PR:**
We all love atmos, don't you love atmos? Of course we all love Atmos. Until the very point where the whole station is flooded with 0.3231 Tritium, the air alarms shut everything down and it takes about one hour for the scrubbers to even pump out half of it. 
If we can flood the station with 4500kPa oxygen in 15 seconds, why shouldn't we be able to clear a room of all air in less than an hour?

Default will still be 300 but can be changed to 900 manually at Air Alarms.

**Screenshots**
https://cdn.discordapp.com/attachments/587233998619541515/988061598553866310/unknown.png
https://cdn.discordapp.com/attachments/587233998619541515/988064039689142312/unknown.png

**Changelog**

:cl:
- change: **MaxTransferRate** of Scrubbers from **300** (Atmospherics.MaxTransferRate default) to **900**