### PR TITLE
Adds TileNotBlocked to atmos stuff

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -326,6 +326,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   name: passive vent
@@ -339,6 +341,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   name: air scrubber
@@ -352,6 +356,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/scrubber.rsi
     state: scrub_off
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   name: air injector
@@ -365,6 +371,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pipe.rsi
     state: pipeHalf
+  conditions:
+    - !type:TileNotBlocked {}
 
 # ATMOS BINARY
 - type: construction
@@ -379,6 +387,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpPressure
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   name: volumetric gas pump
@@ -392,6 +402,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpVolume
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   id: GasPassiveGate
@@ -405,6 +417,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpPassiveGate
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   id: GasValve
@@ -418,6 +432,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/pump.rsi
     state: pumpManualValve
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   id: GasPort
@@ -431,6 +447,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/gascanisterport.rsi
     state: gasCanisterPort
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   id: GasDualPortVentPump
@@ -444,6 +462,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/vent.rsi
     state: vent_off
+  conditions:
+    - !type:TileNotBlocked {}
 
 # ATMOS TRINARY
 - type: construction
@@ -458,6 +478,8 @@
   icon:
     sprite: Structures/Piping/Atmospherics/gasfilter.rsi
     state: gasFilter
+  conditions:
+    - !type:TileNotBlocked {}
 
 - type: construction
   id: GasMixer
@@ -471,4 +493,6 @@
   icon:
     sprite: Structures/Piping/Atmospherics/gasmixer.rsi
     state: gasMixer
+  conditions:
+    - !type:TileNotBlocked {}
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Someone posted a screenshot of 60 air injectors stacked to make super high pressure. Hopefully this prevents this.

web PR so untested.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: You now can’t stack crafted atmos devices on one tile.

