### PR TITLE
Spell sounds are no longer global, also tweaked volumes

### DIFF
--- a/Content.Server/Magic/Events/KnockSpellEvent.cs
+++ b/Content.Server/Magic/Events/KnockSpellEvent.cs
@@ -17,8 +17,7 @@ public sealed class KnockSpellEvent : InstantActionEvent
 
     /// <summary>
     /// Volume control for the spell.
-    /// -6f is default because the base soundfile is really loud
     /// </summary>
     [DataField("knockVolume")]
-    public float KnockVolume = -6f;
+    public float KnockVolume = 5f;
 }

--- a/Content.Server/Magic/Events/TeleportSpellEvent.cs
+++ b/Content.Server/Magic/Events/TeleportSpellEvent.cs
@@ -7,4 +7,11 @@ public sealed class TeleportSpellEvent : WorldTargetActionEvent
 {
     [DataField("blinkSound")]
     public SoundSpecifier BlinkSound = new SoundPathSpecifier("/Audio/Magic/blink.ogg");
+
+
+    /// <summary>
+    /// Volume control for the spell.
+    /// </summary>
+    [DataField("blinkVolume")]
+    public float BlinkVolume = 5f;
 }

--- a/Content.Server/Magic/MagicSystem.cs
+++ b/Content.Server/Magic/MagicSystem.cs
@@ -215,7 +215,7 @@ public sealed class MagicSystem : EntitySystem
 
         transform.WorldPosition = args.Target.Position;
         transform.AttachToGridOrMap();
-        SoundSystem.Play(args.BlinkSound.GetSound(), Filter.Pvs(args.Target));
+        SoundSystem.Play(args.BlinkSound.GetSound(), Filter.Pvs(args.Target), args.Performer, AudioParams.Default.WithVolume(args.BlinkVolume));
         args.Handled = true;
     }
 
@@ -232,7 +232,7 @@ public sealed class MagicSystem : EntitySystem
         var transform = Transform(args.Performer);
         var coords = transform.Coordinates;
 
-        SoundSystem.Play(args.KnockSound.GetSound(), Filter.Pvs(coords), AudioParams.Default.WithVolume(args.KnockVolume));
+        SoundSystem.Play(args.KnockSound.GetSound(), Filter.Pvs(coords), args.Performer, AudioParams.Default.WithVolume(args.KnockVolume));
 
         //Look for doors and don't open them if they're already open.
         foreach (var entity in _lookup.GetEntitiesInRange(coords, args.Range))


### PR DESCRIPTION
Spell sound effects are no longer global, instead come from the caster. Also changed the volumes around a little.
Fixes #8871

:cl:
- tweak: Spell sound effects are no longer global


