### PR TITLE
Hotfix thrown item rotation

### DIFF
--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -21,6 +21,7 @@
     modifier: 0.5
   - type: Physics
     bodyType: Dynamic
+    fixedRotation: false
   - type: Fixtures
     fixtures:
     - shape:


### PR DESCRIPTION
No idea how long fixedrotation has been set...

:cl:
- fix: Items rotate when thrown again.
