### PR TITLE
Fix vow of silence popup spam

### DIFF
--- a/Content.Server/Chat/TypingIndicator/TypingIndicatorSystem.cs
+++ b/Content.Server/Chat/TypingIndicator/TypingIndicatorSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.ActionBlocker;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Chat.TypingIndicator;
 using Robust.Server.GameObjects;
 
@@ -43,7 +43,7 @@ public sealed class TypingIndicatorSystem : SharedTypingIndicatorSystem
         }
 
         // check if this entity can speak or emote
-        if (!_actionBlocker.CanSpeak(ev.Uid) && !_actionBlocker.CanEmote(ev.Uid))
+        if (!_actionBlocker.CanEmote(ev.Uid) && !_actionBlocker.CanSpeak(ev.Uid))
         {
             // nah, make sure that typing indicator is disabled
             SetTypingIndicatorEnabled(ev.Uid, false);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I noticed an issue where if you start typing as a mime it keeps warning you about your vow of silence, even if you're just trying to emote.

The issue was that the speech bubble checks if you can speak or emote, and that was triggering the mime's OnSpeakAttemptEvent, causing the popup.

I've switched the order such that it can check the CanEmote first so mimes and perhaps people muted with the new Mute Toxin don't see the warning unless they actually try to speak.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

The original behavior:
<video src="https://user-images.githubusercontent.com/89101928/174648879-e50b7572-59fd-4c1e-b6d5-ab014f2492d4.mp4"></video>

After the change:
<video src="https://user-images.githubusercontent.com/89101928/174648945-8c8bd499-a334-48d4-bf85-8c960c73e0fd.mp4"></video>

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Mimes no longer warned about their vow when just typing

