### PR TITLE
Fix salvage player deletion

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -25,7 +25,6 @@ namespace Content.Server.Salvage
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
-        [Dependency] private readonly StationSystem _stationSystem = default!;
         [Dependency] private readonly ChatSystem _chatSystem = default!;
 
         private static readonly TimeSpan AttachingTime = TimeSpan.FromSeconds(30);
@@ -204,7 +203,9 @@ namespace Content.Server.Salvage
                     Transform(playerEntityUid).AttachParent(parentTransform);
                 }
             }
-            EntityManager.QueueDeleteEntity(salvage);
+
+            // Deletion has to happen before grid traversal re-parents players.
+            EntityManager.DeleteEntity(salvage);
         }
 
         private void TryGetSalvagePlacementLocation(SalvageMagnetComponent component, out MapCoordinates coords, out Angle angle)


### PR DESCRIPTION
fixes #8971.
Started happening due to grid traversal changes, which stopped queueing movement events for processing during future ticks.
:cl:
- fix: Salvage workers should once again stay behind when the salvage grid despawns.

