### PR TITLE
Get test map

### DIFF
--- a/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/AddTests.cs
@@ -34,9 +34,10 @@ public sealed class AddTests
 
         var guid = Guid.NewGuid();
 
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var coordinates = testMap.GridCoords;
         await server.WaitPost(() =>
         {
-            var coordinates = PoolManager.GetMainEntityCoordinates(sMaps);
             var entity = sEntities.SpawnEntity(null, coordinates);
 
             sAdminLogSystem.Add(LogType.Unknown, $"{entity:Entity} test log: {guid}");
@@ -83,9 +84,10 @@ public sealed class AddTests
 
         var guid = Guid.NewGuid();
 
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var coordinates = testMap.GridCoords;
         await server.WaitPost(() =>
         {
-            var coordinates = PoolManager.GetMainEntityCoordinates(sMaps);
             var entity = sEntities.SpawnEntity(null, coordinates);
 
             sAdminLogSystem.Add(LogType.Unknown, $"{entity} test log: {guid}");
@@ -141,9 +143,10 @@ public sealed class AddTests
 
         var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
 
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var coordinates = testMap.GridCoords;
         await server.WaitPost(() =>
         {
-            var coordinates = PoolManager.GetMainEntityCoordinates(sMaps);
             var entity = sEntities.SpawnEntity(null, coordinates);
 
             for (var i = 0; i < amount; i++)

--- a/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/FilterTests.cs
@@ -23,17 +23,17 @@ public sealed class FilterTests
         var server = pairTracker.Pair.Server;
 
         var sEntities = server.ResolveDependency<IEntityManager>();
-        var sMaps = server.ResolveDependency<IMapManager>();
 
         var sAdminLogSystem = server.ResolveDependency<IAdminLogManager>();
 
         var commonGuid = Guid.NewGuid();
         var firstGuid = Guid.NewGuid();
         var secondGuid = Guid.NewGuid();
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var coordinates = testMap.GridCoords;
 
         await server.WaitPost(() =>
         {
-            var coordinates = PoolManager.GetMainEntityCoordinates(sMaps);
             var entity = sEntities.SpawnEntity(null, coordinates);
 
             sAdminLogSystem.Add(LogType.Unknown, $"{entity:Entity} test log: {commonGuid} {firstGuid}");
@@ -43,7 +43,6 @@ public sealed class FilterTests
 
         await server.WaitPost(() =>
         {
-            var coordinates = PoolManager.GetMainEntityCoordinates(sMaps);
             var entity = sEntities.SpawnEntity(null, coordinates);
 
             sAdminLogSystem.Add(LogType.Unknown, $"{entity:Entity} test log: {commonGuid} {secondGuid}");

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -54,6 +54,9 @@ namespace Content.IntegrationTests.Tests.Buckle
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var coordinates = testMap.GridCoords;
+
             EntityUid human = default;
             EntityUid chair = default;
             BuckleComponent buckle = null;
@@ -66,8 +69,6 @@ namespace Content.IntegrationTests.Tests.Buckle
 
                 var actionBlocker = EntitySystem.Get<ActionBlockerSystem>();
                 var standingState = EntitySystem.Get<StandingStateSystem>();
-
-                var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
 
                 human = entityManager.SpawnEntity(BuckleDummyId, coordinates);
                 chair = entityManager.SpawnEntity(StrapDummyId, coordinates);
@@ -217,6 +218,9 @@ namespace Content.IntegrationTests.Tests.Buckle
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var coordinates = testMap.GridCoords;
+
             EntityUid human = default;
             BuckleComponent buckle = null;
             HandsComponent hands = null;
@@ -226,10 +230,7 @@ namespace Content.IntegrationTests.Tests.Buckle
 
             await server.WaitAssertion(() =>
             {
-                var mapManager = IoCManager.Resolve<IMapManager>();
                 var entityManager = IoCManager.Resolve<IEntityManager>();
-
-                var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
 
                 human = entityManager.SpawnEntity(BuckleDummyId, coordinates);
                 var chair = entityManager.SpawnEntity(StrapDummyId, coordinates);
@@ -301,6 +302,9 @@ namespace Content.IntegrationTests.Tests.Buckle
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var coordinates = testMap.GridCoords;
+
             EntityUid human = default;
             EntityUid chair = default;
             BuckleComponent buckle = null;
@@ -309,8 +313,6 @@ namespace Content.IntegrationTests.Tests.Buckle
             {
                 var mapManager = IoCManager.Resolve<IMapManager>();
                 var entityManager = IoCManager.Resolve<IEntityManager>();
-
-                var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
 
                 human = entityManager.SpawnEntity(BuckleDummyId, coordinates);
                 chair = entityManager.SpawnEntity(StrapDummyId, coordinates);

--- a/Content.IntegrationTests/Tests/Chemistry/SolutionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/SolutionSystemTests.cs
@@ -32,8 +32,8 @@ public sealed class SolutionSystemTests
         var server = pairTracker.Pair.Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var coordinates = testMap.GridCoords;
 
         EntityUid beaker;
 
@@ -70,9 +70,10 @@ public sealed class SolutionSystemTests
         await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
         var server = pairTracker.Pair.Server;
 
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
+        var coordinates = testMap.GridCoords;
 
         EntityUid beaker;
 
@@ -108,9 +109,10 @@ public sealed class SolutionSystemTests
         await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
         var server = pairTracker.Pair.Server;
 
+
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var coordinates = testMap.GridCoords;
 
         EntityUid beaker;
 
@@ -156,8 +158,8 @@ public sealed class SolutionSystemTests
         var server = pairTracker.Pair.Server;
 
         var entityManager = server.ResolveDependency<IEntityManager>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
+        var testMap = await PoolManager.CreateTestMap(pairTracker);
+        var coordinates = testMap.GridCoords;
 
         EntityUid beaker;
 

--- a/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
@@ -32,8 +32,8 @@ namespace Content.IntegrationTests.Tests.Chemistry
 
             var entityManager = server.ResolveDependency<IEntityManager>();
             var prototypeManager = server.ResolveDependency<IPrototypeManager>();
-            var mapManager = server.ResolveDependency<IMapManager>();
-            var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var coordinates = testMap.GridCoords;
 
             foreach (var reactionPrototype in prototypeManager.EnumeratePrototypes<ReactionPrototype>())
             {

--- a/Content.IntegrationTests/Tests/ClickableTest.cs
+++ b/Content.IntegrationTests/Tests/ClickableTest.cs
@@ -54,11 +54,11 @@ namespace Content.IntegrationTests.Tests
             var clientEntManager = client.ResolveDependency<IEntityManager>();
             var serverEntManager = server.ResolveDependency<IEntityManager>();
             var eyeManager = client.ResolveDependency<IEyeManager>();
-            var mapManager = server.ResolveDependency<IMapManager>();
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
             await server.WaitPost(() =>
             {
-                var ent = serverEntManager.SpawnEntity(prototype, PoolManager.GetMainEntityCoordinates(mapManager));
+                var ent = serverEntManager.SpawnEntity(prototype, testMap.GridCoords);
                 serverEntManager.GetComponent<TransformComponent>(ent).WorldRotation = angle;
                 serverEntManager.GetComponent<SpriteComponent>(ent).Scale = (scale, scale);
                 entity = ent;

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageGroupTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageGroupTest.cs
@@ -23,8 +23,9 @@ namespace Content.IntegrationTests.Tests.Destructible
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+
             var sEntityManager = server.ResolveDependency<IEntityManager>();
-            var sMapManager = server.ResolveDependency<IMapManager>();
             var sPrototypeManager = server.ResolveDependency<IPrototypeManager>();
             var sEntitySystemManager = server.ResolveDependency<IEntitySystemManager>();
 
@@ -35,7 +36,7 @@ namespace Content.IntegrationTests.Tests.Destructible
 
             await server.WaitPost(() =>
             {
-                var coordinates = PoolManager.GetMainEntityCoordinates(sMapManager);
+                var coordinates = testMap.GridCoords;
 
                 sDestructibleEntity = sEntityManager.SpawnEntity(DestructibleDamageGroupEntityId, coordinates);
                 sDamageableComponent = IoCManager.Resolve<IEntityManager>().GetComponent<DamageableComponent>(sDestructibleEntity);

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
@@ -22,8 +22,9 @@ namespace Content.IntegrationTests.Tests.Destructible
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+
             var sEntityManager = server.ResolveDependency<IEntityManager>();
-            var sMapManager = server.ResolveDependency<IMapManager>();
             var sEntitySystemManager = server.ResolveDependency<IEntitySystemManager>();
 
             EntityUid sDestructibleEntity = default;
@@ -33,7 +34,7 @@ namespace Content.IntegrationTests.Tests.Destructible
 
             await server.WaitPost(() =>
             {
-                var coordinates = PoolManager.GetMainEntityCoordinates(sMapManager);
+                var coordinates = testMap.GridCoords;
 
                 sDestructibleEntity = sEntityManager.SpawnEntity(DestructibleDamageTypeEntityId, coordinates);
                 sDamageableComponent = IoCManager.Resolve<IEntityManager>().GetComponent<DamageableComponent>(sDestructibleEntity);

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
@@ -21,8 +21,9 @@ namespace Content.IntegrationTests.Tests.Destructible
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+
             var sEntityManager = server.ResolveDependency<IEntityManager>();
-            var sMapManager = server.ResolveDependency<IMapManager>();
             var sPrototypeManager = server.ResolveDependency<IPrototypeManager>();
             var sEntitySystemManager = server.ResolveDependency<IEntitySystemManager>();
 
@@ -31,7 +32,7 @@ namespace Content.IntegrationTests.Tests.Destructible
 
             await server.WaitPost(() =>
             {
-                var coordinates = PoolManager.GetMainEntityCoordinates(sMapManager);
+                var coordinates = testMap.GridCoords;
 
                 sDestructibleEntity = sEntityManager.SpawnEntity(DestructibleDestructionEntityId, coordinates);
                 sTestThresholdListenerSystem = sEntitySystemManager.GetEntitySystem<TestDestructibleListenerSystem>();

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleThresholdActivationTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleThresholdActivationTest.cs
@@ -28,9 +28,10 @@ namespace Content.IntegrationTests.Tests.Destructible
             var server = pairTracker.Pair.Server;
 
             var sEntityManager = server.ResolveDependency<IEntityManager>();
-            var sMapManager = server.ResolveDependency<IMapManager>();
             var sPrototypeManager = server.ResolveDependency<IPrototypeManager>();
             var sEntitySystemManager = server.ResolveDependency<IEntitySystemManager>();
+
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
 
             EntityUid sDestructibleEntity = default;
             DamageableComponent sDamageableComponent = null;
@@ -40,7 +41,7 @@ namespace Content.IntegrationTests.Tests.Destructible
 
             await server.WaitPost(() =>
             {
-                var coordinates = PoolManager.GetMainEntityCoordinates(sMapManager);
+                var coordinates = testMap.GridCoords;
 
                 sDestructibleEntity = sEntityManager.SpawnEntity(DestructibleEntityId, coordinates);
                 sDamageableComponent = IoCManager.Resolve<IEntityManager>().GetComponent<DamageableComponent>(sDestructibleEntity);

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -130,19 +130,20 @@ namespace Content.IntegrationTests.Tests.Disposal
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+
             EntityUid human = default!;
             EntityUid wrench = default!;
             EntityUid disposalUnit = default!;
             EntityUid disposalTrunk = default!;
             DisposalUnitComponent unit = default!;
 
-            var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
 
             await server.WaitAssertion(() =>
             {
                 // Spawn the entities
-                var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
+                var coordinates = testMap.GridCoords;
                 human = entityManager.SpawnEntity("HumanDummy", coordinates);
                 wrench = entityManager.SpawnEntity("WrenchDummy", coordinates);
                 disposalUnit = entityManager.SpawnEntity("DisposalUnitDummy", coordinates);

--- a/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
+++ b/Content.IntegrationTests/Tests/Fluids/PuddleTest.cs
@@ -22,14 +22,15 @@ namespace Content.IntegrationTests.Tests.Fluids
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true});
             var server = pairTracker.Pair.Server;
 
-            var mapManager = server.ResolveDependency<IMapManager>();
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
             var spillSystem = entitySystemManager.GetEntitySystem<SpillableSystem>();
 
             await server.WaitAssertion(() =>
             {
                 var solution = new Solution("Water", FixedPoint2.New(20));
-                var tile = PoolManager.GetMainTile(mapManager);
+                var tile = testMap.Tile;
                 var gridUid = tile.GridUid;
                 var (x, y) = tile.GridIndices;
                 var coordinates = new EntityCoordinates(gridUid, x, y);
@@ -48,7 +49,8 @@ namespace Content.IntegrationTests.Tests.Fluids
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true});
             var server = pairTracker.Pair.Server;
 
-            var mapManager = server.ResolveDependency<IMapManager>();
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+
             var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
             var spillSystem = entitySystemManager.GetEntitySystem<SpillableSystem>();
 
@@ -57,7 +59,7 @@ namespace Content.IntegrationTests.Tests.Fluids
             // Remove all tiles
             await server.WaitPost(() =>
             {
-                grid = PoolManager.GetMainGrid(mapManager);
+                grid = testMap.MapGrid;
 
                 foreach (var tile in grid.GetAllTiles())
                 {

--- a/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
+++ b/Content.IntegrationTests/Tests/Gravity/WeightlessStatusTests.cs
@@ -5,6 +5,7 @@ using Content.Shared.Alert;
 using Content.Shared.Coordinates;
 using NUnit.Framework;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests.Gravity
@@ -43,10 +44,11 @@ namespace Content.IntegrationTests.Tests.Gravity
 
             EntityUid human = default;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+
             await server.WaitAssertion(() =>
             {
-                var coordinates = PoolManager.GetMainEntityCoordinates(mapManager);
-                human = entityManager.SpawnEntity("HumanDummy", coordinates);
+                human = entityManager.SpawnEntity("HumanDummy", testMap.GridCoords);
 
                 Assert.True(entityManager.TryGetComponent(human, out AlertsComponent alerts));
             });

--- a/Content.IntegrationTests/Tests/GravityGridTest.cs
+++ b/Content.IntegrationTests/Tests/GravityGridTest.cs
@@ -33,6 +33,8 @@ namespace Content.IntegrationTests.Tests
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+
             EntityUid generator = default;
             var entityMan = server.ResolveDependency<IEntityManager>();
 
@@ -44,7 +46,7 @@ namespace Content.IntegrationTests.Tests
             {
                 var mapMan = IoCManager.Resolve<IMapManager>();
 
-                var mapId = PoolManager.GetMainGrid(mapMan).ParentMapId;
+                var mapId = testMap.MapId;
                 grid1 = mapMan.CreateGrid(mapId);
                 grid2 = mapMan.CreateGrid(mapId);
 

--- a/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
@@ -37,24 +37,20 @@ namespace Content.IntegrationTests.Tests.Utility
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
-            var sMapManager = server.ResolveDependency<IMapManager>();
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var mapCoordinates = testMap.MapCoords;
+            var entityCoordinates = testMap.GridCoords;
+
             var sEntityManager = server.ResolveDependency<IEntityManager>();
             var broady = server.ResolveDependency<IEntitySystemManager>().GetEntitySystem<SharedBroadphaseSystem>();
 
             await server.WaitAssertion(() =>
             {
-                var grid = PoolManager.GetMainGrid(sMapManager);
-                var gridEnt = grid.GridEntityId;
-                var gridPos = IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(gridEnt).WorldPosition;
-                var entityCoordinates = PoolManager.GetMainEntityCoordinates(sMapManager);
 
                 // Nothing blocking it, only entity is the grid
                 Assert.NotNull(sEntityManager.SpawnIfUnobstructed(null, entityCoordinates, CollisionGroup.Impassable));
                 Assert.True(sEntityManager.TrySpawnIfUnobstructed(null, entityCoordinates, CollisionGroup.Impassable, out var entity));
                 Assert.NotNull(entity);
-
-                var mapId = PoolManager.GetMainGrid(sMapManager).ParentMapId;
-                var mapCoordinates = new MapCoordinates(gridPos.X, gridPos.Y, mapId);
 
                 // Nothing blocking it, only entity is the grid
                 Assert.NotNull(sEntityManager.SpawnIfUnobstructed(null, mapCoordinates, CollisionGroup.Impassable));

--- a/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
@@ -63,14 +63,13 @@ namespace Content.IntegrationTests.Tests.Utility
             await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoClient = true, ExtraPrototypes = Prototypes});
             var server = pairTracker.Pair.Server;
 
-            var mapManager = server.ResolveDependency<IMapManager>();
+            var testMap = await PoolManager.CreateTestMap(pairTracker);
+            var mapCoordinates = testMap.MapCoords;
+
             var sEntities = server.ResolveDependency<IEntityManager>();
 
             await server.WaitAssertion(() =>
             {
-                var mapId = PoolManager.GetMainGrid(mapManager).ParentMapId;
-                var mapCoordinates = new MapCoordinates(0, 0, mapId);
-
                 var validComponent = sEntities.SpawnEntity("ValidComponentDummy", mapCoordinates);
                 var validTag = sEntities.SpawnEntity("ValidTagDummy", mapCoordinates);
 

--- a/Content.Server/StationEvents/Events/StationEvent.cs
+++ b/Content.Server/StationEvents/Events/StationEvent.cs
@@ -210,6 +210,12 @@ namespace Content.Server.StationEvents.Events
             entityManager.EntitySysManager.Resolve(ref stationSystem);
 
             targetCoords = EntityCoordinates.Invalid;
+            if (stationSystem.Stations.Count == 0)
+            {
+                targetStation = EntityUid.Invalid;
+                targetGrid = EntityUid.Invalid;
+                return false;
+            }
             targetStation = robustRandom.Pick(stationSystem.Stations);
             var possibleTargets = entityManager.GetComponent<StationDataComponent>(targetStation).Grids;
             if (possibleTargets.Count == 0)


### PR DESCRIPTION
Instead of trying to guess if a map/tile/grid is working, and using that in a test, which has been very unreliable. The test can now ask for a test map, and the pool manager will make a new one, which is fast enough, and much more reliable.