### PR TITLE
Add DoAfter to eject light bulb

### DIFF
--- a/Content.Server/Light/Components/PoweredLightComponent.cs
+++ b/Content.Server/Light/Components/PoweredLightComponent.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Prototypes;
 using Content.Shared.MachineLinking;
+using System.Threading;
 
 namespace Content.Server.Light.Components
 {
@@ -66,5 +67,13 @@ namespace Content.Server.Light.Components
 
         [DataField("togglePort", customTypeSerializer: typeof(PrototypeIdSerializer<ReceiverPortPrototype>))]
         public string TogglePort = "Toggle";
+
+        public CancellationTokenSource? CancelToken;
+
+        /// <summary>
+        /// How long it takes to eject a bulb from this
+        /// </summary>
+        [DataField("ejectBulbDelay")]
+        public float EjectBulbDelay = 2;
     }
 }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration.Logs;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Systems;
+using Content.Server.DoAfter;
 using Content.Server.Ghost;
 using Content.Server.Light.Components;
 using Content.Server.MachineLinking.Events;
@@ -19,6 +20,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using System.Threading;
 
 namespace Content.Server.Light.EntitySystems
 {
@@ -36,6 +38,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
         [Dependency] private readonly SignalLinkerSystem _signalSystem = default!;
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+        [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
 
         private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(2);
         public const string LightBulbContainer = "light_bulb";
@@ -55,6 +58,9 @@ namespace Content.Server.Light.EntitySystems
             SubscribeLocalEvent<PoweredLightComponent, DeviceNetworkPacketEvent>(OnPacketReceived);
 
             SubscribeLocalEvent<PoweredLightComponent, PowerChangedEvent>(OnPowerChanged);
+
+            SubscribeLocalEvent<EjectBulbCompleteEvent>(OnEjectBulbComplete);
+            SubscribeLocalEvent<EjectBulbCancelledEvent>(OnEjectBulbCancelled);
         }
 
         private void OnInit(EntityUid uid, PoweredLightComponent light, ComponentInit args)
@@ -85,6 +91,9 @@ namespace Content.Server.Light.EntitySystems
         private void OnInteractHand(EntityUid uid, PoweredLightComponent light, InteractHandEvent args)
         {
             if (args.Handled)
+                return;
+
+            if (light.CancelToken != null)
                 return;
 
             // check if light has bulb to eject
@@ -122,8 +131,26 @@ namespace Content.Server.Light.EntitySystems
             }
 
             // all checks passed
-            // just try to eject bulb
-            args.Handled = EjectBulb(uid, userUid, light) != null;
+            // just try to eject bulb after a delay
+            light.CancelToken = new CancellationTokenSource();
+            _doAfterSystem.DoAfter(new DoAfterEventArgs((EntityUid) userUid, light.EjectBulbDelay, light.CancelToken.Token, uid)
+            {
+                BreakOnUserMove = true,
+                BreakOnDamage = true,
+                BreakOnStun = true,
+                BroadcastFinishedEvent = new EjectBulbCompleteEvent()
+                {
+                    Component = light,
+                    User = userUid,
+                    Target = uid,
+                },
+                BroadcastCancelledEvent = new EjectBulbCancelledEvent()
+                {
+                    Component = light,
+                }
+            });
+
+            args.Handled = true;
         }
 
         #region Bulb Logic API
@@ -391,6 +418,29 @@ namespace Content.Server.Light.EntitySystems
 
             light.On = state;
             UpdateLight(uid, light);
+        }
+
+        private void OnEjectBulbComplete(EjectBulbCompleteEvent args)
+        {
+            args.Component.CancelToken = null;
+            EjectBulb(args.Target, args.User, args.Component);
+        }
+
+        private static void OnEjectBulbCancelled(EjectBulbCancelledEvent args)
+        {
+            args.Component.CancelToken = null;
+        }
+
+        private sealed class EjectBulbCompleteEvent : EntityEventArgs
+        {
+            public PoweredLightComponent Component { get; init; } = default!;
+            public EntityUid User { get; init; }
+            public EntityUid Target { get; init; }
+        }
+
+        private sealed class EjectBulbCancelledEvent : EntityEventArgs
+        {
+            public PoweredLightComponent Component { get; init; } = default!;
         }
     }
 }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -59,8 +59,8 @@ namespace Content.Server.Light.EntitySystems
 
             SubscribeLocalEvent<PoweredLightComponent, PowerChangedEvent>(OnPowerChanged);
 
-            SubscribeLocalEvent<EjectBulbCompleteEvent>(OnEjectBulbComplete);
-            SubscribeLocalEvent<EjectBulbCancelledEvent>(OnEjectBulbCancelled);
+            SubscribeLocalEvent<PoweredLightComponent, EjectBulbCompleteEvent>(OnEjectBulbComplete);
+            SubscribeLocalEvent<PoweredLightComponent, EjectBulbCancelledEvent>(OnEjectBulbCancelled);
         }
 
         private void OnInit(EntityUid uid, PoweredLightComponent light, ComponentInit args)
@@ -145,13 +145,13 @@ namespace Content.Server.Light.EntitySystems
                 BreakOnUserMove = true,
                 BreakOnDamage = true,
                 BreakOnStun = true,
-                BroadcastFinishedEvent = new EjectBulbCompleteEvent()
+                TargetFinishedEvent = new EjectBulbCompleteEvent()
                 {
                     Component = light,
                     User = userUid,
                     Target = uid,
                 },
-                BroadcastCancelledEvent = new EjectBulbCancelledEvent()
+                TargetCancelledEvent = new EjectBulbCancelledEvent()
                 {
                     Component = light,
                 }
@@ -427,13 +427,13 @@ namespace Content.Server.Light.EntitySystems
             UpdateLight(uid, light);
         }
 
-        private void OnEjectBulbComplete(EjectBulbCompleteEvent args)
+        private void OnEjectBulbComplete(EntityUid uid, PoweredLightComponent component, EjectBulbCompleteEvent args)
         {
             args.Component.CancelToken = null;
             EjectBulb(args.Target, args.User, args.Component);
         }
 
-        private static void OnEjectBulbCancelled(EjectBulbCancelledEvent args)
+        private static void OnEjectBulbCancelled(EntityUid uid, PoweredLightComponent component, EjectBulbCancelledEvent args)
         {
             args.Component.CancelToken = null;
         }

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -130,8 +130,15 @@ namespace Content.Server.Light.EntitySystems
                 }
             }
 
-            // all checks passed
-            // just try to eject bulb after a delay
+
+            //removing a broken/burned bulb, so allow instant removal
+            if(TryComp<LightBulbComponent>(bulbUid.Value, out var bulb) && bulb.State != LightBulbState.Normal)
+            {
+                args.Handled = EjectBulb(uid, userUid, light) != null;
+                return;
+            }
+
+            // removing a working bulb, so require a delay
             light.CancelToken = new CancellationTokenSource();
             _doAfterSystem.DoAfter(new DoAfterEventArgs((EntityUid) userUid, light.EjectBulbDelay, light.CancelToken.Token, uid)
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Adds a DoAfter for removing a working light bulb
- Broken lights can be removed instantly (we can require delay for both if we want)
- LightReplacer still works the same
- Fixes #8505 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: removing unbroken light bulbs now has a delay
