### PR TITLE
 Rat king tweaks

### DIFF
--- a/Content.Server/RatKing/RatKingComponent.cs
+++ b/Content.Server/RatKing/RatKingComponent.cs
@@ -42,6 +42,6 @@ namespace Content.Server.RatKing
         ///     How many moles of Miasma are released after one us of Domain
         /// </summary>
         [ViewVariables, DataField("molesMiasmaPerDomain")]
-        public float MolesMiasmaPerDomain = 75f;
+        public float MolesMiasmaPerDomain = 100f;
     }
 };

--- a/Content.Shared/Pulling/Components/SharedPullerComponent.cs
+++ b/Content.Shared/Pulling/Components/SharedPullerComponent.cs
@@ -12,6 +12,12 @@
         [ViewVariables]
         public EntityUid? Pulling { get; set; }
 
+        /// <summary>
+        ///     Does this entity need hands to be able to pull something?
+        /// </summary>
+        [DataField("needsHands")]
+        public bool NeedsHands = true;
+
         protected override void Shutdown()
         {
             EntitySystem.Get<SharedPullingStateManagementSystem>().ForceDisconnectPuller(this);

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.Actions.cs
@@ -1,5 +1,6 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.Buckle.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Physics.Pull;
 using Content.Shared.Pulling.Components;
 using Content.Shared.Pulling.Events;
@@ -13,10 +14,16 @@ namespace Content.Shared.Pulling
     {
         [Dependency] private readonly ActionBlockerSystem _blocker = default!;
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+        [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
 
         public bool CanPull(EntityUid puller, EntityUid pulled)
         {
-            if (!EntityManager.HasComponent<SharedPullerComponent>(puller))
+            if (!EntityManager.TryGetComponent<SharedPullerComponent>(puller, out var comp))
+            {
+                return false;
+            }
+
+            if (comp.NeedsHands && !_handsSystem.TryGetEmptyHand(puller, out _))
             {
                 return false;
             }

--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
@@ -54,7 +54,7 @@ namespace Content.Shared.Pulling
 
         private void AddPullVerbs(EntityUid uid, SharedPullableComponent component, GetVerbsEvent<Verb> args)
         {
-            if (args.Hands == null || !args.CanAccess || !args.CanInteract)
+            if (!args.CanAccess || !args.CanInteract)
                 return;
 
             // Are they trying to pull themselves up by their bootstraps?

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -64,6 +64,7 @@
       Dead:
         Base: dead
   - type: Puller
+    needsHands: false
   - type: GhostTakeoverAvailable
     makeSentient: true
     name: Rat King
@@ -180,6 +181,7 @@
       Dead:
         Base: splat-3
   - type: Puller
+    needsHands: false
   - type: DiseaseCarrier
     carrierDiseases:
     - VentCough


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reason for pulling tweaks: incentivizes rat king/servants to be more of a zoner and bring stuff to a central location through pulling. I think it might have even been intended but just didn't work

Domain just wasn't powerful enough IMO

:cl:
- tweak: Rat king and his servants can now pull objects.
- tweak: Rat king 'domain' effect now generates slightly more miasma.

