### PR TITLE
Displaying of player characters in the round end statistics

### DIFF
--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -18,6 +18,8 @@ namespace Content.Client.GameTicking.Managers
     public sealed class ClientGameTicker : SharedGameTicker
     {
         [Dependency] private readonly IStateManager _stateManager = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+
         [ViewVariables] private bool _initialized;
         private Dictionary<EntityUid, Dictionary<string, uint?>>  _jobsAvailable = new();
         private Dictionary<EntityUid, string> _stationNames = new();
@@ -135,7 +137,7 @@ namespace Content.Client.GameTicking.Managers
             RestartSound = message.RestartSound;
 
             //This is not ideal at all, but I don't see an immediately better fit anywhere else.
-            var roundEnd = new RoundEndSummaryWindow(message.GamemodeTitle, message.RoundEndText, message.RoundDuration, message.RoundId, message.AllPlayersEndInfo);
+            var roundEnd = new RoundEndSummaryWindow(message.GamemodeTitle, message.RoundEndText, message.RoundDuration, message.RoundId, message.AllPlayersEndInfo, _entityManager);
         }
 
         private void RoundRestartCleanup(RoundRestartCleanupEvent ev)

--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Client.Message;
 using Content.Shared.GameTicking;
+using Robust.Client.GameObjects;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Utility;
@@ -10,10 +11,13 @@ namespace Content.Client.RoundEnd
 {
     public sealed class RoundEndSummaryWindow : DefaultWindow
     {
+        private readonly IEntityManager _entityManager;
 
         public RoundEndSummaryWindow(string gm, string roundEnd, TimeSpan roundTimeSpan, int roundId,
-            RoundEndMessageEvent.RoundEndPlayerInfo[] info)
+            RoundEndMessageEvent.RoundEndPlayerInfo[] info, IEntityManager entityManager)
         {
+            _entityManager = entityManager;
+
             MinSize = SetSize = (520, 580);
 
             Title = Loc.GetString("round-end-summary-window-title");
@@ -105,7 +109,27 @@ namespace Content.Client.RoundEnd
             //Create labels for each player info.
             foreach (var playerInfo in sortedPlayersInfo)
             {
-                var playerInfoText = new RichTextLabel();
+                var hBox = new BoxContainer
+                {
+                    Orientation = LayoutOrientation.Horizontal,
+                };
+
+                var playerInfoText = new RichTextLabel
+                {
+                    VerticalAlignment = VAlignment.Center,
+                    VerticalExpand = true,
+                };
+
+                if (_entityManager.TryGetComponent(playerInfo.PlayerEntityUid, out ISpriteComponent? sprite))
+                {
+                    hBox.AddChild(new SpriteView
+                    {
+                        Sprite = sprite,
+                        OverrideDirection = Direction.South,
+                        VerticalAlignment = VAlignment.Center,
+                        VerticalExpand = true,
+                    });
+                }
 
                 if (playerInfo.PlayerICName != null)
                 {
@@ -129,7 +153,8 @@ namespace Content.Client.RoundEnd
                                 ("playerRole", Loc.GetString(playerInfo.Role))));
                     }
                 }
-                playerInfoContainer.AddChild(playerInfoText);
+                hBox.AddChild(playerInfoText);
+                playerInfoContainer.AddChild(hBox);
             }
 
             playerInfoContainerScrollbox.AddChild(playerInfoContainer);

--- a/Content.Server/Administration/Commands/ThrowScoreboardCommand.cs
+++ b/Content.Server/Administration/Commands/ThrowScoreboardCommand.cs
@@ -1,0 +1,25 @@
+﻿using Content.Server.GameTicking;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.VarEdit)]
+public sealed class ThrowScoreboardCommand : IConsoleCommand
+{
+    public string Command => "throwscoreboard";
+
+    public string Description => Loc.GetString("throw-scoreboard-command-description");
+
+    public string Help => Loc.GetString("throw-scoreboard-command-help-text");
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length > 0)
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+        EntitySystem.Get<GameTicker>().ShowRoundEndScoreboard();
+    }
+}

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -13,7 +13,6 @@ using Content.Shared.Preferences;
 using Content.Shared.Sound;
 using JetBrains.Annotations;
 using Prometheus;
-using Robust.Server.GameObjects;
 using Robust.Server.Maps;
 using Robust.Server.Player;
 using Robust.Shared.Audio;

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -265,44 +265,6 @@ namespace Content.Server.GameTicking
             ShowRoundEndScoreboard(text);
         }
 
-        public void RestartRound()
-        {
-            // If this game ticker is a dummy, do nothing!
-            if (DummyTicker)
-                return;
-
-            // Handle restart for server update
-            if (_serverUpdates.RoundEnded())
-                return;
-
-            _sawmill.Info("Restarting round!");
-
-            SendServerMessage(Loc.GetString("game-ticker-restart-round"));
-
-            RoundNumberMetric.Inc();
-
-            RunLevel = GameRunLevel.PreRoundLobby;
-            LobbySong = _robustRandom.Pick(_lobbyMusicCollection.PickFiles).ToString();
-            RandomizeLobbyBackground();
-            ResettingCleanup();
-
-            if (!LobbyEnabled)
-            {
-                StartRound();
-            }
-            else
-            {
-                if (_playerManager.PlayerCount == 0)
-                    _roundStartCountdownHasNotStartedYetDueToNoPlayers = true;
-                else
-                    _roundStartTime = _gameTiming.CurTime + LobbyDuration;
-
-                SendStatusToAll();
-
-                ReqWindowAttentionAll();
-            }
-        }
-
         public void ShowRoundEndScoreboard(string text = "")
         {
             //Tell every client the round has ended.
@@ -377,6 +339,44 @@ namespace Content.Server.GameTicking
                 new SoundCollectionSpecifier("RoundEnd").GetSound()));
         }
 
+        public void RestartRound()
+        {
+            // If this game ticker is a dummy, do nothing!
+            if (DummyTicker)
+                return;
+
+            // Handle restart for server update
+            if (_serverUpdates.RoundEnded())
+                return;
+
+            _sawmill.Info("Restarting round!");
+
+            SendServerMessage(Loc.GetString("game-ticker-restart-round"));
+
+            RoundNumberMetric.Inc();
+
+            RunLevel = GameRunLevel.PreRoundLobby;
+            LobbySong = _robustRandom.Pick(_lobbyMusicCollection.PickFiles).ToString();
+            RandomizeLobbyBackground();
+            ResettingCleanup();
+
+            if (!LobbyEnabled)
+            {
+                StartRound();
+            }
+            else
+            {
+                if (_playerManager.PlayerCount == 0)
+                    _roundStartCountdownHasNotStartedYetDueToNoPlayers = true;
+                else
+                    _roundStartTime = _gameTiming.CurTime + LobbyDuration;
+
+                SendStatusToAll();
+
+                ReqWindowAttentionAll();
+            }
+        }
+        
         /// <summary>
         ///     Cleanup that has to run to clear up anything from the previous round.
         ///     Stuff like wiping the previous map clean.

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -1,5 +1,6 @@
 ﻿using Robust.Shared.Network;
 using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.GameTicking
 {
@@ -127,6 +128,7 @@ namespace Content.Shared.GameTicking
             public string PlayerOOCName;
             public string? PlayerICName;
             public string Role;
+            public EntityUid? PlayerEntityUid;
             public bool Antag;
             public bool Observer;
             public bool Connected;

--- a/Resources/Locale/en-US/administration/commands/throw-scoreboard-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/throw-scoreboard-command.ftl
@@ -1,0 +1,2 @@
+throw-scoreboard-command-description = Show round-end scoreboard for all players, but not finish the round
+throw-scoreboard-command-help-text = Usage: throwscoreboard


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Look at the screenshots!

(But I have a bug with SpriteView and idk how to fix it "correctly")

<details> 
  <summary>The Bug</summary>
  

https://user-images.githubusercontent.com/26389417/174855612-8c4c672a-88cd-4b32-b411-6b6ec47326d1.mp4


</details>

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/26389417/174854874-431c3186-3116-4839-99fb-edd5835a5af0.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Displaying of player characters in the round end statistics

