### PR TITLE
Notifies you if you're being stripped or dressed.

### DIFF
--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Popups;
 using Content.Shared.Strip.Components;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
+using Robust.Shared.Player;
 
 namespace Content.Server.Strip
 {
@@ -21,6 +22,7 @@ namespace Content.Server.Strip
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
         [Dependency] private readonly InventorySystem _inventorySystem = default!;
         [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
+        [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
 
         // TODO: ECS popups. Not all of these have ECS equivalents yet.
 
@@ -300,6 +302,14 @@ namespace Content.Server.Strip
                 NeedHand = true,
             };
 
+            if (Check())
+            {
+                if (userHands.ActiveHandEntity != null)
+                {
+                    _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-insert", ("user", user), ("item", userHands.ActiveHandEntity)), component.Owner, Filter.Entities(component.Owner));
+                }
+            }
+
             var result = await _doAfterSystem.WaitDoAfter(doAfterArgs);
             if (result != DoAfterStatus.Finished) return;
 
@@ -354,6 +364,14 @@ namespace Content.Server.Strip
                 NeedHand = true,
             };
 
+            if (Check() && userHands.Hands.TryGetValue(handName, out var handSlot))
+            {
+                if (handSlot.HeldEntity != null)
+                {
+                    _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-insert", ("user", user), ("item", handSlot.HeldEntity)), component.Owner, Filter.Entities(component.Owner));
+                }
+            }
+
             var result = await _doAfterSystem.WaitDoAfter(doAfterArgs);
             if (result != DoAfterStatus.Finished) return;
 
@@ -405,6 +423,17 @@ namespace Content.Server.Strip
                 BreakOnUserMove = true,
             };
 
+            if (Check())
+            {
+                if (slotDef.StripHidden)
+                    _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-hidden", ("slot", slot)), component.Owner, Filter.Entities(component.Owner));
+                else
+                {
+                    if (_inventorySystem.TryGetSlotEntity(component.Owner, slot, out var slotItem))
+                        _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner", ("user", user), ("item", slotItem)), component.Owner, Filter.Entities(component.Owner));
+                }
+            }
+
             var result = await _doAfterSystem.WaitDoAfter(doAfterArgs);
             if (result != DoAfterStatus.Finished) return;
 
@@ -455,6 +484,14 @@ namespace Content.Server.Strip
                 BreakOnTargetMove = true,
                 BreakOnUserMove = true,
             };
+
+            if (Check() && hands.Hands.TryGetValue(handName, out var handSlot))
+            {
+                if (handSlot.HeldEntity != null)
+                {
+                    _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner", ("user", user), ("item", handSlot.HeldEntity)), component.Owner, Filter.Entities(component.Owner));
+                }
+            }
 
             var result = await _doAfterSystem.WaitDoAfter(doAfterArgs);
             if (result != DoAfterStatus.Finished) return;

--- a/Resources/Locale/en-US/strip/strippable-component.ftl
+++ b/Resources/Locale/en-US/strip/strippable-component.ftl
@@ -6,6 +6,9 @@ strippable-component-cannot-put-message = {$owner} cannot put that there!
 strippable-component-item-slot-free-message = {$owner} has nothing there!
 strippable-component-cannot-unequip-message = {$owner} cannot unequip that!
 strippable-component-cannot-drop-message = {$owner} cannot drop that!
+strippable-component-alert-owner = {$user} is removing your {$item}!
+strippable-component-alert-owner-hidden = You feel someone fumbling in your {$slot}!
+strippable-component-alert-owner-insert = {$user} is putting {$item} on you!
 
 # StripVerb
 strip-verb-get-data-text = Strip


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

You will now be notified with a popup above your head only if you're:

A) Being stripped/an item is removed from your hands
B) Being dressed/an item is put on you

It also lets you know who's doing it.

Also there's a caveat for taking items out of pockets. It will alert you that someone is fumbling around in your pocket (or any other obscured itemslot). It won't tell you who's doing it but it will still alert you. Allowing that to be a bit more sneaky.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/54602815/175100532-3e16bde1-e06c-4590-9c53-461c6031ca17.png)

(Note this screenshot shows the user getting the popup, but it's just to demonstrate. Live it will only pop up above the person being stripped/dressed).


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Adds a popup above a person being stripped/dressed.