### PR TITLE
Basic drug shader

### DIFF
--- a/Content.Client/Drugs/DrugOverlaySystem.cs
+++ b/Content.Client/Drugs/DrugOverlaySystem.cs
@@ -1,0 +1,58 @@
+using Content.Shared.Drugs;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+
+namespace Content.Client.Drugs;
+
+/// <summary>
+///     System to handle drug related overlays.
+/// </summary>
+public sealed class DrugOverlaySystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IOverlayManager _overlayMan = default!;
+
+    private RainbowOverlay _overlay = default!;
+
+    public static string RainbowKey = "SeeingRainbows";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SeeingRainbowsComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<SeeingRainbowsComponent, ComponentShutdown>(OnShutdown);
+
+        SubscribeLocalEvent<SeeingRainbowsComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<SeeingRainbowsComponent, PlayerDetachedEvent>(OnPlayerDetached);
+
+        _overlay = new();
+    }
+
+    private void OnPlayerAttached(EntityUid uid, SeeingRainbowsComponent component, PlayerAttachedEvent args)
+    {
+        _overlayMan.AddOverlay(_overlay);
+    }
+
+    private void OnPlayerDetached(EntityUid uid, SeeingRainbowsComponent component, PlayerDetachedEvent args)
+    {
+        _overlay.Intoxication = 0;
+        _overlayMan.RemoveOverlay(_overlay);
+    }
+
+    private void OnInit(EntityUid uid, SeeingRainbowsComponent component, ComponentInit args)
+    {
+        if (_player.LocalPlayer?.ControlledEntity == uid)
+            _overlayMan.AddOverlay(_overlay);
+    }
+
+    private void OnShutdown(EntityUid uid, SeeingRainbowsComponent component, ComponentShutdown args)
+    {
+        if (_player.LocalPlayer?.ControlledEntity == uid)
+        {
+            _overlay.Intoxication = 0;
+            _overlayMan.RemoveOverlay(_overlay);
+        }
+    }
+}

--- a/Content.Client/Drugs/RainbowOverlay.cs
+++ b/Content.Client/Drugs/RainbowOverlay.cs
@@ -1,0 +1,70 @@
+using Content.Shared.Drugs;
+using Content.Shared.StatusEffect;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Drugs;
+
+public sealed class RainbowOverlay : Overlay
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IEntitySystemManager _sysMan = default!;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override bool RequestScreenTexture => true;
+    private readonly ShaderInstance _rainbowShader;
+
+    public float Intoxication = 0.0f;
+
+    private const float VisualThreshold = 10.0f;
+    private const float PowerDivisor = 250.0f;
+
+    private float EffectScale => Math.Clamp((Intoxication - VisualThreshold) / PowerDivisor, 0.0f, 1.0f);
+
+    public RainbowOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _rainbowShader = _prototypeManager.Index<ShaderPrototype>("Rainbow").InstanceUnique();
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        var playerEntity = _playerManager.LocalPlayer?.ControlledEntity;
+
+        if (playerEntity == null)
+            return;
+
+        if (!_entityManager.HasComponent<SeeingRainbowsComponent>(playerEntity)
+            || !_entityManager.TryGetComponent<StatusEffectsComponent>(playerEntity, out var status))
+            return;
+
+        var statusSys = _sysMan.GetEntitySystem<StatusEffectsSystem>();
+        if (!statusSys.TryGetTime(playerEntity.Value, DrugOverlaySystem.RainbowKey, out var time, status))
+            return;
+
+        var timeLeft = (float) (time.Value.Item2 - time.Value.Item1).TotalSeconds;
+        Intoxication += (timeLeft - Intoxication) * args.DeltaSeconds / 16f;
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        return EffectScale > 0;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (ScreenTexture == null)
+            return;
+
+        var handle = args.WorldHandle;
+        _rainbowShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+        _rainbowShader.SetParameter("effectScale", EffectScale);
+        handle.UseShader(_rainbowShader);
+        handle.DrawRect(args.WorldBounds, Color.White);
+    }
+}

--- a/Content.Shared/Drugs/SeeingRainbowsComponent.cs
+++ b/Content.Shared/Drugs/SeeingRainbowsComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Drugs;
+
+/// <summary>
+///     Exists for use as a status effect. Adds a shader to the client that scales with the effect duration.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed class SeeingRainbowsComponent : Component { }

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -80,6 +80,7 @@
     - KnockedDown
     - SlowedDown
     - Stutter
+    - SeeingRainbows
     - Electrocution
     - PressureImmunity
     - Muted

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -89,6 +89,15 @@
     amount: -5
   - !type:PlantAdjustHealth
     amount: -1
+  metabolisms:
+    Narcotic:
+      effects:
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 5
+        refresh: false
 
 - type: reagent
   id: THCOil
@@ -97,6 +106,15 @@
   desc: reagent-desc-thc-oil
   physicalDesc: reagent-physical-desc-skunky
   color: "#DAA520"
+  metabolisms:
+    Narcotic:
+      effects:
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 5
+        refresh: false
 
 - type: reagent
   id: Nicotine
@@ -124,6 +142,15 @@
   desc: reagent-desc-space-drugs
   physicalDesc: reagent-physical-desc-syrupy
   color: "#63806e"
+  metabolisms:
+    Narcotic:
+      effects:
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 5
+        refresh: false
 
 # Probably replace this one with sleeping chem when putting someone in a comatose state is easier
 - type: reagent

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -32,6 +32,11 @@
     life: 0
 
 - type: shader
+  id: Rainbow
+  kind: source
+  path: "/Textures/Shaders/rainbow.swsl"
+
+- type: shader
   id: CameraStatic
   kind: source
   path: "/Textures/Shaders/camera_static.swsl"

--- a/Resources/Prototypes/status_effects.yml
+++ b/Resources/Prototypes/status_effects.yml
@@ -23,6 +23,9 @@
   id: AllCaps
 
 - type: statusEffect
+  id: SeeingRainbows
+
+- type: statusEffect
   id: Electrocution
 
 - type: statusEffect

--- a/Resources/Textures/Shaders/rainbow.swsl
+++ b/Resources/Textures/Shaders/rainbow.swsl
@@ -1,0 +1,63 @@
+﻿uniform sampler2D SCREEN_TEXTURE;
+uniform highp float effectScale;
+
+const highp float TimeScale = 0.15;
+const highp float DistortionScale = 0.02; // how strongly to warp the screen
+const highp float NoiseScale = 4.0; // scale of the random noise
+const highp float MaxColorMix = 0.05; // rainbow effect strength. at 1.0, you wont be able to see the screen anymore
+
+// hash(),  noise(), and hsv2rgb_smooth() were converted from shadertoy examples, which were released under the MIT License:
+// The MIT License
+// Copyright © 2013 Inigo Quilez
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// https://www.youtube.com/c/InigoQuilez
+// https://iquilezles.org
+highp vec2 hash( highp vec2 p ) {
+	p = vec2( dot(p,vec2(127.1,311.7)), dot(p,vec2(269.5,183.3)) );
+	return -1.0 + 2.0*fract(sin(p)*43758.5453123);
+}
+
+highp float noise( highp vec2 p ) {
+    const highp float K1 = 0.366025404;
+    const highp float K2 = 0.211324865;
+
+	highp vec2  i = floor( p + (p.x+p.y)*K1 );
+    highp vec2  a = p - i + (i.x+i.y)*K2;
+    highp float m = step(a.y,a.x); 
+    highp vec2  o = vec2(m,1.0-m);
+    highp vec2  b = a - o + K2;
+	highp vec2  c = a - 1.0 + 2.0*K2;
+    highp vec3  h = max( 0.5-vec3(dot(a,a), dot(b,b), dot(c,c) ), 0.0 );
+	highp vec3  n = h*h*h*h*vec3( dot(a,hash(i+0.0)), dot(b,hash(i+o)), dot(c,hash(i+1.0)));
+    return dot( n, vec3(70.0) );
+}
+
+highp vec3 hsv2rgb_smooth( highp vec3 c ) {
+    highp vec3 rgb = clamp( abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),6.0)-3.0)-1.0, 0.0, 1.0 );
+	rgb = rgb*rgb*(3.0-2.0*rgb);
+	return c.z * mix( vec3(1.0), rgb, c.y);
+}
+
+
+highp float mixNoise(highp vec2 point, highp float phase) {
+    highp float time = TIME * TimeScale + phase;
+	highp float a = noise( NoiseScale * point - time);
+    highp float b = noise( NoiseScale * point + time );
+    return mix(a,b,0.5);
+}
+
+void fragment() {
+    highp vec2 coord = FRAGCOORD.xy * SCREEN_PIXEL_SIZE.xy;
+    
+    // warp the screen.
+    highp vec2 offset = vec2(mixNoise(coord, 0.), mixNoise(coord, 5.));
+    COLOR = zTextureSpec(SCREEN_TEXTURE, coord + effectScale * DistortionScale * offset);
+    
+    // apply rainbow effect.
+    highp float hue = 1. + mixNoise(coord, 10.);
+    highp vec3 color = hsv2rgb_smooth(vec3(hue,1.0,1.0));
+    COLOR.xyz = mix(COLOR.xyz, color, MaxColorMix * effectScale * effectScale);
+}
+
+
+


### PR DESCRIPTION
Adds a basic shader effect for drugs that just distorts and re-colours the screen. Can probably be improved later, along with other effects like involuntary giggling or an accent. There's probably a much better shader that could be used, but this is better than having a blunt do nothing.

Here's an example video showing the effect with with doubled drug potency. Since recording I've increased the distortion and decreased the color effect a bit but its still pretty representative.

https://user-images.githubusercontent.com/60421075/175127799-bdb706ff-f683-4a85-94fb-f53adb0cf1e4.mp4

:cl:
- add: Some drugs now cause a visual effect when metabolised.

