### PR TITLE
Prevent content from overriding sprite shader 

### DIFF
--- a/Content.Client/DragDrop/DragDropSystem.cs
+++ b/Content.Client/DragDrop/DragDropSystem.cs
@@ -40,7 +40,6 @@ namespace Content.Client.DragDrop
         [Dependency] private readonly CombatModeSystem _combatMode = default!;
         [Dependency] private readonly InputSystem _inputSystem = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
-        [Dependency] private readonly SpriteSystem _spriteSystem = default!;
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
         // how often to recheck possible targets (prevents calling expensive
@@ -398,8 +397,13 @@ namespace Content.Client.DragDrop
                         && _interactionSystem.InRangeUnobstructed(dropArgs.Target, dropArgs.Target);
                 }
 
+                if (inRangeSprite.PostShader != null &&
+                    inRangeSprite.PostShader != _dropTargetInRangeShader &&
+                    inRangeSprite.PostShader != _dropTargetOutOfRangeShader)
+                    return;
+
                 // highlight depending on whether its in or out of range
-                _spriteSystem.SetPostShader(inRangeSprite.Owner, valid.Value ? _dropTargetInRangeShader : _dropTargetOutOfRangeShader, inRangeSprite);
+                inRangeSprite.PostShader = valid.Value ? _dropTargetInRangeShader : _dropTargetOutOfRangeShader;
                 inRangeSprite.RenderOrder = EntityManager.CurrentTick.Value;
                 _highlightedSprites.Add(inRangeSprite);
             }
@@ -409,7 +413,10 @@ namespace Content.Client.DragDrop
         {
             foreach (var highlightedSprite in _highlightedSprites)
             {
-                _spriteSystem.SetPostShader(highlightedSprite.Owner, null, highlightedSprite);
+                if (highlightedSprite.PostShader != _dropTargetInRangeShader && highlightedSprite.PostShader != _dropTargetOutOfRangeShader)
+                    continue;
+
+                highlightedSprite.PostShader = null;
                 highlightedSprite.RenderOrder = 0;
             }
 

--- a/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
+++ b/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
@@ -19,22 +19,23 @@ namespace Content.Client.Interactable.Components
         private ShaderInstance? _shader;
         private int _lastRenderScale;
 
-        public void OnMouseEnter(bool inInteractionRange, int renderScale)
+        public void OnMouseEnter(bool inInteractionRange, int renderScale, SpriteSystem sys)
         {
             _lastRenderScale = renderScale;
             _inRange = inInteractionRange;
-            if (_entMan.TryGetComponent(Owner, out ISpriteComponent? sprite))
+            if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite))
             {
-                sprite.PostShader = MakeNewShader(inInteractionRange, renderScale);
+                // TODO why the fuck is this creating a new instance of the outline shader every time the mouse enters???
+                sys.SetPostShader(Owner, MakeNewShader(inInteractionRange, renderScale), sprite);
                 sprite.RenderOrder = _entMan.CurrentTick.Value;
             }
         }
 
-        public void OnMouseLeave()
+        public void OnMouseLeave(SpriteSystem sys)
         {
-            if (_entMan.TryGetComponent(Owner, out ISpriteComponent? sprite))
+            if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite))
             {
-                sprite.PostShader = null;
+                sys.SetPostShader(Owner, null, sprite);
                 sprite.RenderOrder = 0;
             }
 
@@ -42,15 +43,16 @@ namespace Content.Client.Interactable.Components
             _shader = null;
         }
 
-        public void UpdateInRange(bool inInteractionRange, int renderScale)
+        public void UpdateInRange(bool inInteractionRange, int renderScale, SpriteSystem sys)
         {
-            if (_entMan.TryGetComponent(Owner, out ISpriteComponent? sprite)
+            if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite)
                 && (inInteractionRange != _inRange || _lastRenderScale != renderScale))
             {
                 _inRange = inInteractionRange;
                 _lastRenderScale = renderScale;
+
                 _shader = MakeNewShader(_inRange, _lastRenderScale);
-                sprite.PostShader = _shader;
+                sys.SetPostShader(Owner, _shader, sprite);
             }
         }
 

--- a/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
+++ b/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
@@ -25,7 +25,7 @@ namespace Content.Client.Interactable.Components
             _inRange = inInteractionRange;
             if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite))
             {
-                // TODO why the fuck is this creating a new instance of the outline shader every time the mouse enters???
+                // TODO why is this creating a new instance of the outline shader every time the mouse enters???
                 sys.SetPostShader(Owner, MakeNewShader(inInteractionRange, renderScale), sprite);
                 sprite.RenderOrder = _entMan.CurrentTick.Value;
             }

--- a/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
+++ b/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
@@ -19,23 +19,24 @@ namespace Content.Client.Interactable.Components
         private ShaderInstance? _shader;
         private int _lastRenderScale;
 
-        public void OnMouseEnter(bool inInteractionRange, int renderScale, SpriteSystem sys)
+        public void OnMouseEnter(bool inInteractionRange, int renderScale)
         {
             _lastRenderScale = renderScale;
             _inRange = inInteractionRange;
-            if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite))
+            if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite) && sprite.PostShader == null)
             {
                 // TODO why is this creating a new instance of the outline shader every time the mouse enters???
-                sys.SetPostShader(Owner, MakeNewShader(inInteractionRange, renderScale), sprite);
-                sprite.RenderOrder = _entMan.CurrentTick.Value;
+                _shader = MakeNewShader(inInteractionRange, renderScale);
+                sprite.PostShader = _shader;
             }
         }
 
-        public void OnMouseLeave(SpriteSystem sys)
+        public void OnMouseLeave()
         {
             if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite))
             {
-                sys.SetPostShader(Owner, null, sprite);
+                if (sprite.PostShader == _shader)
+                    sprite.PostShader = null;
                 sprite.RenderOrder = 0;
             }
 
@@ -43,16 +44,17 @@ namespace Content.Client.Interactable.Components
             _shader = null;
         }
 
-        public void UpdateInRange(bool inInteractionRange, int renderScale, SpriteSystem sys)
+        public void UpdateInRange(bool inInteractionRange, int renderScale)
         {
             if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite)
+                && sprite.PostShader == _shader
                 && (inInteractionRange != _inRange || _lastRenderScale != renderScale))
             {
                 _inRange = inInteractionRange;
                 _lastRenderScale = renderScale;
 
                 _shader = MakeNewShader(_inRange, _lastRenderScale);
-                sys.SetPostShader(Owner, _shader, sprite);
+                sprite.PostShader = _shader;
             }
         }
 

--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -1,9 +1,9 @@
 using Content.Client.ContextMenu.UI;
-using Content.Client.Interactable;
 using Content.Client.Interactable.Components;
 using Content.Client.Viewport;
 using Content.Shared.CCVar;
 using Content.Shared.Interaction;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
@@ -23,6 +23,7 @@ public sealed class InteractionOutlineSystem : EntitySystem
     [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly SpriteSystem _spriteSystem = default!;
 
     /// <summary>
     ///     Whether to currently draw the outline. The outline may be temporarily disabled by other systems
@@ -63,7 +64,7 @@ public sealed class InteractionOutlineSystem : EntitySystem
             return;
 
         if (TryComp(_lastHoveredEntity, out InteractionOutlineComponent? outline))
-            outline.OnMouseLeave();
+            outline.OnMouseLeave(_spriteSystem);
     }
 
     public void SetEnabled(bool enabled)
@@ -82,7 +83,7 @@ public sealed class InteractionOutlineSystem : EntitySystem
             return;
 
         if (TryComp(_lastHoveredEntity, out InteractionOutlineComponent? outline))
-            outline.OnMouseLeave();
+            outline.OnMouseLeave(_spriteSystem);
     }
 
     public override void FrameUpdate(float frameTime)
@@ -145,7 +146,7 @@ public sealed class InteractionOutlineSystem : EntitySystem
         {
             if (entityToClick != null && TryComp(entityToClick, out outline))
             {
-                outline.UpdateInRange(inRange, renderScale);
+                outline.UpdateInRange(inRange, renderScale, _spriteSystem);
             }
 
             return;
@@ -154,14 +155,14 @@ public sealed class InteractionOutlineSystem : EntitySystem
         if (_lastHoveredEntity != null && !Deleted(_lastHoveredEntity) &&
             TryComp(_lastHoveredEntity, out outline))
         {
-            outline.OnMouseLeave();
+            outline.OnMouseLeave(_spriteSystem);
         }
 
         _lastHoveredEntity = entityToClick;
 
         if (_lastHoveredEntity != null && TryComp(_lastHoveredEntity, out outline))
         {
-            outline.OnMouseEnter(inRange, renderScale);
+            outline.OnMouseEnter(inRange, renderScale, _spriteSystem);
         }
     }
 }

--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -23,7 +23,6 @@ public sealed class InteractionOutlineSystem : EntitySystem
     [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
-    [Dependency] private readonly SpriteSystem _spriteSystem = default!;
 
     /// <summary>
     ///     Whether to currently draw the outline. The outline may be temporarily disabled by other systems
@@ -64,7 +63,7 @@ public sealed class InteractionOutlineSystem : EntitySystem
             return;
 
         if (TryComp(_lastHoveredEntity, out InteractionOutlineComponent? outline))
-            outline.OnMouseLeave(_spriteSystem);
+            outline.OnMouseLeave();
     }
 
     public void SetEnabled(bool enabled)
@@ -83,7 +82,7 @@ public sealed class InteractionOutlineSystem : EntitySystem
             return;
 
         if (TryComp(_lastHoveredEntity, out InteractionOutlineComponent? outline))
-            outline.OnMouseLeave(_spriteSystem);
+            outline.OnMouseLeave();
     }
 
     public override void FrameUpdate(float frameTime)
@@ -146,7 +145,7 @@ public sealed class InteractionOutlineSystem : EntitySystem
         {
             if (entityToClick != null && TryComp(entityToClick, out outline))
             {
-                outline.UpdateInRange(inRange, renderScale, _spriteSystem);
+                outline.UpdateInRange(inRange, renderScale);
             }
 
             return;
@@ -155,14 +154,14 @@ public sealed class InteractionOutlineSystem : EntitySystem
         if (_lastHoveredEntity != null && !Deleted(_lastHoveredEntity) &&
             TryComp(_lastHoveredEntity, out outline))
         {
-            outline.OnMouseLeave(_spriteSystem);
+            outline.OnMouseLeave();
         }
 
         _lastHoveredEntity = entityToClick;
 
         if (_lastHoveredEntity != null && TryComp(_lastHoveredEntity, out outline))
         {
-            outline.OnMouseEnter(inRange, renderScale, _spriteSystem);
+            outline.OnMouseEnter(inRange, renderScale);
         }
     }
 }

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -21,6 +21,7 @@ public sealed class TargetOutlineSystem : EntitySystem
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly SpriteSystem _spriteSystem = default!;
 
     private bool _enabled = false;
 
@@ -145,7 +146,7 @@ public sealed class TargetOutlineSystem : EntitySystem
                 // was this previously valid?
                 if (_highlightedSprites.Remove(sprite))
                 {
-                    sprite.PostShader = null;
+                    _spriteSystem.SetPostShader(sprite.Owner, null, sprite);
                     sprite.RenderOrder = 0;
                 }
 
@@ -163,7 +164,7 @@ public sealed class TargetOutlineSystem : EntitySystem
             }
 
             // highlight depending on whether its in or out of range
-            sprite.PostShader = valid ? _shaderTargetValid : _shaderTargetInvalid;
+            _spriteSystem.SetPostShader(sprite.Owner, valid ? _shaderTargetValid : _shaderTargetInvalid, sprite);
             sprite.RenderOrder = EntityManager.CurrentTick.Value;
             _highlightedSprites.Add(sprite);
         }
@@ -173,7 +174,7 @@ public sealed class TargetOutlineSystem : EntitySystem
     {
         foreach (var sprite in _highlightedSprites)
         {
-            sprite.PostShader = null;
+            _spriteSystem.SetPostShader(sprite.Owner, null, sprite);
             sprite.RenderOrder = 0;
         }
 

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -144,9 +144,9 @@ public sealed class TargetOutlineSystem : EntitySystem
             if (!valid)
             {
                 // was this previously valid?
-                if (_highlightedSprites.Remove(sprite))
+                if (_highlightedSprites.Remove(sprite) && (sprite.PostShader == _shaderTargetValid || sprite.PostShader == _shaderTargetInvalid))
                 {
-                    _spriteSystem.SetPostShader(sprite.Owner, null, sprite);
+                    sprite.PostShader = null;
                     sprite.RenderOrder = 0;
                 }
 
@@ -163,8 +163,13 @@ public sealed class TargetOutlineSystem : EntitySystem
                 valid = (origin - target).LengthSquared <= Range;
             }
 
+            if (sprite.PostShader != null &&
+                sprite.PostShader != _shaderTargetValid &&
+                sprite.PostShader != _shaderTargetInvalid)
+                return;
+
             // highlight depending on whether its in or out of range
-            _spriteSystem.SetPostShader(sprite.Owner, valid ? _shaderTargetValid : _shaderTargetInvalid, sprite);
+            sprite.PostShader = valid ? _shaderTargetValid : _shaderTargetInvalid;
             sprite.RenderOrder = EntityManager.CurrentTick.Value;
             _highlightedSprites.Add(sprite);
         }
@@ -174,7 +179,10 @@ public sealed class TargetOutlineSystem : EntitySystem
     {
         foreach (var sprite in _highlightedSprites)
         {
-            _spriteSystem.SetPostShader(sprite.Owner, null, sprite);
+            if (sprite.PostShader != _shaderTargetValid && sprite.PostShader != _shaderTargetInvalid)
+                continue;
+
+            sprite.PostShader = null;
             sprite.RenderOrder = 0;
         }
 


### PR DESCRIPTION
Previously used a system setter function & cancellable attempt events, but now just explicitly checking if the current shader is null or matches a system's existing shader before making changes.

See space-wizards/RobustToolbox/pull/2974