### PR TITLE
Fix node network error spam

### DIFF
--- a/Content.Server/AME/AMENodeGroup.cs
+++ b/Content.Server/AME/AMENodeGroup.cs
@@ -37,14 +37,21 @@ namespace Content.Server.AME
             base.LoadNodes(groupNodes);
 
             var mapManager = IoCManager.Resolve<IMapManager>();
-            var grid = mapManager.GetGrid(GridId);
+            IMapGrid? grid = null;
 
             foreach (var node in groupNodes)
             {
                 var nodeOwner = node.Owner;
                 if (_entMan.TryGetComponent(nodeOwner, out AMEShieldComponent? shield))
                 {
-                    var nodeNeighbors = grid.GetCellsInSquareArea(_entMan.GetComponent<TransformComponent>(nodeOwner).Coordinates, 1)
+                    var xform = _entMan.GetComponent<TransformComponent>(nodeOwner);
+                    if (xform.GridUid != grid?.GridEntityId && !mapManager.TryGetGrid(xform.GridUid, out grid))
+                        continue;
+
+                    if (grid == null)
+                        continue;
+
+                    var nodeNeighbors = grid.GetCellsInSquareArea(xform.Coordinates, 1)
                         .Where(entity => entity != nodeOwner && _entMan.HasComponent<AMEShieldComponent>(entity));
 
                     if (nodeNeighbors.Count() >= 8)

--- a/Content.Server/NodeContainer/NodeGroups/BaseNodeGroup.cs
+++ b/Content.Server/NodeContainer/NodeGroups/BaseNodeGroup.cs
@@ -56,9 +56,6 @@ namespace Content.Server.NodeContainer.NodeGroups
         [ViewVariables]
         public bool Removed { get; set; } = false;
 
-        [ViewVariables]
-        protected EntityUid GridId { get; private set; }
-
         /// <summary>
         ///     Network ID of this group for client-side debug visualization of nodes.
         /// </summary>
@@ -75,12 +72,6 @@ namespace Content.Server.NodeContainer.NodeGroups
 
         public virtual void Initialize(Node sourceNode, IEntityManager? entMan = null)
         {
-            // TODO: Can we get rid of this GridId?
-            IoCManager.Resolve(ref entMan);
-
-            var xform = entMan.GetComponent<TransformComponent>(sourceNode.Owner);
-            DebugTools.AssertNotNull(xform.GridUid);
-            GridId = xform.GridUid!.Value;
         }
 
         /// <summary>

--- a/Content.Server/NodeContainer/NodeGroups/PipeNet.cs
+++ b/Content.Server/NodeContainer/NodeGroups/PipeNet.cs
@@ -22,13 +22,20 @@ namespace Content.Server.NodeContainer.NodeGroups
 
         [ViewVariables] private AtmosphereSystem? _atmosphereSystem;
 
-        public EntityUid Grid => GridId;
+        public EntityUid? Grid { get; private set; }
 
         public override void Initialize(Node sourceNode, IEntityManager? entMan = null)
         {
+            IoCManager.Resolve(ref entMan);
+
             base.Initialize(sourceNode, entMan);
 
-            _atmosphereSystem = EntitySystem.Get<AtmosphereSystem>();
+            Grid = entMan.GetComponent<TransformComponent>(sourceNode.Owner).GridUid;
+
+            if (Grid == null)
+                Logger.Error($"Created a pipe network without an associated grid. Pipe networks currently need to be tied to a grid for amtos to work. Source entity: {entMan.ToPrettyString(sourceNode.Owner)}");
+
+            _atmosphereSystem = entMan.EntitySysManager.GetEntitySystem<AtmosphereSystem>();
             _atmosphereSystem.AddPipeNet(this);
         }
 

--- a/Content.Server/Power/NodeGroups/ApcNet.cs
+++ b/Content.Server/Power/NodeGroups/ApcNet.cs
@@ -20,8 +20,6 @@ namespace Content.Server.Power.NodeGroups
         void RemovePowerProvider(ApcPowerProviderComponent provider);
 
         void QueueNetworkReconnect();
-
-        EntityUid? GridId { get; }
     }
 
     [NodeGroup(NodeGroupID.Apc)]
@@ -40,8 +38,6 @@ namespace Content.Server.Power.NodeGroups
         [ViewVariables]
         private IEnumerable<ApcPowerReceiverComponent> AllReceivers =>
             Providers.SelectMany(provider => provider.LinkedReceivers);
-
-        EntityUid? IApcNet.GridId => GridId;
 
         [ViewVariables]
         public PowerState.Network NetworkNode { get; } = new();


### PR DESCRIPTION
Stops the node system from crashing if the grid id is null, but something has probably still gone wrong if that is the case.
Wasn't occurring before because grid ids weren't nullable and the problem was just being ignored.