### PR TITLE
Cleans up the appearance and ambience of various atmos devices.

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -30,12 +30,19 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
         {
             base.Initialize();
 
+            SubscribeLocalEvent<GasVolumePumpComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<GasVolumePumpComponent, AtmosDeviceUpdateEvent>(OnVolumePumpUpdated);
+            SubscribeLocalEvent<GasVolumePumpComponent, AtmosDeviceDisabledEvent>(OnVolumePumpLeaveAtmosphere);
             SubscribeLocalEvent<GasVolumePumpComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<GasVolumePumpComponent, InteractHandEvent>(OnPumpInteractHand);
             // Bound UI subscriptions
             SubscribeLocalEvent<GasVolumePumpComponent, GasVolumePumpChangeTransferRateMessage>(OnTransferRateChangeMessage);
             SubscribeLocalEvent<GasVolumePumpComponent, GasVolumePumpToggleStatusMessage>(OnToggleStatusMessage);
+        }
+
+        private void OnInit(EntityUid uid, GasVolumePumpComponent pump, ComponentInit args)
+        {
+            UpdateAppearance(uid, pump);
         }
 
         private void OnExamined(EntityUid uid, GasVolumePumpComponent pump, ExaminedEvent args)
@@ -52,21 +59,15 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
 
         private void OnVolumePumpUpdated(EntityUid uid, GasVolumePumpComponent pump, AtmosDeviceUpdateEvent args)
         {
-            TryComp(uid, out AppearanceComponent? appearance);
-
             if (!pump.Enabled
                 || !TryComp(uid, out NodeContainerComponent? nodeContainer)
                 || !TryComp(uid, out AtmosDeviceComponent? device)
                 || !nodeContainer.TryGetNode(pump.InletName, out PipeNode? inlet)
                 || !nodeContainer.TryGetNode(pump.OutletName, out PipeNode? outlet))
             {
-                appearance?.SetData(PumpVisuals.Enabled, false);
-                _ambientSoundSystem.SetAmbience(pump.Owner, false);
                 _ambientSoundSystem.SetAmbience(pump.Owner, false);
                 return;
             }
-
-            appearance?.SetData(PumpVisuals.Enabled, true);
 
             var inputStartingPressure = inlet.Air.Pressure;
             var outputStartingPressure = outlet.Air.Pressure;
@@ -78,8 +79,6 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             // Overclocked pumps can only force gas a certain amount.
             if ((outputStartingPressure - inputStartingPressure > pump.OverclockThreshold) && pump.Overclocked)
                 return;
-
-            _ambientSoundSystem.SetAmbience(pump.Owner, true);
 
             // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.
             var transferRatio = (float)(pump.TransferRate * (_gameTiming.CurTime - device.LastProcess).TotalSeconds) / inlet.Air.Volume;
@@ -99,17 +98,27 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             }
 
             _atmosphereSystem.Merge(outlet.Air, removed);
+            _ambientSoundSystem.SetAmbience(pump.Owner, removed.TotalMoles > 0f);
         }
 
-        private void OnPumpInteractHand(EntityUid uid, GasVolumePumpComponent component, InteractHandEvent args)
+        private void OnVolumePumpLeaveAtmosphere(EntityUid uid, GasVolumePumpComponent pump, AtmosDeviceDisabledEvent args)
+        {
+            pump.Enabled = false;
+            UpdateAppearance(uid, pump);
+
+            DirtyUI(uid, pump);
+            _userInterfaceSystem.TryCloseAll(uid, GasVolumePumpUiKey.Key);
+        }
+
+        private void OnPumpInteractHand(EntityUid uid, GasVolumePumpComponent pump, InteractHandEvent args)
         {
             if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
                 return;
 
-            if (EntityManager.GetComponent<TransformComponent>(component.Owner).Anchored)
+            if (EntityManager.GetComponent<TransformComponent>(pump.Owner).Anchored)
             {
                 _userInterfaceSystem.TryOpen(uid, GasVolumePumpUiKey.Key, actor.PlayerSession);
-                DirtyUI(uid, component);
+                DirtyUI(uid, pump);
             }
             else
             {
@@ -125,6 +134,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             _adminLogger.Add(LogType.AtmosPowerChanged, LogImpact.Medium,
                 $"{ToPrettyString(args.Session.AttachedEntity!.Value):player} set the power on {ToPrettyString(uid):device} to {args.Enabled}");
             DirtyUI(uid, pump);
+            UpdateAppearance(uid, pump);
         }
 
         private void OnTransferRateChangeMessage(EntityUid uid, GasVolumePumpComponent pump, GasVolumePumpChangeTransferRateMessage args)
@@ -142,6 +152,14 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
 
             _userInterfaceSystem.TrySetUiState(uid, GasVolumePumpUiKey.Key,
                 new GasVolumePumpBoundUserInterfaceState(EntityManager.GetComponent<MetaDataComponent>(pump.Owner).EntityName, pump.TransferRate, pump.Enabled));
+        }
+
+        private void UpdateAppearance(EntityUid uid, GasVolumePumpComponent? pump = null, AppearanceComponent? appearance = null)
+        {
+            if (!Resolve(uid, ref pump, ref appearance, false))
+                return;
+
+            appearance.SetData(PumpVisuals.Enabled, pump.Enabled);
         }
     }
 }


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #8913

- Filter, mixer, pressure pump and volume pump code has been cleaned up.
- They appear on when they're enabled, and off when they're disabled.
- Their ambience only plays if they're actually transferring any gas.

:cl:
- tweak: Filters, mixers, pressure pumps and volume pumps now always appear on when they're enabled, not only when they're transferring gas.
