### PR TITLE
Stop labeling draft PRs with merge conflicts

### DIFF
--- a/.github/workflows/conflict-labeler.yml
+++ b/.github/workflows/conflict-labeler.yml
@@ -9,10 +9,9 @@ on:
 jobs:
   Label:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
       - name: Check for Merge Conflicts
-        uses: eps1lon/actions-label-merge-conflict@513a24fc7dca40990863be2935e059e650728400
+        uses: ike709/actions-label-merge-conflict@9eefdd17e10566023c46d2dc6dc04fcb8ec76142
         with:
           dirtyLabel: "Merge Conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

See title. I don't know if I need to do anything for a "new" uses action but it's not like this will ruin critical infra if it doesn't work.

https://github.com/ike709/actions-label-merge-conflict/commit/9eefdd17e10566023c46d2dc6dc04fcb8ec76142