### PR TITLE
Jetpack Locker Fills and Captain Jetpack Traitor Objective

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -56,6 +56,7 @@
       - id: ClothingNeckGoldmedal
       - id: RubberStampCaptain
       - id: WeaponAntiqueLaser
+      - id: JetpackCaptainFilled
 
 - type: entity
   id: LockerHeadOfPersonnelFilled
@@ -105,6 +106,7 @@
         prob: 0.15
       - id: DoorRemoteEngineering
       - id: RubberStampCE
+      - id: JetpackVoidFilled
 
 - type: entity
   id: LockerChiefMedicalOfficerFilled
@@ -188,3 +190,4 @@
       - id: ClothingUniformJumpsuitHosFormal
       - id: RubberStampHos
       - id: SecurityTechFabCircuitboard
+      - id: JetpackSecurityFilled

--- a/Resources/Prototypes/Objectives/traitorObjectives..yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives..yml
@@ -171,3 +171,16 @@
     - !type:StealCondition
       prototype: WeaponAntiqueLaser
 
+- type: objective
+  id: CaptainJetpackStealObjective
+  issuer: syndicate
+  difficultyOverride: 2.75
+  prob: 0.1
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+  conditions:
+    - !type:StealCondition
+      prototype: JetpackCaptainFilled


### PR DESCRIPTION
changelog
-captains jetpack spawns in captains locker and is a high risk item
-hos has a jetpack in their locker
-ce has a jetpack in their locker
REST WILL HAVE TO BE MAPPED IN FOR EVA AND STUF

