### PR TITLE
The Fatphobic PR (chef main nerf)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -18,6 +18,8 @@
           Quantity: 30
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentID: Cholesterol
+          Quantity: 12
   - type: SliceableFood
     count: 6
   - type: Item
@@ -45,6 +47,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 0.8
+        - ReagentId: Cholesterol
+          Quantity: 2
   - type: Item
     size: 1
   - type: Tag
@@ -167,6 +171,8 @@
           Quantity: 6
         - ReagentId: Omnizine
           Quantity: 9
+        - ReagentId: Cholesterol
+          Quantity: 10.8
 
 
 - type: entity
@@ -189,6 +195,8 @@
           Quantity: 1
         - ReagentId: Omnizine
           Quantity: 1.5
+        - ReagentId: Cholesterol
+          Quantity: 1.8
 # Tastes like crust, tomato, cheese, meat, laziness.
 
 - type: entity
@@ -213,6 +221,8 @@
           Quantity: 5
         - ReagentId: DoctorsDelight
           Quantity: 6
+        - ReagentId: Cholesterol
+          Quantity: 12
 
 - type: entity
   name: slice of dank pizza
@@ -234,6 +244,8 @@
           Quantity: 0.8
         - ReagentId: DoctorsDelight
           Quantity: 1
+        - ReagentId: Cholesterol
+          Quantity: 2
 # Tastes like crust, tomato, cheese, meat, satisfaction.
 
 - type: entity
@@ -354,4 +366,6 @@
           Quantity: 2
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Cholesterol
+          Quantity: 2
 # Tastes like stale crust, rancid cheese, mushroom.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -419,7 +419,7 @@
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 1
-        ReagentId: Cholesterol
+        - ReagentId: Cholesterol
           Quantity: 4
 # Tastes like muffin, bacon.
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -206,6 +206,8 @@
           Quantity: 17
         - ReagentId: Vitamin
           Quantity: 9
+        - ReagentId: Cholesterol
+          Quantity: 7
   - type: Sprite
     state: bigbite
 # Tastes like bun, silver, magic.
@@ -229,6 +231,8 @@
           Quantity: 5
         - ReagentId: Blackpepper
           Quantity: 5
+        - ReagentId: Cholesterol
+          Quantity: 14
   - type: Sprite
     state: superbite
 # Tastes like bun, diabetes.
@@ -254,6 +258,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Cholesterol
+          Quantity: 3
 
 # Tastes like bun, HEAT.
 
@@ -273,6 +279,8 @@
         - ReagentId: Nutriment
           Quantity: 3
         - ReagentId: Vitamin
+          Quantity: 1
+        - ReagentId: Cholesterol
           Quantity: 1
 # Tastes like bun, HEAT.
 
@@ -302,6 +310,8 @@
           Quantity: 19
         - ReagentId: Vitamin
           Quantity: 5
+        - ReagentId: Cholesterol
+          Quantity: 6
 # Tastes like bun, bacon.
 
 - type: entity
@@ -342,6 +352,8 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Cholesterol
+          Quantity: 3
 # Tastes like bun, crab meat.
 
 - type: entity
@@ -384,6 +396,8 @@
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 4
+        - ReagentId: Cholesterol
+          Quantity: 4
 # Tastes like bun, pork patty.
 
 - type: entity
@@ -405,6 +419,8 @@
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 1
+        ReagentId: Cholesterol
+          Quantity: 4
 # Tastes like muffin, bacon.
 
 - type: entity
@@ -426,6 +442,8 @@
           Quantity: 7
         - ReagentId: Vitamin
           Quantity: 1
+        - ReagentId: Cholesterol
+          Quantity: 2
 # Tastes like bun, chicken.
 
 - type: entity
@@ -446,6 +464,8 @@
         - ReagentId: Protein
           Quantity: 7
         - ReagentId: Vitamin
+          Quantity: 1
+        - ReagentId: Cholesterol
           Quantity: 1
 # Tastes like bun, duck.
 
@@ -468,6 +488,8 @@
           Quantity: 7
         - ReagentId: Protein
           Quantity: 1
+        - ReagentId: Cholesterol
+          Quantity: 4
 # TODO: Make this work.
   # - type: Sprite
   #   state: plate

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -63,7 +63,7 @@
   color: “#fcfcfc”
   boilingPoint: 360
   meltingPoint: 148
-    metabolisms:
+  metabolisms:
       Poison:
         effects:
           - !type:HealthChange

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -69,10 +69,10 @@
           - !type:HealthChange
             conditions:
             - !type:ReagentThreshold
-              min: 7
+              min: 15
             damage:
               groups:
-                Asphyxiation: 6
+                Asphyxiation: 8
           - !type:ModifyBleedAmounts #heart attacks cause blood to thicken slightly
             amount: -0.05
           - !type:PopupMessage # technically this should be different by gender but I don't want to complicate it

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -71,7 +71,7 @@
             - !type:ReagentThreshold
               min: 15
             damage:
-              groups:
+              types:
                 Asphyxiation: 8
           - !type:ModifyBleedAmount #heart attacks cause blood to thicken slightly
             amount: -0.05

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -56,28 +56,28 @@
       - !type:SatiateHunger
 
 - type: reagent
-	id: Cholesterol
-	name: reagent-name-cholesterol
-	desc: reagent-desc-cholesterol
-	physicalDesc: reagent-physical-desc-crystalline
-	color: “#fcfcfc”
-	boilingPoint: 360
-	meltingPoint: 148
-	metabolisms:
-		Poison:
-			effects:
-			- !type:HealthChange
-				conditions:
-				- !type:ReagentThreshold
-					min: 7
-				damage:
-					groups:
-						Asphyxiation: 6
-			- !type:ModifyBleedAmounts #heart attacks cause blood to thicken slightly
-				amount: -0.05
-			- !type:PopupMessage # technically this should be different by gender but I don't want to complicate it
-				messages: [“ephedrine-effect-tight-pain”, “ephedrine-effect-heart-pounds”]
-				type: Local
-				probability: 0.05
+id: Cholesterol
+name: reagent-name-cholesterol
+desc: reagent-desc-cholesterol
+physicalDesc: reagent-physical-desc-crystalline
+color: “#fcfcfc”
+boilingPoint: 360
+meltingPoint: 148
+metabolisms:
+Poison:
+effects:
+- !type:HealthChange
+conditions:
+- !type:ReagentThreshold
+min: 7
+damage:
+groups:
+Asphyxiation: 6
+- !type:ModifyBleedAmounts #heart attacks cause blood to thicken slightly
+amount: -0.05
+- !type:PopupMessage # technically this should be different by gender but I don't want to complicate it
+messages: [“ephedrine-effect-tight-pain”, “ephedrine-effect-heart-pounds”]
+type: Local
+probability: 0.05
         
         

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -56,13 +56,13 @@
       - !type:SatiateHunger
 
 - type: reagent
-id: Cholesterol
-name: reagent-name-cholesterol
-desc: reagent-desc-cholesterol
-physicalDesc: reagent-physical-desc-crystalline
-color: “#fcfcfc”
-boilingPoint: 360
-meltingPoint: 148
+  id: Cholesterol
+  name: reagent-name-cholesterol
+  desc: reagent-desc-cholesterol
+  physicalDesc: reagent-physical-desc-crystalline
+  color: “#fcfcfc”
+  boilingPoint: 360
+  meltingPoint: 148
 metabolisms:
 Poison:
 effects:

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -63,16 +63,16 @@
   color: “#fcfcfc”
   boilingPoint: 360
   meltingPoint: 148
-metabolisms:
-Poison:
-effects:
-- !type:HealthChange
-conditions:
-- !type:ReagentThreshold
-min: 7
-damage:
-groups:
-Asphyxiation: 6
+    metabolisms:
+      Poison:
+        effects:
+          - !type:HealthChange
+            conditions:
+            - !type:ReagentThreshold
+              min: 7
+            damage:
+              groups:
+                Asphyxiation: 6
 - !type:ModifyBleedAmounts #heart attacks cause blood to thicken slightly
 amount: -0.05
 - !type:PopupMessage # technically this should be different by gender but I don't want to complicate it

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -60,7 +60,7 @@
   name: reagent-name-cholesterol
   desc: reagent-desc-cholesterol
   physicalDesc: reagent-physical-desc-crystalline
-  color: “#ffffff”
+  color: “#FFFFFF”
   boilingPoint: 360
   meltingPoint: 148
   metabolisms:

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -73,11 +73,11 @@
             damage:
               groups:
                 Asphyxiation: 6
-- !type:ModifyBleedAmounts #heart attacks cause blood to thicken slightly
-amount: -0.05
-- !type:PopupMessage # technically this should be different by gender but I don't want to complicate it
-messages: [“ephedrine-effect-tight-pain”, “ephedrine-effect-heart-pounds”]
-type: Local
-probability: 0.05
+          - !type:ModifyBleedAmounts #heart attacks cause blood to thicken slightly
+            amount: -0.05
+          - !type:PopupMessage # technically this should be different by gender but I don't want to complicate it
+            messages: [“ephedrine-effect-tight-pain”, “ephedrine-effect-heart-pounds”]
+            type: Local
+            probability: 0.05
         
         

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -60,7 +60,7 @@
   name: reagent-name-cholesterol
   desc: reagent-desc-cholesterol
   physicalDesc: reagent-physical-desc-crystalline
-  color: “#fcfcfc”
+  color: “#ffffff”
   boilingPoint: 360
   meltingPoint: 148
   metabolisms:

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -60,7 +60,7 @@
   name: reagent-name-cholesterol
   desc: reagent-desc-cholesterol
   physicalDesc: reagent-physical-desc-crystalline
-  color: “#FFFFFF”
+  color: "#FFFFFF"
   boilingPoint: 360
   meltingPoint: 148
   metabolisms:

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -73,7 +73,7 @@
             damage:
               groups:
                 Asphyxiation: 8
-          - !type:ModifyBleedAmounts #heart attacks cause blood to thicken slightly
+          - !type:ModifyBleedAmount #heart attacks cause blood to thicken slightly
             amount: -0.05
           - !type:PopupMessage # technically this should be different by gender but I don't want to complicate it
             messages: [“ephedrine-effect-tight-pain”, “ephedrine-effect-heart-pounds”]

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -55,3 +55,29 @@
         amount: 1 # weaker than iron but pretty good all things considered
       - !type:SatiateHunger
 
+- type: reagent
+	id: Cholesterol
+	name: reagent-name-cholesterol
+	desc: reagent-desc-cholesterol
+	physicalDesc: reagent-physical-desc-crystalline
+	color: “#fcfcfc”
+	boilingPoint: 360
+	meltingPoint: 148
+	metabolisms:
+		Poison:
+			effects:
+			- !type:HealthChange
+				conditions:
+				- !type:ReagentThreshold
+					min: 7
+				damage:
+					groups:
+						Asphyxiation: 6
+			- !type:ModifyBleedAmounts #heart attacks cause blood to thicken slightly
+				amount: -0.05
+			- !type:PopupMessage # technically this should be different by gender but I don't want to complicate it
+				messages: [“ephedrine-effect-tight-pain”, “ephedrine-effect-heart-pounds”]
+				type: Local
+				probability: 0.05
+        
+        


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cholesterol is now coded in as a reagent, currently only burgers and pizza have cholesterol in them, but this can change. If too much cholesterol is present in a person they will suffer a heart attack. Dealing asphyxiation damage, and _slightly_ slowing any bleeding. They are alerted with chest pains

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Cholesterol has been added to burgers and pizza, have too much cholesterol at once and you'll have a heart attack. Chefs, make some healthier food! Or just don't eat so much
- remove: Removed fun!

