### PR TITLE
Remove common channel from syndie headset

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -70,7 +70,6 @@
   components:
   - type: Headset
     channels:
-    - Common
     - Syndicate
   - type: Sprite
     sprite: Clothing/Ears/Headsets/syndicate.rsi


### PR DESCRIPTION
:cl:
- tweak: Nukies now no longer get the Common channel.