### PR TITLE
Make space mobs immune to stun and knockdown

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -110,8 +110,6 @@
   - type: Internals
   - type: StatusEffects
     allowed:
-    - Stun
-    - KnockedDown
     - SlowedDown
     - Stutter
     - Electrocution
@@ -180,6 +178,13 @@
     damage:
       types:
         Blunt: 0.15 #per second, scales with pressure and other constants.
+  - type: StatusEffects
+    allowed:
+      - Stun
+      - KnockedDown
+      - SlowedDown
+      - Stutter
+      - Electrocution
   - type: ThermalRegulator
     metabolismHeat: 800
     radiatedHeat: 100


### PR DESCRIPTION
The only time stuns are good in this game is security catching traitors, being able to 1v1 stunlock a dragon to death is kinda cringe.

:cl:
- tweak: Space mobs are now stun immune to make combat a bit more interesting.