### PR TITLE
Don't allow you to melee attack yourself

### DIFF
--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -74,7 +74,7 @@ namespace Content.Server.Weapon.Melee
             args.Handled = true;
             var curTime = _gameTiming.CurTime;
 
-            if (curTime < comp.CooldownEnd || args.Target == null)
+            if (curTime < comp.CooldownEnd || args.Target == null || args.Target == owner)
                 return;
 
             var location = Transform(args.User).Coordinates;


### PR DESCRIPTION
There may be some situations to allow it but in actual combat if you have a big sprite like space dragon it's VERY easy to hit yourself and do sizeable damage.

:cl:
- tweak: It's no longer possible to melee yourself.
