### PR TITLE
Fireaxe cabinet lock and fireaxe actually heavy again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -24,7 +24,7 @@
         Blunt: -2 # negative reductions = increases
         Slash: -8
   - type: Clothing
-    size: 20
+    size: 100
     sprite: Objects/Weapons/Melee/fireaxe.rsi
     quickEquip: false
     Slots:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -24,7 +24,7 @@
         Blunt: -2 # negative reductions = increases
         Slash: -8
   - type: Clothing
-    size: 100
+    size: 150
     sprite: Objects/Weapons/Melee/fireaxe.rsi
     quickEquip: false
     Slots:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -33,6 +33,8 @@
     - type: ItemCabinetVisuals
       openState: glass-up
       closedState: glass
+    - type: AccessReader
+      access: [["Atmospherics"]]
   placement:
     mode: SnapgridCenter
 


### PR DESCRIPTION
changelog
-locks fireaxe cabinet to atmos
-makes fireaxe weigh 150 (you cant bag it now you have to wear it on your back)

this needed to happen at some point
this doesnt change the syndi fire axe in anyway just the one from atmos/bridge