### PR TITLE
Trashbag Alt Verb to dump into disposals + Cigars are tagged as trash

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -96,26 +96,28 @@ namespace Content.Server.Disposal.Unit.EntitySystems
                 args.Verbs.Add(flushVerb);
 
                 // Verb to eject the contents
-                AlternativeVerb ejectVerb = new();
-                ejectVerb.Act = () => TryEjectContents(component);
-                ejectVerb.Category = VerbCategory.Eject;
-                ejectVerb.Text = Loc.GetString("disposal-eject-verb-contents");
+                AlternativeVerb ejectVerb = new()
+                {
+                    Act = () => TryEjectContents(component),
+                    Category = VerbCategory.Eject,
+                    Text = Loc.GetString("disposal-eject-verb-contents")
+                };
                 args.Verbs.Add(ejectVerb);
             }
 
             // Behavior if using a trash bag & other dumpable containers
             if (args.Using != null
-                && HasComp<DumpableComponent>(args.Using.Value)
                 && TryComp<DumpableComponent>(args.Using.Value, out var dumpable)
                 && TryComp<ServerStorageComponent>(args.Using.Value, out var storage)
-                && storage.StoredEntities != null
-                && storage.StoredEntities.Count > 0)
+                && storage.StoredEntities is { Count: > 0 })
             {
                 // Verb to dump held container into disposal unit
-                AlternativeVerb dumpVerb = new();
-                dumpVerb.Act = () => _dumpableSystem.StartDoAfter(args.Using.Value, args.Target, args.User, dumpable, storage);
-                dumpVerb.Text = Loc.GetString("dump-disposal-verb-name", ("unit", args.Target));
-                dumpVerb.Priority = 2;
+                AlternativeVerb dumpVerb = new()
+                {
+                    Act = () => _dumpableSystem.StartDoAfter(args.Using.Value, args.Target, args.User, dumpable, storage),
+                    Text = Loc.GetString("dump-disposal-verb-name", ("unit", args.Target)),
+                    Priority = 2
+                };
                 args.Verbs.Add(dumpVerb);
             }
 

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -37,7 +37,6 @@ namespace Content.Server.Disposal.Unit.EntitySystems
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
-        [Dependency] private readonly IEntityManager _entMan = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
         [Dependency] private readonly AtmosphereSystem _atmosSystem = default!;
         [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
@@ -106,7 +105,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
 
             // Behavior if using a trash bag & other dumpable containers
             if (args.Using != null
-                && EntityManager.HasComponent<DumpableComponent>(args.Using.Value)
+                && HasComp<DumpableComponent>(args.Using.Value)
                 && TryComp<DumpableComponent>(args.Using.Value, out var dumpable)
                 && TryComp<ServerStorageComponent>(args.Using.Value, out var storage)
                 && storage.StoredEntities != null
@@ -114,7 +113,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             {
                 // Verb to dump held container into disposal unit
                 AlternativeVerb dumpVerb = new();
-                dumpVerb.Act = () => _entMan.EntitySysManager.GetEntitySystem<DumpableSystem>().StartDoAfter(args.Using.Value, args.Target, args.User, dumpable, storage);
+                dumpVerb.Act = () => _dumpableSystem.StartDoAfter(args.Using.Value, args.Target, args.User, dumpable, storage);
                 dumpVerb.Text = Loc.GetString("dump-disposal-verb-name", ("unit", args.Target));
                 dumpVerb.Priority = 2;
                 args.Verbs.Add(dumpVerb);

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -7,6 +7,8 @@ using Content.Server.DoAfter;
 using Content.Server.Hands.Components;
 using Content.Server.Power.Components;
 using Content.Server.UserInterface;
+using Content.Server.Storage.Components;
+using Content.Server.Storage.EntitySystems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Atmos;
 using Content.Shared.Construction.Components;
@@ -21,6 +23,7 @@ using Content.Shared.Movement;
 using Content.Shared.Movement.Events;
 using Content.Shared.Throwing;
 using Content.Shared.Verbs;
+using Content.Shared.Storage.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
@@ -34,10 +37,12 @@ namespace Content.Server.Disposal.Unit.EntitySystems
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
+        [Dependency] private readonly IEntityManager _entMan = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
         [Dependency] private readonly AtmosphereSystem _atmosSystem = default!;
         [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+        [Dependency] private readonly DumpableSystem _dumpableSystem = default!;
 
         private readonly List<DisposalUnitComponent> _activeDisposals = new();
 
@@ -65,7 +70,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
 
             // Verbs
             SubscribeLocalEvent<DisposalUnitComponent, GetVerbsEvent<InteractionVerb>>(AddInsertVerb);
-            SubscribeLocalEvent<DisposalUnitComponent, GetVerbsEvent<AlternativeVerb>>(AddFlushEjectVerbs);
+            SubscribeLocalEvent<DisposalUnitComponent, GetVerbsEvent<AlternativeVerb>>(AddDisposalAltVerbs);
             SubscribeLocalEvent<DisposalUnitComponent, GetVerbsEvent<Verb>>(AddClimbInsideVerb);
 
             // Units
@@ -75,25 +80,46 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             SubscribeLocalEvent<DisposalUnitComponent, SharedDisposalUnitComponent.UiButtonPressedMessage>(OnUiButtonPressed);
         }
 
-        private void AddFlushEjectVerbs(EntityUid uid, DisposalUnitComponent component, GetVerbsEvent<AlternativeVerb> args)
+        private void AddDisposalAltVerbs(EntityUid uid, DisposalUnitComponent component, GetVerbsEvent<AlternativeVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || component.Container.ContainedEntities.Count == 0)
+            if (!args.CanAccess || !args.CanInteract)
                 return;
 
-            // Verbs to flush the unit
-            AlternativeVerb flushVerb = new();
-            flushVerb.Act = () => Engage(component);
-            flushVerb.Text = Loc.GetString("disposal-flush-verb-get-data-text");
-            flushVerb.IconTexture = "/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png";
-            flushVerb.Priority = 1;
-            args.Verbs.Add(flushVerb);
+            // Behavior for if the disposals bin has items in it
+            if (component.Container.ContainedEntities.Count > 0)
+            {
+                // Verbs to flush the unit
+                AlternativeVerb flushVerb = new();
+                flushVerb.Act = () => Engage(component);
+                flushVerb.Text = Loc.GetString("disposal-flush-verb-get-data-text");
+                flushVerb.IconTexture = "/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png";
+                flushVerb.Priority = 1;
+                args.Verbs.Add(flushVerb);
 
-            // Verb to eject the contents
-            AlternativeVerb ejectVerb = new();
-            ejectVerb.Act = () => TryEjectContents(component);
-            ejectVerb.Category = VerbCategory.Eject;
-            ejectVerb.Text = Loc.GetString("disposal-eject-verb-contents");
-            args.Verbs.Add(ejectVerb);
+                // Verb to eject the contents
+                AlternativeVerb ejectVerb = new();
+                ejectVerb.Act = () => TryEjectContents(component);
+                ejectVerb.Category = VerbCategory.Eject;
+                ejectVerb.Text = Loc.GetString("disposal-eject-verb-contents");
+                args.Verbs.Add(ejectVerb);
+            }
+
+            // Behavior if using a trash bag & other dumpable containers
+            if (args.Using != null
+                && EntityManager.HasComponent<DumpableComponent>(args.Using.Value)
+                && TryComp<DumpableComponent>(args.Using.Value, out var dumpable)
+                && TryComp<ServerStorageComponent>(args.Using.Value, out var storage)
+                && storage.StoredEntities != null
+                && storage.StoredEntities.Count > 0)
+            {
+                // Verb to dump held container into disposal unit
+                AlternativeVerb dumpVerb = new();
+                dumpVerb.Act = () => _entMan.EntitySysManager.GetEntitySystem<DumpableSystem>().StartDoAfter(args.Using.Value, args.Target, args.User, dumpable, storage);
+                dumpVerb.Text = Loc.GetString("dump-disposal-verb-name", ("unit", args.Target));
+                dumpVerb.Priority = 2;
+                args.Verbs.Add(dumpVerb);
+            }
+
         }
 
         private void AddClimbInsideVerb(EntityUid uid, DisposalUnitComponent component, GetVerbsEvent<Verb> args)

--- a/Content.Server/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Server/Storage/EntitySystems/DumpableSystem.cs
@@ -102,7 +102,7 @@ namespace Content.Server.Storage.EntitySystems
             }
         }
 
-        private void StartDoAfter(EntityUid storageUid, EntityUid? targetUid, EntityUid userUid, DumpableComponent dumpable, ServerStorageComponent storage, float multiplier = 1)
+        public void StartDoAfter(EntityUid storageUid, EntityUid? targetUid, EntityUid userUid, DumpableComponent dumpable, ServerStorageComponent storage, float multiplier = 1)
         {
             if (dumpable.CancelToken != null)
             {

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
@@ -14,6 +14,7 @@
   - type: Tag
     tags:
       - Cigar
+      - Trash
   - type: Clothing
     sprite: Objects/Consumable/Smokeables/Cigars/cigar.rsi
     Slots: [ mask ]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -25,6 +25,9 @@
   - type: Smokable
     exposeTemperature: 1173.15
   - type: Cigar
+  - type: Tag
+    tags:
+    - Trash
   - type: InjectableSolution
     solution: smokable
   - type: SolutionContainerManager


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an alt verb to dump trash bags/dumpable stuff into a disposals bin, with a higher priority than flushing.
Additionally marks Cigars as trash able to be picked up, matching cigarettes.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/36012938/175830107-1ee4448b-af86-456d-a92a-053d5e1e95c1.mp4


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: The contents of trash bags can now be dumped into disposals with alt click, you can then flush by alt clicking again
- tweak: Cigars can now be picked up by trash bags
