### PR TITLE
Fixes jetpacks not shutting off on lack of fuel

### DIFF
--- a/Content.Server/Movement/Systems/JetpackSystem.cs
+++ b/Content.Server/Movement/Systems/JetpackSystem.cs
@@ -28,7 +28,7 @@ public sealed class JetpackSystem : SharedJetpackSystem
             active.Accumulator -= UpdateCooldown;
             var air = gasTank.RemoveAir(comp.MoleUsage);
 
-            if (air == null || MathHelper.CloseTo(gasTank.Air.TotalMoles, comp.MoleUsage, 0.1f))
+            if (air == null || !MathHelper.CloseTo(air.TotalMoles, comp.MoleUsage, 0.001f))
             {
                 toDisable.Add(comp);
                 continue;

--- a/Content.Server/Movement/Systems/JetpackSystem.cs
+++ b/Content.Server/Movement/Systems/JetpackSystem.cs
@@ -1,10 +1,7 @@
 using Content.Server.Atmos.Components;
-using Content.Server.Atmos.EntitySystems;
-using Content.Server.Movement.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.Collections;
-using Robust.Shared.GameStates;
 
 namespace Content.Server.Movement.Systems;
 
@@ -31,7 +28,7 @@ public sealed class JetpackSystem : SharedJetpackSystem
             active.Accumulator -= UpdateCooldown;
             var air = gasTank.RemoveAir(comp.MoleUsage);
 
-            if (air == null || !MathHelper.CloseTo(air.TotalMoles, comp.MoleUsage, 0.1f))
+            if (air == null || MathHelper.CloseTo(gasTank.Air.TotalMoles, comp.MoleUsage, 0.1f))
             {
                 toDisable.Add(comp);
                 continue;

--- a/Content.Shared/Movement/Components/JetpackComponent.cs
+++ b/Content.Shared/Movement/Components/JetpackComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Movement.Components;
 public sealed class JetpackComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("moleUsage")]
-    public float MoleUsage = 0.048f;
+    public float MoleUsage = 0.012f;
 
     [ViewVariables, DataField("toggleAction", required: true)]
     public InstantAction ToggleAction = new();


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fix #9204

JetpackSystem checks the amount of air removed from the gasTank against the amount of molesRequired to run the jetpack.
The issue was that MathHelper.CloseTo() takes a tolerance value which was set to 0.1. 

Since 0.048 was being removed every tick, and the molesRequired is 0.048, this would never trigger like intended due to the tolerance being higher than molesRequired.

This is one way to fix it, or you can just make the tolerance smaller. Either works.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Sammy Boy
- fix: Jetpacks will now turn off properly when the tank runs out of air!

