### PR TITLE
Stun baton tweaks

### DIFF
--- a/Content.Server/Stunnable/Components/StunbatonComponent.cs
+++ b/Content.Server/Stunnable/Components/StunbatonComponent.cs
@@ -1,27 +1,27 @@
 using Content.Shared.Sound;
+using Content.Shared.Timing;
 
 namespace Content.Server.Stunnable.Components
 {
-    [RegisterComponent]
+    [RegisterComponent, Access(typeof(StunbatonSystem))]
     public sealed class StunbatonComponent : Component
     {
         public bool Activated = false;
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("paralyzeChanceNoSlowdown")]
-        public float ParalyzeChanceNoSlowdown { get; set; } = 0.35f;
+        /// <summary>
+        /// What the <see cref="UseDelayComponent"/> is when the stun baton is active.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite), DataField("activeCooldown")]
+        public TimeSpan ActiveDelay = TimeSpan.FromSeconds(4);
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("paralyzeChanceWithSlowdown")]
-        public float ParalyzeChanceWithSlowdown { get; set; } = 0.85f;
+        /// <summary>
+        /// Store what the <see cref="UseDelayComponent"/> was before being activated.
+        /// </summary>
+        public TimeSpan? OldDelay;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("paralyzeTime")]
-        public float ParalyzeTime { get; set; } = 10f;
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("slowdownTime")]
-        public float SlowdownTime { get; set; } = 5f;
+        public float ParalyzeTime { get; set; } = 5f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("energyPerUse")]

--- a/Content.Server/Stunnable/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/StunbatonSystem.cs
@@ -124,13 +124,16 @@ namespace Content.Server.Stunnable
             if (!comp.Activated)
                 return;
 
-            if (!TryComp<SpriteComponent>(comp.Owner, out var sprite) ||
-                !TryComp<SharedItemComponent>(comp.Owner, out var item)) return;
+            // TODO stunbaton visualizer
+            if (TryComp<SpriteComponent>(comp.Owner, out var sprite) &&
+                TryComp<SharedItemComponent>(comp.Owner, out var item))
+            {
+                item.EquippedPrefix = "off";
+                sprite.LayerSetState(0, "stunbaton_off");
+            }
 
             SoundSystem.Play(comp.SparksSound.GetSound(), Filter.Pvs(comp.Owner), comp.Owner, AudioHelpers.WithVariation(0.25f));
-            item.EquippedPrefix = "off";
-            // TODO stunbaton visualizer
-            sprite.LayerSetState(0, "stunbaton_off");
+
             comp.Activated = false;
             if (TryComp<UseDelayComponent>(comp.Owner, out var useDelay) && comp.OldDelay != null)
             {
@@ -144,11 +147,14 @@ namespace Content.Server.Stunnable
             if (comp.Activated)
                 return;
 
-            if (!EntityManager.TryGetComponent<SpriteComponent?>(comp.Owner, out var sprite) ||
-                !EntityManager.TryGetComponent<SharedItemComponent?>(comp.Owner, out var item))
-                return;
+            if (EntityManager.TryGetComponent<SpriteComponent?>(comp.Owner, out var sprite) &&
+                EntityManager.TryGetComponent<SharedItemComponent?>(comp.Owner, out var item))
+            {
+                item.EquippedPrefix = "on";
+                sprite.LayerSetState(0, "stunbaton_on");
+            }
 
-            var playerFilter = Filter.Pvs(comp.Owner);
+            var playerFilter = Filter.Pvs(comp.Owner, entityManager: EntityManager);
             if (!TryComp<BatteryComponent>(comp.Owner, out var battery) || battery.CurrentCharge < comp.EnergyPerUse)
             {
                 SoundSystem.Play(comp.TurnOnFailSound.GetSound(), playerFilter, comp.Owner, AudioHelpers.WithVariation(0.25f));
@@ -158,8 +164,6 @@ namespace Content.Server.Stunnable
 
             SoundSystem.Play(comp.SparksSound.GetSound(), playerFilter, comp.Owner, AudioHelpers.WithVariation(0.25f));
 
-            item.EquippedPrefix = "on";
-            sprite.LayerSetState(0, "stunbaton_on");
             comp.Activated = true;
             if (TryComp<UseDelayComponent>(comp.Owner, out var useDelay))
             {

--- a/Content.Server/Stunnable/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/StunbatonSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Power.Events;
 using Content.Server.Speech.EntitySystems;
 using Content.Server.Stunnable.Components;
 using Content.Server.Weapon.Melee;
+using Content.Server.Weapon.Melee.Components;
 using Content.Shared.Audio;
 using Content.Shared.Examine;
 using Content.Shared.Interaction.Events;
@@ -13,18 +14,23 @@ using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
+using Content.Shared.Timing;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Stunnable
 {
     public sealed class StunbatonSystem : EntitySystem
     {
+        [Dependency] private readonly MeleeWeaponSystem _melee = default!;
         [Dependency] private readonly StunSystem _stunSystem = default!;
         [Dependency] private readonly StutteringSystem _stutteringSystem = default!;
         [Dependency] private readonly SharedJitteringSystem _jitterSystem = default!;
+        [Dependency] private readonly UseDelaySystem _useDelay = default!;
+        [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
 
         public override void Initialize()
@@ -39,18 +45,20 @@ namespace Content.Server.Stunnable
 
         private void OnMeleeHit(EntityUid uid, StunbatonComponent comp, MeleeHitEvent args)
         {
-            if (!comp.Activated || !args.HitEntities.Any() || args.Handled)
+            if (!comp.Activated || !args.HitEntities.Any() || args.Handled || _useDelay.ActiveDelay(uid))
                 return;
 
             if (!TryComp<BatteryComponent>(uid, out var battery) || !battery.TryUseCharge(comp.EnergyPerUse))
                 return;
 
-            foreach (EntityUid entity in args.HitEntities)
+            foreach (var entity in args.HitEntities)
             {
                 StunEntity(entity, comp);
                 SendPowerPulse(entity, args.User, uid);
             }
 
+            _melee.SetAttackCooldown(uid, _timing.CurTime + comp.ActiveDelay);
+            _useDelay.BeginDelay(uid);
             // No combat should occur if we successfully stunned.
             args.Handled = true;
         }
@@ -97,25 +105,10 @@ namespace Content.Server.Stunnable
         {
             if (!EntityManager.TryGetComponent(entity, out StatusEffectsComponent? status) || !comp.Activated) return;
 
-            // TODO: Make slowdown inflicted customizable.
-
             SoundSystem.Play(comp.StunSound.GetSound(), Filter.Pvs(comp.Owner), comp.Owner, AudioHelpers.WithVariation(0.25f));
-            if (!EntityManager.HasComponent<SlowedDownComponent>(entity))
-            {
-                if (_robustRandom.Prob(comp.ParalyzeChanceNoSlowdown))
-                    _stunSystem.TryParalyze(entity, TimeSpan.FromSeconds(comp.ParalyzeTime), true, status);
-                else
-                    _stunSystem.TrySlowdown(entity, TimeSpan.FromSeconds(comp.SlowdownTime), true,  0.5f, 0.5f, status);
-            }
-            else
-            {
-                if (_robustRandom.Prob(comp.ParalyzeChanceWithSlowdown))
-                    _stunSystem.TryParalyze(entity, TimeSpan.FromSeconds(comp.ParalyzeTime), true, status);
-                else
-                    _stunSystem.TrySlowdown(entity, TimeSpan.FromSeconds(comp.SlowdownTime), true,  0.5f, 0.5f, status);
-            }
+            _stunSystem.TryParalyze(entity, TimeSpan.FromSeconds(comp.ParalyzeTime), true, status);
 
-            var slowdownTime = TimeSpan.FromSeconds(comp.SlowdownTime);
+            var slowdownTime = TimeSpan.FromSeconds(comp.ParalyzeTime);
             _jitterSystem.DoJitter(entity, slowdownTime, true, status:status);
             _stutteringSystem.DoStutter(entity, slowdownTime, true, status);
 
@@ -129,26 +122,27 @@ namespace Content.Server.Stunnable
         private void TurnOff(StunbatonComponent comp)
         {
             if (!comp.Activated)
-            {
                 return;
-            }
 
-            if (!EntityManager.TryGetComponent<SpriteComponent?>(comp.Owner, out var sprite) ||
-                !EntityManager.TryGetComponent<SharedItemComponent?>(comp.Owner, out var item)) return;
+            if (!TryComp<SpriteComponent>(comp.Owner, out var sprite) ||
+                !TryComp<SharedItemComponent>(comp.Owner, out var item)) return;
 
             SoundSystem.Play(comp.SparksSound.GetSound(), Filter.Pvs(comp.Owner), comp.Owner, AudioHelpers.WithVariation(0.25f));
             item.EquippedPrefix = "off";
             // TODO stunbaton visualizer
             sprite.LayerSetState(0, "stunbaton_off");
             comp.Activated = false;
+            if (TryComp<UseDelayComponent>(comp.Owner, out var useDelay) && comp.OldDelay != null)
+            {
+                useDelay.Delay = comp.OldDelay.Value;
+                comp.OldDelay = null;
+            }
         }
 
         private void TurnOn(StunbatonComponent comp, EntityUid user)
         {
             if (comp.Activated)
-            {
                 return;
-            }
 
             if (!EntityManager.TryGetComponent<SpriteComponent?>(comp.Owner, out var sprite) ||
                 !EntityManager.TryGetComponent<SharedItemComponent?>(comp.Owner, out var item))
@@ -167,6 +161,11 @@ namespace Content.Server.Stunnable
             item.EquippedPrefix = "on";
             sprite.LayerSetState(0, "stunbaton_on");
             comp.Activated = true;
+            if (TryComp<UseDelayComponent>(comp.Owner, out var useDelay))
+            {
+                comp.OldDelay = useDelay.Delay;
+                useDelay.Delay = comp.ActiveDelay;
+            }
         }
 
         private void SendPowerPulse(EntityUid target, EntityUid? user, EntityUid used)

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -74,7 +74,10 @@ namespace Content.Server.Weapon.Melee
             args.Handled = true;
             var curTime = _gameTiming.CurTime;
 
-            if (curTime < comp.CooldownEnd || args.Target == null || args.Target == owner)
+            if (curTime < comp.CooldownEnd ||
+                args.Target == null ||
+                args.Target == owner ||
+                args.User == args.Target)
                 return;
 
             var location = Transform(args.User).Coordinates;

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -117,9 +117,21 @@ namespace Content.Server.Weapon.Melee
             }
 
             comp.LastAttackTime = curTime;
-            comp.CooldownEnd = comp.LastAttackTime + TimeSpan.FromSeconds(comp.CooldownTime);
+            SetAttackCooldown(owner, comp.LastAttackTime + TimeSpan.FromSeconds(comp.CooldownTime), comp);
 
-            RaiseLocalEvent(owner, new RefreshItemCooldownEvent(comp.LastAttackTime, comp.CooldownEnd), false);
+            RaiseLocalEvent(owner, new RefreshItemCooldownEvent(comp.LastAttackTime, comp.CooldownEnd));
+        }
+
+        /// <summary>
+        /// Set the melee weapon cooldown's end to the specified value. Will use the maximum of the existing cooldown or the new one.
+        /// </summary>
+        public void SetAttackCooldown(EntityUid uid, TimeSpan endTime, MeleeWeaponComponent? component = null)
+        {
+            // Some other system may want to artificially inflate melee weapon CD.
+            if (!Resolve(uid, ref component) || component.CooldownEnd > endTime) return;
+
+            component.CooldownEnd = endTime;
+            RaiseLocalEvent(uid, new RefreshItemCooldownEvent(component.LastAttackTime, component.CooldownEnd));
         }
 
         private void OnWideAttack(EntityUid owner, MeleeWeaponComponent comp, WideAttackEvent args)

--- a/Content.Shared/Timing/UseDelaySystem.cs
+++ b/Content.Shared/Timing/UseDelaySystem.cs
@@ -116,6 +116,11 @@ public sealed class UseDelaySystem : EntitySystem
         cooldown.CooldownEnd = component.DelayEndTime;
     }
 
+    public bool ActiveDelay(EntityUid uid, UseDelayComponent? component = null)
+    {
+        return Resolve(uid, ref component, false) && component.ActiveDelay;
+    }
+
     public void Cancel(UseDelayComponent component)
     {
         component.CancellationTokenSource?.Cancel();

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -16,6 +16,8 @@
     range: 1.5
     arcwidth: 60
     arc: default
+  - type: UseDelay
+    delay: 4
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000


### PR DESCRIPTION
Whenever we get stamina the stun should be reduced further. I also removed all of the rng slowdown from it and changed the paralyze time from 10 seconds to 5 seconds.

Given the stun baton stuns I also made it so you can't hit yourself with a weapon either (previously it was just for stuff like xenos so they wouldn't melee attack themselves).

:cl:
- tweak: Whenever a baton successfully stuns it now applies a 4 second attack cooldown.