### PR TITLE
Bump cuff times

### DIFF
--- a/Content.Server/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Server/Cuffs/Components/CuffableComponent.cs
@@ -216,11 +216,11 @@ namespace Content.Server.Cuffs.Components
 
             if (isOwner)
             {
-                SoundSystem.Play(cuff.StartBreakoutSound.GetSound(), Filter.Pvs(Owner), Owner);
+                SoundSystem.Play(cuff.StartBreakoutSound.GetSound(), Filter.Pvs(Owner, entityManager: _entMan), Owner);
             }
             else
             {
-                SoundSystem.Play(cuff.StartUncuffSound.GetSound(), Filter.Pvs(Owner), Owner);
+                SoundSystem.Play(cuff.StartUncuffSound.GetSound(), Filter.Pvs(Owner, entityManager: _entMan), Owner);
             }
 
             var uncuffTime = isOwner ? cuff.BreakoutTime : cuff.UncuffTime;

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -7,10 +7,6 @@
   - type: Item
     size: 3
   - type: Handcuff
-    cuffTime: 3.0
-    uncuffTime: 3.0
-    stunBonus: 2.0
-    breakoutTime: 20.0
     cuffedRSI: Objects/Misc/handcuffs.rsi
     iconState: body-overlay
   - type: Sprite
@@ -29,10 +25,9 @@
   - type: Item
     size: 5
   - type: Handcuff
-    cuffTime: 3.5
-    uncuffTime: 3.5
-    stunBonus: 2.0
-    breakoutTime: 15.0
+    cuffTime: 5
+    uncuffTime: 5
+    breakoutTime: 15
     cuffedRSI: Objects/Misc/cablecuffs.rsi
     bodyIconState: body-overlay
     color: red
@@ -67,11 +62,11 @@
   - type: Item
     size: 2
   - type: Handcuff
-    cuffTime: 3.5
-    uncuffTime: 3.5
+    cuffTime: 5.5
+    uncuffTime: 5.5
     stunBonus: 2.0
-    breakoutTime: 17.5 #halfway between improvised cablecuffs and metal ones
-    cuffedRSI: Objects/Misc/cablecuffs.rsi #cablecuffs will look fine
+    breakoutTime: 20  # halfway between improvised cablecuffs and metal ones
+    cuffedRSI: Objects/Misc/cablecuffs.rsi  # cablecuffs will look fine
     bodyIconState: body-overlay
     breakOnRemove: true
     brokenIconState: cuff-broken


### PR DESCRIPTION
It was 1 second when they're stunned which is very quick. I changed it back around the defaults so 5 seconds to cuff and 3 seconds if they're stunned (baton is 5s after https://github.com/space-wizards/space-station-14/pull/9225 so you still have 2 seconds to cuff them or re-stun).

:cl:
- tweak: Handcuff times have been bumped back up by 2 seconds for stun / non-stunned times.
