### PR TITLE
Add Back in the "Stay Alive" Traitor Objective

### DIFF
--- a/Resources/Prototypes/Objectives/traitorObjectives..yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives..yml
@@ -37,18 +37,16 @@
     - !type:RandomTraitorAliveCondition {}
   canBeDuplicate: true
 
-#  These are disabled until we get an evac shuttle and more involved round ends
-#
-#- type: objective
-#  id: StayAliveObjective
-#  issuer: syndicate
-#  requirements:
-#    - !type:TraitorRequirement {}
-#    - !type:IncompatibleConditionsRequirement
-#        conditions:
-#          - DieCondition
-#  conditions:
-#    - !type:StayAliveCondition {}
+- type: objective
+  id: StayAliveObjective
+  issuer: syndicate
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+        conditions:
+          - DieCondition
+  conditions:
+    - !type:StayAliveCondition {}
 
 - type: objective
   id: DieObjective


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It's stated that it was removed due to an end-round system that wasn't very involved. Now that we have evac shuttle, there's more of a threat to a traitor trying to get on it.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/98561806/175931069-e1137ca4-6544-4fc6-99a3-f4ff8662d39a.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Traitors can now once again get the "Stay Alive" objective.

