### PR TITLE
Make centcomm not votable as a station

### DIFF
--- a/Resources/Prototypes/Maps/centcomm.yml
+++ b/Resources/Prototypes/Maps/centcomm.yml
@@ -3,6 +3,7 @@
   mapName: 'Central Command'
   mapPath: /Maps/centcomm.yml
   minPlayers: 10
+  votable: false
   stations:
     centcomm:
       mapNameTemplate: '{0} Central Command {1}'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9238 
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Centcomm is no longer votable.

