### PR TITLE
Add Different Styles for Instruments

### DIFF
--- a/Content.Server/Instruments/SwappableInstrumentComponent.cs
+++ b/Content.Server/Instruments/SwappableInstrumentComponent.cs
@@ -4,9 +4,11 @@ namespace Content.Server.Instruments;
 public sealed class SwappableInstrumentComponent : Component
 {
     /// <summary>
-    /// string  = the name of the style, used for display
-    /// byte    = the corresponding program number for the instrument
+    /// Used to store the different instruments that can be swapped between.
+    /// string = display name of the instrument
+    /// byte 1 = instrument midi program
+    /// byte 2 = instrument midi bank
     /// </summary>
     [DataField("instrumentList", required: true)]
-    public Dictionary<string, byte> InstrumentList = new();
+    public Dictionary<string, (byte, byte)> InstrumentList = new();
 }

--- a/Content.Server/Instruments/SwappableInstrumentComponent.cs
+++ b/Content.Server/Instruments/SwappableInstrumentComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server.Instruments;
+
+[RegisterComponent]
+public sealed class SwappableInstrumentComponent : Component
+{
+    /// <summary>
+    /// string  = the name of the style, used for display
+    /// byte    = the corresponding program number for the instrument
+    /// </summary>
+    [DataField("instrumentList", required: true)]
+    public Dictionary<string, byte> InstrumentList = new();
+}

--- a/Content.Server/Instruments/SwappableInstrumentSystem.cs
+++ b/Content.Server/Instruments/SwappableInstrumentSystem.cs
@@ -38,7 +38,7 @@ public sealed class SwappableInstrumentSystem : EntitySystem
                 Priority = priority,
                 Act = () =>
                 {
-                    _sharedInstrument.SetInstrumentProgram(instrument, entry.Value);
+                    _sharedInstrument.SetInstrumentProgram(instrument, entry.Value.Item1, entry.Value.Item2);
                     _popup.PopupEntity(Loc.GetString("swappable-instrument-component-style-set", ("style", entry.Key)),
                         args.User, Filter.Entities(args.User));
                 }

--- a/Content.Server/Instruments/SwappableInstrumentSystem.cs
+++ b/Content.Server/Instruments/SwappableInstrumentSystem.cs
@@ -1,5 +1,3 @@
-using Content.Server.Stunnable;
-using Content.Server.UserInterface;
 using Content.Shared.Instruments;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;

--- a/Content.Server/Instruments/SwappableInstrumentSystem.cs
+++ b/Content.Server/Instruments/SwappableInstrumentSystem.cs
@@ -1,0 +1,53 @@
+using Content.Server.Stunnable;
+using Content.Server.UserInterface;
+using Content.Shared.Instruments;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Robust.Shared.Player;
+
+namespace Content.Server.Instruments;
+
+public sealed class SwappableInstrumentSystem : EntitySystem
+{
+    [Dependency] private readonly SharedInstrumentSystem _sharedInstrument = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SwappableInstrumentComponent, GetVerbsEvent<AlternativeVerb>>(AddStyleVerb);
+    }
+
+    private void AddStyleVerb(EntityUid uid, SwappableInstrumentComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess || component.InstrumentList.Count <= 1)
+            return;
+
+        if (!TryComp<SharedInstrumentComponent>(uid, out var instrument))
+            return;
+
+        if (instrument.Playing) //no changing while playing
+            return;
+
+        var priority = 0;
+        foreach (var entry in component.InstrumentList)
+        {
+            AlternativeVerb selection = new()
+            {
+                Text = entry.Key,
+                Category = VerbCategory.InstrumentStyle,
+                Priority = priority,
+                Act = () =>
+                {
+                    _sharedInstrument.SetInstrumentProgram(instrument, entry.Value);
+                    _popup.PopupEntity(Loc.GetString("swappable-instrument-component-style-set", ("style", entry.Key)),
+                        args.User, Filter.Entities(args.User));
+                }
+            };
+
+            priority--;
+            args.Verbs.Add(selection);
+        }
+    }
+}

--- a/Content.Shared/Instruments/SharedInstrumentSystem.cs
+++ b/Content.Shared/Instruments/SharedInstrumentSystem.cs
@@ -18,9 +18,10 @@ public abstract class SharedInstrumentSystem : EntitySystem
     public virtual void EndRenderer(EntityUid uid, bool fromStateChange, SharedInstrumentComponent? instrument = null)
     { }
 
-    public void SetInstrumentProgram(SharedInstrumentComponent component, byte program)
+    public void SetInstrumentProgram(SharedInstrumentComponent component, byte program, byte bank)
     {
         component.InstrumentProgram = program;
+        component.InstrumentBank = bank;
     }
 
     private void OnGetState(EntityUid uid, SharedInstrumentComponent instrument, ref ComponentGetState args)

--- a/Content.Shared/Instruments/SharedInstrumentSystem.cs
+++ b/Content.Shared/Instruments/SharedInstrumentSystem.cs
@@ -18,6 +18,11 @@ public abstract class SharedInstrumentSystem : EntitySystem
     public virtual void EndRenderer(EntityUid uid, bool fromStateChange, SharedInstrumentComponent? instrument = null)
     { }
 
+    public void SetInstrumentProgram(SharedInstrumentComponent component, byte program)
+    {
+        component.InstrumentProgram = program;
+    }
+
     private void OnGetState(EntityUid uid, SharedInstrumentComponent instrument, ref ComponentGetState args)
     {
         args.State =

--- a/Content.Shared/Verbs/VerbCategory.cs
+++ b/Content.Shared/Verbs/VerbCategory.cs
@@ -68,6 +68,9 @@ namespace Content.Shared.Verbs
         public static readonly VerbCategory Split =
             new("verb-categories-split", null);
 
+        public static readonly VerbCategory InstrumentStyle =
+            new("verb-categories-instrument-style", null);
+
         public static readonly VerbCategory SetSensor = new("verb-categories-set-sensor", null);
     }
 }

--- a/Resources/Locale/en-US/instruments/instruments-component.ftl
+++ b/Resources/Locale/en-US/instruments/instruments-component.ftl
@@ -8,3 +8,6 @@ instruments-component-menu-no-midi-support = MIDI support is currently not
                                              FluidSynth or a development package
                                              for FluidSynth.
 
+# SwappableInstrumentComponent
+swappable-instrument-component-style-set = Style set to "{$style}"
+

--- a/Resources/Locale/en-US/verbs/verb-system.ftl
+++ b/Resources/Locale/en-US/verbs/verb-system.ftl
@@ -20,6 +20,7 @@ verb-categories-rotate = Rotate
 verb-categories-smite = Smite
 verb-categories-transfer = Set Transfer Amount
 verb-categories-split = Split
+verb-categories-instrument-style = Instrument Style
 verb-categories-set-sensor = Sensor
 verb-categories-timer = Set Delay
 

--- a/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
@@ -26,6 +26,10 @@
   components:
   - type: Instrument
     program: 62
+  - type: SwappableInstrument
+    instrumentList:
+      "Electro": 62 #i needed generic sounding synth presets, sue me
+      "Bubbles": 63
   - type: Sprite
     sprite: Objects/Fun/Instruments/h_synthesizer.rsi
     state: icon
@@ -43,7 +47,11 @@
   description: Anyway, here's Wonderwall.
   components:
   - type: Instrument
-    program: 25
+    program: 24
+  - type: SwappableInstrument
+    instrumentList:
+      "Nylon": 24
+      "Steel": 25
   - type: Sprite
     sprite: Objects/Fun/Instruments/guitar.rsi
     state: icon
@@ -82,6 +90,10 @@
   components:
   - type: Instrument
     program: 56
+  - type: SwappableInstrument
+    instrumentList:
+      "Standard": 56
+      "Muted": 59
   - type: Sprite
     sprite: Objects/Fun/Instruments/trumpet.rsi
     state: icon
@@ -117,6 +129,11 @@
   components:
   - type: Instrument
     program: 27
+  - type: SwappableInstrument
+    instrumentList:
+      "Clean": 27
+      "Jazz": 25
+      "Muted": 28
   - type: Sprite
     sprite: Objects/Fun/Instruments/eguitar.rsi
     state: icon
@@ -134,6 +151,10 @@
   components:
   - type: Instrument
     program: 21
+  - type: SwappableInstrument
+    instrumentList:
+      "Standard": 21
+      "Tango": 23
   - type: Sprite
     sprite: Objects/Fun/Instruments/accordion.rsi
     state: icon
@@ -240,7 +261,13 @@
   description: An instrument. You could probably grind this into raw jazz.
   components:
   - type: Instrument
-    program: 67
+    program: 66
+  - type: SwappableInstrument
+    instrumentList:
+      "Soprano": 64
+      "Alto": 65
+      "Tenor": 66
+      "Baritone": 67 
   - type: Sprite
     sprite: Objects/Fun/Instruments/saxophone.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/instruments.yml
@@ -28,8 +28,8 @@
     program: 62
   - type: SwappableInstrument
     instrumentList:
-      "Electro": 62 #i needed generic sounding synth presets, sue me
-      "Bubbles": 63
+      "Electro": {62: 0} #i needed generic sounding synth presets, sue me
+      "Bubbles": {63: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/h_synthesizer.rsi
     state: icon
@@ -50,8 +50,8 @@
     program: 24
   - type: SwappableInstrument
     instrumentList:
-      "Nylon": 24
-      "Steel": 25
+      "Nylon": {24: 0}
+      "Steel": {25: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/guitar.rsi
     state: icon
@@ -92,8 +92,8 @@
     program: 56
   - type: SwappableInstrument
     instrumentList:
-      "Standard": 56
-      "Muted": 59
+      "Standard": {56: 0}
+      "Muted": {59: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/trumpet.rsi
     state: icon
@@ -131,9 +131,9 @@
     program: 27
   - type: SwappableInstrument
     instrumentList:
-      "Clean": 27
-      "Jazz": 25
-      "Muted": 28
+      "Clean": {27: 0}
+      "Jazz": {25: 0}
+      "Muted": {28: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/eguitar.rsi
     state: icon
@@ -153,8 +153,8 @@
     program: 21
   - type: SwappableInstrument
     instrumentList:
-      "Standard": 21
-      "Tango": 23
+      "Standard": {21: 0}
+      "Tango": {23: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/accordion.rsi
     state: icon
@@ -264,10 +264,10 @@
     program: 66
   - type: SwappableInstrument
     instrumentList:
-      "Soprano": 64
-      "Alto": 65
-      "Tenor": 66
-      "Baritone": 67 
+      "Soprano": {64: 0}
+      "Alto": {65: 0}
+      "Tenor": {66: 0}
+      "Baritone": {67: 0} 
   - type: Sprite
     sprite: Objects/Fun/Instruments/saxophone.rsi
     state: icon


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds different modes/styles for instruments. This allows the player to specify between a few different sounds.
This has been added for:
- Trumpet (standard and muted)
- Accordion (standard and tango)
- Synth (2 presets)
- Electric Guitar (Clean, jazz, muted)
- Acoustic Guitar (nylon, steel)
- Saxophone (soprano, alto, tenor, baritone)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Certain instruments now have different styles that you can select, changing the way that they sound.

