### PR TITLE
Misc state handling changes

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -131,10 +131,6 @@ namespace Content.Client.Actions
 
         private void HandleState(EntityUid uid, ActionsComponent component, ref ComponentHandleState args)
         {
-            // Client only needs to care about local player.
-            if (uid != _playerManager.LocalPlayer?.ControlledEntity)
-                return;
-
             if (args.Current is not ActionsComponentState state)
                 return;
 
@@ -207,14 +203,14 @@ namespace Content.Client.Actions
 
         public override void AddAction(EntityUid uid, ActionType action, EntityUid? provider, ActionsComponent? comp = null, bool dirty = true)
         {
-            if (uid != _playerManager.LocalPlayer?.ControlledEntity)
-                return;
-
             if (!Resolve(uid, ref comp, false))
                 return;
 
             base.AddAction(uid, action, provider, comp, dirty);
-            UIDirty = true;
+
+
+            if (uid == _playerManager.LocalPlayer?.ControlledEntity)
+                UIDirty = true;
         }
 
         public override void RemoveActions(EntityUid uid, IEnumerable<ActionType> actions, ActionsComponent? comp = null, bool dirty = true)

--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -99,10 +99,8 @@ namespace Content.Client.Audio
             if(_playMan.LocalPlayer is null || _playMan.LocalPlayer.ControlledEntity != message.Entity ||
                !_timing.IsFirstTimePredicted) return;
 
-            if (!TryComp<TransformComponent>(message.Entity, out var xform)) return;
-
             // Check if we traversed to grid.
-            if (_mapManager.TryGetGrid(xform.GridUid, out var grid))
+            if (message.Transform.GridUid != null)
             {
                 if (_currentCollection == _stationAmbience) return;
                 ChangeAmbience(_stationAmbience);

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -409,7 +409,8 @@ public abstract class SharedActionsSystem : EntitySystem
 
         var provided = comp.Actions.Where(act => act.Provider == provider).ToList();
 
-        RemoveActions(uid, provided, comp);
+        if (provided.Count > 0)
+            RemoveActions(uid, provided, comp);
     }
 
     public virtual void RemoveActions(EntityUid uid, IEnumerable<ActionType> actions, ActionsComponent? comp = null, bool dirty = true)

--- a/Content.Shared/Audio/SharedAmbientSoundSystem.cs
+++ b/Content.Shared/Audio/SharedAmbientSoundSystem.cs
@@ -20,7 +20,7 @@ namespace Content.Shared.Audio
                 ambience.Enabled == value) return;
 
             ambience.Enabled = value;
-            ambience.Dirty();
+            Dirty(ambience);
         }
 
         private void HandleCompState(EntityUid uid, AmbientSoundComponent component, ref ComponentHandleState args)

--- a/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
+++ b/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
@@ -17,7 +17,7 @@ namespace Content.Shared.Movement.Components
         public float SprintSpeedModifier = 1.0f;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public float BaseWalkSpeedVV
+        private float _baseWalkSpeedVV
         {
             get => BaseWalkSpeed;
             set
@@ -28,7 +28,7 @@ namespace Content.Shared.Movement.Components
         }
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public float BaseSprintSpeedVV
+        private float _baseSprintSpeedVV
         {
             get => BaseSprintSpeed;
             set

--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -42,9 +42,12 @@ namespace Content.Shared.Movement.Systems
             var ev = new RefreshMovementSpeedModifiersEvent();
             RaiseLocalEvent(uid, ev);
 
+            if (MathHelper.CloseTo(ev.WalkSpeedModifier, move.WalkSpeedModifier) &&
+                MathHelper.CloseTo(ev.SprintSpeedModifier, move.SprintSpeedModifier))
+                return;
+
             move.WalkSpeedModifier = ev.WalkSpeedModifier;
             move.SprintSpeedModifier = ev.SprintSpeedModifier;
-
             Dirty(move);
         }
 

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -265,6 +265,8 @@
   components:
   - type: Sprite
     state: off
+  - type: AmbientSound
+    enabled: true
   - type: PoweredLight
     hasLampOnSpawn: LightBulb
     damage:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -7,7 +7,6 @@
   components:
   - type: AmbientOnPowered
   - type: AmbientSound
-    enabled: false
     volume: -9
     range: 3
     sound:


### PR DESCRIPTION
Spun off from a WIP PR

- Stop dirtying action & movement modifiers anytime any item is picked up or equipped
- Remove & move some action system attached entity checks
  - Required because the initial server state gets handled before player gets attached to an entity.
- Slightly optimize background audio system parent change handling.