### PR TITLE
Entities with hands still respect "needsHands: false" for Puller

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -148,9 +148,12 @@ namespace Content.Server.Hands.Systems
         #endregion
 
         #region pulling
-        private static void HandlePullAttempt(EntityUid uid, HandsComponent component, PullAttemptEvent args)
+        private void HandlePullAttempt(EntityUid uid, HandsComponent component, PullAttemptEvent args)
         {
             if (args.Puller.Owner != uid)
+                return;
+
+            if (TryComp<SharedPullerComponent>(args.Puller.Owner, out var pullerComp) && !pullerComp.NeedsHands)
                 return;
 
             // Cancel pull if all hands full.
@@ -161,6 +164,9 @@ namespace Content.Server.Hands.Systems
         private void HandlePullStarted(EntityUid uid, HandsComponent component, PullStartedMessage args)
         {
             if (args.Puller.Owner != uid)
+                return;
+
+            if (TryComp<SharedPullerComponent>(args.Puller.Owner, out var pullerComp) && !pullerComp.NeedsHands)
                 return;
 
             if (!_virtualItemSystem.TrySpawnVirtualItemInHand(args.Pulled.Owner, uid))

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -54,7 +54,6 @@ namespace Content.Server.Hands.Systems
 
             SubscribeLocalEvent<HandsComponent, DisarmedEvent>(OnDisarmed, before: new[] { typeof(StunSystem) });
 
-            SubscribeLocalEvent<HandsComponent, PullAttemptEvent>(HandlePullAttempt);
             SubscribeLocalEvent<HandsComponent, PullStartedMessage>(HandlePullStarted);
             SubscribeLocalEvent<HandsComponent, PullStoppedMessage>(HandlePullStopped);
 
@@ -148,19 +147,6 @@ namespace Content.Server.Hands.Systems
         #endregion
 
         #region pulling
-        private void HandlePullAttempt(EntityUid uid, HandsComponent component, PullAttemptEvent args)
-        {
-            if (args.Puller.Owner != uid)
-                return;
-
-            if (TryComp<SharedPullerComponent>(args.Puller.Owner, out var pullerComp) && !pullerComp.NeedsHands)
-                return;
-
-            // Cancel pull if all hands full.
-            if (!component.IsAnyHandFree())
-                args.Cancelled = true;
-        }
-
         private void HandlePullStarted(EntityUid uid, HandsComponent component, PullStartedMessage args)
         {
             if (args.Puller.Owner != uid)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Was causing issues for borgs on Nyano. Since we're also using the InnateTool stuff for a lot of things here, this will probably cause problems for other mobs down the line or just whenever borgs get upstreamed.