### PR TITLE
Buff cuff times again

### DIFF
--- a/Content.Server/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Server/Cuffs/Components/HandcuffComponent.cs
@@ -22,14 +22,14 @@ namespace Content.Server.Cuffs.Components
         /// </summary>
         [ViewVariables]
         [DataField("cuffTime")]
-        public float CuffTime { get; set; } = 5f;
+        public float CuffTime { get; set; } = 3.5f;
 
         /// <summary>
         ///     The time it takes to remove a <see cref="CuffedComponent"/> from an entity.
         /// </summary>
         [ViewVariables]
         [DataField("uncuffTime")]
-        public float UncuffTime { get; set; } = 5f;
+        public float UncuffTime { get; set; } = 3.5f;
 
         /// <summary>
         ///     The time it takes for a cuffed entity to remove <see cref="CuffedComponent"/> from itself.

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -25,8 +25,6 @@
   - type: Item
     size: 5
   - type: Handcuff
-    cuffTime: 5
-    uncuffTime: 5
     breakoutTime: 15
     cuffedRSI: Objects/Misc/cablecuffs.rsi
     bodyIconState: body-overlay
@@ -62,9 +60,6 @@
   - type: Item
     size: 2
   - type: Handcuff
-    cuffTime: 5.5
-    uncuffTime: 5.5
-    stunBonus: 2.0
     breakoutTime: 20  # halfway between improvised cablecuffs and metal ones
     cuffedRSI: Objects/Misc/cablecuffs.rsi  # cablecuffs will look fine
     bodyIconState: body-overlay


### PR DESCRIPTION
1.5s to cuff instead of the 3s on master / 1s previously. If you can't start a cuff in the 3.5s buffer for a stun that's on you.

:cl:
- tweak: Cuff time reduced by 1.5 seconds for both stunned and non-stunned targets.

