### PR TITLE
Makes the Pointless tab not pointless

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -459,7 +459,7 @@
 
 - type: uplinkListing
   id: UplinkCostumeClown
-  category: Misc
+  category: Pointless
   itemId: ClothingBackpackDuffelSyndicateCostumeClown
   price: 4
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -368,12 +368,6 @@
   price: 4
 
 - type: uplinkListing
-  id: UplinkBalloon
-  category: Misc
-  itemId: BalloonSyn
-  price: 20
-
-- type: uplinkListing
   id: UplinkDecoyDisk
   category: Misc
   itemId: NukeDiskFake
@@ -412,33 +406,6 @@
 #  price: 4
 
 - type: uplinkListing
-  id: UplinkCostumeClown
-  category: Misc
-  itemId: ClothingBackpackDuffelSyndicateCostumeClown
-  price: 4
-
-- type: uplinkListing
-  id: UplinkCostumePyjama
-  category: Misc
-  itemId: ClothingBackpackDuffelSyndicatePyjamaBundle
-  price: 4
-
-- type: uplinkListing
-  id: UplinkOutlawHat
-  category: Misc
-  itemId: ClothingHeadHatOutlawHat
-  price: 1
-
-- type: uplinkListing
-  id: UplinkCatEars
-  category: Misc
-  itemId: ClothingHeadHatCatEars
-  listingName: Cat Ears
-  description: UwU.
-  price: 21
-
-
-- type: uplinkListing
   id: UplinkGigacancerScanner
   category: Misc
   itemId: HandheldHealthAnalyzerGigacancer
@@ -454,12 +421,6 @@
   price: 5
 
 - type: uplinkListing
-  id: UplinkSyndicateStamp
-  category: Misc
-  itemId: RubberStampSyndicate
-  price: 2
-
-- type: uplinkListing
   id: UplinkSyndicateSegwayCrate
   category: Misc
   itemId: CrateFunSyndicateSegway
@@ -467,3 +428,43 @@
   description: Be an enemy of the corporation, in style!
   price: 5
   surplus: false
+
+ # Pointless
+
+- type: uplinkListing
+  id: UplinkSyndicateStamp
+  category: Pointless
+  itemId: RubberStampSyndicate
+  price: 2
+
+- type: uplinkListing
+  id: UplinkCatEars
+  category: Pointless
+  itemId: ClothingHeadHatCatEars
+  listingName: Cat Ears
+  description: UwU.
+  price: 21
+
+- type: uplinkListing
+  id: UplinkOutlawHat
+  category: Pointless
+  itemId: ClothingHeadHatOutlawHat
+  price: 1
+
+- type: uplinkListing
+  id: UplinkCostumePyjama
+  category: Pointless
+  itemId: ClothingBackpackDuffelSyndicatePyjamaBundle
+  price: 4
+
+- type: uplinkListing
+  id: UplinkCostumeClown
+  category: Misc
+  itemId: ClothingBackpackDuffelSyndicateCostumeClown
+  price: 4
+
+- type: uplinkListing
+  id: UplinkBalloon
+  category: Pointless
+  itemId: BalloonSyn
+  price: 20


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just moves all the Meme "I wanna waste TC" Uplink items into the Pointless tab. Unsure why this wasn't used before tbh


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: The Pointless tab within the uplink now holds your I-Want-To-Waste-TC items.

