### PR TITLE
Content changes required for recursive deletion changes

### DIFF
--- a/Content.Server/Buckle/Systems/BuckleSystem.cs
+++ b/Content.Server/Buckle/Systems/BuckleSystem.cs
@@ -24,10 +24,8 @@ namespace Content.Server.Buckle.Systems
 
             SubscribeLocalEvent<StrapComponent, RotateEvent>(RotateEvent);
 
-            SubscribeLocalEvent<BuckleComponent, EntInsertedIntoContainerMessage>(ContainerModifiedBuckle);
             SubscribeLocalEvent<StrapComponent, EntInsertedIntoContainerMessage>(ContainerModifiedStrap);
 
-            SubscribeLocalEvent<BuckleComponent, EntRemovedFromContainerMessage>(ContainerModifiedBuckle);
             SubscribeLocalEvent<StrapComponent, EntRemovedFromContainerMessage>(ContainerModifiedStrap);
 
             SubscribeLocalEvent<BuckleComponent, InteractHandEvent>(HandleInteractHand);
@@ -97,10 +95,6 @@ namespace Content.Server.Buckle.Systems
             }
         }
 
-        private void ContainerModifiedBuckle(EntityUid uid, BuckleComponent buckle, ContainerModifiedMessage message)
-        {
-            ContainerModifiedReAttach(buckle, buckle.BuckledTo);
-        }
         private void ContainerModifiedStrap(EntityUid uid, StrapComponent strap, ContainerModifiedMessage message)
         {
             foreach (var buckledEntity in strap.BuckledEntities)

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -410,9 +410,7 @@ namespace Content.Server.GameTicking
                 }
                 catch (Exception e)
                 {
-                    _sawmill.Error($"Caught exception while trying to delete entity {ToPrettyString(entity)}, this might corrupt the game state...");
-                    _runtimeLog.LogException(e, nameof(GameTicker));
-                    continue;
+                    throw e;
                 }
 #endif
             }

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -410,7 +410,9 @@ namespace Content.Server.GameTicking
                 }
                 catch (Exception e)
                 {
-                    throw e;
+                    _sawmill.Error($"Caught exception while trying to delete entity {ToPrettyString(entity)}, this might corrupt the game state...");
+                    _runtimeLog.LogException(e, nameof(GameTicker));
+                    continue;
                 }
 #endif
             }

--- a/Content.Server/Gravity/EntitySystems/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/EntitySystems/GravityGeneratorSystem.cs
@@ -21,9 +21,18 @@ namespace Content.Server.Gravity.EntitySystems
 
             SubscribeLocalEvent<GravityGeneratorComponent, ComponentInit>(OnComponentInitialized);
             SubscribeLocalEvent<GravityGeneratorComponent, ComponentShutdown>(OnComponentShutdown);
+            SubscribeLocalEvent<GravityGeneratorComponent, EntParentChangedMessage>(OnParentChanged); // Or just anchor changed?
             SubscribeLocalEvent<GravityGeneratorComponent, InteractHandEvent>(OnInteractHand);
             SubscribeLocalEvent<GravityGeneratorComponent, SharedGravityGeneratorComponent.SwitchGeneratorMessage>(
                 OnSwitchGenerator);
+        }
+
+        private void OnParentChanged(EntityUid uid, GravityGeneratorComponent component, ref EntParentChangedMessage args)
+        {
+            if (component.GravityActive && TryComp(args.OldParent, out GravityComponent? gravity))
+                _gravitySystem.DisableGravity(gravity);
+
+            UpdateGravityActive(component, false);
         }
 
         private void OnComponentShutdown(EntityUid uid, GravityGeneratorComponent component, ComponentShutdown args)

--- a/Content.Server/Gravity/EntitySystems/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/EntitySystems/GravityGeneratorSystem.cs
@@ -29,6 +29,7 @@ namespace Content.Server.Gravity.EntitySystems
 
         private void OnParentChanged(EntityUid uid, GravityGeneratorComponent component, ref EntParentChangedMessage args)
         {
+            // TODO consider stations with more than one generator.
             if (component.GravityActive && TryComp(args.OldParent, out GravityComponent? gravity))
                 _gravitySystem.DisableGravity(gravity);
 

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -1,8 +1,9 @@
-﻿using Content.Shared.Database;
+using Content.Shared.Database;
 using Content.Shared.Follower.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Movement.Events;
 using Content.Shared.Verbs;
+using Robust.Shared.Map;
 
 namespace Content.Shared.Follower;
 
@@ -100,7 +101,13 @@ public sealed class FollowerSystem : EntitySystem
             RemComp<FollowedComponent>(target);
         RemComp<FollowerComponent>(uid);
 
-        Transform(uid).AttachToGridOrMap();
+        var xform = Transform(uid);
+        xform.AttachToGridOrMap();
+        if (xform.MapID == MapId.Nullspace)
+        {
+            Del(uid);
+            return;
+        }
 
         RemComp<OrbitVisualsComponent>(uid);
 


### PR DESCRIPTION
This PR is required for space-wizards/RobustToolbox/pull/3008. It just makes it so that gravity generators disable gravity when changing parents (fix weightless tests), and also gets rid of some buckle system code. The code was causing entities to re-parent to terminating entities. I have NFI why that code was there.

This PR can be merged on its own, but just to check that all tests work with the engine PR:
Requires space-wizards/RobustToolbox/pull/3008