### PR TITLE
Gimps the restart vote.

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -322,6 +322,10 @@ namespace Content.Server.Voting.Managers
             if (voteType != null && _standardVoteTimeout.TryGetValue(voteType.Value, out timeSpan))
                 return false;
 
+            // No, seriously, stop spamming the restart vote!
+            if (voteType == StandardVoteType.Restart && _adminMgr.ActiveAdmins.Count() != 0)
+                return false;
+
             return !_voteTimeout.TryGetValue(initiator.UserId, out timeSpan);
         }
 

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -323,7 +323,7 @@ namespace Content.Server.Voting.Managers
                 return false;
 
             // No, seriously, stop spamming the restart vote!
-            if (voteType == StandardVoteType.Restart && _adminMgr.ActiveAdmins.Count() != 0)
+            if (voteType == StandardVoteType.Restart && _cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
                 return false;
 
             return !_voteTimeout.TryGetValue(initiator.UserId, out timeSpan);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -839,7 +839,7 @@ namespace Content.Shared.CCVar
         ///     The required ratio of the server that must agree for a restart round vote to go through.
         /// </summary>
         public static readonly CVarDef<float> VoteRestartRequiredRatio =
-            CVarDef.Create("vote.restart_required_ratio", 0.7f, CVar.SERVERONLY);
+            CVarDef.Create("vote.restart_required_ratio", 0.85f, CVar.SERVERONLY);
 
         /// <summary>
         ///     The delay which two votes of the same type are allowed to be made by separate people, in seconds.

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -842,6 +842,12 @@ namespace Content.Shared.CCVar
             CVarDef.Create("vote.restart_required_ratio", 0.85f, CVar.SERVERONLY);
 
         /// <summary>
+        /// Whether or not to restrict the restart vote when there's online admins.
+        /// </summary>
+        public static readonly CVarDef<bool> VoteRestartNotAllowedWhenAdminOnline =
+            CVarDef.Create("vote.restart_not_allowed_when_admin_online", true, CVar.SERVERONLY);
+        
+        /// <summary>
         ///     The delay which two votes of the same type are allowed to be made by separate people, in seconds.
         /// </summary>
         public static readonly CVarDef<float> VoteSameTypeTimeout =


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

**Changelog**
:cl: moony
- tweak: The restart vote can no longer be called when admins are online.
- tweak: The restart vote now defaults to needing 85% agreement.

