### PR TITLE
Lower shuttle time + recall turning point

### DIFF
--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -52,7 +52,7 @@ namespace Content.IntegrationTests.Tests
                 // Press the shuttle call button
                 roundEndSystem.RequestRoundEnd();
                 Assert.That(roundEndSystem.ExpectedCountdownEnd, Is.Not.Null, "Shuttle was called, but countdown time was not set");
-                Assert.That(roundEndSystem.CanCall(), Is.False, "Started the shuttle, but didn't have to wait cooldown to press cancel button");
+                Assert.That(roundEndSystem.CanCallOrRecall(), Is.False, "Started the shuttle, but didn't have to wait cooldown to press cancel button");
                 // Check that we can't recall the shuttle yet
                 roundEndSystem.CancelRoundEndCountdown();
                 Assert.That(roundEndSystem.ExpectedCountdownEnd, Is.Not.Null, "Shuttle was cancelled, even though the button was on cooldown");
@@ -62,19 +62,19 @@ namespace Content.IntegrationTests.Tests
 
             await server.WaitAssertion(() =>
             {
-                Assert.That(roundEndSystem.CanCall(), Is.True, "We waited a while, but the cooldown is not expired");
+                Assert.That(roundEndSystem.CanCallOrRecall(), Is.True, "We waited a while, but the cooldown is not expired");
                 Assert.That(roundEndSystem.ExpectedCountdownEnd, Is.Not.Null, "We were waiting for the cooldown, but the round also ended");
                 // Recall the shuttle, which should trigger the cooldown again
                 roundEndSystem.CancelRoundEndCountdown();
                 Assert.That(roundEndSystem.ExpectedCountdownEnd, Is.Null, "Recalled shuttle, but countdown has not ended");
-                Assert.That(roundEndSystem.CanCall(), Is.False, "Recalled shuttle, but cooldown has not been enabled");
+                Assert.That(roundEndSystem.CanCallOrRecall(), Is.False, "Recalled shuttle, but cooldown has not been enabled");
             });
 
             await WaitForEvent(); // Wait for Cooldown
 
             await server.WaitAssertion(() =>
             {
-                Assert.That(roundEndSystem.CanCall(), Is.True, "We waited a while, but the cooldown is not expired");
+                Assert.That(roundEndSystem.CanCallOrRecall(), Is.True, "We waited a while, but the cooldown is not expired");
                 // Press the shuttle call button
                 roundEndSystem.RequestRoundEnd();
             });
@@ -83,7 +83,7 @@ namespace Content.IntegrationTests.Tests
 
             await server.WaitAssertion(() =>
             {
-                Assert.That(roundEndSystem.CanCall(), Is.True, "We waited a while, but the cooldown is not expired");
+                Assert.That(roundEndSystem.CanCallOrRecall(), Is.True, "We waited a while, but the cooldown is not expired");
                 Assert.That(roundEndSystem.ExpectedCountdownEnd, Is.Not.Null, "The countdown ended, but we just wanted the cooldown to end");
             });
 

--- a/Content.Server/Communications/CommunicationsConsoleComponent.cs
+++ b/Content.Server/Communications/CommunicationsConsoleComponent.cs
@@ -7,16 +7,13 @@ namespace Content.Server.Communications
     [RegisterComponent]
     public sealed class CommunicationsConsoleComponent : SharedCommunicationsConsoleComponent
     {
+        public float UIUpdateAccumulator = 0f;
+
         /// <summary>
         /// Remaining cooldown between making announcements.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         public float AnnouncementCooldownRemaining;
-
-        /// <summary>
-        /// Has the UI already been refreshed after the announcement
-        /// </summary>
-        public bool AlreadyRefreshed = false;
 
         /// <summary>
         /// Fluent ID for the announcement title

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -55,6 +55,7 @@ namespace Content.Server.Communications
         {
             foreach (var comp in EntityQuery<CommunicationsConsoleComponent>())
             {
+                // TODO refresh the UI in a less horrible way
                 if (comp.AnnouncementCooldownRemaining >= 0f)
                 {
                     comp.AnnouncementCooldownRemaining -= frameTime;

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -1,15 +1,21 @@
 using System.Globalization;
+using System.Linq;
 using Content.Server.Access.Systems;
 using Content.Server.AlertLevel;
 using Content.Server.Chat;
 using Content.Server.Chat.Systems;
+using Content.Server.Interaction;
 using Content.Server.Popups;
 using Content.Server.RoundEnd;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Systems;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
+using Content.Shared.CCVar;
 using Content.Shared.Communications;
+using Content.Shared.Examine;
+using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 
 namespace Content.Server.Communications
@@ -17,6 +23,7 @@ namespace Content.Server.Communications
     public sealed class CommunicationsConsoleSystem : EntitySystem
     {
         [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
+        [Dependency] private readonly InteractionSystem _interaction = default!;
         [Dependency] private readonly AlertLevelSystem _alertLevelSystem = default!;
         [Dependency] private readonly ChatSystem _chatSystem = default!;
         [Dependency] private readonly IdCardSystem _idCardSystem = default!;
@@ -24,8 +31,10 @@ namespace Content.Server.Communications
         [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
         [Dependency] private readonly ShuttleSystem _shuttle = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
 
         private const int MaxMessageLength = 256;
+        private const float UIUpdateInterval = 5.0f;
 
         public override void Initialize()
         {
@@ -46,15 +55,20 @@ namespace Content.Server.Communications
         {
             foreach (var comp in EntityQuery<CommunicationsConsoleComponent>())
             {
-                // TODO: Find a less ass way of refreshing the UI
-                if (comp.AlreadyRefreshed) continue;
-                if (comp.AnnouncementCooldownRemaining <= 0f)
+                if (comp.AnnouncementCooldownRemaining >= 0f)
                 {
-                    UpdateCommsConsoleInterface(comp);
-                    comp.AlreadyRefreshed = true;
-                    continue;
+                    comp.AnnouncementCooldownRemaining -= frameTime;
                 }
-                comp.AnnouncementCooldownRemaining -= frameTime;
+
+                comp.UIUpdateAccumulator += frameTime;
+
+                if (comp.UIUpdateAccumulator < UIUpdateInterval)
+                    continue;
+
+                comp.UIUpdateAccumulator -= UIUpdateInterval;
+
+                if (comp.UserInterface is {} ui && ui.SubscribedSessions.Count > 0)
+                    UpdateCommsConsoleInterface(comp);
             }
 
             base.Update(frameTime);
@@ -136,7 +150,7 @@ namespace Content.Server.Communications
             comp.UserInterface?.SetState(
                 new CommunicationsConsoleInterfaceState(
                     CanAnnounce(comp),
-                    CanCall(comp),
+                    CanCallOrRecall(comp),
                     levels,
                     currentLevel,
                     currentDelay,
@@ -152,6 +166,10 @@ namespace Content.Server.Communications
 
         private bool CanUse(EntityUid user, EntityUid console)
         {
+            // This shouldn't technically be possible because of BUI but don't trust client.
+            if (!_interaction.InRangeUnobstructed(console, user))
+                return false;
+
             if (TryComp<AccessReaderComponent>(console, out var accessReaderComponent) && accessReaderComponent.Enabled)
             {
                 return _accessReaderSystem.IsAllowed(user, accessReaderComponent);
@@ -159,11 +177,25 @@ namespace Content.Server.Communications
             return true;
         }
 
-        private bool CanCall(CommunicationsConsoleComponent comp)
+        private bool CanCallOrRecall(CommunicationsConsoleComponent comp)
         {
-            if (_shuttle.EmergencyShuttleArrived) return false;
+            // Defer to what the round end system thinks we should be able to do.
+            if (_shuttle.EmergencyShuttleArrived || !_roundEndSystem.CanCallOrRecall())
+                return false;
 
-            return comp.CanCallShuttle && _roundEndSystem.CanCall();
+            // Calling shuttle checks
+            if (_roundEndSystem.ExpectedCountdownEnd is null)
+                return comp.CanCallShuttle;
+
+            // Recalling shuttle checks
+            var recallThreshold = _cfg.GetCVar(CCVars.EmergencyRecallTurningPoint);
+
+            // shouldn't really be happening if we got here
+            if (_roundEndSystem.ShuttleTimeLeft is not { } left
+                || _roundEndSystem.ExpectedShuttleLength is not { } expected)
+                return false;
+
+            return !(left.TotalSeconds / expected.TotalSeconds < recallThreshold);
         }
 
         private void OnSelectAlertLevelMessage(EntityUid uid, CommunicationsConsoleComponent comp, CommunicationsConsoleSelectAlertLevelMessage message)
@@ -207,7 +239,6 @@ namespace Content.Server.Communications
             }
 
             comp.AnnouncementCooldownRemaining = comp.DelayBetweenAnnouncements;
-            comp.AlreadyRefreshed = false;
             UpdateCommsConsoleInterface(comp);
 
             // allow admemes with vv
@@ -225,7 +256,7 @@ namespace Content.Server.Communications
 
         private void OnCallShuttleMessage(EntityUid uid, CommunicationsConsoleComponent comp, CommunicationsConsoleCallEmergencyShuttleMessage message)
         {
-            if (!CanCall(comp)) return;
+            if (!CanCallOrRecall(comp)) return;
             if (message.Session.AttachedEntity is not {Valid: true} mob) return;
             if (!CanUse(mob, uid))
             {
@@ -237,13 +268,14 @@ namespace Content.Server.Communications
 
         private void OnRecallShuttleMessage(EntityUid uid, CommunicationsConsoleComponent comp, CommunicationsConsoleRecallEmergencyShuttleMessage message)
         {
-            if (!CanCall(comp)) return;
+            if (!CanCallOrRecall(comp)) return;
             if (message.Session.AttachedEntity is not {Valid: true} mob) return;
             if (!CanUse(mob, uid))
             {
                 _popupSystem.PopupEntity(Loc.GetString("comms-console-permission-denied"), uid, Filter.Entities(mob));
                 return;
             }
+
             _roundEndSystem.CancelRoundEndCountdown(uid);
         }
     }

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -42,7 +42,10 @@ namespace Content.Server.RoundEnd
 
         private CancellationTokenSource? _countdownTokenSource = null;
         private CancellationTokenSource? _cooldownTokenSource = null;
+        public TimeSpan? LastCountdownStart { get; set; } = null;
         public TimeSpan? ExpectedCountdownEnd { get; set; } = null;
+        public TimeSpan? ExpectedShuttleLength => ExpectedCountdownEnd - LastCountdownStart;
+        public TimeSpan? ShuttleTimeLeft => ExpectedCountdownEnd - _gameTiming.CurTime;
 
         public override void Initialize()
         {
@@ -64,11 +67,12 @@ namespace Content.Server.RoundEnd
                 _cooldownTokenSource = null;
             }
 
+            LastCountdownStart = null;
             ExpectedCountdownEnd = null;
             RaiseLocalEvent(RoundEndSystemChangedEvent.Default);
         }
 
-        public bool CanCall()
+        public bool CanCallOrRecall()
         {
             return _cooldownTokenSource == null;
         }
@@ -133,6 +137,7 @@ namespace Content.Server.RoundEnd
 
             SoundSystem.Play("/Audio/Announcements/shuttlecalled.ogg", Filter.Broadcast());
 
+            LastCountdownStart = _gameTiming.CurTime;
             ExpectedCountdownEnd = _gameTiming.CurTime + countdownTime;
             Timer.Spawn(countdownTime, _shuttle.CallEmergencyShuttle, _countdownTokenSource.Token);
 
@@ -163,6 +168,7 @@ namespace Content.Server.RoundEnd
 
             SoundSystem.Play("/Audio/Announcements/shuttlerecalled.ogg", Filter.Broadcast());
 
+            LastCountdownStart = null;
             ExpectedCountdownEnd = null;
             ActivateCooldown();
             RaiseLocalEvent(RoundEndSystemChangedEvent.Default);
@@ -171,6 +177,7 @@ namespace Content.Server.RoundEnd
         public void EndRound()
         {
             if (_gameTicker.RunLevel != GameRunLevel.InRound) return;
+            LastCountdownStart = null;
             ExpectedCountdownEnd = null;
             RaiseLocalEvent(RoundEndSystemChangedEvent.Default);
             _gameTicker.EndRound();

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -936,6 +936,13 @@ namespace Content.Shared.CCVar
             CVarDef.Create("shuttle.emergency_enabled", true, CVar.SERVERONLY);
 
         /// <summary>
+        ///     The percentage of time passed from the initial call to when the shuttle can no longer be recalled.
+        ///     ex. a call time of 10min and turning point of 0.5 means the shuttle cannot be recalled after 5 minutes.
+        /// </summary>
+        public static readonly CVarDef<float> EmergencyRecallTurningPoint =
+            CVarDef.Create("shuttle.recall_turning_point", 0.5f, CVar.SERVERONLY);
+
+        /// <summary>
         /// The map to load for centcomm for the emergency shuttle to dock to.
         /// </summary>
         public static readonly CVarDef<string> CentcommMap =

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -5,7 +5,7 @@
     green:
       announcement: alert-level-green-announcement
       color: Green
-      shuttleTime: 1200
+      shuttleTime: 600
     blue:
       announcement: alert-level-blue-announcement
       sound: /Audio/Misc/notice1.ogg
@@ -14,12 +14,12 @@
       announcement: alert-level-violet-announcement
       sound: /Audio/Misc/notice1.ogg
       color: Violet
-      shuttleTime: 1200
+      shuttleTime: 600
     yellow:
       announcement: alert-level-yellow-announcement
       sound: /Audio/Misc/notice1.ogg
       color: Yellow
-      shuttleTime: 1200
+      shuttleTime: 400
     red:
       announcement: alert-level-red-announcement
       sound: /Audio/Misc/notice1.ogg


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a recall turning point, so after half of the shuttle time has elapsed it is considered 'in transit' and cannot be recalled thru a comms console. Also changes some UI update stuff cause I had to to make it work. Should be performant still and doesnt update when no one is subscribed anyway

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Basic shuttle call time reduced from 20 minutes to 10 minutes.
- tweak: The shuttle can no longer be recalled after half of the time has elapsed.