### PR TITLE
Fix vomit mopping

### DIFF
--- a/Content.Client/Fluids/PuddleVisualizer.cs
+++ b/Content.Client/Fluids/PuddleVisualizer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Content.Shared.Fluids;
 using JetBrains.Annotations;
@@ -19,6 +19,9 @@ namespace Content.Client.Fluids
 
         // Whether the underlying solution color should be used
         [DataField("recolor")] public bool Recolor;
+
+        // Whether the puddle has a unique sprite we don't want to overwrite
+        [DataField("customPuddleSprite")] public bool CustomPuddleSprite;
 
         public override void InitializeEntity(EntityUid entity)
         {
@@ -75,7 +78,7 @@ namespace Content.Client.Fluids
                 spriteComponent.LayerSetState(0, "sparkles", "Fluids/wet_floor_sparkles.rsi");
                 spriteComponent.Color = spriteComponent.Color.WithAlpha(0.25f); //should be mostly transparent.
             }
-            else
+            else if(!CustomPuddleSprite)
             {
                 spriteComponent.LayerSetState(0, "smear-0", "Fluids/smear.rsi"); // TODO: need a way to implement the random smears again when the mop creates new puddles.
             }

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -155,6 +155,10 @@
   - type: Slippery
     launchForwardsMultiplier: 2.0
   - type: StepTrigger
+  - type: Appearance
+    visuals:
+    - type: PuddleVisualizer
+      customPuddleSprite: true
 
 - type: entity
   name: toxins vomit


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #9337 

The issue wasn't that vomit couldn't be mopped, it was that there was no visualizer to let you know you hit the lower puddle limit. The limit is there to allow the floor to still be slippery for a bit (due to residual water or whatever).

Even when vomit hit this limit, it appeared the same, giving the impression it couldn't be mopped. I've just added an option to the visualizer to avoid losing the custom vomit sprite, but still looking correct once mopped up.

Note: we might want to tweak the slipThreshold and/or evaporateTime for vomit puddles now after this change.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed vomit puddle mopping behavior

