### PR TITLE
Add batch cooking

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -449,13 +449,8 @@ namespace Content.Server.Kitchen.Components
                         : Math.Min(portions, reagents[reagent.Key].Int() / reagent.Value.Int());
             }
 
-            if (_currentCookTimerTime / recipe.CookTime != portions)
-            {
-                //not correct time multiple for the number of portions found
-                return (recipe, 0);
-            }
-
-            return (recipe, portions);
+            //cook only as many of those portions as time allows
+            return (recipe, (int)Math.Min(portions, _currentCookTimerTime / recipe.CookTime));
         }
 
         public void ClickSound()

--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -268,13 +268,10 @@ namespace Content.Server.Kitchen.Components
             }
 
             // Check recipes
-            FoodRecipePrototype? recipeToCook = null;
-            foreach (var r in _recipeManager.Recipes.Where(r =>
-                CanSatisfyRecipe(r, solidsDict, reagentDict)))
-            {
-                recipeToCook = r;
-            }
-
+            (FoodRecipePrototype, int) portionedRecipe = _recipeManager.Recipes.Select(
+                r => CanSatisfyRecipe(r, solidsDict, reagentDict)).Where(r => r.Item2 > 0).FirstOrDefault();
+            FoodRecipePrototype? recipeToCook = portionedRecipe.Item1;
+            
             SetAppearance(MicrowaveVisualState.Cooking);
             var time = _currentCookTimerTime * _cookTimeMultiplier;
             SoundSystem.Play(_startCookingSound.GetSound(), Filter.Pvs(Owner), Owner, AudioParams.Default);
@@ -289,9 +286,12 @@ namespace Content.Server.Kitchen.Components
 
                 if (recipeToCook != null)
                 {
-                    SubtractContents(recipeToCook);
-                    _entities.SpawnEntity(recipeToCook.Result,
-                        _entities.GetComponent<TransformComponent>(Owner).Coordinates);
+                    for (int i = 0; i < portionedRecipe.Item2; i++)
+                    {
+                        SubtractContents(recipeToCook);
+                        _entities.SpawnEntity(recipeToCook.Result,
+                            _entities.GetComponent<TransformComponent>(Owner).Coordinates);
+                    }
                 }
 
                 EjectSolids();
@@ -415,32 +415,40 @@ namespace Content.Server.Kitchen.Components
             }
         }
 
-        private bool CanSatisfyRecipe(FoodRecipePrototype recipe, Dictionary<string, int> solids, Dictionary<string, FixedPoint2> reagents)
+        private (FoodRecipePrototype, int) CanSatisfyRecipe(FoodRecipePrototype recipe, Dictionary<string, int> solids, Dictionary<string, FixedPoint2> reagents)
         {
+            int portions = 0;
+
             if (_currentCookTimerTime != recipe.CookTime)
             {
-                return false;
+                return (recipe, 0);
             }
 
             foreach (var solid in recipe.IngredientsSolids)
             {
                 if (!solids.ContainsKey(solid.Key))
-                    return false;
+                    return (recipe, 0);
 
                 if (solids[solid.Key] < solid.Value)
-                    return false;
+                    return (recipe, 0);
+                else
+                    portions = portions == 0 ? solids[solid.Key] / solid.Value.Int()
+                        : Math.Min(portions, solids[solid.Key] / solid.Value.Int());
             }
 
             foreach (var reagent in recipe.IngredientsReagents)
             {
                 if (!reagents.ContainsKey(reagent.Key))
-                    return false;
+                    return (recipe, 0);
 
                 if (reagents[reagent.Key] < reagent.Value)
-                    return false;
+                    return (recipe, 0);
+                else
+                    portions = portions == 0 ? reagents[reagent.Key].Int() / reagent.Value.Int()
+                        : Math.Min(portions, reagents[reagent.Key].Int() / reagent.Value.Int());
             }
 
-            return true;
+            return (recipe, portions);
         }
 
         public void ClickSound()

--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -419,8 +419,9 @@ namespace Content.Server.Kitchen.Components
         {
             int portions = 0;
 
-            if (_currentCookTimerTime != recipe.CookTime)
+            if(_currentCookTimerTime % recipe.CookTime != 0)
             {
+                //can't be a multiple of this recipe
                 return (recipe, 0);
             }
 
@@ -446,6 +447,12 @@ namespace Content.Server.Kitchen.Components
                 else
                     portions = portions == 0 ? reagents[reagent.Key].Int() / reagent.Value.Int()
                         : Math.Min(portions, reagents[reagent.Key].Int() / reagent.Value.Int());
+            }
+
+            if (_currentCookTimerTime / recipe.CookTime != portions)
+            {
+                //not correct time multiple for the number of portions found
+                return (recipe, 0);
             }
 
             return (recipe, portions);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

There is a planned cooking redesign in the works, but in the meantime, this can help make chefs' lives a bit easier.
This can help them get food out a bit faster and with less damage to the player's wrist.

If you insert multiple of the same recipe in the microwave, you can get multiple portions of that recipe.
e.g. 3 buns, 3 raw meat, 3 cheese wedge for 15 secs = 3 burgers

All of the existing behavior in terms of wrong cooking time, liquid ingredients, and excess or wrong ingredients seems to still work as expected in my testing.

Ingredients don't match any recipe = everything ejected
Wrong cooking time = everything ejected
Extraneous ingredient = correct recipe cooked and extra ingredient ejected
Cooking time a smaller multiple than ingredients = cook smaller multiple of portions

Examples: 
3 potatoes and 2 cheese wedge for 20 secs = 2 loaded potatoes and 1 ejected potato
2 potatoes and 2 cheese wedge for 10 secs = 1 loaded potato and 1 ejected potato and cheese wedge 
2 dough slice and 2 corn for 10 secs = 2 buns and 2 ejected corn
10u cola and 2 miso soup for 30 secs = 2 Salty Sweet Miso Cola Soup (and ejected cup)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Multiple portions of the same recipe can be cooked simultaneously in the microwave by multiplying the ingredients and cooking time.

