### PR TITLE
Separate jetpack movement speed modifier

### DIFF
--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -66,5 +66,6 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
             return;
 
         args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+        args.ModifyJetpackSpeed(component.SprintModifier);
     }
 }

--- a/Content.Shared/Damage/Systems/SlowOnDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/SlowOnDamageSystem.cs
@@ -37,6 +37,7 @@ namespace Content.Shared.Damage
             {
                 var speed = component.SpeedModifierThresholds[closest];
                 args.ModifySpeed(speed, speed);
+                args.ModifyJetpackSpeed(speed);
             }
         }
 

--- a/Content.Shared/Movement/Components/IMoverComponent.cs
+++ b/Content.Shared/Movement/Components/IMoverComponent.cs
@@ -5,16 +5,6 @@ namespace Content.Shared.Movement.Components
     public interface IMoverComponent : IComponent
     {
         /// <summary>
-        ///     Movement speed (m/s) that the entity walks.
-        /// </summary>
-        float CurrentWalkSpeed { get; }
-
-        /// <summary>
-        ///     Movement speed (m/s) that the entity sprints.
-        /// </summary>
-        float CurrentSprintSpeed { get; }
-
-        /// <summary>
         ///     Is the entity Sprinting (running)?
         /// </summary>
         bool Sprinting { get; }

--- a/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
+++ b/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
@@ -16,6 +16,9 @@ namespace Content.Shared.Movement.Components
         [ViewVariables]
         public float SprintSpeedModifier = 1.0f;
 
+        [ViewVariables]
+        public float JetpackSpeedModifier = 1.0f;
+
         [ViewVariables(VVAccess.ReadWrite)]
         private float _baseWalkSpeedVV
         {

--- a/Content.Shared/Movement/Components/SharedDummyInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/SharedDummyInputMoverComponent.cs
@@ -5,8 +5,7 @@ namespace Content.Shared.Movement.Components
     public sealed class SharedDummyInputMoverComponent : Component, IMoverComponent
     {
         public bool IgnorePaused => false;
-        public float CurrentWalkSpeed => 0f;
-        public float CurrentSprintSpeed => 0f;
+
         public bool CanMove { get; set; } = true;
 
         public Angle LastGridAngle { get => Angle.Zero; set {} }

--- a/Content.Shared/Movement/Components/SharedPlayerInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/SharedPlayerInputMoverComponent.cs
@@ -43,18 +43,6 @@ namespace Content.Shared.Movement.Components
         [ViewVariables]
         public Angle LastGridAngle { get; set; } = new(0);
 
-        public float CurrentWalkSpeed =>
-            _entityManager.TryGetComponent<MovementSpeedModifierComponent>(Owner,
-                out var movementSpeedModifierComponent)
-                ? movementSpeedModifierComponent.CurrentWalkSpeed
-                : MovementSpeedModifierComponent.DefaultBaseWalkSpeed;
-
-        public float CurrentSprintSpeed =>
-            _entityManager.TryGetComponent<MovementSpeedModifierComponent>(Owner,
-                out var movementSpeedModifierComponent)
-                ? movementSpeedModifierComponent.CurrentSprintSpeed
-                : MovementSpeedModifierComponent.DefaultBaseSprintSpeed;
-
         public bool Sprinting => !HasFlag(_heldMoveButtons, MoveButtons.Walk);
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -21,7 +21,8 @@ namespace Content.Shared.Movement.Systems
                 BaseWalkSpeed = component.BaseWalkSpeed,
                 BaseSprintSpeed = component.BaseSprintSpeed,
                 WalkSpeedModifier = component.WalkSpeedModifier,
-                SprintSpeedModifier = component.SprintSpeedModifier
+                SprintSpeedModifier = component.SprintSpeedModifier,
+                JetpackSpeedModifier =  component.JetpackSpeedModifier
             };
         }
 
@@ -32,6 +33,7 @@ namespace Content.Shared.Movement.Systems
             component.BaseSprintSpeed = state.BaseSprintSpeed;
             component.WalkSpeedModifier = state.WalkSpeedModifier;
             component.SprintSpeedModifier = state.SprintSpeedModifier;
+            component.JetpackSpeedModifier = state.JetpackSpeedModifier;
         }
 
         public void RefreshMovementSpeedModifiers(EntityUid uid, MovementSpeedModifierComponent? move = null)
@@ -48,6 +50,7 @@ namespace Content.Shared.Movement.Systems
 
             move.WalkSpeedModifier = ev.WalkSpeedModifier;
             move.SprintSpeedModifier = ev.SprintSpeedModifier;
+            move.JetpackSpeedModifier = ev.JetpackSpeedModifier;
             Dirty(move);
         }
 
@@ -58,6 +61,7 @@ namespace Content.Shared.Movement.Systems
             public float BaseSprintSpeed;
             public float WalkSpeedModifier;
             public float SprintSpeedModifier;
+            public float JetpackSpeedModifier;
         }
     }
 
@@ -72,11 +76,17 @@ namespace Content.Shared.Movement.Systems
 
         public float WalkSpeedModifier { get; private set; } = 1.0f;
         public float SprintSpeedModifier { get; private set; } = 1.0f;
+        public float JetpackSpeedModifier { get; private set; } = 1.0f;
 
         public void ModifySpeed(float walk, float sprint)
         {
             WalkSpeedModifier *= walk;
             SprintSpeedModifier *= sprint;
+        }
+
+        public void ModifyJetpackSpeed(float jetpack)
+        {
+            JetpackSpeedModifier *= jetpack;
         }
     }
 }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -153,10 +153,11 @@ namespace Content.Shared.Movement.Systems
 
             var transform = EntityManager.GetComponent<TransformComponent>(mover.Owner);
             var parentRotation = GetParentGridAngle(transform, mover);
+            var moveSpeedComponent = EnsureComp<MovementSpeedModifierComponent>(mover.Owner);
 
             // Regular movement.
             // Target velocity.
-            var total = walkDir * mover.CurrentWalkSpeed + sprintDir * mover.CurrentSprintSpeed;
+            var total = walkDir * moveSpeedComponent.CurrentWalkSpeed + sprintDir * moveSpeedComponent.CurrentSprintSpeed;
 
             var worldTotal = _relativeMovement ? parentRotation.RotateVec(total) : total;
 
@@ -194,6 +195,8 @@ namespace Content.Shared.Movement.Systems
             var (walkDir, sprintDir) = mover.VelocityDir;
             var touching = false;
 
+            var moveSpeedComponent = EnsureComp<MovementSpeedModifierComponent>(mover.Owner);
+
             // Handle wall-pushes.
             if (weightless)
             {
@@ -218,7 +221,15 @@ namespace Content.Shared.Movement.Systems
             // Regular movement.
             // Target velocity.
             // This is relative to the map / grid we're on.
-            var total = walkDir * mover.CurrentWalkSpeed + sprintDir * mover.CurrentSprintSpeed;
+            Vector2 total;
+            if (weightless && HasComp<JetpackUserComponent>(mover.Owner))
+            {
+                total = (walkDir * moveSpeedComponent.BaseWalkSpeed * moveSpeedComponent.JetpackSpeedModifier)
+                        + (sprintDir * moveSpeedComponent.BaseSprintSpeed * moveSpeedComponent.JetpackSpeedModifier);
+            }
+            else
+                total = walkDir * moveSpeedComponent.CurrentWalkSpeed + sprintDir * moveSpeedComponent.CurrentSprintSpeed;
+
             var parentRotation = GetParentGridAngle(xform, mover);
             var worldTotal = _relativeMovement ? parentRotation.RotateVec(total) : total;
 

--- a/Content.Shared/Movement/Systems/SlowContactsSystem.cs
+++ b/Content.Shared/Movement/Systems/SlowContactsSystem.cs
@@ -40,6 +40,7 @@ public sealed class SlowContactsSystem : EntitySystem
         }
 
         args.ModifySpeed(walkSpeed, sprintSpeed);
+        args.ModifyJetpackSpeed(sprintSpeed);
     }
 
     private void OnEntityExit(EntityUid uid, SlowContactsComponent component, EndCollideEvent args)

--- a/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullerSystem.cs
@@ -68,6 +68,7 @@ namespace Content.Shared.Pulling.Systems
         private void OnRefreshMovespeed(EntityUid uid, SharedPullerComponent component, RefreshMovementSpeedModifiersEvent args)
         {
             args.ModifySpeed(component.WalkSpeedModifier, component.SprintSpeedModifier);
+            args.ModifyJetpackSpeed(component.SprintSpeedModifier);
         }
 
         private void RefreshMovementSpeed(SharedPullerComponent component)

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -116,6 +116,7 @@ namespace Content.Shared.Stunnable
         private void OnRefreshMovespeed(EntityUid uid, SlowedDownComponent component, RefreshMovementSpeedModifiersEvent args)
         {
             args.ModifySpeed(component.WalkSpeedModifier, component.SprintSpeedModifier);
+            args.ModifyJetpackSpeed(component.SprintSpeedModifier);
         }
 
         // TODO STUN: Make events for different things. (Getting modifiers, attempt events, informative events...)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a jetpack speed modifier field to allow jetpack movement speed to be modified separately from walking/sprinting. Thirst and hunger no longer affects movement speed of characters using the jetpack while weightless (fixing #9207). Other sources of slowdown: clothing, stuns, etc still apply.

Some questions I have (assuming this is a decent approach) :
- Should there be a separate walk/sprint speed modifier for jetpacks?
- Should there be any different modifiers for jetpacks (i.e. having hardsuits apply a 0.75 modifier for jetpacks, instead of 0.65, as an example).
- Should any more of these systems be omitted from modifying jetpack speed?

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Hunger and thirst will no longer affect jetpack speed.