### PR TITLE
Add SoftMaxPlayers to status response for launcher use

### DIFF
--- a/Content.Server/GameTicking/GameTicker.StatusShell.cs
+++ b/Content.Server/GameTicking/GameTicker.StatusShell.cs
@@ -1,5 +1,7 @@
 using System.Text.Json.Nodes;
+using Content.Shared.CCVar;
 using Robust.Server.ServerStatus;
+using Robust.Shared.Configuration;
 
 namespace Content.Server.GameTicking
 {
@@ -16,6 +18,11 @@ namespace Content.Server.GameTicking
         [ViewVariables]
         private DateTime _roundStartDateTime;
 
+        /// <summary>
+        ///     For access to CVars in status responses.
+        /// </summary>
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
+
         private void InitializeStatusShell()
         {
             IoCManager.Resolve<IStatusHost>().OnStatusRequest += GetStatusResponse;
@@ -28,6 +35,7 @@ namespace Content.Server.GameTicking
             {
                 jObject["name"] = _baseServer.ServerName;
                 jObject["players"] = _playerManager.PlayerCount;
+                jObject["soft_max_players"] = _cfg.GetCVar(CCVars.SoftMaxPlayers);
                 jObject["run_level"] = (int) _runLevel;
                 if (_runLevel >= GameRunLevel.InRound)
                 {


### PR DESCRIPTION
## About the PR
Supporting code for [SS14.Launcher Issue 69](https://github.com/space-wizards/SS14.Launcher/issues/69).

Adds new" soft_max_players" field to "/status" response, which launcher will read and use to show the ratio of current to max players.

Launcher PR: https://github.com/space-wizards/SS14.Launcher/pull/70

**Screenshots**
(note: captured using rand values for maxes, as field is 0 until these changes are live)
![PlayerRatios](https://user-images.githubusercontent.com/69610864/177020452-6c559e5e-9b7b-480d-a973-93f110202460.PNG)

**Changelog**
:cl:
- add: Servers now post their max player counts for the launcher to display alongside current player count

