### PR TITLE
Extends cutting delay for cables from .25 to .50

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -4,6 +4,8 @@
   placement:
     mode: SnapgridCenter
   components:
+  - type: Cable
+    cuttingDelay: 0.5
   - type: Clickable
   - type: InteractionOutline
   - type: Transform

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -5,7 +5,7 @@
     mode: SnapgridCenter
   components:
   - type: Cable
-    cuttingDelay: 0.5
+    cuttingDelay: 1
   - type: Clickable
   - type: InteractionOutline
   - type: Transform


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #9298

This is intended to make so missclicks and wrong inputs have a narrow (but still feasibly cancelable) window to prevent interruptions during fights and stuff, while still maintaining the quickness of snipping wires for sabotage/engineering repair.

IMO 0.5 does that just right. 0.75's fine too, a full second just makes moving cables around a chore.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Sammy Boy
- tweak: Wire snipping takes .25 seconds longer to help prevent missclick consequences!

