### PR TITLE
Intrinsic radio fixes

### DIFF
--- a/Content.Server/Ghost/Components/InherentRadioComponent.cs
+++ b/Content.Server/Ghost/Components/InherentRadioComponent.cs
@@ -12,26 +12,14 @@ namespace Content.Server.Ghost.Components
     /// </summary>
     [RegisterComponent]
     [ComponentReference(typeof(IRadio))]
-    public sealed class GhostRadioComponent : Component, IRadio
+    public sealed class InherentRadioComponent : Component, IRadio
     {
         // TODO: This class is yuck
         [Dependency] private readonly IServerNetManager _netManager = default!;
         [Dependency] private readonly IEntityManager _entMan = default!;
 
-        [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
-        private HashSet<string> _channels = new()
-        {
-            "Common",
-            "Command",
-            "CentCom",
-            "Engineering",
-            "Medical",
-            "Science",
-            "Security",
-            "Service",
-            "Supply",
-            "Syndicate"
-        };
+        [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>), required: true)]
+        private HashSet<string> _channels = new();
 
         public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker)
         {

--- a/Content.Server/Ghost/Components/IntrinsicRadioComponent.cs
+++ b/Content.Server/Ghost/Components/IntrinsicRadioComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Ghost.Components
     /// </summary>
     [RegisterComponent]
     [ComponentReference(typeof(IRadio))]
-    public sealed class InherentRadioComponent : Component, IRadio
+    public sealed class IntrinsicRadioComponent : Component, IRadio
     {
         // TODO: This class is yuck
         [Dependency] private readonly IServerNetManager _netManager = default!;

--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -61,7 +61,9 @@
       attributes:
         proper: true
     - type: Examiner
-    - type: GhostRadio
+    - type: InherentRadio
+      channels:
+      - Common
     - type: DoAfter
     - type: Actions
     - type: MobState
@@ -70,7 +72,7 @@
     #    criticalThreshold: 50
     #    deadThreshold: 120
 
-    
+
 
 - type: entity
   id: LeftArmSkeleton

--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -61,7 +61,7 @@
       attributes:
         proper: true
     - type: Examiner
-    - type: InherentRadio
+    - type: IntrinsicRadio
       channels:
       - Common
     - type: DoAfter

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -29,7 +29,7 @@
   - type: Examiner
     DoRangeCheck: false
   - type: Ghost
-  - type: InherentRadio
+  - type: IntrinsicRadio
     channels:
     - Common
     - Command

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -29,7 +29,18 @@
   - type: Examiner
     DoRangeCheck: false
   - type: Ghost
-  - type: GhostRadio
+  - type: InherentRadio
+    channels:
+    - Common
+    - Command
+    - CentCom
+    - Engineering
+    - Medical
+    - Science
+    - Security
+    - Service
+    - Supply
+    - Syndicate
   - type: Sprite
     overrideContainerOcclusion: true # Ghosts always show up regardless of where they're contained.
     netsync: false

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -33,7 +33,9 @@
       event: !type:OpenUiActionEvent
         key: enum.InstrumentUiKey.Key
   - type: Examiner
-  - type: GhostRadio
+  - type: InherentRadio
+    channels:
+    - Common
   - type: DoAfter
   - type: Actions
   - type: TypingIndicator

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -33,7 +33,7 @@
       event: !type:OpenUiActionEvent
         key: enum.InstrumentUiKey.Key
   - type: Examiner
-  - type: InherentRadio
+  - type: IntrinsicRadio
     channels:
     - Common
   - type: DoAfter


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #9377

- Renames `GhostRadio` to `IntrinsicRadio`
- Makes inherent radio channels a required field and removes the default
- Specifies channels for all usages in YAML

:cl:
- tweak: PAI can now only hear Common radio.
