### PR TITLE
Broadcast salvage over supply instead

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -12,6 +12,9 @@
   - type: Rotatable
   - type: Transform
     noRot: false
+  - type: IntrinsicRadio
+    channels:
+    - Supply
   - type: SalvageMagnet
     offset: 0, -32
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -12,6 +12,10 @@
   - type: Rotatable
   - type: Transform
     noRot: false
+  - type: Speech
+  - type: IntrinsicRadio
+    channels:
+    - Supply
   - type: SalvageMagnet
     offset: 0, -32
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -12,10 +12,6 @@
   - type: Rotatable
   - type: Transform
     noRot: false
-  - type: Speech
-  - type: IntrinsicRadio
-    channels:
-    - Supply
   - type: SalvageMagnet
     offset: 0, -32
   - type: ApcPowerReceiver


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/9154

:cl:
- tweak: Salvage magnet broadcasts over supply instead of announcements now.