### PR TITLE
Allow adminnotes to use username

### DIFF
--- a/Content.Server/Administration/Commands/OpenAdminNotesCommand.cs
+++ b/Content.Server/Administration/Commands/OpenAdminNotesCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.Administration.Notes;
+using Content.Server.Database;
 using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
@@ -12,7 +13,7 @@ public sealed class OpenAdminNotesCommand : IConsoleCommand
 
     public string Command => CommandName;
     public string Description => "Opens the admin notes panel.";
-    public string Help => $"Usage: {Command} <notedPlayerUserId>";
+    public string Help => $"Usage: {Command} <notedPlayerUserId OR notedPlayerUsername>";
 
     public async void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -27,6 +28,18 @@ public sealed class OpenAdminNotesCommand : IConsoleCommand
         switch (args.Length)
         {
             case 1 when Guid.TryParse(args[0], out notedPlayer):
+                break;
+            case 1:
+                var db = IoCManager.Resolve<IServerDbManager>();
+                var dbGuid = await db.GetAssignedUserIdAsync(args[0]);
+
+                if (dbGuid == null)
+                {
+                    shell.WriteError($"Unable to find {args[0]} netuserid");
+                    return;
+                }
+
+                notedPlayer = dbGuid.Value;
                 break;
             default:
                 shell.WriteError($"Invalid arguments.\n{Help}");


### PR DESCRIPTION
No I'm not going to the ban panel to find someone's GUID.