### PR TITLE
Fixes tongue twister disease message, also adds it to the outbreak event

### DIFF
--- a/Content.Server/StationEvents/Events/DiseaseOutbreak.cs
+++ b/Content.Server/StationEvents/Events/DiseaseOutbreak.cs
@@ -30,7 +30,8 @@ public sealed class DiseaseOutbreak : StationEvent
         "VentCough",
         "AMIV",
         "SpaceFlu",
-        "BirdFlew"
+        "BirdFlew",
+        "TongueTwister"
     };
     public override string Name => "DiseaseOutbreak";
     public override float Weight => WeightNormal;

--- a/Resources/Prototypes/Diseases/infectious.yml
+++ b/Resources/Prototypes/Diseases/infectious.yml
@@ -233,9 +233,9 @@
       probability: 0.01
       snoughSound:
         collection: Sneezes
-    - !type:DiseaseSnough
+    - !type:DiseasePopUp
       probability: 0.02
-      snoughMessage: disease-think
+      message: disease-think
   cures:
     - !type:DiseaseBedrestCure
       maxLength: 30


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The popup was a snough instead of a popup. Oops!

I also added it to the outbreak event.

