### PR TITLE
Fixes entity spawner icons

### DIFF
--- a/Resources/Prototypes/Body/Mechanisms/rat.yml
+++ b/Resources/Prototypes/Body/Mechanisms/rat.yml
@@ -13,3 +13,5 @@
   components:
   - type: Stomach
     maxVolume: 50 # they're hungry
+  - type: Sprite
+    state: stomach

--- a/Resources/Prototypes/Body/Parts/animal.yml
+++ b/Resources/Prototypes/Body/Parts/animal.yml
@@ -10,6 +10,9 @@
   components:
   - type: Damageable
     damageContainer: Biological
+  - type: Sprite
+    netsync: false
+    sprite: Mobs/Species/Human/organs.rsi
 
 # For primates mainly
 - type: entity

--- a/Resources/Prototypes/Body/Parts/animal.yml
+++ b/Resources/Prototypes/Body/Parts/animal.yml
@@ -10,9 +10,6 @@
   components:
   - type: Damageable
     damageContainer: Biological
-  - type: Sprite
-    netsync: false
-    sprite: Mobs/Species/Human/organs.rsi
 
 # For primates mainly
 - type: entity
@@ -74,6 +71,9 @@
   abstract: true
   components:
   - type: Mechanism
+  - type: Sprite
+    netsync: false
+    sprite: Mobs/Species/Human/organs.rsi
 
 - type: entity
   id: OrganAnimalLungs

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -43,6 +43,7 @@
   id: BaseGrenade
   name: base grenade
   parent: BaseItem
+  abstract: true
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -9,6 +9,7 @@
     sprite: Structures/Furniture/Tables/frame.rsi
   - type: Icon
     sprite: Structures/Furniture/Tables/frame.rsi
+    state: full
   - type: Fixtures
     fixtures:
     - shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -56,6 +56,7 @@
     sprite: Structures/Furniture/Tables/counterwood.rsi
   - type: Icon
     sprite: Structures/Furniture/Tables/counterwood.rsi
+    state: full
   - type: Fixtures
     fixtures:
     - shape:
@@ -108,6 +109,7 @@
     sprite: Structures/Furniture/Tables/countermetal.rsi
   - type: Icon
     sprite: Structures/Furniture/Tables/countermetal.rsi
+    state: full
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -47,6 +47,7 @@
   id: AsteroidRockMining
   parent: AsteroidRock
   name: asteroid rock
+  suffix: higher ore yield
   description: An asteroid.
   components:
   - type: Gatherable

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -2,6 +2,7 @@
   id: AsteroidRock
   parent: BaseStructure
   name: asteroid rock
+  suffix: Low Ore Yield
   description: A rocky asteroid.
   components:
   - type: Gatherable
@@ -44,7 +45,7 @@
 
 - type: entity
   id: AsteroidRockMining
-  parent: BaseStructure
+  parent: AsteroidRock
   name: asteroid rock
   description: An asteroid.
   components:

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -568,6 +568,9 @@
   components:
   - type: Sprite
     sprite: Structures/Walls/solidrust.rsi
+  - type: Icon
+    sprite: Structures/Walls/solidrust.rsi
+    state: full
   - type: Construction
     graph: Girder
     node: wallrust


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So apparently a bunch of stuff I added in the past didn't have entity spawner icons, plus a few things others added had missing or broken icons.

Fixes everything we could find in this PR. I know I got told not to use Icon components anymore but apparently, setting the sprites to full wasn't enough for it to get that.
