### PR TITLE
Humans can now have their ID cards examined

### DIFF
--- a/Content.Server/Access/Components/IdExaminableComponent.cs
+++ b/Content.Server/Access/Components/IdExaminableComponent.cs
@@ -1,0 +1,8 @@
+﻿using Content.Server.Access.Systems;
+
+namespace Content.Server.Access.Components;
+
+[RegisterComponent, Access(typeof(IdExaminableSystem))]
+public sealed class IdExaminableComponent : Component
+{
+}

--- a/Content.Server/Access/Systems/IdExaminableSystem.cs
+++ b/Content.Server/Access/Systems/IdExaminableSystem.cs
@@ -1,0 +1,77 @@
+﻿using Content.Server.Access.Components;
+using Content.Shared.Access.Components;
+using Content.Shared.Examine;
+using Content.Shared.Inventory;
+using Content.Shared.PDA;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Access.Systems;
+
+public sealed class IdExaminableSystem : EntitySystem
+{
+    [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<IdExaminableComponent, GetVerbsEvent<ExamineVerb>>(OnGetExamineVerbs);
+    }
+
+    private void OnGetExamineVerbs(EntityUid uid, IdExaminableComponent component, GetVerbsEvent<ExamineVerb> args)
+    {
+
+        var detailsRange = _examineSystem.IsInDetailsRange(args.User, uid);
+        var info = GetInfo(component.Owner) ?? Loc.GetString("id-examinable-component-verb-no-id");
+
+        var verb = new ExamineVerb()
+        {
+            Act = () =>
+            {
+                var markup = FormattedMessage.FromMarkup(info);
+                _examineSystem.SendExamineTooltip(args.User, uid, markup, false, false);
+            },
+            Text = Loc.GetString("id-examinable-component-verb-text"),
+            Category = VerbCategory.Examine,
+            Disabled = !detailsRange,
+            Message = Loc.GetString("id-examinable-component-verb-disabled"),
+            IconTexture = "/Textures/Interface/VerbIcons/information.svg.192dpi.png"
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private string? GetInfo(EntityUid uid)
+    {
+        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid))
+        {
+            // PDA
+            if (EntityManager.TryGetComponent(idUid, out PDAComponent? pda) && pda.ContainedID is not null)
+            {
+                return GetNameAndJob(pda.ContainedID);
+            }
+            // ID Card
+            if (EntityManager.TryGetComponent(idUid, out IdCardComponent? id))
+            {
+                return GetNameAndJob(id);
+            }
+        }
+        return null;
+    }
+
+    private string GetNameAndJob(IdCardComponent id)
+    {
+        var jobSuffix = string.IsNullOrWhiteSpace(id.JobTitle) ? string.Empty : $" ({id.JobTitle})";
+
+        var val = string.IsNullOrWhiteSpace(id.FullName)
+            ? Loc.GetString("access-id-card-component-owner-name-job-title-text",
+                ("originalOwnerName", id.OriginalOwnerName),
+                ("jobSuffix", jobSuffix))
+            : Loc.GetString("access-id-card-component-owner-full-name-job-title-text",
+                ("fullName", id.FullName),
+                ("jobSuffix", jobSuffix));
+
+        return val;
+    }
+}

--- a/Resources/Locale/en-US/access/components/id-examinable-component.ftl
+++ b/Resources/Locale/en-US/access/components/id-examinable-component.ftl
@@ -1,0 +1,3 @@
+id-examinable-component-verb-text = ID Card
+id-examinable-component-verb-disabled = Read an ID card in close range.
+id-examinable-component-verb-no-id = No ID card visible.

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -52,6 +52,7 @@
     solution: chemicals
   - type: DrawableSolution
     solution: bloodstream
+  - type: IdExaminable
   - type: HealthExaminable
     examinableTypes:
     - Blunt


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Players can now examine each other's ID card slots while an ID/PDA is worn.

The icon is a placeholder but I'm a coder not an artist so don't expect anything better from me.

**Screenshots**

https://user-images.githubusercontent.com/5714543/177208206-39cfbf38-898e-450e-9143-48f89cc9f1a5.mp4



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Players can now examine each other's ID card slots while an ID/PDA is worn

