### PR TITLE
Fixes Blocking bugs

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -199,7 +199,7 @@ public sealed class BlockingSystem : EntitySystem
         if (component.BlockingToggleAction != null && TryComp<BlockingUserComponent>(user, out var blockingUserComponent)
                                                      && TryComp<PhysicsComponent>(user, out var physicsComponent))
         {
-            if (Transform(user).Anchored)
+            if (xform.Anchored)
                 _transformSystem.Unanchor(xform);
 
             _actionsSystem.SetToggled(component.BlockingToggleAction, false);

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -75,13 +75,11 @@ public sealed class BlockingSystem : EntitySystem
         if(args.Handled)
             return;
 
-        if (component.User != null)
-        {
-            foreach (var shield in _handsSystem.EnumerateHeld(component.User.Value))
+            foreach (var shield in _handsSystem.EnumerateHeld(args.Performer))
             {
                 if (TryComp<BlockingComponent>(shield, out var otherBlockComp))
                 {
-                    if ((!component.IsBlocking && otherBlockComp.IsBlocking))
+                    if (!component.IsBlocking && otherBlockComp.IsBlocking)
                     {
                         StopBlocking(shield, otherBlockComp, args.Performer);
                         StartBlocking(uid, component, args.Performer);
@@ -96,9 +94,8 @@ public sealed class BlockingSystem : EntitySystem
                     }
                 }
             }
-        }
 
-        if (component.IsBlocking)
+            if (component.IsBlocking)
             StopBlocking(uid, component, args.Performer);
         else
             StartBlocking(uid, component, args.Performer);

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -75,27 +75,18 @@ public sealed class BlockingSystem : EntitySystem
         if(args.Handled)
             return;
 
-            foreach (var shield in _handsSystem.EnumerateHeld(args.Performer))
+        foreach (var shield in _handsSystem.EnumerateHeld(args.Performer))
+        {
+            if (shield == uid)
+                continue;
+            if (TryComp<BlockingComponent>(shield, out var otherBlockComp) && otherBlockComp.IsBlocking)
             {
-                if (TryComp<BlockingComponent>(shield, out var otherBlockComp))
-                {
-                    if (!component.IsBlocking && otherBlockComp.IsBlocking)
-                    {
-                        StopBlocking(shield, otherBlockComp, args.Performer);
-                        StartBlocking(uid, component, args.Performer);
-                        return;
-                    }
-
-                    if (component.IsBlocking && !otherBlockComp.IsBlocking)
-                    {
-                        StopBlocking(uid, component, args.Performer);
-                        StartBlocking(shield, otherBlockComp, args.Performer);
-                        return;
-                    }
-                }
+                CantBlockError(args.Performer);
+                return;
             }
+        }
 
-            if (component.IsBlocking)
+        if (component.IsBlocking)
             StopBlocking(uid, component, args.Performer);
         else
             StartBlocking(uid, component, args.Performer);

--- a/Content.Shared/Blocking/BlockingUserSystem.cs
+++ b/Content.Shared/Blocking/BlockingUserSystem.cs
@@ -1,8 +1,10 @@
 ﻿using Content.Shared.Audio;
+using Content.Shared.Buckle.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Hands.EntitySystems;
 using Robust.Shared.Audio;
+using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -21,12 +23,42 @@ public sealed class BlockingUserSystem : EntitySystem
         SubscribeLocalEvent<BlockingUserComponent, DamageChangedEvent>(OnDamageChanged);
         SubscribeLocalEvent<BlockingUserComponent, DamageModifyEvent>(OnUserDamageModified);
 
+        SubscribeLocalEvent<BlockingUserComponent, EntParentChangedMessage>(OnParentChanged);
+        SubscribeLocalEvent<BlockingUserComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
+        SubscribeLocalEvent<BlockingUserComponent, BuckleChangeEvent>(OnBuckle);
         SubscribeLocalEvent<BlockingUserComponent, AnchorStateChangedEvent>(OnAnchorChanged);
+    }
+
+    private void OnParentChanged(EntityUid uid, BlockingUserComponent component, ref EntParentChangedMessage args)
+    {
+        if (TryComp<BlockingComponent>(component.BlockingItem, out var blockComp) && blockComp.IsBlocking)
+        {
+            _blockingSystem.StopBlocking(component.BlockingItem.Value, blockComp, uid);
+        }
+    }
+
+    private void OnInsertAttempt(EntityUid uid, BlockingUserComponent component, ContainerGettingInsertedAttemptEvent args)
+    {
+        if (TryComp<BlockingComponent>(component.BlockingItem, out var blockComp) && blockComp.IsBlocking)
+        {
+            _blockingSystem.StopBlocking(component.BlockingItem.Value, blockComp, uid);
+        }
+    }
+
+    private void OnBuckle(EntityUid uid, BlockingUserComponent component, BuckleChangeEvent args)
+    {
+        if (args.Buckling)
+        {
+            if (TryComp<BlockingComponent>(component.BlockingItem, out var blockComp) && blockComp.IsBlocking)
+            {
+                _blockingSystem.StopBlocking(component.BlockingItem.Value, blockComp, uid);
+            }
+        }
     }
 
     private void OnAnchorChanged(EntityUid uid, BlockingUserComponent component, ref AnchorStateChangedEvent args)
     {
-        if (!args.Anchored)
+        if (args.Anchored)
             return;
 
         if (TryComp<BlockingComponent>(component.BlockingItem, out var blockComp) && blockComp.IsBlocking)

--- a/Content.Shared/Blocking/BlockingUserSystem.cs
+++ b/Content.Shared/Blocking/BlockingUserSystem.cs
@@ -25,7 +25,6 @@ public sealed class BlockingUserSystem : EntitySystem
 
         SubscribeLocalEvent<BlockingUserComponent, EntParentChangedMessage>(OnParentChanged);
         SubscribeLocalEvent<BlockingUserComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
-        SubscribeLocalEvent<BlockingUserComponent, BuckleChangeEvent>(OnBuckle);
         SubscribeLocalEvent<BlockingUserComponent, AnchorStateChangedEvent>(OnAnchorChanged);
     }
 
@@ -42,17 +41,6 @@ public sealed class BlockingUserSystem : EntitySystem
         if (TryComp<BlockingComponent>(component.BlockingItem, out var blockComp) && blockComp.IsBlocking)
         {
             _blockingSystem.StopBlocking(component.BlockingItem.Value, blockComp, uid);
-        }
-    }
-
-    private void OnBuckle(EntityUid uid, BlockingUserComponent component, BuckleChangeEvent args)
-    {
-        if (args.Buckling)
-        {
-            if (TryComp<BlockingComponent>(component.BlockingItem, out var blockComp) && blockComp.IsBlocking)
-            {
-                _blockingSystem.StopBlocking(component.BlockingItem.Value, blockComp, uid);
-            }
         }
     }
 

--- a/Resources/Locale/en-US/actions/actions/blocking.ftl
+++ b/Resources/Locale/en-US/actions/actions/blocking.ftl
@@ -7,4 +7,4 @@ action-popup-blocking-disabling-user = You lower your {$shield}!
 action-popup-blocking-other = {$blockerName} raises their {$shield}!
 action-popup-blocking-disabling-other = {$blockerName} lowers their {$shield}!
 
-action-popup-blocking-user-cant-block = The gravity here prevents you from blocking.
+action-popup-blocking-user-cant-block = You tried to raise your shield, but it was no use.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

closes #9403

Fixes just about everything in the linked issue and what was reported to me, which is about:

Fixes an issue with a blocking entity either being buckled, or blocking while buckling.
Fixes an issue with en entity blocking while inside of a closet or container.
Fixes an issue with an entity blocking where there's no grid.
Fixes an infinite loop if it checked that the entity was anchored.
Fixes an issue where it deleted the Blocking User Component an entity was holding something else that could block.
Fixes an issue if you try to block with another blocking item while already blocking

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Unintended blocking bugs are now fixed.

