### PR TITLE
Make destructible test more reliable

### DIFF
--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Content.Client.IoC;
 using Content.Client.Parallax.Managers;
 using Content.IntegrationTests.Tests;
+using Content.IntegrationTests.Tests.Destructible;
 using Content.IntegrationTests.Tests.DeviceNetwork;
 using Content.IntegrationTests.Tests.Interaction.Click;
 using Content.IntegrationTests.Tests.Networking;
@@ -106,6 +107,7 @@ public static class PoolManager
             IoCManager.Resolve<IEntitySystemManager>()
                 .LoadExtraSystemType<InteractionSystemTests.TestInteractionSystem>();
             IoCManager.Resolve<IEntitySystemManager>().LoadExtraSystemType<DeviceNetworkTestSystem>();
+            IoCManager.Resolve<IEntitySystemManager>().LoadExtraSystemType<TestDestructibleListenerSystem>();
             IoCManager.Resolve<ILogManager>().GetSawmill("loc").Level = LogLevel.Error;
         };
 

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
@@ -39,6 +39,7 @@ namespace Content.IntegrationTests.Tests.Destructible
                 sDestructibleEntity = sEntityManager.SpawnEntity(DestructibleDamageTypeEntityId, coordinates);
                 sDamageableComponent = IoCManager.Resolve<IEntityManager>().GetComponent<DamageableComponent>(sDestructibleEntity);
                 sTestThresholdListenerSystem = sEntitySystemManager.GetEntitySystem<TestDestructibleListenerSystem>();
+                sTestThresholdListenerSystem.ThresholdsReached.Clear();
                 sDamageableSystem = sEntitySystemManager.GetEntitySystem<DamageableSystem>();
             });
 

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
@@ -36,6 +36,7 @@ namespace Content.IntegrationTests.Tests.Destructible
 
                 sDestructibleEntity = sEntityManager.SpawnEntity(DestructibleDestructionEntityId, coordinates);
                 sTestThresholdListenerSystem = sEntitySystemManager.GetEntitySystem<TestDestructibleListenerSystem>();
+                sTestThresholdListenerSystem.ThresholdsReached.Clear();
             });
 
             await server.WaitAssertion(() =>

--- a/Content.IntegrationTests/Tests/Destructible/TestDestructibleListenerSystem.cs
+++ b/Content.IntegrationTests/Tests/Destructible/TestDestructibleListenerSystem.cs
@@ -1,9 +1,8 @@
 using System.Collections.Generic;
 using Content.Server.Destructible;
 using Content.Shared.GameTicking;
-using Content.Shared.Module;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
+using Robust.Shared.Reflection;
 
 namespace Content.IntegrationTests.Tests.Destructible
 {
@@ -11,19 +10,14 @@ namespace Content.IntegrationTests.Tests.Destructible
     ///     This is just a system for testing destructible thresholds. Whenever any threshold is reached, this will add that
     ///     threshold to a list for checking during testing.
     /// </summary>
+    [Reflect(false)]
     public sealed class TestDestructibleListenerSystem : EntitySystem
     {
-        [Dependency] private readonly IModuleManager _modManager;
-
         public readonly List<DamageThresholdReached> ThresholdsReached = new();
 
         public override void Initialize()
         {
             base.Initialize();
-
-            if (_modManager.IsClientModule)
-                return;
-
             SubscribeLocalEvent<DestructibleComponent, DamageThresholdReached>(AddThresholdsToList);
             SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
         }


### PR DESCRIPTION
- Add missing ThresholdsReached clears (so it doesn't accidentally fail when a pooled instance doesn't round restart)
- Prevent the test threshold system from being added to the client (since it doesn't do anything)