### PR TITLE
Fix salvage gibbing

### DIFF
--- a/Content.IntegrationTests/Tests/DummyIconTest.cs
+++ b/Content.IntegrationTests/Tests/DummyIconTest.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using Robust.Client.GameObjects;
 using Robust.Client.ResourceManagement;
+using Robust.Shared.IoC;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests
@@ -17,11 +18,10 @@ namespace Content.IntegrationTests.Tests
             await using var pairTracker = await PoolManager.GetServerClient();
             var client = pairTracker.Pair.Client;
 
-            var prototypeManager = client.ResolveDependency<IPrototypeManager>();
-            var resourceCache = client.ResolveDependency<IResourceCache>();
-            await client.WaitRunTicks(5);
             await client.WaitAssertion(() =>
             {
+                var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+                var resourceCache = IoCManager.Resolve<IResourceCache>();
                 foreach (var proto in prototypeManager.EnumeratePrototypes<EntityPrototype>())
                 {
                     if (proto.NoSpawn || proto.Abstract || !proto.Components.ContainsKey("Sprite")) continue;
@@ -33,7 +33,6 @@ namespace Content.IntegrationTests.Tests
                         proto.ID);
                 }
             });
-            await client.WaitRunTicks(5);
             await pairTracker.CleanReturnAsync();
         }
     }

--- a/Content.Server/Salvage/SalvageMobRestrictionsSystem.cs
+++ b/Content.Server/Salvage/SalvageMobRestrictionsSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Content.Server.Salvage;
 
@@ -63,16 +64,20 @@ public sealed class SalvageMobRestrictionsSystem : EntitySystem
 
     private void OnRemoveGrid(EntityUid uid, SalvageMobRestrictionsGridComponent component, ComponentRemove args)
     {
-        foreach (EntityUid target in component.MobsToKill)
+        var metaQuery = GetEntityQuery<MetaDataComponent>();
+        var bodyQuery = GetEntityQuery<BodyComponent>();
+        var damageQuery = GetEntityQuery<DamageableComponent>();
+        foreach (var target in component.MobsToKill)
         {
-            if (TryComp(target, out BodyComponent? body))
+            if (Deleted(target, metaQuery)) continue;
+            if (bodyQuery.TryGetComponent(target, out var body))
             {
                 // Just because.
                 body.Gib();
             }
-            else if (TryComp(target, out DamageableComponent? dc))
+            else if (damageQuery.TryGetComponent(target, out var damageableComponent))
             {
-                _damageableSystem.SetAllDamage(dc, 200);
+                _damageableSystem.SetAllDamage(damageableComponent, 200);
             }
         }
     }

--- a/Content.Shared/Body/Components/SharedBodyPartComponent.cs
+++ b/Content.Shared/Body/Components/SharedBodyPartComponent.cs
@@ -255,8 +255,9 @@ namespace Content.Shared.Body.Components
 
         private void AddedToBody(SharedBodyComponent body)
         {
-            _entMan.GetComponent<TransformComponent>(Owner).LocalRotation = 0;
-            _entMan.GetComponent<TransformComponent>(Owner).AttachParent(body.Owner);
+            var transformComponent = _entMan.GetComponent<TransformComponent>(Owner);
+            transformComponent.LocalRotation = 0;
+            transformComponent.AttachParent(body.Owner);
             OnAddedToBody(body);
 
             foreach (var mechanism in _mechanisms)
@@ -267,9 +268,9 @@ namespace Content.Shared.Body.Components
 
         private void RemovedFromBody(SharedBodyComponent old)
         {
-            if (!_entMan.GetComponent<TransformComponent>(Owner).Deleted)
+            if (_entMan.TryGetComponent<TransformComponent>(Owner, out var transformComponent))
             {
-                _entMan.GetComponent<TransformComponent>(Owner).AttachToGridOrMap();
+                transformComponent.AttachToGridOrMap();
             }
 
             OnRemovedFromBody(old);


### PR DESCRIPTION
I noticed this test failure on github actions.
https://github.com/space-wizards/space-station-14/runs/7188771647?check_suite_focus=true

```
   1) SERVER: 25.167s [ERRO] runtime: Caught exception in "RemoveComponentImmediate, owner=856, type=Content.Server.Salvage.SalvageMobRestrictionsGridComponent" Exception: System.Collections.Generic.KeyNotFoundException: Entity 2975 does not have a component of type Robust.Shared.GameObjects.TransformComponent
   at Content.Shared.Body.Components.SharedBodyPartComponent.RemovedFromBody(SharedBodyComponent old) in D:\a\space-station-14\space-station-14\Content.Shared\Body\Components\SharedBodyPartComponent.cs:line 270
   at Content.Shared.Body.Components.SharedBodyComponent.OnRemovePart(BodyPartSlot slot, SharedBodyPartComponent part) in D:\a\space-station-14\space-station-14\Content.Shared\Body\Components\SharedBodyComponent.cs:line 161
   at Content.Server.Body.Components.BodyComponent.OnRemovePart(BodyPartSlot slot, SharedBodyPartComponent part) in D:\a\space-station-14\space-station-14\Content.Server\Body\Components\BodyComponent.cs:line 37
   at Content.Shared.Body.Components.SharedBodyComponent.<>c__DisplayClass27_0.<SetSlot>b__1(SharedBodyPartComponent part) in D:\a\space-station-14\space-station-14\Content.Shared\Body\Components\SharedBodyComponent.cs:line 99
   at Content.Shared.Body.Part.BodyPartSlot.RemovePart() in D:\a\space-station-14\space-station-14\Content.Shared\Body\Part\BodyPartSlot.cs:line 91
   at Content.Shared.Body.Components.SharedBodyComponent.Gib(Boolean gibParts) in D:\a\space-station-14\space-station-14\Content.Shared\Body\Components\SharedBodyComponent.cs:line 397
   at Content.Server.Body.Components.BodyComponent.Gib(Boolean gibParts) in D:\a\space-station-14\space-station-14\Content.Server\Body\Components\BodyComponent.cs:line 84
   at Content.Server.Salvage.SalvageMobRestrictionsSystem.OnRemoveGrid(EntityUid uid, SalvageMobRestrictionsGridComponent component, ComponentRemove args) in D:\a\space-station-14\space-station-14\Content.Server\Salvage\SalvageMobRestrictionsSystem.cs:line 71
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass47_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in D:\a\space-station-14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 252
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass58_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in D:\a\space-station-14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 391
   at Robust.Shared.GameObjects.EntityEventBus.DispatchComponent[TEvent](EntityUid euid, IComponent component, CompIdx baseType, Unit& args, Boolean dispatchByReference) in D:\a\space-station-14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 592
   at Robust.Shared.GameObjects.EntityEventBus.Robust.Shared.GameObjects.IDirectedEventBus.RaiseComponentEvent[TEvent](IComponent component, TEvent args) in D:\a\space-station-14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Directed.cs:line 140
   at Robust.Shared.GameObjects.Component.LifeRemoveFromEntity(IEntityManager entManager) in D:\a\space-station-14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\Component.cs:line 127
   at Robust.Shared.GameObjects.EntityManager.RemoveComponentImmediate(Component component, EntityUid uid, Boolean removeProtected) in D:\a\space-station-14\space-station-14\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Components.cs:line 525
```

Code Changes:
- SalvageMobRestrictionsSystem checks if the entity is deleted before doing anything
- Fixed RemovedFromBody check, so it checks, instead of causing a crash.
- Cleaned DummyIconTest (Unrelated), and some of the above files a little bit

I think fixing this bug will fix the un-deletable space carp bug (probably, maybe, we will see).
Fixes: https://github.com/space-wizards/space-station-14/issues/8305