### PR TITLE
Construction/Crafting improvements

### DIFF
--- a/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/MaterialConstructionGraphStep.cs
@@ -25,12 +25,12 @@ namespace Content.Shared.Construction.Steps
 
         public override bool EntityValid(EntityUid uid, IEntityManager entityManager)
         {
-            return entityManager.TryGetComponent(uid, out SharedStackComponent? stack) && stack.StackTypeId == MaterialPrototypeId && stack.Count >= Amount;
+            return entityManager.TryGetComponent(uid, out SharedStackComponent? stack) && stack.StackTypeId == MaterialPrototypeId;
         }
 
         public bool EntityValid(EntityUid entity, [NotNullWhen(true)] out SharedStackComponent? stack)
         {
-            if (IoCManager.Resolve<IEntityManager>().TryGetComponent(entity, out SharedStackComponent? otherStack) && otherStack.StackTypeId == MaterialPrototypeId && otherStack.Count >= Amount)
+            if (IoCManager.Resolve<IEntityManager>().TryGetComponent(entity, out SharedStackComponent? otherStack) && otherStack.StackTypeId == MaterialPrototypeId)
                 stack = otherStack;
             else
                 stack = null;

--- a/Content.Shared/Construction/Steps/PrototypeConstructionGraphStep.cs
+++ b/Content.Shared/Construction/Steps/PrototypeConstructionGraphStep.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Examine;
+using Content.Shared.Examine;
+using Content.Shared.Stacks;
 
 namespace Content.Shared.Construction.Steps
 {
@@ -6,10 +7,27 @@ namespace Content.Shared.Construction.Steps
     public sealed class PrototypeConstructionGraphStep : ArbitraryInsertConstructionGraphStep
     {
         [DataField("prototype")] public string Prototype { get; } = string.Empty;
+        [DataField("amount")] public int Amount { get; } = 1;
 
         public override bool EntityValid(EntityUid uid, IEntityManager entityManager)
         {
             return entityManager.GetComponent<MetaDataComponent>(uid).EntityPrototype?.ID == Prototype;
+        }
+
+        public bool EntityValid(EntityUid entity, out SharedStackComponent? stack)
+        {
+            stack = null;
+            if (IoCManager.Resolve<IEntityManager>().TryGetComponent(entity, out SharedStackComponent? otherStack) && otherStack.StackTypeId == Prototype)
+            {
+                stack = otherStack;
+                return true;
+            }
+            else if (IoCManager.Resolve<IEntityManager>().GetComponent<MetaDataComponent>(entity).EntityPrototype?.ID == Prototype)
+            {
+                return true;
+            }
+
+           return false;
         }
 
         public override void DoExamine(ExaminedEvent examinedEvent)
@@ -23,6 +41,28 @@ namespace Content.Shared.Construction.Steps
                     "construction-insert-prototype",
                     ("entityName", Name)
                 ));
+        }
+
+        public override ConstructionGuideEntry GenerateGuideEntry()
+        {
+            if (Amount > 1)
+            {
+                return new ConstructionGuideEntry()
+                {
+                    Localization = "construction-presenter-prototype-amount-step",
+                    Arguments = new (string, object)[] { ("amount", Amount), ("name", Name) },
+                    Icon = Icon,
+                };
+            }
+            else
+            {
+                return new ConstructionGuideEntry()
+                {
+                    Localization = "construction-presenter-arbitrary-step",
+                    Arguments = new (string, object)[] { ("name", Name) },
+                    Icon = Icon,
+                };
+            }
         }
     }
 }

--- a/Resources/Locale/en-US/construction/ui/construction-menu-presenter.ftl
+++ b/Resources/Locale/en-US/construction/ui/construction-menu-presenter.ftl
@@ -6,4 +6,5 @@ construction-presenter-step-wrapper = {$step-number}. {$text}
 
 construction-presenter-tool-step = Use a {LOC($tool)}.
 construction-presenter-material-step = Add {$amount}x {LOC($material)}.
+construction-presenter-prototype-amount-step = Add {$amount}x {LOC($name)}.
 construction-presenter-arbitrary-step = Add {LOC($name)}.


### PR DESCRIPTION
## About the PR
Closes #9052 
- Prototype construction now supports an optional Amount attribute like materials. Y'know, blunts with 3 cannabis > 1 cannabis. As part of this, recipes that require 1 entity will no longer eat entire stacks

Also noticed a variety of annoying things in this system so I took a shot at basic improvements:
- We now validate **all** ingredients/steps before adding anything to containers, then do all the containing/consumption at the end if everything passes. No more dropping ingredients on the ground because you failed at a later step
- Construction/crafting will now consider and aggregate all stacks/entities of a required item that you own, rather than the first it sees. So if a recipe calls for 2x Steel, you can have two separate stacks of 1 and have it work
- Stacks are now consumed from lesser to higher quantity, so your 1-stack gets eaten before your 5-stack. Game design moment

I have seen the warning signs that the current construction implementation is liable to be nuked at some point. If this code dies with it, that's fine - I'm happy with this as a temp improvement and learning experience.

**Changelog**
:cl:
- tweak: Items will no longer be dropped on the floor when crafting/construction is failed
- tweak: Crafting/construction will now use up smaller stacks before larger ones
- fix: Crafting recipes which use single items will now correctly consume one item instead of a whole stack
- fix: Crafting/construction now considers all stacks of a material you possess, so 2 stacks of 2 properly counts as 4 for recipes

