### PR TITLE
Disable ambience default again

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -265,8 +265,6 @@
   components:
   - type: Sprite
     state: off
-  - type: AmbientSound
-    enabled: true
   - type: PoweredLight
     hasLampOnSpawn: LightBulb
     damage:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -9,6 +9,7 @@
   - type: AmbientSound
     volume: -9
     range: 3
+    enabled: false
     sound:
       path: /Audio/Ambience/Objects/vending_machine_hum.ogg
   - type: Sprite


### PR DESCRIPTION
These get serialized as false anyway and saves us a few hundred lines per map.
