### PR TITLE
Bagel Update 14.1

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -106,7 +106,7 @@ grids:
   - ind: 2,-2
     tiles: MQAAADEAAAAxAAAAJQAAADcAAAA0AAAANAAAADQAAAA0AAAANAAAADQAAAE0AAADNAAAAjQAAAA0AAAANAAAAjEAAAAxAAAAMQAAACUAAAA3AAAANAAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAAzQAAAI0AAADNAAAAzQAAAIxAAAAMQAAADEAAAAlAAAAMQAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAAzQAAAI0AAAANAAAAzQAAAA0AAACMQAAADEAAAAxAAAAJQAAADcAAAA0AAAANAAAADQAAAA0AAAANAAAADQAAAM0AAADNAAAAzQAAAI0AAACNAAAADEAAAAxAAAAMQAAACUAAAA3AAAANAAAADQAAAA0AAAANAAAADQAAAA0AAABNAAAAjQAAAM0AAAANAAAAjQAAAExAAAAMQAAADEAAAAlAAAANwAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAADQAAAI0AAADNAAAADQAAAI0AAACJQAAACMAAAAjAAAAIwAAADcAAAA3AAAANAAAAjQAAAA0AAACNAAAAjcAAAA0AAAANAAAADQAAAA0AAABNAAAAjEAAAMxAAACMQAAAjEAAAI0AAAANAAAADQAAAM0AAAANAAAATQAAAE0AAAANAAAADQAAAI0AAADNwAAADcAAAAxAAABMQAAADEAAAExAAACNAAAADQAAAA0AAACNAAAAzQAAAA0AAADNAAAADQAAAM0AAABNAAAATcAAAA0AAACMQAAADEAAAExAAABMQAAAjQAAAI0AAADNAAAATQAAAE0AAABNAAAADQAAAA0AAABNAAAADQAAAE0AAACNAAAATQAAAM0AAADNAAAATcAAAA3AAAANwAAADQAAAA0AAAANAAAADcAAAA3AAAANAAAADQAAAI0AAAANAAAAjQAAAI0AAABNAAAATQAAAE0AAABNAAAATQAAAE0AAABNAAAATQAAAE0AAAANAAAADQAAAA0AAACNAAAAjQAAAA0AAAANAAAAzQAAAI0AAACNAAAAzQAAAM0AAADNAAAADQAAAM0AAAANAAAADQAAAA0AAAANAAAADQAAAE3AAAANAAAAzQAAAI0AAABNAAAADQAAAM3AAAANwAAADQAAAI0AAAANAAAAzcAAAA3AAAANAAAATQAAAE0AAACNAAAADQAAAA0AAADNAAAATQAAAM0AAACNAAAAzQAAAM0AAACNAAAADQAAAI0AAACNAAAAjQAAAM0AAAANAAAAzQAAAI0AAAANAAAADQAAAA0AAACNAAAADQAAAM0AAAANAAAADQAAAM0AAABNAAAADQAAAE0AAAANAAAATQAAAI0AAABNAAAAA==
   - ind: 3,-3
-    tiles: NwAAADUAAAI1AAACNQAAATUAAAM1AAABNwAAADUAAAE3AAAAMgAAADcAAAA3AAAANwAAAAAAAAA2AAAANgAAADUAAAM1AAABNwAAADUAAAE1AAACNQAAAygAAAA1AAACNQAAATUAAAAyAAAAMgAAADcAAAAAAAAANgAAAAAAAAA1AAADNQAAATcAAAA1AAAANQAAATUAAAEoAAAAKAAAACgAAAA1AAACMgAAADcAAAA3AAAAAAAAADYAAAA2AAAANQAAADUAAAA1AAABNQAAAzUAAAA1AAACKAAAACgAAAA3AAAANQAAADIAAAA3AAAANwAAAAAAAAA2AAAANgAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAAAAAAANgAAADYAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAAAAAADYAAAA2AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAAAAAAAA2AAAANgAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAMwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADMAAAA3AAAAMwAAADMAAAAzAAAANwAAADIAAAAyAAAANwAAADIAAAAyAAAAMgAAADIAAAAyAAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAMgAAADIAAAAyAAAAMgAAADcAAAAyAAAANwAAADcAAAA3AAAAMwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADIAAAAyAAAAMgAAADIAAAAyAAAAMgAAADIAAAA3AAAANwAAADMAAAA3AAAANwAAADcAAAA3AAAAMgAAADcAAAA3AAAAMgAAADIAAAAyAAAAMgAAADcAAAAyAAAANwAAADcAAAAzAAAANwAAAAAAAAA2AAAANgAAADcAAAA3AAAAMgAAADIAAAAyAAAAMgAAADcAAAA3AAAAMgAAADcAAAA3AAAAMwAAADcAAAAAAAAANgAAADYAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAAAAAADYAAAA2AAAANAAAATQAAAE0AAABNAAAAzQAAAA3AAAANgAAADYAAAA3AAAAMwAAADcAAAAzAAAANwAAAAAAAAA2AAAANgAAAA==
+    tiles: NwAAADUAAAI1AAACNQAAATUAAAM1AAABNwAAADUAAAE3AAAAMgAAADcAAAA3AAAANwAAAAAAAAA2AAAANgAAADUAAAM1AAABNwAAADUAAAE1AAACNQAAAygAAAA1AAACNQAAATUAAAAyAAAAMgAAADcAAAAAAAAANgAAAAAAAAA1AAADNQAAATcAAAA1AAAANQAAATcAAAAoAAAAKAAAACgAAAA1AAACMgAAADcAAAA3AAAAAAAAADYAAAA2AAAANQAAADUAAAA1AAABNQAAAzUAAAA3AAAAKAAAACgAAAA3AAAANQAAADIAAAA3AAAANwAAAAAAAAA2AAAANgAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAAAAAAANgAAADYAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAAAAAADYAAAA2AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAAAAAAAA2AAAANgAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAMwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADMAAAA3AAAAMwAAADMAAAAzAAAANwAAADIAAAAyAAAANwAAADIAAAAyAAAAMgAAADIAAAAyAAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAMgAAADIAAAAyAAAAMgAAADcAAAAyAAAANwAAADcAAAA3AAAAMwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADIAAAAyAAAAMgAAADIAAAAyAAAAMgAAADIAAAA3AAAANwAAADMAAAA3AAAANwAAADcAAAA3AAAAMgAAADcAAAA3AAAAMgAAADIAAAAyAAAAMgAAADcAAAAyAAAANwAAADcAAAAzAAAANwAAAAAAAAA2AAAANgAAADcAAAA3AAAAMgAAADIAAAAyAAAAMgAAADcAAAA3AAAAMgAAADcAAAA3AAAAMwAAADcAAAAAAAAANgAAADYAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAAAAAADYAAAA2AAAANAAAATQAAAE0AAABNAAAAzQAAAA3AAAANgAAADYAAAA3AAAAMwAAADcAAAAzAAAANwAAAAAAAAA2AAAANgAAAA==
   - ind: 3,-2
     tiles: NAAAAzQAAAE0AAACNAAAATQAAAM3AAAAAAAAAAAAAAA3AAAAMwAAADcAAAA3AAAANwAAADcAAAA3AAAANgAAADQAAAA0AAADNAAAAjQAAAM0AAACNwAAAAAAAAAAAAAANwAAADMAAAA3AAAANwAAADUAAAA3AAAANwAAADYAAAA0AAACNAAAAzQAAAI0AAADNAAAAzcAAAAAAAAAAAAAADcAAAAzAAAANwAAADcAAAA3AAAANQAAADcAAAA2AAAANAAAAzQAAAI0AAADNAAAATQAAAE3AAAANgAAAAAAAAA3AAAAMwAAADcAAAA3AAAANwAAADcAAAA3AAAANgAAADQAAAE0AAAANAAAAjQAAAA0AAADNwAAAAAAAAAAAAAANwAAADMAAAA3AAAANwAAADcAAAA3AAAANwAAADYAAAA0AAACNAAAAzQAAAE0AAAANAAAAjcAAAAAAAAAAAAAADcAAAAzAAAANwAAADcAAAA1AAAANwAAADcAAAA2AAAANAAAAzQAAAE0AAACNAAAAjQAAAE3AAAANgAAADYAAAA3AAAAMwAAADcAAAA3AAAANQAAADUAAAA3AAAANgAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADYAAAA0AAABNAAAATQAAAA0AAABNwAAADMAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA2AAAANwAAAAAAAAA2AAAANAAAADQAAAE0AAAANAAAAzcAAAAzAAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANgAAADcAAAAAAAAANgAAADQAAAM0AAAANAAAAzQAAAE3AAAAMwAAADcAAAAzAAAAMwAAADMAAAAzAAAANwAAADYAAAA3AAAAAAAAADYAAAA0AAAANAAAAzQAAAE0AAABNwAAADMAAAA3AAAANwAAADMAAAA3AAAANwAAADcAAAA2AAAANwAAAAAAAAA2AAAANAAAAjQAAAE3AAAANAAAATcAAAAzAAAANwAAADcAAAAzAAAANwAAADcAAAA3AAAANgAAADcAAAAAAAAANgAAADQAAAA0AAAANAAAAAAAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADYAAAAAAAAAAAAAADYAAAA0AAAANAAAADQAAAAAAAAANgAAADcAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA2AAAAAAAAAAAAAAA2AAAANAAAADQAAAA0AAABAAAAADYAAAA3AAAANwAAADcAAAA3AAAANwAAADcAAAA3AAAAAAAAAAAAAAAAAAAANgAAAA==
   - ind: 2,-1
@@ -307,9 +307,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -62.5,8.5
+  - pos: -62.5,9.5
     parent: 60
     type: Transform
 - uid: 5
@@ -8268,6 +8268,16 @@ entities:
           color: '#A4610696'
           id: QuarterTileOverlayGreyscale180
           coordinates: 41,16
+        1781:
+          angle: -1.5707963267948966 rad
+          color: '#FFFFFFFF'
+          id: LoadingArea
+          coordinates: 43,6
+        1782:
+          angle: -1.5707963267948966 rad
+          color: '#FFFFFFFF'
+          id: Arrows
+          coordinates: 41,6
       -3,0:
         1653:
           color: '#334E6DC8'
@@ -10598,7 +10608,7 @@ entities:
       -20,-18: 0
       -20,-17: 0
       -19,-32: 0
-      -19,-31: 0
+      -19,-31: 5
       -19,-30: 0
       -19,-29: 0
       -19,-28: 0
@@ -12363,7 +12373,7 @@ entities:
       52,-35: 0
       52,-34: 0
       52,-33: 0
-      53,-42: 5
+      53,-42: 6
       53,-41: 0
       53,-40: 0
       53,-39: 0
@@ -12373,7 +12383,7 @@ entities:
       53,-35: 0
       53,-34: 0
       53,-33: 0
-      54,-42: 6
+      54,-42: 7
       54,-41: 0
       54,-40: 0
       54,-39: 0
@@ -12383,7 +12393,7 @@ entities:
       54,-35: 0
       54,-34: 0
       54,-33: 0
-      55,-42: 7
+      55,-42: 8
       55,-41: 0
       55,-40: 0
       55,-39: 0
@@ -12393,7 +12403,7 @@ entities:
       55,-35: 0
       55,-34: 0
       55,-33: 0
-      56,-42: 8
+      56,-42: 9
       56,-41: 0
       56,-40: 0
       56,-39: 0
@@ -12403,7 +12413,7 @@ entities:
       56,-35: 0
       56,-34: 0
       56,-33: 0
-      57,-42: 9
+      57,-42: 10
       57,-41: 0
       57,-40: 0
       57,-39: 0
@@ -12413,7 +12423,7 @@ entities:
       57,-35: 0
       57,-34: 0
       57,-33: 0
-      58,-42: 10
+      58,-42: 11
       58,-41: 0
       58,-40: 0
       58,-39: 0
@@ -12423,7 +12433,7 @@ entities:
       58,-35: 0
       58,-34: 0
       58,-33: 0
-      59,-42: 11
+      59,-42: 12
       59,-41: 0
       59,-40: 0
       59,-39: 0
@@ -13547,8 +13557,8 @@ entities:
       -54,-10: 0
       -54,-9: 0
       -54,-8: 0
-      -54,-7: 12
-      -54,-6: 12
+      -54,-7: 5
+      -54,-6: 5
       -54,-5: 0
       -54,-3: 0
       -54,-2: 0
@@ -16004,8 +16014,8 @@ entities:
       -32,42: 0
       -32,43: 0
       -32,44: 0
-      -32,45: 12
-      -32,46: 12
+      -32,45: 5
+      -32,46: 5
       -32,47: 0
       -31,34: 0
       -31,35: 0
@@ -16018,8 +16028,8 @@ entities:
       -31,42: 0
       -31,43: 0
       -31,44: 0
-      -31,45: 12
-      -31,46: 12
+      -31,45: 5
+      -31,46: 5
       -31,47: 0
       -30,42: 0
       -29,35: 0
@@ -16139,11 +16149,11 @@ entities:
       18,19: 0
       18,20: 0
       -47,42: 0
-      -46,42: 12
+      -46,42: 5
       -45,41: 0
-      -45,42: 12
+      -45,42: 5
       -45,43: 0
-      -44,42: 12
+      -44,42: 5
       -43,42: 0
       -42,40: 0
       -42,41: 0
@@ -16207,8 +16217,8 @@ entities:
       -33,42: 0
       -33,43: 0
       -33,44: 0
-      -33,45: 12
-      -33,46: 12
+      -33,45: 5
+      -33,46: 5
       -33,47: 0
       -32,48: 0
       -32,49: 0
@@ -17727,9 +17737,9 @@ entities:
       -27,56: 0
       -27,57: 0
       -27,58: 0
-      -27,59: 12
-      -27,60: 12
-      -27,61: 12
+      -27,59: 5
+      -27,60: 5
+      -27,61: 5
       -26,50: 0
       -26,51: 0
       -26,52: 0
@@ -17739,9 +17749,9 @@ entities:
       -26,56: 0
       -26,57: 0
       -26,58: 0
-      -26,59: 12
-      -26,60: 12
-      -26,61: 12
+      -26,59: 5
+      -26,60: 5
+      -26,61: 5
       -25,50: 0
       -25,51: 0
       -25,52: 0
@@ -17751,9 +17761,9 @@ entities:
       -25,56: 0
       -25,57: 0
       -25,58: 0
-      -25,59: 12
-      -25,60: 12
-      -25,61: 12
+      -25,59: 5
+      -25,60: 5
+      -25,61: 5
       -24,50: 0
       -24,51: 0
       -24,52: 0
@@ -20906,8 +20916,8 @@ entities:
       -56,-3: 0
       -56,-1: 0
       -55,-9: 0
-      -55,-7: 12
-      -55,-6: 12
+      -55,-7: 5
+      -55,-6: 5
       -55,-5: 0
       -55,-4: 0
       -55,-3: 0
@@ -21005,8 +21015,8 @@ entities:
       -53,-11: 0
       -53,-10: 0
       -53,-9: 0
-      -53,-7: 12
-      -53,-6: 12
+      -53,-7: 5
+      -53,-6: 5
       -53,-4: 0
       -53,-3: 0
       -53,-2: 0
@@ -21015,8 +21025,8 @@ entities:
       -52,-10: 0
       -52,-9: 0
       -52,-8: 0
-      -52,-7: 12
-      -52,-6: 12
+      -52,-7: 5
+      -52,-6: 5
       -52,-4: 0
       -52,-3: 0
       -52,-2: 0
@@ -21760,38 +21770,38 @@ entities:
       -46,33: 0
       -46,34: 13
       -46,35: 0
-      -46,36: 12
+      -46,36: 5
       -46,37: 0
-      -46,38: 12
+      -46,38: 5
       -46,39: 0
       -46,40: 18
       -46,41: 0
       -46,43: 0
-      -46,44: 12
+      -46,44: 5
       -46,45: 0
       -45,32: 20
       -45,33: 0
       -45,34: 13
       -45,35: 0
-      -45,36: 12
+      -45,36: 5
       -45,37: 0
-      -45,38: 12
+      -45,38: 5
       -45,39: 0
       -45,40: 18
-      -45,44: 12
+      -45,44: 5
       -45,45: 0
       -44,32: 20
       -44,33: 0
       -44,34: 13
       -44,35: 0
-      -44,36: 12
+      -44,36: 5
       -44,37: 0
-      -44,38: 12
+      -44,38: 5
       -44,39: 0
       -44,40: 18
       -44,41: 0
       -44,43: 0
-      -44,44: 12
+      -44,44: 5
       -44,45: 0
       -43,32: 0
       -43,33: 0
@@ -22782,7 +22792,7 @@ entities:
       51,31: 0
       52,29: 0
       52,30: 0
-      52,31: 11
+      52,31: 12
       53,28: 0
       53,29: 0
       53,30: 0
@@ -22802,7 +22812,7 @@ entities:
       54,28: 0
       54,29: 0
       54,30: 0
-      54,31: 11
+      54,31: 12
       55,16: 0
       55,17: 0
       55,18: 0
@@ -23696,104 +23706,104 @@ entities:
       -34,80: 0
       42,31: 0
       56,31: 0
-      -64,16: 12
-      -64,17: 12
-      -64,18: 12
-      -80,17: 12
-      -80,25: 12
-      -79,17: 12
-      -79,25: 12
-      -78,16: 12
-      -78,17: 12
-      -78,25: 12
-      -77,16: 12
-      -77,17: 12
-      -77,18: 12
-      -77,20: 12
-      -77,21: 12
-      -77,22: 12
-      -77,23: 12
-      -77,24: 12
-      -77,25: 12
-      -76,16: 12
-      -76,17: 12
-      -76,18: 12
-      -76,19: 12
-      -76,20: 12
-      -76,21: 12
-      -76,22: 12
-      -76,23: 12
-      -76,25: 12
-      -75,16: 12
-      -75,17: 12
-      -75,18: 12
-      -75,19: 12
-      -75,20: 12
-      -75,21: 12
-      -75,23: 12
-      -75,25: 12
-      -74,16: 12
-      -74,17: 12
-      -74,18: 12
-      -74,19: 12
-      -74,20: 12
-      -74,21: 12
-      -74,23: 12
-      -74,25: 12
-      -73,17: 12
-      -73,18: 12
-      -73,19: 12
-      -73,20: 12
-      -73,21: 12
-      -73,23: 12
-      -72,21: 12
-      -72,23: 12
-      -70,19: 12
-      -69,16: 12
-      -69,17: 12
-      -69,18: 12
-      -69,26: 12
-      -68,16: 12
-      -68,18: 12
-      -68,26: 12
-      -65,16: 12
-      -65,17: 12
-      -65,18: 12
-      -80,12: 12
-      -79,12: 12
-      -78,12: 12
-      -78,13: 12
-      -78,14: 12
-      -78,15: 12
-      -77,12: 12
-      -77,14: 12
-      -76,12: 12
-      -76,14: 12
-      -76,15: 12
-      -75,12: 12
-      -75,14: 12
-      -75,15: 12
-      -74,12: 12
-      -74,14: 12
-      -74,15: 12
-      -81,17: 12
-      59,-43: 12
-      60,-44: 12
+      -64,16: 5
+      -64,17: 5
+      -64,18: 5
+      -80,17: 5
+      -80,25: 5
+      -79,17: 5
+      -79,25: 5
+      -78,16: 5
+      -78,17: 5
+      -78,25: 5
+      -77,16: 5
+      -77,17: 5
+      -77,18: 5
+      -77,20: 5
+      -77,21: 5
+      -77,22: 5
+      -77,23: 5
+      -77,24: 5
+      -77,25: 5
+      -76,16: 5
+      -76,17: 5
+      -76,18: 5
+      -76,19: 5
+      -76,20: 5
+      -76,21: 5
+      -76,22: 5
+      -76,23: 5
+      -76,25: 5
+      -75,16: 5
+      -75,17: 5
+      -75,18: 5
+      -75,19: 5
+      -75,20: 5
+      -75,21: 5
+      -75,23: 5
+      -75,25: 5
+      -74,16: 5
+      -74,17: 5
+      -74,18: 5
+      -74,19: 5
+      -74,20: 5
+      -74,21: 5
+      -74,23: 5
+      -74,25: 5
+      -73,17: 5
+      -73,18: 5
+      -73,19: 5
+      -73,20: 5
+      -73,21: 5
+      -73,23: 5
+      -72,21: 5
+      -72,23: 5
+      -70,19: 5
+      -69,16: 5
+      -69,17: 5
+      -69,18: 5
+      -69,26: 5
+      -68,16: 5
+      -68,18: 5
+      -68,26: 5
+      -65,16: 5
+      -65,17: 5
+      -65,18: 5
+      -80,12: 5
+      -79,12: 5
+      -78,12: 5
+      -78,13: 5
+      -78,14: 5
+      -78,15: 5
+      -77,12: 5
+      -77,14: 5
+      -76,12: 5
+      -76,14: 5
+      -76,15: 5
+      -75,12: 5
+      -75,14: 5
+      -75,15: 5
+      -74,12: 5
+      -74,14: 5
+      -74,15: 5
+      -81,17: 5
+      59,-43: 5
+      60,-44: 5
       60,-43: 21
-      -64,27: 12
-      -64,28: 12
-      -64,29: 12
-      -63,29: 12
-      -62,29: 12
-      -56,29: 12
-      -55,29: 12
-      -54,29: 12
-      -53,29: 12
-      -52,29: 12
-      -68,29: 12
-      -67,29: 12
-      -66,29: 12
-      -65,29: 12
+      -64,27: 5
+      -64,28: 5
+      -64,29: 5
+      -63,29: 5
+      -62,29: 5
+      -56,29: 5
+      -55,29: 5
+      -54,29: 5
+      -53,29: 5
+      -52,29: 5
+      -68,29: 5
+      -67,29: 5
+      -66,29: 5
+      -65,29: 5
     uniqueMixes:
     - volume: 2500
       temperature: 293.15
@@ -23809,8 +23819,8 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 21.806602
-      - 82.03437
+      - 21.821884
+      - 82.09186
       - 0
       - 0
       - 0
@@ -23820,8 +23830,8 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 21.8129
-      - 82.05806
+      - 21.822918
+      - 82.09575
       - 0
       - 0
       - 0
@@ -23831,8 +23841,8 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 21.82003
-      - 82.084885
+      - 21.824085
+      - 82.100136
       - 0
       - 0
       - 0
@@ -23842,8 +23852,19 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 21.823668
-      - 82.09856
+      - 21.82468
+      - 82.10237
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 293.15
+      moles:
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23921,17 +23942,6 @@ entities:
       moles:
       - 16.36866
       - 61.57734
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 293.15
-      moles:
-      - 0
-      - 0
       - 0
       - 0
       - 0
@@ -29504,7 +29514,7 @@ entities:
     parent: 60
     type: Transform
 - uid: 757
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: -14.5,-27.5
     parent: 60
@@ -33176,17 +33186,19 @@ entities:
     parent: 60
     type: Transform
 - uid: 1181
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: -18.5,-29.5
     parent: 60
     type: Transform
 - uid: 1182
-  type: WallSolid
+  type: WeaponLaserCarbine
   components:
-  - pos: -18.5,-30.5
+  - pos: -28.425081,0.9612086
     parent: 60
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 1183
   type: WallSolid
   components:
@@ -34388,10 +34400,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 1333
-  type: WindowReinforcedDirectional
+  type: ShuttleWindow
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -25.5,-62.5
+  - pos: -26.5,-63.5
     parent: 60
     type: Transform
 - uid: 1334
@@ -35624,13 +35635,13 @@ entities:
     parent: 60
     type: Transform
 - uid: 1493
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: -14.5,-28.5
     parent: 60
     type: Transform
 - uid: 1494
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: -14.5,-30.5
     parent: 60
@@ -35875,9 +35886,9 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 1525
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -59.5,-15.5
+  - pos: -60.5,-14.5
     parent: 60
     type: Transform
 - uid: 1526
@@ -40219,7 +40230,7 @@ entities:
     parent: 60
     type: Transform
 - uid: 2073
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: 8.5,-38.5
     parent: 60
@@ -45472,10 +45483,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 2690
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: 1.5707963267948966 rad
-    pos: -13.5,-47.5
+  - pos: -12.5,-47.5
     parent: 60
     type: Transform
 - uid: 2691
@@ -49322,10 +49332,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3174
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: 1.5707963267948966 rad
-    pos: 43.5,-38.5
+  - pos: 42.5,-39.5
     parent: 60
     type: Transform
 - uid: 3175
@@ -49336,10 +49345,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3176
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: 1.5707963267948966 rad
-    pos: 42.5,-39.5
+  - pos: 43.5,-38.5
     parent: 60
     type: Transform
 - uid: 3177
@@ -49742,10 +49750,9 @@ entities:
       Toggle: []
     type: SignalReceiver
 - uid: 3226
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 14.5,-42.5
+  - pos: 16.5,-42.5
     parent: 60
     type: Transform
 - uid: 3227
@@ -49770,17 +49777,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 3230
-  type: WallSolid
+  type: Bed
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 12.5,-44.5
+  - pos: 48.5,-34.5
     parent: 60
     type: Transform
 - uid: 3231
-  type: WallSolid
+  type: BedsheetSpawner
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 12.5,-45.5
+  - pos: 48.5,-34.5
     parent: 60
     type: Transform
 - uid: 3232
@@ -50191,16 +50196,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 3294
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 15.5,-47.5
+  - pos: 15.5,-47.5
     parent: 60
     type: Transform
 - uid: 3295
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 16.5,-47.5
+  - pos: 14.5,-47.5
     parent: 60
     type: Transform
 - uid: 3296
@@ -50303,7 +50307,7 @@ entities:
     parent: 60
     type: Transform
 - uid: 3312
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: 43.5,-43.5
     parent: 60
@@ -50570,9 +50574,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3352
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -62.5,9.5
+  - pos: -62.5,8.5
     parent: 60
     type: Transform
 - uid: 3353
@@ -50790,9 +50794,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3386
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -58.5,-15.5
+  - pos: -59.5,-15.5
     parent: 60
     type: Transform
 - uid: 3387
@@ -50848,9 +50852,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3394
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -53.5,-19.5
+  - pos: -53.5,-20.5
     parent: 60
     type: Transform
 - uid: 3395
@@ -51058,9 +51062,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3425
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 59.5,-28.5
+  - pos: 59.5,-25.5
     parent: 60
     type: Transform
 - uid: 3426
@@ -51112,9 +51116,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3434
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 59.5,-25.5
+  - pos: 59.5,-28.5
     parent: 60
     type: Transform
 - uid: 3435
@@ -51317,7 +51321,7 @@ entities:
     parent: 60
     type: Transform
 - uid: 3463
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: 47.5,-36.5
     parent: 60
@@ -51485,13 +51489,13 @@ entities:
     parent: 60
     type: Transform
 - uid: 3489
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: 55.5,-18.5
     parent: 60
     type: Transform
 - uid: 3490
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: 55.5,-19.5
     parent: 60
@@ -51537,7 +51541,7 @@ entities:
     parent: 60
     type: Transform
 - uid: 3496
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: 56.5,-22.5
     parent: 60
@@ -51634,10 +51638,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3511
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 46.5,-39.5
+  - pos: 46.5,-38.5
     parent: 60
     type: Transform
 - uid: 3512
@@ -51653,7 +51656,7 @@ entities:
     parent: 60
     type: Transform
 - uid: 3514
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: 57.5,-35.5
     parent: 60
@@ -51733,11 +51736,19 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 3526
-  type: MaintenanceWeaponSpawner
+  type: PoweredlightSodium
   components:
-  - pos: 47.5,-34.5
+  - rot: 1.5707963267948966 rad
+    pos: 47.5,-37.5
     parent: 60
     type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
 - uid: 3527
   type: PoweredSmallLight
   components:
@@ -51781,19 +51792,11 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 3531
-  type: PoweredlightSodium
+  type: WallSolidRust
   components:
-  - rot: 1.5707963267948966 rad
-    pos: 47.5,-35.5
+  - pos: 20.5,-50.5
     parent: 60
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-  - inputs:
-      On: []
-      Off: []
-      Toggle: []
-    type: SignalReceiver
 - uid: 3532
   type: PoweredlightSodium
   components:
@@ -52334,10 +52337,9 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3599
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 15.5,-50.5
+  - pos: 12.5,-44.5
     parent: 60
     type: Transform
 - uid: 3600
@@ -52427,31 +52429,27 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 3611
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 19.5,-45.5
+  - pos: 10.5,-42.5
     parent: 60
     type: Transform
 - uid: 3612
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 18.5,-45.5
+  - pos: 14.5,-42.5
     parent: 60
     type: Transform
 - uid: 3613
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 17.5,-45.5
+  - pos: 16.5,-45.5
     parent: 60
     type: Transform
 - uid: 3614
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 16.5,-45.5
+  - pos: 15.5,-42.5
     parent: 60
     type: Transform
 - uid: 3615
@@ -52462,10 +52460,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3616
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 17.5,-43.5
+  - pos: 16.5,-47.5
     parent: 60
     type: Transform
 - uid: 3617
@@ -52535,16 +52532,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 3626
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 14.5,-47.5
+  - pos: 15.5,-50.5
     parent: 60
     type: Transform
 - uid: 3627
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 20.5,-50.5
+  - pos: 12.5,-45.5
     parent: 60
     type: Transform
 - uid: 3628
@@ -52554,9 +52550,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3629
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 20.5,-47.5
+  - pos: 10.5,-47.5
     parent: 60
     type: Transform
 - uid: 3630
@@ -52573,24 +52569,33 @@ entities:
     parent: 60
     type: Transform
 - uid: 3632
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 10.5,-47.5
+  - pos: 20.5,-47.5
     parent: 60
     type: Transform
 - uid: 3633
-  type: WallSolid
+  type: PoweredSmallLight
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 15.5,-42.5
+  - pos: 48.5,-34.5
     parent: 60
     type: Transform
+  - enabled: False
+    type: AmbientSound
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - containers:
+      light_bulb: !type:ContainerSlot {}
+    type: ContainerContainer
+  - inputs:
+      On: []
+      Off: []
+      Toggle: []
+    type: SignalReceiver
 - uid: 3634
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 16.5,-42.5
+  - pos: 57.5,-43.5
     parent: 60
     type: Transform
 - uid: 3635
@@ -52719,9 +52724,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3655
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 50.5,-43.5
+  - pos: 8.5,-42.5
     parent: 60
     type: Transform
 - uid: 3656
@@ -52848,10 +52853,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3676
-  type: WallSolid
+  type: LockerBoozeFilled
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 8.5,-42.5
+  - pos: 47.5,-34.5
     parent: 60
     type: Transform
 - uid: 3677
@@ -52875,10 +52879,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3680
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 10.5,-42.5
+  - pos: -10.5,-49.5
     parent: 60
     type: Transform
 - uid: 3681
@@ -53209,7 +53212,7 @@ entities:
   - pos: 48.5,-39.5
     parent: 60
     type: Transform
-  - SecondsUntilStateChange: -1533.4883
+  - SecondsUntilStateChange: -4389.4155
     state: Opening
     type: Door
 - uid: 3729
@@ -54104,10 +54107,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3850
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - rot: 1.5707963267948966 rad
-    pos: -12.5,-47.5
+  - pos: -17.5,-36.5
     parent: 60
     type: Transform
 - uid: 3851
@@ -54251,9 +54253,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 3871
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -17.5,-36.5
+  - pos: -38.5,-30.5
     parent: 60
     type: Transform
 - uid: 3872
@@ -55830,9 +55832,9 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 4055
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -38.5,-30.5
+  - pos: -62.5,0.5
     parent: 60
     type: Transform
 - uid: 4056
@@ -57031,9 +57033,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4222
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -62.5,0.5
+  - pos: -58.5,-7.5
     parent: 60
     type: Transform
 - uid: 4223
@@ -57681,9 +57683,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4310
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -58.5,-7.5
+  - pos: -44.5,-24.5
     parent: 60
     type: Transform
 - uid: 4311
@@ -57984,11 +57986,14 @@ entities:
     parent: 60
     type: Transform
 - uid: 4345
-  type: WallSolid
+  type: PottedPlant2
   components:
-  - pos: -44.5,-24.5
+  - pos: -22.5,-29.5
     parent: 60
     type: Transform
+  - containers:
+      stash: !type:ContainerSlot {}
+    type: ContainerContainer
 - uid: 4346
   type: WallReinforced
   components:
@@ -58032,14 +58037,11 @@ entities:
     parent: 60
     type: Transform
 - uid: 4351
-  type: PottedPlantRandom
+  type: WallSolidRust
   components:
-  - pos: -22.5,-26.5
+  - pos: -38.5,-35.5
     parent: 60
     type: Transform
-  - containers:
-      stash: !type:ContainerSlot {}
-    type: ContainerContainer
 - uid: 4352
   type: WallReinforced
   components:
@@ -58890,9 +58892,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4482
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -27.5,-33.5
+  - pos: -34.5,-33.5
     parent: 60
     type: Transform
 - uid: 4483
@@ -59156,9 +59158,9 @@ entities:
   - color: '#0335FCFF'
     type: AtmosPipeColor
 - uid: 4517
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -28.5,-33.5
+  - pos: -35.5,-33.5
     parent: 60
     type: Transform
 - uid: 4518
@@ -59399,7 +59401,7 @@ entities:
       Toggle: []
     type: SignalReceiver
 - uid: 4538
-  type: WallSolid
+  type: WallSolidRust
   components:
   - pos: -29.5,-33.5
     parent: 60
@@ -59742,9 +59744,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4570
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -34.5,-33.5
+  - pos: -28.5,-33.5
     parent: 60
     type: Transform
 - uid: 4571
@@ -60009,9 +60011,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4604
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -35.5,-33.5
+  - pos: -27.5,-33.5
     parent: 60
     type: Transform
 - uid: 4605
@@ -60021,9 +60023,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4606
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -38.5,-35.5
+  - pos: -13.5,-47.5
     parent: 60
     type: Transform
 - uid: 4607
@@ -61414,9 +61416,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4833
-  type: WallSolid
+  type: Grille
   components:
-  - pos: -10.5,-49.5
+  - pos: -20.5,-65.5
     parent: 60
     type: Transform
 - uid: 4834
@@ -62722,10 +62724,9 @@ entities:
       Toggle: []
     type: SignalReceiver
 - uid: 4971
-  type: ReinforcedWindow
+  type: ShuttleWindow
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -13.5,-59.5
+  - pos: -15.5,-59.5
     parent: 60
     type: Transform
 - uid: 4972
@@ -62747,9 +62748,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4975
-  type: WallShuttle
+  type: ShuttleWindow
   components:
-  - pos: -15.5,-59.5
+  - pos: -11.5,-59.5
     parent: 60
     type: Transform
 - uid: 4976
@@ -62777,9 +62778,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 4980
-  type: WallShuttle
+  type: ShuttleWindow
   components:
-  - pos: -11.5,-59.5
+  - pos: -11.5,-65.5
     parent: 60
     type: Transform
 - uid: 4981
@@ -62875,27 +62876,25 @@ entities:
 - uid: 4995
   type: WallShuttle
   components:
-  - pos: -11.5,-65.5
+  - pos: -13.5,-59.5
     parent: 60
     type: Transform
 - uid: 4996
-  type: Grille
+  type: WallShuttle
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -13.5,-59.5
+  - pos: -13.5,-65.5
     parent: 60
     type: Transform
 - uid: 4997
-  type: Grille
+  type: ShuttleWindow
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -13.5,-65.5
+  - pos: -15.5,-65.5
     parent: 60
     type: Transform
 - uid: 4998
   type: WallShuttle
   components:
-  - pos: -15.5,-65.5
+  - pos: -19.5,-59.5
     parent: 60
     type: Transform
 - uid: 4999
@@ -62925,25 +62924,25 @@ entities:
 - uid: 5003
   type: WallShuttle
   components:
-  - pos: -20.5,-65.5
+  - pos: -21.5,-59.5
     parent: 60
     type: Transform
 - uid: 5004
-  type: WallShuttle
+  type: ShuttleWindow
   components:
-  - pos: -19.5,-65.5
+  - pos: -20.5,-65.5
     parent: 60
     type: Transform
 - uid: 5005
   type: WallShuttle
   components:
-  - pos: -20.5,-59.5
+  - pos: -19.5,-65.5
     parent: 60
     type: Transform
 - uid: 5006
-  type: WallShuttle
+  type: Grille
   components:
-  - pos: -19.5,-59.5
+  - pos: -20.5,-59.5
     parent: 60
     type: Transform
 - uid: 5007
@@ -62980,10 +62979,9 @@ entities:
   - enabled: False
     type: AmbientSound
 - uid: 5012
-  type: ReinforcedWindow
+  type: ShuttleWindow
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -13.5,-65.5
+  - pos: -20.5,-59.5
     parent: 60
     type: Transform
 - uid: 5013
@@ -63514,9 +63512,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 5067
-  type: WallShuttle
+  type: Grille
   components:
-  - pos: -21.5,-59.5
+  - pos: -15.5,-59.5
     parent: 60
     type: Transform
 - uid: 5068
@@ -63526,10 +63524,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 5069
-  type: ReinforcedWindow
+  type: ShuttleWindow
   components:
-  - rot: 3.141592653589793 rad
-    pos: -25.5,-61.5
+  - pos: -24.5,-60.5
     parent: 60
     type: Transform
 - uid: 5070
@@ -63547,17 +63544,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 5072
-  type: ReinforcedWindow
+  type: ShuttleWindow
   components:
-  - rot: 3.141592653589793 rad
-    pos: -24.5,-64.5
+  - pos: -25.5,-60.5
     parent: 60
     type: Transform
 - uid: 5073
-  type: ReinforcedWindow
+  type: Grille
   components:
-  - rot: 3.141592653589793 rad
-    pos: -25.5,-64.5
+  - pos: -15.5,-65.5
     parent: 60
     type: Transform
 - uid: 5074
@@ -63568,10 +63563,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 5075
-  type: ReinforcedWindow
+  type: Grille
   components:
-  - rot: 3.141592653589793 rad
-    pos: -25.5,-63.5
+  - pos: -11.5,-65.5
     parent: 60
     type: Transform
 - uid: 5076
@@ -63582,40 +63576,41 @@ entities:
     parent: 60
     type: Transform
 - uid: 5077
-  type: ReinforcedWindow
+  type: Grille
   components:
-  - rot: 3.141592653589793 rad
-    pos: -25.5,-60.5
+  - pos: -11.5,-59.5
     parent: 60
     type: Transform
 - uid: 5078
-  type: ReinforcedWindow
+  type: VendingMachineClothing
   components:
-  - rot: 3.141592653589793 rad
-    pos: -24.5,-60.5
+  - pos: -18.5,-60.5
     parent: 60
     type: Transform
+  - enabled: False
+    type: AmbientSound
 - uid: 5079
-  type: ReinforcedWindow
+  type: WallSolidRust
   components:
-  - rot: 3.141592653589793 rad
-    pos: -26.5,-63.5
+  - pos: 54.5,-9.5
     parent: 60
     type: Transform
 - uid: 5080
-  type: ReinforcedWindow
+  type: ShuttleWindow
   components:
-  - rot: 3.141592653589793 rad
-    pos: -26.5,-62.5
+  - pos: -25.5,-64.5
     parent: 60
     type: Transform
 - uid: 5081
-  type: ReinforcedWindow
+  type: WallmountTelescreen
   components:
-  - rot: 3.141592653589793 rad
-    pos: -26.5,-61.5
+  - pos: -25.5,-28.5
     parent: 60
     type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 5082
   type: Grille
   components:
@@ -63917,9 +63912,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 5127
-  type: TableReinforced
+  type: WallSolidRust
   components:
-  - pos: -18.5,-60.5
+  - pos: -58.5,-15.5
     parent: 60
     type: Transform
 - uid: 5128
@@ -70030,9 +70025,9 @@ entities:
       Toggle: []
     type: SignalReceiver
 - uid: 5881
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 54.5,-9.5
+  - pos: 53.5,-45.5
     parent: 60
     type: Transform
 - uid: 5882
@@ -72331,10 +72326,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 6147
-  type: WindowReinforcedDirectional
+  type: ShuttleWindow
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -24.5,-63.5
+  - pos: -25.5,-63.5
     parent: 60
     type: Transform
 - uid: 6148
@@ -74733,15 +74727,11 @@ entities:
     parent: 60
     type: Transform
 - uid: 6457
-  type: ComputerTelevision
+  type: ShuttleWindow
   components:
-  - pos: -25.5,-28.5
+  - pos: -26.5,-62.5
     parent: 60
     type: Transform
-  - containers:
-      board: !type:Container
-        ents: []
-    type: ContainerContainer
 - uid: 6458
   type: WallSolid
   components:
@@ -75721,9 +75711,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 6594
-  type: WallSolid
+  type: ShuttleWindow
   components:
-  - pos: -60.5,-14.5
+  - pos: -24.5,-64.5
     parent: 60
     type: Transform
 - uid: 6595
@@ -75753,9 +75743,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 6599
-  type: WallSolid
+  type: ShuttleWindow
   components:
-  - pos: 57.5,-43.5
+  - pos: -26.5,-61.5
     parent: 60
     type: Transform
 - uid: 6600
@@ -76238,16 +76228,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 6666
-  type: WindowReinforcedDirectional
+  type: ShuttleWindow
   components:
-  - pos: -25.5,-62.5
+  - pos: -25.5,-61.5
     parent: 60
     type: Transform
 - uid: 6667
-  type: WindowReinforcedDirectional
+  type: WallSolidRust
   components:
-  - rot: 3.141592653589793 rad
-    pos: -25.5,-62.5
+  - pos: 46.5,-39.5
     parent: 60
     type: Transform
 - uid: 6668
@@ -77021,23 +77010,21 @@ entities:
   - color: '#FF1212FF'
     type: AtmosPipeColor
 - uid: 6764
-  type: WindowReinforcedDirectional
+  type: WallSolidRust
   components:
-  - pos: -24.5,-63.5
+  - pos: 50.5,-43.5
     parent: 60
     type: Transform
 - uid: 6765
-  type: WindowReinforcedDirectional
+  type: WallSolidRust
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -24.5,-61.5
+  - pos: 53.5,-44.5
     parent: 60
     type: Transform
 - uid: 6766
-  type: WindowReinforcedDirectional
+  type: WallSolidRust
   components:
-  - rot: 3.141592653589793 rad
-    pos: -24.5,-61.5
+  - pos: -64.5,5.5
     parent: 60
     type: Transform
 - uid: 6767
@@ -79295,9 +79282,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 7073
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 46.5,-38.5
+  - pos: -63.5,5.5
     parent: 60
     type: Transform
 - uid: 7074
@@ -84800,19 +84787,29 @@ entities:
     parent: 60
     type: Transform
 - uid: 7835
-  type: WallSolid
+  type: Autolathe
   components:
-  - rot: 3.141592653589793 rad
-    pos: 53.5,-45.5
+  - pos: -41.5,-7.5
     parent: 60
     type: Transform
+  - containers:
+    - machine_parts
+    - machine_board
+    type: Construction
+  - containers:
+      machine_board: !type:Container
+        ents: []
+      machine_parts: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 7836
-  type: WallSolid
+  type: PersonalAI
   components:
-  - rot: 3.141592653589793 rad
-    pos: 53.5,-44.5
+  - pos: 21.509922,1.5610104
     parent: 60
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 7837
   type: WallSolid
   components:
@@ -84834,9 +84831,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 7840
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -63.5,5.5
+  - pos: 53.5,-5.5
     parent: 60
     type: Transform
 - uid: 7841
@@ -86000,9 +85997,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 7997
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -64.5,5.5
+  - pos: -53.5,-19.5
     parent: 60
     type: Transform
 - uid: 7998
@@ -96616,21 +96613,11 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 9475
-  type: Protolathe
+  type: WallSolidRust
   components:
-  - pos: -41.5,-7.5
+  - pos: -54.5,-22.5
     parent: 60
     type: Transform
-  - containers:
-    - machine_parts
-    - machine_board
-    type: Construction
-  - containers:
-      machine_board: !type:Container
-        ents: []
-      machine_parts: !type:Container
-        ents: []
-    type: ContainerContainer
 - uid: 9476
   type: Table
   components:
@@ -97729,20 +97716,13 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 9618
-  type: Autolathe
+  type: PottedPlant28
   components:
-  - pos: -38.5,14.5
+  - pos: -1.5,21.5
     parent: 60
     type: Transform
   - containers:
-    - machine_parts
-    - machine_board
-    type: Construction
-  - containers:
-      machine_board: !type:Container
-        ents: []
-      machine_parts: !type:Container
-        ents: []
+      stash: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 9619
   type: Table
@@ -112056,11 +112036,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 11885
-  type: WallSolid
+  type: WallmountTelevision
   components:
-  - pos: 53.5,-5.5
+  - pos: 33.5,10.5
     parent: 60
     type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 11886
   type: Table
   components:
@@ -118546,11 +118530,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 12905
-  type: WallSolid
+  type: WallmountTelevision
   components:
-  - pos: -53.5,-20.5
+  - pos: 26.5,-21.5
     parent: 60
     type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 12906
   type: WallSolid
   components:
@@ -118564,9 +118552,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 12908
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -54.5,-22.5
+  - pos: -53.5,22.5
     parent: 60
     type: Transform
 - uid: 12909
@@ -141537,46 +141525,23 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 16079
-  type: PottedPlantRandom
+  type: WallSolidRust
   components:
-  - pos: -1.5,21.5
+  - pos: -56.5,25.5
     parent: 60
     type: Transform
-  - containers:
-      stash: !type:ContainerSlot {}
-    type: ContainerContainer
 - uid: 16080
-  type: Autolathe
+  type: WallSolidRust
   components:
-  - pos: -4.5,18.5
+  - pos: -56.5,23.5
     parent: 60
     type: Transform
-  - containers:
-    - machine_parts
-    - machine_board
-    type: Construction
-  - containers:
-      machine_board: !type:Container
-        ents: []
-      machine_parts: !type:Container
-        ents: []
-    type: ContainerContainer
 - uid: 16081
-  type: Protolathe
+  type: WallSolidRust
   components:
-  - pos: -4.5,19.5
+  - pos: -56.5,18.5
     parent: 60
     type: Transform
-  - containers:
-    - machine_parts
-    - machine_board
-    type: Construction
-  - containers:
-      machine_board: !type:Container
-        ents: []
-      machine_parts: !type:Container
-        ents: []
-    type: ContainerContainer
 - uid: 16082
   type: ClothingHeadsetEngineering
   components:
@@ -149833,11 +149798,14 @@ entities:
     parent: 60
     type: Transform
 - uid: 17295
-  type: WallSolid
+  type: PottedPlant22
   components:
-  - pos: -53.5,22.5
+  - pos: -0.5,-2.5
     parent: 60
     type: Transform
+  - containers:
+      stash: !type:ContainerSlot {}
+    type: ContainerContainer
 - uid: 17296
   type: WallReinforced
   components:
@@ -150045,21 +150013,24 @@ entities:
     parent: 60
     type: Transform
 - uid: 17330
-  type: WallSolid
+  type: PottedPlant22
   components:
-  - pos: -56.5,23.5
+  - pos: -0.5,-7.5
     parent: 60
     type: Transform
+  - containers:
+      stash: !type:ContainerSlot {}
+    type: ContainerContainer
 - uid: 17331
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: -56.5,25.5
+  - pos: 50.5,-4.5
     parent: 60
     type: Transform
 - uid: 17332
-  type: WallSolid
+  type: Window
   components:
-  - pos: -56.5,18.5
+  - pos: 32.5,16.5
     parent: 60
     type: Transform
 - uid: 17333
@@ -158476,23 +158447,17 @@ entities:
     parent: 60
     type: Transform
 - uid: 18488
-  type: PottedPlantRandom
+  type: WallSolidRust
   components:
-  - pos: -0.5,-2.5
+  - pos: 31.5,19.5
     parent: 60
     type: Transform
-  - containers:
-      stash: !type:ContainerSlot {}
-    type: ContainerContainer
 - uid: 18489
-  type: PottedPlantRandom
+  type: WallSolidRust
   components:
-  - pos: -0.5,-7.5
+  - pos: 28.5,19.5
     parent: 60
     type: Transform
-  - containers:
-      stash: !type:ContainerSlot {}
-    type: ContainerContainer
 - uid: 18490
   type: PoweredSmallLight
   components:
@@ -163506,9 +163471,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 19104
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 50.5,-4.5
+  - pos: 27.5,19.5
     parent: 60
     type: Transform
 - uid: 19105
@@ -167402,11 +167367,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 19668
-  type: WallSolid
+  type: WallmountTelevision
   components:
-  - pos: 31.5,13.5
+  - pos: 36.5,19.5
     parent: 60
     type: Transform
+  - containers:
+      board: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 19669
   type: WallSolid
   components:
@@ -167420,9 +167389,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 19671
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 31.5,19.5
+  - pos: 31.5,13.5
     parent: 60
     type: Transform
 - uid: 19672
@@ -167438,15 +167407,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 19674
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 28.5,19.5
+  - pos: 31.5,16.5
     parent: 60
     type: Transform
 - uid: 19675
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 27.5,19.5
+  - pos: 30.5,16.5
     parent: 60
     type: Transform
 - uid: 19676
@@ -167460,15 +167429,11 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 19677
-  type: FirelockGlass
+  type: WallSolidRust
   components:
-  - pos: 29.5,13.5
+  - pos: 28.5,-8.5
     parent: 60
     type: Transform
-  - airBlocked: False
-    type: Airtight
-  - canCollide: False
-    type: Physics
 - uid: 19678
   type: filingCabinet
   components:
@@ -167761,21 +167726,21 @@ entities:
     parent: 60
     type: Transform
 - uid: 19716
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 30.5,16.5
+  - pos: 30.5,-3.5
     parent: 60
     type: Transform
 - uid: 19717
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 31.5,16.5
+  - pos: 33.5,5.5
     parent: 60
     type: Transform
 - uid: 19718
-  type: Window
+  type: WallSolidRust
   components:
-  - pos: 32.5,16.5
+  - pos: 33.5,0.5
     parent: 60
     type: Transform
 - uid: 19719
@@ -169395,9 +169360,9 @@ entities:
     parent: 60
     type: Transform
 - uid: 19954
-  type: WallSolid
+  type: WallSolidRust
   components:
-  - pos: 28.5,-8.5
+  - pos: 32.5,-3.5
     parent: 60
     type: Transform
 - uid: 19955
@@ -169665,11 +169630,13 @@ entities:
     parent: 60
     type: Transform
 - uid: 19996
-  type: WallSolid
+  type: WeaponSubMachineGunVector
   components:
-  - pos: 32.5,-3.5
+  - pos: -28.436613,2.4905505
     parent: 60
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 19997
   type: AirlockMaintLocked
   components:
@@ -169683,11 +169650,13 @@ entities:
     parent: 60
     type: Transform
 - uid: 19999
-  type: WallSolid
+  type: WeaponSubMachineGunVector
   components:
-  - pos: 33.5,0.5
+  - pos: -28.436613,2.6468005
     parent: 60
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 20000
   type: WallSolid
   components:
@@ -169707,11 +169676,13 @@ entities:
     parent: 60
     type: Transform
 - uid: 20003
-  type: WallSolid
+  type: SheetSteel
   components:
-  - pos: 33.5,5.5
+  - pos: -24.46965,0.7424586
     parent: 60
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 20004
   type: WallSolid
   components:
@@ -169725,11 +169696,15 @@ entities:
     parent: 60
     type: Transform
 - uid: 20006
-  type: WallSolid
+  type: MagazineMagnumSubMachineGun
   components:
-  - pos: 30.5,-3.5
+  - pos: -24.780363,-0.47819963
     parent: 60
     type: Transform
+  - unspawnedCount: 25
+    type: BallisticAmmoProvider
+  - canCollide: False
+    type: Physics
 - uid: 20007
   type: WallSolid
   components:
@@ -176129,19 +176104,23 @@ entities:
     parent: 60
     type: Transform
 - uid: 21014
-  type: WeaponSubMachineGunVector
+  type: FirelockGlass
   components:
-  - pos: -28.465193,2.6841984
+  - pos: -70.5,17.5
     parent: 60
     type: Transform
+  - airBlocked: False
+    type: Airtight
   - canCollide: False
     type: Physics
 - uid: 21015
-  type: WeaponSubMachineGunVectorRubber
+  type: FirelockGlass
   components:
-  - pos: -28.449568,2.4185734
+  - pos: -60.5,17.5
     parent: 60
     type: Transform
+  - airBlocked: False
+    type: Airtight
   - canCollide: False
     type: Physics
 - uid: 21016
@@ -176153,15 +176132,11 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 21017
-  type: MagazineMagnumSubMachineGunRubber
+  type: PottedPlantRandom
   components:
-  - pos: -24.75233,-0.4746566
+  - pos: 34.5,9.5
     parent: 60
     type: Transform
-  - unspawnedCount: 25
-    type: BallisticAmmoProvider
-  - canCollide: False
-    type: Physics
 - uid: 21018
   type: MagazineMagnumSubMachineGun
   components:
@@ -176324,15 +176299,11 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 21032
-  type: MagazineRifleRubber
+  type: CableApcExtension
   components:
-  - pos: -24.236706,-0.6934066
+  - pos: 8.5,-23.5
     parent: 60
     type: Transform
-  - unspawnedCount: 25
-    type: BallisticAmmoProvider
-  - canCollide: False
-    type: Physics
 - uid: 21033
   type: MagazineMagnumSubMachineGun
   components:
@@ -177877,16 +177848,11 @@ entities:
     parent: 60
     type: Transform
 - uid: 21199
-  type: BlastDoor
+  type: CableApcExtension
   components:
-  - pos: -60.5,17.5
+  - pos: 9.5,-23.5
     parent: 60
     type: Transform
-  - inputs:
-      Open: []
-      Close: []
-      Toggle: []
-    type: SignalReceiver
 - uid: 21200
   type: HighSecCommandLocked
   components:
@@ -178344,16 +178310,11 @@ entities:
     parent: 60
     type: Transform
 - uid: 21269
-  type: BlastDoor
+  type: CableApcExtension
   components:
-  - pos: -70.5,17.5
+  - pos: 10.5,-23.5
     parent: 60
     type: Transform
-  - inputs:
-      Open: []
-      Close: []
-      Toggle: []
-    type: SignalReceiver
 - uid: 21270
   type: SurveillanceCameraCommand
   components:
@@ -178970,14 +178931,11 @@ entities:
     parent: 60
     type: Transform
 - uid: 21347
-  type: PottedPlantRandom
+  type: WindowDirectional
   components:
-  - pos: 33.5,9.5
+  - pos: -67.5,9.5
     parent: 60
     type: Transform
-  - containers:
-      stash: !type:ContainerSlot {}
-    type: ContainerContainer
 - uid: 21348
   type: CarpetOrange
   components:
@@ -179063,4 +179021,46 @@ entities:
       DisposalTransit: !type:Container
         ents: []
     type: ContainerContainer
+- uid: 21358
+  type: WindowDirectional
+  components:
+  - pos: -66.5,9.5
+    parent: 60
+    type: Transform
+- uid: 21359
+  type: WindowDirectional
+  components:
+  - pos: -64.5,9.5
+    parent: 60
+    type: Transform
+- uid: 21360
+  type: WindowDirectional
+  components:
+  - pos: -63.5,9.5
+    parent: 60
+    type: Transform
+- uid: 21361
+  type: PottedPlant27
+  components:
+  - pos: 41.5,7.5
+    parent: 60
+    type: Transform
+  - containers:
+      stash: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 21362
+  type: PottedPlant24
+  components:
+  - pos: -11.5,15.5
+    parent: 60
+    type: Transform
+  - containers:
+      stash: !type:ContainerSlot {}
+    type: ContainerContainer
+- uid: 21363
+  type: PottedPlantRandom
+  components:
+  - pos: 26.5,9.5
+    parent: 60
+    type: Transform
 ...


### PR DESCRIPTION
changelog
-powered the vent and scrubber to the right of hop office
-removed a lingering double wall
-arrivals shuttle uses shuttle windows
-added rusted walls to appropriate places
-unmapped lathes from engineering. ive decided removing even more purpose from sci is cringe and like to encourage social gameplay (sci is now in possession of the only protolathe once again, besides a proto board in circuitry)
-added steel to armory for sec lathe since it is used once every blue moon when hoid is playing HoS.
-redid some DECOR you guys probably dont care
-removed roundstart rubber mags(cringe) and guns from armory and added another laser rifle (rubber rounds can be crafted in sec techfab if needed.)
-skub

