### PR TITLE
Fix hunger/thirst 'Dead' thresholds

### DIFF
--- a/Content.Server/Nutrition/Components/HungerComponent.cs
+++ b/Content.Server/Nutrition/Components/HungerComponent.cs
@@ -64,6 +64,7 @@ namespace Content.Server.Nutrition.Components
             { HungerThreshold.Overfed, AlertType.Overfed },
             { HungerThreshold.Peckish, AlertType.Peckish },
             { HungerThreshold.Starving, AlertType.Starving },
+            { HungerThreshold.Dead, AlertType.Starving },
         };
 
         public void HungerThresholdEffect(bool force = false)

--- a/Content.Server/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Server/Nutrition/Components/ThirstComponent.cs
@@ -48,6 +48,7 @@ namespace Content.Server.Nutrition.Components
             {ThirstThreshold.OverHydrated, AlertType.Overhydrated},
             {ThirstThreshold.Thirsty, AlertType.Thirsty},
             {ThirstThreshold.Parched, AlertType.Parched},
+            {ThirstThreshold.Dead, AlertType.Parched},
         };
     }
 }

--- a/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
         private void OnRefreshMovespeed(EntityUid uid, ThirstComponent component, RefreshMovementSpeedModifiersEvent args)
         {
-            var mod = (component.CurrentThirstThreshold & (ThirstThreshold.Parched | ThirstThreshold.Dead)) != 0x0 ? 0.75f : 1.0f;
+            var mod = component.CurrentThirstThreshold <= ThirstThreshold.Parched ? 0.75f : 1.0f;
             args.ModifySpeed(mod, mod);
         }
 

--- a/Content.Shared/Nutrition/Components/SharedHungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/SharedHungerComponent.cs
@@ -24,10 +24,10 @@ namespace Content.Shared.Nutrition.Components
     [Serializable, NetSerializable]
     public enum HungerThreshold : byte
     {
-        Overfed,
-        Okay,
-        Peckish,
-        Starving,
-        Dead,
+        Overfed = 1 << 3,
+        Okay = 1 << 2,
+        Peckish = 1 << 1,
+        Starving = 1 << 0,
+        Dead = 0,
     }
 }

--- a/Content.Shared/Nutrition/EntitySystems/SharedHungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedHungerSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Movement.Systems;
+using Content.Shared.Movement.Systems;
 using Content.Shared.Nutrition.Components;
 
 namespace Content.Shared.Nutrition.EntitySystems
@@ -14,7 +14,7 @@ namespace Content.Shared.Nutrition.EntitySystems
 
         private void OnRefreshMovespeed(EntityUid uid, SharedHungerComponent component, RefreshMovementSpeedModifiersEvent args)
         {
-            float mod = component.CurrentHungerThreshold == HungerThreshold.Starving ? 0.75f : 1.0f;
+            float mod = component.CurrentHungerThreshold <= HungerThreshold.Starving ? 0.75f : 1.0f;
             args.ModifySpeed(mod, mod);
         }
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #9443

Movement speed modifiers weren't being updated properly when past 'Dead' threshold.

Starvation damage was removed, so Dead threshold doesn't do anything special. We could remove it, but this leaves it in place in case we want to implement something there in the future.

Also, there were no alert icons for Dead threshold, so just set it to use the starving/parched ones for now, since the behavior is the same anyway.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: You can no longer become so hungry that you ascend hunger

