### PR TITLE
Convert rat king to use a ghost role spawner

### DIFF
--- a/Content.Server/StationEvents/Events/MouseMigration.cs
+++ b/Content.Server/StationEvents/Events/MouseMigration.cs
@@ -19,7 +19,7 @@ public sealed class MouseMigration : StationEvent
 
     public override int EarliestStart => 30;
 
-    public override int MinimumPlayers => 35; //this just ensures that it doesn't spawn on lowpop maps. 
+    public override int MinimumPlayers => 35; //this just ensures that it doesn't spawn on lowpop maps.
 
     public override float Weight => WeightLow;
 
@@ -34,7 +34,7 @@ public sealed class MouseMigration : StationEvent
     public override void Startup()
     {
         base.Startup();
-        
+
         var spawnLocations = _entityManager.EntityQuery<VentCritterSpawnLocationComponent, TransformComponent>().ToList();
         _random.Shuffle(spawnLocations);
 
@@ -44,7 +44,7 @@ public sealed class MouseMigration : StationEvent
         {
             var spawnChoice = _random.Pick(SpawnedPrototypeChoices);
             if (_random.Prob(0.01f) || i == 0) //small chance for multiple, but always at least 1
-                spawnChoice = "MobRatKing";
+                spawnChoice = "SpawnPointGhostRatKing";
 
             _entityManager.SpawnEntity(spawnChoice, spawnLocations[i].Item2.Coordinates);
         }

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -1,0 +1,16 @@
+- type: entity
+  id: SpawnPointGhostRatKing
+  name: ghost role spawn point
+  suffix: rat king
+  parent: MarkerBase
+  components:
+  - type: GhostRoleMobSpawner
+    prototype: MobRatKing
+    name: Rat King
+    description: You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
+    rules: You are an antagonist, scavenge, attack, and grow your hoarde!
+  - type: Sprite
+    sprite: Markers/jobs.rsi
+    layers:
+      - state: green
+      - texture: Mobs/Animals/regalrat.rsi/icon.png

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -8,7 +8,7 @@
     prototype: MobRatKing
     name: Rat King
     description: You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
-    rules: You are an antagonist, scavenge, attack, and grow your hoarde!
+    rules: You are an antagonist, scavenge, attack, and grow your hoard!
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -67,7 +67,7 @@
     makeSentient: true
     name: Rat King
     description: You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
-    rules: You are an antagonist, scavenge, attack, and grow your hoarde!
+    rules: You are an antagonist, scavenge, attack, and grow your hoard!
   - type: Tag
     tags:
       - CannotSuicide

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -10,10 +10,6 @@
     baseSprintSpeed : 3.75
   - type: PlayerInputMover
   - type: PlayerMobMover
-  - type: UtilityAI
-    behaviorSets:
-    - Idle
-    - UnarmedAttackHostiles
   - type: Reactive
     groups:
       Flammable: [Touch]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes rat kings use GhostRoleMobSpawner rather than spawning as AI. Related to https://github.com/space-wizards/space-station-14/issues/9455

:cl: Rane
- tweak: Rat kings will not spawn until someone takes the ghost role.

