### PR TITLE
Makes storage insertion failure more explicit

### DIFF
--- a/Content.Server/PneumaticCannon/PneumaticCannonSystem.cs
+++ b/Content.Server/PneumaticCannon/PneumaticCannonSystem.cs
@@ -135,7 +135,7 @@ namespace Content.Server.PneumaticCannon
             if (EntityManager.TryGetComponent<SharedItemComponent?>(args.Used, out var item)
                 && EntityManager.TryGetComponent<ServerStorageComponent?>(component.Owner, out var storage))
             {
-                if (_storageSystem.CanInsert(component.Owner, args.Used, storage))
+                if (_storageSystem.CanInsert(component.Owner, args.Used, out _, storage))
                 {
                     _storageSystem.Insert(component.Owner, args.Used, storage);
                     args.User.PopupMessage(Loc.GetString("pneumatic-cannon-component-insert-item-success",

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -491,7 +491,6 @@ namespace Content.Server.Storage.EntitySystems
                 return false;
             }
 
-
             if (TryComp(insertEnt, out SharedItemComponent? itemComp) &&
                 itemComp.Size > storageComp.StorageCapacityMax - storageComp.StorageUsed)
             {

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -474,29 +474,51 @@ namespace Content.Server.Storage.EntitySystems
         ///     Verifies if an entity can be stored and if it fits
         /// </summary>
         /// <param name="entity">The entity to check</param>
+        /// <param name="reason">If returning false, the reason displayed to the player</param>
         /// <returns>true if it can be inserted, false otherwise</returns>
-        public bool CanInsert(EntityUid uid, EntityUid insertEnt, ServerStorageComponent? storageComp = null)
+        public bool CanInsert(EntityUid uid, EntityUid insertEnt, out string? reason, ServerStorageComponent? storageComp = null)
         {
             if (!Resolve(uid, ref storageComp))
+            {
+                reason = null;
                 return false;
+            }
+
 
             if (TryComp(insertEnt, out ServerStorageComponent? storage) &&
                 storage.StorageCapacityMax >= storageComp.StorageCapacityMax)
+            {
+                reason = "comp-storage-insufficient-capacity";
                 return false;
+            }
+
 
             if (TryComp(insertEnt, out SharedItemComponent? itemComp) &&
                 itemComp.Size > storageComp.StorageCapacityMax - storageComp.StorageUsed)
+            {
+                reason = "comp-storage-insufficient-capacity";
                 return false;
+            }
 
             if (storageComp.Whitelist?.IsValid(insertEnt, EntityManager) == false)
+            {
+                reason = "comp-storage-invalid-container";
                 return false;
+            }
 
             if (storageComp.Blacklist?.IsValid(insertEnt, EntityManager) == true)
+            {
+                reason = "comp-storage-invalid-container";
                 return false;
+            }
 
             if (TryComp(insertEnt, out TransformComponent? transformComp) && transformComp.Anchored)
+            {
+                reason = "comp-storage-anchored-failure";
                 return false;
+            }
 
+            reason = null;
             return true;
         }
 
@@ -510,7 +532,7 @@ namespace Content.Server.Storage.EntitySystems
             if (!Resolve(uid, ref storageComp))
                 return false;
 
-            if (!CanInsert(uid, insertEnt, storageComp) || storageComp.Storage?.Insert(insertEnt) == false)
+            if (!CanInsert(uid, insertEnt, out _, storageComp) || storageComp.Storage?.Insert(insertEnt) == false)
                 return false;
 
             if (storageComp.StorageInsertSound is not null)
@@ -550,9 +572,9 @@ namespace Content.Server.Storage.EntitySystems
 
             var toInsert = hands.ActiveHandEntity;
 
-            if (!CanInsert(uid, toInsert.Value, storageComp) || !_sharedHandsSystem.TryDrop(player, toInsert.Value, handsComp: hands))
+            if (!CanInsert(uid, toInsert.Value, out var reason, storageComp) || !_sharedHandsSystem.TryDrop(player, toInsert.Value, handsComp: hands))
             {
-                Popup(uid, player, "comp-storage-cant-insert", storageComp);
+                Popup(uid, player, reason ?? "comp-storage-cant-insert", storageComp);
                 return false;
             }
 

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -484,7 +484,6 @@ namespace Content.Server.Storage.EntitySystems
                 return false;
             }
 
-
             if (TryComp(insertEnt, out ServerStorageComponent? storage) &&
                 storage.StorageCapacityMax >= storageComp.StorageCapacityMax)
             {

--- a/Resources/Locale/en-US/components/storage-component.ftl
+++ b/Resources/Locale/en-US/components/storage-component.ftl
@@ -1,5 +1,8 @@
 comp-storage-no-item-size = None
 comp-storage-cant-insert = Can't insert.
+comp-storage-insufficient-capacity = Insufficient capacity.
+comp-storage-invalid-container = Invalid container for this item.
+comp-storage-anchored-failure = Can't insert an anchored item.
 comp-storage-window-title = Storage Item
 comp-storage-window-volume = Items: { $itemCount }, Stored: { $usedVolume }/{ $maxVolume }
 comp-storage-window-volume-unlimited = Items: { $itemCount }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I'm really sick of `Can't insert` being the only feedback for failing to insert an item into storage. _Why_ can't I insert? This PR will tell you.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/5714543/177440193-8afb25b4-c25c-4f73-af8d-1113de2c6759.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Failing to insert an item into a storage container will now give you an actual failure reason, such as insufficient capacity.

