### PR TITLE
Add librarian powers

### DIFF
--- a/Content.Server/Abilities/Librarian/LibrarianPowersComponent.cs
+++ b/Content.Server/Abilities/Librarian/LibrarianPowersComponent.cs
@@ -1,0 +1,46 @@
+using Content.Shared.Actions;
+using Content.Shared.Actions.ActionTypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Abilities.Librarian
+{
+    [RegisterComponent]
+    public sealed class LibrarianPowersComponent : Component
+    {
+        /// <summary>
+        /// The range of the librarian's domain, measured from the librarian spawn
+        /// </summary>
+        [DataField("libraryDomainRange")]
+        public float LibraryDomainRange = 15f;
+
+        /// <summary>
+        /// Total time the target will be muted
+        /// </summary>
+        [DataField("shushTime")]
+        public TimeSpan ShushTime = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Accumulator to time the removal of the muted effect
+        /// </summary>
+        [DataField("accumulator")]
+        public float Accumulator = 0f;
+
+        [DataField("shushAction")]
+        public EntityTargetAction ShushAction = new()
+        {
+            UseDelay = TimeSpan.FromSeconds(120),
+            Icon = new SpriteSpecifier.Texture(new ResourcePath("Interface/Alerts/Abilities/silenced.png")),
+            Name = "librarian-shush",
+            Description = "librarian-shush-desc",
+            Priority = -1,
+            CanTargetSelf = false,
+            Event = new ShushActionEvent(),
+        };
+
+        [ViewVariables]
+        [DataField("enabled")]
+        public bool Enabled = false;
+
+        public EntityUid? ShushedEntity;
+    }
+}

--- a/Content.Server/Abilities/Librarian/LibrarianPowersSystem.cs
+++ b/Content.Server/Abilities/Librarian/LibrarianPowersSystem.cs
@@ -16,6 +16,7 @@ namespace Content.Server.Abilities.Librarian
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
         [Dependency] private readonly AlertsSystem _alertsSystem = default!;
+        [Dependency] private readonly StatusEffectsSystem _statusSystem = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
 
         private EntityCoordinates? libraryCoordinates;
@@ -44,7 +45,7 @@ namespace Content.Server.Abilities.Librarian
         private void OnShush(EntityUid uid, LibrarianPowersComponent component, ShushActionEvent args)
         {
             //Can be muted
-            if (TryComp<StatusEffectsComponent>(args.Target, out var effects) && !effects.AllowedEffects.Contains("Muted"))
+            if (!_statusSystem.CanApplyEffect(args.Target, "Muted"))
                 return;
 
             //Already muted

--- a/Content.Server/Abilities/Librarian/LibrarianPowersSystem.cs
+++ b/Content.Server/Abilities/Librarian/LibrarianPowersSystem.cs
@@ -1,0 +1,122 @@
+using Content.Server.Abilities.Mime;
+using Content.Server.Popups;
+using Content.Server.Spawners.Components;
+using Content.Shared.Actions;
+using Content.Shared.Alert;
+using Content.Shared.Roles;
+using Content.Shared.Speech.Muting;
+using Content.Shared.StatusEffect;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Server.Abilities.Librarian
+{
+    public sealed class LibrarianPowersSystem : EntitySystem
+    {
+        [Dependency] private readonly PopupSystem _popupSystem = default!;
+        [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+        [Dependency] private readonly AlertsSystem _alertsSystem = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+
+        private EntityCoordinates? libraryCoordinates;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<LibrarianPowersComponent, ComponentInit>(OnComponentInit);
+            SubscribeLocalEvent<LibrarianPowersComponent, ShushActionEvent>(OnShush);
+        }
+
+        private void OnComponentInit(EntityUid uid, LibrarianPowersComponent component, ComponentInit args)
+        {
+            //find location of library for power range
+            foreach (var spawner in _entityManager.EntityQuery<SpawnPointComponent>(false))
+            {
+                if (spawner.Job?.ID.Equals("Librarian") == true && TryComp<TransformComponent>(spawner.Owner, out var spawnerXform))
+                {
+                    libraryCoordinates = spawnerXform.Coordinates;
+                    break;
+                }
+            }
+        }
+
+        //TODO: force them to whisper instead of muting?
+        private void OnShush(EntityUid uid, LibrarianPowersComponent component, ShushActionEvent args)
+        {
+            //Can be muted
+            if (TryComp<StatusEffectsComponent>(args.Target, out var effects) && !effects.AllowedEffects.Contains("Muted"))
+                return;
+
+            //Already muted
+            if (HasComp<MutedComponent>(args.Target) || (TryComp<MimePowersComponent>(args.Target, out var mime) && !mime.VowBroken))
+                return;
+
+            //Within the librarian's domain
+            if (component.Enabled)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("librarian-shush-popup", ("librarian", args.Performer),
+                    ("target", args.Target)), args.Performer, Filter.Pvs(args.Performer));
+                _popupSystem.PopupEntity(Loc.GetString("librarian-been-shushed"), args.Target, Filter.Entities(args.Target));
+
+                _entityManager.AddComponent<MutedComponent>(args.Target);
+                _alertsSystem.ShowAlert(args.Target, AlertType.Muted, null, (component.ShushTime, component.ShushTime));
+                component.ShushedEntity = args.Target;
+                component.Accumulator = 0f;
+                args.Handled = true;
+            }
+        }
+
+        private void EnterLibraryDomain(LibrarianPowersComponent component)
+        {
+            component.Enabled = true;
+            _alertsSystem.ShowAlert(component.Owner, AlertType.LibraryDomain);
+            _actionsSystem.AddAction(component.Owner, component.ShushAction, component.Owner);
+            _popupSystem.PopupEntity(Loc.GetString("librarian-gain-powers"), component.Owner, Filter.Entities(component.Owner));
+        }
+
+        private void LeaveLibraryDomain(LibrarianPowersComponent component)
+        {
+            component.Enabled = false;
+            _alertsSystem.ClearAlert(component.Owner, AlertType.LibraryDomain);
+            _actionsSystem.RemoveAction(component.Owner, component.ShushAction);
+            _popupSystem.PopupEntity(Loc.GetString("librarian-lose-powers"), component.Owner, Filter.Entities(component.Owner));
+        }
+
+        public override void Update(float frameTime)
+        {
+            base.Update(frameTime);
+
+            foreach (var librarian in EntityQuery<LibrarianPowersComponent>())
+            {
+                //Close enough to library to use powers
+                if (libraryCoordinates != null && TryComp<TransformComponent>(librarian.Owner, out var xform))
+                {
+                    bool inDomain = xform.Coordinates.InRange(_entityManager, (EntityCoordinates) libraryCoordinates, librarian.LibraryDomainRange);
+                    if(!librarian.Enabled && inDomain)
+                        EnterLibraryDomain(librarian);
+                    else if (librarian.Enabled && !inDomain)
+                        LeaveLibraryDomain(librarian);
+                }
+
+                //Remove shushed status
+                if(librarian.ShushedEntity != null)
+                {
+                    if(librarian.Accumulator >= librarian.ShushTime.TotalSeconds)
+                    {
+                        EntityUid uid = (EntityUid)librarian.ShushedEntity;
+                        _entityManager.RemoveComponent<MutedComponent>(uid);
+                        _alertsSystem.ClearAlert(uid, AlertType.Muted);
+                        _popupSystem.PopupEntity(Loc.GetString("librarian-shush-can-speak"), uid, Filter.Entities(uid));
+                        librarian.ShushedEntity = null;
+                    }
+                    else
+                    {
+                        librarian.Accumulator += frameTime;
+                    }
+                }
+            }
+        }
+    }
+
+    public sealed class ShushActionEvent : EntityTargetActionEvent { }
+}

--- a/Content.Shared/Alert/AlertType.cs
+++ b/Content.Shared/Alert/AlertType.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Shared.Alert
+namespace Content.Shared.Alert
 {
     /// <summary>
     /// Every kind of alert. Corresponds to alertType field in alert prototypes defined in YML
@@ -35,6 +35,7 @@
         Muted,
         VowOfSilence,
         VowBroken,
+        LibraryDomain,
         Debug1,
         Debug2,
         Debug3,

--- a/Resources/Locale/en-US/abilities/librarian.ftl
+++ b/Resources/Locale/en-US/abilities/librarian.ftl
@@ -1,0 +1,7 @@
+librarian-shush = Shush
+librarian-shush-desc = People are trying to read here!
+librarian-shush-popup = {CAPITALIZE(THE($librarian))} shushes {$target}.
+librarian-been-shushed = You've been shushed!
+librarian-shush-can-speak = You feel able to speak again.
+librarian-gain-powers = You feel your librarian powers returning.
+librarian-lose-powers = You feel your librarian powers fading.

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -212,6 +212,12 @@
   description: You've broken your vows to Mimes everywhere. You can speak, but you've lost your powers for at least 5 entire minutes!!! Click to try and retake your vow.
 
 - type: alert
+  id: LibraryDomain
+  icon: /Textures/Objects/Misc/books.rsi/book2.png
+  name: Library Domain
+  description: You are empowered with the magic of reading.
+  
+- type: alert
   id: Pulled
   icon: /Textures/Interface/Alerts/Pull/pulled.png
   onClick: !type:StopBeingPulled  { }

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -9,6 +9,10 @@
   access:
   - Service
   - Maintenance
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: LibrarianPowers
 
 - type: startingGear
   id: LibrarianGear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Librarians can now silence troublesome patrons using the magic of reading.

Adds an action that works within a range of the librarian spawn point and silences a target for 30 seconds with a 120 second cooldown. The range is kinda big, but it is needed for maps with larger libraries.

I hope that the Update() method isn't too expensive, as there should be at most one librarian at a time.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

<video src="https://user-images.githubusercontent.com/89101928/177453994-ed4f8d6e-8b46-42fa-b55d-bf3c3ab911c2.mp4
"></video>
<video src="https://user-images.githubusercontent.com/89101928/177454243-c6d47afb-28e2-4fed-9428-a083034ea2d4.mp4"></video>

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Librarians can now silence troublesome patrons using the magic of reading.

