### PR TITLE
Make explosive armor multiplicative and not additive

### DIFF
--- a/Content.Server/Explosion/Components/ExplosionResistanceComponent.cs
+++ b/Content.Server/Explosion/Components/ExplosionResistanceComponent.cs
@@ -16,10 +16,10 @@ namespace Content.Server.Explosion.Components;
 public sealed class ExplosionResistanceComponent : Component
 {
     /// <summary>
-    ///     The resistance values for this component, This fraction is multiplied into the total resistance.
+    ///     The explosive resistance coefficient, This fraction is multiplied into the total resistance.
     /// </summary>
-    [DataField("resistance")]
-    public float GlobalResistance = 1;
+    [DataField("damageCoefficient")]
+    public float DamageCoefficient = 1;
 
     /// <summary>
     ///     Like <see cref="GlobalResistance"/>, but specified specific to each explosion type for more customizability.

--- a/Content.Server/Explosion/Components/ExplosionResistanceComponent.cs
+++ b/Content.Server/Explosion/Components/ExplosionResistanceComponent.cs
@@ -16,10 +16,10 @@ namespace Content.Server.Explosion.Components;
 public sealed class ExplosionResistanceComponent : Component
 {
     /// <summary>
-    ///     The resistance values for this component, This fraction is added to the total resistance.
+    ///     The resistance values for this component, This fraction is multiplied into the total resistance.
     /// </summary>
     [DataField("resistance")]
-    public float GlobalResistance = 0;
+    public float GlobalResistance = 1;
 
     /// <summary>
     ///     Like <see cref="GlobalResistance"/>, but specified specific to each explosion type for more customizability.

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
@@ -143,7 +143,7 @@ public sealed partial class ExplosionSystem : EntitySystem
                 continue;
 
             // evaluate the damage that this damage type would do to this entity
-            FixedPoint2 damagePerIntensity = 1;
+            var damagePerIntensity = FixedPoint2.Zero;
             foreach (var (type, value) in explosionType.DamagePerIntensity.DamageDict)
             {
                 if (!damageable.Damage.DamageDict.ContainsKey(type))
@@ -155,7 +155,7 @@ public sealed partial class ExplosionSystem : EntitySystem
                 var ev = new GetExplosionResistanceEvent(explosionType.ID);
                 RaiseLocalEvent(uid, ev, false);
 
-                damagePerIntensity += value * Math.Clamp(0, ev.Resistance, 1);
+                damagePerIntensity += value * Math.Max(0, ev.DamageCoefficient);
             }
 
             explosionTolerance[index] = (float) ((totalDamageTarget - damageable.TotalDamage) / damagePerIntensity);

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
@@ -143,7 +143,7 @@ public sealed partial class ExplosionSystem : EntitySystem
                 continue;
 
             // evaluate the damage that this damage type would do to this entity
-            var damagePerIntensity = FixedPoint2.Zero;
+            FixedPoint2 damagePerIntensity = 1;
             foreach (var (type, value) in explosionType.DamagePerIntensity.DamageDict)
             {
                 if (!damageable.Damage.DamageDict.ContainsKey(type))
@@ -155,7 +155,7 @@ public sealed partial class ExplosionSystem : EntitySystem
                 var ev = new GetExplosionResistanceEvent(explosionType.ID);
                 RaiseLocalEvent(uid, ev, false);
 
-                damagePerIntensity += value * Math.Clamp(0, 1 - ev.Resistance, 1);
+                damagePerIntensity += value * Math.Clamp(0, ev.Resistance, 1);
             }
 
             explosionTolerance[index] = (float) ((totalDamageTarget - damageable.TotalDamage) / damagePerIntensity);

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -362,14 +362,16 @@ public sealed partial class ExplosionSystem : EntitySystem
             var ev = new GetExplosionResistanceEvent(id);
             RaiseLocalEvent(uid, ev, false);
 
-            if (ev.Resistance == 1)
+            ev.DamageCoefficient = Math.Max(0, ev.DamageCoefficient);
+
+            if (ev.DamageCoefficient == 1)
             {
                 // no damage-dict multiplication required.
                 _damageableSystem.TryChangeDamage(uid, damage, ignoreResistances: true, damageable: damageable);
             }
-            else if (ev.Resistance < 1)
+            else
             {
-                _damageableSystem.TryChangeDamage(uid, damage * ev.Resistance, ignoreResistances: true, damageable: damageable);
+                _damageableSystem.TryChangeDamage(uid, damage * ev.DamageCoefficient, ignoreResistances: true, damageable: damageable);
             }
         }
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -362,14 +362,14 @@ public sealed partial class ExplosionSystem : EntitySystem
             var ev = new GetExplosionResistanceEvent(id);
             RaiseLocalEvent(uid, ev, false);
 
-            if (ev.Resistance == 0)
+            if (ev.Resistance == 1)
             {
                 // no damage-dict multiplication required.
                 _damageableSystem.TryChangeDamage(uid, damage, ignoreResistances: true, damageable: damageable);
             }
             else if (ev.Resistance < 1)
             {
-                _damageableSystem.TryChangeDamage(uid, damage * (1 - ev.Resistance), ignoreResistances: true, damageable: damageable);
+                _damageableSystem.TryChangeDamage(uid, damage * ev.Resistance, ignoreResistances: true, damageable: damageable);
             }
         }
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -93,9 +93,9 @@ public sealed partial class ExplosionSystem : EntitySystem
 
     private void OnGetResistance(EntityUid uid, ExplosionResistanceComponent component, GetExplosionResistanceEvent args)
     {
-        args.Resistance *= component.GlobalResistance;
+        args.DamageCoefficient *= component.DamageCoefficient;
         if (component.Resistances.TryGetValue(args.ExplotionPrototype, out var resistance))
-            args.Resistance *= resistance;
+            args.DamageCoefficient *= resistance;
     }
 
     /// <summary>

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -93,9 +93,9 @@ public sealed partial class ExplosionSystem : EntitySystem
 
     private void OnGetResistance(EntityUid uid, ExplosionResistanceComponent component, GetExplosionResistanceEvent args)
     {
-        args.Resistance += component.GlobalResistance;
+        args.Resistance *= component.GlobalResistance;
         if (component.Resistances.TryGetValue(args.ExplotionPrototype, out var resistance))
-            args.Resistance += resistance;
+            args.Resistance *= resistance;
     }
 
     /// <summary>

--- a/Content.Shared/Explosion/ExplosionEvents.cs
+++ b/Content.Shared/Explosion/ExplosionEvents.cs
@@ -14,7 +14,7 @@ public sealed class GetExplosionResistanceEvent : EntityEventArgs, IInventoryRel
     ///     Can be set to whatever, but currently is being additively increased by components & clothing. So think twice
     ///     before multiplying or directly setting this.
     /// </summary>
-    public float Resistance = 0;
+    public float Resistance = 1;
 
     public readonly string ExplotionPrototype;
 

--- a/Content.Shared/Explosion/ExplosionEvents.cs
+++ b/Content.Shared/Explosion/ExplosionEvents.cs
@@ -11,10 +11,9 @@ namespace Content.Shared.Explosion;
 public sealed class GetExplosionResistanceEvent : EntityEventArgs, IInventoryRelayEvent
 {
     /// <summary>
-    ///     Can be set to whatever, but currently is being additively increased by components & clothing. So think twice
-    ///     before multiplying or directly setting this.
+    ///     A coefficient applied to overall explosive damage.
     /// </summary>
-    public float Resistance = 1;
+    public float DamageCoefficient = 1;
 
     public readonly string ExplotionPrototype;
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -135,7 +135,7 @@
         Piercing: 0.9
         Heat: 0.9
   - type: ExplosionResistance
-    resistance: 0.9
+    damageCoefficient: 0.9
 
 - type: entity
   parent: ClothingOuterBase
@@ -155,7 +155,7 @@
         Piercing: 0.4
         Heat: 0.9
   - type: ExplosionResistance
-    resistance: 0.8
+    damageCoefficient: 0.8
 
 - type: entity
   parent: ClothingOuterBase
@@ -175,7 +175,7 @@
         Piercing: 0.6
         Heat: 0.5
   - type: ExplosionResistance
-    resistance: 0.65
+    damageCoefficient: 0.65
     
 - type: entity
   parent: ClothingOuterBase
@@ -199,4 +199,4 @@
     walkModifier: 0.7
     sprintModifier: 0.65 
   - type: ExplosionResistance
-    resistance: 0.5
+    damageCoefficient: 0.5

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -25,7 +25,7 @@
   - type: TemperatureProtection
     coefficient: 0.001
   - type: ExplosionResistance
-    resistance: 0.8
+    damageCoefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
 
@@ -54,7 +54,7 @@
         Heat: 0.3
         Radiation: 0.1
   - type: ExplosionResistance
-    resistance: 0.5
+    damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
 
@@ -83,7 +83,7 @@
         Heat: 0.2
         Radiation: 0.2
   - type: ExplosionResistance
-    resistance: 0.3
+    damageCoefficient: 0.3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
 
@@ -112,7 +112,7 @@
         Heat: 0.7
         Radiation: 0.35
   - type: ExplosionResistance
-    resistance: 0.8
+    damageCoefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
 
@@ -141,7 +141,7 @@
         Heat: 0.4
         Radiation: 0.25
   - type: ExplosionResistance
-    resistance: 0.8
+    damageCoefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite
 
@@ -251,7 +251,7 @@
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: ExplosionResistance
-    resistance: 0.7
+    damageCoefficient: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitRd
   - type: StaticPrice
@@ -282,7 +282,7 @@
         Heat: 0.85
         Radiation: 0.5
   - type: ExplosionResistance
-    resistance: 0.7
+    damageCoefficient: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
 
@@ -308,7 +308,7 @@
         Heat: 0.8
         Radiation: 0.25
   - type: ExplosionResistance
-    resistance: 0.6
+    damageCoefficient: 0.6
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
 
@@ -337,7 +337,7 @@
         Heat: 0.8
         Radiation: 0.25
   - type: ExplosionResistance
-    resistance: 0.6
+    damageCoefficient: 0.6
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
 
@@ -366,7 +366,7 @@
         Heat: 0.4 #all the combat numbers are pumped up here
         Radiation: 0.20
   - type: ExplosionResistance
-    resistance: 0.5
+    damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndie
 
@@ -395,7 +395,7 @@
         Heat: 0.25
         Radiation: 0.20
   - type: ExplosionResistance
-    resistance: 0.5
+    damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
 
@@ -424,7 +424,7 @@
         Heat: 0.5
         Radiation: 0.3
   - type: ExplosionResistance
-    resistance: 0.8
+    damageCoefficient: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLing
 
@@ -507,7 +507,7 @@
         Heat: 0.35
         Radiation: 0.1
   - type: ExplosionResistance
-    resistance: 0.2
+    damageCoefficient: 0.2
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
 
@@ -536,7 +536,7 @@
         Heat: 0.3
         Radiation: 0.20
   - type: ExplosionResistance
-    resistance: 0.5
+    damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
 
@@ -567,7 +567,7 @@
         Heat: 0.2
         Radiation: 0.20
   - type: ExplosionResistance
-    resistance: 0.3
+    damageCoefficient: 0.3
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
 
@@ -600,7 +600,7 @@
         Shock: 0.1
         Radiation: 0.1
   - type: ExplosionResistance
-    resistance: 0.7
+    damageCoefficient: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -16,7 +16,7 @@
         Piercing: 0.9
         Heat: 0.75
   - type: ExplosionResistance
-    resistance: 0.65 # +0.25 from helmet -> 90%
+    damageCoefficient: 0.65 
 
 - type: entity
   parent: ClothingOuterEVASuitBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -16,7 +16,7 @@
         Piercing: 0.5
         Heat: 0.9
   - type: ExplosionResistance
-    resistance: 0.9
+    damageCoefficient: 0.9
     
 - type: entity
   parent: ClothingOuterStorageBase
@@ -36,7 +36,7 @@
         Piercing: 0.3
         Heat: 0.9
   - type: ExplosionResistance
-    resistance: 0.9
+    damageCoefficient: 0.9
 
 - type: entity
   parent: ClothingOuterBase
@@ -56,7 +56,7 @@
         Piercing: 0.4
         Heat: 0.9
   - type: ExplosionResistance
-    resistance: 0.9
+    damageCoefficient: 0.9
 
 - type: entity
   parent: ClothingOuterBase
@@ -76,7 +76,7 @@
         Piercing: 0.75
         Heat: 0.9
   - type: ExplosionResistance
-    resistance: 0.9
+    damageCoefficient: 0.9
 
 - type: entity
   parent: ClothingOuterBase


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
no more 100% explosion resist.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Explosion resistance is now multiplicative and not additive.

