### PR TITLE
Use map coordinates for spraying

### DIFF
--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Chemistry.Components
         internal bool Reached;
         internal float ReactTimer;
         internal float Timer;
-        internal EntityCoordinates Target;
+        internal MapCoordinates Target;
         internal bool Active;
         internal float AliveTime;
     }

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Server.Chemistry.EntitySystems
             }
         }
 
-        public void Start(VaporComponent vapor, Vector2 dir, float speed, EntityCoordinates target, float aliveTime)
+        public void Start(VaporComponent vapor, Vector2 dir, float speed, MapCoordinates target, float aliveTime)
         {
             vapor.Active = true;
             vapor.Target = target;
@@ -112,8 +112,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             // Check if we've reached our target.
             if (!vapor.Reached &&
-                vapor.Target.TryDistance(EntityManager, xform.Coordinates, out var distance) &&
-                distance <= 0.5f)
+                (vapor.Target.Position - xform.MapPosition.Position).LengthSquared <= 0.25f)
             {
                 vapor.Reached = true;
             }

--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -60,9 +60,14 @@ public sealed class SpraySystem : EntitySystem
         var playerMapPos = Transform(args.User).MapPosition;
         var clickMapPos = args.ClickLocation.ToMap(EntityManager);
 
-        var mapDirection = (clickMapPos.Position - playerMapPos.Position).Normalized;
-        var threeQuarters = mapDirection * 0.75f;
-        var quarter = mapDirection * 0.25f;
+        var diffPos = clickMapPos.Position - playerMapPos.Position;
+        var diffLength = diffPos.Length;
+        if (diffLength == 0f)
+            return;
+
+        var diffNorm = diffPos.Normalized;
+        var threeQuarters = diffNorm * 0.75f;
+        var quarter = diffNorm * 0.25f;
 
         var amount = Math.Max(Math.Min((solution.CurrentVolume / component.TransferAmount).Int(), component.VaporAmount), 1);
 
@@ -70,12 +75,8 @@ public sealed class SpraySystem : EntitySystem
 
         for (var i = 0; i < amount; i++)
         {
-            var rotation = new Angle(mapDirection.ToAngle() + Angle.FromDegrees(spread * i) -
+            var rotation = new Angle(diffNorm.ToAngle() + Angle.FromDegrees(spread * i) -
                                      Angle.FromDegrees(spread * (amount - 1) / 2));
-
-            var diffPos = clickMapPos.Position - playerMapPos.Position;
-            var diffNorm = diffPos.Normalized;
-            var diffLength = diffPos.Length;
 
             var target = playerMapPos
                 .Offset((diffNorm + rotation.ToVec()).Normalized * diffLength + quarter);

--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -62,8 +62,8 @@ public sealed class SpraySystem : EntitySystem
 
         // The grid/map entity to attach the vapor to.
         EntityUid vaporSpawnEntityUid;
-        if (_mapManager.TryGetGrid(userXform.GridUid, out var grid))
-            vaporSpawnEntityUid = grid.GridEntityId;
+        if (userXform.GridUid != null)
+            vaporSpawnEntityUid = userXform.GridUid.Value;
         else if (userXform.MapUid != null)
             vaporSpawnEntityUid = userXform.MapUid.Value;
         else


### PR DESCRIPTION
Changes spray system to use MapCoordinates, allowing targeting of sprayables between grids and fixing a crash when using a sprayable from a vehicle, fixing  #9321.
