### PR TITLE
Fix pipe net null error

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasCanisterComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasCanisterComponent.cs
@@ -3,7 +3,7 @@ using Content.Shared.Atmos;
 namespace Content.Server.Atmos.Piping.Unary.Components
 {
     [RegisterComponent]
-    public sealed class GasCanisterComponent : Component
+    public sealed class GasCanisterComponent : Component, IGasMixtureHolder
     {
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("port")]
@@ -18,7 +18,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("gasMixture")]
-        public GasMixture Air { get; } = new();
+        public GasMixture Air { get; set; } = new();
 
         /// <summary>
         ///     Last recorded pressure, for appearance-updating purposes.

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -139,14 +139,14 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnCanisterUpdated(EntityUid uid, GasCanisterComponent canister, AtmosDeviceUpdateEvent args)
         {
+            _atmosphereSystem.React(canister.Air, canister);
+
             if (!EntityManager.TryGetComponent(uid, out NodeContainerComponent? nodeContainer)
                 || !EntityManager.TryGetComponent(uid, out AppearanceComponent? appearance))
                 return;
 
             if (!nodeContainer.TryGetNode(canister.PortName, out PortablePipeNode? portNode))
                 return;
-
-            _atmosphereSystem.React(canister.Air, portNode);
 
             if (portNode.NodeGroup is PipeNet {NodeCount: > 1} net)
             {

--- a/Content.Server/NodeContainer/NodeGroups/BaseNodeGroup.cs
+++ b/Content.Server/NodeContainer/NodeGroups/BaseNodeGroup.cs
@@ -20,7 +20,7 @@ namespace Content.Server.NodeContainer.NodeGroups
 
         void Create(NodeGroupID groupId);
 
-        void Initialize(Node sourceNode, IEntityManager? entMan = null);
+        void Initialize(Node sourceNode, IEntityManager entMan);
 
         void RemoveNode(Node node);
 
@@ -70,7 +70,7 @@ namespace Content.Server.NodeContainer.NodeGroups
             GroupId = groupId;
         }
 
-        public virtual void Initialize(Node sourceNode, IEntityManager? entMan = null)
+        public virtual void Initialize(Node sourceNode, IEntityManager entMan)
         {
         }
 

--- a/Content.Server/NodeContainer/NodeGroups/PipeNet.cs
+++ b/Content.Server/NodeContainer/NodeGroups/PipeNet.cs
@@ -32,8 +32,7 @@ namespace Content.Server.NodeContainer.NodeGroups
 
             if (Grid == null)
             {
-                Logger.Error($"Created a pipe network without an associated grid. Pipe networks currently need to be tied to a grid for amtos to work. Source entity: {entMan.ToPrettyString(sourceNode.Owner)}");
-                // This is probably due to a cannister being spawned in space. Currently canisters need to spawned on grids to function properly, and they'll stop updating if their original grid gets deleted
+                // This is probably due to a cannister or something like that being spawned in space.
                 return;
             }
 

--- a/Content.Server/NodeContainer/NodeGroups/PipeNet.cs
+++ b/Content.Server/NodeContainer/NodeGroups/PipeNet.cs
@@ -24,10 +24,8 @@ namespace Content.Server.NodeContainer.NodeGroups
 
         public EntityUid? Grid { get; private set; }
 
-        public override void Initialize(Node sourceNode, IEntityManager? entMan = null)
+        public override void Initialize(Node sourceNode, IEntityManager entMan)
         {
-            IoCManager.Resolve(ref entMan);
-
             base.Initialize(sourceNode, entMan);
 
             Grid = entMan.GetComponent<TransformComponent>(sourceNode.Owner).GridUid;
@@ -35,6 +33,7 @@ namespace Content.Server.NodeContainer.NodeGroups
             if (Grid == null)
             {
                 Logger.Error($"Created a pipe network without an associated grid. Pipe networks currently need to be tied to a grid for amtos to work. Source entity: {entMan.ToPrettyString(sourceNode.Owner)}");
+                // This is probably due to a cannister being spawned in space. Currently canisters need to spawned on grids to function properly, and they'll stop updating if their original grid gets deleted
                 return;
             }
 
@@ -82,13 +81,11 @@ namespace Content.Server.NodeContainer.NodeGroups
                     newAir.Add(newPipeNet.Air);
             }
 
-            _atmosphereSystem!.DivideInto(Air, newAir);
+            _atmosphereSystem?.DivideInto(Air, newAir);
         }
 
         private void RemoveFromGridAtmos()
         {
-            DebugTools.AssertNotNull(_atmosphereSystem);
-
             if (Grid == null)
                 return;
 

--- a/Content.Server/Power/NodeGroups/ApcNet.cs
+++ b/Content.Server/Power/NodeGroups/ApcNet.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Power.NodeGroups
     [UsedImplicitly]
     public sealed class ApcNet : BaseNetConnectorNodeGroup<IApcNet>, IApcNet
     {
-        private readonly PowerNetSystem _powerNetSystem = EntitySystem.Get<PowerNetSystem>();
+        private PowerNetSystem? _powerNetSystem;
 
         [ViewVariables] public readonly List<ApcComponent> Apcs = new();
         [ViewVariables] public readonly List<ApcPowerProviderComponent> Providers = new();
@@ -42,10 +42,11 @@ namespace Content.Server.Power.NodeGroups
         [ViewVariables]
         public PowerState.Network NetworkNode { get; } = new();
 
-        public override void Initialize(Node sourceNode, IEntityManager? entMan = null)
+        public override void Initialize(Node sourceNode, IEntityManager entMan)
         {
             base.Initialize(sourceNode, entMan);
 
+            _powerNetSystem = entMan.EntitySysManager.GetEntitySystem<PowerNetSystem>();
             _powerNetSystem.InitApcNet(this);
         }
 
@@ -53,7 +54,7 @@ namespace Content.Server.Power.NodeGroups
         {
             base.AfterRemake(newGroups);
 
-            _powerNetSystem.DestroyApcNet(this);
+            _powerNetSystem?.DestroyApcNet(this);
         }
 
         public void AddApc(ApcComponent apc)
@@ -104,7 +105,7 @@ namespace Content.Server.Power.NodeGroups
 
         public void QueueNetworkReconnect()
         {
-            _powerNetSystem.QueueReconnectApcNet(this);
+            _powerNetSystem?.QueueReconnectApcNet(this);
         }
 
         protected override void SetNetConnectorNet(IBaseNetConnectorComponent<IApcNet> netConnectorComponent)
@@ -114,6 +115,9 @@ namespace Content.Server.Power.NodeGroups
 
         public override string? GetDebugData()
         {
+            if (_powerNetSystem == null)
+                return null;
+
             // This is just recycling the multi-tool examine.
 
             var ps = _powerNetSystem.GetNetworkStatistics(NetworkNode);


### PR DESCRIPTION
The main fix is just replacing `_atmosphereSystem!.DivideInto()` with `_atmosphereSystem?.DivideInto()`, the rest of the PR is also updating power nets to reduce IoC resolves.

![unknown](https://user-images.githubusercontent.com/60421075/177674602-1dca012d-7935-4c38-ba15-889ab788ee09.png)

edit:
Now also removes the error log and makes minor changes to canister component by making it implement `IGasMixtureHolder`.