### PR TITLE
Makes smite spell funnier

### DIFF
--- a/Content.Server/Magic/MagicSystem.cs
+++ b/Content.Server/Magic/MagicSystem.cs
@@ -174,7 +174,7 @@ public sealed class MagicSystem : EntitySystem
                 // This is shit but you get the idea.
                 var directionPos = casterXform.Coordinates.Offset(casterXform.LocalRotation.ToWorldVec().Normalized);
 
-                if (!_mapManager.TryGetGrid(casterXform.GridID, out var mapGrid))
+                if (!_mapManager.TryGetGrid(casterXform.GridUid, out var mapGrid))
                     return new List<EntityCoordinates>();
 
                 if (!directionPos.TryGetTileRef(out var tileReference, EntityManager, _mapManager))
@@ -272,6 +272,10 @@ public sealed class MagicSystem : EntitySystem
     {
         if (ev.Handled)
             return;
+
+        var direction = Transform(ev.Target).MapPosition.Position - Transform(ev.Performer).MapPosition.Position;
+        var impulseVector = direction * 10000;
+        Comp<PhysicsComponent>(ev.Target).ApplyLinearImpulse(impulseVector);
 
         if (!TryComp<BodyComponent>(ev.Target, out var body))
             return;


### PR DESCRIPTION
## About the PR
Smite spell now knocks back its target 6-7 tiles

## Why is this good for the game
i think its funny

**Screenshots**

https://user-images.githubusercontent.com/60196617/177872178-538bfeca-177b-41d8-9f00-70e3af968ec7.mp4

**Changelog**

:cl:
- tweak: Smite spell now knocks back its target

