### PR TITLE
Fix #9549

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -221,7 +221,7 @@
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
-    proto: CartridgePistol
+    proto: CartridgePistolHighVelocity
   - type: Sprite
     layers:
     - state: high_velocity


### PR DESCRIPTION
## Quick fix for issue #9549
Fixes #9549
Switches "machine pistol magazine (.35 auto high-velocity)" to actual high-velocity cartridges.

**Changelog**
:cl:
- fix: machine pistol magazine (.35 auto high-velocity) now comes with corresponding stronger cartridges instead of regular ones

