### PR TITLE
Fix nearby warping

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Hyperspace.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Hyperspace.cs
@@ -251,7 +251,8 @@ public sealed partial class ShuttleSystem
     private bool TryHyperspaceDock(ShuttleComponent component, EntityUid targetUid)
     {
         if (!TryComp<TransformComponent>(component.Owner, out var xform) ||
-            !TryComp<TransformComponent>(targetUid, out var targetXform)) return false;
+            !TryComp<TransformComponent>(targetUid, out var targetXform) ||
+            targetXform.MapUid == null) return false;
 
         var config = GetDockingConfig(component, targetUid);
 
@@ -291,7 +292,7 @@ public sealed partial class ShuttleSystem
             shuttleBody.AngularVelocity = 0f;
         }
 
-        xform.WorldPosition = spawnPos;
+        xform.Coordinates = new EntityCoordinates(targetXform.MapUid.Value, spawnPos);
         xform.WorldRotation = _random.NextAngle();
         return false;
     }


### PR DESCRIPTION
Woops, forgot to update the parentuid. Fixes https://github.com/space-wizards/space-station-14/issues/9536

:cl:
- fix: Emergency shuttle will now actually warp-in nearby if there's no available docks.