### PR TITLE
Client command perms cleanup.

### DIFF
--- a/Content.Shared/Administration/AdminCommandPermissions.cs
+++ b/Content.Shared/Administration/AdminCommandPermissions.cs
@@ -1,0 +1,83 @@
+﻿using System.IO;
+using System.Linq;
+using Robust.Shared.Utility;
+using YamlDotNet.RepresentationModel;
+
+namespace Content.Shared.Administration;
+
+public sealed class AdminCommandPermissions
+{
+    // Commands executable by anybody.
+    public readonly HashSet<string> AnyCommands = new();
+
+    // Commands only executable by admins with one of the given flag masks.
+    public readonly Dictionary<string, AdminFlags[]> AdminCommands = new();
+
+    public void LoadPermissionsFromStream(Stream fs)
+    {
+        using var reader = new StreamReader(fs, EncodingHelpers.UTF8);
+        var yStream = new YamlStream();
+        yStream.Load(reader);
+        var root = (YamlSequenceNode) yStream.Documents[0].RootNode;
+
+        foreach (var child in root)
+        {
+            var map = (YamlMappingNode) child;
+            var commands = map.GetNode<YamlSequenceNode>("Commands").Select(p => p.AsString());
+            if (map.TryGetNode("Flags", out var flagsNode))
+            {
+                var flagNames = flagsNode.AsString().Split(",", StringSplitOptions.RemoveEmptyEntries);
+                var flags = AdminFlagsHelper.NamesToFlags(flagNames);
+                foreach (var cmd in commands)
+                {
+                    if (!AdminCommands.TryGetValue(cmd, out var exFlags))
+                    {
+                        AdminCommands.Add(cmd, new[] {flags});
+                    }
+                    else
+                    {
+                        var newArr = new AdminFlags[exFlags.Length + 1];
+                        exFlags.CopyTo(newArr, 0);
+                        exFlags[^1] = flags;
+                        AdminCommands[cmd] = newArr;
+                    }
+                }
+            }
+            else
+            {
+                AnyCommands.UnionWith(commands);
+            }
+        }
+    }
+
+    public bool CanCommand(string cmdName, AdminData? admin)
+    {
+        if (AnyCommands.Contains(cmdName))
+        {
+            // Anybody can use this command.
+            return true;
+        }
+
+        if (!AdminCommands.TryGetValue(cmdName, out var flagsReq))
+        {
+            // Server-console only.
+            return false;
+        }
+
+        if (admin == null)
+        {
+            // Player isn't an admin.
+            return false;
+        }
+
+        foreach (var flagReq in flagsReq)
+        {
+            if (admin.HasFlag(flagReq))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -1,3 +1,31 @@
+# Available to everybody
+- Commands:
+    - disconnect
+    - help
+    - list
+    - quit
+    - hardquit
+    - svbind
+    - bind
+    - exec # macro moment
+    - cls
+    - vram
+    - monitor
+    - setmonitor
+    - keyinfo
+    - setclipboard
+    - getclipboard
+    - net_graph
+    - net_watchent
+    - net_draw_interp
+    - devwindow
+    - fill
+    - dumpentities
+    - ">"
+    - gcf
+    - gc
+    - gc_mode
+
 - Flags: DEBUG
   Commands:
     - atvrange

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -1,32 +1,3 @@
-# Available to everybody
-- Commands:
-  - disconnect
-  - help
-  - list
-  - quit
-  - hardquit
-  - cvar
-  - svbind
-  - bind
-  - exec # macro moment
-  - clear
-  - vram
-  - monitor
-  - setmonitor
-  - keyinfo
-  - setclipboard
-  - getclipboard
-  - gcf
-  - net_graph
-  - net_watchent
-  - net_draw_interp
-  - devwindow
-  - fill
-  - dumpentities
-  - getcomponentregistration
-  - fuck
-  - ">"
-
 - Flags: VAREDIT
   Commands:
   - addcomp
@@ -141,6 +112,10 @@
   - scsi
   - csi
   - lsasm
+  - cvar
+  - gcf
+  - getcomponentregistration
+  - fuck
 
 - Flags: QUERY
   Commands:


### PR DESCRIPTION
Share more code between client and server. Also allows us to remove the `#if` hack on client command perms on the client.