### PR TITLE
Fix medical techfab and add unused bodybag recipe to it

### DIFF
--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -28,6 +28,7 @@
     - Bucket
     - MopItem
     - SprayBottle
+    - BodyBag
 
 # Biological Technology Tree
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -373,6 +373,7 @@
       - Dropper
       - Syringe
       - PillCanister
+      - BodyBag
   - type: Machine
     board: MedicalTechFabCircuitboard
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -351,9 +351,8 @@
   - type: LatheVisuals
     idleState: icon
     runningState: icon
-  - type: LatheDatabase
-    static: true
-    recipes:
+  - type: ProtolatheDatabase
+    protolatherecipes:
       - HandheldHealthAnalyzer
       - ClothingHandsGlovesLatex
       - ClothingHandsGlovesNitrile

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -48,12 +48,12 @@
     Steel: 200
 
 - type: latheRecipe
-  id: BodyBag_Folded
+  id: BodyBag
   icon: Objects/Specific/Medical/Morgue/bodybags.rsi/bag_folded.png
   result: BodyBag_Folded
-  completetime: 1.2
+  completetime: 2
   materials:
-    Plastic: 200
+    Plastic: 300
 
 - type: latheRecipe
   id: HandheldCrewMonitor
@@ -97,7 +97,7 @@
   result: ClothingMaskSterile
   completetime: 2
   materials:
-    Plastic: 300
+    Plastic: 100
 
 - type: latheRecipe
   id: DiseaseSwab


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Bottom text. Also I fixed a mistake with medical techfabs

![image](https://user-images.githubusercontent.com/60792108/178162913-9156b7ec-7bd2-4f48-9771-fe1734878d3f.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- add: Bodybags are now printable in the medical techfab.
- fix: Medical techfab doesn't start with all recipes unlocked anymore.

