### PR TITLE
Fix disappearing decals bug

### DIFF
--- a/Content.Client/Commands/ZoomCommand.cs
+++ b/Content.Client/Commands/ZoomCommand.cs
@@ -1,0 +1,58 @@
+using JetBrains.Annotations;
+using Robust.Client.Graphics;
+using Robust.Shared.Console;
+
+namespace Content.Client.Commands;
+
+[UsedImplicitly]
+public sealed class ZoomCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEyeManager _eyeMan = default!;
+
+    public string Command => "zoom";
+    public string Description => Loc.GetString("zoom-command-description");
+    public string Help => Loc.GetString("zoom-command-help");
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        Vector2 zoom;
+        if (args.Length is not (1 or 2))
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+
+        if (!float.TryParse(args[0], out var arg0))
+        {
+            shell.WriteError(Loc.GetString("cmd-parse-failure-float", ("arg", args[0])));
+            return;
+        }
+
+        if (arg0 > 0)
+            zoom = new(arg0, arg0);
+        else
+        {
+            shell.WriteError(Loc.GetString("zoom-command-error"));
+            return;
+        }
+
+        if (args.Length == 2)
+        {
+            if (!float.TryParse(args[1], out var arg1))
+            {
+                shell.WriteError(Loc.GetString("cmd-parse-failure-float", ("arg", args[1])));
+                return;
+            }
+
+            if (arg1 > 0)
+                zoom.Y = arg1;
+            else
+            {
+                shell.WriteError(Loc.GetString("zoom-command-error"));
+                return;
+            }
+        }
+
+        _eyeMan.CurrentEye.Zoom = zoom;
+    }
+}

--- a/Resources/Locale/en-US/commands/zoom-command.ftl
+++ b/Resources/Locale/en-US/commands/zoom-command.ftl
@@ -1,0 +1,3 @@
+zoom-command-description = Sets the zoom of the main eye.
+zoom-command-help = zoom ( <scale> | <X-scale> <Y-scale> )
+zoom-command-error = scale has to be greater than 0

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -45,6 +45,7 @@
     - showspread
     - showambient
     - showemergencyshuttle
+    - zoom
 
 - Flags: MAPPING
   Commands:


### PR DESCRIPTION
Fixes a bug that was causing decals to sometimes not be sent to players. The cause was that if a system update only involved removing stale chunks without adding any new ones, then the previously sent chunks list was not updated. So if a chunk left a player's view, and then re-entered, the server would not re-send the chunk data, because it thought it already sent it previously.

Other changes:
- Adds a `/zoom` command to change the current-eye's zoom levels without having to use VV. Can make debugging PVS & decal stuff slightly easier.
- Replaced some `GetComps` with `TryGet` + error logs. Grid deletion seems to cause some issues where a client tries to apply decals to deleted grids or something like that.
- Made misc changes to try slightly speed up the get & handle decal state logic 

:cl:
- fix: Fixed a bug that caused decals to sometimes disappear.

