### PR TITLE
More nukie tweaks

### DIFF
--- a/Content.Client/Nuke/NukeMenu.xaml.cs
+++ b/Content.Client/Nuke/NukeMenu.xaml.cs
@@ -104,7 +104,7 @@ namespace Content.Client.Nuke
             SecondStatusLabel.Text = secondMsg;
 
             EjectButton.Disabled = !state.DiskInserted || state.Status == NukeStatus.ARMED;
-            AnchorButton.Disabled = !state.DiskInserted;
+            AnchorButton.Disabled = state.Status == NukeStatus.ARMED;
             AnchorButton.Pressed = state.IsAnchored;
             ArmButton.Disabled = !state.AllowArm;
         }

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -128,8 +128,8 @@ namespace Content.Server.Nuke
 
         private void CheckAnchorAttempt(EntityUid uid, NukeComponent component, BaseAnchoredAttemptEvent args)
         {
-            // cancel any anchor attempt without nuke disk
-            if (!component.DiskSlot.HasItem)
+            // cancel any anchor attempt if armed
+            if (component.Status == NukeStatus.ARMED)
             {
                 var msg = Loc.GetString("nuke-component-cant-anchor");
                 _popups.PopupEntity(msg, uid, Filter.Entities(args.User));
@@ -422,15 +422,22 @@ namespace Content.Server.Nuke
                 _alertLevel.SetLevel(stationUid.Value, component.AlertLevelOnActivate, true, true, true, true);
             }
 
+            var nukeXform = Transform(uid);
+            var pos =  nukeXform.MapPosition;
+            var x = (int) pos.X;
+            var y = (int) pos.Y;
+            var posText = $"({x}, {y})";
+
             // warn a crew
             var announcement = Loc.GetString("nuke-component-announcement-armed",
-                ("time", (int) component.RemainingTime));
+                ("time", (int) component.RemainingTime), ("position", posText));
             var sender = Loc.GetString("nuke-component-announcement-sender");
             _chatSystem.DispatchStationAnnouncement(uid, announcement, sender, false, Color.Red);
 
             NukeArmedAudio(component);
 
             _itemSlots.SetLock(uid, component.DiskSlot, true);
+            nukeXform.Anchored = true;
             component.Status = NukeStatus.ARMED;
             UpdateUserInterface(uid, component);
         }

--- a/Resources/Locale/en-US/nuke/nuke-component.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-component.ftl
@@ -1,6 +1,6 @@
 nuke-component-cant-anchor = The bolts seems to be blocked without disk!
 nuke-component-announcement-sender = Nuclear Fission Explosive
-nuke-component-announcement-armed = Attention! The station's self-destruct mechanism has been engaged. {$time} seconds until detonation.
+nuke-component-announcement-armed = Attention! The station's self-destruct mechanism has been engaged at global coordinates {$position}. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.
 nuke-component-announcement-unarmed = The station's self-destruct was deactivated! Have a nice day!
 nuke-component-announcement-send-codes = Attention! Requested self-destruction codes was sent to communication consoles.
 nuke-component-doafter-warning = You start fiddling with wires and knobs in order to disarm the nuke.. This may take a while.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Bit of a boring meta I observed with the last tweaks is that nukies can just run around with the nuke while its armed. Thats lame. So

- Forcibly anchors the nuke when armed and doesn't allow it to be unanchored
- Announces coordinates of the nuke which you can locate with a GPS when armed

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: The nuke now forcibly anchors when armed.
- tweak: The nuke now announces its coordinates when armed.
