### PR TITLE
Update misleading Phalanximine description to accurate one

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -50,7 +50,7 @@ reagent-name-barozine = barozine
 reagent-desc-barozine = A somewhat toxic medicine that prevents pressure damage. Causes extreme pain and jittering. Very poisonous when overdosed.
 
 reagent-name-phalanximine = phalanximine
-reagent-desc-phalanximine = Used in the treatment of cancer, is as effective as Anti-Toxin. Causes moderate radiation and hair loss.
+reagent-desc-phalanximine = Used in the treatment of cancer. Causes moderate radiation poisoning.
 
 reagent-name-romerol = romerol
 reagent-desc-romerol = A difficult to procure chemical used in the reversal of the zombification process. Tastes like death.


### PR DESCRIPTION
## Update misleading Phalanximine description to accurate one
Ditches flawed description in favor of accurate one. Previous one suggests that Phalanximine is "Anti-Toxin". This line notably is used by official Wiki.

Fixed version of brainfart pull request #9624

**Changelog**
:cl:
- fix: Corrected Phalanximine description. It's not "Anti-Toxin", actually it's mildly radioactive!