### PR TITLE
Fix exception on toggleready when there are no arguments

### DIFF
--- a/Content.Server/GameTicking/Commands/ToggleReadyCommand.cs
+++ b/Content.Server/GameTicking/Commands/ToggleReadyCommand.cs
@@ -14,6 +14,11 @@ namespace Content.Server.GameTicking.Commands
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             var player = shell.Player as IPlayerSession;
+            if (args.Length != 1)
+            {
+                shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+                return;
+            }
             if (player == null)
             {
                 return;


### PR DESCRIPTION
Found this really small bug while doing something else
