### PR TITLE
Nuke ops start with a nuclear pinpointer in their bags

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -227,6 +227,7 @@
       - id: SurvivalKnife
       - id: WeaponPistolViper
       - id: BaseUplinkRadio40TC
+      - id: PinpointerNuclear
 
 
 - type: entity
@@ -247,3 +248,4 @@
       - id: BoxSurvivalSyndicate
       - id: SurvivalKnife
       - id: WeaponPistolViper
+      - id: PinpointerNuclear


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Adds a pinpointer to the operative and medic operative duffel bags. 

A lack of pinpointers is a shockingly common cause of fluke ops, hopefully this proves to be a decent QoL change that results in fewer flukes and stall-outs when an op gets separated from their friend with the pointer, or jumps out of the ship in the wrong direction.

Even though this is like a two line change it's my first time coding anything in years and the first time I've really fucked around with git so please let me know if I'm doing something wrong in my process here. <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Nuclear Operatives now start with a pinpointer in their bag

