### PR TITLE
Nerf disease outbreak

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -24,6 +24,8 @@
   config:
     !type:StationEventRuleConfiguration
     startAnnouncement: station-event-disease-outbreak-announcement
+    startAudio:
+      path: /Audio/Announcements/outbreak7.ogg
     id: DiseaseOutbreak
     weight: 5
     endAfter: 1

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -23,9 +23,12 @@
   id: DiseaseOutbreak
   config:
     !type:StationEventRuleConfiguration
+    startAnnouncement: station-event-disease-outbreak-announcement
     id: DiseaseOutbreak
-    weight: 10
+    weight: 5
     endAfter: 1
+    earliestStart: 15
+    maxOccurrences: 3
 
 - type: gameRule
   id: FalseAlarm


### PR DESCRIPTION
:cl:
- tweak: Disease outbreak has been nerfed: its weight is reduced to half, its earliest start is now 15 minutes, and it can no longer occur more than 3 times.