### PR TITLE
Fix interaction outline jankiness at high speeds

### DIFF
--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -4,6 +4,7 @@ using Content.Client.Interactable.Components;
 using Content.Client.Viewport;
 using Content.Shared.CCVar;
 using Content.Shared.Interaction;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
@@ -41,6 +42,7 @@ public sealed class InteractionOutlineSystem : EntitySystem
         base.Initialize();
 
         _configManager.OnValueChanged(CCVars.OutlineEnabled, SetCvarEnabled);
+        UpdatesAfter.Add(typeof(EyeUpdateSystem));
     }
 
     public override void Shutdown()


### PR DESCRIPTION
Converting mouse to eye pos is better done after the eye has its frameupdate.

:cl:
- fix: Interaction outlines won't be so jank at high speeds anymore (e.g. emergency shuttle).