### PR TITLE
Add current station time to game lobby

### DIFF
--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -32,6 +32,7 @@ namespace Content.Client.GameTicking.Managers
         [ViewVariables] public bool DisallowedLateJoin { get; private set; }
         [ViewVariables] public string? ServerInfoBlob { get; private set; }
         [ViewVariables] public TimeSpan StartTime { get; private set; }
+        [ViewVariables] public TimeSpan RoundStartTimeSpan { get; private set; }
         [ViewVariables] public new bool Paused { get; private set; }
         [ViewVariables] public Dictionary<NetUserId, LobbyPlayerStatus> Status { get; private set; } = new();
         [ViewVariables] public IReadOnlyDictionary<EntityUid, Dictionary<string, uint?>> JobsAvailable => _jobsAvailable;
@@ -87,6 +88,7 @@ namespace Content.Client.GameTicking.Managers
         private void LobbyStatus(TickerLobbyStatusEvent message)
         {
             StartTime = message.StartTime;
+            RoundStartTimeSpan = message.RoundStartTimeSpan;
             IsGameStarted = message.IsRoundStarted;
             AreWeReady = message.YouAreReady;
             LobbySong = message.LobbySong;

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -136,7 +136,7 @@ namespace Content.Client.Lobby
             if (gameTicker.IsGameStarted)
             {
                 _lobby.StartTime.Text = string.Empty;
-                _lobby.StationTime.Text = Loc.GetString("lobby-state-player-status-station-time", ("stationTime", _gameTiming.RealTime.Subtract(_gameTicker.StartTime).ToString("hh\\:mm")));
+                _lobby.StationTime.Text = Loc.GetString("lobby-state-player-status-station-time", ("stationTime", _gameTiming.RealTime.Subtract(_gameTicker.RoundStartTimeSpan).ToString("hh\\:mm")));
                 return;
             }
 

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Content.Client.Message;
 using Content.Client.Chat;
 using Content.Client.Chat.Managers;
 using Content.Client.EscapeMenu.UI;
@@ -44,7 +45,6 @@ namespace Content.Client.Lobby
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IVoteManager _voteManager = default!;
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
-
         [ViewVariables] private CharacterSetupGui? _characterSetup;
         [ViewVariables] private LobbyGui? _lobby;
 
@@ -136,6 +136,7 @@ namespace Content.Client.Lobby
             if (gameTicker.IsGameStarted)
             {
                 _lobby.StartTime.Text = string.Empty;
+                _lobby.StationTime.Text = Loc.GetString("lobby-state-player-status-station-time", ("stationTime", _gameTiming.RealTime.Subtract(_gameTicker.StartTime).ToString("hh\\:mm")));
                 return;
             }
 
@@ -159,6 +160,7 @@ namespace Content.Client.Lobby
                 }
             }
 
+            _lobby.StationTime.Text =  Loc.GetString("lobby-state-player-status-station-time", ("stationTime", TimeSpan.Zero.ToString("hh\\:mm")));
             _lobby.StartTime.Text = Loc.GetString("lobby-state-round-start-countdown-text", ("timeLeft", text));
         }
 

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Content.Client.Message;
 using Content.Client.Chat;
 using Content.Client.Chat.Managers;
 using Content.Client.EscapeMenu.UI;
@@ -45,6 +44,7 @@ namespace Content.Client.Lobby
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IVoteManager _voteManager = default!;
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+
         [ViewVariables] private CharacterSetupGui? _characterSetup;
         [ViewVariables] private LobbyGui? _lobby;
 

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -65,6 +65,7 @@
                     <!-- Server info -->
                     <hudUi:NanoHeading Text="{Loc 'ui-lobby-server-info-block'}" />
                     <info:ServerInfo Name="ServerInfo" Access="Public" MinSize="0 30" VerticalExpand="false" Margin="3 3 3 3" MaxWidth="400"  HorizontalAlignment="Left"/>
+                    <Label Name="StationTime" Access="Public" FontColorOverride="{x:Static maths:Color.LightGray}" Margin="3 3 3 3" HorizontalAlignment="Left"/>
                     <ui:HSpacer Spacing="5"/>
                     <lobbyUi:LobbyCharacterPreviewPanel Name="CharacterPreview" Access="Public"></lobbyUi:LobbyCharacterPreviewPanel>
                     <ui:HSpacer Spacing="5"/>

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -67,7 +67,7 @@ namespace Content.Server.GameTicking
         private TickerLobbyStatusEvent GetStatusMsg(IPlayerSession session)
         {
             _playersInLobby.TryGetValue(session, out var status);
-            return new TickerLobbyStatusEvent(RunLevel != GameRunLevel.PreRoundLobby, LobbySong, LobbyBackground,status == LobbyPlayerStatus.Ready, _roundStartTime, Paused);
+            return new TickerLobbyStatusEvent(RunLevel != GameRunLevel.PreRoundLobby, LobbySong, LobbyBackground,status == LobbyPlayerStatus.Ready, _roundStartTime, _roundStartTimeSpan, Paused);
         }
 
         private void SendStatusToAll()

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -46,8 +46,7 @@ namespace Content.Server.GameTicking
             var mapName = map?.MapName ?? Loc.GetString("game-ticker-no-map-selected");
             var gmTitle = Loc.GetString(Preset.ModeTitle);
             var desc = Loc.GetString(Preset.Description);
-            var roundTime = RoundDuration().ToString("hh\\:mm");
-            return Loc.GetString("game-ticker-get-info-text",("roundId", RoundId), ("playerCount", playerCount),("mapName", mapName), ("roundTime", roundTime), ("gmTitle", gmTitle),("desc", desc));
+            return Loc.GetString("game-ticker-get-info-text",("roundId", RoundId), ("playerCount", playerCount),("mapName", mapName), ("gmTitle", gmTitle),("desc", desc));
         }
 
         private TickerLobbyReadyEvent GetStatusSingle(ICommonSession player, LobbyPlayerStatus status)

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -40,13 +40,12 @@ namespace Content.Server.GameTicking
                 return string.Empty;
             }
 
-
             var playerCount = $"{_playerManager.PlayerCount}";
             var map = _gameMapManager.GetSelectedMap();
             var mapName = map?.MapName ?? Loc.GetString("game-ticker-no-map-selected");
             var gmTitle = Loc.GetString(Preset.ModeTitle);
             var desc = Loc.GetString(Preset.Description);
-            return Loc.GetString("game-ticker-get-info-text",("roundId", RoundId), ("playerCount", playerCount),("mapName", mapName), ("gmTitle", gmTitle),("desc", desc));
+            return Loc.GetString("game-ticker-get-info-text",("roundId", RoundId), ("playerCount", playerCount),("mapName", mapName),("gmTitle", gmTitle),("desc", desc));
         }
 
         private TickerLobbyReadyEvent GetStatusSingle(ICommonSession player, LobbyPlayerStatus status)

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -45,7 +45,8 @@ namespace Content.Server.GameTicking
             var mapName = map?.MapName ?? Loc.GetString("game-ticker-no-map-selected");
             var gmTitle = Loc.GetString(Preset.ModeTitle);
             var desc = Loc.GetString(Preset.Description);
-            return Loc.GetString("game-ticker-get-info-text",("roundId", RoundId), ("playerCount", playerCount),("mapName", mapName),("gmTitle", gmTitle),("desc", desc));
+            var roundTime = _gameTiming.RealTime.ToString("hh\\:mm");
+            return Loc.GetString("game-ticker-get-info-text",("roundId", RoundId), ("playerCount", playerCount),("mapName", mapName), ("roundTime", roundTime), ("gmTitle", gmTitle),("desc", desc));
         }
 
         private TickerLobbyReadyEvent GetStatusSingle(ICommonSession player, LobbyPlayerStatus status)

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -40,12 +40,13 @@ namespace Content.Server.GameTicking
                 return string.Empty;
             }
 
+
             var playerCount = $"{_playerManager.PlayerCount}";
             var map = _gameMapManager.GetSelectedMap();
             var mapName = map?.MapName ?? Loc.GetString("game-ticker-no-map-selected");
             var gmTitle = Loc.GetString(Preset.ModeTitle);
             var desc = Loc.GetString(Preset.Description);
-            var roundTime = _gameTiming.RealTime.ToString("hh\\:mm");
+            var roundTime = RoundDuration().ToString("hh\\:mm");
             return Loc.GetString("game-ticker-get-info-text",("roundId", RoundId), ("playerCount", playerCount),("mapName", mapName), ("roundTime", roundTime), ("gmTitle", gmTitle),("desc", desc));
         }
 

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -45,15 +45,17 @@ namespace Content.Shared.GameTicking
         public bool YouAreReady { get; }
         // UTC.
         public TimeSpan StartTime { get; }
+        public TimeSpan RoundStartTimeSpan { get; }
         public bool Paused { get; }
 
-        public TickerLobbyStatusEvent(bool isRoundStarted, string? lobbySong, string? lobbyBackground, bool youAreReady, TimeSpan startTime, bool paused)
+        public TickerLobbyStatusEvent(bool isRoundStarted, string? lobbySong, string? lobbyBackground, bool youAreReady, TimeSpan startTime, TimeSpan roundStartTimeSpan, bool paused)
         {
             IsRoundStarted = isRoundStarted;
             LobbySong = lobbySong;
             LobbyBackground = lobbyBackground;
             YouAreReady = youAreReady;
             StartTime = startTime;
+            RoundStartTimeSpan = roundStartTimeSpan;
             Paused = paused;
         }
     }

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -11,7 +11,6 @@ game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/co
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color]
                             The current map is: [color=white]{$mapName}[/color]
-                            The Station Time is: [color=white]{$roundTime}[/color]
                             The current game mode is: [color=white]{$gmTitle}[/color]
                             >[color=yellow]{$desc}[/color]
 game-ticker-no-map-selected = [color=red]No map selected![/color]

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -11,6 +11,7 @@ game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/co
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color]
                             The current map is: [color=white]{$mapName}[/color]
+                            Station Time is: [color=white]{$roundTime}[/color]
                             The current game mode is: [color=white]{$gmTitle}[/color]
                             >[color=yellow]{$desc}[/color]
 game-ticker-no-map-selected = [color=red]No map selected![/color]

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -11,7 +11,7 @@ game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/co
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color]
                             The current map is: [color=white]{$mapName}[/color]
-                            Station Time is: [color=white]{$roundTime}[/color]
+                            The Station Time is: [color=white]{$roundTime}[/color]
                             The current game mode is: [color=white]{$gmTitle}[/color]
                             >[color=yellow]{$desc}[/color]
 game-ticker-no-map-selected = [color=red]No map selected![/color]

--- a/Resources/Locale/en-US/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-state.ftl
@@ -7,3 +7,4 @@ lobby-state-ready-button-ready-up-state = Ready Up
 lobby-state-player-status-not-ready = Not Ready
 lobby-state-player-status-ready = Ready
 lobby-state-player-status-observer = Observer
+lobby-state-player-status-station-time =  The Station Time is: {$stationTime}

--- a/Resources/Locale/en-US/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-state.ftl
@@ -7,4 +7,4 @@ lobby-state-ready-button-ready-up-state = Ready Up
 lobby-state-player-status-not-ready = Not Ready
 lobby-state-player-status-ready = Ready
 lobby-state-player-status-observer = Observer
-lobby-state-player-status-station-time =  The Station Time is: {$stationTime}
+lobby-state-player-status-station-time =  The station time is: {$stationTime}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds current station time to the lobby screen. It's useful for late joiners so they get an idea of how long the round has been going on. Also doesn't update unless the rest of the text is updated but I don't really know if it needs to be.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/31836813/178603873-ee125a06-5c6a-4e04-92ac-3e79f3bca8b7.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: You can now see the station time in the lobby screen
