### PR TITLE
You can now unanchor and destroy the robot showcase

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Decoration/showcase.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/showcase.yml
@@ -1,6 +1,39 @@
 - type: entity
-  id: ShowcaseRobot
+  id: BaseShowcaseRobot
   parent: BaseStructure
+  name: security robot showcase
+  description: A non-functional replica of an old security robot.
+  components:
+    - type: Anchorable
+    - type: Damageable
+      damageContainer: Inorganic
+      damageModifierSet: Metallic
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 150
+          behaviors:
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+        - trigger:
+            !type:DamageTrigger
+            damage: 75
+          behaviors:
+            - !type:PlaySoundBehavior
+              sound:
+                path: /Audio/Effects/metalbreak.ogg
+            - !type:SpawnEntitiesBehavior
+              spawn:
+                PartRodMetal1:
+                  min: 5
+                  max: 10
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+
+- type: entity
+  id: ShowcaseRobot
+  parent: BaseShowcaseRobot
   name: security robot showcase
   description: A non-functional replica of an old security robot.
   components:
@@ -10,7 +43,7 @@
 
 - type: entity
   id: ShowcaseRobotWhite
-  parent: BaseStructure
+  parent: BaseShowcaseRobot
   name: white robot showcase
   description: A non-functional replica of an old robot.
   components:
@@ -20,7 +53,7 @@
 
 - type: entity
   id: ShowcaseRobotAntique
-  parent: BaseStructure
+  parent: BaseShowcaseRobot
   name: cargo robot showcase
   description: A non-functional replica of an old cargo robot.
   components:
@@ -30,7 +63,7 @@
 
 - type: entity
   id: ShowcaseRobotMarauder
-  parent: BaseStructure
+  parent: BaseShowcaseRobot
   name: marauder showcase
   description: A non-functional replica of a marauder, painted green.
   components:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
These monoliths keep getting in the way

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Robot showcase statue is now anchorable