### PR TITLE
Reduce radar minimap radius

### DIFF
--- a/Content.Client/Shuttles/UI/RadarControl.cs
+++ b/Content.Client/Shuttles/UI/RadarControl.cs
@@ -20,7 +20,7 @@ public sealed class RadarControl : Control
 
     private const float ScrollSensitivity = 8f;
 
-    private const int MinimapRadius = 384;
+    private const int MinimapRadius = 320;
     private const int MinimapMargin = 4;
     private const float GridLinesDistance = 32f;
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On a 2560x1440 display on Windows 10 using 175% UI scaling, the cargo shuttle window is too big and requires some dragging foo to get the top bar visible and close the screen (see screenshots). This is because `RadarControl` hard-codes the display radius and presumably it worked well at the developer's screen resolution and scaling.

It would be best if the radar could figure out how big the screen was and adjust itself appropriately. Until then, I do think this PR is an improvement, albeit marginal.

Responding to some initial feedback from Discord:

- _Why not just reduce UI scale?_ Everything else looks smaller too. And my poor eyes. And you can mouse scroll zoom in/out the radar screen so it doesn't really even matter.

**Screenshots**
Current
![pre](https://user-images.githubusercontent.com/3229565/178643025-65002634-e6be-4bcc-a6b7-8bc8c402193e.png)

Proposed
![post](https://user-images.githubusercontent.com/3229565/178643033-32295a5c-e4c6-4d41-b8b6-9a4c842f66cb.png)

**Changelog**
Not deserving of a CL entry.