### PR TITLE
Make entity storage lookup range positive

### DIFF
--- a/Content.Server/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Server/Storage/Components/EntityStorageComponent.cs
@@ -28,11 +28,11 @@ public sealed class EntityStorageComponent : Component
     public int RemovedMasks;
 
     [ViewVariables]
-    [DataField("Capacity")]
-    public int StorageCapacityMax = 30;
+    [DataField("capacity")]
+    public int Capacity = 30;
 
     [ViewVariables]
-    [DataField("IsCollidableWhenOpen")]
+    [DataField("isCollidableWhenOpen")]
     public bool IsCollidableWhenOpen;
 
     //The offset for where items are emptied/vacuumed for the EntityStorage. 
@@ -44,7 +44,7 @@ public sealed class EntityStorageComponent : Component
     public readonly CollisionGroup EnteringOffsetCollisionFlags = CollisionGroup.Impassable | CollisionGroup.MidImpassable;
 
     [ViewVariables]
-    [DataField("EnteringRange")]
+    [DataField("enteringRange")]
     public float EnteringRange = 0.18f;
 
     [DataField("showContents")]

--- a/Content.Server/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Server/Storage/Components/EntityStorageComponent.cs
@@ -45,7 +45,7 @@ public sealed class EntityStorageComponent : Component
 
     [ViewVariables]
     [DataField("EnteringRange")]
-    public float EnteringRange = -0.18f;
+    public float EnteringRange = 0.18f;
 
     [DataField("showContents")]
     public bool ShowContents;

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -162,7 +162,7 @@ public sealed class EntityStorageSystem : EntitySystem
                 continue;
 
             count++;
-            if (count >= component.StorageCapacityMax)
+            if (count >= component.Capacity)
                 break;
         }
 
@@ -202,7 +202,7 @@ public sealed class EntityStorageSystem : EntitySystem
         if (component.Open)
             return true;
 
-        if (component.Contents.ContainedEntities.Count >= component.StorageCapacityMax)
+        if (component.Contents.ContainedEntities.Count >= component.Capacity)
             return false;
 
         return true;

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -38,8 +38,8 @@
       mask:
       - Impassable
   - type: EntityStorage
-    Capacity: 1
-    IsCollidableWhenOpen: true
+    capacity: 1
+    isCollidableWhenOpen: true
     closeSound:
       path: /Audio/Misc/zip.ogg
     openSound:

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -39,7 +39,7 @@
       sprite: Structures/Storage/Crates/artifact.rsi
       state: artifact_container_icon
     - type: EntityStorage
-      Capacity: 1
+      capacity: 1
       whitelist:
         components:
         - Artifact

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -31,7 +31,7 @@
       layer:
       - MachineLayer
   - type: EntityStorage
-    Capacity: 500
+    capacity: 500
   - type: Weldable
   - type: PlaceableSurface
   - type: Damageable
@@ -94,7 +94,7 @@
       layer:
       - MachineLayer
   - type: EntityStorage
-    Capacity: 500
+    capacity: 500
   - type: Weldable
   - type: PlaceableSurface
   - type: Damageable

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -580,7 +580,7 @@
   parent: CrateGeneric
   components:
   - type: EntityStorage
-    Capacity: 500
+    capacity: 500
   - type: Sprite
     sprite: Structures/Storage/Crates/livestock.rsi
     layers:

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -32,9 +32,9 @@
       layer:
       - WallLayer
   - type: EntityStorage
-    IsCollidableWhenOpen: true
+    isCollidableWhenOpen: true
     showContents: false
-    Capacity: 1
+    capacity: 1
     enteringOffset: 0, -1
     closeSound:
       path: /Audio/Items/deconstruct.ogg
@@ -124,9 +124,9 @@
       layer:
       - MachineLayer
   - type: EntityStorage
-    IsCollidableWhenOpen: true
+    isCollidableWhenOpen: true
     showContents: false
-    Capacity: 1
+    capacity: 1
     enteringOffset: 0, -1
     closeSound:
       path: /Audio/Items/deconstruct.ogg


### PR DESCRIPTION
Makes the entity lookup range positive. See comment in #9732. Also fixes some datafield naming & capitalization.
Eventually lockers should probably use some sort of  physics collision stuff with some vacuum/pickup fixture.

Fixes #9730 

:cl:
- fix: Lockers/morgues/etc should now properly take items.

