### PR TITLE
Remove telekinesis

### DIFF
--- a/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
+++ b/Content.Shared/Pulling/Systems/SharedPullingSystem.cs
@@ -10,6 +10,7 @@ using JetBrains.Annotations;
 using Robust.Shared.Containers;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
+using Robust.Shared.Physics;
 using Robust.Shared.Players;
 
 namespace Content.Shared.Pulling
@@ -41,6 +42,7 @@ namespace Content.Shared.Pulling
             SubscribeLocalEvent<PullStartedMessage>(OnPullStarted);
             SubscribeLocalEvent<PullStoppedMessage>(OnPullStopped);
             SubscribeLocalEvent<EntInsertedIntoContainerMessage>(HandleContainerInsert);
+            SubscribeLocalEvent<SharedPullableComponent, JointRemovedEvent>(OnJointRemoved);
 
             SubscribeLocalEvent<SharedPullableComponent, PullStartedMessage>(PullableHandlePullStarted);
             SubscribeLocalEvent<SharedPullableComponent, PullStoppedMessage>(PullableHandlePullStopped);
@@ -50,6 +52,28 @@ namespace Content.Shared.Pulling
             CommandBinds.Builder
                 .Bind(ContentKeyFunctions.MovePulledObject, new PointerInputCmdHandler(HandleMovePulledObject))
                 .Register<SharedPullingSystem>();
+        }
+
+        private void OnJointRemoved(EntityUid uid, SharedPullableComponent component, JointRemovedEvent args)
+        {
+            if (component.Puller != args.OtherBody.Owner)
+                return;
+
+            // Do we have some other join with our Puller?
+            // or alternatively:
+            // TODO track the relevant joint.
+
+            if (TryComp(uid, out JointComponent? joints))
+            {
+                foreach (var jt in joints.GetJoints)
+                {
+                    if (jt.BodyAUid == component.Puller || jt.BodyBUid == component.Puller)
+                        return;
+                }
+            }
+
+            // No more joints with puller -> force stop pull.
+            _pullSm.ForceDisconnectPullable(component);
         }
 
         private void AddPullVerbs(EntityUid uid, SharedPullableComponent component, GetVerbsEvent<Verb> args)


### PR DESCRIPTION
This PR ensures that pulling gets stopped if all joints are removed. This partially fixes #9736 in the sense that it stops the long-range pull, but the actual bug that caused this to happen in the first place is fixed in space-wizards/RobustToolbox/pull/3050