### PR TITLE
Ghost role probability

### DIFF
--- a/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
@@ -18,6 +18,13 @@ namespace Content.Server.Ghost.Roles.Components
         [ViewVariables(VVAccess.ReadWrite)] [DataField("makeSentient")]
         protected bool MakeSentient = true;
 
+        /// <summary>
+        ///     The probability that this ghost role will be available after init.
+        ///     Used mostly for takeover roles that want some probability of being takeover, but not 100%.
+        /// </summary>
+        [DataField("prob")]
+        public float Probability = 1f;
+
         // We do this so updating RoleName and RoleDescription in VV updates the open EUIs.
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -17,6 +17,7 @@ using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Ghost.Roles
@@ -27,6 +28,7 @@ namespace Content.Server.Ghost.Roles
         [Dependency] private readonly EuiManager _euiManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly FollowerSystem _followerSystem = default!;
 
         private uint _nextRoleIdentifier;
@@ -265,6 +267,12 @@ namespace Content.Server.Ghost.Roles
 
         private void OnInit(EntityUid uid, GhostRoleComponent role, ComponentInit args)
         {
+            if (role.Probability < 1f && !_random.Prob(role.Probability))
+            {
+                RemComp<GhostRoleComponent>(uid);
+                return;
+            }
+
             if (role.RoleRules == "")
                 role.RoleRules = Loc.GetString("ghost-role-component-default-rules");
             RegisterGhostRole(role);

--- a/Resources/Maps/Salvage/medium-pet-hospital.yml
+++ b/Resources/Maps/Salvage/medium-pet-hospital.yml
@@ -2231,43 +2231,43 @@ entities:
   - canCollide: False
     type: Physics
 - uid: 212
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 6.5,-5.5
     parent: 0
     type: Transform
 - uid: 213
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 3.5,-6.5
     parent: 0
     type: Transform
 - uid: 214
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 4.5,-4.5
     parent: 0
     type: Transform
 - uid: 215
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 8.5,-4.5
     parent: 0
     type: Transform
 - uid: 216
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 8.5,-6.5
     parent: 0
     type: Transform
 - uid: 217
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 1.5,-2.5
     parent: 0
     type: Transform
 - uid: 218
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 5.5,-9.5
     parent: 0
@@ -2606,7 +2606,7 @@ entities:
       light_bulb: !type:ContainerSlot {}
     type: ContainerContainer
 - uid: 254
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 11.5,-9.5
     parent: 0

--- a/Resources/Maps/Salvage/wh-salvage.yml
+++ b/Resources/Maps/Salvage/wh-salvage.yml
@@ -1364,13 +1364,13 @@ entities:
   - solution: drink
     type: DrainableSolution
 - uid: 127
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: -3.5,2.5
     parent: 0
     type: Transform
 - uid: 128
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - pos: 2.5,2.5
     parent: 0
@@ -2503,7 +2503,7 @@ entities:
         ents: []
     type: ContainerContainer
 - uid: 280
-  type: SpawnMobBear
+  type: SpawnMobBearSalvage
   components:
   - rot: 3.141592653589793 rad
     pos: 8.5,7.5

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
@@ -87,6 +87,20 @@
         - MobTickSalvage
 
 - type: entity
+  name: Salvage Space Bear Spawner
+  id: SpawnMobBearSalvage
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - state: bear
+      sprite: Mobs/Animals/bear.rsi
+  - type: ConditionalSpawner
+    prototypes:
+    - MobBearSpaceSalvage
+
+- type: entity
   id: SalvageMobSpawner75
   parent: SalvageMobSpawner
   suffix: 75

--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -69,6 +69,11 @@
         Brute: 15
   - type: ReplacementAccent
     accent: genericAggressive
+  - type: GhostTakeoverAvailable
+    prob: 0.05
+    name: space bear
+    description: |
+      You're a bear! Do bear things.
 
 - type: entity
   id: MobBearSpaceSalvage

--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -69,3 +69,15 @@
         Brute: 15
   - type: ReplacementAccent
     accent: genericAggressive
+
+- type: entity
+  id: MobBearSpaceSalvage
+  parent: MobBearSpace
+  suffix: "Salvage Ruleset"
+  components:
+  - type: GhostTakeoverAvailable
+    prob: 0.05
+    name: space bear on salvage wreck
+    description: |
+      Defend the loot inside the salvage wreck!
+  - type: SalvageMobRestrictions

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -120,6 +120,7 @@
   suffix: "Salvage Ruleset"
   components:
   - type: GhostTakeoverAvailable
+    prob: 0.33
     name: space carp on salvage wreck
     description: |
       Defend the loot inside the salvage wreck!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -91,6 +91,7 @@
   suffix: "Salvage Ruleset"
   components:
   - type: GhostTakeoverAvailable
+    prob: 0.33
     name: space tick on salvage wreck
     description: |
       Defend the loot inside the salvage wreck!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -78,6 +78,7 @@
   - type: SolutionTransfer
     maxTransferAmount: 5
   - type: GhostTakeoverAvailable
+    prob: 0.33
     makeSentient: true
     name: space tick
     description: |
@@ -91,7 +92,6 @@
   suffix: "Salvage Ruleset"
   components:
   - type: GhostTakeoverAvailable
-    prob: 0.33
     name: space tick on salvage wreck
     description: |
       Defend the loot inside the salvage wreck!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Adds probability to ghost role comps, which is just the chance that it will stay available after init. If prob fails just removes the comp
- Gives probability of 0.33 to space tick and space carp, so less chance for large groups of ganks while still keeping the roles available on occasion
- Gives all bears a 5% chance to be ghost role takeover

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Space carp and space ticks now only have a 33% chance to be inhabitable by a ghost.
- tweak: Space bears now have a 5% chance to be inhabitable by a ghost.
