### PR TITLE
Add a log to cut cables. How did this not exist before?

### DIFF
--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -1,7 +1,9 @@
+using Content.Server.Administration.Logs;
 using Content.Server.Electrocution;
 using Content.Server.Power.Components;
 using Content.Server.Stack;
 using Content.Server.Tools;
+using Content.Shared.Database;
 using Content.Shared.Interaction;
 using Robust.Shared.Map;
 
@@ -14,6 +16,7 @@ public sealed partial class CableSystem : EntitySystem
     [Dependency] private readonly ToolSystem _toolSystem = default!;
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly ElectrocutionSystem _electrocutionSystem = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogs = default!;
 
     public override void Initialize()
     {
@@ -41,6 +44,8 @@ public sealed partial class CableSystem : EntitySystem
     {
         if (_electrocutionSystem.TryDoElectrifiedAct(uid, args.User))
             return;
+
+        _adminLogs.Add(LogType.CableCut, LogImpact.Medium, $"The {ToPrettyString(uid)} at {Transform(uid).Coordinates} was cut by {ToPrettyString(args.User)}.");
 
         Spawn(cable.CableDroppedOnCutPrototype, Transform(uid).Coordinates);
         QueueDel(uid);

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -73,5 +73,6 @@ public enum LogType
     // haha so funny
     Emag = 69,
     Gib = 70,
-    Identity = 71
+    Identity = 71,
+    CableCut = 72,
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Logs cables being cut in admin logs.