### PR TITLE
Make passive gates great

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/Components/GasPassiveGateComponent.cs
+++ b/Content.Server/Atmos/Piping/Binary/Components/GasPassiveGateComponent.cs
@@ -5,17 +5,6 @@ namespace Content.Server.Atmos.Piping.Binary.Components
     [RegisterComponent]
     public sealed class GasPassiveGateComponent : Component
     {
-        [DataField("enabled")]
-        [ViewVariables(VVAccess.ReadWrite)]
-        public bool Enabled { get; set; } = true;
-
-        /// <summary>
-        ///     This is the minimum difference needed to overcome the friction in the mechanism.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("frictionDifference")]
-        public float FrictionPressureDifference { get; set; } = 10f;
-
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("inlet")]
         public string InletName { get; set; } = "inlet";
@@ -24,8 +13,8 @@ namespace Content.Server.Atmos.Piping.Binary.Components
         [DataField("outlet")]
         public string OutletName { get; set; } = "outlet";
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("targetPressure")]
-        public float TargetPressure { get; set; } = Atmospherics.OneAtmosphere;
+        [ViewVariables(VVAccess.ReadOnly)]
+        [DataField("flowRate")]
+        public float FlowRate { get; set; } = 0;
     }
 }

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPassiveGateSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPassiveGateSystem.cs
@@ -46,8 +46,9 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
 
             float dt = 1/_atmosphereSystem.AtmosTickRate;
             float dV = 0;
+            var denom = (T1*V2 + T2*V1);
 
-            if (pressureDelta > 0 && n1 > 0 && T1 > 0)
+            if (pressureDelta > 0 && P1 > 0 && denom > 0)
             {
                 // Calculate the number of moles to transfer to equalize the final pressure of
                 // both sides of the valve. You can derive this equation yourself by solving
@@ -64,10 +65,10 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 // If you don't want to push through the math, just know that this behaves like a
                 // pump that can equalize pressure instantly, i.e. much faster than pressure or
                 // volume pumps.
-                var transferMoles = n1 - (n1+n2)*T2*V1 / (T1*V2 + T2*V1);
+                var transferMoles = n1 - (n1+n2)*T2*V1 / denom;
 
                 // Get the volume transfered to update our flow meter.
-                dV = n1*Atmospherics.R*T1/T1;
+                dV = n1*Atmospherics.R*T1/P1;
 
                 // Actually transfer the gas.
                 _atmosphereSystem.Merge(outlet.Air, inlet.Air.Remove(transferMoles));

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPassiveGateSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPassiveGateSystem.cs
@@ -4,6 +4,9 @@ using Content.Server.Atmos.Piping.Components;
 using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Shared.Atmos;
+using Content.Shared.Examine;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
 using JetBrains.Annotations;
 
 namespace Content.Server.Atmos.Piping.Binary.EntitySystems
@@ -12,19 +15,18 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
     public sealed class GasPassiveGateSystem : EntitySystem
     {
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+        [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
 
         public override void Initialize()
         {
             base.Initialize();
 
             SubscribeLocalEvent<GasPassiveGateComponent, AtmosDeviceUpdateEvent>(OnPassiveGateUpdated);
+            SubscribeLocalEvent<GasPassiveGateComponent, GetVerbsEvent<ExamineVerb>>(OnGetExamineVerbs);
         }
 
         private void OnPassiveGateUpdated(EntityUid uid, GasPassiveGateComponent gate, AtmosDeviceUpdateEvent args)
         {
-            if (!gate.Enabled)
-                return;
-
             if (!EntityManager.TryGetComponent(uid, out NodeContainerComponent? nodeContainer))
                 return;
 
@@ -32,22 +34,70 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 || !nodeContainer.TryGetNode(gate.OutletName, out PipeNode? outlet))
                 return;
 
-            var outputStartingPressure = outlet.Air.Pressure;
-            var inputStartingPressure = inlet.Air.Pressure;
+            var n1 = inlet.Air.TotalMoles;
+            var n2 = outlet.Air.TotalMoles;
+            var P1 = inlet.Air.Pressure;
+            var P2 = outlet.Air.Pressure;
+            var V1 = inlet.Air.Volume;
+            var V2 = outlet.Air.Volume;
+            var T1 = inlet.Air.Temperature;
+            var T2 = outlet.Air.Temperature;
+            var pressureDelta = P1 - P2;
 
-            if (outputStartingPressure >= MathF.Min(gate.TargetPressure, inputStartingPressure - gate.FrictionPressureDifference))
-                return; // No need to pump gas, target reached or input pressure too low.
+            float dt = 1/_atmosphereSystem.AtmosTickRate;
+            float dV = 0;
 
-            if (inlet.Air.TotalMoles > 0 && inlet.Air.Temperature > 0)
+            if (pressureDelta > 0 && n1 > 0 && T1 > 0)
             {
-                // We calculate the necessary moles to transfer using our good ol' friend PV=nRT.
-                var pressureDelta = MathF.Min(gate.TargetPressure - outputStartingPressure, (inputStartingPressure - outputStartingPressure)/2);
-                // We can't have a pressure delta that would cause outlet pressure > inlet pressure.
+                // Calculate the number of moles to transfer to equalize the final pressure of
+                // both sides of the valve. You can derive this equation yourself by solving
+                // the equations:
+                //
+                //    P_inlet,final = P_outlet,final (pressure equilibrium)
+                //    n_inlet,initial + n_outlet,initial = n_inlet,final + n_outlet,final (mass conservation)
+                //
+                // These simplifying assumptions allow an easy closed-form solution:
+                //
+                //    T_inlet,initial = T_inlet,final
+                //    T_outlet,initial = T_outlet,final
+                //
+                // If you don't want to push through the math, just know that this behaves like a
+                // pump that can equalize pressure instantly, i.e. much faster than pressure or
+                // volume pumps.
+                var transferMoles = n1 - (n1+n2)*T2*V1 / (T1*V2 + T2*V1);
 
-                var transferMoles = pressureDelta * outlet.Air.Volume / (inlet.Air.Temperature * Atmospherics.R);
+                // Get the volume transfered to update our flow meter.
+                dV = n1*Atmospherics.R*T1/T1;
 
                 // Actually transfer the gas.
                 _atmosphereSystem.Merge(outlet.Air, inlet.Air.Remove(transferMoles));
+            }
+
+            // Update transfer rate with an exponential moving average.
+            var tau = 1;    // Time constant (averaging time) in seconds
+            var a = dt/tau;
+            gate.FlowRate = a*dV/tau + (1-a)*gate.FlowRate; // in L/sec
+        }
+
+        private void OnGetExamineVerbs(EntityUid uid, GasPassiveGateComponent component, GetVerbsEvent<ExamineVerb> args)
+        {
+            if (_examineSystem.IsInDetailsRange(args.User, args.Target))
+            {
+                var verb = new ExamineVerb
+                {
+                    Disabled = false,
+                    Message = Loc.GetString("gas-passive-gate-component-tooltip"),
+                    Text = Loc.GetString("verb-categories-examine"),
+                    Category = VerbCategory.Examine,
+                    IconTexture = "/Textures/Interface/VerbIcons/examine.svg.192dpi.png",
+                    Act = () =>
+                    {
+                        var markup = FormattedMessage.FromMarkup(
+                            Loc.GetString("gas-passive-gate-examined", ("flowRate", $"{component.FlowRate:0.#}")));
+                        _examineSystem.SendExamineTooltip(args.User, uid, markup, false, false);
+                    }
+                };
+                args.Verbs.Add(verb);
             }
         }
     }

--- a/Resources/Locale/en-US/atmos/gas-passive-gate-component.ftl
+++ b/Resources/Locale/en-US/atmos/gas-passive-gate-component.ftl
@@ -1,1 +1,1 @@
-gas-passive-gate-examined = Flow Rate: {$flowRate} L/sec
+gas-passive-gate-examined = The flow rate meter indicates [color=lightblue]{$flowRate} liters/sec[/color].

--- a/Resources/Locale/en-US/atmos/gas-passive-gate-component.ftl
+++ b/Resources/Locale/en-US/atmos/gas-passive-gate-component.ftl
@@ -1,0 +1,2 @@
+gas-passive-gate-component-tooltip = Check the flow rate
+gas-passive-gate-examined = Flow Rate: {$flowRate} L/sec

--- a/Resources/Locale/en-US/atmos/gas-passive-gate-component.ftl
+++ b/Resources/Locale/en-US/atmos/gas-passive-gate-component.ftl
@@ -1,2 +1,1 @@
-gas-passive-gate-component-tooltip = Check the flow rate
 gas-passive-gate-examined = Flow Rate: {$flowRate} L/sec


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Passive gates are currently not very useful. They are mapped one time in one map (the Syndie Puddle). They feature low transfer rates and no added benefit.

This patch gives passive gates two important features:

1. The passive gate equalizes pressure between the input and output pipe nets instantly, which means that they are nearly equivalent to connecting two pipe nets and are much faster than pressure and volume pumps. They are still one-way and can only move gas from high pressure to low pressure, though.

2. Passive gates have a built-in flow meter. This means that you can install them in a pipe net and measure flow, i.e. to determine whether or not there is a giant leak on the station.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
Pressure gates now equalize input and output pressure instantly:
![passive-gate-1](https://user-images.githubusercontent.com/3229565/179369049-6f30164e-ef08-44ec-b7a1-edc66e57fb32.png)

This atmos tech did not increase the pressure of the pressure pumps going into the mixer, and so is pumping up dist very slowly. Bad atmos tech!
![passive-gate-2](https://user-images.githubusercontent.com/3229565/179369065-c80089f9-5569-4a1c-8a25-f78bc5ccafb0.png)

This based atmos tech has configured the pressure pumps going into the mixer so that dist can be pumped up quickly. They can check the result of their handiwork on the flowmeter, which shows much more flow than the un-based atmos tech.
![passive-gate-3](https://user-images.githubusercontent.com/3229565/179369079-e7f94d3a-d13f-4b4f-8b40-fe60fbc7c04e.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: notafet
- Tweak: Passive gates now equalize pressure instantly and come with a built-in gas flow meter.
