### PR TITLE
Add under-pressure lockout to air vents

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -33,6 +33,13 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField("pressureChecks")]
         public VentPressureBound PressureChecks { get; set; } = VentPressureBound.ExternalBound;
 
+        /// <summary>
+        ///     In releasing mode, do not pump when environment pressure is below this limit.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("underPressureLockout")]
+        public float UnderPressureLockout = 1;
+
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("externalPressureBound")]
         public float ExternalPressureBound

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -33,12 +33,16 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField("pressureChecks")]
         public VentPressureBound PressureChecks { get; set; } = VentPressureBound.ExternalBound;
 
+        [ViewVariables(VVAccess.ReadOnly)]
+        [DataField("underPressureLockout")]
+        public bool UnderPressureLockout { get; set; } = false;
+
         /// <summary>
         ///     In releasing mode, do not pump when environment pressure is below this limit.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("underPressureLockout")]
-        public float UnderPressureLockout = 1;
+        [DataField("underPressureLockoutThreshold")]
+        public float UnderPressureLockoutThreshold = 1;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("externalPressureBound")]

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -83,6 +83,9 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 if (environment.Pressure > vent.MaxPressure)
                     return;
 
+                if (environment.Pressure < vent.UnderPressureLockout)
+                    return;
+
                 if ((vent.PressureChecks & VentPressureBound.ExternalBound) != 0)
                     pressureDelta = MathF.Min(pressureDelta, vent.ExternalPressureBound - environment.Pressure);
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Atmos.Monitor;
 using Content.Shared.Atmos.Piping.Unary.Components;
 using Content.Shared.Atmos.Visuals;
 using Content.Shared.Audio;
+using Content.Shared.Examine;
 using JetBrains.Annotations;
 using Robust.Shared.Timing;
 
@@ -41,6 +42,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             SubscribeLocalEvent<GasVentPumpComponent, PowerChangedEvent>(OnPowerChanged);
             SubscribeLocalEvent<GasVentPumpComponent, DeviceNetworkPacketEvent>(OnPacketRecv);
             SubscribeLocalEvent<GasVentPumpComponent, ComponentInit>(OnInit);
+            SubscribeLocalEvent<GasVentPumpComponent, ExaminedEvent>(OnExamine);
             SubscribeLocalEvent<GasVentPumpComponent, SignalReceivedEvent>(OnSignalReceived);
         }
 
@@ -83,8 +85,12 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 if (environment.Pressure > vent.MaxPressure)
                     return;
 
-                if (environment.Pressure < vent.UnderPressureLockout)
+                if (environment.Pressure < vent.UnderPressureLockoutThreshold)
+                {
+                    vent.UnderPressureLockout = true;
                     return;
+                }
+                vent.UnderPressureLockout = false;
 
                 if ((vent.PressureChecks & VentPressureBound.ExternalBound) != 0)
                     pressureDelta = MathF.Min(pressureDelta, vent.ExternalPressureBound - environment.Pressure);
@@ -256,6 +262,19 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             {
                 _ambientSoundSystem.SetAmbience(uid, false);
                 appearance.SetData(VentPumpVisuals.State, VentPumpState.Welded);
+            }
+        }
+
+        private void OnExamine(EntityUid uid, GasVentPumpComponent component, ExaminedEvent args)
+        {
+            if (!TryComp<GasVentPumpComponent>(uid, out var pumpComponent))
+                return;
+            if (args.IsInDetailsRange)
+            {
+                if (pumpComponent.UnderPressureLockout)
+                {
+                    args.PushMarkup(Loc.GetString("gas-vent-pump-uvlo"));
+                }
             }
         }
     }

--- a/Resources/Locale/en-US/atmos/gas-vent-pump.ftl
+++ b/Resources/Locale/en-US/atmos/gas-vent-pump.ftl
@@ -1,0 +1,1 @@
+gas-vent-pump-uvlo = It is in [color=red]under-pressure lock out[/color].


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When some part of the station inevitably get spaced, air vents pump air from dist to un-space it. Because air vents are "pressure-based" pumps, they tend to transfer air faster to locations that have low pressure (good).

Unfortunately, this also means that until a room with an air vent is patched up, these air vents tend to pump a lot of precious dist air into space. This means that widespread spacing can cause the pressure in the dist network to fall, and when that happens, areas that are not spaced (but are at low pressure because passengers hold doors open) also do not get repressurized by dist (bad).

This is a problem easily fixable by **NT-patented A.I. technology!** _Brought to you by RD's AI CORE_.

The complicated A.I. technology is too top-secret and patented to be disclosed lest Syndicate corporations steal their secrets, but can be summarized as:

1. Is the pressure less than the _under-pressure lockout (UPLO) threshold_? If so, this area is probably spaced. Don't pump air.
2. Otherwise, pump air.

This means that dist focuses on keeping aired up parts of the station all gassed up. Of course, to repair spacing, clever atmospheric technicians will have to 1) seal a breech and 2) figure out how to bring the pressure above the UPLO threshold.

### Balance
I believe this change strikes the right balance between making sabotage possible and making bad situations recoverable.

This change makes air vents (the default air distribution device used by many mappers) more spacing-proof. Currently, even minor spacing events can depressurize dist to the point where it is ineffective at gassing up areas that are not spaced. The layout of most dist networks are not conducive to the type of debugging that we would like to see, i.e. tracing the dist net until spacing is found, because 1) there are many maps with very different layouts in rotation, and 2) because dist frequently crosses into areas where atmospheric technicians do not have access. For large stations, it can be extremely difficult to locate breeches.

This change does not mean that atmospheric technicians can lounge around. They are still required to repair breeches and bring the pressure up above the UPLO before dist can kick in. We can adjust the UPLO as a built-in difficulty knob:

- 20 kPa: You need to get an atmos tech to drag a gas can in to re-pressurize a room, before the vent will kick in
- **1 kPa (this PR)**: opening a door to an un-spaced area will transfer enough air to turn on the vent
- 0.001 kPa: Breathing will be enough to get the UPLO to go away and turn the vent back on

Unsavory players can still shut down dist with a passive vent to space.

**Mappers:** If you dislike your crew that much, you can replace air vents with air injectors.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: notafet
- add: Air vents are now more resilient to spacing