### PR TITLE
Make FTL arrive closer

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -471,17 +471,18 @@ public sealed partial class ShuttleSystem
             lastCount = nearbyGrids.Count;
 
             // Mishap moment, dense asteroid field or whatever
-            if (iteration == 3)
-            {
-                foreach (var grid in _mapManager.GetAllGrids())
-                {
-                    // Don't add anymore as it is irrelevant, but that doesn't mean we need to re-do existing work.
-                    if (nearbyGrids.Contains(grid.GridEntityId)) continue;
+            if (iteration != 3) continue;
 
-                    targetAABB = targetAABB.Union(_transform.GetWorldMatrix(grid.GridEntityId, xformQuery)
-                        .TransformBox(Comp<IMapGridComponent>(grid.GridEntityId).Grid.LocalAABB));
-                }
+            foreach (var grid in _mapManager.GetAllGrids())
+            {
+                // Don't add anymore as it is irrelevant, but that doesn't mean we need to re-do existing work.
+                if (nearbyGrids.Contains(grid.GridEntityId)) continue;
+
+                targetAABB = targetAABB.Union(_transform.GetWorldMatrix(grid.GridEntityId, xformQuery)
+                    .TransformBox(Comp<IMapGridComponent>(grid.GridEntityId).Grid.LocalAABB));
             }
+
+            break;
         }
 
         var minRadius = (MathF.Max(targetAABB.Width, targetAABB.Height) + MathF.Max(shuttleAABB.Width, shuttleAABB.Height)) / 2f;


### PR DESCRIPTION
- Only considers nearby grids now.
- Fix the minradius, woops.

Used FTL destination changelog coz it was a lot of work and mommi scammed us and so people stop making issues for intended mechanics.

:cl: metalgearsloth and DogZeroX
- add: FTL mechanics have been added allowing you to go (for now, limited) other destinations, ported from Vilous Station 14.
- add: Nukies now start on a nukie planet and have to FTL to the station. No more seeking out their shuttle at roundstart.
- add: Additional shuttles can now travel to Centcomm after the emergency shuttle departs (e.g. cargo)
- fix: Fix autodocking when only 1 port was blocked (woops).
- tweak: IFF labels now show much further away, at the edge of the radar (no more cargo shuttle getting lost).