### PR TITLE
make nukies actual antags

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Content.Server.Traitor;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -242,20 +243,24 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         for (var i = 0; i < operatives.Count; i++)
         {
             string name;
+            string role;
             StartingGearPrototype gear;
 
             switch (i)
             {
                 case 0:
                     name = $"Commander " + _random.PickAndTake<string>(syndicateNamesElite);
+                    role = NukeopsCommanderPrototypeId;
                     gear = commanderGear;
                     break;
                 case 1:
                     name = $"Agent " + _random.PickAndTake<string>(syndicateNamesNormal);
+                    role = NukeopsPrototypeId;
                     gear = medicGear;
                     break;
                 default:
                     name = $"Operator " + _random.PickAndTake<string>(syndicateNamesNormal);
+                    role = NukeopsPrototypeId;
                     gear = starterGear;
                     break;
             }
@@ -266,6 +271,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
                 CharacterName = name
             };
             newMind.ChangeOwningPlayer(session.UserId);
+            newMind.AddRole(new TraitorRole(newMind, _prototypeManager.Index<AntagPrototype>(role)));
 
             var mob = EntityManager.SpawnEntity("MobHuman", _random.Pick(spawns));
             EntityManager.GetComponent<MetaDataComponent>(mob).EntityName = name;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
literally already existed for syndies and zombies. the prototypes were already there as well.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Nuclear Operatives are now internally (i.e. badmins) recognized as antags. You have been legitimized.

