### PR TITLE
Various localization fixes

### DIFF
--- a/Content.Client/Administration/UI/AdminAnnounceWindow.xaml
+++ b/Content.Client/Administration/UI/AdminAnnounceWindow.xaml
@@ -1,15 +1,15 @@
 <DefaultWindow
     xmlns="https://spacestation14.io"
-    Title="{Loc 'admin-announce-title'}"
+    Title="{Loc admin-announce-title}"
     MinWidth="500">
     <GridContainer Columns="1">
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
-            <LineEdit Name="Announcer" Access="Public" PlaceHolder="{Loc 'announcer-placeholder'}" Text="{Loc 'Central Command'}" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
+            <LineEdit Name="Announcer" Access="Public" PlaceHolder="{Loc admin-announce-announcer-placeholder}" Text="{Loc admin-announce-announcer-default}" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
             <Control HorizontalExpand="True" SizeFlagsStretchRatio="1" />
             <OptionButton Name="AnnounceMethod" Access="Public" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
         </BoxContainer>
-        <LineEdit Name="Announcement" Access="Public" PlaceHolder="{Loc 'announcement-placeholder'}"/>
+        <LineEdit Name="Announcement" Access="Public" PlaceHolder="{Loc admin-announce-announcement-placeholder}"/>
 
-        <Button Name="AnnounceButton" Access="Public" Disabled="True" Text="{Loc 'Announce'}" HorizontalAlignment="Center"/>
+        <Button Name="AnnounceButton" Access="Public" Disabled="True" Text="{Loc admin-announce-button}" HorizontalAlignment="Center"/>
     </GridContainer>
 </DefaultWindow>

--- a/Content.Client/Administration/UI/AdminAnnounceWindow.xaml.cs
+++ b/Content.Client/Administration/UI/AdminAnnounceWindow.xaml.cs
@@ -19,9 +19,9 @@ namespace Content.Client.Administration.UI
             RobustXamlLoader.Load(this);
             IoCManager.InjectDependencies(this);
 
-            AnnounceMethod.AddItem(_localization.GetString("announce-type-station"));
+            AnnounceMethod.AddItem(_localization.GetString("admin-announce-type-station"));
             AnnounceMethod.SetItemMetadata(0, AdminAnnounceType.Station);
-            AnnounceMethod.AddItem(_localization.GetString("announce-type-server"));
+            AnnounceMethod.AddItem(_localization.GetString("admin-announce-type-server"));
             AnnounceMethod.SetItemMetadata(1, AdminAnnounceType.Server);
             AnnounceMethod.OnItemSelected += AnnounceMethodOnOnItemSelected;
             Announcement.OnTextChanged += AnnouncementOnOnTextChanged;

--- a/Content.Client/Administration/UI/Tabs/AdminTab/AdminTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/AdminTab/AdminTab.xaml
@@ -8,14 +8,14 @@
     <BoxContainer Orientation="Vertical">
         <GridContainer Columns="3">
             <cc:UICommandButton Command="kick" Text="{Loc admin-player-actions-window-title}" WindowType="{x:Type at:PlayerActionsWindow}" />
-            <cc:UICommandButton Command="ban" Text="{Loc Ban}" WindowType="{x:Type at:BanWindow}" />
-            <cc:CommandButton Command="aghost" Text="{Loc Admin Ghost}" />
-            <cc:UICommandButton Command="tpto" Text="{Loc Teleport}" WindowType="{x:Type at:TeleportWindow}" />
-            <cc:CommandButton Command="permissions" Text="{Loc Permissions Panel}" />
-            <cc:CommandButton Command="announceui" Text="{Loc Announce}"/>
-            <cc:UICommandButton Command="callshuttle" Text="{Loc (Re)call Shuttle}" WindowType="{x:Type at:AdminShuttleWindow}"/>
-            <cc:CommandButton Command="adminlogs" Text="{Loc Admin Logs}"/>
-            <cc:CommandButton Command="adminnotes" Text="{Loc Admin Notes}"/>
+            <cc:UICommandButton Command="ban" Text="{Loc admin-player-actions-window-ban}" WindowType="{x:Type at:BanWindow}" />
+            <cc:CommandButton Command="aghost" Text="{Loc admin-player-actions-window-admin-ghost}" />
+            <cc:UICommandButton Command="tpto" Text="{Loc admin-player-actions-window-teleport}" WindowType="{x:Type at:TeleportWindow}" />
+            <cc:CommandButton Command="permissions" Text="{Loc admin-player-actions-window-permissions}" />
+            <cc:CommandButton Command="announceui" Text="{Loc admin-player-actions-window-announce}"/>
+            <cc:UICommandButton Command="callshuttle" Text="{Loc admin-player-actions-window-shuttle}" WindowType="{x:Type at:AdminShuttleWindow}"/>
+            <cc:CommandButton Command="adminlogs" Text="{Loc admin-player-actions-window-admin-logs}"/>
+            <cc:CommandButton Command="adminnotes" Text="{Loc admin-player-actions-window-admin-notes}"/>
         </GridContainer>
     </BoxContainer>
 </Control>

--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.cs
@@ -35,7 +35,7 @@ namespace Content.Client.Communications.UI
                 SizeFlagsStretchRatio = 1
             };
             AnnounceButton = new Button();
-            AnnounceButton.Text = "Announce";
+            AnnounceButton.Text = Loc.GetString("comms-console-menu-announcement-button");
             AnnounceButton.OnPressed += (_) => Owner.AnnounceButtonPressed(_messageInput.Text.Trim());
             AnnounceButton.Disabled = !owner.CanAnnounce;
 

--- a/Content.Client/MachineLinking/UI/SignalPortSelectorMenu.xaml
+++ b/Content.Client/MachineLinking/UI/SignalPortSelectorMenu.xaml
@@ -1,4 +1,4 @@
-<DefaultWindow xmlns="https://spacestation14.io" Title="Port Selector" MinSize="400 200">
+<DefaultWindow xmlns="https://spacestation14.io" Title="{Loc signal-port-selector-menu-title}" MinSize="400 200">
     <BoxContainer Orientation="Vertical" VerticalExpand="True">
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True">
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="0.3">
@@ -12,8 +12,8 @@
             </BoxContainer>
         </BoxContainer>
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
-            <Button Name="ButtonClear" Text="Clear"/>
-            <Button Name="ButtonLinkDefault" Text="Link Defaults"/>
+            <Button Name="ButtonClear" Text="{Loc signal-port-selector-menu-clear}"/>
+            <Button Name="ButtonLinkDefault" Text="{Loc signal-port-selector-menu-link-defaults}"/>
         </BoxContainer>
     </BoxContainer>
 </DefaultWindow>

--- a/Resources/Locale/en-US/administration/ui/admin-announce-window.ftl
+++ b/Resources/Locale/en-US/administration/ui/admin-announce-window.ftl
@@ -1,5 +1,7 @@
 admin-announce-title = Make Announcement
-announcer-placeholder = Announcer
-announcement-placeholder = Announcement text
-announce-type-station = Station
-announce-type-server = Server
+admin-announce-announcement-placeholder = Announcement text
+admin-announce-announcer-placeholder = Announcer
+admin-announce-announcer-default = Central Command
+admin-announce-button = Announce
+admin-announce-type-station = Station
+admin-announce-type-server = Server

--- a/Resources/Locale/en-US/administration/ui/tabs/admin-tab/player-actions-window.ftl
+++ b/Resources/Locale/en-US/administration/ui/tabs/admin-tab/player-actions-window.ftl
@@ -1,1 +1,9 @@
 admin-player-actions-window-title = Player Actions Panel
+admin-player-actions-window-ban = Ban
+admin-player-actions-window-admin-ghost = Admin Ghost
+admin-player-actions-window-teleport = Teleport
+admin-player-actions-window-permissions = Permissions Panel
+admin-player-actions-window-announce = Announce
+admin-player-actions-window-shuttle = (Re)call Shuttle
+admin-player-actions-window-admin-logs = Admin Logs
+admin-player-actions-window-admin-notes = Admin Notes

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -1,6 +1,7 @@
 ﻿# User interface
 comms-console-menu-title = Communications Console
 comms-console-menu-announcement-placeholder = Announcement
+comms-console-menu-announcement-button = Announce
 comms-console-menu-call-shuttle = Call emergency shuttle
 comms-console-menu-recall-shuttle = Recall emergency shuttle
 

--- a/Resources/Locale/en-US/machine-linking/port-selector.ftl
+++ b/Resources/Locale/en-US/machine-linking/port-selector.ftl
@@ -1,0 +1,3 @@
+signal-port-selector-menu-title = Port Selector
+signal-port-selector-menu-clear = Clear
+signal-port-selector-menu-link-defaults = Link Defaults

--- a/Resources/Locale/en-US/machine-linking/port-selector.ftl
+++ b/Resources/Locale/en-US/machine-linking/port-selector.ftl
@@ -1,3 +1,3 @@
 signal-port-selector-menu-title = Port Selector
 signal-port-selector-menu-clear = Clear
-signal-port-selector-menu-link-defaults = Link Defaults
+signal-port-selector-menu-link-defaults = Link defaults

--- a/Resources/Prototypes/Access/cargo.yml
+++ b/Resources/Prototypes/Access/cargo.yml
@@ -1,11 +1,14 @@
 - type: accessLevel
   id: Quartermaster
+  name: Quartermaster
 
 - type: accessLevel
   id: Cargo
+  name: Cargo
 
 - type: accessLevel
   id: Salvage
+  name: Salvage
 
 - type: accessGroup
   id: Cargo

--- a/Resources/Prototypes/Access/command.yml
+++ b/Resources/Prototypes/Access/command.yml
@@ -1,8 +1,10 @@
 - type: accessLevel
   id: Command
+  name: Command
 
 - type: accessLevel
   id: Captain
+  name: Captain
 
 - type: accessLevel
   id: HeadOfPersonnel

--- a/Resources/Prototypes/Access/engineering.yml
+++ b/Resources/Prototypes/Access/engineering.yml
@@ -4,9 +4,11 @@
 
 - type: accessLevel
   id: Engineering
-  
+  name: Engineering
+
 - type: accessLevel
   id: Atmospherics
+  name: Atmospherics
 
 - type: accessGroup
   id: Engineering

--- a/Resources/Prototypes/Access/external.yml
+++ b/Resources/Prototypes/Access/external.yml
@@ -1,2 +1,3 @@
 - type: accessLevel
   id: External
+  name: External

--- a/Resources/Prototypes/Access/maintenance.yml
+++ b/Resources/Prototypes/Access/maintenance.yml
@@ -1,2 +1,3 @@
 - type: accessLevel
   id: Maintenance
+  name: Maintenance

--- a/Resources/Prototypes/Access/medical.yml
+++ b/Resources/Prototypes/Access/medical.yml
@@ -4,9 +4,11 @@
 
 - type: accessLevel
   id: Medical
+  name: Medical
 
 - type: accessLevel
   id: Chemistry
+  name: Chemistry
 
 - type: accessGroup
   id: Medical

--- a/Resources/Prototypes/Access/research.yml
+++ b/Resources/Prototypes/Access/research.yml
@@ -4,6 +4,7 @@
 
 - type: accessLevel
   id: Research
+  name: Research
 
 - type: accessGroup
   id: Research

--- a/Resources/Prototypes/Access/security.yml
+++ b/Resources/Prototypes/Access/security.yml
@@ -4,12 +4,15 @@
 
 - type: accessLevel
   id: Security
+  name: Security
 
 - type: accessLevel
   id: Armory
+  name: Armory
 
 - type: accessLevel
   id: Brig
+  name: Brig
 
 #- type: accessLevel
 #  id: Detective

--- a/Resources/Prototypes/Access/service.yml
+++ b/Resources/Prototypes/Access/service.yml
@@ -1,23 +1,30 @@
 - type: accessLevel
   id: Bar
+  name: Bar
 
 - type: accessLevel
   id: Kitchen
+  name: Kitchen
 
 - type: accessLevel
   id: Hydroponics
+  name: Hydroponics
 
 - type: accessLevel
   id: Service
+  name: Service
 
 - type: accessLevel
   id: Janitor
+  name: Janitor
 
 - type: accessLevel
   id: Theatre
+  name: Theatre
 
 - type: accessLevel
   id: Chapel
+  name: Chapel
 
 - type: accessGroup
   id: Service

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -38,7 +38,6 @@
 
 - type: latheRecipe
   id: CableStack
-  name: LV cable
   icon: /Textures/Objects/Tools/cable-coils.rsi/coillv-30.png
   result: CableApcStack1
   completetime: 2
@@ -47,7 +46,6 @@
 
 - type: latheRecipe
   id: CableMVStack
-  name: MV cable coil
   icon: /Textures/Objects/Tools/cable-coils.rsi/coilmv-30.png
   result: CableMVStack1
   completetime: 2
@@ -56,7 +54,6 @@
 
 - type: latheRecipe
   id: CableHVStack
-  name: HV cable coil
   icon: /Textures/Objects/Tools/cable-coils.rsi/coilhv-30.png
   result: CableHVStack1
   completetime: 2


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before this PR almost all access levels had their code names used as names in the UI, thus they could not be changed for the sake of localization. Only exceptions are access levels "Head of ...", because of multiple words. Those had a separate field "name" for the UI.

Also I've removed redundant "name" fields from tools.yml with lathe recipies for cables. For some reason these fields were left there preventing lathe cable recipes from getting names from .ftl files. 
I've simply added the field "name" for all access levels in order for all of them to be customizable.

Replaced hardcoded values for various UI elements with .ftl ones in admin console and announcement interface.

Added localization possibilities for Multitool's Port Selector interface.