### PR TITLE
Immovable rod now uses TimedDespawn

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodComponent.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Sound;
+using Content.Shared.Sound;
 
 namespace Content.Server.ImmovableRod;
 
@@ -12,12 +12,6 @@ public sealed class ImmovableRodComponent : Component
 
     [DataField("hitSoundProbability")]
     public float HitSoundProbability = 0.1f;
-
-    /// <summary>
-    ///     The rod will be automatically cleaned up after this time.
-    /// </summary>
-    [DataField("lifetime")]
-    public TimeSpan Lifetime = TimeSpan.FromSeconds(30);
 
     [DataField("minSpeed")]
     public float MinSpeed = 10f;
@@ -42,7 +36,4 @@ public sealed class ImmovableRodComponent : Component
     /// </summary>
     [DataField("destroyTiles")]
     public bool DestroyTiles = true;
-
-    [DataField("accumulator")]
-    public float Accumulator = 0f;
 }

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Body.Components;
+using Content.Server.Body.Components;
 using Content.Server.Popups;
 using Content.Shared.Examine;
 using Content.Shared.Popups;
@@ -23,14 +23,6 @@ public sealed class ImmovableRodSystem : EntitySystem
         // we are deliberately including paused entities. rod hungers for all
         foreach (var (rod, trans) in EntityManager.EntityQuery<ImmovableRodComponent, TransformComponent>(true))
         {
-            rod.Accumulator += frameTime;
-
-            if (rod.Accumulator > rod.Lifetime.TotalSeconds)
-            {
-                QueueDel(rod.Owner);
-                return;
-            }
-
             if (!rod.DestroyTiles)
                 continue;
             if (!_map.TryGetGrid(trans.GridID, out var grid))

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -13,6 +13,8 @@
     state: icon
     noRot: false
   - type: ImmovableRod
+  - type: TimedDespawn
+    lifetime: 30.0
   - type: Physics
     bodyType: Dynamic
     linearDamping: 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9777

Immovable rod now uses the TimedDespawn component instead of handling its own lifetime, as per #9777. All lifetime related fields from the ImmovableRodComponent were removed.
