### PR TITLE
Doesn't let someone block if they're too close or if they're in a doorway.

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -141,11 +141,10 @@ public sealed class BlockingSystem : EntitySystem
 
             //Don't allow someone to block if someone else is on the same tile.
             var playerTileRef = xform.Coordinates.GetTileRef();
-
             if (playerTileRef != null)
             {
                 var intersecting = _lookup.GetEntitiesIntersecting(playerTileRef.Value);
-                var query =GetEntityQuery<MobStateComponent>();
+                var query = GetEntityQuery<MobStateComponent>();
 
                 foreach (var uid in intersecting)
                 {

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -134,6 +134,12 @@ public sealed class BlockingSystem : EntitySystem
                 return false;
             }
 
+            if (TryComp<PhysicsComponent>(user, out var physics) && physics.ContactCount > 1)
+            {
+                TooCloseError(user);
+                return false;
+            }
+
             _transformSystem.AnchorEntity(xform);
             if (!xform.Anchored)
             {
@@ -165,6 +171,12 @@ public sealed class BlockingSystem : EntitySystem
     private void CantBlockError(EntityUid user)
     {
         var msgError = Loc.GetString("action-popup-blocking-user-cant-block");
+        _popupSystem.PopupEntity(msgError, user, Filter.Entities(user));
+    }
+
+    private void TooCloseError(EntityUid user)
+    {
+        var msgError = Loc.GetString("action-popup-blocking-user-too-close");
         _popupSystem.PopupEntity(msgError, user, Filter.Entities(user));
     }
 

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -146,10 +146,11 @@ public sealed class BlockingSystem : EntitySystem
                 var intersecting = _lookup.GetEntitiesIntersecting(playerTileRef.Value);
                 var mobQuery = GetEntityQuery<MobStateComponent>();
                 var doorQuery = GetEntityQuery<DoorComponent>();
+                var xformQuery = GetEntityQuery<TransformComponent>();
 
                 foreach (var uid in intersecting)
                 {
-                    if (uid != user && mobQuery.HasComponent(uid) || Transform(uid).Anchored && doorQuery.HasComponent(uid))
+                    if (uid != user && mobQuery.HasComponent(uid) || xformQuery.GetComponent(uid).Anchored && doorQuery.HasComponent(uid))
                     {
                         TooCloseError(user);
                         return false;

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -139,31 +139,21 @@ public sealed class BlockingSystem : EntitySystem
                 return false;
             }
 
-            //Don't allow someone to block if someone else is on the same tile.
+            //Don't allow someone to block if someone else is on the same tile or if they're inside of a doorway
             var playerTileRef = xform.Coordinates.GetTileRef();
             if (playerTileRef != null)
             {
                 var intersecting = _lookup.GetEntitiesIntersecting(playerTileRef.Value);
-                var query = GetEntityQuery<MobStateComponent>();
+                var mobQuery = GetEntityQuery<MobStateComponent>();
+                var doorQuery = GetEntityQuery<DoorComponent>();
 
                 foreach (var uid in intersecting)
                 {
-                    if (query.HasComponent(uid) && uid != user)
+                    if (uid != user && mobQuery.HasComponent(uid) || Transform(uid).Anchored && doorQuery.HasComponent(uid))
                     {
                         TooCloseError(user);
                         return false;
                     }
-                }
-            }
-
-            //Don't allow someone to block if they're in a doorway
-            var intersectingAnchoredEntities = _lookup.GetEntitiesIntersecting(user, LookupFlags.Anchored);
-            foreach (var entity in intersectingAnchoredEntities)
-            {
-                if (HasComp<DoorComponent>(entity))
-                {
-                    TooCloseError(user);
-                    return false;
                 }
             }
 

--- a/Resources/Locale/en-US/actions/actions/blocking.ftl
+++ b/Resources/Locale/en-US/actions/actions/blocking.ftl
@@ -8,3 +8,5 @@ action-popup-blocking-other = {CAPITALIZE(THE($blockerName))} raises {POSS-ADJ($
 action-popup-blocking-disabling-other = {CAPITALIZE(THE($blockerName))} lowers {POSS-ADJ($blockerName)} {$shield}!
 
 action-popup-blocking-user-cant-block = You tried to raise your shield, but it was no use.
+action-popup-blocking-user-too-close = There's no room here to block. Try moving a bit!
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #9731
Fixes #9502

This prevents someone from blocking if they're too close to a solid structure or entity.

It also prevents someone from blocking if they're intersecting a door.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: You can no longer clip people into walls with riot shields.
- fix: You can no longer hide behind doors while using a shield.

