### PR TITLE
Gas pipes now need to be unanchored before deconstruction.

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_binary.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_binary.yml
@@ -9,35 +9,44 @@
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: volumepump
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: passivegate
       steps:
       - material: Steel
         amount: 2
-        doAfter: 1    
+        doAfter: 1
+
     - to: valve
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: port
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: dualportventpump
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
   - node: pressurepump
     entity: GasPressurePump
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -46,10 +55,14 @@
       steps:
       - tool: Welding
         doAfter: 1
+
   - node: volumepump
     entity: GasVolumePump
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -58,10 +71,14 @@
       steps:
       - tool: Welding
         doAfter: 1
+
   - node: passivegate
     entity: GasPassiveGate
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -70,10 +87,14 @@
       steps:
       - tool: Welding
         doAfter: 1
+
   - node: valve
     entity: GasValve
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -81,11 +102,15 @@
       - !type:DeleteEntity
       steps:
       - tool: Welding
-        doAfter: 1 
+        doAfter: 1
+
   - node: port
     entity: GasPort
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -93,11 +118,15 @@
       - !type:DeleteEntity
       steps:
       - tool: Welding
-        doAfter: 1 
+        doAfter: 1
+
   - node: dualportventpump
     entity: GasDualPortVentPump
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_pipes.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_pipes.yml
@@ -9,30 +9,38 @@
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: straight
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: bend
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: tjunction
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: fourway
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
   - node: half
     entity: GasPipeHalf
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -41,10 +49,14 @@
       steps:
       - tool: Welding
         doAfter: 1
+
   - node: straight
     entity: GasPipeStraight
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -53,10 +65,14 @@
       steps:
       - tool: Welding
         doAfter: 1
+
   - node: bend
     entity: GasPipeBend
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -65,10 +81,14 @@
       steps:
       - tool: Welding
         doAfter: 1
+
   - node: tjunction
     entity: GasPipeTJunction
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -77,10 +97,14 @@
       steps:
       - tool: Welding
         doAfter: 1
+
   - node: fourway
     entity: GasPipeFourway
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_trinary.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_trinary.yml
@@ -9,15 +9,20 @@
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: mixer
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
   - node: filter
     entity: GasFilter
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -26,10 +31,14 @@
       steps:
       - tool: Welding
         doAfter: 1
+
   - node: mixer
     entity: GasMixer
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_unary.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_unary.yml
@@ -9,25 +9,32 @@
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: passivevent
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: ventscrubber
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
     - to: outletinjector
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
   - node: ventpump
     entity: GasVentPump
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -38,10 +45,14 @@
         doAfter: 1
       - tool: Welding
         doAfter: 1
+
   - node: passivevent
     entity: GasPassiveVent
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -52,10 +63,14 @@
         doAfter: 1
       - tool: Welding
         doAfter: 1
+
   - node: ventscrubber
     entity: GasVentScrubber
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -66,10 +81,14 @@
         doAfter: 1
       - tool: Welding
         doAfter: 1
+
   - node: outletinjector
     entity: GasOutletInjector
     edges:
     - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1
@@ -78,4 +97,3 @@
       steps:
       - tool: Welding
         doAfter: 1
-    


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gas pipes could be deconstructed while anchored, which bypassed its "leak gas on unanchor" behavior.
Also cleans up all gas pipe graphs, they were unreadable.

Fixes #9904

**Changelog**

:cl:
- tweak: Gas pipes need to be unanchored before being able to deconstruct them. 

