### PR TITLE
Allow pAIs to play MIDI again

### DIFF
--- a/Content.Client/Instruments/UI/InstrumentMenu.xaml.cs
+++ b/Content.Client/Instruments/UI/InstrumentMenu.xaml.cs
@@ -142,13 +142,17 @@ namespace Content.Client.Instruments.UI
             if (instrumentEnt == null || instrument == null)
                 return false;
 
-            // If we're a handheld instrument, we might be in a container. Get it just in case.
-            instrumentEnt.Value.TryGetContainerMan(out var conMan);
-
             var localPlayer = IoCManager.Resolve<IPlayerManager>().LocalPlayer;
 
             // If we don't have a player or controlled entity, we return.
             if (localPlayer?.ControlledEntity == null) return false;
+
+            // By default, allow an instrument to play itself and skip all other checks
+            if (localPlayer.ControlledEntity == instrumentEnt)
+                return true;
+
+            // If we're a handheld instrument, we might be in a container. Get it just in case.
+            instrumentEnt.Value.TryGetContainerMan(out var conMan);
 
             // If the instrument is handheld and we're not holding it, we return.
             if ((instrument.Handheld && (conMan == null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This should fix #9427. The problem got introduced when a check was added to the MIDI UI that checks whether the player entity can actually interact with the instrument or not. Since pAIs aren't allowed to interact with anything they also can't interact with themselves when trying to play MIDI, so the check fails without feedback and nothing happens.

These checks are probably there for a reason but I decided to skip them if the player entity and the instrument entity are identical as is the case for personal AIs. If the player entity and the instrument entity are identical the only check that might matter is the CanInteract one and I figure it's probably fine to allow an instrument entity to always play itself.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: pAIs can play MIDI again

