### PR TITLE
Make Barozine safer and more useful

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -47,7 +47,7 @@ reagent-name-leporazine = leporazine
 reagent-desc-leporazine = This keeps a patient's body temperature stable. High doses can allow short periods of unprotected EVA, but prevents use of the cryogenics tubes.
 
 reagent-name-barozine = barozine
-reagent-desc-barozine = A somewhat toxic medicine that prevents pressure damage. Causes extreme pain and jittering. Very poisonous when overdosed.
+reagent-desc-barozine = A potent drug that prevents pressure damage. Causes extreme pain and jittering. Very poisonous when overdosed.
 
 reagent-name-phalanximine = phalanximine
 reagent-desc-phalanximine = Used in the treatment of cancer. Causes moderate radiation poisoning.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -133,16 +133,16 @@
         emptySpriteName: hypovolemic_empty
   - type: Hypospray
     solutionName: pen
-    transferAmount: 20
+    transferAmount: 30
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 20
+        maxVol: 30
         reagents:
           - ReagentId: Leporazine
             Quantity: 10
           - ReagentId: Barozine
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   name: pen

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -395,15 +395,14 @@
     Medicine:
       effects:
       - !type:HealthChange
+        probability: 0.3
         damage:
-          types:
-            Poison: 1
           groups:
-            Brute: -1.5
+            Heat: 0.5
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
-            min: 15
+            min: 30
         damage:
           types:
             Poison: 3

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -397,7 +397,7 @@
       - !type:HealthChange
         probability: 0.3
         damage:
-          groups:
+          types:
             Heat: 0.5
       - !type:HealthChange
         conditions:


### PR DESCRIPTION
## Make Barozine safer and more useful
Why? Old Barozine is something you rarely want in your mob. Yes, that old space medipen would protect you from barotrauma for whopping 20 seconds... and give you 20 Poison damage while at it. Dylovene is somewhat hard to come by.

This PR makes it no-brainer to pop your space medipen should you see that dreaded "you won't be having fun this round" alert pop up.

**Changelog**
:cl:
- tweak: New Barozine overdose threshold is at 30 units (with same effects)
- tweak: Space medipen now comes with 20 units of Barozine (and keeps it's 10 units of Leporazine), giving you about extra 30 seconds to find spacesuit of some kind, oxygen not included!
- tweak: Poisoning and brute healing aspect of Barozine were replaced with very minor burn damage