### PR TITLE
Magboot & Stunbaton visualizers

### DIFF
--- a/Content.Server/Clothing/MagbootsSystem.cs
+++ b/Content.Server/Clothing/MagbootsSystem.cs
@@ -1,12 +1,7 @@
 using Content.Server.Atmos.Components;
 using Content.Shared.Alert;
 using Content.Shared.Clothing;
-using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
-using Content.Shared.Item;
-using Content.Shared.Toggleable;
-using Robust.Server.GameObjects;
-using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using static Content.Shared.Clothing.MagbootsComponent;
 
@@ -15,8 +10,6 @@ namespace Content.Server.Clothing;
 public sealed class MagbootsSystem : SharedMagbootsSystem
 {
     [Dependency] private readonly AlertsSystem _alertsSystem = default!;
-    [Dependency] private readonly InventorySystem _inventory = default!;
-    [Dependency] private readonly SharedContainerSystem _sharedContainer = default!;
 
     public override void Initialize()
     {
@@ -24,11 +17,10 @@ public sealed class MagbootsSystem : SharedMagbootsSystem
 
         SubscribeLocalEvent<MagbootsComponent, GotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<MagbootsComponent, GotUnequippedEvent>(OnGotUnequipped);
-        SubscribeLocalEvent<MagbootsComponent, ToggleActionEvent>(OnToggleAction);
         SubscribeLocalEvent<MagbootsComponent, ComponentGetState>(OnGetState);
     }
 
-    private void UpdateMagbootEffects(EntityUid parent, EntityUid uid, bool state, MagbootsComponent? component)
+    protected override void UpdateMagbootEffects(EntityUid parent, EntityUid uid, bool state, MagbootsComponent? component)
     {
         if (!Resolve(uid, ref component))
             return;
@@ -47,28 +39,6 @@ public sealed class MagbootsSystem : SharedMagbootsSystem
         {
             _alertsSystem.ClearAlert(parent, AlertType.Magboots);
         }
-    }
-
-    private void OnToggleAction(EntityUid uid, MagbootsComponent component, ToggleActionEvent args)
-    {
-        if (args.Handled)
-            return;
-
-        args.Handled = true;
-        component.On = !component.On;
-
-        if (_sharedContainer.TryGetContainingContainer(uid, out var container) &&
-            _inventory.TryGetSlotEntity(container.Owner, "shoes", out var entityUid) && entityUid == component.Owner)
-            UpdateMagbootEffects(container.Owner, component.Owner, true, component);
-
-        if (TryComp<SharedItemComponent>(component.Owner, out var item))
-            item.EquippedPrefix = component.On ? "on" : null;
-
-        if (TryComp<SpriteComponent>(component.Owner, out var sprite))
-            sprite.LayerSetState(0, component.On ? "icon-on" : "icon");
-
-        OnChanged(component);
-        Dirty(component);
     }
 
     private void OnGotUnequipped(EntityUid uid, MagbootsComponent component, GotUnequippedEvent args)

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Jittering;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 using Content.Shared.Throwing;
+using Content.Shared.Toggleable;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
@@ -87,13 +88,11 @@ namespace Content.Server.Stunnable.Systems
             if (!comp.Activated)
                 return;
 
-            // TODO stunbaton visualizer
-            if (TryComp<SpriteComponent>(comp.Owner, out var sprite) &&
-                TryComp<SharedItemComponent>(comp.Owner, out var item))
-            {
+            if (TryComp<SharedItemComponent>(comp.Owner, out var item))
                 item.EquippedPrefix = "off";
-                sprite.LayerSetState(0, "stunbaton_off");
-            }
+
+            if (TryComp(comp.Owner, out AppearanceComponent? appearance))
+                appearance.SetData(ToggleVisuals.Toggled, false);
 
             SoundSystem.Play(comp.SparksSound.GetSound(), Filter.Pvs(comp.Owner), comp.Owner, AudioHelpers.WithVariation(0.25f));
 
@@ -113,12 +112,12 @@ namespace Content.Server.Stunnable.Systems
                 return;
             }
 
-            if (EntityManager.TryGetComponent<SpriteComponent?>(comp.Owner, out var sprite) &&
-                EntityManager.TryGetComponent<SharedItemComponent?>(comp.Owner, out var item))
-            {
+
+            if (TryComp<SharedItemComponent>(comp.Owner, out var item))
                 item.EquippedPrefix = "on";
-                sprite.LayerSetState(0, "stunbaton_on");
-            }
+
+            if (TryComp(comp.Owner, out AppearanceComponent? appearance))
+                appearance.SetData(ToggleVisuals.Toggled, true);
 
             SoundSystem.Play(comp.SparksSound.GetSound(), playerFilter, comp.Owner, AudioHelpers.WithVariation(0.25f));
             comp.Activated = true;

--- a/Content.Shared/Clothing/SharedMagbootsSystem.cs
+++ b/Content.Shared/Clothing/SharedMagbootsSystem.cs
@@ -1,7 +1,10 @@
 using Content.Shared.Actions;
+using Content.Shared.Inventory;
+using Content.Shared.Item;
 using Content.Shared.Slippery;
 using Content.Shared.Toggleable;
 using Content.Shared.Verbs;
+using Robust.Shared.Containers;
 
 namespace Content.Shared.Clothing;
 
@@ -9,6 +12,8 @@ public abstract class SharedMagbootsSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _sharedActions = default!;
     [Dependency] private readonly ClothingSpeedModifierSystem _clothingSpeedModifier = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedContainerSystem _sharedContainer = default!;
 
     public override void Initialize()
     {
@@ -17,7 +22,32 @@ public abstract class SharedMagbootsSystem : EntitySystem
         SubscribeLocalEvent<MagbootsComponent, GetVerbsEvent<ActivationVerb>>(AddToggleVerb);
         SubscribeLocalEvent<MagbootsComponent, SlipAttemptEvent>(OnSlipAttempt);
         SubscribeLocalEvent<MagbootsComponent, GetItemActionsEvent>(OnGetActions);
+        SubscribeLocalEvent<MagbootsComponent, ToggleActionEvent>(OnToggleAction);
     }
+
+    private void OnToggleAction(EntityUid uid, MagbootsComponent component, ToggleActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.Handled = true;
+        component.On = !component.On;
+
+        if (_sharedContainer.TryGetContainingContainer(uid, out var container) &&
+            _inventory.TryGetSlotEntity(container.Owner, "shoes", out var entityUid) && entityUid == component.Owner)
+            UpdateMagbootEffects(container.Owner, uid, true, component);
+
+        if (TryComp<SharedItemComponent>(uid, out var item))
+            item.EquippedPrefix = component.On ? "on" : null;
+
+        if (TryComp(uid, out AppearanceComponent? appearance))
+            appearance.SetData(ToggleVisuals.Toggled, component.On);
+
+        OnChanged(component);
+        Dirty(component);
+    }
+
+    protected virtual void UpdateMagbootEffects(EntityUid parent, EntityUid uid, bool state, MagbootsComponent? component) { }
 
     protected void OnChanged(MagbootsComponent component)
     {

--- a/Content.Shared/Toggleable/ToggleActionEvent.cs
+++ b/Content.Shared/Toggleable/ToggleActionEvent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Toggleable;
 
@@ -6,3 +7,13 @@ namespace Content.Shared.Toggleable;
 ///     Generic action-event for toggle-able components.
 /// </summary>
 public sealed class ToggleActionEvent : InstantActionEvent { }
+
+/// <summary>
+///     Generic enum keys for toggle-visualizer appearance data & sprite layers.
+/// </summary>
+[Serializable, NetSerializable]
+public enum ToggleVisuals : byte
+{
+    Toggled,
+    Layer
+}

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -6,7 +6,10 @@
   components:
     - type: Sprite
       sprite: Clothing/Shoes/Boots/magboots.rsi
-      state: icon
+      netsync: false
+      layers:
+      - state: icon
+        map: [ "enum.ToggleVisuals.Layer" ]
     - type: Clothing
       sprite: Clothing/Shoes/Boots/magboots.rsi
     - type: Magboots
@@ -21,6 +24,13 @@
       walkModifier: 0.85
       sprintModifier: 0.8
       enabled: false
+    - type: Appearance
+    - type: GenericVisualizer
+      visuals:
+        enum.ToggleVisuals.Toggled:
+          enum.ToggleVisuals.Layer:
+            True: {state: icon-on}
+            False: {state: icon}
 
 - type: entity
   parent: ClothingShoesBootsMag

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -6,7 +6,10 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Melee/stunbaton.rsi
-    state: stunbaton_off
+    netsync: false
+    layers:
+    - state: stunbaton_off
+      map: [ "enum.ToggleVisuals.Layer" ]
   - type: Stunbaton
     energyPerUse: 100
   - type: MeleeWeapon
@@ -33,6 +36,13 @@
     - Belt
   - type: DisarmMalus
     malus: 0.225
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+     enum.ToggleVisuals.Toggled:
+        enum.ToggleVisuals.Layer:
+          True: {state: stunbaton_on}
+          False: {state: stunbaton_off}
 
 - type: entity
   name: flash


### PR DESCRIPTION
Updates magboots & stun batons so that they no longer use the server sprite component an use a visualizer instead.

