### PR TITLE
Vending visualizer update

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -73,7 +73,6 @@ namespace Content.Client.Entry
             // Do not add to these, they are legacy.
             factory.RegisterClass<SharedLatheComponent>();
             factory.RegisterClass<SharedSpawnPointComponent>();
-            factory.RegisterClass<SharedVendingMachineComponent>();
             factory.RegisterClass<SharedReagentDispenserComponent>();
             factory.RegisterClass<SharedChemMasterComponent>();
             factory.RegisterClass<SharedGravityGeneratorComponent>();

--- a/Content.Client/VendingMachines/UI/VendingMachineVisualizer.cs
+++ b/Content.Client/VendingMachines/UI/VendingMachineVisualizer.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
+using Content.Shared.VendingMachines;
 using JetBrains.Annotations;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
+using Robust.Client.ResourceManagement;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager.Attributes;
 using static Content.Shared.VendingMachines.SharedVendingMachineComponent;
@@ -139,7 +142,18 @@ namespace Content.Client.VendingMachines.UI
             base.OnChangeData(component);
 
             var entMan = IoCManager.Resolve<IEntityManager>();
-            var sprite = entMan.GetComponent<ISpriteComponent>(component.Owner);
+            var sprite = entMan.GetComponent<SpriteComponent>(component.Owner);
+
+            // TODO when moving to a system visualizer, re work how this is done
+            // Currently this only gets called during init, so unless it NEEEDS to be configurable, just make this party of the entity prototype.
+            if (component.TryGetData(VendingMachineVisuals.Inventory, out string? invId) &&
+                IoCManager.Resolve<IPrototypeManager>().TryIndex(invId, out VendingMachineInventoryPrototype? prototype) &&
+                IoCManager.Resolve<IResourceCache>().TryGetResource<RSIResource>(
+                    SharedSpriteComponent.TextureRoot / $"Structures/Machines/VendingMachines/{prototype.SpriteName}.rsi", out var res))
+            {
+                sprite.BaseRSI = res.RSI;
+            }
+
             var animPlayer = entMan.GetComponent<AnimationPlayerComponent>(component.Owner);
             if (!component.TryGetData(VendingMachineVisuals.VisualState, out VendingMachineVisualState state))
             {

--- a/Content.Client/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Client/VendingMachines/VendingMachineComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.VendingMachines;
+
+namespace Content.Client.VendingMachines;
+
+[RegisterComponent]
+[ComponentReference(typeof(SharedVendingMachineComponent))]
+public sealed class VendingMachineComponent : SharedVendingMachineComponent
+{
+
+}

--- a/Content.Client/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Client/VendingMachines/VendingMachineSystem.cs
@@ -1,0 +1,7 @@
+using Content.Shared.VendingMachines;
+
+namespace Content.Client.VendingMachines;
+
+public sealed class VendingMachineSystem : SharedVendingMachineSystem
+{
+}

--- a/Content.Server/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Server/VendingMachines/VendingMachineComponent.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.VendingMachines
 {
     [RegisterComponent]
+    [ComponentReference(typeof(SharedVendingMachineComponent))]
     public sealed class VendingMachineComponent : SharedVendingMachineComponent
     {
         public bool Ejecting;

--- a/Content.Server/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Server/VendingMachines/VendingMachineComponent.cs
@@ -13,8 +13,6 @@ namespace Content.Server.VendingMachines
     {
         public bool Ejecting;
 
-        public TimeSpan AnimationDuration = TimeSpan.Zero;
-
         public bool Broken;
 
         /// <summary>

--- a/Content.Server/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Server/VendingMachines/VendingMachineComponent.cs
@@ -14,11 +14,6 @@ namespace Content.Server.VendingMachines
 
         public TimeSpan AnimationDuration = TimeSpan.Zero;
 
-        [ViewVariables] [DataField("pack", customTypeSerializer:typeof(PrototypeIdSerializer<VendingMachineInventoryPrototype>))]
-        public string PackPrototypeId = string.Empty;
-
-        public string SpriteName = "";
-
         public bool Broken;
 
         /// <summary>

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -20,7 +20,7 @@ using static Content.Shared.VendingMachines.SharedVendingMachineComponent;
 
 namespace Content.Server.VendingMachines
 {
-    public sealed class VendingMachineSystem : EntitySystem
+    public sealed class VendingMachineSystem : SharedVendingMachineSystem
     {
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -32,7 +32,7 @@ namespace Content.Server.VendingMachines
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<VendingMachineComponent, ComponentInit>(OnComponentInit);
+
             SubscribeLocalEvent<VendingMachineComponent, PowerChangedEvent>(OnPowerChanged);
             SubscribeLocalEvent<VendingMachineComponent, InventorySyncRequestMessage>(OnInventoryRequestMessage);
             SubscribeLocalEvent<VendingMachineComponent, VendingMachineEjectMessage>(OnInventoryEjectMessage);
@@ -43,9 +43,11 @@ namespace Content.Server.VendingMachines
             SubscribeLocalEvent<VendingMachineComponent, VendingMachineSelfDispenseEvent>(OnSelfDispense);
         }
 
-        private void OnComponentInit(EntityUid uid, VendingMachineComponent component, ComponentInit args)
+        protected override void OnComponentInit(EntityUid uid, SharedVendingMachineComponent sharedComponent, ComponentInit args)
         {
-            base.Initialize();
+            base.OnComponentInit(uid, sharedComponent, args);
+
+            var component = (VendingMachineComponent) sharedComponent;
 
             if (TryComp<ApcPowerReceiverComponent>(component.Owner, out var receiver))
             {
@@ -57,8 +59,6 @@ namespace Content.Server.VendingMachines
                 var action = new InstantAction(_prototypeManager.Index<InstantActionPrototype>(component.Action));
                 _action.AddAction(uid, action, uid);
             }
-
-            InitializeFromPrototype(uid, component);
         }
 
         private void OnInventoryRequestMessage(EntityUid uid, VendingMachineComponent component, InventorySyncRequestMessage args)
@@ -121,58 +121,6 @@ namespace Content.Server.VendingMachines
 
             args.Handled = true;
             EjectRandom(uid, true, component);
-        }
-
-        public void InitializeFromPrototype(EntityUid uid, VendingMachineComponent? vendComponent = null)
-        {
-            if (!Resolve(uid, ref vendComponent))
-                return;
-
-            if (!_prototypeManager.TryIndex(vendComponent.PackPrototypeId, out VendingMachineInventoryPrototype? packPrototype))
-                return;
-            
-            MetaData(uid).EntityName = packPrototype.Name;
-            vendComponent.AnimationDuration = TimeSpan.FromSeconds(packPrototype.AnimationDuration);
-
-            if (TryComp(vendComponent.Owner, out AppearanceComponent? appearance))
-                appearance.SetData(VendingMachineVisuals.Inventory, vendComponent.PackPrototypeId);
-
-            AddInventoryFromPrototype(uid, packPrototype.StartingInventory, InventoryType.Regular, vendComponent);
-            AddInventoryFromPrototype(uid, packPrototype.EmaggedInventory, InventoryType.Emagged, vendComponent);
-            AddInventoryFromPrototype(uid, packPrototype.ContrabandInventory, InventoryType.Contraband, vendComponent);
-        }
-
-        private void AddInventoryFromPrototype(EntityUid uid, Dictionary<string, uint>? entries,
-            InventoryType type,
-            VendingMachineComponent? component = null)
-        {
-            if (!Resolve(uid, ref component) || entries == null)
-            {
-                return;
-            }
-
-            var inventory = new List<VendingMachineInventoryEntry>();
-
-            foreach (var (id, amount) in entries)
-            {
-                if (_prototypeManager.HasIndex<EntityPrototype>(id))
-                {
-                    inventory.Add(new VendingMachineInventoryEntry(type, id, amount));
-                }
-            }
-
-            switch (type)
-            {
-                case InventoryType.Regular:
-                    component.Inventory.AddRange(inventory);
-                    break;
-                case InventoryType.Emagged:
-                    component.EmaggedInventory.AddRange(inventory);
-                    break;
-                case InventoryType.Contraband:
-                    component.ContrabandInventory.AddRange(inventory);
-                    break;
-            }
         }
 
         public void Deny(EntityUid uid, VendingMachineComponent? vendComponent = null)

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -128,23 +128,14 @@ namespace Content.Server.VendingMachines
             if (!Resolve(uid, ref vendComponent))
                 return;
 
-            if (string.IsNullOrEmpty(vendComponent.PackPrototypeId)) { return; }
-
             if (!_prototypeManager.TryIndex(vendComponent.PackPrototypeId, out VendingMachineInventoryPrototype? packPrototype))
-            {
                 return;
-            }
-
+            
             MetaData(uid).EntityName = packPrototype.Name;
             vendComponent.AnimationDuration = TimeSpan.FromSeconds(packPrototype.AnimationDuration);
-            vendComponent.SpriteName = packPrototype.SpriteName;
-            if (!string.IsNullOrEmpty(vendComponent.SpriteName))
-            {
-                if (TryComp<SpriteComponent>(vendComponent.Owner, out var spriteComp)) {
-                    const string vendingMachineRSIPath = "Structures/Machines/VendingMachines/{0}.rsi";
-                    spriteComp.BaseRSIPath = string.Format(vendingMachineRSIPath, vendComponent.SpriteName);
-                }
-            }
+
+            if (TryComp(vendComponent.Owner, out AppearanceComponent? appearance))
+                appearance.SetData(VendingMachineVisuals.Inventory, vendComponent.PackPrototypeId);
 
             AddInventoryFromPrototype(uid, packPrototype.StartingInventory, InventoryType.Regular, vendComponent);
             AddInventoryFromPrototype(uid, packPrototype.EmaggedInventory, InventoryType.Emagged, vendComponent);

--- a/Content.Shared/VendingMachines/SharedVendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineComponent.cs
@@ -5,9 +5,8 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.VendingMachines
 {
-    [Virtual]
     [NetworkedComponent()]
-    public class SharedVendingMachineComponent : Component
+    public abstract class SharedVendingMachineComponent : Component
     {
         [DataField("pack", customTypeSerializer: typeof(PrototypeIdSerializer<VendingMachineInventoryPrototype>))]
         public string PackPrototypeId = string.Empty;

--- a/Content.Shared/VendingMachines/SharedVendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Actions;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.VendingMachines
 {
@@ -8,6 +9,9 @@ namespace Content.Shared.VendingMachines
     [NetworkedComponent()]
     public class SharedVendingMachineComponent : Component
     {
+        [DataField("pack", customTypeSerializer: typeof(PrototypeIdSerializer<VendingMachineInventoryPrototype>))]
+        public string PackPrototypeId = string.Empty;
+
         [ViewVariables] public List<VendingMachineInventoryEntry> Inventory = new();
         [ViewVariables] public List<VendingMachineInventoryEntry> EmaggedInventory = new();
         [ViewVariables] public List<VendingMachineInventoryEntry> ContrabandInventory = new();
@@ -32,6 +36,7 @@ namespace Content.Shared.VendingMachines
         public enum VendingMachineVisuals
         {
             VisualState,
+            Inventory,
         }
 
         [Serializable, NetSerializable]

--- a/Content.Shared/VendingMachines/SharedVendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineComponent.cs
@@ -11,6 +11,8 @@ namespace Content.Shared.VendingMachines
         [DataField("pack", customTypeSerializer: typeof(PrototypeIdSerializer<VendingMachineInventoryPrototype>))]
         public string PackPrototypeId = string.Empty;
 
+        public TimeSpan AnimationDuration = TimeSpan.Zero;
+
         [ViewVariables] public List<VendingMachineInventoryEntry> Inventory = new();
         [ViewVariables] public List<VendingMachineInventoryEntry> EmaggedInventory = new();
         [ViewVariables] public List<VendingMachineInventoryEntry> ContrabandInventory = new();

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -1,0 +1,65 @@
+using Robust.Shared.Prototypes;
+using static Content.Shared.VendingMachines.SharedVendingMachineComponent;
+
+namespace Content.Shared.VendingMachines;
+
+public abstract class SharedVendingMachineSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SharedVendingMachineComponent, ComponentInit>(OnComponentInit);;
+    }
+
+    protected virtual void OnComponentInit(EntityUid uid, SharedVendingMachineComponent component, ComponentInit args)
+    {
+        if (!_prototypeManager.TryIndex(component.PackPrototypeId, out VendingMachineInventoryPrototype? packPrototype))
+            return;
+
+        MetaData(uid).EntityName = packPrototype.Name;
+        component.AnimationDuration = TimeSpan.FromSeconds(packPrototype.AnimationDuration);
+
+        if (TryComp(component.Owner, out AppearanceComponent? appearance))
+            appearance.SetData(VendingMachineVisuals.Inventory, component.PackPrototypeId);
+
+        AddInventoryFromPrototype(uid, packPrototype.StartingInventory, InventoryType.Regular, component);
+        AddInventoryFromPrototype(uid, packPrototype.EmaggedInventory, InventoryType.Emagged, component);
+        AddInventoryFromPrototype(uid, packPrototype.ContrabandInventory, InventoryType.Contraband, component);
+    }
+
+    private void AddInventoryFromPrototype(EntityUid uid, Dictionary<string, uint>? entries,
+        InventoryType type,
+        SharedVendingMachineComponent? component = null)
+    {
+        if (!Resolve(uid, ref component) || entries == null)
+        {
+            return;
+        }
+
+        var inventory = new List<VendingMachineInventoryEntry>();
+
+        foreach (var (id, amount) in entries)
+        {
+            if (_prototypeManager.HasIndex<EntityPrototype>(id))
+            {
+                inventory.Add(new VendingMachineInventoryEntry(type, id, amount));
+            }
+        }
+
+        switch (type)
+        {
+            case InventoryType.Regular:
+                component.Inventory.AddRange(inventory);
+                break;
+            case InventoryType.Emagged:
+                component.EmaggedInventory.AddRange(inventory);
+                break;
+            case InventoryType.Contraband:
+                component.ContrabandInventory.AddRange(inventory);
+                break;
+        }
+    }
+}
+

--- a/Content.Shared/VendingMachines/VendingMachineInventoryPrototype.cs
+++ b/Content.Shared/VendingMachines/VendingMachineInventoryPrototype.cs
@@ -16,6 +16,7 @@ namespace Content.Shared.VendingMachines
         [DataField("animationDuration")]
         public double AnimationDuration { get; }
 
+        // TODO make this a proper sprite specifier for yaml linting.
         [DataField("spriteName")]
         public string SpriteName { get; } = string.Empty;
 


### PR DESCRIPTION
Removes uses of the server sprite component from vending machines by moving inventory prototype related logic to the visualizer.