### PR TITLE
Remove more server sprite component uses

### DIFF
--- a/Content.Client/Buckle/BuckleComponent.cs
+++ b/Content.Client/Buckle/BuckleComponent.cs
@@ -46,14 +46,18 @@ namespace Content.Client.Buckle
                 return;
             }
 
-            if (_buckled && buckle.DrawDepth.HasValue)
+            // TODO when ECSing, make this a visualizer
+            if (_buckled &&
+                LastEntityBuckledTo != null &&
+                EntMan.GetComponent<TransformComponent>(LastEntityBuckledTo.Value).LocalRotation.GetCardinalDir() == Direction.North &&
+                EntMan.TryGetComponent<SpriteComponent>(LastEntityBuckledTo, out var buckledSprite))
             {
                 _originalDrawDepth ??= ownerSprite.DrawDepth;
-                ownerSprite.DrawDepth = buckle.DrawDepth.Value;
+                ownerSprite.DrawDepth = buckledSprite.DrawDepth - 1;
                 return;
             }
 
-            if (_originalDrawDepth.HasValue && !buckle.DrawDepth.HasValue)
+            if (_originalDrawDepth.HasValue && !_buckled)
             {
                 ownerSprite.DrawDepth = _originalDrawDepth.Value;
                 _originalDrawDepth = null;

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -99,6 +99,14 @@ namespace Content.Client.Hands
         }
         #endregion
 
+        public override void DoDrop(EntityUid uid, Hand hand, bool doDropInteraction = true, SharedHandsComponent? hands = null)
+        {
+            base.DoDrop(uid, hand, doDropInteraction, hands);
+
+            if (TryComp(hand.HeldEntity, out SpriteComponent? sprite))
+                sprite.RenderOrder = EntityManager.CurrentTick.Value;
+        }
+
         public EntityUid? GetActiveHandEntity()
         {
             return TryGetPlayerHands(out var hands) ? hands.ActiveHandEntity : null;

--- a/Content.IntegrationTests/Tests/ClickableTest.cs
+++ b/Content.IntegrationTests/Tests/ClickableTest.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Content.Client.Clickable;
 using NUnit.Framework;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
-using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 
@@ -60,7 +60,6 @@ namespace Content.IntegrationTests.Tests
             {
                 var ent = serverEntManager.SpawnEntity(prototype, testMap.GridCoords);
                 serverEntManager.GetComponent<TransformComponent>(ent).WorldRotation = angle;
-                serverEntManager.GetComponent<SpriteComponent>(ent).Scale = (scale, scale);
                 entity = ent;
             });
 
@@ -71,6 +70,8 @@ namespace Content.IntegrationTests.Tests
 
             await client.WaitPost(() =>
             {
+                clientEntManager.GetComponent<SpriteComponent>(entity).Scale = (scale, scale);
+
                 // these tests currently all assume player eye is 0
                 eyeManager.CurrentEye.Rotation = 0;
 

--- a/Content.MapRenderer/Painters/MapPainter.cs
+++ b/Content.MapRenderer/Painters/MapPainter.cs
@@ -1,22 +1,19 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Content.IntegrationTests;
-using Content.Shared.CCVar;
 using Robust.Client.GameObjects;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
-using Robust.Shared;
-using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SpriteComponent = Robust.Server.GameObjects.SpriteComponent;
+using SpriteComponent = Robust.Client.GameObjects.SpriteComponent;
 
 namespace Content.MapRenderer.Painters
 {
@@ -40,7 +37,7 @@ namespace Content.MapRenderer.Painters
 
             await client.WaitPost(() =>
             {
-                if (cEntityManager.TryGetComponent(cPlayerManager.LocalPlayer!.ControlledEntity!, out Robust.Client.GameObjects.SpriteComponent? sprite))
+                if (cEntityManager.TryGetComponent(cPlayerManager.LocalPlayer!.ControlledEntity!, out SpriteComponent? sprite))
                 {
                     sprite.Visible = false;
                 }
@@ -48,14 +45,6 @@ namespace Content.MapRenderer.Painters
 
             var sEntityManager = server.ResolveDependency<IServerEntityManager>();
             var sPlayerManager = server.ResolveDependency<IPlayerManager>();
-
-            await server.WaitPost(() =>
-            {
-                if (sEntityManager.TryGetComponent(sPlayerManager.ServerSessions.Single().AttachedEntity!, out SpriteComponent? sprite))
-                {
-                    sprite.Visible = false;
-                }
-            });
 
             await PoolManager.RunTicksSync(pairTracker.Pair, 10);
             await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());

--- a/Content.Server/Buckle/Components/BuckleComponent.cs
+++ b/Content.Server/Buckle/Components/BuckleComponent.cs
@@ -356,16 +356,7 @@ namespace Content.Server.Buckle.Components
 
         public override ComponentState GetComponentState()
         {
-            int? drawDepth = null;
-
-            if (BuckledTo != null &&
-                EntMan.GetComponent<TransformComponent>(BuckledTo.Owner).LocalRotation.GetCardinalDir() == Direction.North &&
-                EntMan.TryGetComponent<SpriteComponent>(BuckledTo.Owner, out var spriteComponent))
-            {
-                drawDepth = spriteComponent.DrawDepth - 1;
-            }
-
-            return new BuckleComponentState(Buckled, drawDepth, LastEntityBuckledTo, DontCollide);
+            return new BuckleComponentState(Buckled, LastEntityBuckledTo, DontCollide);
         }
     }
 }

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -112,9 +112,6 @@ namespace Content.Server.Hands.Systems
 
             // update gui of anyone stripping this entity.
             _strippableSystem.SendUpdate(uid);
-
-            if (TryComp(hand.HeldEntity, out SpriteComponent? sprite))
-                sprite.RenderOrder = EntityManager.CurrentTick.Value;
         }
 
         public override void DoPickup(EntityUid uid, Hand hand, EntityUid entity, SharedHandsComponent? hands = null)

--- a/Content.Server/ParticleAccelerator/Components/ParticleProjectileComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleProjectileComponent.cs
@@ -2,7 +2,6 @@ using Content.Server.Projectiles;
 using Content.Server.Projectiles.Components;
 using Content.Server.Singularity.Components;
 using Content.Shared.Singularity.Components;
-using Robust.Server.GameObjects;
 using Robust.Shared.Timing;
 
 namespace Content.Server.ParticleAccelerator.Components
@@ -49,24 +48,12 @@ namespace Content.Server.ParticleAccelerator.Components
             };
             singuloFoodComponent.Energy = 10 * multiplier;
 
-            var suffix = state switch
+            if (_entMan.TryGetComponent(Owner, out AppearanceComponent? appearance))
             {
-                ParticleAcceleratorPowerState.Level0 => "0",
-                ParticleAcceleratorPowerState.Level1 => "1",
-                ParticleAcceleratorPowerState.Level2 => "2",
-                ParticleAcceleratorPowerState.Level3 => "3",
-                _ => "0"
-            };
-
-            if (!_entMan.TryGetComponent<SpriteComponent?>(Owner, out var spriteComponent))
-            {
-                Logger.Error("ParticleProjectile tried firing, but it was spawned without a SpriteComponent");
-                return;
+                appearance.SetData(ParticleAcceleratorVisuals.VisualState, state);
             }
-            spriteComponent.LayerSetState(0, $"particle{suffix}");
 
-            physicsComponent
-                .LinearVelocity = angle.ToWorldVec() * 20f;
+            physicsComponent.LinearVelocity = angle.ToWorldVec() * 20f;
 
             _entMan.GetComponent<TransformComponent>(Owner).LocalRotation = angle;
             Timer.Spawn(3000, () => _entMan.DeleteEntity(Owner));

--- a/Content.Server/Pointing/Components/PointingArrowComponent.cs
+++ b/Content.Server/Pointing/Components/PointingArrowComponent.cs
@@ -53,16 +53,6 @@ namespace Content.Server.Pointing.Components
         [DataField("rogue")]
         public bool Rogue = false;
 
-        protected override void Startup()
-        {
-            base.Startup();
-
-            if (_entMan.TryGetComponent(Owner, out SpriteComponent? sprite))
-            {
-                sprite.DrawDepth = (int) DrawDepth.Overlays;
-            }
-        }
-
         public void Update(float frameTime)
         {
             var movement = _speed * frameTime * (_up ? 1 : -1);

--- a/Content.Server/Pointing/EntitySystems/RoguePointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/RoguePointingSystem.cs
@@ -17,21 +17,6 @@ namespace Content.Server.Pointing.EntitySystems
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly ExplosionSystem _explosion = default!;
 
-        public override void Initialize()
-        {
-            base.Initialize();
-
-            SubscribeLocalEvent<RoguePointingArrowComponent, ComponentStartup>(OnStartup);
-        }
-
-        private void OnStartup(EntityUid uid, RoguePointingArrowComponent component, ComponentStartup args)
-        {
-            if (EntityManager.TryGetComponent(uid, out SpriteComponent? sprite))
-            {
-                sprite.DrawDepth = (int) DrawDepth.Overlays;
-            }
-        }
-
         private EntityUid? RandomNearbyPlayer(EntityUid uid, RoguePointingArrowComponent? component = null, TransformComponent? transform = null)
         {
             if (!Resolve(uid, ref component, ref transform))

--- a/Content.Server/Sandbox/SandboxSystem.cs
+++ b/Content.Server/Sandbox/SandboxSystem.cs
@@ -157,11 +157,6 @@ namespace Content.Server.Sandbox
             void UpgradeId(EntityUid id)
             {
                 _access.TrySetTags(id, allAccess);
-
-                if (TryComp<SpriteComponent>(id, out var sprite))
-                {
-                    sprite.LayerSetState(0, "gold");
-                }
             }
 
             EntityUid CreateFreshId()

--- a/Content.Shared/Buckle/Components/SharedBuckleComponent.cs
+++ b/Content.Shared/Buckle/Components/SharedBuckleComponent.cs
@@ -70,10 +70,9 @@ namespace Content.Shared.Buckle.Components
     [Serializable, NetSerializable]
     public sealed class BuckleComponentState : ComponentState
     {
-        public BuckleComponentState(bool buckled, int? drawDepth, EntityUid? lastEntityBuckledTo, bool dontCollide)
+        public BuckleComponentState(bool buckled, EntityUid? lastEntityBuckledTo, bool dontCollide)
         {
             Buckled = buckled;
-            DrawDepth = drawDepth;
             LastEntityBuckledTo = lastEntityBuckledTo;
             DontCollide = dontCollide;
         }
@@ -81,7 +80,6 @@ namespace Content.Shared.Buckle.Components
         public bool Buckled { get; }
         public EntityUid? LastEntityBuckledTo { get; }
         public bool DontCollide { get; }
-        public int? DrawDepth;
     }
 
     public sealed class BuckleChangeEvent : EntityEventArgs

--- a/Resources/Prototypes/Entities/Markers/pointing.yml
+++ b/Resources/Prototypes/Entities/Markers/pointing.yml
@@ -10,6 +10,7 @@
     netsync: false
     sprite: Interface/Misc/pointing.rsi
     state: pointing
+    drawDepth: 9
   - type: PointingArrow
     duration: 4
     step: 0.5

--- a/Resources/Prototypes/Entities/Markers/pointing.yml
+++ b/Resources/Prototypes/Entities/Markers/pointing.yml
@@ -10,7 +10,7 @@
     netsync: false
     sprite: Interface/Misc/pointing.rsi
     state: pointing
-    drawDepth: 9
+    drawDepth: Overlays
   - type: PointingArrow
     duration: 4
     step: 0.5

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -9,6 +9,7 @@
       - sprite: Structures/Power/Generation/PA/particle.rsi
         state: particle0
         shader: unshaded
+        map: [ "unshaded" ]
     - type: Projectile
       deleteOnCollide: false
       soundHit:
@@ -31,3 +32,12 @@
     - type: ParticleProjectile
     - type: SinguloFood
       # Energy is setup by the PA particle fire function.
+    - type: Appearance
+    - type: GenericVisualizer
+      visuals:
+        enum.ParticleAcceleratorVisuals.VisualState:
+          unshaded:
+            Level0: {state: particle0}
+            Level1: {state: particle1}
+            Level2: {state: particle2}
+            Level3: {state: particle3}


### PR DESCRIPTION
- Buckle draw depth changes now done client-side
- PA projectiles now use the generic visualizer to set RSI states.
- Dropped item render orders now set client-side
- Pointing arrows now just set the draw depth in the prototype.
- Removed uses from tests & map renderer

