### PR TITLE
Fix thrusters using generic Burn damage group instead of Heat type

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -16,8 +16,8 @@
       rotateWhileAnchored: true
     - type: Thruster
       damage:
-        groups:
-          Burn: 40
+        types:
+          Heat: 40
     - type: InteractionOutline
     - type: Sprite
       netsync: false


### PR DESCRIPTION
## Fix thrusters using generic Burn damage group instead of Heat type
Getting high temperature, electric and frostbite burns at once is silly.

**Screenshots**
Prevents this:
![burned_by_thruster](https://user-images.githubusercontent.com/108953437/180587458-5112068f-21b9-4f60-a6d4-1053da3e59db.png)

**Changelog**
:cl:
- fix: Thrusters now kill you with Heat type damage specifically.