### PR TITLE
Removed open and unlock for mobs with no hands

### DIFF
--- a/Content.Server/Lock/LockSystem.cs
+++ b/Content.Server/Lock/LockSystem.cs
@@ -181,7 +181,7 @@ namespace Content.Server.Lock
 
         private void AddToggleLockVerb(EntityUid uid, LockComponent component, GetVerbsEvent<AlternativeVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || !CanToggleLock(uid, args.User))
+            if (!args.CanAccess || !args.CanInteract || !CanToggleLock(uid, args.User) || args.Hands == null)
                 return;
 
             AlternativeVerb verb = new();

--- a/Content.Server/Lock/LockSystem.cs
+++ b/Content.Server/Lock/LockSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Emag.Systems;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Examine;
+using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Storage;
@@ -147,10 +148,13 @@ namespace Content.Server.Lock
         /// <summary>
         ///     Before locking the entity, check whether it's a locker. If is, prevent it from being locked from the inside or while it is open.
         /// </summary>
-        public bool CanToggleLock(EntityUid uid, EntityUid user, EntityStorageComponent? storage = null, bool quiet = true)
+        public bool CanToggleLock(EntityUid uid, EntityUid user, EntityStorageComponent? storage = null, bool quiet = true, SharedHandsComponent? hands = null)
         {
             if (!Resolve(uid, ref storage, logMissing: false))
                 return true;
+
+            if (!Resolve(user, ref hands))
+            return false;
 
             // Cannot lock if the entity is currently opened.
             if (storage.Open)
@@ -181,7 +185,7 @@ namespace Content.Server.Lock
 
         private void AddToggleLockVerb(EntityUid uid, LockComponent component, GetVerbsEvent<AlternativeVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || !CanToggleLock(uid, args.User) || args.Hands == null)
+            if (!args.CanAccess || !args.CanInteract || !CanToggleLock(uid, args.User, null, true, args.Hands))
                 return;
 
             AlternativeVerb verb = new();

--- a/Content.Server/Lock/LockSystem.cs
+++ b/Content.Server/Lock/LockSystem.cs
@@ -148,13 +148,13 @@ namespace Content.Server.Lock
         /// <summary>
         ///     Before locking the entity, check whether it's a locker. If is, prevent it from being locked from the inside or while it is open.
         /// </summary>
-        public bool CanToggleLock(EntityUid uid, EntityUid user, EntityStorageComponent? storage = null, bool quiet = true, SharedHandsComponent? hands = null)
+        public bool CanToggleLock(EntityUid uid, EntityUid user, EntityStorageComponent? storage = null, bool quiet = true)
         {
             if (!Resolve(uid, ref storage, logMissing: false))
                 return true;
 
-            if (!Resolve(user, ref hands))
-            return false;
+            if (!HasComp<SharedHandsComponent>(user))
+                return false;
 
             // Cannot lock if the entity is currently opened.
             if (storage.Open)
@@ -185,7 +185,7 @@ namespace Content.Server.Lock
 
         private void AddToggleLockVerb(EntityUid uid, LockComponent component, GetVerbsEvent<AlternativeVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || !CanToggleLock(uid, args.User, null, true, args.Hands))
+            if (!args.CanAccess || !args.CanInteract || !CanToggleLock(uid, args.User))
                 return;
 
             AlternativeVerb verb = new();

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -149,7 +149,6 @@ public sealed class EntityStorageSystem : EntitySystem
 
         var ev = new StorageBeforeCloseEvent(uid, entities);
         RaiseLocalEvent(uid, ev, true);
-
         var count = 0;
         foreach (var entity in ev.Contents)
         {

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -229,12 +229,12 @@ public sealed class EntityStorageSystem : EntitySystem
         return true;
     }
 
-    public bool CanOpen(EntityUid user, EntityUid target, bool silent = false, EntityStorageComponent? component = null, SharedHandsComponent? hands = null)
+    public bool CanOpen(EntityUid user, EntityUid target, bool silent = false, EntityStorageComponent? component = null)
     {
         if (!Resolve(target, ref component))
             return false;
 
-        if (!Resolve(user, ref hands))
+        if (!HasComp<SharedHandsComponent>(user))
             return false;
 
         if (component.IsWeldedShut)

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -365,6 +365,5 @@ public sealed class EntityStorageSystem : EntitySystem
             appearance.SetData(StorageVisuals.Open, component.Open);
             appearance.SetData(StorageVisuals.HasContents, component.Contents.ContainedEntities.Count() > 0);
         }
-
     }
 }

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Storage.Components;
 using Content.Server.Tools.Systems;
 using Content.Shared.Body.Components;
 using Content.Shared.Destructible;
+using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Placeable;
@@ -148,7 +149,7 @@ public sealed class EntityStorageSystem : EntitySystem
 
         var ev = new StorageBeforeCloseEvent(uid, entities);
         RaiseLocalEvent(uid, ev, true);
-        
+
         var count = 0;
         foreach (var entity in ev.Contents)
         {
@@ -228,9 +229,12 @@ public sealed class EntityStorageSystem : EntitySystem
         return true;
     }
 
-    public bool CanOpen(EntityUid user, EntityUid target, bool silent = false, EntityStorageComponent? component = null)
+    public bool CanOpen(EntityUid user, EntityUid target, bool silent = false, EntityStorageComponent? component = null, SharedHandsComponent? hands = null)
     {
         if (!Resolve(target, ref component))
+            return false;
+
+        if (!Resolve(user, ref hands))
             return false;
 
         if (component.IsWeldedShut)
@@ -361,6 +365,6 @@ public sealed class EntityStorageSystem : EntitySystem
             appearance.SetData(StorageVisuals.Open, component.Open);
             appearance.SetData(StorageVisuals.HasContents, component.Contents.ContainedEntities.Count() > 0);
         }
-            
+
     }
 }

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -99,10 +99,10 @@ namespace Content.Server.Storage.EntitySystems
 
         private void AddToggleOpenVerb(EntityUid uid, EntityStorageComponent component, GetVerbsEvent<InteractionVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+            if (!args.CanAccess || !args.CanInteract)
                 return;
 
-            if (!_entityStorage.CanOpen(args.User, args.Target, silent: true, component))
+            if (!_entityStorage.CanOpen(args.User, args.Target, silent: true, component, args.Hands))
                 return;
 
             InteractionVerb verb = new();

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -99,7 +99,7 @@ namespace Content.Server.Storage.EntitySystems
 
         private void AddToggleOpenVerb(EntityUid uid, EntityStorageComponent component, GetVerbsEvent<InteractionVerb> args)
         {
-            if (!args.CanAccess || !args.CanInteract)
+            if (!args.CanAccess || !args.CanInteract || args.Hands == null)
                 return;
 
             if (!_entityStorage.CanOpen(args.User, args.Target, silent: true, component))

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -102,7 +102,7 @@ namespace Content.Server.Storage.EntitySystems
             if (!args.CanAccess || !args.CanInteract)
                 return;
 
-            if (!_entityStorage.CanOpen(args.User, args.Target, silent: true, component, args.Hands))
+            if (!_entityStorage.CanOpen(args.User, args.Target, silent: true, component))
                 return;
 
             InteractionVerb verb = new();


### PR DESCRIPTION
fixes #9911

Mobs now cant see the verbs open and unlock on the UI. They cant open morgues or closets anymore. In the future, we should have more refined checks that disallow certain interactions even if you have hands, to allow for brain damage preventing some interactions, etc.

:cl:
- fix: Entities without hands can no longer open/close storage and toggle locks.