### PR TITLE
Add action to security masks to shout at criminals

### DIFF
--- a/Content.Server/Clothing/Components/MaskComponent.cs
+++ b/Content.Server/Clothing/Components/MaskComponent.cs
@@ -13,8 +13,16 @@ namespace Content.Server.Clothing.Components
         [DataField("toggleAction")]
         public InstantAction? ToggleAction = null;
 
+        /// <summary>
+        /// When triggered, make the wearer say something.
+        /// </summary>
+        [DataField("maskShoutAction")]
+        public InstantAction? MaskShoutAction = null;
+
         public bool IsToggled = false;
     }
 
     public sealed class ToggleMaskEvent : InstantActionEvent { }
+
+    public sealed class MaskShoutEvent : InstantActionEvent { }
 }

--- a/Content.Server/Clothing/MaskSystem.cs
+++ b/Content.Server/Clothing/MaskSystem.cs
@@ -36,6 +36,9 @@ namespace Content.Server.Clothing
         {
             if (component.ToggleAction != null && !args.InHands)
                 args.Actions.Add(component.ToggleAction);
+
+            if (component.MaskShoutAction != null && !args.InHands)
+                args.Actions.Add(component.MaskShoutAction);
         }
 
         private void OnToggleMask(EntityUid uid, MaskComponent mask, ToggleMaskEvent args)
@@ -97,6 +100,9 @@ namespace Content.Server.Clothing
             // toggle breath tool connection (skip during equip since that is handled in LungSystem)
             if (isEquip || !TryComp<BreathToolComponent>(uid, out var breathTool))
                 return;
+
+            if (mask.MaskShoutAction != null)
+                mask.MaskShoutAction.Enabled = !mask.IsToggled;
 
             if (mask.IsToggled)
             {

--- a/Resources/Locale/en-US/actions/actions/mask.ftl
+++ b/Resources/Locale/en-US/actions/actions/mask.ftl
@@ -2,3 +2,5 @@ action-name-mask = Toggle Mask
 action-description-mask-toggle = Handy, but prevents insertion of pie into your pie hole.
 action-mask-pull-up-popup-message = You pull up your {$mask}.
 action-mask-pull-down-popup-message = You pull down your {$mask}.
+action-mask-shout = Shout Through Mask
+action-security-mask-shout = Halt, you are under arrest!

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -20,6 +20,15 @@
   name: security gas mask
   description: A standard issue Security gas mask.
   components:
+  - type: Mask
+    maskShoutAction:
+      name: action-mask-shout
+      description: action-security-mask-shout
+      speech: action-security-mask-shout
+      icon: Interface/Actions/scream.png
+      useDelay: 10
+      priority: -1
+      event: !type:MaskShoutEvent
   - type: Sprite
     sprite: Clothing/Mask/gassecurity.rsi
   - type: Clothing


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add an action to security masks that allows the wearer to shout at criminals when worn.

**Screenshots**
![secmask](https://user-images.githubusercontent.com/3229565/180624154-4ee29c66-f66c-48f3-af2d-23e09e4425e5.png)

**Changelog**
:cl: notafet
- add: Security gas masks can be used to shout at criminals.