### PR TITLE
Add announcement wrap to department radio messages for non-player sources

### DIFF
--- a/Content.Server/Ghost/Components/IntrinsicRadioComponent.cs
+++ b/Content.Server/Ghost/Components/IntrinsicRadioComponent.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Ghost.Components
         [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>), required: true)]
         private HashSet<string> _channels = new();
 
-        public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker)
+        public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker, bool announcement = false)
         {
             if (!_channels.Contains(channel.ID) || !_entMan.TryGetComponent(Owner, out ActorComponent? actor))
                 return;

--- a/Content.Server/Headset/HeadsetComponent.cs
+++ b/Content.Server/Headset/HeadsetComponent.cs
@@ -4,9 +4,7 @@ using Content.Shared.Chat;
 using Content.Shared.Radio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Network;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 
 namespace Content.Server.Headset
@@ -49,9 +47,11 @@ namespace Content.Server.Headset
 
         public void Receive(string message, RadioChannelPrototype channel, EntityUid source)
         {
-            if (!Channels.Contains(channel.ID) || !Owner.TryGetContainer(out var container)) return;
+            if (!Channels.Contains(channel.ID) || !Owner.TryGetContainer(out var container))
+                return;
 
-            if (!_entMan.TryGetComponent(container.Owner, out ActorComponent? actor)) return;
+            if (!_entMan.TryGetComponent(container.Owner, out ActorComponent? actor))
+                return;
 
             var playerChannel = actor.PlayerSession.ConnectedClient;
 
@@ -62,6 +62,18 @@ namespace Content.Server.Headset
                 //Square brackets are added here to avoid issues with escaping
                 MessageWrap = Loc.GetString("chat-radio-message-wrap", ("color", channel.Color), ("channel", $"\\[{channel.LocalizedName}\\]"), ("name", _entMan.GetComponent<MetaDataComponent>(source).EntityName))
             };
+
+            // If the source isn't a player, we set the chat message accordingly
+            if (!_entMan.TryGetComponent(source, out ActorComponent? _))
+            {
+                msg = new MsgChatMessage
+                {
+                    Channel = ChatChannel.Radio,
+                    Message = message,
+                    //Square brackets are added here to avoid issues with escaping
+                    MessageWrap = Loc.GetString("announcement-radio-message-wrap", ("color", channel.Color), ("channel", $"\\[{channel.LocalizedName}\\]"))
+                };
+            }
 
             _netManager.ServerSendMessage(msg, playerChannel);
         }

--- a/Content.Server/Headset/HeadsetComponent.cs
+++ b/Content.Server/Headset/HeadsetComponent.cs
@@ -45,7 +45,7 @@ namespace Content.Server.Headset
             return Channels.Contains(prototype.ID) && RadioRequested;
         }
 
-        public void Receive(string message, RadioChannelPrototype channel, EntityUid source)
+        public void Receive(string message, RadioChannelPrototype channel, EntityUid source, bool announcement = false)
         {
             if (!Channels.Contains(channel.ID) || !Owner.TryGetContainer(out var container))
                 return;
@@ -64,7 +64,7 @@ namespace Content.Server.Headset
             };
 
             // If the source isn't a player, we set the chat message accordingly
-            if (!_entMan.TryGetComponent(source, out ActorComponent? _))
+            if (announcement)
             {
                 msg = new MsgChatMessage
                 {

--- a/Content.Server/Radio/Components/HandheldRadioComponent.cs
+++ b/Content.Server/Radio/Components/HandheldRadioComponent.cs
@@ -80,7 +80,7 @@ namespace Content.Server.Radio.Components
                    EntitySystem.Get<SharedInteractionSystem>().InRangeUnobstructed(Owner, source, range: ListenRange);
         }
 
-        public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker)
+        public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker, bool announcement = false)
         {
             if (_channels.Contains(channel.ID) && RadioOn)
             {

--- a/Content.Server/Radio/Components/IRadio.cs
+++ b/Content.Server/Radio/Components/IRadio.cs
@@ -4,7 +4,7 @@ namespace Content.Server.Radio.Components
 {
     public interface IRadio : IComponent
     {
-        void Receive(string message, RadioChannelPrototype channel, EntityUid speaker);
+        void Receive(string message, RadioChannelPrototype channel, EntityUid speaker, bool announcement = false);
 
         void Broadcast(string message, EntityUid speaker, RadioChannelPrototype channel);
     }

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Radio.EntitySystems
             args.PushMarkup(Loc.GetString("handheld-radio-component-on-examine",("frequency", component.BroadcastFrequency)));
         }
 
-        public void SpreadMessage(IRadio source, EntityUid speaker, string message, RadioChannelPrototype channel)
+        public void SpreadMessage(IRadio source, EntityUid speaker, string message, RadioChannelPrototype channel, bool announcement = false)
         {
             if (_messages.Contains(message)) return;
 
@@ -44,7 +44,7 @@ namespace Content.Server.Radio.EntitySystems
             foreach (var radio in EntityManager.EntityQuery<IRadio>(true))
             {
                 //TODO: once voice identity gets added, pass into receiver via source.GetSpeakerVoice()
-                radio.Receive(message, channel, speaker);
+                radio.Receive(message, channel, speaker, announcement);
             }
 
             _messages.Remove(message);

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -311,7 +311,7 @@ namespace Content.Server.Salvage
 
             var message = args.Length == 0 ? Loc.GetString(messageKey) : Loc.GetString(messageKey, args);
             var channel = _prototypeManager.Index<RadioChannelPrototype>(channelName);
-            _radioSystem.SpreadMessage(radio, source, message, channel);
+            _radioSystem.SpreadMessage(radio, source, message, channel, true);
         }
 
         private void Transition(SalvageMagnetComponent magnet, TimeSpan currentTime)

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -1,5 +1,6 @@
 # Chat window radio wrap (prefix and postfix)
 chat-radio-message-wrap = [color={$color}]{$channel} {$name} says, "{"{"}0{"}"}"[/color]
+announcement-radio-message-wrap = [color={$color}]{$channel} Announcement: {"{"}0{"}"}[/color]
 
 examine-radio-frequency = It's set to broadcast over the {$frequency} frequency.
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before, things like the salvage magnet would "say" that it's pulling in debris to the Salvage radio channel
Now, whenever something that isn't a player (lacks `ActorComponent`, idk what is a better way to check) it gives the message the formatting of a proper announcement

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![Screen Shot 2022-07-24 at 9 11 54 AM](https://user-images.githubusercontent.com/1261392/180656218-b7e93922-78fd-416f-8be2-88f436fb8af8.jpg)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
N/A - too minor of tweak

