### PR TITLE
Adds backpacks to the Clothesmate

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -2,6 +2,9 @@
   id: ClothesMateInventory
   name: ClothesMate
   startingInventory:
+    ClothingBackpack: 5
+    ClothingBackpackDuffel: 5
+    ClothingBackpackSatchel: 5
     HatBandBlack: 2
     HatBandBlue: 2
     HatBandGreen: 2


### PR DESCRIPTION
It's weirdly annoying to just get a normal backpack replacement. Also, most drobes stock some department backpacks, so it seems to make sense that the clothesmate would do the same.

:cl:
- add: The clothesmate now stocks backpacks

