### PR TITLE
Move some default window positions

### DIFF
--- a/Content.Client/Inventory/StrippableBoundUserInterface.cs
+++ b/Content.Client/Inventory/StrippableBoundUserInterface.cs
@@ -33,7 +33,7 @@ namespace Content.Client.Inventory
             _strippingMenu = new StrippingMenu($"{Loc.GetString("strippable-bound-user-interface-stripping-menu-title", ("ownerName", Identity.Name(Owner.Owner, entMan)))}");
 
             _strippingMenu.OnClose += Close;
-            _strippingMenu.OpenCentered();
+            _strippingMenu.OpenCenteredLeft();
             UpdateMenu();
         }
 

--- a/Content.Client/PDA/PDABoundUserInterface.cs
+++ b/Content.Client/PDA/PDABoundUserInterface.cs
@@ -20,7 +20,7 @@ namespace Content.Client.PDA
             base.Open();
             SendMessage(new PDARequestUpdateInterfaceMessage());
             _menu = new PDAMenu();
-            _menu.OpenToLeft();
+            _menu.OpenCenteredLeft();
             _menu.OnClose += Close;
             _menu.FlashLightToggleButton.OnToggled += _ =>
             {

--- a/Content.Client/Storage/StorageBoundUserInterface.cs
+++ b/Content.Client/Storage/StorageBoundUserInterface.cs
@@ -31,7 +31,7 @@ namespace Content.Client.Storage
                 _window.StorageContainerButton.OnPressed += TouchedContainerButton;
 
                 _window.OnClose += Close;
-                _window.OpenCentered();
+                _window.OpenCenteredLeft();
             }
             else
             {

--- a/Content.Client/Wires/UI/WiresBoundUserInterface.cs
+++ b/Content.Client/Wires/UI/WiresBoundUserInterface.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Wires;
+using Content.Shared.Wires;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 
@@ -18,7 +18,7 @@ namespace Content.Client.Wires.UI
 
             _menu = new WiresMenu(this);
             _menu.OnClose += Close;
-            _menu.OpenCentered();
+            _menu.OpenCenteredLeft();
         }
 
         protected override void UpdateState(BoundUserInterfaceState state)


### PR DESCRIPTION
Moves the default window positions for stroage, hacking, stripping, and pda to a "centered left". This way these windows aren't guaranteed to cover up the player's entity. 

Eventually it might be nice to have "smart" window opening function that attempts to find a suitable position without covering important elements (player, inventory, HUD & other windows).

Requires space-wizards/RobustToolbox/pull/3073
