### PR TITLE
Fix cursor popups

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -157,7 +157,8 @@ namespace Content.Client.Popups
 
         public override void FrameUpdate(float frameTime)
         {
-            if (_aliveWorldLabels.Count == 0) return;
+            if (_aliveWorldLabels.Count == 0 && _aliveCursorLabels.Count == 0)
+                return;
 
             var player = _playerManager.LocalPlayer?.ControlledEntity;
             var playerPos = player != null ? Transform(player.Value).MapPosition : MapCoordinates.Nullspace;
@@ -234,13 +235,13 @@ namespace Content.Client.Popups
 
             public CursorPopupLabel(ScreenCoordinates screenCoords) : base()
             {
-                InitialPos = screenCoords.Position / UIScale - DesiredSize / 2;
+                InitialPos = screenCoords.Position - DesiredSize / 2;
             }
 
             protected override void FrameUpdate(FrameEventArgs eventArgs)
             {
                 base.FrameUpdate(eventArgs);
-                LayoutContainer.SetPosition(this, InitialPos - (0, 20 * (TotalTime * TotalTime + TotalTime)));
+                LayoutContainer.SetPosition(this, InitialPos / UIScale - (0, 20 * (TotalTime * TotalTime + TotalTime)));
             }
         }
 


### PR DESCRIPTION
1. Weren't getting disposed (woops)
2. Position didn't account for UI scale

:cl:
- fix: Cursor popups now show at the correct spot for non-100% UI scales.
