### PR TITLE
Swap Rotate and Strafe keybindings

### DIFF
--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -45,19 +45,19 @@ binds:
   key: W
 - function: ShuttleStrafeLeft
   type: State
-  key: Q
+  key: A
 - function: ShuttleStrafeRight
   type: State
-  key: E
+  key: D
 - function: ShuttleStrafeDown
   type: State
   key: S
 - function: ShuttleRotateLeft
   type: State
-  key: A
+  key: Q
 - function: ShuttleRotateRight
   type: State
-  key: D
+  key: E
 - function: ShuttleBrake
   type: State
   key: Space


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Swaps the Rotate and Strafe keybindings.

**Q: Why did you do this if they can just swap it themselves**
- A: Because we use strafing way more than rotating, and other games like KSP use E/Q to rotate the ship.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: eclips_e
- tweak: Rotating and Strafing keybinds have been swapped. Use E/Q to rotate the shuttle, A/D to strafe.

