### PR TITLE
Minor identity bugfix

### DIFF
--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -141,7 +141,7 @@ public class IdentitySystem : SharedIdentitySystem
         // Get their name and job from their ID for their presumed name.
         if (_idCard.TryFindIdCard(target, out var id))
         {
-            presumedName = id.FullName;
+            presumedName = id.FullName == string.Empty ? null : id.FullName;
             presumedJob = id.JobTitle?.ToLowerInvariant();
         }
 

--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -141,7 +141,7 @@ public class IdentitySystem : SharedIdentitySystem
         // Get their name and job from their ID for their presumed name.
         if (_idCard.TryFindIdCard(target, out var id))
         {
-            presumedName = id.FullName == string.Empty ? null : id.FullName;
+            presumedName = string.IsNullOrWhiteSpace(id.FullName) ? null : id.FullName;
             presumedJob = id.JobTitle?.ToLowerInvariant();
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

:cl:
- fix: People with empty-name ID cards no longer show up as having an empty identity.