### PR TITLE
Throwing event improvements

### DIFF
--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -97,9 +97,9 @@ namespace Content.Shared.ActionBlocker
             return !ev.Cancelled;
         }
 
-        public bool CanThrow(EntityUid user)
+        public bool CanThrow(EntityUid user, EntityUid itemUid)
         {
-            var ev = new ThrowAttemptEvent(user);
+            var ev = new ThrowAttemptEvent(user, itemUid);
             RaiseLocalEvent(user, ev, true);
 
             return !ev.Cancelled;

--- a/Content.Shared/Throwing/BeforeThrowEvent.cs
+++ b/Content.Shared/Throwing/BeforeThrowEvent.cs
@@ -1,0 +1,18 @@
+namespace Content.Shared.Throwing
+{
+    public sealed class BeforeThrowEvent : HandledEntityEventArgs
+    {
+        public BeforeThrowEvent(EntityUid itemUid, Vector2 direction, float throwStrength,  EntityUid playerUid)
+        {
+           ItemUid = itemUid;
+           Direction = direction;
+           ThrowStrength = throwStrength;
+           PlayerUid = playerUid;
+        }
+
+        public EntityUid ItemUid { get; set; }
+        public Vector2 Direction { get; }
+        public float ThrowStrength { get; set;}
+        public EntityUid PlayerUid { get; }
+    }
+}

--- a/Content.Shared/Throwing/ThrowAttemptEvent.cs
+++ b/Content.Shared/Throwing/ThrowAttemptEvent.cs
@@ -2,12 +2,15 @@
 {
     public sealed class ThrowAttemptEvent : CancellableEntityEventArgs
     {
-        public ThrowAttemptEvent(EntityUid uid)
+        public ThrowAttemptEvent(EntityUid uid, EntityUid itemUid)
         {
             Uid = uid;
+            ItemUid = itemUid;
         }
 
         public EntityUid Uid { get; }
+
+        public EntityUid ItemUid { get; }
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basically this just passes the item in CanThrow (so certain entities can't throw certain items that aren't unremovable otherwise), and allows other systems to change the thrown entity or throwing force before a throw happens.

In anticipation of changes to carrying (which I plan on upstreaming soon) while also giving an easy way to add some items to make you throw stuff better, and a simpler way to restrict throwing but not all throwing.

