### PR TITLE
removed saw from bagel map

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -718,7 +718,7 @@ entities:
 - uid: 60
   components:
   - pos: 0.4558292,0.42837813
-    parent: null
+    parent: 943
     type: Transform
   - index: 0
     type: MapGrid
@@ -23822,9 +23822,17 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 293.15
       moles:
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23844,11 +23852,19 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 293.0791
       moles:
       - 21.81955
       - 82.08308
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23866,11 +23882,19 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 292.01544
       moles:
       - 21.739624
       - 81.7824
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23888,11 +23912,19 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 274.9969
       moles:
       - 20.460823
       - 76.97167
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23910,10 +23942,18 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 293.15
       moles:
       - 6666.982
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23932,11 +23972,19 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 284.07346
       moles:
       - 21.14285
       - 79.5374
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23954,11 +24002,19 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 147.925
       moles:
       - 10.912439
       - 41.05156
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23972,6 +24028,10 @@ entities:
       - 0
       - 0
       - 6666.982
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -23987,6 +24047,10 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 293.15
       moles:
@@ -23998,11 +24062,19 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     - volume: 2500
       temperature: 220.5375
       moles:
       - 5.4562197
       - 20.52578
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -30972,13 +31044,9 @@ entities:
   - color: '#0335FCFF'
     type: AtmosPipeColor
 - uid: 943
-  type: SawAdvanced
   components:
-  - pos: 38.567486,-14.251746
-    parent: 60
-    type: Transform
-  - canCollide: False
-    type: Physics
+  - index: 20
+    type: Map
 - uid: 944
   type: ScalpelLaser
   components:
@@ -35179,8 +35247,6 @@ entities:
   components:
   - parent: 7982
     type: Transform
-  - canCollide: False
-    type: Physics
   - containers:
       storagebase: !type:Container
         ents: []
@@ -41041,10 +41107,14 @@ entities:
   - pos: 11.479033,-35.451874
     parent: 60
     type: Transform
+  - unspawnedCount: 12
+    type: BallisticAmmoProvider
   - canCollide: False
     type: Physics
   - containers:
       storagebase: !type:Container
+        ents: []
+      ballistic-ammo: !type:Container
         ents: []
     type: ContainerContainer
 - uid: 2178
@@ -41053,10 +41123,14 @@ entities:
   - pos: 11.479033,-35.3425
     parent: 60
     type: Transform
+  - unspawnedCount: 12
+    type: BallisticAmmoProvider
   - canCollide: False
     type: Physics
   - containers:
       storagebase: !type:Container
+        ents: []
+      ballistic-ammo: !type:Container
         ents: []
     type: ContainerContainer
 - uid: 2179
@@ -53031,7 +53105,7 @@ entities:
   - pos: 48.5,-39.5
     parent: 60
     type: Transform
-  - SecondsUntilStateChange: -8729.462
+  - SecondsUntilStateChange: -8907.955
     state: Opening
     type: Door
 - uid: 3729
@@ -73707,7 +73781,7 @@ entities:
 - uid: 6383
   components:
   - pos: 0.4558292,0.42837813
-    parent: null
+    parent: 943
     type: Transform
   - index: 1
     type: MapGrid
@@ -73737,11 +73811,15 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     type: GridAtmosphere
 - uid: 6384
   components:
   - pos: 0.4558292,0.42837813
-    parent: null
+    parent: 943
     type: Transform
   - index: 2
     type: MapGrid
@@ -73772,11 +73850,15 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     type: GridAtmosphere
 - uid: 6385
   components:
   - pos: 0.4558292,0.42837813
-    parent: null
+    parent: 943
     type: Transform
   - index: 3
     type: MapGrid
@@ -73806,11 +73888,15 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     type: GridAtmosphere
 - uid: 6386
   components:
   - pos: 0.4558292,0.42837813
-    parent: null
+    parent: 943
     type: Transform
   - index: 4
     type: MapGrid
@@ -73841,11 +73927,15 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     type: GridAtmosphere
 - uid: 6387
   components:
   - pos: 0.4558292,0.42837813
-    parent: null
+    parent: 943
     type: Transform
   - index: 5
     type: MapGrid
@@ -73875,11 +73965,15 @@ entities:
       - 0
       - 0
       - 0
+      - 0
+      - 0
+      - 0
+      - 0
     type: GridAtmosphere
 - uid: 6388
   components:
   - pos: 0.4558292,0.42837813
-    parent: null
+    parent: 943
     type: Transform
   - index: 6
     type: MapGrid
@@ -73903,6 +73997,10 @@ entities:
       moles:
       - 21.824879
       - 82.10312
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -117529,7 +117627,7 @@ entities:
 - uid: 12837
   components:
   - pos: -70.95334,19.107948
-    parent: null
+    parent: 943
     type: Transform
   - index: 7
     type: MapGrid
@@ -117561,6 +117659,10 @@ entities:
       moles:
       - 21.824879
       - 82.10312
+      - 0
+      - 0
+      - 0
+      - 0
       - 0
       - 0
       - 0
@@ -129784,7 +129886,7 @@ entities:
   - pos: 31.5,-19.5
     parent: 60
     type: Transform
-  - SecondsUntilStateChange: -2242.361
+  - SecondsUntilStateChange: -2420.8545
     state: Closing
     type: Door
   - canCollide: False
@@ -157497,6 +157599,10 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
+  - containers:
+      storagebase: !type:Container
+        ents: []
+    type: ContainerContainer
 - uid: 18461
   type: ClothingNeckBling
   components:
@@ -169437,7 +169543,7 @@ entities:
 - uid: 20082
   components:
   - pos: 69.64972,-19.646618
-    parent: null
+    parent: 943
     type: Transform
   - index: 8
     type: MapGrid
@@ -175238,10 +175344,14 @@ entities:
   - pos: -24.464367,0.49183664
     parent: 60
     type: Transform
+  - unspawnedCount: 12
+    type: BallisticAmmoProvider
   - canCollide: False
     type: Physics
   - containers:
       storagebase: !type:Container
+        ents: []
+      ballistic-ammo: !type:Container
         ents: []
     type: ContainerContainer
 - uid: 21012
@@ -175250,10 +175360,14 @@ entities:
   - pos: -24.464367,0.74183667
     parent: 60
     type: Transform
+  - unspawnedCount: 12
+    type: BallisticAmmoProvider
   - canCollide: False
     type: Physics
   - containers:
       storagebase: !type:Container
+        ents: []
+      ballistic-ammo: !type:Container
         ents: []
     type: ContainerContainer
 - uid: 21013


### PR DESCRIPTION
fix #10053

Only map with it mapped and it does the 2nd-most damage to fireaxe which at least requires wielding.
