### PR TITLE
Standard contests + disarm math tweak

### DIFF
--- a/Content.Server/Contests/ContestsSystem.cs
+++ b/Content.Server/Contests/ContestsSystem.cs
@@ -17,6 +17,10 @@ namespace Content.Server.Contests
     public sealed class ContestsSystem : EntitySystem
     {
         [Dependency] private readonly SharedMobStateSystem _mobStateSystem = default!;
+
+        /// <summary>
+        /// Returns the roller's mass divided by the target's.
+        /// </summary>
         public float MassContest(EntityUid roller, EntityUid target, PhysicsComponent? rollerPhysics = null, PhysicsComponent? targetPhysics = null)
         {
             if (!Resolve(roller, ref rollerPhysics) || !Resolve(target, ref targetPhysics))
@@ -31,6 +35,12 @@ namespace Content.Server.Contests
             return (rollerPhysics.FixturesMass / targetPhysics.FixturesMass);
         }
 
+        /// <summary>
+        /// Tries to compare both entities damage to the damage they will enter crit at.
+        /// After that, it runs the % towards crit through a converter that smooths out and makes
+        /// the the ratios less severe.
+        /// Returns the roller's adjusted damage value divided by the target's. Higher is better for the roller.
+        /// <summary>
         public float DamageContest(EntityUid roller, EntityUid target, DamageableComponent? rollerDamage = null, DamageableComponent? targetDamage = null)
         {
             if (!Resolve(roller, ref rollerDamage) || !Resolve(target, ref targetDamage))
@@ -58,6 +68,11 @@ namespace Content.Server.Contests
             return DamageThresholdConverter(rollerDamageScore) / DamageThresholdConverter(targetDamageScore);
         }
 
+        /// <summary>
+        /// Finds the % of each entity's stamina damage towards its stam crit threshold.
+        /// It then runs the % towards the converter to smooth/soften it.
+        /// Returns the roller's decimal % divided by the target's. Higher value is better for the roller.
+        /// <summary>
         public float StaminaContest(EntityUid roller, EntityUid target, StaminaComponent? rollerStamina = null, StaminaComponent? targetStamina = null)
         {
             if (!Resolve(roller, ref rollerStamina) || !Resolve(target, ref targetStamina))
@@ -72,6 +87,11 @@ namespace Content.Server.Contests
             return DamageThresholdConverter(rollerDamageScore) / DamageThresholdConverter(targetDamageScore);
         }
 
+        /// <summary>
+        /// This will compare the roller and target's damage, mass, and stamina. See the functions for what each one does.
+        /// You can change the 'weighting' to make the tests weigh more or less than the other tests.
+        /// Returns a weighted average of all 3 tests.
+        /// <summary>
         public float OverallStrengthContest(EntityUid roller, EntityUid target, float damageWeight = 1f, float massWeight = 1f, float stamWeight = 1f)
         {
             var weightTotal = damageWeight + massWeight + stamWeight;
@@ -83,6 +103,10 @@ namespace Content.Server.Contests
                     + (StaminaContest(roller, target) * stamMultiplier));
         }
 
+        /// <summary>
+        /// This softens out the huge advantages that damage contests would lead to otherwise.
+        /// Once you are crit or near crit, we just let the massive advantages roll with what could be a 20x.
+        /// </summary>
         public float DamageThresholdConverter(float score)
         {
             return score switch

--- a/Content.Server/Contests/ContestsSystem.cs
+++ b/Content.Server/Contests/ContestsSystem.cs
@@ -1,0 +1,99 @@
+using Content.Shared.Damage;
+using Content.Shared.MobState.EntitySystems;
+using Content.Shared.MobState.Components;
+using Content.Server.Damage.Components;
+
+namespace Content.Server.Contests
+{
+    /// <summary>
+    /// Standardized contests.
+    /// A contest is figuring out, based on data in components on two entities,
+    /// which one has an advantage in a situation. The advantage is expressed by a multiplier.
+    /// 1 = No advantage to either party.
+    /// >1 = Advantage to roller
+    /// <1 = Advantage to target
+    /// Roller should be the entity with an advantage from being bigger/healthier/more skilled, etc.
+    /// <summary>
+    public sealed class ContestsSystem : EntitySystem
+    {
+        [Dependency] private readonly SharedMobStateSystem _mobStateSystem = default!;
+        public float MassContest(EntityUid roller, EntityUid target, PhysicsComponent? rollerPhysics = null, PhysicsComponent? targetPhysics = null)
+        {
+            if (!Resolve(roller, ref rollerPhysics) || !Resolve(target, ref targetPhysics))
+                return 1f;
+
+            if (rollerPhysics == null || targetPhysics == null)
+                return 1f;
+
+            if (targetPhysics.FixturesMass == 0)
+                return 1f;
+
+            return (rollerPhysics.FixturesMass / targetPhysics.FixturesMass);
+        }
+
+        public float DamageContest(EntityUid roller, EntityUid target, DamageableComponent? rollerDamage = null, DamageableComponent? targetDamage = null)
+        {
+            if (!Resolve(roller, ref rollerDamage) || !Resolve(target, ref targetDamage))
+                return 1f;
+
+            if (rollerDamage == null || targetDamage == null)
+                return 1f;
+
+            // First, we'll see what health they go into crit at.
+            float rollerThreshold = 100f;
+            float targetThreshold = 100f;
+
+            if (TryComp<MobStateComponent>(roller, out var rollerState) && rollerState != null &&
+                _mobStateSystem.TryGetEarliestIncapacitatedState(rollerState, 10000, out _, out var rollerCritThreshold))
+                rollerThreshold = (float) rollerCritThreshold;
+
+            if (TryComp<MobStateComponent>(target, out var targetState) && targetState != null &&
+                _mobStateSystem.TryGetEarliestIncapacitatedState(targetState, 10000, out _, out var targetCritThreshold))
+                targetThreshold = (float) targetCritThreshold;
+
+            // Next, we'll see how their damage compares
+            float rollerDamageScore = (float) rollerDamage.TotalDamage / rollerThreshold;
+            float targetDamageScore = (float) targetDamage.TotalDamage / targetThreshold;
+
+            return DamageThresholdConverter(rollerDamageScore) / DamageThresholdConverter(targetDamageScore);
+        }
+
+        public float StaminaContest(EntityUid roller, EntityUid target, StaminaComponent? rollerStamina = null, StaminaComponent? targetStamina = null)
+        {
+            if (!Resolve(roller, ref rollerStamina) || !Resolve(target, ref targetStamina))
+                return 1f;
+
+            if (rollerStamina == null || targetStamina == null)
+                return 1f;
+
+            var rollerDamageScore= rollerStamina.StaminaDamage / rollerStamina.CritThreshold;
+            var targetDamageScore = targetStamina.StaminaDamage / targetStamina.CritThreshold;
+
+            return DamageThresholdConverter(rollerDamageScore) / DamageThresholdConverter(targetDamageScore);
+        }
+
+        public float OverallStrengthContest(EntityUid roller, EntityUid target, float damageWeight = 1f, float massWeight = 1f, float stamWeight = 1f)
+        {
+            var weightTotal = damageWeight + massWeight + stamWeight;
+            var damageMultiplier = damageWeight / weightTotal;
+            var massMultiplier = massWeight / weightTotal;
+            var stamMultiplier = stamWeight / weightTotal;
+
+            return ((DamageContest(roller, target) * damageMultiplier) + (MassContest(roller, target) * massMultiplier)
+                    + (StaminaContest(roller, target) * stamMultiplier));
+        }
+
+        public float DamageThresholdConverter(float score)
+        {
+            return score switch
+            {
+                <= 0 => 1f,
+                <= 0.25f => 0.9f,
+                <= 0.5f => 0.75f,
+                <= 0.75f => 0.6f,
+                <= 0.95f => 0.45f,
+                _ => 0.05f
+            };
+        }
+    }
+}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes https://github.com/space-wizards/space-station-14/issues/9728
I swear there was another issue about the disarm math this also closes.

Adds contests (as in, contested rolls) in a helper system. You can get a value based on relative mass, relative damage, relative stamina damage, or all 3.

Anyway, this should cut down on code duplication a lot for what's starting to become a pretty standard mechanic.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Disarm math now takes into account mass, damage, and stamina damage.

