### PR TITLE
Increases size of desklamps and floodlights

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -15,6 +15,7 @@
     netsync: false
   - type: Item
     sprite: Objects/Misc/Lights/lights.rsi
+    size: 20
   - type: PointLight
     netsync: false
     enabled: false
@@ -79,6 +80,8 @@
   parent: BaseLamp
   description: A pole with powerful mounted lights on it.
   components:
+  - type: Item
+    size: 50
   - type: Sprite
     layers:
       - state: floodlight


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Desklamps inherited base item size 5, seems very small for an awkward sized object.

Similarly floodlights inherited size 5. These are meant to be structures really. I like the idea of carrying them in one hand so I made them 50 so people are less likely to backpack lots of them. Realistically to light a big area it'll be a light on a telescopic pole which a heavy battery in so.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Desk lamps and floodlights are now heavier.

