### PR TITLE
Fix identity bug

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -32,6 +32,7 @@
       - !type:WashCreamPieReaction
   - type: Flashable
   - type: Polymorphable
+  - type: Identity
   - type: Hands
   - type: MovementSpeedModifier
   - type: MovedByPressure


### PR DESCRIPTION
Identity component was removed during the species prototype cleanup. This adds it to `BaseMobOrganic`.

Fixes #10081 

:cl:
- fix: Fixed a bug preventing the Identity system from working for most players.
