### PR TITLE
Make miasma start being visible later

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -149,7 +149,7 @@ namespace Content.Server.Atmos.EntitySystems
                     if (moles >= gas.GasMolesVisible)
                     {
                         opacity[i] = (byte) (ContentHelpers.RoundToLevels(
-                            MathHelper.Clamp01(moles / gas.GasMolesVisibleMax) * 255, byte.MaxValue, _thresholds) * 255 / (_thresholds - 1));
+                            MathHelper.Clamp01((moles - gas.GasMolesVisible) / (gas.GasMolesVisibleMax - gas.GasMolesVisible)) * 255, byte.MaxValue, _thresholds) * 255 / (_thresholds - 1));
                     }
                     i++;
                 }
@@ -262,7 +262,7 @@ namespace Content.Server.Atmos.EntitySystems
                 // Not all grids have atmospheres.
                 if (!_overlay.TryGetValue(grid, out var gridData))
                     continue;
-                
+
                 List<GasOverlayChunk> dataToSend = new();
                 ev.UpdatedChunks[grid] = dataToSend;
 

--- a/Content.Shared/Atmos/Prototypes/GasPrototype.cs
+++ b/Content.Shared/Atmos/Prototypes/GasPrototype.cs
@@ -44,7 +44,10 @@ namespace Content.Shared.Atmos.Prototypes
         /// <summary>
         ///     Visibility for this gas will be max after this value.
         /// </summary>
-        public float GasMolesVisibleMax => GasMolesVisible * Atmospherics.FactorGasVisibleMax;
+        public float GasMolesVisibleMax => GasMolesVisible * GasVisibilityFactor;
+
+        [DataField("gasVisbilityFactor")]
+        public float GasVisibilityFactor = Atmospherics.FactorGasVisibleMax;
 
         /// <summary>
         ///     If this reagent is in gas form, this is the path to the overlay that will be used to make the gas visible.

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -66,6 +66,8 @@
   molarMass: 44
   gasOverlaySprite: /Textures/Effects/atmospherics.rsi
   gasOverlayState: miasma
+  gasMolesVisible: 2
+  gasVisbilityFactor: 3.5
   color: 56941E
   reagent: Miasma
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tested a bunch of values, now visible miasma actually indicates it could start becoming problematic soon. 

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Miasma is no longer visible until it's approaching dangerous levels.

