### PR TITLE
Add prices for gas canisters

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.Atmos.Piping.Unary.Components;
+using Content.Server.Cargo.Systems;
 using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.NodeGroups;
 using Content.Server.NodeContainer.Nodes;
@@ -23,6 +24,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
         [Dependency] private readonly UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly PricingSystem _pricing = default!;
         [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
 
         public override void Initialize()
@@ -36,6 +38,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             SubscribeLocalEvent<GasCanisterComponent, InteractUsingEvent>(OnCanisterInteractUsing);
             SubscribeLocalEvent<GasCanisterComponent, EntInsertedIntoContainerMessage>(OnCanisterContainerInserted);
             SubscribeLocalEvent<GasCanisterComponent, EntRemovedFromContainerMessage>(OnCanisterContainerRemoved);
+            SubscribeLocalEvent<GasCanisterComponent, PriceCalculationEvent>(CalculateCanisterPrice);
             // Bound UI subscriptions
             SubscribeLocalEvent<GasCanisterComponent, GasCanisterHoldingTankEjectMessage>(OnHoldingTankEjectMessage);
             SubscribeLocalEvent<GasCanisterComponent, GasCanisterChangeReleasePressureMessage>(OnCanisterChangeReleasePressure);
@@ -283,6 +286,26 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             containerAir.Clear();
             _atmosphereSystem.Merge(containerAir, buffer);
             containerAir.Multiply(containerAir.Volume / buffer.Volume);
+        }
+
+        private void CalculateCanisterPrice(EntityUid uid, GasCanisterComponent component, ref PriceCalculationEvent args)
+        {
+            float basePrice = 0; // moles of gas * price/mole
+            float totalMoles = 0; // total number of moles in can
+            float maxComponent = 0; // moles of the dominant gas
+            for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+            {
+                basePrice += component.Air.Moles[i] * _atmosphereSystem.GetGas(i).PricePerMole;
+                totalMoles += component.Air.Moles[i];
+                maxComponent = Math.Max(maxComponent, component.Air.Moles[i]);
+            }
+
+            // Pay more for gas canisters that are more pure
+            float purity = 1;
+            if (totalMoles > 0) {
+                purity = maxComponent / totalMoles;
+            }
+            args.Price += basePrice * purity;
         }
     }
 }

--- a/Content.Shared/Atmos/Prototypes/GasPrototype.cs
+++ b/Content.Shared/Atmos/Prototypes/GasPrototype.cs
@@ -80,5 +80,8 @@ namespace Content.Shared.Atmos.Prototypes
         public string? Reagent { get; } = default!;
 
         [DataField("color")] public string Color { get; } = string.Empty;
+
+        [DataField("pricePerMole")]
+        public float PricePerMole { get; set; } = 0;
     }
 }

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -6,7 +6,7 @@
   molarMass: 32
   color: 2887E8
   reagent: Oxygen
-  pricePerMole: 0.6
+  pricePerMole: 0.3
 
 - type: gas
   id: 1
@@ -16,7 +16,7 @@
   molarMass: 28
   color: DA1010
   reagent: Nitrogen
-  pricePerMole: 1.2
+  pricePerMole: 0.6
 
 - type: gas
   id: 2

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -6,6 +6,7 @@
   molarMass: 32
   color: 2887E8
   reagent: Oxygen
+  pricePerMole: 0.6
 
 - type: gas
   id: 1
@@ -15,6 +16,7 @@
   molarMass: 28
   color: DA1010
   reagent: Nitrogen
+  pricePerMole: 1.2
 
 - type: gas
   id: 2
@@ -24,6 +26,7 @@
   molarMass: 44
   color: 4e4e4e
   reagent: CarbonDioxide
+  pricePerMole: 0.4
 
 - type: gas
   id: 3
@@ -35,6 +38,7 @@
   gasOverlayState: plasma
   color: FF3300
   reagent: Plasma
+  pricePerMole: 2.5
 
 - type: gas
   id: 4
@@ -46,6 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
+  pricePerMole: 5
 
 - type: gas
   id: 5
@@ -57,6 +62,7 @@
   gasOverlayState: water_vapor
   color: bffffd
   reagent: Water
+  pricePerMole: 0.4
 
 - type: gas
   id: 6
@@ -70,6 +76,7 @@
   gasVisbilityFactor: 3.5
   color: 56941E
   reagent: Miasma
+  pricePerMole: 0.15
 
 - type: gas
   id: 7
@@ -79,6 +86,7 @@
   molarMass: 44
   color: 2887E8
   reagent: NitrousOxide
+  pricePerMole: 2.5
 
 - type: gas
   id: 8
@@ -91,3 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
+  pricePerMole: 7.5

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -6,7 +6,7 @@
     sprite: Structures/Storage/canister.rsi
     state: grey
   product: AirCanister
-  cost: 1000
+  cost: 2700
   category: Atmospherics
   group: market
 
@@ -18,7 +18,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 1000
+  cost: 2000
   category: Atmospherics
   group: market
 
@@ -30,7 +30,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 1000
+  cost: 3700
   category: Atmospherics
   group: market
 
@@ -42,7 +42,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 1000
+  cost: 1400
   category: Atmospherics
   group: market
 
@@ -54,7 +54,7 @@
 #    sprite: Structures/Storage/canister.rsi
 #    state: water_vapor
 #  product: WaterVaporCanister
-#  cost: 1000
+#  cost: 1300
 #  category: Atmospherics
 #  group: market
 
@@ -66,7 +66,7 @@
 #    sprite: Structures/Storage/canister.rsi
 #    state: orange
 #  product: PlasmaCanister
-#  cost: 2000
+#  cost: 7400
 #  category: Atmospherics
 #  group: market
 
@@ -78,6 +78,6 @@
 #    sprite: Structures/Storage/canister.rsi
 #    state: green
 #  product: TritiumCanister
-#  cost: 2000
+#  cost: 14300
 #  category: Atmospherics
 #  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -18,7 +18,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 2000
+  cost: 2300
   category: Atmospherics
   group: market
 
@@ -30,7 +30,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 3700
+  cost: 3200
   category: Atmospherics
   group: market
 
@@ -42,7 +42,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 1400
+  cost: 2600
   category: Atmospherics
   group: market
 
@@ -54,7 +54,7 @@
 #    sprite: Structures/Storage/canister.rsi
 #    state: water_vapor
 #  product: WaterVaporCanister
-#  cost: 1300
+#  cost: 2600
 #  category: Atmospherics
 #  group: market
 
@@ -66,7 +66,7 @@
 #    sprite: Structures/Storage/canister.rsi
 #    state: orange
 #  product: PlasmaCanister
-#  cost: 7400
+#  cost: 8500
 #  category: Atmospherics
 #  group: market
 
@@ -78,6 +78,6 @@
 #    sprite: Structures/Storage/canister.rsi
 #    state: green
 #  product: TritiumCanister
-#  cost: 14300
+#  cost: 15500
 #  category: Atmospherics
 #  group: market

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -81,7 +81,7 @@
     - type: GasPortable
     - type: GasCanister
     - type: StaticPrice
-      price: 200
+      price: 1000
 
 - type: entity
   parent: GasCanister

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -80,6 +80,8 @@
           volume: 1
     - type: GasPortable
     - type: GasCanister
+    - type: StaticPrice
+      price: 200
 
 - type: entity
   parent: GasCanister


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gas canisters can now be sold for money. Gas prices have never been more important on SS 14!

Gas canisters (the container themselves) have been given a small base value of 200. They are worth some money even if empty.

In addition, appraising gas canisters now considers the value of the gas inside. Gas prototypes have gained a "pricePerMole", which are consulted when appraising filled gas containers. However, you cannot simply dump the result of your tritium burn into a tank: NanoTrasen values pure gases (a container with a single type of gas) more valuable than mixed gases.

While here, re-compute the cargo prices for the canisters that are on the cargo manifest by using the appraisal tool, marking up the price by 50% (NanoTrasen needs to make money), and rounding to the nearest hundred credits.

**Screenshots**
![gas_prices](https://user-images.githubusercontent.com/3229565/181676996-04a4fe30-29ce-4e1d-bd0d-a18a14551392.png)

## Balance
**Does this mean a station can generate infinite money, if it has a miner?**
No, there are limited gas canisters on the station.

**Changelog**
:cl: notafet
- add: Gas canisters can now be sold for money.

