### PR TITLE
Fix syndicate shoulder holster whitelisting "MeeleeWeapon"

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -453,7 +453,7 @@
     whitelist:
       components:
         - Gun
-        - MeeleeWeapon
+        - MeleeWeapon
         - BallisticAmmoProvider
         - CartridgeAmmo
 


### PR DESCRIPTION
## Fix syndicate shoulder holster whitelisting "MeeleeWeapon"
I wanna stash my swords in there as intended.

**Changelog**
:cl:
- fix: syndicate shoulder holster will now accept melee weapons