### PR TITLE
Add lathe recipe tooltips

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.cs
@@ -26,7 +26,7 @@ namespace Content.Client.Lathe.UI
         public Button ServerConnectButton;
         public Button ServerSyncButton;
 
-        public const float RecipieTooltipDelay = 0.5f;
+        public const float RecipeTooltipDelay = 0.5f;
 
         public LatheBoundUserInterface Owner { get; }
 
@@ -121,7 +121,7 @@ namespace Content.Client.Lathe.UI
                 ev.ItemList.HideTooltip();
                 ev.ItemList.ToolTip = ev.ItemList[ev.ItemIndex].TooltipText;
             };
-            _items.TooltipDelay = RecipieTooltipDelay;
+            _items.TooltipDelay = RecipeTooltipDelay;
 
             _items.OnItemSelected += ItemSelected;
 

--- a/Content.Client/Lathe/UI/LatheMenu.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text;
 using Content.Client.Lathe.Components;
 using Content.Shared.Lathe;
 using Content.Shared.Materials;
@@ -24,6 +25,8 @@ namespace Content.Client.Lathe.UI
         public Button QueueButton;
         public Button ServerConnectButton;
         public Button ServerSyncButton;
+
+        public const float RecipieTooltipDelay = 0.5f;
 
         public LatheBoundUserInterface Owner { get; }
 
@@ -112,6 +115,14 @@ namespace Content.Client.Lathe.UI
                 SelectMode = ItemList.ItemListSelectMode.Button,
             };
 
+            // This is a shitty hack, because item lists apparently don't actually support tooltips. Yay..
+            _items.OnItemHover += (ev) =>
+            {
+                ev.ItemList.HideTooltip();
+                ev.ItemList.ToolTip = ev.ItemList[ev.ItemIndex].TooltipText;
+            };
+            _items.TooltipDelay = RecipieTooltipDelay;
+
             _items.OnItemSelected += ItemSelected;
 
             _amountLineEdit = new LineEdit()
@@ -152,6 +163,9 @@ namespace Content.Client.Lathe.UI
 
         public void ItemSelected(ItemList.ItemListSelectedEventArgs args)
         {
+            args.ItemList.HideTooltip();
+            args.ItemList.ToolTip = args.ItemList[args.ItemIndex].TooltipText;
+
             int.TryParse(_amountLineEdit.Text, out var quantity);
             if (quantity <= 0) quantity = 1;
             Owner.Queue(_shownRecipes[args.ItemIndex], quantity);
@@ -199,7 +213,26 @@ namespace Content.Client.Lathe.UI
             _items.Clear();
             foreach (var prototype in _shownRecipes)
             {
-                _items.AddItem(prototype.Name, prototype.Icon.Frame0());
+                var item = _items.AddItem(prototype.Name, prototype.Icon.Frame0());
+
+                StringBuilder sb = new();
+                bool first = true;
+                foreach (var (id, quantity) in prototype.RequiredMaterials)
+                {
+                    if (!_prototypeManager.TryIndex<MaterialPrototype>(id, out var proto))
+                        continue;
+
+                    if (first)
+                        first = false;
+                    else
+                        sb.Append("\n");
+
+                    sb.Append(quantity.ToString());
+                    sb.Append(" ");
+                    sb.Append(proto.Name);
+                }
+
+                item.TooltipText = sb.ToString();
             }
 
             PopulateDisabled();


### PR DESCRIPTION
Adds a basic tooltip to indicate the materials required for a given lathe recipe. The item list doesn't actually support tooltips, so its a bit janky, but its good enough for now.

![img](https://user-images.githubusercontent.com/60421075/181860563-a5061cfa-97a5-4500-8418-b1aa5768844a.png)
Mouse doesn't show up in the screenshot, but its hovering over the screwdriver.


:cl:
- add: Hovering over lathe recipes now shows a tooltip that lists the required materials.

