### PR TITLE
Adds trash tag to more items. New component "TrashOnEmpty"

### DIFF
--- a/Content.Server/Nutrition/Components/TrashOnEmptyComponent.cs
+++ b/Content.Server/Nutrition/Components/TrashOnEmptyComponent.cs
@@ -7,5 +7,10 @@ namespace Content.Server.Nutrition.Components
     [RegisterComponent]
     public sealed class TrashOnEmptyComponent : Component
     {
+        /// <summary>
+        /// The name of the solution of which to check emptiness
+        /// </summary>
+        [ViewVariables] [DataField("solution")]
+        public string Solution { get; set; } = string.Empty;
     }
 }

--- a/Content.Server/Nutrition/Components/TrashOnEmptyComponent.cs
+++ b/Content.Server/Nutrition/Components/TrashOnEmptyComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.Nutrition.Components
+{
+
+    [RegisterComponent]
+    public sealed class TrashOnEmptyComponent : Component
+    {
+
+    }
+}

--- a/Content.Server/Nutrition/Components/TrashOnEmptyComponent.cs
+++ b/Content.Server/Nutrition/Components/TrashOnEmptyComponent.cs
@@ -1,9 +1,11 @@
 namespace Content.Server.Nutrition.Components
 {
-
+    /// <summary>
+    /// Component that tags solution containers as trash when their contents have been emptied.
+    /// Used for things like used ketchup packets or used syringes.
+    /// </summary>
     [RegisterComponent]
     public sealed class TrashOnEmptyComponent : Component
     {
-
     }
 }

--- a/Content.Server/Nutrition/EntitySystems/TrashOnEmptySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/TrashOnEmptySystem.cs
@@ -1,0 +1,31 @@
+using Content.Server.Chemistry.Components.SolutionManager;
+using Content.Server.Chemistry.EntitySystems;
+using Content.Server.Nutrition.Components;
+using Content.Shared.Tag;
+
+namespace Content.Server.Nutrition.EntitySystems
+{
+    public sealed class TrashOnEmptySystem : EntitySystem
+    {
+        [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
+        [Dependency] private readonly TagSystem _tagSystem = default!;
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<TrashOnEmptyComponent, SolutionChangedEvent>(OnSolutionChange);
+        }
+
+        private void OnSolutionChange(EntityUid uid, TrashOnEmptyComponent component, SolutionChangedEvent args)
+        {
+            if (!EntityManager.HasComponent<SolutionContainerManagerComponent>((component).Owner))
+                return;
+            if (_tagSystem.HasTag(component.Owner, "Trash"))
+                return;
+            if (!_solutionContainerSystem.TryGetDrainableSolution(component.Owner, out var drinkSolution) || drinkSolution.DrainAvailable <= 0)
+            {
+                EntityManager.EnsureComponent<TagComponent>(component.Owner);
+                _tagSystem.AddTag(component.Owner, "Trash");
+            }
+        }
+    }
+}

--- a/Content.Server/Nutrition/EntitySystems/TrashOnEmptySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/TrashOnEmptySystem.cs
@@ -1,11 +1,8 @@
 using Content.Server.Chemistry.Components.SolutionManager;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Nutrition.Components;
-using Content.Server.Popups;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Popups;
 using Content.Shared.Tag;
-using Robust.Shared.Player;
 
 namespace Content.Server.Nutrition.EntitySystems
 {
@@ -13,29 +10,36 @@ namespace Content.Server.Nutrition.EntitySystems
     {
         [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
-        [Dependency] private readonly PopupSystem _popupSystem = default!;
 
         public override void Initialize()
         {
             base.Initialize();
+            SubscribeLocalEvent<TrashOnEmptyComponent, ComponentStartup>(OnStartup);
             SubscribeLocalEvent<TrashOnEmptyComponent, SolutionChangedEvent>(OnSolutionChange);
         }
 
-        private void OnSolutionChange(EntityUid uid, TrashOnEmptyComponent component, SolutionChangedEvent args)
+        public void OnStartup(EntityUid uid, TrashOnEmptyComponent component, ComponentStartup args)
+        {
+            CheckSolutions(component);
+        }
+
+        public void OnSolutionChange(EntityUid uid, TrashOnEmptyComponent component, SolutionChangedEvent args)
+        {
+            CheckSolutions(component);
+        }
+
+        public void CheckSolutions(TrashOnEmptyComponent component)
         {
             EntityManager.EnsureComponent<TagComponent>(component.Owner);
 
             if (!EntityManager.HasComponent<SolutionContainerManagerComponent>((component).Owner))
                 return;
 
-            if (_solutionContainerSystem.TryGetDrainableSolution(component.Owner, out var solution))
+            if (_solutionContainerSystem.TryGetSolution(component.Owner, component.Solution, out var solution))
                 UpdateTags(component, solution);
-            // have to do this because syringes don't have drainable solution OR injectable solution for some reason :(
-            if (_solutionContainerSystem.TryGetSolution(component.Owner, "injector", out var injectableSolution))
-                UpdateTags(component, injectableSolution);
         }
 
-        private void UpdateTags(TrashOnEmptyComponent component, Solution solution)
+        public void UpdateTags(TrashOnEmptyComponent component, Solution solution)
         {
             if (solution.DrainAvailable <= 0)
             {

--- a/Content.Server/Nutrition/EntitySystems/TrashOnEmptySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/TrashOnEmptySystem.cs
@@ -1,7 +1,11 @@
 using Content.Server.Chemistry.Components.SolutionManager;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Nutrition.Components;
+using Content.Server.Popups;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Popups;
 using Content.Shared.Tag;
+using Robust.Shared.Player;
 
 namespace Content.Server.Nutrition.EntitySystems
 {
@@ -9,6 +13,8 @@ namespace Content.Server.Nutrition.EntitySystems
     {
         [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
+        [Dependency] private readonly PopupSystem _popupSystem = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -17,15 +23,27 @@ namespace Content.Server.Nutrition.EntitySystems
 
         private void OnSolutionChange(EntityUid uid, TrashOnEmptyComponent component, SolutionChangedEvent args)
         {
+            EntityManager.EnsureComponent<TagComponent>(component.Owner);
+
             if (!EntityManager.HasComponent<SolutionContainerManagerComponent>((component).Owner))
                 return;
-            if (_tagSystem.HasTag(component.Owner, "Trash"))
-                return;
-            if (!_solutionContainerSystem.TryGetDrainableSolution(component.Owner, out var drinkSolution) || drinkSolution.DrainAvailable <= 0)
+
+            if (_solutionContainerSystem.TryGetDrainableSolution(component.Owner, out var solution))
+                UpdateTags(component, solution);
+            // have to do this because syringes don't have drainable solution OR injectable solution for some reason :(
+            if (_solutionContainerSystem.TryGetSolution(component.Owner, "injector", out var injectableSolution))
+                UpdateTags(component, injectableSolution);
+        }
+
+        private void UpdateTags(TrashOnEmptyComponent component, Solution solution)
+        {
+            if (solution.DrainAvailable <= 0)
             {
-                EntityManager.EnsureComponent<TagComponent>(component.Owner);
                 _tagSystem.AddTag(component.Owner, "Trash");
+                return;
             }
+            if (_tagSystem.HasTag(component.Owner, "Trash"))
+                _tagSystem.RemoveTag(component.Owner, "Trash");
         }
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -34,12 +34,11 @@
     - type: DrinkCanVisualizer
       stateClosed: icon
       stateOpen: icon_open
-  - type: Tag
-    tags:
-    - Trash
   - type: ItemCooldown
   - type: Recyclable
   - type: SpaceGarbage
+  - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkCanBaseFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -174,6 +174,7 @@
         maxVol: 20
   - type: Sprite
     sprite: Objects/Consumable/Drinks/hot_coffee.rsi
+  - type: TrashOnEmpty
 
 - type: entity
   parent: DrinkBaseCup
@@ -191,6 +192,7 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/teacup.rsi
     state: icon-1
+  - type: TrashOnEmpty
 
 - type: entity
   parent: DrinkBaseCup
@@ -210,6 +212,7 @@
     state: icon
   - type: Item
     sprite: Objects/Consumable/Drinks/lean.rsi
+  - type: TrashOnEmpty
 
 - type: entity
   parent: DrinkBaseCup

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -175,6 +175,7 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/hot_coffee.rsi
   - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkBaseCup
@@ -193,6 +194,7 @@
     sprite: Objects/Consumable/Drinks/teacup.rsi
     state: icon-1
   - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkBaseCup
@@ -213,6 +215,7 @@
   - type: Item
     sprite: Objects/Consumable/Drinks/lean.rsi
   - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkBaseCup
@@ -231,3 +234,5 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/water_cup.rsi
     state: icon-1
+  - type: TrashOnEmpty
+    solution: drink

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -34,6 +34,7 @@
     sprite: Objects/Consumable/Food/condiments.rsi
     state: packet-empty
   - type: TrashOnEmpty
+    solution: food
 
 - type: entity
   parent: FoodCondimentPacket
@@ -359,6 +360,7 @@
       maxFillLevels: 6
       fillBaseName: bottle-alpha-
   - type: TrashOnEmpty
+    solution: food
 
 - type: entity
   parent: FoodCondimentBottle
@@ -504,6 +506,7 @@
       maxFillLevels: 3
       fillBaseName: bottle-s-alpha-
   - type: TrashOnEmpty
+    solution: food
 
 - type: entity
   parent: FoodCondimentBottleSmall

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -33,6 +33,7 @@
   - type: Icon
     sprite: Objects/Consumable/Food/condiments.rsi
     state: packet-empty
+  - type: TrashOnEmpty
 
 - type: entity
   parent: FoodCondimentPacket
@@ -357,6 +358,7 @@
     - type: SolutionContainerVisualizer
       maxFillLevels: 6
       fillBaseName: bottle-alpha-
+  - type: TrashOnEmpty
 
 - type: entity
   parent: FoodCondimentBottle
@@ -501,6 +503,7 @@
     - type: SolutionContainerVisualizer
       maxFillLevels: 3
       fillBaseName: bottle-s-alpha-
+  - type: TrashOnEmpty
 
 - type: entity
   parent: FoodCondimentBottleSmall

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -43,7 +43,9 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     heldPrefix: packet
     size: 3
-
+  - type: Tag
+    tags:
+      - Trash
 # Tins
 
 # Need something that you can open these tins with. I suggest a prying or cutting tool.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -489,6 +489,9 @@
     netsync: false
   - type: Item
     size: 1
+  - type: Tag
+    tags:
+      - Trash
 
 - type: entity
   name: onion

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -298,4 +298,3 @@
         reagents:
         - ReagentId: Corpium
           Quantity: 10
-

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -232,6 +232,7 @@
         reagents:
         - ReagentId: Ephedrine
           Quantity: 15
+  - type: TrashOnEmpty
 
 - type: entity
   name: inaprovaline syringe
@@ -245,6 +246,7 @@
         reagents:
         - ReagentId: Inaprovaline
           Quantity: 15
+  - type: TrashOnEmpty
 
 - type: entity
   name: tranexamic acid syringe
@@ -258,6 +260,7 @@
         reagents:
         - ReagentId: TranexamicAcid
           Quantity: 15
+  - type: TrashOnEmpty
 
 - type: entity
   name: spaceacillin syringe
@@ -271,6 +274,7 @@
         reagents:
         - ReagentId: Spaceacillin
           Quantity: 15
+  - type: TrashOnEmpty
 
 - type: entity
   name: ipecac syringe
@@ -284,6 +288,7 @@
         reagents:
         - ReagentId: Ipecac
           Quantity: 15
+  - type: TrashOnEmpty
 
 #this is where all the syringes are so i didn't know where to put it
 - type: entity
@@ -298,3 +303,5 @@
         reagents:
         - ReagentId: Corpium
           Quantity: 10
+  - type: TrashOnEmpty
+

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -232,7 +232,6 @@
         reagents:
         - ReagentId: Ephedrine
           Quantity: 15
-  - type: TrashOnEmpty
 
 - type: entity
   name: inaprovaline syringe
@@ -246,7 +245,6 @@
         reagents:
         - ReagentId: Inaprovaline
           Quantity: 15
-  - type: TrashOnEmpty
 
 - type: entity
   name: tranexamic acid syringe
@@ -260,7 +258,6 @@
         reagents:
         - ReagentId: TranexamicAcid
           Quantity: 15
-  - type: TrashOnEmpty
 
 - type: entity
   name: spaceacillin syringe
@@ -274,7 +271,6 @@
         reagents:
         - ReagentId: Spaceacillin
           Quantity: 15
-  - type: TrashOnEmpty
 
 - type: entity
   name: ipecac syringe
@@ -288,7 +284,6 @@
         reagents:
         - ReagentId: Ipecac
           Quantity: 15
-  - type: TrashOnEmpty
 
 #this is where all the syringes are so i didn't know where to put it
 - type: entity
@@ -303,5 +298,4 @@
         reagents:
         - ReagentId: Corpium
           Quantity: 10
-  - type: TrashOnEmpty
 

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -40,6 +40,8 @@
     sprite: Objects/Specific/Chemistry/beaker.rsi
   - type: Spillable
     solution: drink
+  - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   name: bottle
@@ -161,7 +163,7 @@
   components:
   - type: SolutionContainerManager
     solutions:
-      drink: 
+      drink:
         maxVol: 30
         reagents:
         - ReagentId: Ephedrine
@@ -174,7 +176,7 @@
   components:
   - type: SolutionContainerManager
     solutions:
-      drink: 
+      drink:
         maxVol: 30
         reagents:
         - ReagentId: Omnizine

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -235,6 +235,8 @@
     injectOnly: false
   - type: Spillable
     solution: injector
+  - type: TrashOnEmpty
+    solution: injector
   - type: Appearance
     visuals:
       # this visualizer used for reagent inside


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds trash tag to corn cobs and empty tins

- Adds new component: TrashOnEmpty. It adds the trash tag to items once they've run out of solution. Finally, janitors can throw away the teacups and ketchup packets. 

- Adds the component to: syringes that come with stuff in them, condiment packets, condiment bottles, teacups, and coffee cups

part of #9772

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Janitors can now throw away more things, including empty teacups and empty ketchup packets!
