### PR TITLE
Belt Storage Fix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
@@ -10,9 +10,6 @@
   - type: Clothing
     slots: [belt]
     quickEquip: false
-  - type: Storage
-    equipSound:
-      path: /Audio/Items/belt_equip.ogg
 
 - type: entity
   abstract: true
@@ -21,6 +18,8 @@
   components:
   - type: Storage
     capacity: 40
+    equipSound:
+      path: /Audio/Items/belt_equip.ogg
   - type: UserInterface
     interfaces:
     - key: enum.StorageUiKey.Key


### PR DESCRIPTION
Fixes #10123

Removed storage component from ClothingBeltBase and moved the belt equip sound effect to ClothingBeltStorageBase.