### PR TITLE
spruced up canned food a bit

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -64,7 +64,7 @@
       behaviors:
       - !type:PlaySoundBehavior
         sound:
-          collection: canOpenSounds
+          path: /Audio/Items/can_open3.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
           FoodTinPeachesOpen:
@@ -115,7 +115,7 @@
       behaviors:
       - !type:PlaySoundBehavior
         sound:
-          collection: canOpenSounds
+          path: /Audio/Items/can_open3.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
           FoodTinPeachesMaintOpen:
@@ -165,7 +165,7 @@
       behaviors:
       - !type:PlaySoundBehavior
         sound:
-          collection: canOpenSounds
+          path: /Audio/Items/can_open3.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
           FoodTinBeansOpen:
@@ -204,6 +204,7 @@
   parent: FoodTinBase
   id: FoodTinMRE
   name: tinned meat
+  description: A standard issue tin of meat with a convenient pull tab.
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/mre.rsi
@@ -216,7 +217,7 @@
       behaviors:
       - !type:PlaySoundBehavior
         sound:
-          collection: canOpenSounds
+          path: /Audio/Items/can_open3.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
           FoodTinMREOpen:
@@ -224,12 +225,18 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: SpawnItemsOnUse
+    items:
+      - id: FoodTinMREOpen
+    sound:
+      path: /Audio/Items/can_open3.ogg
 
 
 - type: entity
   parent: FoodTinBase
   id: FoodTinMREOpen
   name: tinned meat
+  description: A standard issue tin of meat.
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/mre.rsi


### PR DESCRIPTION
Fixes #10151

Added descriptions to sealed/opened "tinned meat".

Added SpawnItemsOnUse component to tinned meat, so you can open it without resorting to violence and to make it more newbie friendly. You can still open it the old way.

Changed sound effect for all canned foods to one that doesn't hiss like a soda can. If your can of beans or peaches spews gas when you open it, you really shouldn't eat it.