### PR TITLE
Adds detailed logging to AME and PA interactions

### DIFF
--- a/Content.Server/AME/Components/AMEControllerComponent.cs
+++ b/Content.Server/AME/Components/AMEControllerComponent.cs
@@ -178,10 +178,10 @@ namespace Content.Server.AME.Components
                 var humanReadableState = _injecting ? "Inject" : "Not inject";
 
                 if (msg.Button == UiButton.IncreaseFuel || msg.Button == UiButton.DecreaseFuel)
-                    _adminLogger.Add(LogType.Action, LogImpact.High, $"{_entities.ToPrettyString(mindComponent.Owner):player} has set the AME to inject {InjectionAmount} while set to {humanReadableState}");
+                    _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"{_entities.ToPrettyString(mindComponent.Owner):player} has set the AME to inject {InjectionAmount} while set to {humanReadableState}");
 
                 if (msg.Button == UiButton.ToggleInjection)
-                    _adminLogger.Add(LogType.Action, LogImpact.High, $"{_entities.ToPrettyString(mindComponent.Owner):player} has set the AME to {humanReadableState}");
+                    _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"{_entities.ToPrettyString(mindComponent.Owner):player} has set the AME to {humanReadableState}");
             }
 
             GetAMENodeGroup()?.UpdateCoreVisuals();

--- a/Content.Server/AME/Components/AMEControllerComponent.cs
+++ b/Content.Server/AME/Components/AMEControllerComponent.cs
@@ -79,8 +79,6 @@ namespace Content.Server.AME.Components
             {
                 var availableInject = fuelJar.FuelAmount >= InjectionAmount ? InjectionAmount : fuelJar.FuelAmount;
                 _powerSupplier.MaxSupply = group.InjectFuel(availableInject, out var overloading);
-                if(overloading)
-                    _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"The AME was set to inject {InjectionAmount}, causing it to start overloading.");
                 fuelJar.FuelAmount -= availableInject;
                 InjectSound(overloading);
                 UpdateUserInterface();

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -1,12 +1,16 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Content.Server.Administration.Logs;
+using Content.Server.Mind.Components;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.UserInterface;
+using Content.Shared.Database;
 // using Content.Server.WireHacking;
 using Content.Shared.Singularity.Components;
 using Robust.Server.GameObjects;
+using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Utility;
 // using static Content.Shared.Wires.SharedWiresComponent;
@@ -25,6 +29,7 @@ namespace Content.Server.ParticleAccelerator.Components
     {
         [Dependency] private readonly IEntityManager _entMan = default!;
         [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly IAdminLogManager _adminLogger = default!;
 
         [ViewVariables]
         private BoundUserInterface? UserInterface => Owner.GetUIOrNull(ParticleAcceleratorControlBoxUiKey.Key);
@@ -143,7 +148,7 @@ namespace Content.Server.ParticleAccelerator.Components
                     break;
 
                 case ParticleAcceleratorSetPowerStateMessage stateMessage:
-                    SetStrength(stateMessage.State);
+                    SetStrength(stateMessage.State, obj.Session);
                     break;
 
                 case ParticleAcceleratorRescanPartsMessage _:
@@ -501,7 +506,7 @@ namespace Content.Server.ParticleAccelerator.Components
             UpdatePartVisualStates();
         }
 
-        public void SetStrength(ParticleAcceleratorPowerState state)
+        public void SetStrength(ParticleAcceleratorPowerState state, IPlayerSession? playerSession = null)
         {
             if (_wireStrengthCut)
             {
@@ -516,6 +521,12 @@ namespace Content.Server.ParticleAccelerator.Components
             _selectedStrength = state;
             UpdateAppearance();
             UpdatePartVisualStates();
+
+            // Logging
+            _entMan.TryGetComponent(playerSession?.AttachedEntity, out MindComponent? mindComponent);
+            var humanReadableState = _isEnabled ? "Turned On" : "Turned Off";
+            if(mindComponent != null && state == MaxPower)
+                _adminLogger.Add(LogType.Action, LogImpact.High, $"{_entMan.ToPrettyString(mindComponent.Owner):player} has set the strength of the Particle Accelerator to a dangerous level while the PA was {humanReadableState}");
 
             if (_isEnabled)
             {

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -526,7 +526,7 @@ namespace Content.Server.ParticleAccelerator.Components
             _entMan.TryGetComponent(playerSession?.AttachedEntity, out MindComponent? mindComponent);
             var humanReadableState = _isEnabled ? "Turned On" : "Turned Off";
             if(mindComponent != null && state == MaxPower)
-                _adminLogger.Add(LogType.Action, LogImpact.High, $"{_entMan.ToPrettyString(mindComponent.Owner):player} has set the strength of the Particle Accelerator to a dangerous level while the PA was {humanReadableState}");
+                _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"{_entMan.ToPrettyString(mindComponent.Owner):player} has set the strength of the Particle Accelerator to a dangerous level while the PA was {humanReadableState}");
 
             if (_isEnabled)
             {


### PR DESCRIPTION
## About the PR 

Shrimply adds more detail to Admin Logging when it comes to interacting with the values of AME and PA.

This makes it much, much easier to sus out who was the last person that interacted with both engines AND DID SOMETHING BAD.
I had a few experiences where one of them were sabotaged, but someone else interacted with the console trying to fix it, so I couldn't tell who did what.

**Screenshots**

![Screenshot 2022-07-30 131137](https://user-images.githubusercontent.com/52474532/181925795-ee564c85-1859-4b6b-b083-318266a3da23.jpg)
![Screenshot 2022-07-30 131257](https://user-images.githubusercontent.com/52474532/181925798-2cf83175-8162-446e-bcb8-a9c22760fa79.jpg)

