### PR TITLE
Fix invisible helmet icons

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -65,8 +65,6 @@
   id: ClothingHeadEVAHelmetBase
   name: base space helmet
   components:
-  - type: Sprite
-    state: icon # default state used by most inheritors
   - type: Item
     size: 10
   - type: PressureProtection

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -65,6 +65,8 @@
   id: ClothingHeadEVAHelmetBase
   name: base space helmet
   components:
+  - type: Sprite
+    state: icon # default state used by most inheritors
   - type: Item
     size: 10
   - type: PressureProtection
@@ -87,6 +89,8 @@
   name: base hardsuit helmet
   noSpawn: true
   components:
+  - type: Sprite
+    state: icon # default state used by most inheritors
   - type: Clickable
   - type: InteractionOutline
   - type: Clothing


### PR DESCRIPTION
Toggleable hardsuit helmets stopped inheriting from normal headwear as they are no longer standard items, but in the process lost the inherited default sprite state leading to invisible inventory & action icons.

:cl:
- fix: Fixed some some hardsuit helmet icons not showing up in the inventory and actions UI

