### PR TITLE
Add dizziness as a symptom of bloodloss

### DIFF
--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -113,7 +113,9 @@ public sealed class BloodstreamSystem : EntitySystem
                 _damageableSystem.TryChangeDamage(uid, amt, true, false);
 
                 // Apply dizziness as a symptom of bloodloss.
-                _drunkSystem.TryApplyDrunkenness(uid, bloodstream.UpdateInterval * (bloodstream.BloodlossThreshold / bloodPercentage), false);
+                // So, threshold is 0.9, you have 0.85 percent blood, it adds (5 * 1.05) or 5.25 seconds of drunkenness.
+                // So, it'd max at 1.9 by default with 0% blood.
+                _drunkSystem.TryApplyDrunkenness(uid, bloodstream.UpdateInterval * (1 + (bloodstream.BloodlossThreshold - bloodPercentage)), false);
             }
             else
             {

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.IdentityManagement;
 using Content.Shared.MobState.Components;
 using Content.Shared.Popups;
+using Content.Shared.Drunk;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -27,6 +28,8 @@ public sealed class BloodstreamSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
+
+    [Dependency] private readonly SharedDrunkSystem _drunkSystem = default!;
 
     // TODO here
     // Update over time. Modify bloodloss damage in accordance with (amount of blood / max blood level), and reduce bleeding over time
@@ -108,6 +111,9 @@ public sealed class BloodstreamSystem : EntitySystem
                 var amt = bloodstream.BloodlossDamage / (0.1f + bloodPercentage);
 
                 _damageableSystem.TryChangeDamage(uid, amt, true, false);
+
+                // Apply dizziness as a symptom of bloodloss.
+                _drunkSystem.TryApplyDrunkenness(uid, bloodstream.UpdateInterval * (bloodstream.BloodlossThreshold / bloodPercentage), false);
             }
             else
             {

--- a/Content.Server/Chemistry/ReagentEffects/Drunk.cs
+++ b/Content.Server/Chemistry/ReagentEffects/Drunk.cs
@@ -11,9 +11,15 @@ public sealed class Drunk : ReagentEffect
     [DataField("boozePower")]
     public float BoozePower = 2f;
 
+    /// <summary>
+    ///     Whether speech should be slurred.
+    /// </summary>
+    [DataField("slurSpeech")]
+    public bool SlurSpeech = true;
+
     public override void Effect(ReagentEffectArgs args)
     {
         var drunkSys = args.EntityManager.EntitySysManager.GetEntitySystem<SharedDrunkSystem>();
-        drunkSys.TryApplyDrunkenness(args.SolutionEntity, BoozePower);
+        drunkSys.TryApplyDrunkenness(args.SolutionEntity, BoozePower, SlurSpeech);
     }
 }

--- a/Content.Shared/Drunk/DrunkSystem.cs
+++ b/Content.Shared/Drunk/DrunkSystem.cs
@@ -10,13 +10,15 @@ public abstract class SharedDrunkSystem : EntitySystem
     [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
     [Dependency] private readonly SharedSlurredSystem _slurredSystem = default!;
 
-    public void TryApplyDrunkenness(EntityUid uid, float boozePower,
+    public void TryApplyDrunkenness(EntityUid uid, float boozePower, bool applySlur = true,
         StatusEffectsComponent? status = null)
     {
         if (!Resolve(uid, ref status, false))
             return;
 
-        _slurredSystem.DoSlur(uid, TimeSpan.FromSeconds(boozePower), status);
+        if (applySlur)
+            _slurredSystem.DoSlur(uid, TimeSpan.FromSeconds(boozePower), status);
+
         if (!_statusEffectsSystem.HasStatusEffect(uid, DrunkKey, status))
         {
             _statusEffectsSystem.TryAddStatusEffect<DrunkComponent>(uid, DrunkKey, TimeSpan.FromSeconds(boozePower), true, status);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It was suggested by someone in idea guys. Helps with our medical diagnostics goals. The start of the Rane blood mechanics arc. Magnitude is affected by how far below your threshold you are.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- add: Bloodloss now makes you dizzy.

