### PR TITLE
add missing Gas to AirAlarm component

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -28,6 +28,7 @@
       WaterVapor: danger
       Miasma: danger
       NitrousOxide: danger
+      Frezon: danger
   - type: AtmosAlarmable
     alarmedBy: ["AirAlarm"]
   - type: AtmosDevice


### PR DESCRIPTION
Fixes #10164

AirAlarm component configuration was missing "Frezon" as a threshold