### PR TITLE
crew monitor window now has consistent size

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -19,6 +19,7 @@ namespace Content.Client.Access.UI
         private readonly IdCardConsoleBoundUserInterface _owner;
 
         private readonly Dictionary<string, Button> _accessButtons = new();
+        private readonly int _maxLength = 30;
 
         private string? _lastFullName;
         private string? _lastJobTitle;
@@ -87,6 +88,7 @@ namespace Content.Client.Access.UI
             if (!fullNameDirty)
             {
                 FullNameLineEdit.Text = state.TargetIdFullName ?? string.Empty;
+                FullNameLineEdit.Text = FullNameLineEdit.Text.Substring(0, Math.Min(FullNameLineEdit.Text.Length, _maxLength));
             }
 
             FullNameSaveButton.Disabled = !interfaceEnabled || !fullNameDirty;
@@ -96,6 +98,7 @@ namespace Content.Client.Access.UI
             if (!jobTitleDirty)
             {
                 JobTitleLineEdit.Text = state.TargetIdJobTitle ?? string.Empty;
+                JobTitleLineEdit.Text = JobTitleLineEdit.Text.Substring(0, Math.Min(JobTitleLineEdit.Text.Length, _maxLength));
             }
 
             JobTitleSaveButton.Disabled = !interfaceEnabled || !jobTitleDirty;
@@ -116,8 +119,8 @@ namespace Content.Client.Access.UI
         private void SubmitData()
         {
             _owner.SubmitData(
-                FullNameLineEdit.Text,
-                JobTitleLineEdit.Text,
+                FullNameLineEdit.Text.Substring(0, Math.Min(FullNameLineEdit.Text.Length, _maxLength)),
+                JobTitleLineEdit.Text.Substring(0, Math.Min(JobTitleLineEdit.Text.Length, _maxLength)),
                 // Iterate over the buttons dictionary, filter by `Pressed`, only get key from the key/value pair
                 _accessButtons.Where(x => x.Value.Pressed).Select(x => x.Key).ToList());
         }

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -19,7 +19,6 @@ namespace Content.Client.Access.UI
         private readonly IdCardConsoleBoundUserInterface _owner;
 
         private readonly Dictionary<string, Button> _accessButtons = new();
-        private readonly int _maxLength = 30;
 
         private string? _lastFullName;
         private string? _lastJobTitle;
@@ -117,8 +116,8 @@ namespace Content.Client.Access.UI
         private void SubmitData()
         {
             _owner.SubmitData(
-                FullNameLineEdit.Text.Substring(0, Math.Min(FullNameLineEdit.Text.Length, _maxLength)),
-                JobTitleLineEdit.Text.Substring(0, Math.Min(JobTitleLineEdit.Text.Length, _maxLength)),
+                FullNameLineEdit.Text,
+                JobTitleLineEdit.Text,
                 // Iterate over the buttons dictionary, filter by `Pressed`, only get key from the key/value pair
                 _accessButtons.Where(x => x.Value.Pressed).Select(x => x.Key).ToList());
         }

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -88,7 +88,6 @@ namespace Content.Client.Access.UI
             if (!fullNameDirty)
             {
                 FullNameLineEdit.Text = state.TargetIdFullName ?? string.Empty;
-                FullNameLineEdit.Text = FullNameLineEdit.Text.Substring(0, Math.Min(FullNameLineEdit.Text.Length, _maxLength));
             }
 
             FullNameSaveButton.Disabled = !interfaceEnabled || !fullNameDirty;
@@ -98,7 +97,6 @@ namespace Content.Client.Access.UI
             if (!jobTitleDirty)
             {
                 JobTitleLineEdit.Text = state.TargetIdJobTitle ?? string.Empty;
-                JobTitleLineEdit.Text = JobTitleLineEdit.Text.Substring(0, Math.Min(JobTitleLineEdit.Text.Length, _maxLength));
             }
 
             JobTitleSaveButton.Disabled = !interfaceEnabled || !jobTitleDirty;

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
             Title="{Loc 'crew-monitoring-user-interface-title'}"
-            SetSize="450 400">
+            SetSize="775 400">
     <ScrollContainer HorizontalExpand="True"
                      VerticalExpand="True">
         <GridContainer Name="SensorsTable"

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -15,11 +15,6 @@ namespace Content.Client.Medical.CrewMonitoring
     {
         private List<Control> _rowsContent = new();
 
-        // Limiter for how long a mobs's name or job can be. Without this the HoP can set a ridiculously
-        // long name and make it near impossible for someone to use the crew monitoring window.
-        private int _nameMaxLength = 30;
-        private int _jobMaxLength = 30;
-
         public static int IconSize = 16; // XAML has a `VSeparationOverride` of 20 for each row.
 
         public CrewMonitoringWindow()
@@ -42,7 +37,7 @@ namespace Content.Client.Medical.CrewMonitoring
                 // format: UserName (Job)
                 var nameLabel = new Label()
                 {
-                    Text = $"{sensor.Name.Substring(0, Math.Min(sensor.Name.Length, _nameMaxLength))} ({sensor.Job.Substring(0, Math.Min(sensor.Job.Length, _jobMaxLength))})"
+                    Text = $"{sensor.Name} ({sensor.Job})"
                 };
                 nameLabel.HorizontalExpand = true;
                 SensorsTable.AddChild(nameLabel);

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -15,6 +15,11 @@ namespace Content.Client.Medical.CrewMonitoring
     {
         private List<Control> _rowsContent = new();
 
+        // Limiter for how long a mobs's name or job can be. Without this the HoP can set a ridiculously
+        // long name and make it near impossible for someone to use the crew monitoring window.
+        private int _nameMaxLength = 30;
+        private int _jobMaxLength = 30;
+
         public static int IconSize = 16; // XAML has a `VSeparationOverride` of 20 for each row.
 
         public CrewMonitoringWindow()
@@ -37,8 +42,9 @@ namespace Content.Client.Medical.CrewMonitoring
                 // format: UserName (Job)
                 var nameLabel = new Label()
                 {
-                    Text = $"{sensor.Name} ({sensor.Job})"
+                    Text = $"{sensor.Name.Substring(0, Math.Min(sensor.Name.Length, _nameMaxLength))} ({sensor.Job.Substring(0, Math.Min(sensor.Job.Length, _jobMaxLength))})"
                 };
+                nameLabel.HorizontalExpand = true;
                 SensorsTable.AddChild(nameLabel);
                 _rowsContent.Add(nameLabel);
 

--- a/Content.Shared/Access/Components/SharedIdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/SharedIdCardConsoleComponent.cs
@@ -8,8 +8,8 @@ namespace Content.Shared.Access.Components
     [NetworkedComponent]
     public abstract class SharedIdCardConsoleComponent : Component
     {
-        public const int MaxFullNameLength = 256;
-        public const int MaxJobTitleLength = 256;
+        public const int MaxFullNameLength = 30;
+        public const int MaxJobTitleLength = 30;
 
         public static string PrivilegedIdCardSlotId = "IdCardConsole-privilegedId";
         public static string TargetIdCardSlotId = "IdCardConsole-targetId";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I was getting annoyed at how every time I used the crew monitor console I would have to adjust the window to see their coords. This is because various names and jobs have different lengths and cause the window scroll to the right. Names and Jobs (set by the HoP) have a very high limit (which can make for hilarious centcom announcements). To address this I've capped the names and jobs for the crew monitor console's character limit to 30 each. This doesn't affect anything else, just how it displays on the crew monitor console. Then I've widened the window size to 775 pixels, this fit the worse case scenario of a name = '123456789012345678901234567890' and job = '123456789012345678901234567890'. Lastly I've updated the text for the name / job to horizontally fill.

fixes: #9285

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
Before
![Screenshot_2022-07-30_20-46-06](https://user-images.githubusercontent.com/8183999/182011068-77bf359f-5f34-48a2-a041-7460977cd23f.png)
After
![Screenshot_2022-07-30_23-58-44](https://user-images.githubusercontent.com/8183999/182011069-debd58b7-fe34-4c49-95fc-cdb3a73f03bc.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: crew monitoring console now has proper window size
- fix: id card console limits name and job lengths to 30 characters

