### PR TITLE
Give FingerprintMask and Fiber component to ThievingGloves

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -250,3 +250,7 @@
     - type: Thieving
       stealTime: 1.5
       stealthy: true
+    - type: Fiber
+      fiberMaterial: fibers-synthetic
+      fiberColor: fibers-black
+    - type: FingerprintMask


### PR DESCRIPTION
## Give FingerprintMask and Fiber component to ThievingGloves
Stealth traitor gloves not hiding fingerprint like their plain black gloves counterpart - that does not look intentional.

**Changelog**
:cl:
- fix: Thieving Gloves will not reveal your fingerprints to detective