### PR TITLE
Add petting interaction to bots

### DIFF
--- a/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
@@ -33,6 +33,16 @@ petting-failure-sloth = You reach out to pet {THE($target)}, but {SUBJECT($targe
 petting-failure-holo = You reach out to pet {THE($target)}, but {POSS-ADJ($target)} spikes almost impale your hand!
 petting-failure-dragon = You raise your hand, but as {THE($target)} roars, you decide you'd rather not be toasty carp food.
 
+## Petting silicons
+
+petting-success-honkbot = You pet {THE{$target}} on {POSS-ADJ($target)} slippery metal head.
+petting-success-cleanbot = You pet {THE{$target}} on {POSS-ADJ($target)} damp metal head.
+petting-success-medibot = You pet {THE{$target}} on {POSS-ADJ($target)} sterile metal head.
+
+petting-failure-honkbot = You reach out to pet {THE($target)}, but {SUBJECT($target)} honks in refusal!
+petting-failure-cleanbot = You reach out to pet {THE($target)}, but {SUBJECT($target)} {CONJUGATE-BE($target)} busy mopping!
+petting-failure-medibot = You reach out to pet {THE($target)}, but {POSS-ADJ($target)} syringe nearly stabs your hand!
+
 ## Knocking on windows
 
 # Shown when knocking on a window

--- a/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
@@ -35,9 +35,9 @@ petting-failure-dragon = You raise your hand, but as {THE($target)} roars, you d
 
 ## Petting silicons
 
-petting-success-honkbot = You pet {THE{$target}} on {POSS-ADJ($target)} slippery metal head.
-petting-success-cleanbot = You pet {THE{$target}} on {POSS-ADJ($target)} damp metal head.
-petting-success-medibot = You pet {THE{$target}} on {POSS-ADJ($target)} sterile metal head.
+petting-success-honkbot = You pet {THE($target)} on {POSS-ADJ($target)} slippery metal head.
+petting-success-cleanbot = You pet {THE($target)} on {POSS-ADJ($target)} damp metal head.
+petting-success-medibot = You pet {THE($target)} on {POSS-ADJ($target)} sterile metal head.
 
 petting-failure-honkbot = You reach out to pet {THE($target)}, but {SUBJECT($target)} honks in refusal!
 petting-failure-cleanbot = You reach out to pet {THE($target)}, but {SUBJECT($target)} {CONJUGATE-BE($target)} busy mopping!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -132,7 +132,7 @@
     interactSuccessString: petting-success-honkbot
     interactFailureString: petting-failure-honkbot
     interactSuccessSound:
-      path: /Audio/Ambience/Items/bikehorn.ogg
+      path: /Audio/Items/bikehorn.ogg
 
 - type: entity
   parent: MobSiliconBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -128,6 +128,11 @@
     makeSentient: true
     name: honkbot
     description: An artificial being of pure evil.
+  - type: InteractionPopup
+    interactSuccessString: petting-success-honkbot
+    interactFailureString: petting-failure-honkbot
+    interactSuccessSound:
+      path: /Audio/Ambience/Items/bikehorn.ogg
 
 - type: entity
   parent: MobSiliconBase
@@ -156,6 +161,11 @@
         maxVol: 30
   - type: DrainableSolution
     solution: drainBuffer
+  - type: InteractionPopup
+    interactSuccessString: petting-success-cleanbot
+    interactFailureString: petting-failure-cleanbot
+    interactSuccessSound:
+      path: /Audio/Ambience/Objects/periodic_beep.ogg
 
 - type: entity
   parent: MobSiliconBase
@@ -175,3 +185,8 @@
   - type: Construction
     graph: MediBot
     node: bot
+  - type: InteractionPopup
+    interactSuccessString: petting-success-medibot
+    interactFailureString: petting-failure-medibot
+    interactSuccessSound:
+      path: /Audio/Ambience/Objects/periodic_beep.ogg


### PR DESCRIPTION
## About the PR
Added a petting interaction to honkbots, cleanbots, and medibots. Audio for honkbots is a honk, for cleanbots and medibots a beep.

Closes #10093. Thanks for the walkthrough.

**Changelog**

:cl: Anthemic
- add: You can now pet bots.

