### PR TITLE
Printable holofans

### DIFF
--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -238,6 +238,7 @@
     - ComputerTelevisionCircuitboard
     - AirAlarmElectronics
     - FireAlarmElectronics
+    - HolofanProjector
 
 - type: technology
   name: material sheet printing

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -199,6 +199,7 @@
       - ProximitySensor
       - LeftArmBorg
       - RightArmBorg
+      - HolofanProjector
   - type: ActivatableUI
     key: enum.LatheUiKey.Key #Yes only having 1 of them here doesn't break anything
   - type: ActivatableUIRequiresPower

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -152,7 +152,9 @@
 
 - type: latheRecipe
   id: HolofanProjector
-  icon: /Textures/Objects/Tools/cable-coils.rsi/coilhv-30.png
+  icon: 
+    sprite: Objects/Devices/Holoprojectors/atmos.rsi
+    state: icon
   result: HolofanProjector
   completetime: 8
   materials: # Inherited materials and time from PowerCellMedium recipe

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -149,3 +149,14 @@
   materials:
     Steel: 300
     Plastic: 100
+
+- type: latheRecipe
+  id: HolofanProjector
+  icon: /Textures/Objects/Tools/cable-coils.rsi/coilhv-30.png
+  result: HolofanProjector
+  completetime: 8
+  materials: # Inherited materials and time from PowerCellMedium recipe
+    Steel: 600
+    Glass: 350
+    Plastic: 150
+    Gold: 10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR 

Makes holofan projectors printable in the protolathe. Unlocked by Industrial Engineering tech tree. Because it comes with a medium power cell, it costs 600 steel, 350 glass, 150 plastic, and 10 gold -- an added 300 steel, 50 glass, and 50 plastic from the medium power cell recipe.

**Changelog**

:cl: Anthemic
- add: Holofan projectors can now be printed in protolathes.

