### PR TITLE
Fix gas tank bug

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -213,13 +213,17 @@ namespace Content.Server.Atmos.EntitySystems
             UpdateUserInterface(component);
         }
 
-        public void DisconnectFromInternals(GasTankComponent component, EntityUid? owner = null)
+        public void DisconnectFromInternals(GasTankComponent component)
         {
-            if (!component.IsConnected) return;
+            if (component.User == null)
+                return;
+
+            var internals = GetInternalsComponent(component);
             component.User = null;
+
             _actions.SetToggled(component.ToggleAction, false);
 
-            _internals.DisconnectTank(GetInternalsComponent(component, owner));
+            _internals.DisconnectTank(internals);
             component.DisconnectStream?.Stop();
 
             if (component.DisconnectSound != null)
@@ -230,6 +234,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         private InternalsComponent? GetInternalsComponent(GasTankComponent component, EntityUid? owner = null)
         {
+            owner ??= component.User;
             if (Deleted(component.Owner)) return null;
             if (owner != null) return CompOrNull<InternalsComponent>(owner.Value);
             return _containers.TryGetContainingContainer(component.Owner, out var container)

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -197,8 +197,7 @@ namespace Content.Server.Atmos.EntitySystems
             var internals = GetInternalsComponent(component);
             if (internals == null) return;
 
-            if (_internals.TryConnectTank(internals, component.Owner))
-                component.User = internals.Owner;
+            _internals.TryConnectTank(internals, component.Owner);
 
             _actions.SetToggled(component.ToggleAction, component.IsConnected);
 

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -197,7 +197,8 @@ namespace Content.Server.Atmos.EntitySystems
             var internals = GetInternalsComponent(component);
             if (internals == null) return;
 
-            _internals.TryConnectTank(internals, component.Owner);
+            if (_internals.TryConnectTank(internals, component.Owner))
+                component.User = internals.Owner;
 
             _actions.SetToggled(component.ToggleAction, component.IsConnected);
 

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Atmos.Components;
+using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Components;
 using Content.Server.Hands.Systems;
@@ -79,7 +79,7 @@ public sealed class InternalsSystem : EntitySystem
 
         if (TryComp(component.GasTankEntity, out GasTankComponent? tank))
         {
-            _gasTank.DisconnectFromInternals(tank, component.Owner);
+            _gasTank.DisconnectFromInternals(tank);
         }
 
         component.GasTankEntity = null;
@@ -93,7 +93,7 @@ public sealed class InternalsSystem : EntitySystem
 
         if (TryComp(component.GasTankEntity, out GasTankComponent? tank))
         {
-            _gasTank.DisconnectFromInternals(tank, component.Owner);
+            _gasTank.DisconnectFromInternals(tank);
         }
 
         component.GasTankEntity = tankEntity;

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -91,11 +91,11 @@ public sealed class InternalsSystem : EntitySystem
         if (component.BreathToolEntity == null)
             return false;
 
-        if (TryComp(component.GasTankEntity, out GasTankComponent? tank))
-        {
-            _gasTank.DisconnectFromInternals(tank);
-        }
+        if (!TryComp(component.GasTankEntity, out GasTankComponent? tank))
+            return false;
 
+        _gasTank.DisconnectFromInternals(tank);
+        tank.User = component.Owner;
         component.GasTankEntity = tankEntity;
         _alerts.ShowAlert(component.Owner, AlertType.Internals, GetSeverity(component));
         return true;

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -91,11 +91,11 @@ public sealed class InternalsSystem : EntitySystem
         if (component.BreathToolEntity == null)
             return false;
 
-        if (!TryComp(component.GasTankEntity, out GasTankComponent? tank))
-            return false;
+        if (TryComp(component.GasTankEntity, out GasTankComponent? tank))
+        {
+            _gasTank.DisconnectFromInternals(tank);
+        }
 
-        _gasTank.DisconnectFromInternals(tank);
-        tank.User = component.Owner;
         component.GasTankEntity = tankEntity;
         _alerts.ShowAlert(component.Owner, AlertType.Internals, GetSeverity(component));
         return true;


### PR DESCRIPTION
I didn't properly test some of my changes in #9700  after #9567 was merged. The issue was that the user wasn't being passed into `DisconnectFromInternals()`. Fixed by making it default to `component.User`.

:cl:
- fix: Fixed gas tanks not being disconnected when dropped (again).

