### PR TITLE
Disable certain Item pickup behavior when in attack mode

### DIFF
--- a/Content.Server/Interaction/InteractionSystem.cs
+++ b/Content.Server/Interaction/InteractionSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Item;
 using Content.Shared.Pulling.Components;
+using Content.Shared.Tag;
 using Content.Shared.Weapons.Melee;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
@@ -34,6 +35,7 @@ namespace Content.Server.Interaction
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly InventorySystem _inventory = default!;
+        [Dependency] private readonly TagSystem _tagSystem = default!;
 
 
         public override void Initialize()
@@ -252,9 +254,10 @@ namespace Content.Server.Interaction
                         }
                     }
                 }
-                else if (!wideAttack && target != null && HasComp<ItemComponent>(target.Value))
+                else if (!wideAttack && target != null && HasComp<ItemComponent>(target.Value) && !_tagSystem.HasTag(target.Value, "NoPickupOnAttack"))
                 {
                     // We pick up items if our hand is empty, even if we're in combat mode.
+                    // NoPickupOnAttack Tag disables this behavior, e.g. for MobMouse
                     InteractHand(user, target.Value);
                     return;
                 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -815,6 +815,7 @@
     tags:
     - Trash
     - CannotSuicide
+    - NoPickupOnAttack
   - type: Recyclable
   - type: Respirator
     damage:

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -321,6 +321,9 @@
   id: Mop
 
 - type: Tag
+  id: NoPickupOnAttack # disable picking up an Item if attack mode is active with empty hands
+
+- type: Tag
   id: NoSpinOnThrow
 
 - type: Tag


### PR DESCRIPTION
Fixes #10176

MobMouse is both an Item and a Mob. Interacting with Items when empty handed in attack mode picks up the Item by default, good for weapons, but not so good when you want to kill a mouse with your bare hands.

Added NoPickupOnAttack Tag for Item prototypes you want to prevent picking up when in combat.