### PR TITLE
fix backpack and duffels in hand display

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -9,12 +9,10 @@
     state: icon
   - type: Item
     size: 9999
-    sprite: Clothing/Back/Backpacks/backpack.rsi
   - type: Clothing
     quickEquip: false
     slots:
     - back
-    sprite: Clothing/Back/Backpacks/backpack.rsi
   - type: Storage
     capacity: 100
   - type: UserInterface
@@ -30,10 +28,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/clown.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/clown.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/clown.rsi
   - type: Storage
     storageOpenSound:
       collection: BikeHorn
@@ -46,10 +40,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/security.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/security.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/security.rsi
 
 - type: entity
   parent: ClothingBackpack
@@ -58,10 +48,6 @@
   description: It's a tough backpack for the daily grind of station life.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/engineering.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/engineering.rsi
-  - type: Clothing
     sprite: Clothing/Back/Backpacks/engineering.rsi
 
 - type: entity
@@ -72,10 +58,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/medical.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/medical.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/medical.rsi
 
 - type: entity
   parent: ClothingBackpack
@@ -84,10 +66,6 @@
   description: It's a special backpack made exclusively for Nanotrasen officers.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/captain.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/captain.rsi
-  - type: Clothing
     sprite: Clothing/Back/Backpacks/captain.rsi
 
 - type: entity
@@ -98,10 +76,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/mime.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/mime.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/mime.rsi
 
 - type: entity
   parent: ClothingBackpack
@@ -110,10 +84,6 @@
   description: A backpack specially designed to repel stains and hazardous liquids.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/chemistry.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/chemistry.rsi
-  - type: Clothing
     sprite: Clothing/Back/Backpacks/chemistry.rsi
 
 - type: entity
@@ -124,10 +94,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/botany.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/botany.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/botany.rsi
 
 - type: entity
   parent: ClothingBackpack
@@ -136,10 +102,6 @@
   description: A backpack specially designed to repel stains and hazardous liquids.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/science.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/science.rsi
-  - type: Clothing
     sprite: Clothing/Back/Backpacks/science.rsi
 
 - type: entity
@@ -150,10 +112,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/virology.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/virology.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/virology.rsi
 
 #ERT
 - type: entity
@@ -163,10 +121,6 @@
   description: A spacious backpack with lots of pockets, worn by the Commander of an Emergency Response Team.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/ertleader.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/ertleader.rsi
-  - type: Clothing
     sprite: Clothing/Back/Backpacks/ertleader.rsi
   - type: Storage
     capacity: 200
@@ -179,10 +133,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/ertsec.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/ertsec.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/ertsec.rsi
 
 - type: entity
   parent: ClothingBackpackERTLeader
@@ -191,10 +141,6 @@
   description: A spacious backpack with lots of pockets, worn by Medical Officers of an Emergency Response Team.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/ertmed.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/ertmed.rsi
-  - type: Clothing
     sprite: Clothing/Back/Backpacks/ertmed.rsi
 
 - type: entity
@@ -205,10 +151,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/erteng.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/erteng.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/erteng.rsi
 
 - type: entity
   parent: ClothingBackpackERTLeader
@@ -218,10 +160,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/ertjanitor.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/ertjanitor.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Backpacks/ertjanitor.rsi
 
 - type: entity
   parent: ClothingBackpackERTLeader
@@ -230,10 +168,6 @@
   description: A spacious backpack with lots of pockets, worn by Clowns of an Emergency Response Team.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Backpacks/ertclown.rsi
-  - type: Item
-    sprite: Clothing/Back/Backpacks/ertclown.rsi
-  - type: Clothing
     sprite: Clothing/Back/Backpacks/ertclown.rsi
 
 #Special
@@ -250,9 +184,7 @@
     - state: holding
     - state: holding-unlit
       shader: unshaded
-  - type: Item
-    sprite: Clothing/Back/Backpacks/holding.rsi
   - type: Clothing
-    sprite: Clothing/Back/Backpacks/holding.rsi
+    equippedPrefix: holding
   - type: Storage
     capacity: 10000

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -30,6 +30,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/clown.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/clown.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/clown.rsi
   - type: Storage
@@ -44,6 +46,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/security.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/security.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/security.rsi
 
@@ -54,6 +58,8 @@
   description: It's a tough backpack for the daily grind of station life.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Backpacks/engineering.rsi
+  - type: Item
     sprite: Clothing/Back/Backpacks/engineering.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/engineering.rsi
@@ -66,6 +72,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/medical.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/medical.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/medical.rsi
 
@@ -76,6 +84,8 @@
   description: It's a special backpack made exclusively for Nanotrasen officers.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Backpacks/captain.rsi
+  - type: Item
     sprite: Clothing/Back/Backpacks/captain.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/captain.rsi
@@ -88,6 +98,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/mime.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/mime.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/mime.rsi
 
@@ -98,6 +110,8 @@
   description: A backpack specially designed to repel stains and hazardous liquids.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Backpacks/chemistry.rsi
+  - type: Item
     sprite: Clothing/Back/Backpacks/chemistry.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/chemistry.rsi
@@ -110,6 +124,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/botany.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/botany.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/botany.rsi
 
@@ -120,6 +136,8 @@
   description: A backpack specially designed to repel stains and hazardous liquids.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Backpacks/science.rsi
+  - type: Item
     sprite: Clothing/Back/Backpacks/science.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/science.rsi
@@ -132,6 +150,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/virology.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/virology.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/virology.rsi
 
@@ -143,6 +163,8 @@
   description: A spacious backpack with lots of pockets, worn by the Commander of an Emergency Response Team.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Backpacks/ertleader.rsi
+  - type: Item
     sprite: Clothing/Back/Backpacks/ertleader.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/ertleader.rsi
@@ -157,6 +179,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/ertsec.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/ertsec.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/ertsec.rsi
 
@@ -167,6 +191,8 @@
   description: A spacious backpack with lots of pockets, worn by Medical Officers of an Emergency Response Team.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Backpacks/ertmed.rsi
+  - type: Item
     sprite: Clothing/Back/Backpacks/ertmed.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/ertmed.rsi
@@ -179,6 +205,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/erteng.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/erteng.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/erteng.rsi
 
@@ -190,6 +218,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/ertjanitor.rsi
+  - type: Item
+    sprite: Clothing/Back/Backpacks/ertjanitor.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/ertjanitor.rsi
 
@@ -200,6 +230,8 @@
   description: A spacious backpack with lots of pockets, worn by Clowns of an Emergency Response Team.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Backpacks/ertclown.rsi
+  - type: Item
     sprite: Clothing/Back/Backpacks/ertclown.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/ertclown.rsi
@@ -218,6 +250,8 @@
     - state: holding
     - state: holding-unlit
       shader: unshaded
+  - type: Item
+    sprite: Clothing/Back/Backpacks/holding.rsi
   - type: Clothing
     sprite: Clothing/Back/Backpacks/holding.rsi
   - type: Storage

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -8,10 +8,8 @@
     sprite: Clothing/Back/Duffels/duffel.rsi
     state: icon
   - type: Item
-    sprite: Clothing/Back/Duffels/duffel.rsi
     size: 9999
   - type: Clothing
-    sprite: Clothing/Back/Duffels/duffel.rsi
     quickEquip: false
     slots:
     - back
@@ -33,10 +31,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/engineering.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/engineering.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Duffels/engineering.rsi
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -45,10 +39,6 @@
   description: A large duffel bag for holding extra medical supplies.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Duffels/medical.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/medical.rsi
-  - type: Clothing
     sprite: Clothing/Back/Duffels/medical.rsi
 
 - type: entity
@@ -59,10 +49,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/captain.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/captain.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Duffels/captain.rsi
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -71,10 +57,6 @@
   description: A large duffel bag for holding extra honk goods.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Duffels/clown.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/clown.rsi
-  - type: Clothing
     sprite: Clothing/Back/Duffels/clown.rsi
   - type: Storage
     storageOpenSound:
@@ -88,10 +70,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/security.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/security.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Duffels/security.rsi
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -101,10 +79,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/chemistry.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/chemistry.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Duffels/chemistry.rsi
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -113,10 +87,6 @@
   description: A large duffel bag for holding... mime... stuff.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Duffels/mime.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/mime.rsi
-  - type: Clothing
     sprite: Clothing/Back/Duffels/mime.rsi
     storageOpenSound:
       collection: null
@@ -131,10 +101,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/science.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/science.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Duffels/science.rsi
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -143,10 +109,6 @@
   description: A large duffel bag for holding various traitor goods.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Duffels/syndicate.rsi
-  - type: Item
-    sprite: Clothing/Back/Duffels/syndicate.rsi
-  - type: Clothing
     sprite: Clothing/Back/Duffels/syndicate.rsi
   - type: Storage
     capacity: 131
@@ -160,10 +122,8 @@
     sprite: Clothing/Back/Duffels/syndicate.rsi
     state: icon-ammo
   - type: Item
-    sprite: Clothing/Back/Duffels/syndicate.rsi
     heldPrefix: ammo
   - type: Clothing
-    sprite: Clothing/Back/Duffels/syndicate.rsi
     equippedPrefix: ammo
 
 - type: entity
@@ -175,10 +135,8 @@
     sprite: Clothing/Back/Duffels/syndicate.rsi
     state: icon-med
   - type: Item
-    sprite: Clothing/Back/Duffels/syndicate.rsi
     heldPrefix: med
   - type: Clothing
-    sprite: Clothing/Back/Duffels/syndicate.rsi
     equippedPrefix: med
 
 - type: entity
@@ -194,9 +152,5 @@
     - state: icon
     - state: icon-unlit
       shader: unshaded
-  - type: Item
-    sprite: Clothing/Back/Duffels/holding.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Duffels/holding.rsi
   - type: Storage
     capacity: 10000

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -33,6 +33,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/engineering.rsi
+  - type: Item
+    sprite: Clothing/Back/Duffels/engineering.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/engineering.rsi
 
@@ -43,6 +45,8 @@
   description: A large duffel bag for holding extra medical supplies.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Duffels/medical.rsi
+  - type: Item
     sprite: Clothing/Back/Duffels/medical.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/medical.rsi
@@ -55,6 +59,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/captain.rsi
+  - type: Item
+    sprite: Clothing/Back/Duffels/captain.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/captain.rsi
 
@@ -65,6 +71,8 @@
   description: A large duffel bag for holding extra honk goods.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Duffels/clown.rsi
+  - type: Item
     sprite: Clothing/Back/Duffels/clown.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/clown.rsi
@@ -80,6 +88,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/security.rsi
+  - type: Item
+    sprite: Clothing/Back/Duffels/security.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/security.rsi
 
@@ -91,6 +101,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/chemistry.rsi
+  - type: Item
+    sprite: Clothing/Back/Duffels/chemistry.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/chemistry.rsi
 
@@ -101,6 +113,8 @@
   description: A large duffel bag for holding... mime... stuff.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Duffels/mime.rsi
+  - type: Item
     sprite: Clothing/Back/Duffels/mime.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/mime.rsi
@@ -117,6 +131,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Duffels/science.rsi
+  - type: Item
+    sprite: Clothing/Back/Duffels/science.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/science.rsi
 
@@ -127,6 +143,8 @@
   description: A large duffel bag for holding various traitor goods.
   components:
   - type: Sprite
+    sprite: Clothing/Back/Duffels/syndicate.rsi
+  - type: Item
     sprite: Clothing/Back/Duffels/syndicate.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/syndicate.rsi
@@ -141,9 +159,12 @@
   - type: Sprite
     sprite: Clothing/Back/Duffels/syndicate.rsi
     state: icon-ammo
-  - type: Clothing
+  - type: Item
     sprite: Clothing/Back/Duffels/syndicate.rsi
     heldPrefix: ammo
+  - type: Clothing
+    sprite: Clothing/Back/Duffels/syndicate.rsi
+    equippedPrefix: ammo
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicate
@@ -153,9 +174,12 @@
   - type: Sprite
     sprite: Clothing/Back/Duffels/syndicate.rsi
     state: icon-med
-  - type: Clothing
+  - type: Item
     sprite: Clothing/Back/Duffels/syndicate.rsi
     heldPrefix: med
+  - type: Clothing
+    sprite: Clothing/Back/Duffels/syndicate.rsi
+    equippedPrefix: med
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -170,6 +194,8 @@
     - state: icon
     - state: icon-unlit
       shader: unshaded
+  - type: Item
+    sprite: Clothing/Back/Duffels/holding.rsi
   - type: Clothing
     sprite: Clothing/Back/Duffels/holding.rsi
   - type: Storage

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -13,7 +13,6 @@
     quickEquip: false
     slots:
     - back
-    sprite: Clothing/Back/Satchels/satchel.rsi
   - type: Storage
     capacity: 100
   - type: UserInterface
@@ -29,8 +28,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Satchels/engineering.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Satchels/engineering.rsi
 
 - type: entity
   parent: ClothingBackpackSatchel
@@ -39,8 +36,6 @@
   description: A sterile satchel used in medical departments.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Satchels/medical.rsi
-  - type: Clothing
     sprite: Clothing/Back/Satchels/medical.rsi
 
 - type: entity
@@ -51,8 +46,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Satchels/chemistry.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Satchels/chemistry.rsi
 
 - type: entity
   parent: ClothingBackpackSatchel
@@ -61,8 +54,6 @@
   description: Useful for holding research materials.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Satchels/science.rsi
-  - type: Clothing
     sprite: Clothing/Back/Satchels/science.rsi
 
 - type: entity
@@ -73,8 +64,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Satchels/security.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Satchels/security.rsi
 
 - type: entity
   parent: ClothingBackpackSatchel
@@ -84,8 +73,6 @@
   components:
   - type: Sprite
     sprite: Clothing/Back/Satchels/captain.rsi
-  - type: Clothing
-    sprite: Clothing/Back/Satchels/captain.rsi
 
 - type: entity
   parent: ClothingBackpackSatchel
@@ -94,8 +81,6 @@
   description: A satchel made of all natural fibers.
   components:
   - type: Sprite
-    sprite: Clothing/Back/Satchels/hydroponics.rsi
-  - type: Clothing
     sprite: Clothing/Back/Satchels/hydroponics.rsi
 
 - type: entity
@@ -111,7 +96,5 @@
     - state: icon
     - state: icon-unlit
       shader: unshaded
-  - type: Clothing
-    sprite: Clothing/Back/Satchels/holding.rsi
   - type: Storage
     capacity: 10000


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10147.
This appears to be caused by #9706. Just needed to add the Item component to each of the backpacks and duffels.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: backpack and duffels no longer only display default gray when held
