### PR TITLE
Make early launches a cvar

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.EmergencyConsole.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.EmergencyConsole.cs
@@ -5,6 +5,7 @@ using Content.Server.RoundEnd;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.Station.Components;
+using Content.Server.UserInterface;
 using Content.Shared.Access.Systems;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
@@ -82,6 +83,18 @@ public sealed partial class ShuttleSystem
         SubscribeLocalEvent<EmergencyShuttleConsoleComponent, EmergencyShuttleAuthorizeMessage>(OnEmergencyAuthorize);
         SubscribeLocalEvent<EmergencyShuttleConsoleComponent, EmergencyShuttleRepealMessage>(OnEmergencyRepeal);
         SubscribeLocalEvent<EmergencyShuttleConsoleComponent, EmergencyShuttleRepealAllMessage>(OnEmergencyRepealAll);
+        SubscribeLocalEvent<EmergencyShuttleConsoleComponent, ActivatableUIOpenAttemptEvent>(OnEmergencyOpenAttempt);
+    }
+
+    private void OnEmergencyOpenAttempt(EntityUid uid, EmergencyShuttleConsoleComponent component, ActivatableUIOpenAttemptEvent args)
+    {
+        // I'm hoping ActivatableUI checks it's open before allowing these messages.
+        if (!_configManager.GetCVar(CCVars.EmergencyEarlyLaunchAllowed))
+        {
+            args.Cancel();
+            _popup.PopupEntity(Loc.GetString("emergency-shuttle-console-no-early-launches"), uid, Filter.Entities(args.User));
+            return;
+        }
     }
 
     private void SetAuthorizeTime(float obj)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -887,6 +887,12 @@ namespace Content.Shared.CCVar
          */
 
         /// <summary>
+        /// Is the emergency shuttle allowed to be early launched.
+        /// </summary>
+        public static readonly CVarDef<bool> EmergencyEarlyLaunchAllowed =
+            CVarDef.Create("shuttle.emergency_early_launch_allowed", false, CVar.SERVERONLY);
+
+        /// <summary>
         /// How long the emergency shuttle remains docked with the station, in seconds.
         /// </summary>
         public static readonly CVarDef<float> EmergencyShuttleDockTime =

--- a/Resources/Locale/en-US/shuttles/emergency.ftl
+++ b/Resources/Locale/en-US/shuttles/emergency.ftl
@@ -18,6 +18,7 @@ emergency-shuttle-good-luck = The Emergency Shuttle is unable to find a station.
 emergency-shuttle-nearby = The Emergency Shuttle is unable to find a valid docking port. It has warped in {$direction} of the station.
 
 # Emergency shuttle console popup / announcement
+emergency-shuttle-console-no-early-launches = Early launch is disabled
 emergency-shuttle-console-auth-left = {$remaining} authorizations needed until shuttle is launched early.
 emergency-shuttle-console-auth-revoked = Early launch authorization revoked, {$remaining} authorizations needed.
 emergency-shuttle-console-denied = Access denied


### PR DESCRIPTION
Apparently our LRP playerbase sucks.

:cl:
- tweak: Early launches are now disabled by default.
