### PR TITLE
Listener fix for speech

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -264,6 +264,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             ("entityName", Name(source)));
 
         SendInVoiceRange(ChatChannel.Local, message, messageWrap, source, hideChat);
+        _listener.PingListeners(source, message, null);
 
         var ev = new EntitySpokeEvent(message);
         RaiseLocalEvent(source, ev);

--- a/Content.Server/Headset/HeadsetComponent.cs
+++ b/Content.Server/Headset/HeadsetComponent.cs
@@ -42,9 +42,9 @@ namespace Content.Server.Headset
             _radioSystem = EntitySystem.Get<RadioSystem>();
         }
 
-        public bool CanListen(string message, EntityUid source, RadioChannelPrototype prototype)
+        public bool CanListen(string message, EntityUid source, RadioChannelPrototype? prototype)
         {
-            return Channels.Contains(prototype.ID) && RadioRequested;
+            return prototype != null && Channels.Contains(prototype.ID) && RadioRequested;
         }
 
         public void Receive(string message, RadioChannelPrototype channel, EntityUid source)
@@ -66,8 +66,13 @@ namespace Content.Server.Headset
             _netManager.ServerSendMessage(msg, playerChannel);
         }
 
-        public void Listen(string message, EntityUid speaker, RadioChannelPrototype channel)
+        public void Listen(string message, EntityUid speaker, RadioChannelPrototype? channel)
         {
+            if (channel == null)
+            {
+                return;
+            }
+
             Broadcast(message, speaker, channel);
         }
 

--- a/Content.Server/Radio/Components/HandheldRadioComponent.cs
+++ b/Content.Server/Radio/Components/HandheldRadioComponent.cs
@@ -77,7 +77,13 @@ namespace Content.Server.Radio.Components
 
         public bool CanListen(string message, EntityUid source, RadioChannelPrototype? prototype)
         {
-            if (_channels.Count == 0 && !_prototypeManager.HasIndex<RadioChannelPrototype>(BroadcastChannel))
+            if (_channels.Count == 0 || prototype == null)
+            {
+                return false;
+            }
+
+            if (!_channels.Contains(prototype.ID)
+                || !_prototypeManager.HasIndex<RadioChannelPrototype>(BroadcastChannel))
             {
                 return false;
             }
@@ -96,11 +102,6 @@ namespace Content.Server.Radio.Components
 
         public void Listen(string message, EntityUid speaker, RadioChannelPrototype? prototype)
         {
-            if (_channels.Count == 0)
-            {
-                return;
-            }
-
             // if we can't get the channel, we need to just use the broadcast frequency
             if (prototype == null
                 && !_prototypeManager.TryIndex(BroadcastChannel, out prototype))

--- a/Content.Server/Radio/Components/HandheldRadioComponent.cs
+++ b/Content.Server/Radio/Components/HandheldRadioComponent.cs
@@ -103,7 +103,6 @@ namespace Content.Server.Radio.Components
 
             // if we can't get the channel, we need to just use the broadcast frequency
             if (prototype == null
-                || !_channels.TryGetValue(prototype.ID, out var channel)
                 && !_prototypeManager.TryIndex(BroadcastChannel, out prototype))
             {
                 return;

--- a/Content.Server/Radio/Components/HandheldRadioComponent.cs
+++ b/Content.Server/Radio/Components/HandheldRadioComponent.cs
@@ -77,12 +77,7 @@ namespace Content.Server.Radio.Components
 
         public bool CanListen(string message, EntityUid source, RadioChannelPrototype? prototype)
         {
-            if (_channels.Count == 0 || prototype == null)
-            {
-                return false;
-            }
-
-            if (!_channels.Contains(prototype.ID)
+            if (prototype != null && !_channels.Contains(prototype.ID)
                 || !_prototypeManager.HasIndex<RadioChannelPrototype>(BroadcastChannel))
             {
                 return false;

--- a/Content.Server/Radio/Components/HandheldRadioComponent.cs
+++ b/Content.Server/Radio/Components/HandheldRadioComponent.cs
@@ -77,7 +77,7 @@ namespace Content.Server.Radio.Components
 
         public bool CanListen(string message, EntityUid source, RadioChannelPrototype? prototype)
         {
-            if (_channels.Count == 0)
+            if (_channels.Count == 0 && !_prototypeManager.HasIndex<RadioChannelPrototype>(BroadcastChannel))
             {
                 return false;
             }

--- a/Content.Server/Radio/Components/IListen.cs
+++ b/Content.Server/Radio/Components/IListen.cs
@@ -10,8 +10,8 @@ namespace Content.Server.Radio.Components
     {
         int ListenRange { get; }
 
-        bool CanListen(string message, EntityUid source, RadioChannelPrototype channelPrototype);
+        bool CanListen(string message, EntityUid source, RadioChannelPrototype? channelPrototype);
 
-        void Listen(string message, EntityUid speaker, RadioChannelPrototype channel);
+        void Listen(string message, EntityUid speaker, RadioChannelPrototype? channel);
     }
 }

--- a/Content.Server/Radio/EntitySystems/ListeningSystem.cs
+++ b/Content.Server/Radio/EntitySystems/ListeningSystem.cs
@@ -7,7 +7,7 @@ namespace Content.Server.Radio.EntitySystems
     [UsedImplicitly]
     public sealed class ListeningSystem : EntitySystem
     {
-        public void PingListeners(EntityUid source, string message, RadioChannelPrototype channel)
+        public void PingListeners(EntityUid source, string message, RadioChannelPrototype? channel)
         {
             foreach (var listener in EntityManager.EntityQuery<IListen>(true))
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes it so that speaking will now attempt to activate IListen entities, except with a null channel in place of an actual radio channel.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Nanotrasen has found where all the microphones for handheld radios went. Enjoy your usage of handheld radio technology, today!

