### PR TITLE
Added localization functionality for cargo orders

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-armory.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-armory.ftl
@@ -1,0 +1,5 @@
+ent-ArmorySmg = { ent-CrateArmorySMG }
+    .desc = { ent-CrateArmorySMG.desc }
+
+ent-ArmoryShotgun = { ent-CrateArmoryShotgun }
+    .desc = { ent-CrateArmoryShotgun.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-atmospherics.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-atmospherics.ftl
@@ -1,0 +1,11 @@
+ent-AtmosphericsAir = { ent-AirCanister }
+    .desc = { ent-AirCanister.desc }
+
+ent-AtmosphericsOxygen = { ent-OxygenCanister }
+    .desc = { ent-OxygenCanister.desc }
+
+ent-AtmosphericsNitrogen = { ent-CrateNPCCat }
+    .desc = { ent-CrateNPCCat.desc }
+
+ent-AtmosphericsCarbonDioxide = { ent-CarbonDioxideCanister }
+    .desc = { ent-CarbonDioxideCanister.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-botany.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-botany.ftl
@@ -1,0 +1,11 @@
+ent-HydroponicsSeedsExotic = { ent-CrateHydroponicsSeedsExotic }
+    .desc = { ent-CrateHydroponicsSeedsExotic.desc }
+
+ent-HydroponicsSeedsMedicinal = { ent-CrateHydroponicsSeedsMedicinal }
+    .desc = { ent-CrateHydroponicsSeedsMedicinal.desc }
+
+ent-HydroponicsTools = { ent-CrateHydroponicsTools }
+    .desc = { ent-CrateHydroponicsTools.desc }
+
+ent-HydroponicsSeeds = { ent-CrateHydroponicsSeeds }
+    .desc = { ent-CrateHydroponicsSeeds.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-emergency.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-emergency.ftl
@@ -1,0 +1,14 @@
+ent-EmergencyExplosive = { ent-CrateEmergencyExplosive }
+    .desc = { ent-CrateEmergencyExplosive.desc }
+
+ent-EmergencyFire = { ent-CrateEmergencyFire }
+    .desc = { ent-CrateEmergencyFire.desc }
+
+ent-EmergencyInternals = { ent-CrateEmergencyInternals }
+    .desc = { ent-CrateEmergencyInternals.desc }
+
+ent-EmergencyRadiation = { ent-CrateEmergencyRadiation }
+    .desc = { ent-CrateEmergencyRadiation.desc }
+
+ent-EmergencyInflatablewall = { ent-CrateEmergencyInflatablewall }
+    .desc = { ent-CrateEmergencyInflatablewall.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-engineering.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-engineering.ftl
@@ -1,0 +1,14 @@
+ent-EngineeringCableLv = { ent-CrateEngineeringCableLV }
+    .desc = { ent-CrateEngineeringCableLV.desc }
+
+ent-EngineeringCableMv = { ent-CrateEngineeringCableMV }
+    .desc = { ent-CrateEngineeringCableMV.desc }
+
+ent-EngineeringCableHv = { ent-CrateEngineeringCableHV }
+    .desc = { ent-CrateEngineeringCableHV.desc }
+
+ent-EngineeringCableBulk = { ent-CrateEngineeringCableBulk }
+    .desc = { ent-CrateEngineeringCableBulk.desc }
+
+ent-EngineeringElectricalSupplies = { ent-CrateEngineeringElectricalSupplies }
+    .desc = { ent-CrateEngineeringElectricalSupplies.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-engines.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-engines.ftl
@@ -1,0 +1,23 @@
+ent-EngineAmeShielding = { ent-CrateEngineeringAMEShielding }
+    .desc = { ent-CrateEngineeringAMEShielding.desc }
+
+ent-EngineAmeJar = { ent-CrateEngineeringAMEJar }
+    .desc = { ent-CrateEngineeringAMEJar.desc }
+
+ent-EngineAmeControl = { ent-CrateEngineeringAMEControl }
+    .desc = { ent-CrateEngineeringAMEControl.desc }
+
+ent-EngineSingularityGenerator = { ent-CrateEngineeringSingularityGenerator }
+    .desc = { ent-CrateEngineeringSingularityGenerator.desc }
+
+ent-EngineSingularityContainment = { ent-CrateEngineeringSingularityContainment }
+    .desc = { ent-CrateEngineeringSingularityContainment.desc }
+
+ent-EngineSingularityCollector = { ent-CrateEngineeringSingularityCollector }
+    .desc = { ent-CrateEngineeringSingularityCollector.desc }
+
+ent-EngineParticleAccelerator = { ent-CrateEngineeringParticleAccelerator }
+    .desc = { ent-CrateEngineeringParticleAccelerator.desc }
+
+ent-EngineSolar = { ent-CrateEngineeringSolar }
+    .desc = { ent-CrateEngineeringSolar.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-food.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-food.ftl
@@ -1,0 +1,11 @@
+ent-FoodPizza = { ent-CrateFoodPizza }
+    .desc = { ent-CrateFoodPizza.desc }
+
+ent-FoodMRE = { ent-CrateFoodMRE }
+    .desc = { ent-CrateFoodMRE.desc }
+
+ent-FoodCook = { ent-CrateFoodCooking }
+    .desc = { ent-CrateFoodCooking.desc }
+
+ent-FoodCrateKvassTank = { ent-CrateFoodKvassTank }
+    .desc = { ent-CrateFoodKvassTank.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-fun.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-fun.ftl
@@ -1,0 +1,17 @@
+ent-FunPlushies = { ent-CrateFunPlushie }
+    .desc = { ent-CrateFunPlushie.desc }
+
+ent-FunInstruments = { ent-CrateFunInstruments }
+    .desc = { ent-CrateFunInstruments.desc }
+
+ent-FunBrass = { ent-CrateFunBrass }
+    .desc = { ent-CrateFunBrass.desc }
+
+ent-FunArtSupplies = { ent-CrateFunArtSupplies }
+    .desc = { ent-CrateFunArtSupplies.desc }
+
+ent-FunBoardGames = { ent-CrateFunBoardGames }
+    .desc = { ent-CrateFunBoardGames.desc }
+
+ent-FunATV = { ent-CrateFunATV }
+    .desc = { ent-CrateFunATV.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-livestock.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-livestock.ftl
@@ -1,0 +1,44 @@
+ent-LivestockBee = { ent-CrateNPCBee }
+    .desc = { ent-CrateNPCBee.desc }
+
+ent-LivestockButterfly = { ent-CrateNPCButterflies }
+    .desc = { ent-CrateNPCButterflies.desc }
+
+ent-LivestockCat = { ent-CrateNPCCat }
+    .desc = { ent-CrateNPCCat.desc }
+
+ent-LivestockChicken = { ent-CrateNPCChicken }
+    .desc = { ent-CrateNPCChicken.desc }
+
+ent-LivestockDuck = { ent-CrateNPCDuck }
+    .desc = { ent-CrateNPCDuck.desc }
+
+ent-LivestockCorgi = { ent-CrateNPCCorgi }
+    .desc = { ent-CrateNPCCorgi.desc }
+
+ent-LivestockCow = { ent-CrateNPCCow }
+    .desc = { ent-CrateNPCCow.desc }
+
+ent-LivestockGoat = { ent-CrateNPCGoat }
+    .desc = { ent-CrateNPCGoat.desc }
+
+ent-LivestockGoose = { ent-CrateNPCGoose }
+    .desc = { ent-CrateNPCGoose.desc }
+
+ent-LivestockGorilla = { ent-CrateNPCGorilla }
+    .desc = { ent-CrateNPCGorilla.desc }
+
+ent-LivestockMonkeyCube = { ent-CrateNPCMonkeyCube }
+    .desc = { ent-CrateNPCMonkeyCube.desc }
+
+ent-LivestockMouse = { ent-CrateNPCMouse }
+    .desc = { ent-CrateNPCMouse.desc }
+
+ent-LivestockParrot = { ent-CrateNPCParrot }
+    .desc = { ent-CrateNPCParrot.desc }
+
+ent-LivestockPenguin = { ent-CrateNPCPenguin }
+    .desc = { ent-CrateNPCPenguin.desc }
+
+ent-LivestockSnake = { ent-CrateNPCSnake }
+    .desc = { ent-CrateNPCSnake.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-materials.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-materials.ftl
@@ -1,0 +1,20 @@
+ent-MaterialGlass = { ent-CrateMaterialGlass }
+    .desc = { ent-CrateMaterialGlass.desc }
+
+ent-MaterialSteel = { ent-CrateMaterialSteel }
+    .desc = { ent-CrateMaterialSteel.desc }
+
+ent-MaterialPlastic = { ent-CrateMaterialPlastic }
+    .desc = { ent-CrateMaterialPlastic.desc }
+
+ent-MaterialPlasteel = { ent-CrateMaterialPlasteel }
+    .desc = { ent-CrateMaterialPlasteel.desc }
+
+ent-MaterialPlasma = { ent-CrateMaterialPlasma }
+    .desc = { ent-CrateMaterialPlasma.desc }
+
+ent-MaterialFuelTank = { ent-WeldingFuelTankFull }
+    .desc = { ent-WeldingFuelTankFull.desc }
+
+ent-MaterialWaterTank = { ent-WaterTankFull }
+    .desc = { ent-WaterTankFull.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-medical.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-medical.ftl
@@ -1,0 +1,5 @@
+ent-MedicalSupplies = { ent-CrateMedicalSupplies }
+    .desc = { ent-CrateMedicalSupplies.desc }
+
+ent-MedicalChemistrySupplies = { ent-CrateChemistrySupplies }
+    .desc = { ent-CrateChemistrySupplies.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-science.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-science.ftl
@@ -1,0 +1,2 @@
+ent-ArtifactContainer = { CrateArtifactContainer }
+    .desc = { CrateArtifactContainer.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-security.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-security.ftl
@@ -1,0 +1,20 @@
+ent-SecurityArmor = { ent-CrateSecurityArmor }
+    .desc = { ent-CrateSecurityArmor.desc }
+
+ent-SecurityHelmet = { ent-CrateSecurityHelmet }
+    .desc = { ent-CrateSecurityHelmet.desc }
+
+ent-SecurityNonLethal = { ent-CrateSecurityNonlethal }
+    .desc = { ent-CrateSecurityNonlethal.desc }
+
+ent-SecurityLaser = { ent-CrateSecurityLaser }
+    .desc = { ent-CrateSecurityLaser.desc }
+
+ent-SecurityRiot = { ent-CrateSecurityRiot }
+    .desc = { ent-CrateSecurityRiot.desc }
+
+ent-SecuritySupplies = { ent-CrateSecuritySupplies }
+    .desc = { ent-CrateSecuritySupplies.desc }
+
+ent-SecurityRestraints = { ent-CrateRestraints }
+    .desc = { ent-CrateRestraints.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-service.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-service.ftl
@@ -1,0 +1,20 @@
+ent-ServiceJanitorial = { ent-CrateServiceJanitorialSupplies }
+    .desc = { ent-CrateServiceJanitorialSupplies.desc }
+
+ent-ServiceLightsReplacement = { ent-CrateServiceReplacementLights }
+    .desc = { ent-CrateServiceReplacementLights.desc }
+
+ent-MousetrapBoxes = { ent-CrateMousetrapBoxes }
+    .desc = { ent-CrateMousetrapBoxes.desc }
+
+ent-ServiceSmokeables = { ent-CrateServiceSmokeables }
+    .desc = { ent-CrateServiceSmokeables.desc }
+
+ent-ServiceCustomSmokable = { ent-CrateServiceCustomSmokable }
+    .desc = { ent-CrateServiceCustomSmokable.desc }
+
+ent-ServiceBureaucracy = { ent-CrateServiceBureaucracy }
+    .desc = { ent-CrateServiceBureaucracy.desc }
+
+ent-ServicePersonnel = { ent-CrateServicePersonnel }
+    .desc = { ent-CrateServicePersonnel.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-shuttle.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-shuttle.ftl
@@ -1,0 +1,8 @@
+ent-ShuttleThruster = { ent-Thruster }
+    .desc = { ent-Thruster.desc }
+
+ent-ShuttleGyroscope = { ent-Gyroscope }
+    .desc = { ent-Gyroscope.desc }
+
+ent-ShuttlePowerKit = Shuttle powering crate
+    .desc = Contains boards for wallmounted power utilities.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
@@ -1,0 +1,5 @@
+ent-CrateArmorySMG = SMG crate
+    .desc = Contains two high-powered, semiautomatic rifles with four mags. Requires Armory access to open.
+
+ent-CrateArmoryShotgun = Shotgun crate
+    .desc = For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer Combat Shotguns, and some standard shotgun shells. Requires Armory access to open.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/botany-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/botany-crates.ftl
@@ -1,0 +1,11 @@
+ent-CrateHydroponicsSeedsExotic = Exotic seeds crate
+    .desc = Any entrepreneuring botanist's dream. Contains many different exotic seeds. Requires Hydroponics access to open.
+
+ent-CrateHydroponicsSeedsMedicinal = Medicinal seeds crate
+    .desc = The wannabe chemist's dream. The power of medicine is at your fingertips! Requires Hydroponics access to open.
+
+ent-CrateHydroponicsTools = Hydroponics equipment crate
+    .desc = Supplies for growing a great garden! Contains some spray bottles of plant chemicals, a hatchet, a mini-hoe, scythe, as well as a pair of leather gloves and a botanist's apron.
+
+ent-CrateHydroponicsSeeds = Seeds crate
+    .desc = Big things have small beginnings. Contains twelve different seeds.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/emergency-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/emergency-crates.ftl
@@ -1,0 +1,14 @@
+ent-CrateEmergencyExplosive = Bomb suit crate
+    .desc = Science gone bonkers? Beeping behind the airlock? Buy now and be the hero the station des... I mean needs! (time not included)
+
+ent-CrateEmergencyFire = Firefighting crate
+    .desc = Only you can prevent station fires. Partner up with two firefighter suits, gas masks, flashlights, large oxygen tanks, extinguishers, and hardhats!
+
+ent-CrateEmergencyInternals = Internals crate
+    .desc = Master your life energy and control your breathing with three breath masks, three emergency oxygen tanks and three large air tanks.
+
+ent-CrateEmergencyRadiation = Radiation protection crate
+    .desc = Survive the Nuclear Apocalypse and Supermatter Engine alike with two sets of Radiation suits. Each set contains a helmet, suit, and Geiger counter. We'll even throw in a bottle of vodka and some glasses too, considering the life-expectancy of people who order this.
+
+ent-CrateEmergencyInflatablewall = Inflatable wall crate
+    .desc = Three stacks of inflatable walls for when the stations metal walls don't want to hold atmosphere anymore.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/engineering-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/engineering-crates.ftl
@@ -1,0 +1,23 @@
+ent-CrateEngineeringGear = Engineering gear crate
+    .desc = Various engineering gear parts.
+
+ent-CrateEngineeringToolbox = Toolbox crate
+    .desc = Two mechanical and two electrical toolboxes.
+
+ent-CrateEngineeringPowercell = AME crate
+    .desc = Three microcreactor powercells.
+
+ent-CrateEngineeringCableLV = LV cable crate
+    .desc = 3 coils of LV cables.
+
+ent-CrateEngineeringCableMV = MV cable crate
+    .desc = 3 coils of MV cables.
+
+ent-CrateEngineeringCableHV = HV cable crate
+    .desc = 3 coils of HV cables.
+
+ent-CrateEngineeringCableBulk = Bulk cable crate
+    .desc = 2 coils each for every cable type.
+
+ent-CrateEngineeringElectricalSupplies = Electrical Supplies Crate
+    .desc = NT is not responsible for any workplace infighting relating to the insulated gloves included within these crates.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/engines-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/engines-crates.ftl
@@ -1,0 +1,30 @@
+ent-CrateEngineeringAMEShielding = Packaged antimatter reactor crate
+    .desc = 9 parts for the main body of an antimatter reactor, or for expanding an existing one.
+
+ent-CrateEngineeringAMEJar = Antimatter containment jar crate
+    .desc = 3 antimatter jars, for fuelling an antimatter reactor.
+
+ent-CrateEngineeringAMEControl = Antimatter control unit crate
+    .desc = The control unit of an antimatter reactor.
+
+ent-CrateEngineeringSingularityEmitter = Emitter crate
+    .desc = An emitter, best used for singularity engines.
+
+ent-CrateEngineeringSingularityCollector = Radiation collector crate
+    .desc = A radiation collector, best used for singularity engines.
+
+ent-CrateEngineeringSingularityContainment = Containment field generator crate
+    .desc = A containment field generator, keeps the singulo in submission.
+
+ent-CrateEngineeringSingularityGenerator = Singularity generator crate
+    .desc = A singularity generator, the mother of the beast.
+
+ent-CrateEngineeringParticleAccelerator = PA crate
+    .desc = Complex to setup, but rewarding as fuck.
+
+ent-CrateEngineeringGenerator = Generator crate
+
+ent-CrateEngineeringSolar = Solar assembly crate
+    .desc = Parts for constructing solar panels and trackers.
+
+ent-CrateEngineeringShuttle = Shuttle powering crate

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/food-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/food-crates.ftl
@@ -1,0 +1,11 @@
+ent-CrateFoodPizza = Emergency pizza delivery
+    .desc = Help do your part to end station hunger by distributing pizza to underfunded departments!
+
+ent-CrateFoodMRE = MRE crate
+    .desc = A military style meal fit to feed a whole department.
+
+ent-CrateFoodCooking = Kitchen supplies crate
+    .desc = Extra kitchen supplies, in case the botanists are absent.
+
+ent-CrateFoodKvassTank = Kvass tank crate
+    .desc = A tank with refreshing kvass, which helps so much in the heat.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/fun-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/fun-crates.ftl
@@ -1,0 +1,20 @@
+ent-CrateFunPlushie = Plushie crate
+    .desc = A buncha soft plushies. Throw them around and then wonder how you're gonna explain this purchase to NT.
+
+ent-CrateFunInstruments = Big band instrument collection
+    .desc = Get your sad station movin' and groovin' with this fine collection! Contains thirteen different instruments.
+
+ent-CrateFunBrass = Brass instrument ensemble crate
+    .desc = Bring some jazz to the station with the brass ensemble. Contains a variety of brass instruments for the whole station to play.
+
+ent-CrateFunArtSupplies = Art supplies
+    .desc = Make some happy little accidents with lots of crayons!
+
+ent-CrateFunBoardGames = Board game crate
+    .desc = Game nights have been proven to either decrease boredom or increase murderous rage depending on the game.
+
+ent-CrateFunATV = ATV crate
+    .desc = Bring some jazz to the station with the brass ensemble. Contains a variety of brass instruments for the whole station to play.
+
+ent-CrateFunSyndicateSegway = Syndicate segway crate
+    .desc = Bring some jazz to the station with the brass ensemble. Contains a variety of brass instruments for the whole station to play.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/livestock-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/livestock-crates.ftl
@@ -1,0 +1,44 @@
+ent-CrateNPCBee = Crate of bees
+    .desc = A crate containing a swarm of eight bees.
+
+ent-CrateNPCButterflies = Crate of butterflies
+    .desc = A crate containing five butterflies.
+
+ent-CrateNPCCat = Cat crate
+    .desc = A crate containing a single cat.
+
+ent-CrateNPCChicken = Chicken crate
+    .desc = A crate containing four fully grown chickens.
+
+ent-CrateNPCDuck = Duck crate
+    .desc = A crate containing six fully grown ducks.
+
+ent-CrateNPCCorgi = Corgi crate
+    .desc = A crate containing a single corgi.
+
+ent-CrateNPCCow = Cow crate
+    .desc = A crate containing a single cow.
+
+ent-CrateNPCGoat = Goat crate
+    .desc = A crate containing a single goat.
+
+ent-CrateNPCGoose = Goose crate
+    .desc = A crate containing two geese.
+
+ent-CrateNPCGorilla = Gorilla crate
+    .desc = A crate containing a single gorilla.
+
+ent-CrateNPCMonkeyCube = Monkey cube crate
+    .desc = A crate containing three boxes of monkey cubes.
+
+ent-CrateNPCMouse = Mice crate
+    .desc = A crate containing five mice.
+
+ent-CrateNPCParrot = Parrot crate
+    .desc = A crate containing three parrots.
+
+ent-CrateNPCPenguin = Penguin crate
+    .desc = A crate containing two penguins.
+
+ent-CrateNPCSnake = Snake crate
+    .desc = A crate containing three snakes.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/materials-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/materials-crates.ftl
@@ -1,0 +1,17 @@
+ent-CrateMaterialGlass = Glass sheet crate
+    .desc = 90 sheets of glass, packed with care.
+
+ent-CrateMaterialSteel = Steel sheet crate
+    .desc = 90 sheets of steel.
+
+ent-CrateMaterialPlastic = Plastic sheet crate
+    .desc = 90 sheets of plastic.
+
+ent-CrateMaterialWood = Wood crate
+    .desc = Bunch of wood planks.
+
+ent-CrateMaterialPlasteel = Plasteel crate
+    .desc = 90 sheets of plasteel.
+
+ent-CrateMaterialPlasma = Solid plasma crate
+    .desc = 90 sheets of plasma.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/medical-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/medical-crates.ftl
@@ -1,0 +1,13 @@
+ent-CrateMedicalDefib = Defibrillator crate
+
+ent-CrateMedicalSupplies = Medical supplies crate
+    .desc = Basic medical supplies.
+
+ent-CrateChemistrySupplies = Chemistry supplies crate
+    .desc = Basic chemistry supplies.
+
+ent-CrateMedicalSurgery = Surgical supplies crate
+    .desc = Surgical instruments.
+
+ent-CrateMedicalScrubs = Medical scrubs crate
+    .desc = Medical clothings.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/salvage-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/salvage-crates.ftl
@@ -1,0 +1,2 @@
+ent-CrateSalvageEquipment = Salvage equipment crate
+    .desc = For the daring.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/security-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/security-crates.ftl
@@ -1,0 +1,20 @@
+ent-CrateSecurityArmor = armor crate
+    .desc = Three vests of well-rounded, decently-protective armor. Requires Security access to open.
+
+ent-CrateSecurityHelmet = helmet crate
+    .desc = Contains three standard-issue brain buckets. Requires Security access to open.
+
+ent-CrateSecurityNonlethal = nonlethals crate
+    .desc = Disabler weapons. Requires Security access to open.
+
+ent-CrateSecurityLaser = lasers crate
+    .desc = Contains three lethal, high-energy laser guns. Requires Security access to open.
+
+ent-CrateSecurityRiot = swat crate
+    .desc = Contains two sets of heavy body armor and helmets and 2 shotguns with 6 rounds of beanbag shells each. Requires Armory access to open.
+
+ent-CrateSecuritySupplies = security supplies crate
+    .desc = Contains various supplies for the station's Security team. Requires Security access to open.
+
+ent-CrateRestraints = restraints crate
+    .desc = Contains two boxes each of handcuffs and zipties. Requires Security access to open.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/service-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/service-crates.ftl
@@ -1,0 +1,20 @@
+ent-CrateServiceJanitorialSupplies = Janitorial supplies crate
+    .desc = Fight back against dirt and grime with Nanotrasen's Janitorial Essentials(tm)! Contains three buckets, caution signs, and cleaner grenades. Also has a single mop, broom, spray cleaner, rag, and trash bag.
+
+ent-CrateServiceReplacementLights = Replacement lights crate
+    .desc = May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs.
+
+ent-CrateMousetrapBoxes = Mousetraps crate
+    .desc = Mousetraps, for when all of service is being haunted by an entire horde of rats. Use sparingly... or not.
+
+ent-CrateServiceSmokeables = Smokeables crate
+    .desc = Tired of a quick death on the station? Order this crate and chain-smoke your way to a coughy demise!
+
+ent-CrateServiceCustomSmokable = DIY smokeables crate
+    .desc = Want to get a little creative with what you use to destroy your lungs? Then this crate is for you! Has everything you need to roll your own cigarettes.
+
+ent-CrateServiceBureaucracy = Bureaucracy crate
+    .desc = Several stacks of paper and a few pens, what more can you ask for.
+
+ent-CrateServicePersonnel = Personnel crate
+    .desc = Contains a box of blank ID cards and PDAs.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/syndicate-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/syndicate-crates.ftl
@@ -1,0 +1,5 @@
+ent-CrateSyndicateSurplusBundle = Syndicate surplus crate
+    .desc = Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
+
+ent-CrateSyndicateSuperSurplusBundle = Syndicate super surplus crate.
+    .desc = Contains 125 telecrystals worth of completely random Syndicate items.

--- a/Resources/Locale/en-US/prototypes/entities/objects/specific/xenoarchaelogy/artifact-equipment.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/objects/specific/xenoarchaelogy/artifact-equipment.ftl
@@ -1,0 +1,2 @@
+ent-CrateArtifactContainer = Artifact container
+    .desc = Used to safely contain and move artifacts.

--- a/Resources/Locale/en-US/prototypes/entities/structures/shuttles/thrusters.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/shuttles/thrusters.ftl
@@ -1,0 +1,14 @@
+ent-BaseThruster = Thruster
+    .desc = A thruster that allows a shuttle to move.
+
+ent-Thruster = { ent-BaseThruster }
+    .desc = { ent-BaseThruster.desc }
+
+ent-DebugThruster = Debug thruster
+    .desc = It goes nyooooooom. It doesn't need power nor space.
+
+ent-Gyroscope = Gyroscope
+    .desc = Increases the shuttle's potential angular rotation.
+
+ent-DebugGyroscope = Debug gyroscope
+    .desc = { ent-Gyroscope.desc }

--- a/Resources/Locale/en-US/prototypes/entities/structures/storage/canisters/gas-canisters.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/storage/canisters/gas-canisters.ftl
@@ -1,0 +1,71 @@
+ent-GasCanister = Gas canister
+    .desc = A canister that can contain any type of gas. It can be attached to connector ports using a wrench.
+
+ent-StorageCanister = Storage canister
+    .desc = { ent-GasCanister.desc }
+
+ent-AirCanister = Air canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain air mixture. It can be attached to connector ports using a wrench.
+
+ent-OxygenCanister = Oxygen canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain oxygen. It can be attached to connector ports using a wrench.
+
+ent-NitrogenCanister = Nitrogen canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain nitrogen. It can be attached to connector ports using a wrench.
+
+ent-CarbonDioxideCanister = Carbon dioxide canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain carbon dioxide. It can be attached to connector ports using a wrench.
+
+ent-PlasmaCanister = Plasma canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain plasma. It can be attached to connector ports using a wrench.
+
+ent-TritiumCanister = Tritium canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain tritium. It can be attached to connector ports using a wrench.
+
+ent-WaterVaporCanister = Water vapor canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain water vapor. It can be attached to connector ports using a wrench.
+
+ent-MiasmaCanister = Miasma canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain miasma. It can be attached to connector ports using a wrench.
+
+ent-NitrousOxideCanister = Nitrous oxide canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain nitrous oxide. It can be attached to connector ports using a wrench.
+
+ent-FrezonCanister = Frezon canister
+    .desc = A coolant with light hallucinogenic properties. Proceed.
+
+ent-GasCanisterBrokenBase = Broken gas canister
+    .desc = A broken gas canister. Not useless yet, as it can be salvaged for high quality materials.
+
+ent-StorageCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-AirCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-OxygenCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-NitrogenCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-CarbonDioxideCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-PlasmaCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-TritiumCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-WaterVaporCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-MiasmaCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-NitrousOxideCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }
+
+ent-FrezonCanisterBroken = { ent-GasCanisterBrokenBase }
+    .desc = { ent-GasCanisterBrokenBase.desc }

--- a/Resources/Locale/en-US/prototypes/entities/structures/storage/tanks/tanks.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/storage/tanks/tanks.ftl
@@ -1,0 +1,23 @@
+ent-WeldingFuelTank = Fuel tank
+    .desc = A fuel tank. It's used to store high amounts of fuel.
+
+ent-WeldingFuelTankFull = { ent-WeldingFuelTank }
+    .desc = { ent-WeldingFuelTank.desc }
+
+ent-WaterTank = Water tank
+    .desc = A water tank. It's used to store high amounts of water.
+
+ent-WaterTankFull = { ent-WaterTank }
+    .desc = { ent-WaterTank.desc }
+
+ent-WaterCooler = Water cooler
+    .desc = Seems like a good place to stand and waste time.
+
+ent-WaterTankHighCapacity = High-capacity water tank
+    .desc = A highly pressurized water tank made to hold gargantuan amounts of water.
+
+ent-KvassTank = КВАС
+    .desc = A cool refreshing drink with a taste of socialism.
+
+ent-KvassTankFull = { ent-KvassTank }
+    .desc = { ent-KvassTank.desc }

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "smg crate"
   id: ArmorySmg
-  description: "Contains three WT-550 SMGs with six mags. Requires Armory access to open."
   icon:
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
     state: icon
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "shotgun crate"
   id: ArmoryShotgun
-  description: "For when the enemy absolutely needs to be replaced with lead. Contains three Enforcer Combat Shotguns, and some standard shotgun shells. Requires Armory access to open."
   icon:
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
     state: icon

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "air canister"
   id: AtmosphericsAir
-  description: "Air canister"
   icon:
     sprite: Structures/Storage/canister.rsi
     state: grey
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "oxygen canister"
   id: AtmosphericsOxygen
-  description: "Oxygen canister"
   icon:
     sprite: Structures/Storage/canister.rsi
     state: blue
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "nitrogen canister"
   id: AtmosphericsNitrogen
-  description: "Nitrogen canister"
   icon:
     sprite: Structures/Storage/canister.rsi
     state: red
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "carbon dioxide canister"
   id: AtmosphericsCarbonDioxide
-  description: "Carbon dioxide canister"
   icon:
     sprite: Structures/Storage/canister.rsi
     state: black

--- a/Resources/Prototypes/Catalog/Cargo/cargo_botany.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_botany.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "exotic seeds crate"
   id: HydroponicsSeedsExotic
-  description: "Any entrepreneuring botanist's dream. Contains many different exotic seeds. Requires Hydroponics access to open."
   icon:
     sprite: Objects/Specific/Hydroponics/banana.rsi
     state: seed
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "Medicinal seeds crate"
   id: HydroponicsSeedsMedicinal
-  description: "A wannabe chemist's dream! Contains many different medicinal seeds. Requires Hydroponics access to open."
   icon:
     sprite: Objects/Specific/Hydroponics/galaxythistle.rsi
     state: seed
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "hydroponics crate"
   id: HydroponicsTools
-  description: "Supplies for growing a great garden! Contains two bottles of ammonia, two Plant-B-Gone spray bottles, a hatchet, cultivator, plant analyzer, as well as a pair of leather gloves and a botanist's apron."
   icon:
     sprite: Objects/Tools/Hydroponics/hoe.rsi
     state: icon
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "seeds crate"
   id: HydroponicsSeeds
-  description: "Big things have small beginnings. Contains nine different seeds."
   icon:
     sprite: Objects/Specific/Hydroponics/apple.rsi
     state: seed

--- a/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "explosive emergency crate"
   id: EmergencyExplosive
-  description: "Science gone bonkers? Beeping behind the airlock? Buy now and be the hero the station des... I mean needs! (time not included)"
   icon:
     sprite: Clothing/Head/Helmets/bombsuit.rsi
     state: icon
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "firefighting crate"
   id: EmergencyFire
-  description: "Only you can prevent station fires. Partner up with two firefighter suits, gas masks, flashlights, large oxygen tanks, extinguishers, and hardhats!"
   icon:
     sprite: Objects/Misc/fire_extinguisher.rsi
     state: fire_extinguisher_closed
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "internals crate"
   id: EmergencyInternals
-  description: "Master your life energy and control your breathing with three breath masks, three emergency oxygen tanks and three large air tanks."
   icon:
     sprite: Clothing/Mask/breath.rsi
     state: icon
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "radiation protection crate"
   id: EmergencyRadiation
-  description: "Survive the Nuclear Apocalypse and Supermatter Engine alike with two sets of Radiation suits. Each set contains a helmet, suit, and Geiger counter. We'll even throw in a bottle of vodka and some glasses too, considering the life-expectancy of people who order this."
   icon:
     sprite: Structures/Wallmounts/signs.rsi
     state: radiation
@@ -47,9 +39,7 @@
   group: market
 
 - type: cargoProduct
-  name: "inflatable wall crate"
   id: EmergencyInflatablewall
-  description: "Three stacks of inflatable walls for when the stations metal walls don't want to hold atmosphere anymore."
   icon:
     sprite: Objects/Misc/inflatable_wall.rsi
     state: item_wall

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "LV cables crate"
   id: EngineeringCableLv
-  description: "3 coils of LV cables."
   icon:
     sprite: Objects/Tools/cable-coils.rsi
     state: coillv-30
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "MV cables crate"
   id: EngineeringCableMv
-  description: "3 coils of MV cables."
   icon:
     sprite: Objects/Tools/cable-coils.rsi
     state: coilmv-30
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "HV cables crate"
   id: EngineeringCableHv
-  description: "3 coils of HV cables."
   icon:
     sprite: Objects/Tools/cable-coils.rsi
     state: coilhv-30
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "bulk cables crate"
   id: EngineeringCableBulk
-  description: "2 coils each for every cable type."
   icon:
     sprite: Objects/Tools/cable-coils.rsi
     state: coilall-30
@@ -47,9 +39,7 @@
   group: market
 
 - type: cargoProduct
-  name: "electrical supplies crate"
   id: EngineeringElectricalSupplies
-  description: "N.T. is not responsible for any workplace infighting relating to the insulated gloves included within these crates."
   icon:
     sprite: Objects/Tools/Toolboxes/toolbox_yellow.rsi
     state: icon

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "packaged antimatter reactor crate"
   id: EngineAmeShielding
-  description: "9 parts for the main body of an antimatter reactor, or for expanding an existing one."
   icon:
     sprite: Objects/Power/AME/ame_part.rsi
     state: box
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "antimatter containment jar crate"
   id: EngineAmeJar
-  description: "3 antimatter jars, for fuelling an antimatter reactor."
   icon:
     sprite: Objects/Power/AME/ame_jar.rsi
     state: jar
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "antimatter control unit crate"
   id: EngineAmeControl
-  description: "The control unit of an antimatter reactor."
   icon:
     sprite: Structures/Power/Generation/ame.rsi
     state: control
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "singularity generator crate"
   id: EngineSingularityGenerator
-  description: "Contains a singularity generator. The mother of the beast."
   icon:
     sprite: Structures/Power/Generation/Singularity/generator.rsi
     state: icon
@@ -47,9 +39,7 @@
   group: market
 
 - type: cargoProduct
-  name: "singularity containment crate"
   id: EngineSingularityContainment
-  description: "Contains a singularity containment field generator."
   icon:
     sprite: Structures/Power/Generation/Singularity/containment.rsi
     state: icon
@@ -71,9 +61,7 @@
 #  group: market
 
 - type: cargoProduct
-  name: "radiation collector crate"
   id: EngineSingularityCollector
-  description: "Contains a radiation collector. Safety first!"
   icon:
     sprite: Structures/Power/Generation/Singularity/collector.rsi
     state: ca_on
@@ -83,9 +71,7 @@
   group: market
 
 - type: cargoProduct
-  name: "particle accelerator crate"
   id: EngineParticleAccelerator
-  description: "Contains all the boards needed to construct a Particle Accelerator."
   icon:
     sprite: Structures/Power/Generation/PA/control_box.rsi
     state: boxc
@@ -93,11 +79,9 @@
   cost: 10000
   category: Engineering
   group: market
-  
+
 - type: cargoProduct
-  name: "solar assembly parts"
   id: EngineSolar
-  description: "Parts for constructing solar panels and trackers."
   icon:
     sprite: Objects/Power/solar_parts.rsi
     state: solar_assembly_parts

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "emergency pizza crate"
   id: FoodPizza
-  description: Help do your part to end station hunger by distributing pizza to underfunded departments!
   icon:
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "MRE crate"
   id: FoodMRE
-  description: A military style meal fit to feed a whole department.
   icon:
     sprite: Objects/Consumable/Food/snacks.rsi
     state: nutribrick
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "kitchen supplies crate"
   id: FoodCook
-  description: Extra kitchen supplies, in case the botanists are absent.
   icon:
     sprite: Objects/Consumable/Food/ingredients.rsi
     state: flour-big
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: kvass tank crate
   id: FoodCrateKvassTank
-  description: A tank with refreshing kvass, which helps so much in the heat.
   icon:
     sprite: Structures/Storage/kvass.rsi
     state: kvass

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "big band instrument collection"
   id: FunInstruments
-  description: "Get your sad station movin' and groovin' with this fine collection! Contains thirteen different instruments"
   icon:
     sprite: Objects/Fun/Instruments/accordion.rsi
     state: icon
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "brass instrument ensemble crate"
   id: FunBrass
-  description: "Bring some jazz to the station with the brass ensemble. Contains a variety of brass instruments for the whole station to play."
   icon:
     sprite: Structures/Furniture/instruments.rsi
     state: tuba
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "art supplies"
   id: FunArtSupplies
-  description: "Make some happy little accidents with lots of crayons!"
   icon:
     sprite: Objects/Fun/crayons.rsi
     state: box
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "plushie crate"
   id: FunPlushies
-  description: "A buncha soft plushies. Throw them around and then wonder how you're gonna explain this purchase to NT"
   icon:
     sprite: Objects/Fun/toys.rsi
     state: plushie_h
@@ -47,9 +39,7 @@
   group: market
 
 - type: cargoProduct
-  name: "board game crate"
   id: FunBoardGames
-  description: "Game nights have been proven to either decrease boredom or increase murderous rage depending on the game"
   icon:
     sprite: Objects/Fun/dice.rsi
     state: d66
@@ -59,9 +49,7 @@
   group: market
 
 - type: cargoProduct
-  name: "ATV crate"
   id: FunATV
-  description: "An Absolutely Taxable Vehicle to help cargo with hauling."
   icon:
     sprite: Objects/Vehicles/atv.rsi
     state: vehicle

--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "bee crate"
   id: LivestockBee
-  description: "A crate containing a swarm of eight bees"
   icon:
     sprite: Mobs/Animals/bee.rsi
     state: 0
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "butterfly crate"
   id: LivestockButterfly
-  description: "A crate containing five butterflies"
   icon:
     sprite: Mobs/Animals/butterfly.rsi
     state: butterfly
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "cat crate"
   id: LivestockCat
-  description: "A crate containing a single cat"
   icon:
     sprite: Mobs/Pets/cat.rsi
     state: cat
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "chicken crate"
   id: LivestockChicken
-  description: "A crate containing four fully grown chickens"
   icon:
     sprite: Mobs/Animals/chicken.rsi
     state: icon-1
@@ -47,9 +39,7 @@
   group: market
 
 - type: cargoProduct
-  name: "duck crate"
   id: LivestockDuck
-  description: "A crate containing six fully grown ducks"
   icon:
     sprite: Mobs/Animals/duck.rsi
     state: icon-0
@@ -59,9 +49,7 @@
   group: market
 
 - type: cargoProduct
-  name: "corgi crate"
   id: LivestockCorgi
-  description: "A crate containing a single corgi"
   icon:
     sprite: Mobs/Pets/corgi.rsi
     state: corgi
@@ -71,9 +59,7 @@
   group: market
 
 - type: cargoProduct
-  name: "cow crate"
   id: LivestockCow
-  description: "A crate containing a single cow"
   icon:
     sprite: Mobs/Animals/cow.rsi
     state: cow
@@ -83,9 +69,7 @@
   group: market
 
 - type: cargoProduct
-  name: "goat crate"
   id: LivestockGoat
-  description: "A crate containing a single goat"
   icon:
     sprite: Mobs/Animals/goat.rsi
     state: goat
@@ -95,9 +79,7 @@
   group: market
 
 - type: cargoProduct
-  name: "goose crate"
   id: LivestockGoose
-  description: "A crate containing two geese"
   icon:
     sprite: Mobs/Animals/goose.rsi
     state: goose
@@ -107,9 +89,7 @@
   group: market
 
 - type: cargoProduct
-  name: "gorilla crate"
   id: LivestockGorilla
-  description: "A crate containing a single gorilla"
   icon:
     sprite: Mobs/Animals/gorilla.rsi
     state: icon
@@ -119,9 +99,7 @@
   group: market
 
 - type: cargoProduct
-  name: "monkey cube crate"
   id: LivestockMonkeyCube
-  description: "A crate containing three boxes of monkey cubes"
   icon:
     sprite: Mobs/Animals/monkey.rsi
     state: monkey
@@ -131,9 +109,7 @@
   group: market
 
 - type: cargoProduct
-  name: "mice crate"
   id: LivestockMouse
-  description: "A crate containing five -blind- mice"
   icon:
     sprite: Mobs/Animals/mouse.rsi
     state: icon-0
@@ -143,9 +119,7 @@
   group: market
 
 - type: cargoProduct
-  name: "parrot crate"
   id: LivestockParrot
-  description: "A crate containing three parrots"
   icon:
     sprite: Mobs/Animals/parrot.rsi
     state: parrot
@@ -155,9 +129,7 @@
   group: market
 
 - type: cargoProduct
-  name: "penguin crate"
   id: LivestockPenguin
-  description: "A crate containing two penguins"
   icon:
     sprite: Mobs/Animals/penguin.rsi
     state: penguin
@@ -167,9 +139,7 @@
   group: market
 
 - type: cargoProduct
-  name: "snake crate"
   id: LivestockSnake
-  description: "A crate containing three snakes"
   icon:
     sprite: Mobs/Animals/snake.rsi
     state: snake

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -1,31 +1,5 @@
 - type: cargoProduct
-  name: "water tank"
-  id: MaterialWaterTank
-  description: "A tank of fresh water for when the station has ran out."
-  icon:
-    sprite: Structures/Storage/tanks.rsi
-    state: watertank
-  product: WaterTankFull
-  cost: 2000
-  category: Materials
-  group: market
-
-- type: cargoProduct
-  name: "fuel tank"
-  id: MaterialFuelTank
-  description: "A tank of welder fuel for when the station has ran out."
-  icon:
-    sprite: Structures/Storage/tanks.rsi
-    state: fueltank
-  product: WeldingFuelTankFull
-  cost: 2000
-  category: Materials
-  group: market
-
-- type: cargoProduct
-  name: "crate of glass sheets"
   id: MaterialGlass
-  description: "90 sheets of glass, packed with care."
   icon:
     sprite: Objects/Materials/Sheets/glass.rsi
     state: glass_3
@@ -35,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "crate of steel sheets"
   id: MaterialSteel
-  description: "90 sheets of steel."
   icon:
     sprite: Objects/Materials/Sheets/metal.rsi
     state: steel_3
@@ -47,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "crate of plastic sheets"
   id: MaterialPlastic
-  description: "90 sheets of plastic."
   icon:
     sprite: Objects/Materials/Sheets/other.rsi
     state: plastic_3
@@ -59,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "crate of plasteel sheets"
   id: MaterialPlasteel
-  description: "90 sheets of plasteel."
   icon:
     sprite: Objects/Materials/Sheets/metal.rsi
     state: plasteel_3
@@ -71,9 +39,7 @@
   group: market
 
 - type: cargoProduct
-  name: "crate of solid plasma"
   id: MaterialPlasma
-  description: "90 sheets of plasma."
   icon:
     sprite: Objects/Materials/Sheets/other.rsi
     state: plasma_3
@@ -82,3 +48,22 @@
   category: Materials
   group: market
 
+- type: cargoProduct
+  id: MaterialFuelTank
+  icon:
+    sprite: Structures/Storage/tanks.rsi
+    state: fueltank
+  product: WeldingFuelTankFull
+  cost: 2000
+  category: Materials
+  group: market
+
+- type: cargoProduct
+  id: MaterialWaterTank
+  icon:
+    sprite: Structures/Storage/tanks.rsi
+    state: watertank
+  product: WaterTankFull
+  cost: 2000
+  category: Materials
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "Medical Supplies"
   id: MedicalSupplies
-  description: Basic medical supplies.
   icon:
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: firstaid
@@ -9,11 +7,9 @@
   cost: 1000
   category: Medical
   group: market
-  
+
 - type: cargoProduct
-  name: "Chemistry Supplies"
   id: MedicalChemistrySupplies
-  description: Basic chemistry supplies.
   icon:
     sprite: Objects/Specific/Chemistry/beaker.rsi
     state: beaker

--- a/Resources/Prototypes/Catalog/Cargo/cargo_science.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_science.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "Artifact Container"
   id: ArtifactContainer
-  description: Used to safely contain and move artifacts.
   icon:
     sprite: Structures/Storage/Crates/artifact.rsi
     state: artifact_container_icon

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "armor crate"
   id: SecurityArmor
-  description: "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
   icon:
     sprite: Clothing/OuterClothing/Vests/oldarmor.rsi
     state: icon
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "helmet crate"
   id: SecurityHelmet
-  description: "Contains three standard-issue brain buckets. Requires Security access to open."
   icon:
     sprite: Clothing/Head/Helmets/security.rsi
     state: icon
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "non-lethals crate"
   id: SecurityNonLethal
-  description: "Stamina-draining disabler weapons. Requires Security access to open."
   icon:
     sprite: Objects/Weapons/Guns/Battery/taser.rsi
     state: icon
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "Lasers Crate"
   id: SecurityLaser
-  description: "Contains three lethal, high-energy laser guns. Requires Security access to open."
   icon:
     sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
     state: icon
@@ -47,9 +39,7 @@
   group: market
 
 - type: cargoProduct
-  name: "riot crate"
   id: SecurityRiot
-  description: "Contains two sets of heavy body armor and helmets and 2 shotguns with 6 rounds of beanbag shells each. Requires Armory access to open."
   icon:
     sprite: Clothing/OuterClothing/Armor/riot.rsi
     state: icon
@@ -59,9 +49,7 @@
   group: market
 
 - type: cargoProduct
-  name: "security supplies crate"
   id: SecuritySupplies
-  description: "Contains various supplies for the station's Security team. Requires Security access to open."
   icon:
     sprite: Objects/Storage/boxes.rsi
     state: box_security
@@ -71,9 +59,7 @@
   group: market
 
 - type: cargoProduct
-  name: "restraints crate"
   id: SecurityRestraints
-  description: "Contains two boxes each of handcuffs and zipties. Requires Security access to open."
   icon:
     sprite: Objects/Misc/handcuffs.rsi
     state: handcuff

--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: "janitorial supplies crate"
   id: ServiceJanitorial
-  description: "Fight back against dirt and grime with Nanotrasen's Janitorial Essentials(tm)! Contains three buckets, caution signs, a single mop and bucket, spray cleaner, and soap."
   icon:
     sprite: Objects/Specific/Janitorial/janitorial.rsi
     state: cleaner
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: "replacement lights crate"
   id: ServiceLightsReplacement
-  description: "May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs."
   icon:
     sprite: Objects/Power/light_bulb.rsi
     state: normal
@@ -23,9 +19,7 @@
   group: market
 
 - type: cargoProduct
-  name: "mousetraps crate"
   id: MousetrapBoxes
-  description: "Mousetraps, for when all of service is being haunted by an entire horde of rats. Use sparingly... or not."
   icon:
     sprite: Objects/Devices/mousetrap.rsi
     state: mousetrap
@@ -35,9 +29,7 @@
   group: market
 
 - type: cargoProduct
-  name: "lung cancer crate"
   id: ServiceSmokeables
-  description: "Tired of a quick death on the station? Order this crate and chain-smoke your way to a coughy demise!"
   icon:
     sprite: Objects/Consumable/Smokeables/Cigarettes/Cartons/green.rsi
     state: closed
@@ -47,9 +39,7 @@
   group: market
 
 - type: cargoProduct
-  name: "DIY lung cancer crate"
   id: ServiceCustomSmokable
-  description: "Want to get a little creative with what you use to destroy your lungs? Then this crate is for you! Has everything you need to roll your own cigarettes."
   icon:
     sprite: Objects/Consumable/Smokeables/Cigarettes/Cartons/green.rsi
     state: closed
@@ -59,9 +49,7 @@
   group: market
 
 - type: cargoProduct
-  name: "bureaucracy crate"
   id: ServiceBureaucracy
-  description: "Several stacks of paper and a few pens, what more can you ask for."
   icon:
     sprite: Objects/Misc/bureaucracy.rsi
     state: pen
@@ -71,9 +59,7 @@
   group: market
 
 - type: cargoProduct
-  name: "personnel crate"
   id: ServicePersonnel
-  description: "Contains a box of blank ID cards and PDAs"
   icon:
     sprite: Objects/Misc/id_cards.rsi
     state: default

--- a/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
@@ -1,7 +1,5 @@
 - type: cargoProduct
-  name: shuttle thruster
   id: ShuttleThruster
-  description: A thruster that allows a shuttle to move.
   icon:
     sprite: Structures/Shuttles/thruster.rsi
     state: base
@@ -11,9 +9,7 @@
   group: market
 
 - type: cargoProduct
-  name: shuttle gyroscope
   id: ShuttleGyroscope
-  description: A gyroscope for use in rotating a shuttle.
   icon:
     sprite: Structures/Shuttles/gyroscope.rsi
     state: base
@@ -23,9 +19,7 @@
   group: market
 
 # - type: cargoProduct
-  # name: shuttle powering crate
   # id: ShuttlePowerKit
-  # description: Contains boards for wallmounted power utilities.
   # icon:
     # sprite: Structures/Machines/computers.rsi
     # state: avionics-systems

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -1,8 +1,6 @@
 - type: entity
   id: CrateArmorySMG
-  name: smg crate
   parent: CrateWeaponSecure
-  description: "Contains two high-powered, semiautomatic rifles with four mags. Requires Armory access to open."
   components:
   - type: StorageFill
     contents:
@@ -13,9 +11,7 @@
 
 - type: entity
   id: CrateArmoryShotgun
-  name: shotgun crate
   parent: CrateWeaponSecure
-  description: "For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer Combat Shotguns, and some standard shotgun shells. Requires Armory access to open."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/botany.yml
@@ -1,8 +1,6 @@
 - type: entity
   id: CrateHydroponicsSeedsExotic
-  name: exotic seeds crate
   parent: CrateHydroSecure
-  description: "Any entrepreneuring botanist's dream. Contains many different exotic seeds. Requires Hydroponics access to open."
   components:
   - type: StorageFill
     contents:
@@ -25,9 +23,7 @@
 
 - type: entity
   id: CrateHydroponicsSeedsMedicinal
-  name: medicinal seeds crate
   parent: CrateHydroSecure
-  description: "The wannabe chemist's dream. The power of medicine is at your fingertips! Requires Hydroponics access to open."
   components:
   - type: StorageFill
     contents:
@@ -44,9 +40,7 @@
 
 - type: entity
   id: CrateHydroponicsTools
-  name: hydroponics equipment crate
   parent: CrateHydroponics
-  description: "Supplies for growing a great garden! Contains some spray bottles of plant chemicals, a hatchet, a mini-hoe, scythe, as well as a pair of leather gloves and a botanist's apron."
   components:
   - type: StorageFill
     contents:
@@ -69,9 +63,7 @@
 
 - type: entity
   id: CrateHydroponicsSeeds
-  name: seeds crate
   parent: CrateHydroponics
-  description: "Big things have small beginnings. Contains twelve different seeds."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -1,6 +1,5 @@
 - type: entity
   id: CrateEmergencyExplosive
-  name: bomb suit crate
   parent: CrateSecgear
   components:
   - type: StorageFill
@@ -20,7 +19,6 @@
 
 - type: entity
   id: CrateEmergencyFire
-  name: firefighting crate
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -40,7 +38,6 @@
 
 - type: entity
   id: CrateEmergencyInternals
-  name: internals crate
   parent: CrateInternals
   components:
   - type: StorageFill
@@ -58,7 +55,6 @@
 
 - type: entity
   id: CrateEmergencyRadiation
-  name: radiation protection crate
   parent: CrateRadiation
   components:
   - type: StorageFill
@@ -76,7 +72,6 @@
 
 - type: entity
   id: CrateEmergencyInflatablewall
-  name: inflatable wall crate
   parent: CratePlastic
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -1,6 +1,5 @@
 - type: entity
   id: CrateEngineeringGear
-  name: engineering gear crate
   parent: CrateEngineering
   components:
   - type: StorageFill
@@ -20,7 +19,6 @@
 
 - type: entity
   id: CrateEngineeringToolbox
-  name: toolbox crate
   parent: CrateEngineering
   components:
   - type: StorageFill
@@ -32,7 +30,6 @@
 
 #- type: entity
 #  id: CrateEngineeringPowercell
-#  name:  ame crate
 #  parent: CrateElectrical
 #  components:
 #  - type: StorageFill
@@ -42,7 +39,6 @@
 
 - type: entity
   id: CrateEngineeringCableLV
-  name: LV cable crate
   parent: CrateElectrical
   components:
   - type: StorageFill
@@ -52,7 +48,6 @@
 
 - type: entity
   id: CrateEngineeringCableMV
-  name: MV cable crate
   parent: CrateElectrical
   components:
   - type: StorageFill
@@ -62,7 +57,6 @@
 
 - type: entity
   id: CrateEngineeringCableHV
-  name: HV cable crate
   parent: CrateElectrical
   components:
   - type: StorageFill
@@ -72,7 +66,6 @@
 
 - type: entity
   id: CrateEngineeringCableBulk
-  name: bulk cable crate
   parent: CrateElectrical
   components:
   - type: StorageFill
@@ -86,7 +79,6 @@
 
 - type: entity
   id: CrateEngineeringElectricalSupplies
-  name: Electrical Supplies Crate
   parent: CrateElectrical
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -2,8 +2,6 @@
 
 - type: entity
   id: CrateEngineeringAMEShielding
-  name: packaged antimatter reactor crate
-  description: "9 parts for the main body of an antimatter reactor, or for expanding an existing one."
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill
@@ -13,8 +11,6 @@
 
 - type: entity
   id: CrateEngineeringAMEJar
-  name: antimatter containment jar crate
-  description: "3 antimatter jars, for fuelling an antimatter reactor."
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill
@@ -24,8 +20,6 @@
 
 - type: entity
   id: CrateEngineeringAMEControl
-  name: antimatter control unit crate
-  description: "The control unit of an antimatter reactor."
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill
@@ -37,8 +31,6 @@
 
 - type: entity
   id: CrateEngineeringSingularityEmitter
-  name: emitter crate
-  description: "An emitter, best used for singularity engines."
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill
@@ -48,8 +40,6 @@
 
 - type: entity
   id: CrateEngineeringSingularityCollector
-  name: radiation collector crate
-  description: "A radiation collector, best used for singularity engines."
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill
@@ -59,8 +49,6 @@
 
 - type: entity
   id: CrateEngineeringSingularityContainment
-  name: containment field generator crate
-  description: "A containment field generator, keeps the singulo in submission."
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill
@@ -70,8 +58,6 @@
 
 - type: entity
   id: CrateEngineeringSingularityGenerator
-  name: singularity generator crate
-  description: "A singularity generator, the mother of the beast."
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill
@@ -83,8 +69,6 @@
 
 - type: entity
   id: CrateEngineeringParticleAccelerator
-  name: PA crate
-  description: "Complex to setup, but rewarding as fuck."
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill
@@ -119,7 +103,6 @@
 
 - type: entity
   id: CrateEngineeringGenerator
-  name: generator crate
   parent: CrateEngineering
   components:
   - type: StorageFill
@@ -129,7 +112,6 @@
 
 - type: entity
   id: CrateEngineeringSolar
-  name: solar assembly crate
   parent: CrateEngineering
   components:
   - type: StorageFill
@@ -139,7 +121,6 @@
 
 - type: entity
   id: CrateEngineeringShuttle
-  name: shuttle powering crate
   parent: CrateEngineeringSecure
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -1,7 +1,5 @@
 - type: entity
   id: CrateFoodPizza
-  name: emergency pizza delivery
-  description: Help do your part to end station hunger by distributing pizza to underfunded departments!
   parent: CratePlastic
   components:
   - type: StorageFill
@@ -13,8 +11,6 @@
 
 - type: entity
   id: CrateFoodMRE
-  name: MRE crate
-  description: A military style meal fit to feed a whole department.
   parent: CratePlastic
   components:
   - type: StorageFill
@@ -24,8 +20,6 @@
 
 - type: entity
   id: CrateFoodCooking
-  name: kitchen supplies crate
-  description: Extra kitchen supplies, in case the botanists are absent.
   parent: CratePlastic
   components:
   - type: StorageFill
@@ -47,7 +41,6 @@
 
 - type: entity
   id: CrateFoodKvassTank
-  name:  kvass tank crate
   parent: CrateGenericSteel
   components:
     - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -1,6 +1,5 @@
 - type: entity
   id: CrateFunPlushie
-  name: plushie crate
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -30,8 +29,6 @@
 
 - type: entity
   id: CrateFunInstruments
-  name: big band instrument collection
-  description: Get your sad station movin' and groovin' with this fine collection! Contains thirteen different instruments.
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -65,8 +62,6 @@
 
 - type: entity
   id: CrateFunBrass
-  name: brass instrument ensemble crate
-  description: Bring some jazz to the station with the brass ensemble. Contains a variety of brass instruments for the whole station to play.
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -84,7 +79,6 @@
 
 - type: entity
   id: CrateFunArtSupplies
-  name: art supplies
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -96,7 +90,6 @@
 
 - type: entity
   id: CrateFunBoardGames
-  name: board game crate
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -114,7 +107,6 @@
 
 - type: entity
   id: CrateFunATV
-  name: ATV crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -126,7 +118,6 @@
 
 - type: entity
   id: CrateFunSyndicateSegway
-  name: syndicate segway crate
   parent: CrateLivestock
   components:
     - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -1,6 +1,5 @@
 - type: entity
   id: CrateMaterialGlass
-  name:  glass sheet crate
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -10,7 +9,6 @@
 
 - type: entity
   id: CrateMaterialSteel
-  name:  steel sheet crate
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -20,7 +18,6 @@
 
 - type: entity
   id: CrateMaterialPlastic
-  name:  plastic sheet crate
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -30,13 +27,30 @@
 
 - type: entity
   id: CrateMaterialWood
-  name:  wood crate
   parent: CrateGenericSteel
   components:
   - type: StorageFill
     contents:
       - id: MaterialWoodPlank
         amount: 1
+
+- type: entity
+  id: CrateMaterialPlasteel
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: SheetPlasteel
+        amount: 3
+
+- type: entity
+  id: CrateMaterialPlasma
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: SheetPlasma
+        amount: 3
 
 #- type: entity
 #  id: CrateMaterialHFuelTank
@@ -57,23 +71,3 @@
 #    contents:
 #      - id: WaterTankFull
 #        amount: 1
-
-- type: entity
-  id: CrateMaterialPlasteel
-  name: plasteel crate
-  parent: CrateGenericSteel
-  components:
-  - type: StorageFill
-    contents:
-      - id: SheetPlasteel
-        amount: 3
-
-- type: entity
-  id: CrateMaterialPlasma
-  name: solid plasma crate
-  parent: CrateGenericSteel
-  components:
-  - type: StorageFill
-    contents:
-      - id: SheetPlasma
-        amount: 3

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -1,6 +1,5 @@
 - type: entity
   id: CrateMedicalDefib
-  name:  defibrillator crate
   parent: CrateMedical
   components:
   - type: StorageFill
@@ -10,7 +9,6 @@
 
 - type: entity
   id: CrateMedicalSupplies
-  name: medical supplies crate
   parent: CrateMedical
   components:
   - type: StorageFill
@@ -28,7 +26,6 @@
 
 - type: entity
   id: CrateChemistrySupplies
-  name: chemistry supplies crate
   parent: CrateMedical
   components:
   - type: StorageFill
@@ -44,7 +41,6 @@
 
 - type: entity
   id: CrateMedicalSurgery
-  name: surgical supplies crate
   parent: CrateSurgery
   components:
   - type: StorageFill
@@ -66,7 +62,6 @@
 
 - type: entity
   id: CrateMedicalScrubs
-  name: medical scrubs crate
   parent: CrateMedical
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/npc.yml
@@ -1,6 +1,5 @@
 - type: entity
   id: CrateNPCBee
-  name: crate of bees
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -11,7 +10,6 @@
 
 - type: entity
   id: CrateNPCButterflies
-  name: crate of butterflies
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -22,7 +20,6 @@
 
 - type: entity
   id: CrateNPCCat
-  name: cat crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -33,7 +30,6 @@
 
 - type: entity
   id: CrateNPCChicken
-  name: chicken crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -44,7 +40,6 @@
 
 - type: entity
   id: CrateNPCDuck
-  name: duck crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -59,7 +54,6 @@
 
 - type: entity
   id: CrateNPCCorgi
-  name: corgi crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -69,7 +63,6 @@
 
 - type: entity
   id: CrateNPCCow
-  name: cow crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -80,7 +73,6 @@
 
 - type: entity
   id: CrateNPCGoat
-  name: goat crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -91,7 +83,6 @@
 
 - type: entity
   id: CrateNPCGoose
-  name: goose crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -102,7 +93,6 @@
 
 - type: entity
   id: CrateNPCGorilla
-  name: gorilla crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -113,7 +103,6 @@
 
 - type: entity
   id: CrateNPCMonkeyCube
-  name: monkey cube crate
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -123,7 +112,6 @@
 
 - type: entity
   id: CrateNPCMouse
-  name: mice crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -133,7 +121,6 @@
 
 - type: entity
   id: CrateNPCParrot
-  name: parrot crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -144,7 +131,6 @@
 
 - type: entity
   id: CrateNPCPenguin
-  name: penguin crate
   parent: CrateLivestock
   components:
   - type: StorageFill
@@ -155,7 +141,6 @@
 
 - type: entity
   id: CrateNPCSnake
-  name: snake crate
   parent: CrateLivestock
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/security.yml
@@ -1,8 +1,6 @@
 - type: entity
   id: CrateSecurityArmor
-  name: armor crate
   parent: CrateSecgear
-  description: "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
   components:
   - type: StorageFill
     contents:
@@ -11,9 +9,7 @@
 
 - type: entity
   id: CrateSecurityHelmet
-  name: helmet crate
   parent: CrateSecgear
-  description: "Contains three standard-issue brain buckets. Requires Security access to open."
   components:
   - type: StorageFill
     contents:
@@ -22,7 +18,6 @@
 
 - type: entity
   id: CrateSecurityNonlethal
-  name: nonlethals crate
   parent: CrateSecgear
   components:
   - type: StorageFill
@@ -40,7 +35,6 @@
 
 - type: entity
   id: CrateSecurityLaser
-  name: lasers crate
   parent: CrateSecgear
   components:
   - type: StorageFill
@@ -50,7 +44,6 @@
 
 - type: entity
   id: CrateSecurityRiot
-  name: swat crate
   parent: CrateSecgear
   components:
   - type: StorageFill
@@ -68,7 +61,6 @@
 
 - type: entity
   id: CrateSecuritySupplies
-  name: security supplies crate
   parent: CrateSecgear
   components:
   - type: StorageFill
@@ -83,7 +75,6 @@
 
 - type: entity
   id: CrateRestraints
-  name: restraints crate
   parent: CrateSecgear
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -1,7 +1,5 @@
 - type: entity
   id: CrateServiceJanitorialSupplies
-  name: janitorial supplies crate
-  description: Fight back against dirt and grime with Nanotrasen's Janitorial Essentials(tm)! Contains three buckets, caution signs, and cleaner grenades. Also has a single mop, broom, spray cleaner, rag, and trash bag.
   parent: CratePlastic
   components:
   - type: StorageFill
@@ -23,8 +21,6 @@
 
 - type: entity
   id: CrateServiceReplacementLights
-  name: replacement lights crate
-  description: May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs.
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -36,8 +32,6 @@
 
 - type: entity
   id: CrateMousetrapBoxes
-  name: mousetraps crate
-  description: Mousetraps, for when all of service is being haunted by an entire horde of rats. Use sparingly... or not.
   parent: CrateGenericSteel
   components:
     - type: StorageFill
@@ -47,8 +41,6 @@
 
 - type: entity
   id: CrateServiceSmokeables
-  name: smokeables crate
-  description: "Tired of a quick death on the station? Order this crate and chain-smoke your way to a coughy demise!"
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -73,8 +65,6 @@
 
 - type: entity
   id: CrateServiceCustomSmokable
-  name: DIY smokeables crate
-  description: Want to get a little creative with what you use to destroy your lungs? Then this crate is for you! Has everything you need to roll your own cigarettes.
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -88,8 +78,6 @@
 
 - type: entity
   id: CrateServiceBureaucracy
-  name: bureaucracy crate
-  description: Several stacks of paper and a few pens, what more can you ask for.
   parent: CrateGenericSteel
   components:
   - type: StorageFill
@@ -105,8 +93,6 @@
 
 - type: entity
   id: CrateServicePersonnel
-  name: personnel crate
-  description: Contains a box of blank ID cards and PDAs.
   parent: CrateCommandSecure
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -1,6 +1,5 @@
 - type: entity
   id: CrateSyndicateSurplusBundle
-  name: syndicate surplus crate
   parent: CrateGenericSteel
   components:
     - type: SurplusBundle
@@ -8,7 +7,6 @@
 
 - type: entity
   id: CrateSyndicateSuperSurplusBundle
-  name: syndicate super surplus crate
   parent: CrateGenericSteel
   components:
     - type: SurplusBundle

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -1,7 +1,5 @@
 ﻿- type: entity
   id: CrateArtifactContainer
-  name: artifact container
-  description: Used to safely contain and move artifacts.
   parent: BaseStructureDynamic
   components:
     - type: Transform

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -1,8 +1,6 @@
 - type: entity
   id: BaseThruster
   parent: BaseStructureDynamic
-  name: thruster
-  description: It goes nyooooooom.
   abstract: true
   components:
     - type: AmbientSound
@@ -44,8 +42,6 @@
 - type: entity
   id: Thruster
   parent: BaseThruster
-  name: thruster
-  description: It goes nyooooooom.
   components:
   - type: Thruster
   - type: Sprite
@@ -64,9 +60,7 @@
 - type: entity
   id: DebugThruster
   parent: BaseThruster
-  name: thruster
   suffix: DEBUG
-  description: It goes nyooooooom. It doesn't need power nor space.
   components:
   - type: Thruster
     requireSpace: false
@@ -89,8 +83,6 @@
 - type: entity
   id: Gyroscope
   parent: BaseThruster
-  name: Gyroscope
-  description: Increases the shuttle's potential angular rotation.
   components:
   - type: Thruster
     thrusterType: Angular
@@ -122,9 +114,7 @@
 - type: entity
   id: DebugGyroscope
   parent: Gyroscope
-  name: gyroscope
   suffix: DEBUG
-  description: Increases the shuttle's potential angular rotation.
   components:
     - type: Thruster
       requireSpace: false

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -2,8 +2,6 @@
   abstract: true
   parent: BaseStructureDynamic
   id: GasCanister
-  name: gas canister
-  description: A canister that can contain any type of gas. It can be attached to connector ports using a wrench.
   components:
     - type: InteractionOutline
     - type: Transform
@@ -84,7 +82,6 @@
 - type: entity
   parent: GasCanister
   id: StorageCanister
-  name: storage canister
   components:
     - type: Sprite
       layers:
@@ -122,7 +119,6 @@
 - type: entity
   parent: GasCanister
   id: AirCanister
-  name: air canister
   components:
   - type: Sprite
     layers:
@@ -154,7 +150,6 @@
 - type: entity
   parent: GasCanister
   id: OxygenCanister
-  name: oxygen canister
   components:
   - type: Sprite
     layers:
@@ -185,7 +180,6 @@
 - type: entity
   parent: GasCanister
   id: NitrogenCanister
-  name: nitrogen canister
   components:
     - type: Sprite
       layers:
@@ -217,7 +211,6 @@
 - type: entity
   parent: GasCanister
   id: CarbonDioxideCanister
-  name: carbon dioxide canister
   components:
     - type: Sprite
       layers:
@@ -250,7 +243,6 @@
 - type: entity
   parent: GasCanister
   id: PlasmaCanister
-  name: plasma canister
   components:
     - type: Sprite
       layers:
@@ -285,7 +277,6 @@
 - type: entity
   parent: GasCanister
   id: TritiumCanister
-  name: tritium canister
   components:
     - type: Sprite
       layers:
@@ -320,7 +311,6 @@
 - type: entity
   parent: GasCanister
   id: WaterVaporCanister
-  name: water vapor canister
   components:
     - type: Sprite
       layers:
@@ -356,7 +346,6 @@
 - type: entity
   parent: GasCanister
   id: MiasmaCanister
-  name: miasma canister
   components:
     - type: Sprite
       layers:
@@ -393,7 +382,6 @@
 - type: entity
   parent: GasCanister
   id: NitrousOxideCanister
-  name: nitrous oxide canister
   components:
     - type: Sprite
       layers:
@@ -431,8 +419,6 @@
 - type: entity
   parent: GasCanister
   id: FrezonCanister
-  name: frezon canister
-  description: A coolant with light hallucinogenic properties. Proceed.
   components:
   - type: Sprite
     layers:
@@ -472,8 +458,6 @@
 - type: entity
   parent: BaseStructure
   id: GasCanisterBrokenBase
-  name: broken gas canister
-  description: A broken gas canister. Not useless yet, as it can be salvaged for high quality materials.
   components:
     - type: Destructible
       thresholds:
@@ -514,7 +498,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: StorageCanisterBroken
-  name: broken storage canister
   noSpawn: true
   components:
     - type: Sprite
@@ -523,7 +506,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: AirCanisterBroken
-  name: broken air canister
   noSpawn: true
   components:
   - type: Sprite
@@ -532,7 +514,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: OxygenCanisterBroken
-  name: broken oxygen canister
   noSpawn: true
   components:
   - type: Sprite
@@ -541,7 +522,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: NitrogenCanisterBroken
-  name: broken nitrogen canister
   noSpawn: true
   components:
     - type: Sprite
@@ -550,7 +530,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: CarbonDioxideCanisterBroken
-  name: broken carbon dioxide canister
   noSpawn: true
   components:
     - type: Sprite
@@ -559,7 +538,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: PlasmaCanisterBroken
-  name: broken plasma canister
   noSpawn: true
   components:
     - type: Sprite
@@ -568,7 +546,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: TritiumCanisterBroken
-  name: broken tritium canister
   noSpawn: true
   components:
     - type: Sprite
@@ -586,7 +563,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: MiasmaCanisterBroken
-  name: broken miasma canister
   noSpawn: true
   components:
     - type: Sprite
@@ -595,7 +571,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: NitrousOxideCanisterBroken
-  name: broken nitrous oxide canister
   noSpawn: true
   components:
     - type: Sprite
@@ -604,7 +579,6 @@
 - type: entity
   parent: GasCanisterBrokenBase
   id: FrezonCanisterBroken
-  name: broken frezon canister
   noSpawn: true
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -3,9 +3,7 @@
 - type: entity
   id: WeldingFuelTank
   parent: StorageTank
-  name: fuel tank
   suffix: Empty
-  description: A fuel tank. It's used to store high amounts of fuel.
   components:
   - type: StaticPrice
     price: 1200
@@ -27,9 +25,7 @@
 - type: entity
   id: WeldingFuelTankFull
   parent: WeldingFuelTank
-  name: fuel tank
   suffix: Full
-  description: A storage tank containing welding fuel.
   components:
   - type: StaticPrice
     price: 1200
@@ -45,9 +41,7 @@
 - type: entity
   id: WaterTank
   parent: StorageTank
-  name: water tank
   suffix: Empty
-  description: "A water tank. It's used to store high amounts of water."
   components:
   - type: StaticPrice
     price: 1200
@@ -72,8 +66,6 @@
 - type: entity
   parent: WaterTankFull
   id: WaterCooler
-  name: water cooler
-  description: Seems like a good place to stand and waste time.
   components:
   - type: Sprite
     sprite: Structures/Storage/tanks.rsi
@@ -88,9 +80,7 @@
 - type: entity
   parent: StorageTank
   id: WaterTankHighCapacity
-  name: high-capacity water tank
   suffix: Full
-  description: A highly pressurized water tank made to hold gargantuan amounts of water.
   components:
   - type: Sprite
     sprite: Structures/Storage/tanks.rsi
@@ -111,9 +101,7 @@
 - type: entity
   id: KvassTank
   parent: StorageTank
-  name: КВАС
   suffix: Empty
-  description: A cool refreshing drink with a taste of socialism.
   components:
     - type: Sprite
       sprite: Structures/Storage/kvass.rsi


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

In this PR I've added localization to cargo order menu and items that are used in cargo orders (for inheritance of descriptions and stuff like that).

In order to do that I've just moved name and description field contents from .yml entities to appropriate .ftl files like it's described in documentation
