### PR TITLE
Role localization

### DIFF
--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -16,13 +16,25 @@ namespace Content.Shared.Roles
         ///     The name of this antag as displayed to players.
         /// </summary>
         [DataField("name")]
-        public string Name { get; } = string.Empty;
+        private string _name { get; } = string.Empty;
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public string Name
+        {
+            get => Loc.GetString(_name);
+        }
 
         /// <summary>
         ///     The antag's objective, displayed at round-start to the player.
         /// </summary>
         [DataField("objective")]
-        public string Objective { get; private set; } = string.Empty;
+        private string _objective { get; } = string.Empty;
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public string Objective
+        {
+            get => Loc.GetString(_objective);
+        }
 
         /// <summary>
         ///     Whether or not the antag role is one of the bad guys.

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -65,7 +65,21 @@ namespace Content.Shared.Roles
         public JobSpecial[] Special { get; private set; } = Array.Empty<JobSpecial>();
 
         [DataField("departments")]
-        public IReadOnlyCollection<string> Departments { get; } = Array.Empty<string>();
+        private IReadOnlyCollection<string> _departments { get; } = Array.Empty<string>();
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public IReadOnlyCollection<string> Departments
+        {
+            get
+            {
+                var departments = new List<string>();
+                foreach (var department in _departments)
+                {
+                    departments.Add(Loc.GetString(department));
+                }
+                return departments;
+            }
+        }
 
         [DataField("access", customTypeSerializer: typeof(PrototypeIdListSerializer<AccessLevelPrototype>))]
         public IReadOnlyCollection<string> Access { get; } = Array.Empty<string>();

--- a/Resources/Locale/en-US/prototypes/roles/antags/antag-role-info.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags/antag-role-info.ftl
@@ -1,0 +1,20 @@
+antag-role-syndicate-agent-name = Syndicate agent
+antag-role-syndicate-agent-objective = Complete your objectives without being caught.
+
+antag-role-initial-infected-name = Initial infected
+antag-role-initial-infected-objective = Once you turn, infect as many other crew members as possible.
+
+antag-role-zombie-name = Zombie
+antag-role-zombie-objective = Turn as many humans as possible into zombies.
+
+antag-role-suspicion-innocent-name = Innocent
+antag-role-suspicion-innocent-objective = Discover and eliminate all traitors.
+
+antag-role-suspicion-suspect-name = Suspect
+antag-role-suspicion-suspect-objective = Kill the innocents.
+
+antag-role-nuclear-operative-commander-name = Nuclear operative commander
+antag-role-nuclear-operative-commander-objective = Lead your team to the destruction of the station.
+
+antag-role-nuclear-operative-name = Nuclear operative
+antag-role-nuclear-operative-objective = Find the nuke disk and blow up the station.

--- a/Resources/Locale/en-US/prototypes/roles/jobs/job-list-department-names.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/jobs/job-list-department-names.ftl
@@ -1,0 +1,7 @@
+job-department-command = Command
+job-department-security = Security
+job-department-engineering = Engineering
+job-department-science = Science
+job-department-medical = Medical
+job-department-cargo = Cargo
+job-department-civilian = Civilian

--- a/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_innocent.yml
+++ b/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_innocent.yml
@@ -1,6 +1,6 @@
 - type: antag
   id: SuspicionInnocent
-  name: "Innocent"
+  name: antag-role-suspicion-innocent-name
   antagonist: false
   setPreference: false
-  objective: "Discover and eliminate all traitors."
+  objective: antag-role-suspicion-innocent-objective

--- a/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_traitor.yml
@@ -1,6 +1,6 @@
 - type: antag
   id: SuspicionTraitor
-  name: "Suspect"
+  name: antag-role-suspicion-suspect-name
   antagonist: true
   setPreference: true
-  objective: "Kill the innocents."
+  objective: antag-role-suspicion-suspect-objective

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -1,13 +1,13 @@
 - type: antag
   id: Nukeops
-  name: "Nuclear Operative"
+  name: antag-role-nuclear-operative-name
   antagonist: true
   setPreference: true
-  objective: "Find the nuke disk and blow up the station."
+  objective: antag-role-nuclear-operative-objective
 
 - type: antag
   id: NukeopsCommander
-  name: "Nuclear Operative Commander"
+  name: antag-role-nuclear-operative-commander-name
   antagonist: true
   setPreference: true
-  objective: "Lead your team to the destruction of the station."
+  objective: antag-role-nuclear-operative-commander-objective

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -1,6 +1,6 @@
 - type: antag
   id: Traitor
-  name: "Syndicate Agent"
+  name: antag-role-syndicate-agent-name
   antagonist: true
   setPreference: true
-  objective: "Complete your objectives without being caught."
+  objective: antag-role-syndicate-agent-objective

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -1,13 +1,13 @@
 - type: antag
   id: InitialInfected
-  name: "Initial Infected"
+  name: antag-role-initial-infected-name
   antagonist: true
   setPreference: true
-  objective: "Once you turn, infect as many other crew members as possible"
+  objective: antag-role-initial-infected-objective
 
 - type: antag
   id: Zombie
-  name: "Zombie"
+  name: antag-role-zombie-name
   antagonist: true
   setPreference: false
-  objective: "Turn as many humans as possible into zombies."
+  objective: antag-role-zombie-objective

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -3,7 +3,7 @@
   name: job-name-cargoteh
   startingGear: CargoTechGear
   departments:
-  - Cargo
+  - job-department-cargo
   icon: "CargoTechnician"
   supervisors: job-supervisors-hop-qm
   access:

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -4,7 +4,7 @@
   weight: 10
   startingGear: QuartermasterGear
   departments:
-  - Cargo
+  - job-department-cargo
   icon: "QuarterMaster"
   supervisors: job-supervisors-hop
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -4,7 +4,7 @@
   icon: "ShaftMiner"
   startingGear: SalvageSpecialistGear
   departments:
-  - Cargo
+  - job-department-cargo
   supervisors: job-supervisors-hop-qm
   access:
   - Cargo

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -3,7 +3,7 @@
   name: job-name-passenger
   startingGear: PassengerGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Passenger"
   supervisors: job-supervisors-everyone
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -3,7 +3,7 @@
   name: job-name-bartender
   startingGear: BartenderGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Bartender"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
@@ -3,7 +3,7 @@
   name: job-name-botanist
   startingGear: BotanistGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Botanist"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -3,7 +3,7 @@
   name: job-name-chaplain
   startingGear: ChaplainGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Chaplain"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chef.yml
@@ -3,7 +3,7 @@
   name: job-name-chef
   startingGear: ChefGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Chef"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -3,7 +3,7 @@
   name: job-name-clown
   startingGear: ClownGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Clown"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -3,7 +3,7 @@
   name: job-name-janitor
   startingGear: JanitorGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Janitor"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -3,7 +3,7 @@
   name: job-name-lawyer
   startingGear: LawyerGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Lawyer"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -3,7 +3,7 @@
   name: job-name-librarian
   startingGear: LibrarianGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Librarian"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -3,7 +3,7 @@
   name: job-name-mime
   startingGear: MimeGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Mime"
   supervisors: job-supervisors-hop
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -3,7 +3,7 @@
   name: job-name-musician
   startingGear: MusicianGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Musician"
   supervisors: job-supervisors-hire
   access:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -3,7 +3,7 @@
   name: job-name-serviceworker
   startingGear: ServiceWorkerGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "ServiceWorker"
   supervisors: job-supervisors-service
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -4,7 +4,7 @@
   weight: 20
   startingGear: CaptainGear
   departments:
-  - Command
+  - job-department-command
   icon: "Captain"
   requireAdminNotify: true
   joinNotifyCrew: true

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -4,7 +4,7 @@
   setPreference: false
   startingGear: CentcomGear
   departments:
-  - Command
+  - job-department-command
   icon: "Nanotrasen"
   supervisors: job-supervisors-hos
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -4,8 +4,8 @@
   weight: 20
   startingGear: HoPGear
   departments:
-  - Command
-  - Civilian
+  - job-department-command
+  - job-department-civilian
   icon: "HeadOfPersonnel"
   requireAdminNotify: true
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -3,7 +3,7 @@
   name: job-name-atmostech
   startingGear: AtmosphericTechnicianGear
   departments:
-  - Engineering
+  - job-department-engineering
   icon: "AtmosphericTechnician"
   supervisors: job-supervisors-ce
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -4,8 +4,8 @@
   weight: 10
   startingGear: ChiefEngineerGear
   departments:
-  - Command
-  - Engineering
+  - job-department-command
+  - job-department-engineering
   icon: "ChiefEngineer"
   requireAdminNotify: true
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -3,7 +3,7 @@
   name: job-name-engineer
   startingGear: StationEngineerGear
   departments:
-  - Engineering
+  - job-department-engineering
   icon: "StationEngineer"
   supervisors: job-supervisors-ce
   access:

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -3,8 +3,8 @@
   name: job-name-assistant
   startingGear: TechnicalAssistantGear
   departments:
-  - Civilian
-  - Engineering
+  - job-department-civilian
+  - job-department-engineering
   icon: "TechnicalAssistant"
   supervisors: job-supervisors-engineering
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Fun/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/emergencyresponseteam.yml
@@ -5,7 +5,7 @@
   setPreference: false
   startingGear: ERTLeaderGearEVA
   departments:
-  - Command
+  - job-department-command
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -52,7 +52,7 @@
   setPreference: false
   startingGear: ERTEngineerGearEVA
   departments:
-  - Command
+  - job-department-command
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -98,7 +98,7 @@
   setPreference: false
   startingGear: ERTEngineerGearEVA
   departments:
-  - Command
+  - job-department-command
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -144,7 +144,7 @@
   setPreference: false
   startingGear: ERTMedicalGearEVA
   departments:
-  - Command
+  - job-department-command
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -191,7 +191,7 @@
   setPreference: false
   startingGear: ERTJanitorGearEVA
   departments:
-  - Command
+  - job-department-command
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -3,7 +3,7 @@
   name: job-name-chemist
   startingGear: ChemistGear
   departments:
-  - Medical
+  - job-department-medical
   icon: "Chemist"
   supervisors: job-supervisors-cmo
   access:

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -6,8 +6,8 @@
   weight: 10
   startingGear: CMOGear
   departments:
-  - Command
-  - Medical
+  - job-department-command
+  - job-department-medical
   icon: "ChiefMedicalOfficer"
   requireAdminNotify: true
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -3,7 +3,7 @@
   name: job-name-doctor
   startingGear: DoctorGear
   departments:
-  - Medical
+  - job-department-medical
   icon: "MedicalDoctor"
   supervisors: job-supervisors-cmo
   access:

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -3,8 +3,8 @@
   name: job-name-intern
   startingGear: MedicalInternGear
   departments:
-  - Civilian
-  - Medical
+  - job-department-civilian
+  - job-department-medical
   icon: "MedicalIntern"
   supervisors: job-supervisors-medicine
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -4,8 +4,8 @@
   weight: 10
   startingGear: ResearchDirectorGear
   departments:
-  - Command
-  - Science
+  - job-department-command
+  - job-department-science
   icon: "ResearchDirector"
   requireAdminNotify: true
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -3,7 +3,7 @@
   name: job-name-scientist
   startingGear: ScientistGear
   departments:
-  - Science
+  - job-department-science
   icon: "Scientist"
   supervisors: job-supervisors-rd
   access:

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -3,7 +3,7 @@
   name: job-name-detective
   startingGear: DetectiveGear
   departments:
-  - Security
+  - job-department-security
   icon: "Detective"
   supervisors: job-supervisors-hos
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -4,8 +4,8 @@
   weight: 10
   startingGear: HoSGear
   departments:
-  - Command
-  - Security
+  - job-department-command
+  - job-department-security
   icon: "HeadOfSecurity"
   requireAdminNotify: true
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -3,8 +3,8 @@
   name: job-name-cadet
   startingGear: SecurityCadetGear
   departments:
-  - Civilian
-  - Security
+  - job-department-civilian
+  - job-department-security
   icon: "SecurityCadet"
   supervisors: job-supervisors-security
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -3,7 +3,7 @@
   name: job-name-security
   startingGear: SecurityOfficerGear
   departments:
-  - Security
+  - job-department-security
   icon: "SecurityOfficer"
   supervisors: job-supervisors-hos
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -3,7 +3,7 @@
   name: job-name-warden
   startingGear: WardenGear
   departments:
-  - Security
+  - job-department-security
   icon: "Warden"
   supervisors: job-supervisors-hos
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
@@ -4,7 +4,7 @@
   startingGear: BoxerGear
   setPreference: false
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Boxer"
   supervisors: "the head of personnel"
   access:

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -3,7 +3,7 @@
   name: job-name-psychologist
   startingGear: PsychologistGear
   departments:
-  - Medical
+  - job-department-medical
   icon: "Psychologist"
   supervisors: job-supervisors-cmo
   access:

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -3,7 +3,7 @@
   name: job-name-reporter
   startingGear: ReporterGear
   departments:
-  - Civilian
+  - job-department-civilian
   icon: "Reporter"
   supervisors: job-supervisors-hop
   access:


### PR DESCRIPTION
## About the PR

In this PR I've localized departments and antag roles. You can see departments in character editor and during late join role selection. These are role categories. "job" was localized, but the names themselves like Security or Civilian were not.

Also I've localized antag role name and descriptions. These can also be seen in character editor. Nothing fancy.
