### PR TITLE
You can no longer spill closed solution containers

### DIFF
--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -4,6 +4,8 @@ using Content.Server.Administration.Logs;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Clothing.Components;
 using Content.Server.Fluids.Components;
+using Content.Server.Nutrition.Components;
+using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Database;
@@ -109,6 +111,9 @@ public sealed class SpillableSystem : EntitySystem
             return;
 
         if (!_solutionContainerSystem.TryGetDrainableSolution(args.Target, out var solution))
+            return;
+
+        if (TryComp<DrinkComponent>(args.Target, out var drink) && (!drink.Opened))
             return;
 
         if (solution.DrainAvailable == FixedPoint2.Zero)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mice nerf, you can no longer spill closed containers only opened containers.
Fixes #8337

:cl:
- tweak: You can no longer spill closed drinks