### PR TITLE
Make auto-closing admin announce window optional

### DIFF
--- a/Content.Client/Administration/UI/AdminAnnounceWindow.xaml
+++ b/Content.Client/Administration/UI/AdminAnnounceWindow.xaml
@@ -10,6 +10,9 @@
         </BoxContainer>
         <LineEdit Name="Announcement" Access="Public" PlaceHolder="{Loc admin-announce-announcement-placeholder}"/>
 
-        <Button Name="AnnounceButton" Access="Public" Disabled="True" Text="{Loc admin-announce-button}" HorizontalAlignment="Center"/>
+        <GridContainer Rows="1">
+            <CheckBox Name="KeepWindowOpen" Access="Public" Text="{Loc 'admin-announce-keep-open'}" />
+            <Button Name="AnnounceButton" Access="Public" Disabled="True" Text="{Loc admin-announce-button}" HorizontalAlignment="Center"/>
+        </GridContainer>
     </GridContainer>
 </DefaultWindow>

--- a/Content.Client/Administration/UI/AdminMenuWindowEui.cs
+++ b/Content.Client/Administration/UI/AdminMenuWindowEui.cs
@@ -22,7 +22,7 @@ namespace Content.Client.Administration.UI
                 Announcement = _window.Announcement.Text,
                 Announcer =  _window.Announcer.Text,
                 AnnounceType =  (AdminAnnounceType) (_window.AnnounceMethod.SelectedMetadata ?? AdminAnnounceType.Station),
-                CloseAfter = true,
+                CloseAfter = !_window.KeepWindowOpen.Pressed,
             });
 
         }

--- a/Resources/Locale/en-US/administration/ui/admin-announce-window.ftl
+++ b/Resources/Locale/en-US/administration/ui/admin-announce-window.ftl
@@ -5,3 +5,4 @@ admin-announce-announcer-default = Central Command
 admin-announce-button = Announce
 admin-announce-type-station = Station
 admin-announce-type-server = Server
+admin-announce-keep-open = Keep open


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a checkbox to turn off auto-closing on announce for the announce ui.
Because Beridot wanted it.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: The admin announcement UI auto-closing is now optional.

