### PR TITLE
Nuke anchor fixes + cargo sell blacklist

### DIFF
--- a/Content.Server/Cargo/Components/CargoSellBlacklistComponent.cs
+++ b/Content.Server/Cargo/Components/CargoSellBlacklistComponent.cs
@@ -1,0 +1,9 @@
+﻿namespace Content.Server.Cargo.Components;
+
+/// <summary>
+///     Marks an entity as unable to be sold through the cargo shuttle.
+/// </summary>
+[RegisterComponent]
+public sealed class CargoSellBlacklistComponent : Component
+{
+}

--- a/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
@@ -317,10 +317,15 @@ public sealed partial class CargoSystem
                 // Don't re-sell anything, sell anything anchored (e.g. light fixtures), or anything blacklisted
                 // (e.g. players).
                 if (toSell.Contains(ent) ||
-                    (xformQuery.TryGetComponent(ent, out var xform) && xform.Anchored)) continue;
+                    (xformQuery.TryGetComponent(ent, out var xform) && xform.Anchored))
+                    continue;
+
+                if (HasComp<CargoSellBlacklistComponent>(ent))
+                    continue;
 
                 var price = _pricing.GetPrice(ent);
-                if (price == 0) continue;
+                if (price == 0)
+                    continue;
                 toSell.Add(ent);
                 amount += price;
             }

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -140,6 +140,13 @@ namespace Content.Server.Nuke
         private void OnAnchorChanged(EntityUid uid, NukeComponent component, ref AnchorStateChangedEvent args)
         {
             UpdateUserInterface(uid, component);
+
+            if (args.Anchored == false && component.Status == NukeStatus.ARMED && component.RemainingTime > component.DisarmDoafterLength)
+            {
+                // yes, this means technically if you can find a way to unanchor the nuke, you can disarm it
+                // without the doafter. but that takes some effort, and it won't allow you to disarm a nuke that can't be disarmed by the doafter.
+                DisarmBomb(uid, component);
+            }
         }
 
         #endregion

--- a/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseStructureDynamic
+  parent: BaseStructure
   id: NuclearBomb
   name: nuclear fission explosive
   description: You probably shouldn't stick around to see if this is armed.
@@ -45,8 +45,9 @@
     interfaces:
     - key: enum.NukeUiKey.Key
       type: NukeBoundUserInterface
-  - type: StaticPrice # TODO: Make absolutely certain cargo cannot sell this, that'd be horrible. Presumably, add an export ban component so only the yarrs get a deal here.
+  - type: StaticPrice
     price: 50000 # YOU STOLE A NUCLEAR FISSION EXPLOSIVE?!
+  - type: CargoSellBlacklist
 
 - type: entity
   parent: NuclearBomb

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -11,6 +11,7 @@
     state: icon
   - type: StaticPrice
     price: 2000
+  - type: CargoSellBlacklist
   - type: WarpPoint
     location: nuke disk
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

i hate players

:cl:
- fix: Nukes can no longer be unanchored once they are armed, without disarming the nuke.
- fix: The nuke and disk can no longer be sold to cargo.
