### PR TITLE
Fix recipe title case

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -271,7 +271,7 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
-    
+
 - type: construction
   name: metal counter
   id: TableCounterMetal
@@ -288,7 +288,7 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
-    
+
 - type: construction
   name: wood counter
   id: TableCounterWood
@@ -344,7 +344,7 @@
 
 - type: construction
   id: MedicalBed
-  name: Medical Bed
+  name: medical bed
   description: A hospital bed for patients to recover in. Resting here provides fairly slow healing.
   graph: bed
   startNode: start
@@ -393,7 +393,7 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
-    
+
 - type: construction
   id: MeatSpike
   name: meat spike

--- a/Resources/Prototypes/Recipes/Construction/modular.yml
+++ b/Resources/Prototypes/Recipes/Construction/modular.yml
@@ -1,5 +1,5 @@
 - type: construction
-  name: Modular Grenade
+  name: modular grenade
   id: ModularGrenadeRecipe
   graph: ModularGrenadeGraph
   startNode: start
@@ -12,7 +12,7 @@
   objectType: Item
 
 - type: construction
-  name: Modular Mine
+  name: modular mine
   id: ModularMineRecipe
   graph: ModularMineGraph
   startNode: start


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Construction recipes prefer all lowercase in recipe titles, because the objects being constructed are not proper nouns. Fix incorrect case in a few construction recipes.

**Screenshots**
None

**Changelog**
None