### PR TITLE
Fix stuck lathe queue

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -207,6 +207,7 @@ namespace Content.Server.Lathe
             foreach (var (material, amount) in recipe.RequiredMaterials)
             {
                 // This should always return true, otherwise CanProduce fucked up.
+                // TODO just remove materials when first queuing, to avoid queuing more items than can actually be produced.
                 storage.RemoveMaterial(material, amount);
             }
 
@@ -282,6 +283,7 @@ namespace Content.Server.Lathe
             {
                 for (var i = 0; i < args.Quantity; i++)
                 {
+                    // TODO check required materials exist and make materials unavailable.
                     component.Queue.Add(recipe.ID);
                 }
 

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -187,12 +187,16 @@ namespace Content.Server.Lathe
                 component.Queue.RemoveAt(0);
                 return TryStartProducing(uid, prodComp, component);
             }
-                
+
             if (!component.CanProduce(recipe) || !TryComp(uid, out MaterialStorageComponent? storage))
+            {
+                component.Queue.RemoveAt(0);
                 return false;
+            }
 
             prodComp ??= EnsureComp<LatheProducingComponent>(uid);
 
+            // Do nothing if the lathe is already producing something.
             if (prodComp.Recipe != null)
                 return false;
 


### PR DESCRIPTION
The lathe queue can get stuck until more materials are added if there are insufficient materials to produce a queued item. This changes the behaviour so that these items get removed from the queue, which AFAIK was the behaviour before #10156.

:cl:
- fix: Fixed items not getting removed from the lathe queue when there are insufficient resources.

