### PR TITLE
Don't copy null actions on the client

### DIFF
--- a/Content.Shared/Actions/ActionTypes/InstantAction.cs
+++ b/Content.Shared/Actions/ActionTypes/InstantAction.cs
@@ -28,12 +28,12 @@ public class InstantAction : ActionType
 
         // Server doesn't serialize events to us.
         // As such we don't want them to bulldoze any events we may have gotten locally.
-        if (objectToClone is not InstantAction toClone ||
-            toClone.Event == null)
+        if (objectToClone is not InstantAction toClone)
             return;
 
         // Events should be re-usable, and shouldn't be modified during prediction.
-        Event = toClone.Event;
+        if (toClone.Event != null)
+            Event = toClone.Event;
     }
 
     public override object Clone()

--- a/Content.Shared/Actions/ActionTypes/InstantAction.cs
+++ b/Content.Shared/Actions/ActionTypes/InstantAction.cs
@@ -26,7 +26,10 @@ public class InstantAction : ActionType
     {
         base.CopyFrom(objectToClone);
 
-        if (objectToClone is not InstantAction toClone)
+        // Server doesn't serialize events to us.
+        // As such we don't want them to bulldoze any events we may have gotten locally.
+        if (objectToClone is not InstantAction toClone ||
+            toClone.Event == null)
             return;
 
         // Events should be re-usable, and shouldn't be modified during prediction.

--- a/Content.Shared/Actions/ActionTypes/TargetedAction.cs
+++ b/Content.Shared/Actions/ActionTypes/TargetedAction.cs
@@ -104,7 +104,8 @@ public class EntityTargetAction : TargetedAction
         Whitelist = toClone.Whitelist;
 
         // Events should be re-usable, and shouldn't be modified during prediction.
-        Event = toClone.Event;
+        if (toClone.Event != null)
+            Event = toClone.Event;
     }
 
     public override object Clone()
@@ -141,7 +142,8 @@ public class WorldTargetAction : TargetedAction
             return;
 
         // Events should be re-usable, and shouldn't be modified during prediction.
-        Event = toClone.Event;
+        if (toClone.Event != null)
+            Event = toClone.Event;
     }
 
     public override object Clone()


### PR DESCRIPTION
Fixes combat mode toggle misprediction because all client actions just got bulldozed by the server.