### PR TITLE
Mining Fix

### DIFF
--- a/Content.Server/Kitchen/Components/KitchenSpikeComponent.cs
+++ b/Content.Server/Kitchen/Components/KitchenSpikeComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Server.Kitchen.Components
     [RegisterComponent, Access(typeof(KitchenSpikeSystem))]
     public sealed class KitchenSpikeComponent : SharedKitchenSpikeComponent
     {
-        public List<string>? PrototypesToSpawn;
+        public List<string?>? PrototypesToSpawn;
 
         // TODO: Spiking alive mobs? (Replace with uid) (deal damage to their limbs on spiking, kill on first butcher attempt?)
         public string MeatSource1p = "?";

--- a/Content.Shared/EntityList/EntityLootTablePrototype.cs
+++ b/Content.Shared/EntityList/EntityLootTablePrototype.cs
@@ -15,7 +15,7 @@ public sealed class EntityLootTablePrototype : IPrototype
     public ImmutableList<EntitySpawnEntry> Entries = ImmutableList<EntitySpawnEntry>.Empty;
 
     /// <inheritdoc cref="EntitySpawnCollection.GetSpawns"/>
-    public List<string> GetSpawns(IRobustRandom? random = null)
+    public List<string?> GetSpawns(IRobustRandom? random = null)
     {
         return EntitySpawnCollection.GetSpawns(Entries, random);
     }

--- a/Content.Shared/Storage/EntitySpawnEntry.cs
+++ b/Content.Shared/Storage/EntitySpawnEntry.cs
@@ -13,8 +13,8 @@ namespace Content.Shared.Storage;
 public struct EntitySpawnEntry : IPopulateDefaultValues
 {
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("id", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string PrototypeId;
+    [DataField("id", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string? PrototypeId;
 
     /// <summary>
     ///     The probability that an item will spawn. Takes decimal form so 0.05 is 5%, 0.50 is 50% etc.
@@ -83,17 +83,18 @@ public static class EntitySpawnCollection
     /// <param name="entries">The entity spawn entries.</param>
     /// <param name="random">Resolve param.</param>
     /// <returns>A list of entity prototypes that should be spawned.</returns>
-    public static List<string> GetSpawns(IEnumerable<EntitySpawnEntry> entries,
+    public static List<string?> GetSpawns(IEnumerable<EntitySpawnEntry> entries,
         IRobustRandom? random = null)
     {
         IoCManager.Resolve(ref random);
 
-        var spawned = new List<string>();
+        var spawned = new List<string?>();
         var orGroupedSpawns = new Dictionary<string, OrGroup>();
 
         // collect groups together, create singular items that pass probability
         foreach (var entry in entries)
         {
+
             // Handle "Or" groups
             if (!string.IsNullOrEmpty(entry.GroupId))
             {

--- a/Content.Shared/Storage/EntitySpawnEntry.cs
+++ b/Content.Shared/Storage/EntitySpawnEntry.cs
@@ -94,7 +94,6 @@ public static class EntitySpawnCollection
         // collect groups together, create singular items that pass probability
         foreach (var entry in entries)
         {
-
             // Handle "Or" groups
             if (!string.IsNullOrEmpty(entry.GroupId))
             {

--- a/Resources/Prototypes/LootTables/mining_loot_table.yml
+++ b/Resources/Prototypes/LootTables/mining_loot_table.yml
@@ -1,43 +1,47 @@
 - type: entityLootTable
   id: MiningLootTable
   entries:
+  - prob: 0.5 #null value, doesn't drop anything
+    orGroup: Asteroid
   - id: SteelOre1
-    prob: 0.25
+    prob: 0.125
     orGroup: Asteroid
   - id: GoldOre1
-    prob: 0.05
+    prob: 0.025
     orGroup: Asteroid
   - id: SpaceQuartz1
-    prob: 0.20
-    orGroup: Asteroid
-  - id: PlasmaOre1
     prob: 0.10
     orGroup: Asteroid
+  - id: PlasmaOre1
+    prob: 0.05
+    orGroup: Asteroid
   - id: SilverOre1
-    prob: 0.025
+    prob: 0.0125
     orGroup: Asteroid
   - id: UraniumOre1
-    prob: 0.025
+    prob: 0.0125
     orGroup: Asteroid
     
 - type: entityLootTable
   id: MiningLootTableLowYield
   entries:
+  - prob: 0.75 #null value, doesn't drop anything
+    orGroup: Asteroid
   - id: SteelOre1
-    prob: 0.05
+    prob: 0.0125
     orGroup: Asteroid
   - id: GoldOre1
-    prob: 0.01
+    prob: 0.0025
     orGroup: Asteroid
   - id: SpaceQuartz1
-    prob: 0.05
+    prob: 0.0125
     orGroup: Asteroid
   - id: PlasmaOre1
-    prob: 0.025
+    prob: 0.00625
     orGroup: Asteroid
   - id: SilverOre1
-    prob: 0.02
+    prob: 0.005
     orGroup: Asteroid
   - id: UraniumOre1
-    prob: 0.02
+    prob: 0.005
     orGroup: Asteroid


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
yeah they shouldn't spawn ores after every single fucking doafter. balance yo shit, nerds.

high yield now only gives ores 50% of the time where low yield only gives 25% of the time.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Asteroid rocks are no longer guaranteed to spawn ores each time they are mined.

