### PR TITLE
Disable NPCs in debug

### DIFF
--- a/Content.Server/AI/EntitySystems/NPCSystem.cs
+++ b/Content.Server/AI/EntitySystems/NPCSystem.cs
@@ -34,6 +34,11 @@ namespace Content.Server.AI.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
+            // Makes physics etc debugging easier.
+#if DEBUG
+            _configurationManager.OverrideDefault(CCVars.NPCEnabled, false);
+#endif
+
             _sawmill = Logger.GetSawmill("npc");
             InitializeUtility();
             SubscribeLocalEvent<NPCComponent, MobStateChangedEvent>(OnMobStateChange);


### PR DESCRIPTION
Slight perf for potato PCs + makes physics debugging easier when I don't have to turn it off
