### PR TITLE
Add webp and json generation options to the map renderer

### DIFF
--- a/Content.MapRenderer/CommandLineArguments.cs
+++ b/Content.MapRenderer/CommandLineArguments.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Content.MapRenderer.Extensions;
 
 namespace Content.MapRenderer;
 
@@ -10,9 +11,17 @@ public sealed class CommandLineArguments
     public OutputFormat Format { get; set; } = OutputFormat.png;
     public bool ExportViewerJson { get; set; } = false;
 
+    public string OutputPath { get; set; } = DirectoryExtensions.MapImages().FullName;
+
     public static bool TryParse(IReadOnlyList<string> args, [NotNullWhen(true)] out CommandLineArguments? parsed)
     {
         parsed = new CommandLineArguments();
+
+        if (args.Count == 0)
+        {
+            PrintHelp();
+            return false;
+        }
 
         using var enumerator = args.GetEnumerator();
 
@@ -38,6 +47,17 @@ public sealed class CommandLineArguments
                     parsed.ExportViewerJson = true;
                     break;
 
+                case "-o":
+                case "--output":
+                    enumerator.MoveNext();
+                    parsed.OutputPath = enumerator.Current;
+                    break;
+
+                case "-h":
+                case "--help":
+                    PrintHelp();
+                    return false;
+
                 default:
                     parsed.Maps.Add(argument);
                     break;
@@ -45,6 +65,23 @@ public sealed class CommandLineArguments
         }
 
         return true;
+    }
+
+    public static void PrintHelp()
+    {
+        Console.WriteLine(@"Content.MapRenderer <options> [map names]
+Options:
+    --format <png|webp>
+        Specifies the format the map images will be exported as.
+        Defaults to: png
+    --viewer
+        Causes the map renderer to create the map.json files required for use with the map viewer.
+        Also puts the maps in the required directory structure.
+    -o / --output <output path>
+        Changes the path the rendered maps will get saved to.
+        Defaults to Resources/MapImages
+    -h / --help
+        Displays this help text");
     }
 }
 

--- a/Content.MapRenderer/CommandLineArguments.cs
+++ b/Content.MapRenderer/CommandLineArguments.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Content.MapRenderer;
+
+public sealed class CommandLineArguments
+{
+    public List<string> Maps { get; set; } = new();
+    public OutputFormat Format { get; set; } = OutputFormat.png;
+    public bool ExportViewerJson { get; set; } = false;
+
+    public static bool TryParse(IReadOnlyList<string> args, [NotNullWhen(true)] out CommandLineArguments? parsed)
+    {
+        parsed = new CommandLineArguments();
+
+        using var enumerator = args.GetEnumerator();
+
+        while (enumerator.MoveNext())
+        {
+            var argument = enumerator.Current;
+            switch (argument)
+            {
+                case "--format":
+                    enumerator.MoveNext();
+
+                    if (!Enum.TryParse<OutputFormat>(enumerator.Current, out var format))
+                    {
+                        Console.WriteLine("Invalid format specified for option: {0}", argument);
+                        parsed = null;
+                        return false;
+                    }
+
+                    parsed.Format = format;
+                    break;
+
+                case "--viewer":
+                    parsed.ExportViewerJson = true;
+                    break;
+
+                default:
+                    parsed.Maps.Add(argument);
+                    break;
+            }
+        }
+
+        return true;
+    }
+}
+
+public class CommandLineArgumentException : Exception
+{
+    public CommandLineArgumentException(string? message) : base(message)
+    {
+    }
+}
+
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum OutputFormat
+{
+    png,
+    webp
+}

--- a/Content.MapRenderer/Content.MapRenderer.csproj
+++ b/Content.MapRenderer/Content.MapRenderer.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
       <PackageReference Include="NUnit" Version="3.13.3" />
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     </ItemGroup>
 
 </Project>

--- a/Content.MapRenderer/MapViewerData.cs
+++ b/Content.MapRenderer/MapViewerData.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using Robust.Shared.Maths;
+
+namespace Content.MapRenderer;
+
+public sealed class MapViewerData
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public bool Tiled { get; set; } = false;
+    public string Url { get; set; } = string.Empty;
+    public Extent Extent { get; set; } = new();
+    public string? Attributions { get; set; }
+    public List<LayerGroup> LayerGroups { get; set; } = new();
+}
+
+public sealed class LayerGroup
+{
+    public Vector2 Scale { get; set; } = new();
+    public Vector2 Offset { get; set; } = new();
+    public bool Static { get; set; } = false;
+    public float? MinScale { get; set; }
+    public GroupSource Source { get; set; } = new();
+    public List<Layer> Layers { get; set; } = new();
+}
+
+public sealed class GroupSource
+{
+    public string Url { get; set; } = string.Empty;
+    public Extent Extent { get; set; } = new();
+}
+
+public sealed class Layer
+{
+    public string Url { get; set; } = string.Empty;
+    public string Composition { get; set; } = "source-over";
+    public Vector2 ParallaxScale { get; set; } = new(0.1f, 0.1f);
+}
+
+public readonly struct Extent
+{
+    public Extent()
+    {
+        X1 = 0;
+        Y1 = 0;
+        X2 = 0;
+        Y2 = 0;
+    }
+
+    public Extent(float x2, float y2)
+    {
+        X1 = 0;
+        Y1 = 0;
+        X2 = x2;
+        Y2 = y2;
+    }
+
+    public Extent(float x1, float y1, float x2, float y2)
+    {
+        X1 = x1;
+        Y1 = y1;
+        X2 = x2;
+        Y2 = y2;
+    }
+
+    public readonly float X1;
+    public readonly float Y1;
+    public readonly float X2;
+    public readonly float Y2;
+}

--- a/Content.MapRenderer/MapViewerData.cs
+++ b/Content.MapRenderer/MapViewerData.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using Robust.Shared.Maths;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace Content.MapRenderer;
 
@@ -7,21 +9,71 @@ public sealed class MapViewerData
 {
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
-    public bool Tiled { get; set; } = false;
-    public string Url { get; set; } = string.Empty;
-    public Extent Extent { get; set; } = new();
+    public List<GridLayer> Grids { get; set; } = new();
     public string? Attributions { get; set; }
-    public List<LayerGroup> LayerGroups { get; set; } = new();
+    public List<LayerGroup> ParallaxLayers { get; set; } = new();
+}
+
+public sealed class GridLayer
+{
+    public string GridId { get; set; } = string.Empty;
+    public Position Offset { get; set; }
+    public bool Tiled { get; set; } = false;
+    public string Url { get; set; }
+    public Extent Extent { get; set; }
+
+    public GridLayer(RenderedGridImage<Rgba32> gridImage, string url)
+    {
+        //Get the internal _uid as string
+        if (gridImage.GridUid.HasValue)
+            GridId = gridImage.GridUid.Value.GetHashCode().ToString();
+
+        Offset = new Position(gridImage.Offset);
+        Extent = new Extent(gridImage.Image.Width, gridImage.Image.Height);
+        Url = url;
+    }
 }
 
 public sealed class LayerGroup
 {
-    public Vector2 Scale { get; set; } = new();
-    public Vector2 Offset { get; set; } = new();
+    public Position Scale { get; set; } = Position.One();
+    public Position Offset { get; set; } = Position.Zero();
     public bool Static { get; set; } = false;
     public float? MinScale { get; set; }
     public GroupSource Source { get; set; } = new();
     public List<Layer> Layers { get; set; } = new();
+
+    public static LayerGroup DefaultParallax()
+    {
+        return new LayerGroup()
+        {
+            Scale = new Position(0.1f, 0.1f),
+            Source = new GroupSource()
+            {
+                Url = "https://i.imgur.com/3YO8KRd.png",
+                Extent = new Extent(6000, 4000)
+            },
+            Layers = new List<Layer>()
+            {
+                new Layer()
+                {
+                    Url = "https://i.imgur.com/IannmmK.png"
+                },
+                new Layer()
+                {
+                    Url = "https://i.imgur.com/T3W6JsE.png",
+                    Composition = "lighter",
+                    ParallaxScale = new Position(0.2f, 0.2f)
+                },
+                new Layer()
+                {
+                    Url = "https://i.imgur.com/T3W6JsE.png",
+                    Composition = "lighter",
+                    ParallaxScale = new Position(0.3f, 0.3f)
+                }
+            }
+        };
+    }
 }
 
 public sealed class GroupSource
@@ -34,11 +86,16 @@ public sealed class Layer
 {
     public string Url { get; set; } = string.Empty;
     public string Composition { get; set; } = "source-over";
-    public Vector2 ParallaxScale { get; set; } = new(0.1f, 0.1f);
+    public Position ParallaxScale { get; set; } = new(0.1f, 0.1f);
 }
 
 public readonly struct Extent
 {
+    public readonly float X1;
+    public readonly float Y1;
+    public readonly float X2;
+    public readonly float Y2;
+
     public Extent()
     {
         X1 = 0;
@@ -62,9 +119,32 @@ public readonly struct Extent
         X2 = x2;
         Y2 = y2;
     }
+}
 
-    public readonly float X1;
-    public readonly float Y1;
-    public readonly float X2;
-    public readonly float Y2;
+public readonly struct Position
+{
+    public readonly float X;
+    public readonly float Y;
+
+    public Position(float x, float y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public Position(Vector2 vector2)
+    {
+        X = vector2.X;
+        Y = vector2.Y;
+    }
+
+    public static Position Zero()
+    {
+        return new Position(0, 0);
+    }
+
+    public static Position One()
+    {
+        return new Position(0, 0);
+    }
 }

--- a/Content.MapRenderer/Painters/MapPainter.cs
+++ b/Content.MapRenderer/Painters/MapPainter.cs
@@ -75,14 +75,12 @@ namespace Content.MapRenderer.Painters
             await PoolManager.RunTicksSync(pairTracker.Pair, 10);
             await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
 
-            Vector2? initialOffset = null;
-
             foreach (var grid in grids)
             {
                 // Skip empty grids
                 if (grid.LocalAABB.IsEmpty())
                 {
-                    Console.WriteLine($"Warning: Grid {grid.Index} was empty. Skipping image rendering.");
+                    Console.WriteLine($"Warning: Grid {grid.GridEntityId} was empty. Skipping image rendering.");
                     continue;
                 }
 
@@ -111,16 +109,7 @@ namespace Content.MapRenderer.Painters
 
                 var renderedImage = new RenderedGridImage<Rgba32>(gridCanvas);
                 renderedImage.GridUid = grid.GridEntityId;
-
-                if (!initialOffset.HasValue)
-                {
-                    initialOffset = grid.WorldPosition;
-                    renderedImage.Base = true;
-                }
-                else
-                {
-                    renderedImage.Offset = grid.WorldPosition - initialOffset.Value;
-                }
+                renderedImage.Offset = grid.WorldPosition;
 
                 yield return renderedImage;
             }

--- a/Content.MapRenderer/Program.cs
+++ b/Content.MapRenderer/Program.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Content.MapRenderer.Extensions;
 using Content.MapRenderer.Painters;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Webp;
 
 namespace Content.MapRenderer
 {
@@ -24,72 +25,53 @@ namespace Content.MapRenderer
                 Console.WriteLine("Didn't specify any maps to paint! Provide map names (as map prototype names).");
             }
 
-            // var created = Environment.GetEnvironmentVariable(MapsAddedEnvKey);
-            // var modified = Environment.GetEnvironmentVariable(MapsModifiedEnvKey);
-            //
-            // var yamlStream = new YamlStream();
-            //
-            // if (created != null)
-            // {
-            //     yamlStream.Load(new StringReader(created));
-            // }
-            //
-            // if (modified != null)
-            // {
-            //     yamlStream.Load(new StringReader(modified));
-            // }
-            //
-            // var files = new YamlSequenceNode();
-            //
-            // foreach (var doc in yamlStream.Documents)
-            // {
-            //     var filesModified = (YamlSequenceNode) doc.RootNode;
-            //
-            //     foreach (var node in filesModified)
-            //     {
-            //         files.Add(node);
-            //     }
-            // }
+            if (!CommandLineArguments.TryParse(args, out var arguments))
+                return;
 
-            // var maps = new List<string>();
-
-            // foreach (var node in files)
-            // {
-            //     var fileName = node.AsString();
-            //
-            //     if (!fileName.StartsWith("Resources/Maps/") ||
-            //         !fileName.EndsWith("yml"))
-            //     {
-            //         continue;
-            //     }
-            //
-            //     maps.Add(fileName);
-            // }
-
-            await Run(new List<string>(args));
+            await Run(arguments);
         }
 
-        private static async Task Run(List<string> maps)
+        private static async Task Run(CommandLineArguments arguments)
         {
-            Console.WriteLine($"Creating images for {maps.Count} maps");
+
+            Console.WriteLine($"Creating images for {arguments.Maps.Count} maps");
 
             var mapNames = new List<string>();
-            foreach (var map in maps)
+            foreach (var map in arguments.Maps)
             {
                 Console.WriteLine($"Painting map {map}");
 
                 int i = 0;
-                await foreach (var grid in MapPainter.Paint(map))
+                await foreach (var renderedGrid in MapPainter.Paint(map))
                 {
+                    var grid = renderedGrid.Image;
                     var directory = DirectoryExtensions.MapImages().FullName;
                     Directory.CreateDirectory(directory);
 
                     var fileName = Path.GetFileNameWithoutExtension(map);
-                    var savePath = $"{directory}{Path.DirectorySeparatorChar}{fileName}-{i}.png";
+                    var savePath = $"{directory}{Path.DirectorySeparatorChar}{fileName}-{i}.{arguments.Format.ToString()}";
 
                     Console.WriteLine($"Writing grid of size {grid.Width}x{grid.Height} to {savePath}");
 
-                    await grid.SaveAsPngAsync(savePath);
+                    switch (arguments.Format)
+                    {
+                        case OutputFormat.webp:
+                            var encoder = new WebpEncoder
+                            {
+                                Method = WebpEncodingMethod.BestQuality,
+                                FileFormat = WebpFileFormatType.Lossless,
+                                TransparentColorMode = WebpTransparentColorMode.Preserve
+                            };
+
+                            await grid.SaveAsync(savePath, encoder);
+                            break;
+
+                        default:
+                        case OutputFormat.png:
+                            await grid.SaveAsPngAsync(savePath);
+                            break;
+                    }
+
                     grid.Dispose();
 
                     mapNames.Add(fileName);
@@ -99,7 +81,7 @@ namespace Content.MapRenderer
 
             var mapNamesString = $"[{string.Join(',', mapNames.Select(s => $"\"{s}\""))}]";
             Console.WriteLine($@"::set-output name=map_names::{mapNamesString}");
-            Console.WriteLine($"Created {maps.Count} map images.");
+            Console.WriteLine($"Created {arguments.Maps.Count} map images.");
         }
     }
 }

--- a/Content.MapRenderer/RenderedGridImage.cs
+++ b/Content.MapRenderer/RenderedGridImage.cs
@@ -10,7 +10,6 @@ public sealed class RenderedGridImage <T> where T : unmanaged, IPixel<T>
     public Image<T> Image;
     public Vector2 Offset { get; set; } = Vector2.Zero;
     public EntityUid? GridUid { get; set; }
-    public bool Base { get; set; } = false;
 
     public RenderedGridImage(Image<T> image)
     {

--- a/Content.MapRenderer/RenderedGridImage.cs
+++ b/Content.MapRenderer/RenderedGridImage.cs
@@ -1,0 +1,19 @@
+﻿using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Content.MapRenderer;
+
+public sealed class RenderedGridImage <T> where T : unmanaged, IPixel<T>
+{
+    public Image<T> Image;
+    public Vector2 Offset { get; set; } = Vector2.Zero;
+    public EntityUid? GridUid { get; set; }
+    public bool Base { get; set; } = false;
+
+    public RenderedGridImage(Image<T> image)
+    {
+        Image = image;
+    }
+}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows the map viewer to output images as webp, makes maps be exported into their own sub-directories and adds an option to generate the json files that are required for the map viewer.

It also adds help text that shows up when no arguments are provided and an option to specify the output directory.

WebPs are exported as lossless, best quality and preserve transparency.
An export of lighthouse is 5.34 MB as PNG vs 2.31 MB for WebP showing a reduction in size of 43%.

### Help text:
```
Content.MapRenderer <options> [map names]
Options:
    --format <png|webp>
        Specifies the format the map images will be exported as.
        Defaults to: png
    --viewer
        Causes the map renderer to create the map.json files required for use with the map viewer.
        Also puts the maps in the required directory structure.
    -o / --output <output path>
        Changes the path the rendered maps will get saved to.
        Defaults to Resources/MapImages
    -h / --help
        Displays this help text
```

### Example JSON file:
The parallax layer is a default placeholder for now
```json
{
    "Id": "lighthouse",
    "Name": "Lighthouse",
    "Grids": [
        {
            "GridId": "102",
            "Offset": {
                "X": 632.61664,
                "Y": -408.32028
            },
            "Tiled": false,
            "Url": "lighthouse\\lighthouse-0.webp",
            "Extent": {
                "X1": 0.0,
                "Y1": 0.0,
                "X2": 4352.0,
                "Y2": 5600.0
            }
        }
    ],
    "Attributions": null,
    "ParallaxLayers": [
        {
            "Scale": {
                "X": 0.1,
                "Y": 0.1
            },
            "Offset": {
                "X": 0.0,
                "Y": 0.0
            },
            "Static": false,
            "MinScale": null,
            "Source": {
                "Url": "https://i.imgur.com/3YO8KRd.png",
                "Extent": {
                    "X1": 0.0,
                    "Y1": 0.0,
                    "X2": 6000.0,
                    "Y2": 4000.0
                }
            },
            "Layers": [
                {
                    "Url": "https://i.imgur.com/IannmmK.png",
                    "Composition": "source-over",
                    "ParallaxScale": {
                        "X": 0.1,
                        "Y": 0.1
                    }
                },
                {
                    "Url": "https://i.imgur.com/T3W6JsE.png",
                    "Composition": "lighter",
                    "ParallaxScale": {
                        "X": 0.2,
                        "Y": 0.2
                    }
                },
                {
                    "Url": "https://i.imgur.com/T3W6JsE.png",
                    "Composition": "lighter",
                    "ParallaxScale": {
                        "X": 0.3,
                        "Y": 0.3
                    }
                }
            ]
        }
    ]
}
```

### Example result for `.\Content.MapRenderer.exe --viewer --format webp lighthouse`
[lighthouse.zip](https://github.com/space-wizards/space-station-14/files/9275445/lighthouse.zip)

Requires space-wizards/RobustToolbox#3092