### PR TITLE
Increase robust harvest effectiveness

### DIFF
--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -1,6 +1,7 @@
 using Content.Server.Botany.Components;
 using Content.Server.Botany.Systems;
 using Content.Shared.Atmos;
+using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
@@ -63,7 +64,7 @@ public struct SeedChemQuantity
 
 // TODO reduce the number of friends to a reasonable level. Requires ECS-ing things like plant holder component.
 [Virtual, DataDefinition]
-[Access(typeof(BotanySystem), typeof(PlantHolderSystem), typeof(SeedExtractorSystem), typeof(PlantHolderComponent))]
+[Access(typeof(BotanySystem), typeof(PlantHolderSystem), typeof(SeedExtractorSystem), typeof(PlantHolderComponent), typeof(ReagentEffect))]
 public class SeedData
 {
     #region Tracking

--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/RobustHarvest.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/RobustHarvest.cs
@@ -18,14 +18,14 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
 
             var random = IoCManager.Resolve<IRobustRandom>();
 
-            if (plantHolderComp.Seed.Potency < 100 && random.Prob(0.1f))
+            if (plantHolderComp.Seed.Potency < 100)
             {
                 plantHolderComp.EnsureUniqueSeed();
-                plantHolderComp.Seed.Potency++;
+                plantHolderComp.Seed.Potency += 3;
             }
-
-            if (plantHolderComp.Seed.Yield > 1 && random.Prob(0.1f))
+            else if (plantHolderComp.Seed.Yield > 1 && random.Prob(0.1f))
             {
+                // Too much of a good thing reduces yield
                 plantHolderComp.EnsureUniqueSeed();
                 plantHolderComp.Seed.Yield--;
             }

--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/RobustHarvest.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/RobustHarvest.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
             if (plantHolderComp.Seed.Potency < 100)
             {
                 plantHolderComp.EnsureUniqueSeed();
-                plantHolderComp.Seed.Potency += 3;
+                plantHolderComp.Seed.Potency = Math.Min(plantHolderComp.Seed.Potency + 3, 100);
             }
             else if (plantHolderComp.Seed.Yield > 1 && random.Prob(0.1f))
             {

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -414,7 +414,7 @@
   idealLight: 9
   idealHeat: 298
   chemicals:
-    Nutriment:
+    Egg:
       Min: 1
       Max: 10
       PotencyDivisor: 10


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Each unit of robust harvest has a 10% chance of increasing potency. This means that on average, it takes 1000u to bring a single plant to full potency. This seems a bit unreasonable.

Change robust harvest to guarantee 3 potency per unit. This brings full potency down to a little over 30u, or a whole bottle. Keep in mind that botanists usually have multiple plants and only 3 bottles of robust harvest to start.

Remove robust harvest yield reduction unless potency would exceed 100. It is almost always more effective to produce a bunch of small fruit than one large fruit. Consequently, nobody wants to use robust harvest.

Hopefully this encourages botanists to actually use robust harvest instead of giving up after seeing that it doesn't do anything.

**Changelog**
:cl: notafet
- tweak: Robust harvest is significantly more effective.
