### PR TITLE
Fix plant clonexadone

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -148,6 +148,7 @@
       amount: -5
     - !type:PlantAdjustHealth
       amount: 5
+    - !type:PlantClonexadone {}
 
 - type: reagent
   id: Dermaline


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Plant clonexadone metabolism is broken because it's missing the appropriate type entry in the YAML file.

**Changelog**
:cl: notafet
- fix: Plants correctly metabolize clonexadone.