### PR TITLE
paper is now burnable

### DIFF
--- a/Content.Server/Atmos/Components/FlammableComponent.cs
+++ b/Content.Server/Atmos/Components/FlammableComponent.cs
@@ -35,5 +35,12 @@ namespace Content.Server.Atmos.Components
         /// </summary>
         [DataField("flammableCollisionShape")]
         public IPhysShape FlammableCollisionShape = new PhysShapeCircle() { Radius = 0.35f };
+
+        /// <summary>
+        ///     Should the component be set on fire by interactions with isHot entities
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("ignitable")]
+        public bool Ignitable { get; private set; } = false;
     }
 }

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -71,6 +71,8 @@ public sealed class StepTriggerSystem : EntitySystem
         if (!ourAabb.Intersects(otherAabb))
             return true;
 
+        Logger.Debug("Intersects!");
+
         if (otherPhysics.LinearVelocity.Length < component.RequiredTriggerSpeed
             || component.CurrentlySteppedOn.Contains(otherUid)
             || otherAabb.IntersectPercentage(ourAabb) < component.IntersectRatio

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -71,8 +71,6 @@ public sealed class StepTriggerSystem : EntitySystem
         if (!ourAabb.Intersects(otherAabb))
             return true;
 
-        Logger.Debug("Intersects!");
-
         if (otherPhysics.LinearVelocity.Length < component.RequiredTriggerSpeed
             || component.CurrentlySteppedOn.Contains(otherUid)
             || otherAabb.IntersectPercentage(ourAabb) < component.IntersectRatio

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -27,12 +27,34 @@
   - type: Tag
     tags:
     - Document
-    - Paper
   - type: Appearance
   - type: PaperVisuals
+  - type: StepTrigger
+    intersectRatio: 0.2
+    requiredTriggeredSpeed: 0
+  - type: CollisionWake
+    enabled: false
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+    - shape:
+        !type:PhysShapeAabb
+        bounds: "-0.4,-0.4,0.4,0.4"
+      id: "slips"
+      hard: false
+      layer:
+      - SlipLayer
+    - shape:
+        !type:PhysShapeAabb
+        bounds: "-0.4,-0.4,0.4,0.4"
+      mass: 5
+      mask:
+      - ItemMask
   - type: Flammable
     fireSpread: true
     canResistFire: false
+    ignitable: true
     damage:
       types:
         Heat: 1 #per second, scales with number of fire 'stacks'
@@ -45,7 +67,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 40
+        damage: 10
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -27,8 +27,33 @@
   - type: Tag
     tags:
     - Document
+    - Paper
   - type: Appearance
   - type: PaperVisuals
+  - type: Flammable
+    fireSpread: true
+    canResistFire: false
+    damage:
+      types:
+        Heat: 1 #per second, scales with number of fire 'stacks'
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 40
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: Paper

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -29,28 +29,6 @@
     - Document
   - type: Appearance
   - type: PaperVisuals
-  - type: StepTrigger
-    intersectRatio: 0.2
-    requiredTriggeredSpeed: 0
-  - type: CollisionWake
-    enabled: false
-  - type: Physics
-    bodyType: Dynamic
-  - type: Fixtures
-    fixtures:
-    - shape:
-        !type:PhysShapeAabb
-        bounds: "-0.4,-0.4,0.4,0.4"
-      id: "slips"
-      hard: false
-      layer:
-      - SlipLayer
-    - shape:
-        !type:PhysShapeAabb
-        bounds: "-0.4,-0.4,0.4,0.4"
-      mass: 5
-      mask:
-      - ItemMask
   - type: Flammable
     fireSpread: true
     canResistFire: false
@@ -67,7 +45,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 10
+        damage: 15
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -91,7 +91,12 @@
   - type: Sprite
     netsync: false
     sprite: Objects/Materials/materials.rsi
+    noRot: true
     state: ash
   - type: Tag
     tags:
     - Trash
+  - type: Stack
+    stackType: Ash
+  - type: StackPrice
+    price: 0.1

--- a/Resources/Prototypes/Stacks/ash_stacks.yml
+++ b/Resources/Prototypes/Stacks/ash_stacks.yml
@@ -1,0 +1,5 @@
+- type: stack
+  id: Ash
+  name: ash
+  icon: Textures/Objects/Materials/materials.rsi
+  spawn: Ash

--- a/Resources/Prototypes/Stacks/ash_stacks.yml
+++ b/Resources/Prototypes/Stacks/ash_stacks.yml
@@ -1,5 +1,4 @@
 - type: stack
   id: Ash
   name: ash
-  icon: Textures/Objects/Materials/materials.rsi
   spawn: Ash

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -336,6 +336,9 @@
   id: PaintableAirlock
 
 - type: Tag
+  id: Paper # for Ignitable detection
+
+- type: Tag
   id: PercussionInstrument
 
 - type: Tag


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This started by wanting to Implement Charcoal #10042. To begin with it I wanted to have a easy way for the players to make ash. So down the rabbit hole I went and found myself playing with fire. So now you can burn papers. It works fairly well, you can burn whole piles of paper with any isHot tool. Fire can spread to nearby papers but they currently have to be really damn close to one other. 

Things I would like to improve (now or later):
- Expand this to other burnable entities like wooden chairs, tables, floors, etc. However, I found myself stuck on getting the fire visual sprite to render on the tables. I really could use some help on identifying what is wrong.
- Spread the fire to nearby Flammable components, I could do this with some sort of collision or by checking the nearest tile. 
- Fix the fire extinguisher to actually put out the fires.
- Balance the burn time with its base material
- Spread the fire to mobs on collision, right now this would work except then they wouldn't be able to put themselves out

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![Screenshot_2022-08-06_15-03-41](https://user-images.githubusercontent.com/8183999/183264499-975df555-55f1-4b9b-9c63-a23ca4d50b2e.png)
![Screenshot_2022-08-06_15-03-53](https://user-images.githubusercontent.com/8183999/183264500-3c04fab4-fab0-494f-bb3b-4d8f7353fab7.png)
![Screenshot_2022-08-06_15-03-59](https://user-images.githubusercontent.com/8183999/183264501-72e61064-2511-4fa8-8cf5-a4adb721d111.png)
![Screenshot_2022-08-06_15-04-15](https://user-images.githubusercontent.com/8183999/183264502-7b557871-5c69-44ea-8beb-1b464411638d.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: papers can be set on fire

