### PR TITLE
Fix durathread recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/materials/durathread.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/materials/durathread.yml
@@ -7,7 +7,7 @@
         - to: MaterialDurathread
           completed:
             - !type:SetStackCount
-              amount: 1
+              amount: 5
           steps:
             - material: Cloth
               amount: 5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/materials/durathread.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/materials/durathread.yml
@@ -7,11 +7,11 @@
         - to: MaterialDurathread
           completed:
             - !type:SetStackCount
-              amount: 5
+              amount: 1
           steps:
             - material: Cloth
-              amount: 5
+              amount: 1
             - material: Plastic
-              amount: 5
+              amount: 1
     - node: MaterialDurathread
       entity: MaterialDurathread


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
5 cloth and 5 plastic for one piece is fucking awful.
fixes it so that it gives the proper amount, 5, which is what i originally intended.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: The durathread crafting recipe now gives the proper amount (5, not 1).

