### PR TITLE
Make egg-plants contain actual egg

### DIFF
--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -414,7 +414,7 @@
   idealLight: 9
   idealHeat: 298
   chemicals:
-    Nutriment:
+    Egg:
       Min: 1
       Max: 10
       PotencyDivisor: 10


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Eggs from the egg-plant contain nutriment instead of egg, so when cracked they can't be used to make egg-things.

This PR makes eggs from egg-plants contain actual eggs.

**Changelog**
:cl: notafet
- fix: Eggs from egg-plants now contain real eggs.
