### PR TITLE
Preserve explosion error stack trace

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -133,7 +133,9 @@ public sealed partial class ExplosionSystem : EntitySystem
             {
                 // Ensure the system does not get stuck in an error-loop.
                 _activeExplosion = null;
-                throw e;
+                RaiseNetworkEvent(new ExplosionOverlayUpdateEvent(_explosionCounter, int.MaxValue));
+                _nodeGroupSystem.Snoozing = false;
+                throw;
             }
 #endif
         }


### PR DESCRIPTION
Also ensures that the client-side visuals are cleared and node groups don't continue napping.
