### PR TITLE
Fix ExtinguisherCabinet insert sound (#10247)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -50,6 +50,9 @@
         enabled:
           True: { state: fire_extinguisher_closed }
           False: { state: fire_extinguisher_open }
+  - type: Tag
+    tags:
+    - FireExtinguisher
 
 - type: entity
   name: extinguisher spray

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/extinguisher_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/extinguisher_cabinet.yml
@@ -23,7 +23,7 @@
       cabinetSlot:
         ejectOnInteract: true
         whitelist:
-          components:
+          tags:
           - FireExtinguisher
       doorSound:
         path: /Audio/Machines/machine_switch.ogg
@@ -52,7 +52,7 @@
       ejectOnInteract: true
       startingItem: FireExtinguisher
       whitelist:
-        components:
+        tags:
         - FireExtinguisher
 
 - type: entity

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -187,6 +187,9 @@
   id: FireAxe
 
 - type: Tag
+  id: FireExtinguisher
+
+- type: Tag
   id: FirelockElectronics
 
 - type: Tag


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

 This is my first contribution fixing the following issue: ExtinguisherCabinet insert sound (#10247)
 
 I looked into two ways of solving this both suggested  by @ElectroJr :
1. By adding a tag as suggested
2. Alternatively by making the FireExtinguisherComponent shared and available in the client so it passes the item slot whitelist check on the cabinet. 

In the end I went with option 1 as this is how the very similar `fireaxe_cabinet.yml` also works.

## Reproduction Copied from Issue

- Open wallmounted fire extinguisher cabinet
- Eject fire extinguisher from cabinet
- Eject sound was played
- Insert fire extinguisher to cabinet
- No insert sound was played


## Testing performed

I manually checked before that indeed no sound was being played, and inserted log temporary lines into the Whitelisting component to confirm that this was because it was filtering the FireExtingisher component due to it not being regisitered / available in the frontend. After the fix the sound now plays.


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: fixed no sound being played when putting a fire extinguisher into a wall-mounted cabinet.
