### PR TITLE
Bring ointment in line with bruise pack on healing power

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -26,7 +26,7 @@
     damageContainer: Biological
     damage:
       groups:
-        Burn: -10 # 5 for each type in the group
+        Burn: -15 # 5 for each type in the group
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:


### PR DESCRIPTION
## Bring ointment in line with bruise pack on healing power
Comment "5 for each type in the group" was introduced by commit df584ad44695777b879070dc529b31a2c80d51b3.
Oddly enough, Burn damage group with Heat, Shock and Cold types (3 of them) was introduced in very same commit.

This PR fixes ointment healing 3.33something of Burn damage instead of intended 5 per use.

**Changelog**
:cl:
- fix: Ointments heal 5 points of Burn damage per use, instead of 3.33
