### PR TITLE
Dragon rift fixes

### DIFF
--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -27,13 +27,13 @@ public sealed class DragonRiftComponent : SharedDragonRiftComponent
     /// Accumulation of the spawn timer.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("spawnAccumulator")]
-    public float SpawnAccumulator = 60f;
+    public float SpawnAccumulator = 30f;
 
     /// <summary>
     /// How long it takes for a new spawn to be added.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("spawnCooldown")]
-    public float SpawnCooldown = 60f;
+    public float SpawnCooldown = 30f;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("spawn", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string SpawnPrototype = "MobCarpDragon";

--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -38,6 +38,8 @@ namespace Content.Server.Dragon
         /// </summary>
         private const int RiftRange = 15;
 
+        private const int RiftsAllowed = 3;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -80,7 +82,7 @@ namespace Content.Server.Dragon
                 }
 
                 // At max rifts
-                if (comp.Rifts.Count >= 3)
+                if (comp.Rifts.Count >= RiftsAllowed)
                 {
                     continue;
                 }
@@ -202,7 +204,7 @@ namespace Content.Server.Dragon
                 return;
             }
 
-            if (component.Rifts.Count >= 3)
+            if (component.Rifts.Count >= RiftsAllowed)
             {
                 _popupSystem.PopupEntity(Loc.GetString("carp-rift-max"), uid, Filter.Entities(uid));
                 return;

--- a/Resources/Locale/en-US/actions/actions/dragon.ftl
+++ b/Resources/Locale/en-US/actions/actions/dragon.ftl
@@ -17,6 +17,7 @@ carp-rift-duplicate = Cannot have 2 charging rifts at the same time!
 carp-rift-examine = It is [color=yellow]{$percentage}%[/color] charged!
 carp-rift-max = You have reached your maximum amount of rifts
 carp-rift-anchor = Rifts require a stable surface to spawn.
+carp-rift-proximity = Too close to a nearby rift! Need to be at least {$proximity}m away.
 carp-rift-weakened = You are unable to summon more rifts in your weakened state.
 carp-rift-destroyed = A rift has been destroyed! You are now weakened temporarily.
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -148,7 +148,7 @@
   name: space carp
   id: MobCarpDragon
   suffix: DragonBrood
-  parent: MobCarp
+  parent: BaseMobCarp
   components:
     - type: GhostTakeoverAvailable
       makeSentient: true


### PR DESCRIPTION
1. Minimum range on rifts
2. The halfway announcement
3. Dragon carps can talk again
