### PR TITLE
Allow C4's auto-starting when stickied quality to be toggled

### DIFF
--- a/Content.Server/Explosion/Components/OnUseTimerTriggerComponent.cs
+++ b/Content.Server/Explosion/Components/OnUseTimerTriggerComponent.cs
@@ -38,5 +38,11 @@ namespace Content.Server.Explosion.Components
         /// </summary>
         [DataField("startOnStick")]
         public bool StartOnStick;
+
+        /// <summary>
+        ///     Allows changing the start-on-stick quality.
+        /// </summary>
+        [DataField("canToggleStartOnStick")]
+        public bool AllowToggleStartOnStick;
     }
 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.OnUse.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.OnUse.cs
@@ -87,6 +87,15 @@ public sealed partial class TriggerSystem
                 },
             });
         }
+
+        if (component.AllowToggleStartOnStick)
+        {
+            args.Verbs.Add(new AlternativeVerb()
+            {
+                Text = Loc.GetString("verb-toggle-start-on-stick"),
+                Act = () => ToggleStartOnStick(uid, args.User, component)
+            });
+        }
     }
 
     private void CycleDelay(OnUseTimerTriggerComponent component, EntityUid user)
@@ -113,6 +122,20 @@ public sealed partial class TriggerSystem
                 _popupSystem.PopupEntity(Loc.GetString("popup-trigger-timer-set", ("time", option)), user, Filter.Entities(user));
                 return;
             }
+        }
+    }
+
+    private void ToggleStartOnStick(EntityUid grenade, EntityUid user, OnUseTimerTriggerComponent comp)
+    {
+        if (comp.StartOnStick)
+        {
+            comp.StartOnStick = false;
+            _popupSystem.PopupEntity(Loc.GetString("popup-start-on-stick-off"), grenade, Filter.Entities(user));
+        }
+        else
+        {
+            comp.StartOnStick = true;
+            _popupSystem.PopupEntity(Loc.GetString("popup-start-on-stick-on"), grenade, Filter.Entities(user));
         }
     }
 

--- a/Resources/Locale/en-US/weapons/grenades/timer-trigger.ftl
+++ b/Resources/Locale/en-US/weapons/grenades/timer-trigger.ftl
@@ -6,3 +6,7 @@ verb-trigger-timer-cycle = Cycle Time Delay
 examine-trigger-timer = The timer is set to {$time} seconds.
 
 popup-trigger-timer-set = Timer set to {$time} seconds.
+
+verb-toggle-start-on-stick = Toggle auto-activation
+popup-start-on-stick-off = The device will no longer activate automatically when planted
+popup-start-on-stick-on = The device will now activate automatically when planted

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -16,6 +16,7 @@
       initialBeepDelay: 0
       beepSound: /Audio/Machines/Nuke/general_beep.ogg
       startOnStick: true
+      canToggleStartOnStick: true
     - type: TriggerOnSignal
     - type: SignalReceiver
     - type: Sticky


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows you to disable C4 automatically activating when planted.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: You can now stop C-4 from automatically activating when planted.

