### PR TITLE
Singulo checks to see if a field gen is connected before colliding and field gen power fix

### DIFF
--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -41,7 +41,7 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
         foreach (var generator in EntityQuery<ContainmentFieldGeneratorComponent>())
         {
             if (generator.PowerBuffer <= 0) //don't drain power if there's no power, or if it's somehow less than 0.
-                return;
+                continue;
 
             generator.Accumulator += frameTime;
 

--- a/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
@@ -131,10 +131,10 @@ namespace Content.Server.Singularity.EntitySystems
             return entity != component.Owner &&
                    !EntityManager.HasComponent<IMapGridComponent>(entity) &&
                    !EntityManager.HasComponent<GhostComponent>(entity) &&
-                   !EntityManager.HasComponent<StationDataComponent>(entity) && // these SHOULD be in null-space... but just in case. Also, maybe someone moves a singularity there.. 
+                   !EntityManager.HasComponent<StationDataComponent>(entity) && // these SHOULD be in null-space... but just in case. Also, maybe someone moves a singularity there..
                    (component.Level > 4 ||
                    !EntityManager.HasComponent<ContainmentFieldComponent>(entity) &&
-                   !EntityManager.HasComponent<ContainmentFieldGeneratorComponent>(entity));
+                   !(EntityManager.TryGetComponent<ContainmentFieldGeneratorComponent>(entity, out var fieldGen) && fieldGen.IsConnected));
         }
 
         private void HandleDestroy(ServerSingularityComponent component, EntityUid entity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

closes #10328

closes #10327

(I think it closes this second one, I cannot reproduce that at all)

Adds a new check to make sure the singulo won't bounce on a bunch of deactivated containment field generators.

Also fixes a potential power gen reducing issue.