### PR TITLE
make windoor, railing, and directional window bounds not awful

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -16,7 +16,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.49,-0.49,0.49,-0.3"
+        bounds: "-0.49,-0.49,0.49,-0.45"
       mass: 50
       mask:
       - TabletopMachineMask

--- a/Resources/Prototypes/Entities/Structures/Walls/railing.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/railing.yml
@@ -18,7 +18,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.49,-0.49,0.49,-0.3"
+        bounds: "-0.49,-0.49,0.49,-0.45"
       mass: 50
       mask:
       - TableMask
@@ -70,7 +70,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.49,-0.49,0.49,-0.3"
+        bounds: "-0.49,-0.49,0.49,-0.45"
       mass: 50
       mask:
       - TableMask
@@ -78,7 +78,7 @@
       - TableLayer
     - shape:
         !type:PhysShapeAabb
-        bounds: "0.49,0.49,0.3,-0.49"
+        bounds: "0.49,0.49,0.45,-0.49"
       mass: 50
       mask:
       - TableMask
@@ -130,7 +130,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.49,0.49,-0.3,0.3"
+        bounds: "-0.49,0.49,-0.45,0.45"
       mass: 50
       mask:
       - TableMask
@@ -161,4 +161,3 @@
   - type: Construction
     graph: Railing
     node: railingCornerSmall
-

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -123,7 +123,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.49,-0.49,0.49,-0.3"
+        bounds: "-0.49,-0.49,0.49,-0.45"
       mass: 50
       mask:
       - FullTileMask


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mappers seem to map these assuming that entities that fit through single doors can fit in between these without issue. That is not the case. This makes most of the openings people would create when mapping these closer to door sized, so I have to teleport people and objects out of them much less often.
