### PR TITLE
Pass through vehicle damage to rider

### DIFF
--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Actions;
 using Content.Shared.Audio;
 using Content.Server.Light.Components;
 using Content.Server.Hands.Systems;
+using Content.Shared.Damage;
 using Content.Shared.Tag;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.Audio;
@@ -26,6 +27,7 @@ namespace Content.Server.Vehicle
         [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
         [Dependency] private readonly SharedMoverController _mover = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
+        [Dependency] private readonly DamageableSystem _damageableSystem = default!;
 
         private const string KeySlot = "key_slot";
 
@@ -39,6 +41,7 @@ namespace Content.Server.Vehicle
             SubscribeLocalEvent<VehicleComponent, BuckleChangeEvent>(OnBuckleChange);
             SubscribeLocalEvent<VehicleComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
             SubscribeLocalEvent<VehicleComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
+            SubscribeLocalEvent<VehicleComponent, DamageChangedEvent>(OnVehicleDamageChanged);
         }
 
         /// <summary>
@@ -128,6 +131,16 @@ namespace Content.Server.Vehicle
             // Reset component
             component.HasRider = false;
             component.Rider = null;
+        }
+
+        /// <summary>
+        /// Will pass through damage the vehicle receives to the player
+        /// </summary>
+        private void OnVehicleDamageChanged(EntityUid uid, VehicleComponent component, DamageChangedEvent args)
+        {
+            if (args.DamageDelta == null)
+                return;
+            _damageableSystem.TryChangeDamage(component.Rider, args.DamageDelta * component.DamageShare);
         }
 
         /// <summary>

--- a/Content.Shared/Vehicle/Components/VehicleComponent.cs
+++ b/Content.Shared/Vehicle/Components/VehicleComponent.cs
@@ -56,6 +56,13 @@ namespace Content.Shared.Vehicle.Components
         };
 
         /// <summary>
+        /// Percentage of damage dealt to the vehicle that will be dealt to the rider.
+        /// </summary>
+        [ViewVariables]
+        [DataField("damageShare")]
+        public float DamageShare { get; set; } = 1f;
+
+        /// <summary>
         /// Whether the vehicle has a key currently inside it or not.
         /// </summary>
         public bool HasKey = false;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Will pass through vehicle damage to the rider.

can be tweaked by changing "damageShare" on the vehicle if you want the vehicle to provide some protection

Fixes #10108


:cl:
- tweak: Vehicle damage will now get passed through to the rider.