### PR TITLE
Heal breaks shield fix

### DIFF
--- a/Content.Shared/Blocking/BlockingUserSystem.cs
+++ b/Content.Shared/Blocking/BlockingUserSystem.cs
@@ -54,14 +54,15 @@ public sealed class BlockingUserSystem : EntitySystem
 
     private void OnDamageChanged(EntityUid uid, BlockingUserComponent component, DamageChangedEvent args)
     {
-        if (component.BlockingItem != null && IsDamageValid(args))
+        //TODO: Have a way to tell where the damage is coming from. Is it coming from another player? That way we can tell if it makes sense that the damage could be blocked.
+        if (component.BlockingItem != null && args.DamageIncreased && IsDamageValid(args))
         {
             RaiseLocalEvent(component.BlockingItem.Value, args);
         }
     }
 
     /// <summary>
-    /// This method ensures that the damage being done to the sheild is in fact valid for damaging the sheild. E.G: Sheild should take damage to asphyxiation, radiation, etc. just Slash, Blunt, and Piercing.
+    /// This method ensures that the damage being done to the sheild is in fact valid for damaging the sheild. E.G: Sheild should take damage to asphyxiation, radiation, etc., just stuff that makes sense to be able to be blocked.
     /// </summary>
     /// <param name="args"></param>
     /// <returns>Bool: True when valid damage type, false when not valid damage or the damageDelta is null.</returns>
@@ -72,7 +73,8 @@ public sealed class BlockingUserSystem : EntitySystem
             return false;
         }
 
-        return args.DamageDelta.DamageDict.ContainsKey("Slash") || args.DamageDelta.DamageDict.ContainsKey("Blunt") || args.DamageDelta.DamageDict.ContainsKey("Piercing");
+        return !(args.DamageDelta.DamageDict.ContainsKey("Asphyxiation") || args.DamageDelta.DamageDict.ContainsKey("Bloodloss") || args.DamageDelta.DamageDict.ContainsKey("Cellular")
+            || args.DamageDelta.DamageDict.ContainsKey("Poison") || args.DamageDelta.DamageDict.ContainsKey("Radiation"));
     }
 
     private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)

--- a/Content.Shared/Blocking/BlockingUserSystem.cs
+++ b/Content.Shared/Blocking/BlockingUserSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Audio;
+using Content.Shared.Audio;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Robust.Shared.Audio;
@@ -54,10 +54,25 @@ public sealed class BlockingUserSystem : EntitySystem
 
     private void OnDamageChanged(EntityUid uid, BlockingUserComponent component, DamageChangedEvent args)
     {
-        if (component.BlockingItem != null)
+        if (component.BlockingItem != null && IsDamageValid(args))
         {
             RaiseLocalEvent(component.BlockingItem.Value, args);
         }
+    }
+
+    /// <summary>
+    /// This method ensures that the damage being done to the sheild is in fact valid for damaging the sheild. E.G: Sheild should take damage to asphyxiation, radiation, etc. just Slash, Blunt, and Piercing.
+    /// </summary>
+    /// <param name="args"></param>
+    /// <returns>Bool: True when valid damage type, false when not valid damage or the damageDelta is null.</returns>
+    private bool IsDamageValid(DamageChangedEvent args)
+    {
+        if (args.DamageDelta == null)
+        {
+            return false;
+        }
+
+        return args.DamageDelta.DamageDict.ContainsKey("Slash") || args.DamageDelta.DamageDict.ContainsKey("Blunt") || args.DamageDelta.DamageDict.ContainsKey("Piercing");
     }
 
     private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)

--- a/Content.Shared/Blocking/BlockingUserSystem.cs
+++ b/Content.Shared/Blocking/BlockingUserSystem.cs
@@ -54,27 +54,10 @@ public sealed class BlockingUserSystem : EntitySystem
 
     private void OnDamageChanged(EntityUid uid, BlockingUserComponent component, DamageChangedEvent args)
     {
-        //TODO: Have a way to tell where the damage is coming from. Is it coming from another player? That way we can tell if it makes sense that the damage could be blocked.
-        if (component.BlockingItem != null && args.DamageIncreased && IsDamageValid(args))
+        if (component.BlockingItem != null && args.DamageIncreased)
         {
             RaiseLocalEvent(component.BlockingItem.Value, args);
         }
-    }
-
-    /// <summary>
-    /// This method ensures that the damage being done to the sheild is in fact valid for damaging the sheild. E.G: Sheild should take damage to asphyxiation, radiation, etc., just stuff that makes sense to be able to be blocked.
-    /// </summary>
-    /// <param name="args"></param>
-    /// <returns>Bool: True when valid damage type, false when not valid damage or the damageDelta is null.</returns>
-    private bool IsDamageValid(DamageChangedEvent args)
-    {
-        if (args.DamageDelta == null)
-        {
-            return false;
-        }
-
-        return !(args.DamageDelta.DamageDict.ContainsKey("Asphyxiation") || args.DamageDelta.DamageDict.ContainsKey("Bloodloss") || args.DamageDelta.DamageDict.ContainsKey("Cellular")
-            || args.DamageDelta.DamageDict.ContainsKey("Poison") || args.DamageDelta.DamageDict.ContainsKey("Radiation"));
     }
 
     private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the problem of applying ointment to a damaged Urist wielding a shield utterly demolishing the shield. This problem was also causing the demolition of the shield when Urist was downed, gasping, and also wielding the shield. Both of these are fixed.

Also, fixes the problem of the stripping menu not being updated when the shield breaks.

**Changelog**
- fix: Wonderous buckler destruction upon heal, as well as destruction of buckler upon taking asphyxiation damage whilst down and wielding shield.
- fix: Broken shields not updating strip menu upon item destruction.

Closes: #10405
Closes: #10423