### PR TITLE
Add "already full" message when refilling welder

### DIFF
--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -224,6 +224,10 @@ namespace Content.Server.Tools
                     SoundSystem.Play(welder.WelderRefill.GetSound(), Filter.Pvs(uid), uid);
                     target.PopupMessage(args.User, Loc.GetString("welder-component-after-interact-refueled-message"));
                 }
+                else if (welderSolution.AvailableVolume <= 0)
+                {
+                    target.PopupMessage(args.User, Loc.GetString("welder-component-already-full"));
+                }
                 else
                 {
                     target.PopupMessage(args.User, Loc.GetString("welder-component-no-fuel-in-tank", ("owner", args.Target)));

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -9,7 +9,6 @@ using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
-using Content.Shared.Popups;
 using Content.Shared.Temperature;
 using Content.Shared.Tools.Components;
 using Robust.Server.GameObjects;
@@ -222,15 +221,15 @@ namespace Content.Server.Tools
                     var drained = _solutionContainerSystem.Drain(target, targetSolution,  trans);
                     _solutionContainerSystem.TryAddSolution(uid, welderSolution, drained);
                     SoundSystem.Play(welder.WelderRefill.GetSound(), Filter.Pvs(uid), uid);
-                    target.PopupMessage(args.User, Loc.GetString("welder-component-after-interact-refueled-message"));
+                    _popupSystem.PopupEntity(Loc.GetString("welder-component-after-interact-refueled-message"), uid, Filter.Entities(args.User));
                 }
                 else if (welderSolution.AvailableVolume <= 0)
                 {
-                    target.PopupMessage(args.User, Loc.GetString("welder-component-already-full"));
+                    _popupSystem.PopupEntity(Loc.GetString("welder-component-already-full"), uid, Filter.Entities(args.User));
                 }
                 else
                 {
-                    target.PopupMessage(args.User, Loc.GetString("welder-component-no-fuel-in-tank", ("owner", args.Target)));
+                    _popupSystem.PopupEntity(Loc.GetString("welder-component-no-fuel-in-tank", ("owner", args.Target)), uid, Filter.Entities(args.User));
                 }
             }
 

--- a/Resources/Locale/en-US/prototypes/entities/structures/storage/tanks/tanks.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/storage/tanks/tanks.ftl
@@ -1,16 +1,16 @@
-ent-WeldingFuelTank = Fuel tank
+ent-WeldingFuelTank = fuel tank
     .desc = A fuel tank. It's used to store high amounts of fuel.
 
 ent-WeldingFuelTankFull = { ent-WeldingFuelTank }
     .desc = { ent-WeldingFuelTank.desc }
 
-ent-WaterTank = Water tank
+ent-WaterTank = water tank
     .desc = A water tank. It's used to store high amounts of water.
 
 ent-WaterTankFull = { ent-WaterTank }
     .desc = { ent-WaterTank.desc }
 
-ent-WaterCooler = Water cooler
+ent-WaterCooler = water cooler
     .desc = Seems like a good place to stand and waste time.
 
 ent-WaterTankHighCapacity = High-capacity water tank

--- a/Resources/Locale/en-US/tools/components/welder-component.ftl
+++ b/Resources/Locale/en-US/tools/components/welder-component.ftl
@@ -1,7 +1,7 @@
 welder-component-welder-not-lit-message = The welder is turned off!
 welder-component-cannot-weld-message = The welder does not have enough fuel for that!
 welder-component-no-fuel-message = The welder has no fuel left!
-welder-component-no-fuel-in-tank = {$owner} is empty
+welder-component-no-fuel-in-tank = The {$owner} is empty.
 welder-component-on-examine-welder-lit-message = [color=orange]Lit[/color]
 welder-component-on-examine-welder-not-lit-message = Not lit
 welder-component-on-examine-detailed-message = Fuel: [color={$colorName}]{$fuelLeft}/{$fuelCapacity}[/color]. {$status}
@@ -10,3 +10,4 @@ welder-component-suicide-lit-message = You weld your every orifice closed!
 welder-component-suicide-unlit-others-message = {$victim} bashes themselves with the unlit welding torch!
 welder-component-suicide-unlit-message = You bash yourself with the unlit welding torch!
 welder-component-after-interact-refueled-message = Refueled!
+welder-component-already-full = The welder is already full.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Due to a logic error, refilling a full welder on a fuel tank shows the "fuel tank is empty" message. This change adds an appropriate message to show that the welder is already full.

While here, adjust the entity name of the fuel tank (and other entities in the same file) to uncapitalize the first letter to be consistent with all the other entity names.

**Changelog**
None