### PR TITLE
Add HoP and Detective spawn point to NSS Pillar

### DIFF
--- a/Resources/Maps/nss_pillar.yml
+++ b/Resources/Maps/nss_pillar.yml
@@ -152657,4 +152657,16 @@ entities:
       storagebase: !type:Container
         ents: []
     type: ContainerContainer
+- uid: 18097
+  type: SpawnPointHeadOfPersonnel
+  components:
+  - pos: -13.5,-10.5
+    parent: 130
+    type: Transform
+- uid: 18098
+  type: SpawnPointDetective
+  components:
+  - pos: -49.5,5.5
+    parent: 130
+    type: Transform
 ...


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR 
fixes #10464
there was no spawnpoint for these 2 jobs

**Changelog**

:cl:
- fix: fix spawn point for HoP and Detective on NSS Pillar
