### PR TITLE
Emagged Chem Dispenser has Water and Welding Fuel

### DIFF
--- a/Resources/Prototypes/Catalog/ReagentDispensers/chemical.yml
+++ b/Resources/Prototypes/Catalog/ReagentDispensers/chemical.yml
@@ -29,3 +29,5 @@
   - Toxin
   - Epinephrine
   - Ultravasculine
+  - Water
+  - WeldingFuel


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This addition makes Emagging a chem Dispenser more useful. As it is, the only item in the Emagged Chem Dispenser that is truly useful is the Epinephrine and ultravasculine as the other items can be substituted easily. However, it's more useful to the rest of medbay than a traitor chemist/scientist trying to kill people. The addition of water and Welding Fuel makes them more useful to a chemist as it unlocks the easy ability to make potassium bombs as well as unlocks the advanced chems that normally need welding fuel and water.

**Changelog**
🆑 Added Water and WeldingFuel to Emagged Chemical Dispensers



