### PR TITLE
Fix cans that cant be spilled

### DIFF
--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -95,6 +95,9 @@ public sealed class SpillableSystem : EntitySystem
     {
         if (!_solutionContainerSystem.TryGetSolution(uid, component.SolutionName, out var solution)) return;
 
+        if (TryComp<DrinkComponent>(uid, out var drink) && (!drink.Opened))
+            return;
+
         if (args.User != null)
         {
             _adminLogger.Add(LogType.Landed,

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -34,6 +34,8 @@
     - type: DrinkCanVisualizer
       stateClosed: icon
       stateOpen: icon_open
+  - type: Spillable
+    solution: drink
   - type: ItemCooldown
   - type: Recyclable
   - type: SpaceGarbage

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
@@ -18,6 +18,8 @@
     solution: drink
   - type: SolutionTransfer
     canChangeTransferAmount: true
+  - type: Spillable
+    solution: drink
   - type: Sprite
     sprite: Objects/Consumable/Drinks/shaker.rsi
     state: icon


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
closes #10527 
Added Spillable Component to cans and shakers
Added a check to ensure that closed cans do not spill when thrown a short distance

**Changelog**

:cl:
- add: Cans and shakers can now be spilled on floor

