### PR TITLE
Fix audio occlusion

### DIFF
--- a/Content.Client/Audio/ContentAudioSystem.cs
+++ b/Content.Client/Audio/ContentAudioSystem.cs
@@ -1,0 +1,8 @@
+using Content.Shared.Audio;
+
+namespace Content.Client.Audio;
+
+public sealed class ContentAudioSystem : SharedContentAudioSystem
+{
+
+}

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -1,0 +1,8 @@
+using Content.Shared.Audio;
+
+namespace Content.Server.Audio;
+
+public sealed class ContentAudioSystem : SharedContentAudioSystem
+{
+
+}

--- a/Content.Shared/Audio/SharedContentAudioSystem.cs
+++ b/Content.Shared/Audio/SharedContentAudioSystem.cs
@@ -1,0 +1,14 @@
+using Content.Shared.Physics;
+
+namespace Content.Shared.Audio;
+
+public abstract class SharedContentAudioSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _audio.OcclusionCollisionMask = (int) CollisionGroup.Impassable;
+    }
+}


### PR DESCRIPTION
It got removed in the audio refactor PR. Ideally we need some content system that gets called instead for whenever we get custom EFX anyway so.

:cl:
- fix: Audio occlusion is working again