### PR TITLE
Log storage error

### DIFF
--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -349,6 +349,12 @@ namespace Content.Server.Storage.EntitySystems
             if (args.Session.AttachedEntity is not EntityUid player)
                 return;
 
+            if (!Exists(args.InteractedItemUID))
+            {
+                Logger.Error($"Player {args.Session} interacted with non-existent item {args.InteractedItemUID} stored in {ToPrettyString(uid)}");
+                return;
+            }
+
             if (!_actionBlockerSystem.CanInteract(player, args.InteractedItemUID))
                 return;
 


### PR DESCRIPTION
Adds logs to narrow down the cause of this exception:

```
Caught exception while dispatching SystemMessage: System.ArgumentException: Entity is not valid. (Parameter 'uid')
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid, T component, Boolean overwrite) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 243
   at Robust.Shared.GameObjects.EntityManager.AddComponent[T](EntityUid uid) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 184
   at Content.Server.Forensics.ForensicsSystem.ApplyEvidence(EntityUid user, EntityUid target) in /home/runner/work/space-station-14/space-station-14/Content.Server/Forensics/Systems/ForensicsSystem.cs:line 36
   at Content.Server.Forensics.ForensicsSystem.OnInteract(EntityUid uid, FingerprintComponent component, UserInteractedWithItemEvent args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Forensics/Systems/ForensicsSystem.cs:line 19
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass47_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 252
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass58_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 391
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 176
   at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystem.cs:line 105
   at Content.Shared.ActionBlocker.ActionBlockerSystem.InteractWithItem(EntityUid user, EntityUid item) in /home/runner/work/space-station-14/space-station-14/Content.Shared/ActionBlocker/ActionBlockerSystem.cs:line 185
   at Content.Shared.ActionBlocker.ActionBlockerSystem.CanInteract(EntityUid user, Nullable`1 target) in /home/runner/work/space-station-14/space-station-14/Content.Shared/ActionBlocker/ActionBlockerSystem.cs:line 75
   at Content.Server.Storage.EntitySystems.StorageSystem.OnInteractWithItem(EntityUid uid, ServerStorageComponent storageComp, StorageInteractWithItemEvent args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Storage/EntitySystems/StorageSystem.cs:line 352
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass47_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 252
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass58_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 391
   at Robust.Server.GameObjects.UserInterfaceSystem.OnMessageReceived(BoundUIWrapMessage msg, EntitySessionEventArgs args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs:line 52
   at Robust.Shared.GameObjects.EventBusExt.HandlerWrapper`1.Invoke(EntitySessionMessage`1 msg) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EventBusExt.cs:line 47
   at Robust.Shared.GameObjects.EntityEventBus.ProcessSingleEventCore(EventSource source, Unit& unitRef, EventData subs, Boolean byRef) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 321
   at Robust.Server.GameObjects.ServerEntityManager.<Initialize>b__9_0(Object _, Object systemMsg) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 40
   at Robust.Server.GameObjects.ServerEntityManager.DispatchEntityNetworkMessage(MsgEntity message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 295
 Sawmill=net.ent
```

