### PR TITLE
Fix restart error

### DIFF
--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -31,6 +31,7 @@ using Robust.Shared.ContentPack;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Server.Station.Systems;
 
 namespace Content.Server.Entry
 {
@@ -160,6 +161,7 @@ namespace Content.Server.Entry
         protected override void Dispose(bool disposing)
         {
             _playTimeTracking?.Shutdown();
+            IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<StationSystem>().OnServerDispose();
         }
     }
 }

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -75,6 +75,14 @@ public sealed class StationSystem : EntitySystem
         _player.PlayerStatusChanged -= OnPlayerStatusChanged;
     }
 
+    /// <summary>
+    ///     Called when the server shuts down or restarts to avoid uneccesarily logging mid-round station deletion errors.
+    /// </summary>
+    public void OnServerDispose()
+    {
+        _stations.Clear();
+    }
+
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
     {
         if (e.NewStatus == SessionStatus.Connected)
@@ -97,7 +105,8 @@ public sealed class StationSystem : EntitySystem
         if (_stations.Contains(uid) && // Was not deleted via DeleteStation()
             _gameTicker.RunLevel == GameRunLevel.InRound) // And not due to a round restart
         {
-            throw new InvalidOperationException($"Station entity {ToPrettyString(uid)} is getting deleted mid-round.");
+            // printing a stack trace, rather than throwing an exception so that entity deletion continues as normal.
+            Logger.Error($"Station entity {ToPrettyString(uid)} is getting deleted mid-round. Trace: {Environment.StackTrace}");
         }
 
         _stations.Remove(uid);


### PR DESCRIPTION
Fixes #10452
There are still other restart errors (e.g., a networking peers enumeration-modification error).

