### PR TITLE
Attribution tweaks

### DIFF
--- a/Resources/Audio/Lobby/attributions.yml
+++ b/Resources/Audio/Lobby/attributions.yml
@@ -10,9 +10,9 @@
 
 - files: ["space_asshole.ogg"]
   license: "Custom"
-  copyright: "Space Asshole by Chris Remo is used with special permission from the author, under the condition that the project remains non-commercial and open source. At the author's request, here is a link to his bandcamp: https://chrisremo.bandcamp.com/"
+  copyright: "Space Asshole by Chris Remo is used with special permission from the author, under the condition that the project remains non-commercial and open source. The author also requested that a link to his bandcamp be included: https://chrisremo.bandcamp.com/"
   source: "https://idlethumbs.bandcamp.com/track/space-asshole"
-  # source is a direct link the the track, but not the "main" bandcamp of the author. Hence it is also in the copyright.
+  # The source is a direct link the the track, but not the "main" bandcamp of the author. Hence the link is also included separately in the copyright.
 
 - files: ["absconditus.ogg"]
   license: "CC-BY-NC-SA-3.0"

--- a/Resources/Audio/Lobby/attributions.yml
+++ b/Resources/Audio/Lobby/attributions.yml
@@ -10,8 +10,9 @@
 
 - files: ["space_asshole.ogg"]
   license: "Custom"
-  copyright: "Space Asshole by Chris Remo is used with special permission from the author, under the condition that the project remains non-commercial and open source."
-  source: "https://chrisremo.bandcamp.com"
+  copyright: "Space Asshole by Chris Remo is used with special permission from the author, under the condition that the project remains non-commercial and open source. At the author's request, here is a link to his bandcamp: https://chrisremo.bandcamp.com/"
+  source: "https://idlethumbs.bandcamp.com/track/space-asshole"
+  # source is a direct link the the track, but not the "main" bandcamp of the author. Hence it is also in the copyright.
 
 - files: ["absconditus.ogg"]
   license: "CC-BY-NC-SA-3.0"

--- a/Resources/Textures/LobbyScreens/attributions.yml
+++ b/Resources/Textures/LobbyScreens/attributions.yml
@@ -1,7 +1,7 @@
 - files: ["supermatter.png", "robotics.png"]
   license: "CC-BY-NC-SA-3.0"
   copyright: "Veritius#2351 (257233913951289344) on discord / @Veritius on GitHub"
-  source: "https://github.com/space-wizards/space-station-14"
+  source: "https://github.com/Veritius"
 
 - files: ["warden.png", "pharmacy.png"]
   license: "CC-BY-NC-SA-3.0"


### PR DESCRIPTION
Set the source URL for Veritius' art to their github ([discord messages](https://discord.com/channels/310555209753690112/770682801607278632/1008487678364356660)).

Updated space asshole URL to link directly to the track, while still linking the main bandcamp in the copyright field. Also changed the test to make it clear that the author requested that the link to their bandcamp be included, because maybe that attribution request is part of the "custom license"?