### PR TITLE
Rebalance some hardsuits to be better/make more sense (RD, death squad) and renamed captain's armour

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -32,8 +32,8 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCap
-  name: captain's armor
-  description: A suit of protective formal armor made for the station's captain.
+  name: captain's armored spacesuit
+  description: A formal armored spacesuit, made for the station's captain.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/capspace.rsi
@@ -83,7 +83,7 @@
         Heat: 0.2
         Radiation: 0.2
   - type: ExplosionResistance
-    damageCoefficient: 0.7
+    damageCoefficient: 0.2
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
 
@@ -139,7 +139,7 @@
         Slash: 0.85
         Piercing: 0.8
         Heat: 0.4
-        Radiation: 0.25
+        Radiation: 0.0
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: ToggleableClothing
@@ -237,21 +237,21 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.05
+    highPressureMultiplier: 0.02
     lowPressureMultiplier: 5500
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
-        Slash: 0.75
+        Slash: 0.8
         Piercing: 0.95
-        Heat: 0.65
-        Radiation: 0.25
+        Heat: 0.3
+        Radiation: 0.1
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: ExplosionResistance
-    damageCoefficient: 0.3
+    damageCoefficient: 0.1
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitRd
   - type: StaticPrice
@@ -345,7 +345,7 @@
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSyndie
   name: blood red hardsuit
-  description: A dual-mode advanced hardsuit designed for work in special operations.
+  description: A heavily armored and agile advanced hardsuit designed for work in special operations.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR 
 This changes some things about hardsuits. For example, the Experimental Research Hardsuit had its heat, radiation and explosion resistance buffed (it is a syndicate objective, and it also makes sense because those are all things that would be happening the lab) as well as being made on par with engineering suits high pressure resistance. Deathsquad suit got explosion resistance buffed to what it should be as it was 0.7 before and hadn't been changed with the explosion resist change.

Captain's spacesuit got renamed so it makes more sense (it's not really a set of armour). Redid the description of the Bloodred a bit as it didn't make sense before. I think I also made the CE suit radiation proof. Please discuss. This is my first PR and first time with github so if I did anything goofy and wrong please tell me.


:cl: Hoid
- tweak: Experimental Research Hardsuit now protects more effectively against things that can go wrong in the lab - including explosions. 

