### PR TITLE
Keep player status on disconnect

### DIFF
--- a/Content.IntegrationTests/Tests/Lobby/ServerReloginTest.cs
+++ b/Content.IntegrationTests/Tests/Lobby/ServerReloginTest.cs
@@ -1,0 +1,6 @@
+namespace Content.IntegrationTests.Tests.Lobby;
+
+public class ServerReloginTest
+{
+    
+}

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -86,8 +86,6 @@ namespace Content.Server.GameTicking
 
                 case SessionStatus.Disconnected:
                 {
-                    _playerGameStatuses.Remove(session.UserId);
-
                     _chatManager.SendAdminAnnouncement(Loc.GetString("player-leave-message", ("name", args.Session.Name)));
 
                     _userDb.ClientDisconnected(session);
@@ -120,9 +118,6 @@ namespace Content.Server.GameTicking
         public void PlayerJoinGame(IPlayerSession session)
         {
             _chatManager.DispatchServerMessage(session, Loc.GetString("game-ticker-player-join-game-message"));
-
-            if (!_playerGameStatuses.ContainsKey(session.UserId))
-                _playerGameStatuses.Remove(session.UserId);
 
             _playerGameStatuses[session.UserId] = PlayerGameStatus.JoinedGame;
 


### PR DESCRIPTION
Fix https://github.com/space-wizards/space-station-14/issues/10623

Made a test for this, but toolbox makes the user id random on every connection, so I need to change how that works, and I'm not doing that in this PR.