### PR TITLE
Remove ability for sleeping players to point

### DIFF
--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Ghost.Components;
 using Content.Server.Players;
 using Content.Server.Pointing.Components;
 using Content.Server.Visible;
+using Content.Shared.Bed.Sleep;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
@@ -108,6 +109,11 @@ namespace Content.Server.Pointing.EntitySystems
             // Checking mob state directly instead of some action blocker, as many action blockers are blocked for
             // ghosts and there is no obvious choice for pointing.
             if (TryComp(player, out MobStateComponent? mob) && mob.IsIncapacitated())
+            {
+                return false;
+            }
+
+            if (HasComp<SleepingComponent>(player))
             {
                 return false;
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removed the ability to point while asleep, thought about adding a message saying that the person can't point because he's asleep but decided against it as I find it unnecessary, open to other opinions.

Fixes #10149

**Screenshots**
Not Applicable

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Removed the ability to point while asleep

