### PR TITLE
Kicks players after being AFK too long

### DIFF
--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -84,10 +84,10 @@ namespace Content.Server.Chat.Managers
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Server announcement: {message}");
         }
 
-        public void DispatchServerMessage(IPlayerSession player, string message)
+        public void DispatchServerMessage(IPlayerSession player, string message, Color? colorOverride = null)
         {
             var messageWrap = Loc.GetString("chat-manager-server-wrap-message");
-            ChatMessageToOne(ChatChannel.Server, message, messageWrap, default, false, player.ConnectedClient);
+            ChatMessageToOne(ChatChannel.Server, message, messageWrap, default, false, player.ConnectedClient, colorOverride);
 
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Server message to {player:Player}: {message}");
         }

--- a/Content.Server/Chat/Managers/IChatManager.cs
+++ b/Content.Server/Chat/Managers/IChatManager.cs
@@ -16,7 +16,7 @@ namespace Content.Server.Chat.Managers
         /// <param name="colorOverride">Override the color of the message being sent.</param>
         void DispatchServerAnnouncement(string message, Color? colorOverride = null);
 
-        void DispatchServerMessage(IPlayerSession player, string message);
+        void DispatchServerMessage(IPlayerSession player, string message, Color? colorOverride = null);
 
         void TrySendOOCMessage(IPlayerSession player, string message, OOCChatType type);
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1032,8 +1032,8 @@ namespace Content.Shared.CCVar
         /// <summary>
         /// How long a client can go after being detected as AFK before being kicked;
         /// </summary>
-        public static readonly CVarDef<int> AfkKickTime =
-            CVarDef.Create("afk.kick_time", 10, CVar.SERVERONLY);
+        public static readonly CVarDef<float> AfkKickTime =
+            CVarDef.Create("afk.kick_time", 120f, CVar.SERVERONLY);
 
         /*
          * IC

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1033,7 +1033,7 @@ namespace Content.Shared.CCVar
         /// How long a client can go after being detected as AFK before being kicked;
         /// </summary>
         public static readonly CVarDef<float> AfkKickTime =
-            CVarDef.Create("afk.kick_time", 120f, CVar.SERVERONLY);
+            CVarDef.Create("afk.kick_time", 600f, CVar.SERVERONLY);
 
         /*
          * IC

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1029,6 +1029,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> AfkTime =
             CVarDef.Create("afk.time", 60f, CVar.SERVERONLY);
 
+        /// <summary>
+        /// How long a client can go after being detected as AFK before being kicked;
+        /// </summary>
+        public static readonly CVarDef<int> AfkKickTime =
+            CVarDef.Create("afk.kick_time", 10, CVar.SERVERONLY);
+
         /*
          * IC
          */

--- a/Resources/Locale/en-US/afk/afk.ftl
+++ b/Resources/Locale/en-US/afk/afk.ftl
@@ -1,0 +1,2 @@
+afk-system-kick-warning = You will be kicked for being AFK soon!
+afk-system-kick-reason = You were kicked for being AFK!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Creates a CVar with the amount of time before an AFK player is kicked. (Default is 10 minutes)
- One minute before the player is kicked, he's sent a warning.

- Adds `colorOverride` to `DispatchServerMessage`.

Fixes #10577 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![](https://i.imgur.com/mavjoP9.png)
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Kick AFK Players

