### PR TITLE
Check for StorageFillComponent before initializing item mapped layers

### DIFF
--- a/Content.Client/Storage/StorageFillComponent.cs
+++ b/Content.Client/Storage/StorageFillComponent.cs
@@ -1,7 +1,0 @@
-using Content.Shared.Storage.Components;
-
-namespace Content.Client.Storage.Components
-{
-    [RegisterComponent]
-    public sealed class StorageFillComponent : SharedStorageFillComponent {};
-}

--- a/Content.Client/Storage/StorageFillComponent.cs
+++ b/Content.Client/Storage/StorageFillComponent.cs
@@ -1,9 +1,7 @@
-using Content.Server.Storage.EntitySystems;
 using Content.Shared.Storage.Components;
 
-namespace Content.Server.Storage.Components
+namespace Content.Client.Storage.Components
 {
     [RegisterComponent]
-    [Access(typeof(StorageSystem))]
     public sealed class StorageFillComponent : SharedStorageFillComponent {};
 }

--- a/Content.Client/Storage/Systems/ItemMapperSystem.cs
+++ b/Content.Client/Storage/Systems/ItemMapperSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Client.Storage.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Client.GameObjects;
@@ -30,6 +31,7 @@ public sealed class ItemMapperSystem : SharedItemMapperSystem
             if (component.SpriteLayers.Count == 0)
             {
                 InitLayers(component, spriteComponent, args.Component);
+                return;
             }
 
             EnableLayers(component, spriteComponent, args.Component);
@@ -41,13 +43,14 @@ public sealed class ItemMapperSystem : SharedItemMapperSystem
         if (!appearance.TryGetData<ShowLayerData>(StorageMapVisuals.InitLayers, out var wrapper))
             return;
 
+        TryComp<StorageFillComponent>(component.Owner, out var storageFill);
         component.SpriteLayers.AddRange(wrapper.QueuedEntities);
 
         foreach (var sprite in component.SpriteLayers)
         {
             spriteComponent.LayerMapReserveBlank(sprite);
             spriteComponent.LayerSetSprite(sprite, new SpriteSpecifier.Rsi(component.RSIPath!, sprite));
-            spriteComponent.LayerSetVisible(sprite, false);
+            spriteComponent.LayerSetVisible(sprite, storageFill != null);
         }
     }
 

--- a/Content.Client/Storage/Systems/ItemMapperSystem.cs
+++ b/Content.Client/Storage/Systems/ItemMapperSystem.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Content.Client.Storage.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Client.GameObjects;

--- a/Content.IntegrationTests/Tests/StorageTest.cs
+++ b/Content.IntegrationTests/Tests/StorageTest.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using System.Threading.Tasks;
+using Content.Shared.Storage.Components;
 using Content.Server.Storage.Components;
 using Content.Shared.Item;
-using Content.Shared.Storage;
 using NUnit.Framework;
 using Robust.Shared.Prototypes;
 

--- a/Content.Server/Storage/Components/StorageFillComponent.cs
+++ b/Content.Server/Storage/Components/StorageFillComponent.cs
@@ -1,9 +1,0 @@
-using Content.Server.Storage.EntitySystems;
-using Content.Shared.Storage.Components;
-
-namespace Content.Server.Storage.Components
-{
-    [RegisterComponent]
-    [Access(typeof(StorageSystem))]
-    public sealed class StorageFillComponent : SharedStorageFillComponent {};
-}

--- a/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
@@ -1,4 +1,5 @@
 using Content.Server.Storage.Components;
+using Content.Shared.Storage.Components;
 using Content.Shared.Storage;
 
 namespace Content.Server.Storage.EntitySystems;

--- a/Content.Shared/Storage/Components/SharedStorageFillComponent.cs
+++ b/Content.Shared/Storage/Components/SharedStorageFillComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Storage.Components;
+
+[NetworkedComponent]
+public abstract class SharedStorageFillComponent : Component
+{
+    [DataField("contents")] public List<EntitySpawnEntry> Contents = new();
+}

--- a/Content.Shared/Storage/Components/SharedStorageFillComponent.cs
+++ b/Content.Shared/Storage/Components/SharedStorageFillComponent.cs
@@ -3,7 +3,8 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Storage.Components;
 
 [NetworkedComponent]
-public abstract class SharedStorageFillComponent : Component
+[RegisterComponent]
+public class StorageFillComponent : Component
 {
     [DataField("contents")] public List<EntitySpawnEntry> Contents = new();
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10622 
Just needed to check if it's an entity with a StorageFillComponent to determine if it should have the layers on initialization.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![2022-08-16_22-17](https://user-images.githubusercontent.com/8183999/185028167-a548f759-9860-4bda-8bb6-8ec8e8e2abdc.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Filled containers like toolbelts and crayon boxes properly show their contents on spawn

