### PR TITLE
Fix empty guns

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -127,8 +127,13 @@ public abstract partial class SharedGunSystem
 
     private void OnBallisticMapInit(EntityUid uid, BallisticAmmoProviderComponent component, MapInitEvent args)
     {
+        // TODO this should be part of the prototype, not set on map init.
+        // Alternatively, just track spawned count, instead of unspawned count.
         if (component.FillProto != null)
-            component.UnspawnedCount -= Math.Min(component.UnspawnedCount, component.Container.ContainedEntities.Count);
+        {
+            component.UnspawnedCount = Math.Max(0, component.Capacity - component.Container.ContainedEntities.Count);
+            Dirty(component);
+        }
     }
 
     protected int GetBallisticShots(BallisticAmmoProviderComponent component)


### PR DESCRIPTION
Fixes bug added in #10274. Tested AKMS & Minigun.

:cl:
- fix: Fixed guns spawning w/o ammo.

