### PR TITLE
Fly-by sound tweaks

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/FlyBySoundSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/FlyBySoundSystem.cs
@@ -13,6 +13,7 @@ public sealed class FlyBySoundSystem : SharedFlyBySoundSystem
 {
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
 
     public override void Initialize()
     {
@@ -28,11 +29,18 @@ public sealed class FlyBySoundSystem : SharedFlyBySoundSystem
         if (attachedEnt == null ||
             args.OtherFixture.Body.Owner != attachedEnt ||
             TryComp<ProjectileComponent>(args.OurFixture.Body.Owner, out var projectile) &&
-            projectile.Shooter == attachedEnt) return;
+            projectile.Shooter == attachedEnt)
+        {
+            return;
+        }
 
         if (args.OurFixture.ID != FlyByFixture ||
-            !_random.Prob(component.Prob)) return;
+            !_random.Prob(component.Prob))
+        {
+            return;
+        }
 
-        SoundSystem.Play(component.Sound.GetSound(), Filter.Local(), uid, component.Sound.Params);
+        // Play attached to our entity because the projectile may immediately delete or the likes.
+        _audio.Play(component.Sound, Filter.Local(), attachedEnt.Value);
     }
 }

--- a/Content.Shared/Weapons/Ranged/Components/FlyBySoundComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/FlyBySoundComponent.cs
@@ -13,13 +13,13 @@ public sealed class FlyBySoundComponent : Component
     /// Probability that the sound plays
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("prob")]
-    public float Prob = 0.75f;
+    public float Prob = 0.10f;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("sound")]
     public SoundSpecifier Sound = new SoundCollectionSpecifier("BulletMiss")
     {
-        Params = AudioParams.Default.WithVolume(5f),
+        Params = AudioParams.Default,
     };
 
-    [ViewVariables, DataField("range")] public float Range = 1.5f;
+    [ViewVariables, DataField("range")] public float Range = 1f;
 }

--- a/Content.Shared/Weapons/Ranged/Components/FlyBySoundComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/FlyBySoundComponent.cs
@@ -21,5 +21,5 @@ public sealed class FlyBySoundComponent : Component
         Params = AudioParams.Default,
     };
 
-    [ViewVariables, DataField("range")] public float Range = 1f;
+    [ViewVariables, DataField("range")] public float Range = 1.5f;
 }


### PR DESCRIPTION
- Play sounds from the player (so it doesn't abruptly cut when the entity deletes)
- Reduced probability
- Reduced volume

:cl:
- tweak: Tweaks to bullet flyby sounds to be less grating.