### PR TITLE
Add a tag for immunity from shoe-required step triggers

### DIFF
--- a/Content.Shared/StepTrigger/Systems/ShoesRequiredStepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/ShoesRequiredStepTriggerSystem.cs
@@ -1,12 +1,14 @@
 ﻿using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.StepTrigger.Components;
+using Content.Shared.Tag;
 
 namespace Content.Shared.StepTrigger.Systems;
 
 public sealed class ShoesRequiredStepTriggerSystem : EntitySystem
 {
     [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -17,6 +19,12 @@ public sealed class ShoesRequiredStepTriggerSystem : EntitySystem
 
     private void OnStepTriggerAttempt(EntityUid uid, ShoesRequiredStepTriggerComponent component, ref StepTriggerAttemptEvent args)
     {
+        if (_tagSystem.HasTag(args.Tripper, "ShoesRequiredStepTriggerImmune"))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
         if (!TryComp<InventoryComponent>(args.Tripper, out var inventory))
             return;
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -73,6 +73,7 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+    - ShoesRequiredStepTriggerImmune
   - type: MobState
     thresholds:
       0: Alive

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -61,6 +61,9 @@
     safe: false
   - type: StandingState
   - type: Alerts
+  - type: Tag
+    tags:
+      - ShoesRequiredStepTriggerImmune
 
 - type: entity
   name: drone
@@ -162,6 +165,7 @@
     autoRot: true
   - type: Tag
     tags:
+      - ShoesRequiredStepTriggerImmune
       - CannotSuicide
 
 - type: entity

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -409,6 +409,9 @@
   id: SecwayKeys
 
 - type: Tag
+  id: ShoesRequiredStepTriggerImmune
+
+- type: Tag
   id: Sheet
 
 - type: Tag


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flying mobs are still bugged. Their collision groups are set up correctly, it's a deeper issue. This fixes our current silicons and is a nice step on the road to upstreaming borgs though.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: Silicons will no longer take damage from glass shards. Flying mobs are still bugged.

