### PR TITLE
Fix missing fluent var

### DIFF
--- a/Content.Client/Storage/UI/StorageWindow.cs
+++ b/Content.Client/Storage/UI/StorageWindow.cs
@@ -133,7 +133,7 @@ namespace Content.Client.Storage.UI
                         new Label
                         {
                             Align = Label.AlignMode.Right,
-                            Text = item?.Size.ToString() ?? Loc.GetString("no-item-size")
+                            Text = item?.Size.ToString() ?? Loc.GetString("comp-storage-no-item-size"),
                         }
                     }
             });

--- a/Resources/Locale/en-US/components/storage-component.ftl
+++ b/Resources/Locale/en-US/components/storage-component.ftl
@@ -1,4 +1,4 @@
-comp-storage-no-item-size = None
+comp-storage-no-item-size = N/A
 comp-storage-cant-insert = Can't insert.
 comp-storage-insufficient-capacity = Insufficient capacity.
 comp-storage-invalid-container = Invalid container for this item.


### PR DESCRIPTION
Should fix this:

![image](https://user-images.githubusercontent.com/39844191/185176467-5fef2044-b6dd-4222-b3e9-130584cc4277.png)

Shouldn't really happen in the first place, but you never know with admemes.

I haven't tested the fix, because I'm not really sure how to reproduce it.