### PR TITLE
Let clowns and mimes rename themselves on spawn

### DIFF
--- a/Content.Server/CharacterInfo/RenameOnSpawnComponent.cs
+++ b/Content.Server/CharacterInfo/RenameOnSpawnComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server.CharacterInfo
+{
+
+    /// <summary>
+    /// This component is given to jobs that should be able to rename themselves when they spawn ingame (clowns, mimes)
+    /// </summary>
+    [RegisterComponent]
+    public sealed class RenameOnSpawnComponent : Component
+    {
+
+    }
+}

--- a/Content.Server/CharacterInfo/RenameOnSpawnSystem.cs
+++ b/Content.Server/CharacterInfo/RenameOnSpawnSystem.cs
@@ -22,7 +22,7 @@ namespace Content.Server.CharacterInfo
         [Dependency] private readonly PDASystem _pdaSystem = default!;
         [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
-        /// <inheritdoc/>
+
         public override void Initialize()
         {
             base.Initialize();

--- a/Content.Server/CharacterInfo/RenameOnSpawnSystem.cs
+++ b/Content.Server/CharacterInfo/RenameOnSpawnSystem.cs
@@ -1,0 +1,107 @@
+using Content.Server.Access.Systems;
+using Content.Server.Administration;
+using Content.Server.Administration.Systems;
+using Content.Server.Mind.Components;
+using Content.Server.PDA;
+using Content.Server.Station.Systems;
+using Content.Server.StationRecords;
+using Content.Shared.Access.Components;
+using Content.Shared.PDA;
+using Content.Shared.StationRecords;
+using Robust.Server.GameObjects;
+using Robust.Server.Player;
+using Robust.Shared.Enums;
+
+namespace Content.Server.CharacterInfo
+{
+    public sealed class RenameOnSpawnSystem : EntitySystem
+    {
+        [Dependency] private readonly IdCardSystem _idCardSystem = default!;
+        [Dependency] private readonly QuickDialogSystem _quickDialog = default!;
+        [Dependency] private readonly AdminSystem _adminSystem = default!;
+        [Dependency] private readonly PDASystem _pdaSystem = default!;
+        [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
+        [Dependency] private readonly StationSystem _stationSystem = default!;
+        /// <inheritdoc/>
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<RenameOnSpawnComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        }
+
+        private void OnPlayerAttached(EntityUid uid, RenameOnSpawnComponent component, PlayerAttachedEvent args)
+        {
+            ShowNameChangePopup(component, args.Player);
+        }
+
+        public void ShowNameChangePopup(RenameOnSpawnComponent component, IPlayerSession player)
+        {
+            //popup rename menu
+            _quickDialog.OpenDialog(player, "Rename yourself", "Name", (string newName) =>
+            {
+                TryNameChange(component, newName, player);
+            });
+        }
+
+        private void TryNameChange(RenameOnSpawnComponent component, string newName, IPlayerSession player)
+        {
+            var oldName = player.Name;
+
+            if (oldName == newName)
+                return;
+
+            //check if new name is too long
+            if (newName.Length > SharedIdCardConsoleComponent.MaxFullNameLength)
+            {
+                ShowNameChangePopup(component, player);
+                return;
+            }
+
+            //get metadata component
+            if (!TryComp<MetaDataComponent>(component.Owner, out var metaDataComponent))
+                return;
+
+            //Get ID card
+            if (!_idCardSystem.TryFindIdCard(component.Owner, out var idCard))
+                return;
+
+            //Change name in station records
+            var station = _stationSystem.GetOwningStation(component.Owner);
+            if (station == null)
+                return;
+            if (!TryComp<StationRecordKeyStorageComponent>(idCard.Owner, out var stationRecordKeyStorageComponent) || stationRecordKeyStorageComponent.Key == null)
+                return;
+            if (!_stationRecords.TryGetRecord(station.Value, stationRecordKeyStorageComponent.Key.Value, out GeneralStationRecord? record))
+                return;
+            record.Name = newName;
+
+
+            //change name in metadata
+            metaDataComponent.EntityName = newName;
+
+            //change name in mind
+            if (TryComp<MindComponent>(component.Owner, out var mindComponent) && mindComponent.Mind != null)
+            {
+                mindComponent.Mind.CharacterName = newName;
+            }
+
+            //change name on ID
+            _idCardSystem.TryChangeFullName(idCard.Owner, newName, idCard);
+
+            //change name on PDA
+            foreach (var pdaComponent in EntityQuery<PDAComponent>())
+            {
+                if (pdaComponent.OwnerName != oldName)
+                    continue;
+                _pdaSystem.SetOwner(pdaComponent, newName);
+            }
+
+            //update name on admin list
+            _adminSystem.UpdatePlayerList(player);
+
+            //remove component since the deed is done
+            RemComp<RenameOnSpawnComponent>(component.Owner);
+
+        }
+    }
+}

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -18,6 +18,7 @@
           Piercing: 4
         groups:
           Burn: 3
+    - type: RenameOnSpawn
 
 - type: startingGear
   id: ClownGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -12,6 +12,7 @@
   - !type:AddComponentSpecial
     components:
     - type: MimePowers
+    - type: RenameOnSpawn
 
 - type: startingGear
   id: MimeGear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Will let clowns and mimes give themselves a funny name when they arrive on station


**Screenshots**
![image](https://user-images.githubusercontent.com/31836813/185254103-1582c1f9-1454-4cc1-b5bb-0a7339877cc0.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Clowns and Mimes can now give themselves funny names when they arrive on the station!

