### PR TITLE
Fix logic error in role timers

### DIFF
--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
@@ -124,7 +124,6 @@ public sealed class PlayTimeTrackingManager
             if (data.NeedRefreshTackers)
             {
                 RefreshSingleTracker(player, data, time);
-                data.NeedRefreshTackers = true;
             }
 
             if (data.NeedSendTimers)


### PR DESCRIPTION
## About the PR
`PlayTimeTrackingManager` has a logic error that results in unnecessary calls to `RefreshSingleTracker()`.

In `UpdateDirtyPlayers()`, which is called in every `Update()`, each dirty player has their trackers updated if an update was queued as a result of an event that would update the active timer set. However, due to a logic error, the active timer set is updated each `Update()` instead of only when a change is needed.

Note that the call to `RefreshSingleTracker()` contains a `data.NeedRefreshTackers = false`, so the fix is simply to remove the extra set in *PlayTimeTrackingManager.cs*:127.

**Screenshots**
N/A

**Changelog**
N/A