### PR TITLE
Fix comments that were ported from YAML to FTL

### DIFF
--- a/Resources/Locale/en-US/guardian/guardian.ftl
+++ b/Resources/Locale/en-US/guardian/guardian.ftl
@@ -6,7 +6,8 @@ guardian-already-present-invalid-creation = You are NOT re-living that haunting 
 guardian-no-actions-invalid-creation = You don't have the ability to host a guardian!
 guardian-activator-empty-invalid-creation = The injector is spent.
 guardian-activator-empty-examine = [color=#ba1919]The injector is spent.[/color]
-guardian-activator-invalid-target = Only humans can be injected! # Change this once other species can inject it?
+# TODO: Change this once other species can inject it?
+guardian-activator-invalid-target = Only humans can be injected!
 guardian-no-soul = Your guardian has no soul.
 guardian-available = Your guardian now has a soul.
 

--- a/Resources/Locale/en-US/reagents/meta/elements.ftl
+++ b/Resources/Locale/en-US/reagents/meta/elements.ftl
@@ -50,7 +50,7 @@ reagent-name-sulfur = sulfur
 reagent-desc-sulfur = A yellow, crystalline solid.
 
 reagent-name-sodium = sodium
-reagent-desc-sodium = A silvery-white alkali metal. Highly reactive in its pure form. #thanks visne <3
+reagent-desc-sodium = A silvery-white alkali metal. Highly reactive in its pure form.
 
 reagent-name-uranium = uranium
 reagent-desc-uranium = A grey metallic chemical element in the actinide series, weakly radioactive.


### PR DESCRIPTION
Some YAML comments were accidentally ported to Fluent files by #7916.  Since Fluent doesn't have inline comments, they show up in the game.