### PR TITLE
SanitizeMessagePeriod: Add Period at the end of sentences

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.Radio.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Radio.cs
@@ -74,7 +74,7 @@ public sealed partial class ChatSystem
         }
 
         // Re-capitalize message since we removed the prefix.
-        message = SanitizeMessageCapital(source, message);
+        message = SanitizeMessageCapital(message);
 
         if (_inventory.TryGetSlotEntity(source, "ears", out var entityUid) &&
             TryComp(entityUid, out HeadsetComponent? headset))

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -474,7 +474,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     {
         if (string.IsNullOrEmpty(message))
             return message;
-        // Add period if there isn't any pontuation at the end.
+        // Adds a period if the last character is a letter.
         if (char.IsLetter(message[^1]))
             message += ".";
         return message;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -127,8 +127,9 @@ public sealed partial class ChatSystem : SharedChatSystem
             return;
 
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
+        bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
 
-        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize);
+        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldPunctuate);
 
         // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
@@ -423,12 +424,13 @@ public sealed partial class ChatSystem : SharedChatSystem
     }
 
     // ReSharper disable once InconsistentNaming
-    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true)
+    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false)
     {
         var newMessage = message.Trim();
         if (capitalize)
             newMessage = SanitizeMessageCapital(newMessage);
-        newMessage = SanitizeMessagePeriod(newMessage);
+        if (punctuate)
+            newMessage = SanitizeMessagePeriod(newMessage);
         newMessage = FormattedMessage.EscapeText(newMessage);
 
         _sanitizer.TrySanitizeOutSmilies(newMessage, source, out newMessage, out emoteStr);

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -475,7 +475,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (string.IsNullOrEmpty(message))
             return message;
         // Add period if there isn't any pontuation at the end.
-        if (message[^1] != '.' && message[^1] != '!' && message[^1] != '?')
+        if (char.IsLetter(message[^1]))
             message += ".";
         return message;
     }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -428,6 +428,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         var newMessage = message.Trim();
         if (capitalize)
             newMessage = SanitizeMessageCapital(source, newMessage);
+        newMessage = SanitizeMessagePeriod(source, newMessage);
         newMessage = FormattedMessage.EscapeText(newMessage);
 
         _sanitizer.TrySanitizeOutSmilies(newMessage, source, out newMessage, out emoteStr);
@@ -466,6 +467,16 @@ public sealed partial class ChatSystem : SharedChatSystem
             return message;
         // Capitalize first letter
         message = message[0].ToString().ToUpper() + message.Remove(0, 1);
+        return message;
+    }
+
+    private string SanitizeMessagePeriod(EntityUid source, string message)
+    {
+        if (string.IsNullOrEmpty(message))
+            return message;
+        // Add period if there isn't one
+        if (message[^1] != '.')
+            message += ".";
         return message;
     }
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -427,8 +427,8 @@ public sealed partial class ChatSystem : SharedChatSystem
     {
         var newMessage = message.Trim();
         if (capitalize)
-            newMessage = SanitizeMessageCapital(source, newMessage);
-        newMessage = SanitizeMessagePeriod(source, newMessage);
+            newMessage = SanitizeMessageCapital(newMessage);
+        newMessage = SanitizeMessagePeriod(newMessage);
         newMessage = FormattedMessage.EscapeText(newMessage);
 
         _sanitizer.TrySanitizeOutSmilies(newMessage, source, out newMessage, out emoteStr);
@@ -461,7 +461,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             .Select(p => p.ConnectedClient);
     }
 
-    private string SanitizeMessageCapital(EntityUid source, string message)
+    private string SanitizeMessageCapital(string message)
     {
         if (string.IsNullOrEmpty(message))
             return message;
@@ -470,12 +470,12 @@ public sealed partial class ChatSystem : SharedChatSystem
         return message;
     }
 
-    private string SanitizeMessagePeriod(EntityUid source, string message)
+    private string SanitizeMessagePeriod(string message)
     {
         if (string.IsNullOrEmpty(message))
             return message;
-        // Add period if there isn't one
-        if (message[^1] != '.')
+        // Add period if there isn't any pontuation at the end.
+        if (message[^1] != '.' && message[^1] != '!' && message[^1] != '?')
             message += ".";
         return message;
     }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1045,6 +1045,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> FlavorText =
             CVarDef.Create("ic.flavor_text", false, CVar.SERVER | CVar.REPLICATED);
 
+        /// <summary>
+        /// Adds a period at the end of a sentence if the sentence ends in a letter.
+        /// </summary>
+        public static readonly CVarDef<bool> ChatPunctuation =
+            CVarDef.Create("ic.punctuation", false, CVar.SERVER | CVar.REPLICATED);
+
         /*
          * Salvage
          */

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1049,7 +1049,7 @@ namespace Content.Shared.CCVar
         /// Adds a period at the end of a sentence if the sentence ends in a letter.
         /// </summary>
         public static readonly CVarDef<bool> ChatPunctuation =
-            CVarDef.Create("ic.punctuation", false, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("ic.punctuation", false, CVar.SERVER);
 
         /*
          * Salvage


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Creates method ``SanitizeMessagePeriod`` that adds a period at the end of sentences.

Closes #9261

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->