### PR TITLE
Only use Bible on Mobs

### DIFF
--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -101,7 +101,7 @@ namespace Content.Server.Bible
                 return;
             }
 
-            if (args.Target == null || args.Target == args.User || _mobStateSystem.IsDead(args.Target.Value))
+            if (args.Target == null || args.Target == args.User || !_mobStateSystem.IsAlive(args.Target.Value))
             {
                 return;
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Since ```SharedMobStateSystem.IsDead()``` returns false when mob is dead, or target isn't a mob. It was possible to use the bible on pretty much everything. Quick change to ```!SharedMobStateSystem.IsAlive()``` fixes it.

Fixes #10089