### PR TITLE
Set MoverController angular velocities to zero

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -233,6 +233,9 @@ namespace Content.Shared.Movement.Systems
                 Accelerate(ref velocity, in worldTotal, accel, frameTime);
 
             PhysicsSystem.SetLinearVelocity(physicsComponent, velocity);
+
+            // Ensures that players do not spiiiiiiin
+            PhysicsSystem.SetAngularVelocity(physicsComponent, 0);
         }
 
         private void Friction(float minimumFrictionSpeed, float frameTime, float friction, ref Vector2 velocity)


### PR DESCRIPTION
If players get some angular velocity there isn't any angular damping, so they just keep spinning. Easy way to reproduce this is by just spawning a small grid, hopping on that, using the /spin command, then moving back to the "main" grid. Because linear & angular velocity is preserved as you move across maps, you'll just be stuck spinning. I'm not sure if that's the main cause of the spinning, there are probably other ways that players can pick up angular velocity.

There are a few solutions that should work:
- Add angular damping
- Modify the physics component so that entities can have angular velocity fixed to zero (similar to no-rot for transform comp).
- Just set angular velocity to zero in the MoverController

This PR just takes the last option, but maybe the other's are preferable. This does mean player's wont spin freely in space either.

Fixes  #10177.

:cl:
- fix: Fixed players being unable to suppress their inner ballerina (fix player's getting stuck with angular velocity. no more eternal spinning).

