### PR TITLE
reduce lighter size to 1, zippos can go to hell

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -41,7 +41,7 @@
       visible: false
     - state: basic_icon_top
   - type: Item
-    size: 2
+    size: 1
     sprite: Objects/Tools/lighters.rsi
     heldPrefix: off
   - type: ItemCooldown


### PR DESCRIPTION
Make lighters size 1.
Zippos don't exist and should actually not be able to do this.
![image](https://user-images.githubusercontent.com/7510010/185736694-c4bcc768-204b-4e6b-b0af-2874dce2ccb3.png)

Fixes #10723 