### PR TITLE
Add cat ears as emagged inventory to ClothesMate

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -55,3 +55,5 @@
     ClothingHeadHatCake: 2
     ClothingOuterWinterCoat: 3
     ClothingHeadFishCap: 2
+  emaggedInventory:
+    ClothingHeadHatCatEars: 1


### PR DESCRIPTION
## About the PR

I added the cat ears as an emagged inventory item to the ClothesMate. This makes more sense to me, as the clothesmate already has bunny ears included and adding it as an emag option still makes it qualify as a syndie item. Still not sure why cat girls are considered eeeeeevil...

Another possible change is removing it from uplink for being redundant, but I think it was put in there as a waste of TC when you order a surplus package. I would be willing to add that change to this PR if necessary.

**Changelog**

:cl: Pixel
- add: Added another inventory item to ClothesMate when emagged

