### PR TITLE
Fix PA error

### DIFF
--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -191,8 +191,10 @@ namespace Content.Server.ParticleAccelerator.Components
 
         protected override void OnRemove()
         {
-            UserInterface?.CloseAll();
-            base.OnRemove();
+            foreach (var part in AllParts())
+            {
+                part.Master = null;
+            }
         }
 
         /*
@@ -331,12 +333,12 @@ namespace Content.Server.ParticleAccelerator.Components
             _partEmitterCenter = null;
             _partEmitterRight = null;
 
+            var xform = _entMan.GetComponent<TransformComponent>(Owner);
+
             // Find fuel chamber first by scanning cardinals.
-            if (_entMan.GetComponent<TransformComponent>(Owner).Anchored)
+            if (xform.Anchored && _entMan.TryGetComponent(xform.GridUid, out IMapGridComponent? grid))
             {
-                var grid = _mapManager.GetGrid(_entMan.GetComponent<TransformComponent>(Owner).GridUid!.Value);
-                var coords = _entMan.GetComponent<TransformComponent>(Owner).Coordinates;
-                foreach (var maybeFuel in grid.GetCardinalNeighborCells(coords))
+                foreach (var maybeFuel in grid.Grid.GetCardinalNeighborCells(xform.Coordinates))
                 {
                     if (_entMan.TryGetComponent(maybeFuel, out _partFuelChamber))
                     {
@@ -354,7 +356,7 @@ namespace Content.Server.ParticleAccelerator.Components
             // Align ourselves to match fuel chamber orientation.
             // This means that if you mess up the orientation of the control box it's not a big deal,
             // because the sprite is far from obvious about the orientation.
-            _entMan.GetComponent<TransformComponent>(Owner).LocalRotation = _entMan.GetComponent<TransformComponent>(_partFuelChamber.Owner).LocalRotation;
+            xform.LocalRotation = _entMan.GetComponent<TransformComponent>(_partFuelChamber.Owner).LocalRotation;
 
             var offsetEndCap = RotateOffset((1, 1));
             var offsetPowerBox = RotateOffset((1, -1));

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -191,10 +191,13 @@ namespace Content.Server.ParticleAccelerator.Components
 
         protected override void OnRemove()
         {
+            Master = null;
             foreach (var part in AllParts())
             {
                 part.Master = null;
             }
+
+            base.OnRemove();
         }
 
         /*


### PR DESCRIPTION
Fixes a grafana error:
```
Caught exception in RemoveComponentImmediate, owner=68197, type=Content.Server.ParticleAccelerator.Components.ParticleAcceleratorFuelChamberComponent
System.InvalidOperationException: Nullable object must have a value.
   at Content.Server.ParticleAccelerator.Components.ParticleAcceleratorControlBoxComponent.RescanParts() in /home/runner/work/space-station-14/space-station-14/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs:line 320
   at Robust.Shared.GameObjects.EntityManager.RemoveComponentImmediate(Component component, EntityUid uid, Boolean removeProtected) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 525
 Catcher="RemoveComponentImmediate, owner=68197, type=Content.Server.ParticleAccelerator.Components.ParticleAcceleratorFuelChamberComponent" Sawmill=runtime

```