### PR TITLE
Give Barozine in OD emetogenic effect, halved chance compared to Ipecac

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -407,6 +407,11 @@
         damage:
           types:
             Poison: 3
+      - !type:ChemVomit
+        probability: 0.15
+        conditions:
+          - !type:ReagentThreshold
+            min: 30
       - !type:GenericStatusEffect
         key: PressureImmunity
         component: PressureImmunity


### PR DESCRIPTION
## Give Barozine in OD emetogenic effect, halved chance compared to Ipecac
This might fix issue #10752. OD effect would remain highly unpleasant, yet induced vomiting is likely to save victim from death.

**Changelog**
:cl:
- add: Barozine in overdose will cause you to vomit, potentially saving you from fatal poisoning!
