### PR TITLE
Fixed playtime requirement tooltip

### DIFF
--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -247,19 +247,21 @@ namespace Content.Client.LateJoin
 
                         string? reason = null;
 
-                        if (tracker.IsAllowed(prototype, out reason) == false)
+                        if (!tracker.IsAllowed(prototype, out reason))
                         {
+
+                            jobButton.Disabled = true;
+
                             if (!string.IsNullOrEmpty(reason))
                             {
                                 jobButton.ToolTip = reason;
-                                jobButton.Disabled = true;
                             }
-                        }
-
-                        if (value == 0)
+                        } else if (value == 0)
                         {
                             jobButton.Disabled = true;
                         }
+
+
 
                         _jobButtons[id][prototype.ID] = jobButton;
                     }

--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -256,11 +256,11 @@ namespace Content.Client.LateJoin
                                 jobButton.ToolTip = reason;
                             }
                         }
-
-                        else if (value == 0);
+                        else if (value == 0)
                         {
                             jobButton.Disabled = true;
                         }
+
                         _jobButtons[id][prototype.ID] = jobButton;
                     }
                 }

--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -247,14 +247,18 @@ namespace Content.Client.LateJoin
 
                         string? reason = null;
 
-                        if (value == 0 || !tracker.IsAllowed(prototype, out reason))
+                        if (tracker.IsAllowed(prototype, out reason) == false)
                         {
-                            jobButton.Disabled = true;
-
                             if (!string.IsNullOrEmpty(reason))
                             {
                                 jobButton.ToolTip = reason;
+                                jobButton.Disabled = true;
                             }
+                        }
+
+                        if (value == 0)
+                        {
+                            jobButton.Disabled = true;
                         }
 
                         _jobButtons[id][prototype.ID] = jobButton;

--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -249,20 +249,18 @@ namespace Content.Client.LateJoin
 
                         if (!tracker.IsAllowed(prototype, out reason))
                         {
-
                             jobButton.Disabled = true;
 
                             if (!string.IsNullOrEmpty(reason))
                             {
                                 jobButton.ToolTip = reason;
                             }
-                        } else if (value == 0)
+                        }
+
+                        else if (value == 0);
                         {
                             jobButton.Disabled = true;
                         }
-
-
-
                         _jobButtons[id][prototype.ID] = jobButton;
                     }
                 }

--- a/Resources/Locale/en-US/job/role-timers.ftl
+++ b/Resources/Locale/en-US/job/role-timers.ftl
@@ -1,8 +1,8 @@
-﻿role-timer-department-insufficient = Requires {TOSTRING($time, "0")} more minutes in {$department} department for this role.
-role-timer-department-too-high = Requires {TOSTRING($time, "0")} fewer minutes in {$department} department for this role. (Are you trying to play a trainee role?)
-role-timer-overall-insufficient = Requires {TOSTRING($time, "0")} more minutes of playtime for this role.
-role-timer-overall-too-high = Requires {TOSTRING($time, "0")} fewer minutes of playtime. (Are you trying to play a trainee role?)
-role-timer-role-insufficient = Requires {TOSTRING($time, "0")} more minutes with {$job} for this role.
-role-timer-role-too-high = Requires {TOSTRING($time, "0")} fewer minutes with {$job} for this role. (Are you trying to play a trainee role?)
+﻿role-timer-department-insufficient = You require {TOSTRING($time, "0")} more minutes in {$department} department to play this role.
+role-timer-department-too-high = You require {TOSTRING($time, "0")} fewer minutes in {$department} department to play this role. (Are you trying to play a trainee role?)
+role-timer-overall-insufficient = You require {TOSTRING($time, "0")} more minutes of playtime to play this role.
+role-timer-overall-too-high = You require {TOSTRING($time, "0")} fewer minutes of playtime to play this role. (Are you trying to play a trainee role?)
+role-timer-role-insufficient = You require {TOSTRING($time, "0")} more minutes with {$job} to play this role.
+role-timer-role-too-high = You require {TOSTRING($time, "0")} fewer minutes with {$job} to play this role. (Are you trying to play a trainee role?)
 
 role-timer-locked = Locked (hover for details)

--- a/Resources/Locale/en-US/job/role-timers.ftl
+++ b/Resources/Locale/en-US/job/role-timers.ftl
@@ -1,8 +1,8 @@
-﻿role-timer-department-insufficient = Require {TOSTRING($time, "0")} more minutes in {$department} department.
-role-timer-department-too-high = Requires {TOSTRING($time, "0")} fewer minutes in {$department} department. (Are you trying to play a trainee role?)
-role-timer-overall-insufficient = Require {TOSTRING($time, "0")} more minutes of playtime.
-role-timer-overall-too-high = Require {TOSTRING($time, "0")} fewer minutes of playtime. (Are you trying to play a trainee role?)
-role-timer-role-insufficient = Require {TOSTRING($time, "0")} more minutes with {$job} for this role.
-role-timer-role-too-high = Require {TOSTRING($time, "0")} fewer minutes with {$job} for this role. (Are you trying to play a trainee role?)
+﻿role-timer-department-insufficient = Requires {TOSTRING($time, "0")} more minutes in {$department} department for this role.
+role-timer-department-too-high = Requires {TOSTRING($time, "0")} fewer minutes in {$department} department for this role. (Are you trying to play a trainee role?)
+role-timer-overall-insufficient = Requires {TOSTRING($time, "0")} more minutes of playtime for this role.
+role-timer-overall-too-high = Requires {TOSTRING($time, "0")} fewer minutes of playtime. (Are you trying to play a trainee role?)
+role-timer-role-insufficient = Requires {TOSTRING($time, "0")} more minutes with {$job} for this role.
+role-timer-role-too-high = Requires {TOSTRING($time, "0")} fewer minutes with {$job} for this role. (Are you trying to play a trainee role?)
 
 role-timer-locked = Locked (hover for details)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the playtime requirement tooltip not showing up on roles which have no open slots, also changed text slightly

**Screenshots**
![tooltip2](https://user-images.githubusercontent.com/63034378/185795008-940d98e8-397d-4fdf-ae8e-436fccb722b4.PNG)


**Changelog**

:cl:
- fix: Fixed playtime requirement tooltips not showing on roles with no open slots
- tweak: Tweaked playtime requirement tooltip text slightly
