### PR TITLE
Fix xenos prying doors from afar

### DIFF
--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -27,9 +27,9 @@ public sealed class DoorSystem : SharedDoorSystem
     }
 
     // TODO AUDIO PREDICT see comments in server-side PlaySound()
-    protected override void PlaySound(EntityUid uid, string sound, AudioParams audioParams, EntityUid? predictingPlayer, bool predicted)
+    protected override void PlaySound(EntityUid uid, SoundSpecifier soundSpecifier, AudioParams audioParams, EntityUid? predictingPlayer, bool predicted)
     {
         if (GameTiming.InPrediction && GameTiming.IsFirstTimePredicted)
-            SoundSystem.Play(sound, Filter.Local(), uid, audioParams);
+            Audio.Play(soundSpecifier, Filter.Local(), uid, audioParams);
     }
 }

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -317,7 +317,7 @@ public sealed class DoorSystem : SharedDoorSystem
         if (!Resolve(uid, ref door))
             return;
 
-        DoorState lastState = door.State;
+        var lastState = door.State;
 
         SetState(uid, DoorState.Opening, door);
 

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -95,11 +95,12 @@ public sealed class DoorSystem : SharedDoorSystem
     /// Selectively send sound to clients, taking care to not send the double-audio.
     /// </summary>
     /// <param name="uid">The audio source</param>
-    /// <param name="sound">The sound</param>
+    /// <param name="soundSpecifier">The sound</param>
+    /// <param name="audioParams">The audio parameters.</param>
     /// <param name="predictingPlayer">The user (if any) that instigated an interaction</param>
     /// <param name="predicted">Whether this interaction would have been predicted. If the predicting player is null,
     /// this assumes it would have been predicted by all players in PVS range.</param>
-    protected override void PlaySound(EntityUid uid, string sound, AudioParams audioParams, EntityUid? predictingPlayer, bool predicted)
+    protected override void PlaySound(EntityUid uid, SoundSpecifier soundSpecifier, AudioParams audioParams, EntityUid? predictingPlayer, bool predicted)
     {
         // If this sound would have been predicted by all clients, do not play any audio.
         if (predicted && predictingPlayer == null)
@@ -114,7 +115,7 @@ public sealed class DoorSystem : SharedDoorSystem
         }
 
         // send the sound to players.
-        SoundSystem.Play(sound, filter, uid, audioParams);
+        Audio.Play(soundSpecifier, filter, uid, audioParams);
     }
 
 #region DoAfters
@@ -304,7 +305,7 @@ public sealed class DoorSystem : SharedDoorSystem
             if (door.State == DoorState.Closed)
             {
                 SetState(uid, DoorState.Emagging, door);
-                PlaySound(uid, door.SparkSound.GetSound(), AudioParams.Default.WithVolume(8), args.UserUid, false);
+                PlaySound(uid, door.SparkSound, AudioParams.Default.WithVolume(8), args.UserUid, false);
                 args.Handled = true;
             }
         }
@@ -320,7 +321,7 @@ public sealed class DoorSystem : SharedDoorSystem
         SetState(uid, DoorState.Opening, door);
 
         if (door.OpenSound != null)
-            PlaySound(uid, door.OpenSound.GetSound(), AudioParams.Default.WithVolume(-5), user, predicted);
+            PlaySound(uid, door.OpenSound, AudioParams.Default.WithVolume(-5), user, predicted);
 
         if(lastState == DoorState.Emagging && TryComp<AirlockComponent>(door.Owner, out var airlockComponent))
             airlockComponent?.SetBoltsWithAudio(!airlockComponent.IsBolted());

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -30,7 +30,6 @@ public sealed class DoorSystem : SharedDoorSystem
     [Dependency] private readonly AirtightSystem _airtightSystem = default!;
     [Dependency] private readonly ConstructionSystem _constructionSystem = default!;
     [Dependency] private readonly ToolSystem _toolSystem = default!;
-    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
 
     public override void Initialize()

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -161,10 +161,10 @@ public sealed class DoorSystem : SharedDoorSystem
 
     private void OnDoorAltVerb(EntityUid uid, DoorComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanInteract || !TryComp<ToolComponent>(args.User, out var tool) || !tool.Qualities.Contains(component.PryingQuality))
+        if (!args.CanInteract || !args.CanAccess)
             return;
 
-        if (!_interactionSystem.InRangeUnobstructed(args.User, uid))
+        if (!TryComp<ToolComponent>(args.User, out var tool) || !tool.Qualities.Contains(component.PryingQuality))
             return;
 
         args.Verbs.Add(new AlternativeVerb()

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -30,6 +30,7 @@ public sealed class DoorSystem : SharedDoorSystem
     [Dependency] private readonly AirtightSystem _airtightSystem = default!;
     [Dependency] private readonly ConstructionSystem _constructionSystem = default!;
     [Dependency] private readonly ToolSystem _toolSystem = default!;
+    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
 
     public override void Initialize()
     {
@@ -158,7 +159,11 @@ public sealed class DoorSystem : SharedDoorSystem
 
     private void OnDoorAltVerb(EntityUid uid, DoorComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanInteract || !TryComp<ToolComponent>(args.User, out var tool) || !tool.Qualities.Contains(component.PryingQuality)) return;
+        if (!args.CanInteract || !TryComp<ToolComponent>(args.User, out var tool) || !tool.Qualities.Contains(component.PryingQuality))
+            return;
+
+        if (!_interactionSystem.InRangeUnobstructed(args.User, uid))
+            return;
 
         args.Verbs.Add(new AlternativeVerb()
         {
@@ -173,7 +178,8 @@ public sealed class DoorSystem : SharedDoorSystem
     /// </summary>
     private bool TryPryDoor(EntityUid target, EntityUid tool, EntityUid user, DoorComponent door, bool force = false)
     {
-        if (door.BeingPried) return false;
+        if (door.BeingPried)
+            return false;
 
         if (door.State == DoorState.Welded)
             return false;

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -31,6 +31,7 @@ public sealed class DoorSystem : SharedDoorSystem
     [Dependency] private readonly ConstructionSystem _constructionSystem = default!;
     [Dependency] private readonly ToolSystem _toolSystem = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
 
     public override void Initialize()
     {
@@ -281,9 +282,9 @@ public sealed class DoorSystem : SharedDoorSystem
         if (string.IsNullOrEmpty(door.BoardPrototype))
             return;
 
-        var container = uid.EnsureContainer<Container>("board", out var existed);
+        var container = _containerSystem.EnsureContainer<Container>(uid, "board", out var existed);
 
-        if (existed & container.ContainedEntities.Count != 0)
+        if (existed && container.ContainedEntities.Count != 0)
         {
             // We already contain a board. Note: We don't check if it's the right one!
             return;

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -25,6 +25,7 @@ public abstract class SharedDoorSystem : EntitySystem
     [Dependency] protected readonly IGameTiming GameTiming = default!;
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
     /// <summary>
     ///     A body must have an intersection percentage larger than this in order to be considered as colliding with a
@@ -169,7 +170,7 @@ public abstract class SharedDoorSystem : EntitySystem
         if (!TryComp(uid, out AppearanceComponent? appearance))
             return;
 
-        appearance.SetData(DoorVisuals.State, door.State);
+        _appearance.SetData(uid, DoorVisuals.State, door.State);
     }
     #endregion
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -23,6 +23,7 @@ public abstract class SharedDoorSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stunSystem = default!;
     [Dependency] protected readonly TagSystem Tags = default!;
     [Dependency] protected readonly IGameTiming GameTiming = default!;
+    [Dependency] protected readonly SharedAudioSystem Audio = default!;
 
     /// <summary>
     ///     A body must have an intersection percentage larger than this in order to be considered as colliding with a
@@ -199,7 +200,7 @@ public abstract class SharedDoorSystem : EntitySystem
         SetState(uid, DoorState.Denying, door);
 
         if (door.DenySound != null)
-            PlaySound(uid, door.DenySound.GetSound(), AudioParams.Default.WithVolume(-3), user, predicted);
+            PlaySound(uid, door.DenySound, AudioParams.Default.WithVolume(-3), user, predicted);
     }
 
     public bool TryToggleDoor(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
@@ -265,14 +266,14 @@ public abstract class SharedDoorSystem : EntitySystem
         SetState(uid, DoorState.Opening, door);
 
         if (door.OpenSound != null)
-            PlaySound(uid, door.OpenSound.GetSound(), AudioParams.Default.WithVolume(-5), user, predicted);
+            PlaySound(uid, door.OpenSound, AudioParams.Default.WithVolume(-5), user, predicted);
 
         // I'm not sure what the intent here is/was? It plays a sound if the user is opening a door with a hands
         // component, but no actual hands!? What!? Is this the sound of them head-butting the door to get it to open??
         // I'm 99% sure something is wrong here, but I kind of want to keep it this way.
 
         if (user != null && TryComp(user.Value, out SharedHandsComponent? hands) && hands.Hands.Count == 0)
-            PlaySound(uid, door.TryOpenDoorSound.GetSound(), AudioParams.Default.WithVolume(-2), user, predicted);
+            PlaySound(uid, door.TryOpenDoorSound, AudioParams.Default.WithVolume(-2), user, predicted);
     }
 
     /// <summary>
@@ -329,7 +330,7 @@ public abstract class SharedDoorSystem : EntitySystem
         SetState(uid, DoorState.Closing, door);
 
         if (door.CloseSound != null)
-            PlaySound(uid, door.CloseSound.GetSound(), AudioParams.Default.WithVolume(-5), user, predicted);
+            PlaySound(uid, door.CloseSound, AudioParams.Default.WithVolume(-5), user, predicted);
     }
 
     /// <summary>
@@ -614,5 +615,5 @@ public abstract class SharedDoorSystem : EntitySystem
     }
     #endregion
 
-    protected abstract void PlaySound(EntityUid uid, string sound, AudioParams audioParams, EntityUid? predictingPlayer, bool predicted);
+    protected abstract void PlaySound(EntityUid uid, SoundSpecifier soundSpecifier, AudioParams audioParams, EntityUid? predictingPlayer, bool predicted);
 }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -24,6 +24,7 @@ public abstract class SharedDoorSystem : EntitySystem
     [Dependency] protected readonly TagSystem Tags = default!;
     [Dependency] protected readonly IGameTiming GameTiming = default!;
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
 
     /// <summary>
     ///     A body must have an intersection percentage larger than this in order to be considered as colliding with a
@@ -423,7 +424,8 @@ public abstract class SharedDoorSystem : EntitySystem
             yield break;
 
         // TODO SLOTH fix electro's code.
-        var doorAABB = physics.GetWorldAABB();
+        // ReSharper disable once InconsistentNaming
+        var doorAABB = _entityLookup.GetWorldAABB(uid);
 
         foreach (var otherPhysics in PhysicsSystem.GetCollidingEntities(Transform(uid).MapID, doorAABB))
         {
@@ -437,7 +439,7 @@ public abstract class SharedDoorSystem : EntitySystem
                 && (otherPhysics.CollisionMask & physics.CollisionLayer) == 0)
                 continue;
 
-            if (otherPhysics.GetWorldAABB().IntersectPercentage(doorAABB) < IntersectPercentage)
+            if (_entityLookup.GetWorldAABB(otherPhysics.Owner).IntersectPercentage(doorAABB) < IntersectPercentage)
                 continue;
 
             yield return otherPhysics.Owner;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes mobs with a ToolComponent containing the prying quality being capable of opening doors whilst being outside of interact range. There are also some changes to resolve warnings about obsolete functions.

Fixes #10769 

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Xenos can no longer pry doors open from afar.
