### PR TITLE
Add Health Analyzer to Medical Intern PDA

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -106,7 +106,7 @@
   parent: BasePDA
   id: MedicalInternPDA
   name: medical intern PDA
-  description: Why isn't it white?
+  description: Why isn't it white? Has a built-in health analyzer.
   components:
   - type: PDA
     id: MedicalInternIDCard
@@ -116,6 +116,8 @@
       state: pda-internmed
   - type: Icon
     state: pda-internmed
+    - type: HealthAnalyzer
+    scanDelay: 1.4
 
 - type: entity
   parent: BasePDA

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -116,7 +116,7 @@
       state: pda-internmed
   - type: Icon
     state: pda-internmed
-    - type: HealthAnalyzer
+  - type: HealthAnalyzer
     scanDelay: 1.4
 
 - type: entity


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When I played Medical Intern for those sweet role timer points, I noticed that their PDA doesn't have a health analyzer, and it felt a little weird, so I changed it.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Medical Intern PDA's now have Health Analyzers built into them.

