### PR TITLE
Remove problematic body code

### DIFF
--- a/Content.Shared/Body/Components/SharedBodyPartComponent.cs
+++ b/Content.Shared/Body/Components/SharedBodyPartComponent.cs
@@ -257,9 +257,6 @@ namespace Content.Shared.Body.Components
 
         private void AddedToBody(SharedBodyComponent body)
         {
-            var transformComponent = _entMan.GetComponent<TransformComponent>(Owner);
-            transformComponent.LocalRotation = 0;
-            transformComponent.AttachParent(body.Owner);
             OnAddedToBody(body);
 
             foreach (var mechanism in _mechanisms)


### PR DESCRIPTION
The transform changes are already applied by the container insertion, and the way that this gets called can mess up entity state application. This will probably cause conflicts for #10278, but its required for the engine PR that fixes container bugs.

