### PR TITLE
Salvage spawning adjustments and AABBs in prototypes

### DIFF
--- a/Content.Server/Salvage/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/SalvageMagnetComponent.cs
@@ -11,13 +11,25 @@ namespace Content.Server.Salvage
     public sealed class SalvageMagnetComponent : Component
     {
         /// <summary>
-        ///     Offset relative to magnet that salvage should spawn.
-        ///     Keep in sync with marker sprite (if any???)
+        ///     Offset relative to magnet used as centre of the placement circle.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("offset")]
         public Vector2 Offset = Vector2.Zero; // TODO: Maybe specify a direction, and find the nearest edge of the magnets grid the salvage can fit at
 
+        /// <summary>
+        ///     Minimum distance from the offset position that will be used as a salvage's spawnpoint.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("offsetRadiusMin")]
+        public float OffsetRadiusMin = 0f;
+
+        /// <summary>
+        ///     Maximum distance from the offset position that will be used as a salvage's spawnpoint.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("offsetRadiusMax")]
+        public float OffsetRadiusMax = 0f;
 
         /// <summary>
         ///     The entity attached to the magnet

--- a/Content.Server/Salvage/SalvageMapPrototype.cs
+++ b/Content.Server/Salvage/SalvageMapPrototype.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Robust.Shared.Maths;
 
 namespace Content.Server.Salvage
 {
@@ -18,11 +19,11 @@ namespace Content.Server.Salvage
         public ResourcePath MapPath { get; } = default!;
 
         /// <summary>
-        /// Size *from 0,0* in units of the map (used to determine if it fits)
+        /// Map rectangle in world coordinates (to check if it fits)
         /// </summary>
         [ViewVariables]
-        [DataField("size", required: true)]
-        public float Size { get; } = 1.0f; // TODO: Find a way to figure out the size automatically
+        [DataField("bounds", required: true)]
+        public Box2 Bounds { get; } = Box2.UnitCentered;
 
         /// <summary>
         /// Name for admin use

--- a/Content.Server/Salvage/SalvageRulerCommand.cs
+++ b/Content.Server/Salvage/SalvageRulerCommand.cs
@@ -1,0 +1,70 @@
+using Content.Server.Preferences.Managers;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using Robust.Server.GameObjects;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Map;
+using Robust.Shared.IoC;
+
+namespace Content.Server.Salvage;
+
+[AdminCommand(AdminFlags.Admin)]
+sealed class SalvageRulerCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entities = default!;
+    [Dependency] private readonly IMapManager _maps = default!;
+
+    public string Command => "salvageruler";
+
+    public string Description => Loc.GetString("salvage-ruler-command-description");
+
+    public string Help => Loc.GetString("salvage-ruler-command-help-text", ("command",Command));
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 0)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        if (shell.Player is not IPlayerSession player)
+        {
+            shell.WriteError(Loc.GetString("shell-only-players-can-run-this-command"));
+            return;
+        }
+
+        var entity = player.AttachedEntity;
+
+        if (entity == null)
+        {
+            shell.WriteError(Loc.GetString("shell-must-be-attached-to-entity"));
+            return;
+        }
+
+        var entityTransform = _entities.GetComponent<TransformComponent>(entity.Value);
+        var total = Box2.UnitCentered;
+        var first = true;
+        foreach (var mapGrid in _maps.GetAllMapGrids(entityTransform.MapID))
+        {
+            var aabb = mapGrid.WorldAABB;
+            if (first)
+            {
+                total = aabb;
+            }
+            else
+            {
+                total = total.ExtendToContain(aabb.TopLeft);
+                total = total.ExtendToContain(aabb.TopRight);
+                total = total.ExtendToContain(aabb.BottomLeft);
+                total = total.ExtendToContain(aabb.BottomRight);
+            }
+            first = false;
+        }
+        shell.WriteLine(total.ToString());
+    }
+}
+

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -272,7 +272,7 @@ namespace Content.Server.Salvage
                     var randomOffset = _random.NextAngle().ToWorldVec() * randomRadius;
                     spawnLocation = spl.Position + randomOffset;
 
-                    var box2 = Box2.CenteredAround(spawnLocation, new Vector2(attemptedMap.Size * 2.0f, attemptedMap.Size * 2.0f));
+                    var box2 = Box2.CenteredAround(spawnLocation + attemptedMap.Bounds.Center, attemptedMap.Bounds.Size);
                     var box2rot = new Box2Rotated(box2, spAngle, spawnLocation);
 
                     // This doesn't stop it from spawning on top of random things in space

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -37,6 +37,7 @@ namespace Content.Server.Salvage
         private static readonly TimeSpan HoldTime = TimeSpan.FromMinutes(4);
         private static readonly TimeSpan DetachingTime = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan CooldownTime = TimeSpan.FromMinutes(1);
+        private static readonly int SalvageLocationPlaceAttempts = 16;
 
         // TODO: This is probably not compatible with multi-station
         private readonly Dictionary<GridId, SalvageGridState> _salvageGridStates = new();
@@ -239,7 +240,6 @@ namespace Content.Server.Salvage
         private bool SpawnSalvage(SalvageMagnetComponent component)
         {
             TryGetSalvagePlacementLocation(component, out var spl, out var spAngle);
-            SalvageMapPrototype? map = null;
 
             var forcedSalvage = _configurationManager.GetCVar<string>(CCVars.SalvageForced);
             List<SalvageMapPrototype> allSalvageMaps;
@@ -250,28 +250,40 @@ namespace Content.Server.Salvage
             else
             {
                 allSalvageMaps = new();
-                if (_prototypeManager.TryIndex<SalvageMapPrototype>(forcedSalvage, out map))
+                if (_prototypeManager.TryIndex<SalvageMapPrototype>(forcedSalvage, out var forcedMap))
                 {
-                    allSalvageMaps.Add(map);
+                    allSalvageMaps.Add(forcedMap);
                 }
                 else
                 {
                     Logger.ErrorS("c.s.salvage", $"Unable to get forced salvage map prototype {forcedSalvage}");
                 }
             }
+
+            SalvageMapPrototype? map = null;
+            Vector2 spawnLocation = Vector2.Zero;
+
             for (var i = 0; i < allSalvageMaps.Count; i++)
             {
-                map = _random.PickAndTake(allSalvageMaps);
-                var box2 = Box2.CenteredAround(spl.Position, new Vector2(map.Size * 2.0f, map.Size * 2.0f));
-                var box2rot = new Box2Rotated(box2, spAngle, spl.Position);
-
-                // This doesn't stop it from spawning on top of random things in space
-                // Might be better like this, ghosts could stop it before
-                if (_mapManager.FindGridsIntersecting(spl.MapId, box2rot).Any())
+                SalvageMapPrototype attemptedMap = _random.PickAndTake(allSalvageMaps);
+                for (var attempt = 0; attempt < SalvageLocationPlaceAttempts; attempt++)
                 {
-                    map = null;
+                    var randomRadius = _random.NextFloat(component.OffsetRadiusMin, component.OffsetRadiusMax);
+                    var randomOffset = _random.NextAngle().ToWorldVec() * randomRadius;
+                    spawnLocation = spl.Position + randomOffset;
+
+                    var box2 = Box2.CenteredAround(spawnLocation, new Vector2(attemptedMap.Size * 2.0f, attemptedMap.Size * 2.0f));
+                    var box2rot = new Box2Rotated(box2, spAngle, spawnLocation);
+
+                    // This doesn't stop it from spawning on top of random things in space
+                    // Might be better like this, ghosts could stop it before
+                    if (!_mapManager.FindGridsIntersecting(spl.MapId, box2rot).Any())
+                    {
+                        map = attemptedMap;
+                        break;
+                    }
                 }
-                else
+                if (map != null)
                 {
                     break;
                 }
@@ -285,7 +297,7 @@ namespace Content.Server.Salvage
 
             var opts = new MapLoadOptions
             {
-                Offset = spl.Position
+                Offset = spawnLocation
             };
 
             var (_, salvageEntityId) = _mapLoader.LoadBlueprint(spl.MapId, map.MapPath.ToString(), opts);

--- a/Resources/Locale/en-US/salvage/salvage-ruler-command.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-ruler-command.ftl
@@ -1,0 +1,2 @@
+salvage-ruler-command-description = Measures grids on this map to get a total world AABB. Use for salvage bounds specifications.
+salvage-ruler-command-help-text = Usage: {$command}

--- a/Resources/Locale/en-US/shell.ftl
+++ b/Resources/Locale/en-US/shell.ftl
@@ -8,6 +8,7 @@ shell-invalid-command = Invalid command.
 shell-invalid-command-specific = Invalid {$commandName} command.
 shell-cannot-run-command-from-server = You cannot run this command from the server.
 shell-only-players-can-run-this-command = Only players can run this command.
+shell-must-be-attached-to-entity = You must be attached to an entity to run this command.
 
 ## Arguments
 

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -16,7 +16,9 @@
     channels:
     - Supply
   - type: SalvageMagnet
-    offset: 0, -32
+    offset: 0, 0
+    offsetRadiusMin: 24
+    offsetRadiusMax: 48
   - type: ApcPowerReceiver
     powerLoad: 2500 # TODO change this to a HV power draw that really hits the grid hard WHEN active
 
@@ -28,7 +30,9 @@
   description: "Locates salvage."
   components:
   - type: SalvageMagnet
-    offset: 0, -12
+    offset: 0, 0
+    offsetRadiusMin: 12
+    offsetRadiusMax: 48
   - type: ApcPowerReceiver
     powerLoad: 1000
 

--- a/Resources/Prototypes/Maps/salvage.yml
+++ b/Resources/Prototypes/Maps/salvage.yml
@@ -1,5 +1,5 @@
-# ALL SALVAGE MAPS SHOULD BE SETUP SUCH THAT TILE REF -1,-1 IS THEIR OFFICIAL CENTRE,
-# AND FOR EASE OF UNDERSTANDING, USE - pos: 0.5, 0.5 FOR SAVED POSITION.
+# So the way things are done as of now is that Salvages are measured by world AABBs in their maps.
+# Remember, first two coordinates should be the minimum X/Y, second two should be maximum.
 
 # "Small"-class maps - Max size square: 7x7, indicated size: 3.5
 
@@ -7,37 +7,37 @@
   id: small1
   name: "Small / Engineering Storage 1"
   mapPath: /Maps/Salvage/small-1.yml
-  size: 3.5
+  bounds: "-3.5,-3.5,3.5,3.5"
 
 - type: salvageMap
   id: small2
   name: "Small / Gaming Nook 1"
   mapPath: /Maps/Salvage/small-2.yml
-  size: 3.5
+  bounds: "-3.5,-3.5,3.5,3.5"
 
 - type: salvageMap
   id: small-ship-1
   name: "Small / Ship 1 (Pill)"
   mapPath: /Maps/Salvage/small-ship-1.yml
-  size: 3.5
+  bounds: "-3.5,-3.5,3.5,3.5"
 
 - type: salvageMap
   id: small3
   name: "Small / Laundromat 1"
   mapPath: /Maps/Salvage/small-3.yml
-  size: 3.5
+  bounds: "-3.5,-3.5,3.5,3.5"
 
 - type: salvageMap
   id: smallAISurveyDrone
   name: "Small / AI Survey Drone"
   mapPath: /Maps/Salvage/small-ai-survey-drone.yml
-  size: 3.5
+  bounds: "-3.5,-3.5,3.5,3.5"
 
 - type: salvageMap
   id: small4
   name: "Small / Bar Salvage"
   mapPath: /Maps/Salvage/small-4.yml
-  size: 3.5
+  bounds: "-3.5,-3.5,3.5,3.5"
 
 # Small - Asteroids
 
@@ -45,7 +45,7 @@
   id: smallA1
   name: "Small / Asteroid 1 Plasmafire"
   mapPath: /Maps/Salvage/small-a-1.yml
-  size: 3.5
+  bounds: "-3.5,-3.5,3.5,3.5"
 
 # "Medium"-class maps - Max size square: 15x15, indicated size: 7.5
 
@@ -53,73 +53,73 @@
   id: medium1
   name: "Medium / Plasma-Trapped Cache 1"
   mapPath: /Maps/Salvage/medium-1.yml
-  size: 7.5
+  bounds: "-7.5,-7.5,7.5,7.5"
 
 - type: salvageMap
   id: mediumvault1
   name: "Medium / Vault 1"
   mapPath: /Maps/Salvage/medium-vault-1.yml
-  size: 7.5
+  bounds: "-7.5,-7.5,7.5,7.5"
 
 - type: salvageMap
   id: mediumOrchestra
   name: "Medium / Silent Orchestra"
   mapPath: /Maps/Salvage/medium-silent-orchestra.yml
-  size: 7.5
+  bounds: "-7.5,-7.5,7.5,7.5"
 
 - type: salvageMap
   id: mediumLibraryWreck
   name: "Medium / Abandoned Library"
   mapPath: /Maps/Salvage/medium-library.yml
-  size: 7.5
+  bounds: "-7.5,-7.5,7.5,7.5"
 
 - type: salvageMap
   id: mediumCargoWreck
   name: "Medium / Cargo Department Wreck"
   mapPath: /Maps/Salvage/cargo-1.yml
-  size: 7.5
+  bounds: "-7.5,-7.5,7.5,7.5"
 
 - type: salvageMap
   id: mediumPirateWreck
   name: "Medium / Pirate Barge Fragment"
   mapPath: /Maps/Salvage/medium-pirate.yml
-  size: 7.5
+  bounds: "-7.5,-7.5,7.5,7.5"
 
 - type: salvageMap
   id: tickColony
   name: "Space Tick colony"
   mapPath: /Maps/Salvage/tick-colony.yml
-  size: 8.5
+  bounds: "-8.5,-8.5,8.5,8.5"
 
 - type: salvageMap
   id: cargoDock
   name: "Asteroid Cargo Dock"
   mapPath: /Maps/Salvage/medium-dock.yml
-  size: 8.5
+  bounds: "-8.5,-8.5,8.5,8.5"
 
 - type: salvageMap
   id: spaceWaffleHome
   name: "Waffle Home"
   mapPath: /Maps/Salvage/wh-salvage.yml
-  size: 12
+  bounds: "-12,-12,12,12"
 
 - type: salvageMap
   id: mediumShuttleWreck
   name: "Medium / Ruined Emergency Shuttle"
   mapPath: /Maps/Salvage/medium-ruined-emergency-shuttle.yml
-  size: 8.5 # Over standard medium wreck size, may need future adjustment.
+  bounds: "-8.5,-8.5,8.5,8.5"
   
 - type: salvageMap
   id: mediumPetHospital
   name: "Medium / Pet and Bear Hospital"
   mapPath: /Maps/Salvage/medium-pet-hospital.yml
-  size: 8.5
+  bounds: "-8.5,-8.5,8.5,8.5"
 
 - type: salvageMap
   id: mediumCrashedShuttle
   name: "Crashed Shuttle"
   mapPath: /Maps/Salvage/medium-crashed-shuttle.yml
-  size: 9.5
+  bounds: "-9.5,-9.5,9.5,9.5"
 
 # """Large""" maps
 
@@ -127,16 +127,17 @@
   id: stationstation
   name: "StationStation"
   mapPath: /Maps/Salvage/stationstation.yml
-  size: 24
+  bounds: "-24,-24,24,24"
 
 - type: salvageMap
   id: asteroidBase
   name: "Asteroid Base"
   mapPath: /Maps/Salvage/asteroid-base.yml
-  size: 16
+  bounds: "-16,-16,16,16"
 
 - type: salvageMap
   id: ruinCargoBase
   name: "Ruined Cargo Storage"
   mapPath: /Maps/Salvage/ruin-cargo-salvage.yml
-  size: 22.5
+  bounds: "-22.5,-22.5,22.5,22.5"
+

--- a/Resources/Prototypes/Maps/salvage.yml
+++ b/Resources/Prototypes/Maps/salvage.yml
@@ -1,5 +1,7 @@
 # So the way things are done as of now is that Salvages are measured by world AABBs in their maps.
 # Remember, first two coordinates should be the minimum X/Y, second two should be maximum.
+# You can also use the salvageruler command to get these, once you're sure the transform's been reset.
+# Ultimately, you should still be keeping the maps centred.
 
 # "Small"-class maps - Max size square: 7x7, indicated size: 3.5
 
@@ -7,7 +9,7 @@
   id: small1
   name: "Small / Engineering Storage 1"
   mapPath: /Maps/Salvage/small-1.yml
-  bounds: "-3.5,-3.5,3.5,3.5"
+  bounds: "-2.5,-3.5,3.5,3.5"
 
 - type: salvageMap
   id: small2
@@ -19,13 +21,13 @@
   id: small-ship-1
   name: "Small / Ship 1 (Pill)"
   mapPath: /Maps/Salvage/small-ship-1.yml
-  bounds: "-3.5,-3.5,3.5,3.5"
+  bounds: "-1.5,-0.5,2.5,1.5"
 
 - type: salvageMap
   id: small3
   name: "Small / Laundromat 1"
   mapPath: /Maps/Salvage/small-3.yml
-  bounds: "-3.5,-3.5,3.5,3.5"
+  bounds: "-3.5,-3.5,2.5,3.5"
 
 - type: salvageMap
   id: smallAISurveyDrone
@@ -71,37 +73,37 @@
   id: mediumLibraryWreck
   name: "Medium / Abandoned Library"
   mapPath: /Maps/Salvage/medium-library.yml
-  bounds: "-7.5,-7.5,7.5,7.5"
+  bounds: "-8.5,-8.5,6.5,7.5"
 
 - type: salvageMap
   id: mediumCargoWreck
   name: "Medium / Cargo Department Wreck"
   mapPath: /Maps/Salvage/cargo-1.yml
-  bounds: "-7.5,-7.5,7.5,7.5"
+  bounds: "-5.5,-5.5,5.5,9.5"
 
 - type: salvageMap
   id: mediumPirateWreck
   name: "Medium / Pirate Barge Fragment"
   mapPath: /Maps/Salvage/medium-pirate.yml
-  bounds: "-7.5,-7.5,7.5,7.5"
+  bounds: "-3.5,-9.5,6.5,7.5"
 
 - type: salvageMap
   id: tickColony
   name: "Space Tick colony"
   mapPath: /Maps/Salvage/tick-colony.yml
-  bounds: "-8.5,-8.5,8.5,8.5"
+  bounds: "-6,-7,5,7"
 
 - type: salvageMap
   id: cargoDock
   name: "Asteroid Cargo Dock"
   mapPath: /Maps/Salvage/medium-dock.yml
-  bounds: "-8.5,-8.5,8.5,8.5"
+  bounds: "-7,-6,4,8"
 
 - type: salvageMap
   id: spaceWaffleHome
   name: "Waffle Home"
   mapPath: /Maps/Salvage/wh-salvage.yml
-  bounds: "-12,-12,12,12"
+  bounds: "-13,-12,14,11"
 
 - type: salvageMap
   id: mediumShuttleWreck
@@ -113,13 +115,13 @@
   id: mediumPetHospital
   name: "Medium / Pet and Bear Hospital"
   mapPath: /Maps/Salvage/medium-pet-hospital.yml
-  bounds: "-8.5,-8.5,8.5,8.5"
+  bounds: "-5.5,-8.5,5.5,8.5"
 
 - type: salvageMap
   id: mediumCrashedShuttle
   name: "Crashed Shuttle"
   mapPath: /Maps/Salvage/medium-crashed-shuttle.yml
-  bounds: "-9.5,-9.5,9.5,9.5"
+  bounds: "-7,-8,5,9"
 
 # """Large""" maps
 
@@ -127,17 +129,17 @@
   id: stationstation
   name: "StationStation"
   mapPath: /Maps/Salvage/stationstation.yml
-  bounds: "-24,-24,24,24"
+  bounds: "-17,-15,35,29"
 
 - type: salvageMap
   id: asteroidBase
   name: "Asteroid Base"
   mapPath: /Maps/Salvage/asteroid-base.yml
-  bounds: "-16,-16,16,16"
+  bounds: "-12,-13,15,11"
 
 - type: salvageMap
   id: ruinCargoBase
   name: "Ruined Cargo Storage"
   mapPath: /Maps/Salvage/ruin-cargo-salvage.yml
-  bounds: "-22.5,-22.5,22.5,22.5"
+  bounds: "-15,-13,22,14"
 


### PR DESCRIPTION
## About the PR

This PR's purpose is to make Salvaging a bit less predictable.
Salvage is now spawned somewhere in the vicinity of the salvage magnet, randomly (random angle with a distance range).

It's assumed that the fancy mass-scanning-shuttle-computer UI will be usable to locate the salvage. If not, well, happy hunting.

This PR also changes how salvages are measured.
It adds a command, `salvageruler`, which returns the total world AABB for the salvage map.

The main use of this change is to deal with large, uneven salvages (stationstation) and to guarantee precision as the random spawning mechanics could lead to unwanted collisions otherwise.

**Changelog**

:cl:
- tweak: Salvages now spawn somewhere near the salvage magnet, rather than directly in front of it.


