### PR TITLE
Fix typing indicator input validation.

### DIFF
--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.CCVar;
+using Content.Shared.CCVar;
 using Content.Shared.Chat.TypingIndicator;
 using Robust.Client.Player;
 using Robust.Shared.Configuration;
@@ -67,12 +67,11 @@ public sealed class TypingIndicatorSystem : SharedTypingIndicatorSystem
         _isClientTyping = isClientTyping;
 
         // check if player controls any pawn
-        var playerPawn = _playerManager.LocalPlayer?.ControlledEntity;
-        if (playerPawn == null)
+        if (_playerManager.LocalPlayer?.ControlledEntity == null)
             return;
 
         // send a networked event to server
-        RaiseNetworkEvent(new TypingChangedEvent(playerPawn.Value, isClientTyping));
+        RaiseNetworkEvent(new TypingChangedEvent(isClientTyping));
     }
 
     private void OnShowTypingChanged(bool showTyping)

--- a/Content.Server/Chat/TypingIndicator/TypingIndicatorSystem.cs
+++ b/Content.Server/Chat/TypingIndicator/TypingIndicatorSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.Chat.TypingIndicator;
 using Robust.Server.GameObjects;
+using Robust.Shared.Players;
 
 namespace Content.Server.Chat.TypingIndicator;
 
@@ -33,24 +34,24 @@ public sealed class TypingIndicatorSystem : SharedTypingIndicatorSystem
         SetTypingIndicatorEnabled(uid, false);
     }
 
-    private void OnClientTypingChanged(TypingChangedEvent ev)
+    private void OnClientTypingChanged(TypingChangedEvent ev, EntitySessionEventArgs args)
     {
-        // make sure that this entity still exist
-        if (!Exists(ev.Uid))
+        var uid = args.SenderSession.AttachedEntity;
+        if (!Exists(uid))
         {
-            Logger.Warning($"Client attached entity {ev.Uid} from TypingChangedEvent doesn't exist on server.");
+            Logger.Warning($"Client {args.SenderSession} sent TypingChangedEvent without an attached entity.");
             return;
         }
 
         // check if this entity can speak or emote
-        if (!_actionBlocker.CanEmote(ev.Uid) && !_actionBlocker.CanSpeak(ev.Uid))
+        if (!_actionBlocker.CanEmote(uid.Value) && !_actionBlocker.CanSpeak(uid.Value))
         {
             // nah, make sure that typing indicator is disabled
-            SetTypingIndicatorEnabled(ev.Uid, false);
+            SetTypingIndicatorEnabled(uid.Value, false);
             return;
         }
 
-        SetTypingIndicatorEnabled(ev.Uid, ev.IsTyping);
+        SetTypingIndicatorEnabled(uid.Value, ev.IsTyping);
     }
 
     private void SetTypingIndicatorEnabled(EntityUid uid, bool isEnabled, AppearanceComponent? appearance = null)

--- a/Content.Shared/Chat/TypingIndicator/TypingChangedEvent.cs
+++ b/Content.Shared/Chat/TypingIndicator/TypingChangedEvent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Chat.TypingIndicator;
 
@@ -9,12 +9,10 @@ namespace Content.Shared.Chat.TypingIndicator;
 [Serializable, NetSerializable]
 public sealed class TypingChangedEvent : EntityEventArgs
 {
-    public readonly EntityUid Uid;
     public readonly bool IsTyping;
 
-    public TypingChangedEvent(EntityUid uid, bool isTyping)
+    public TypingChangedEvent(bool isTyping)
     {
-        Uid = uid;
         IsTyping = isTyping;
     }
 }


### PR DESCRIPTION
Currently the server just accepts any typing messages with a valid uid, so a malicious client can just dictate who is and isn't typing.