### PR TITLE
Fix nonlethals crate entry showing taser in Cargo console

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -21,7 +21,7 @@
 - type: cargoProduct
   id: SecurityNonLethal
   icon:
-    sprite: Objects/Weapons/Guns/Battery/taser.rsi
+    sprite: Objects/Weapons/Guns/Battery/disabler.rsi
     state: icon
   product: CrateSecurityNonlethal
   cost: 1500

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -22,7 +22,7 @@
   id: SecurityNonLethal
   icon:
     sprite: Objects/Weapons/Guns/Battery/disabler.rsi
-    state: icon
+    state: base
   product: CrateSecurityNonlethal
   cost: 1500
   category: Security


### PR DESCRIPTION
## Fix nonlethals crate entry showing taser in Cargo console
Crate contains disablers, not tasers.
Fixes this:
![tasers_are_fake_news](https://user-images.githubusercontent.com/108953437/186491856-486b683e-17fd-45c8-bf11-e975bd48fd9e.png)

**Changelog**
:cl:
- fix: nonlethals crate icon no longer suggests that crate contains tasers (crate actually contains disablers)