### PR TITLE
Send server rules over the network

### DIFF
--- a/Content.Client/Info/InfoSection.xaml.cs
+++ b/Content.Client/Info/InfoSection.xaml.cs
@@ -11,9 +11,12 @@ public sealed partial class InfoSection : BoxContainer
     public InfoSection(string title, string text, bool markup = false)
     {
         RobustXamlLoader.Load(this);
+        SetText(title, text, markup);
+    }
 
+    public void SetText(string title, string text, bool markup = false)
+    {
         TitleLabel.Text = title;
-
         if (markup)
             Content.SetMessage(FormattedMessage.FromMarkup(text.Trim()));
         else

--- a/Content.Client/Info/InfoSystem.cs
+++ b/Content.Client/Info/InfoSystem.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Info;
+using Robust.Shared.Log;
+
+namespace Content.Client.Info;
+
+public sealed class InfoSystem : EntitySystem
+{
+    public RulesMessage Rules = new RulesMessage("Server Rules", "The server did not send any rules.");
+    [Dependency] private readonly RulesManager _rules = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeNetworkEvent<RulesMessage>(OnRulesReceived);
+        Logger.DebugS("info", "Requested server info.");
+        RaiseNetworkEvent(new RequestRulesMessage());
+    }
+
+    protected void OnRulesReceived(RulesMessage message, EntitySessionEventArgs eventArgs)
+    {
+        Logger.DebugS("info", "Received server rules.");
+        Rules = message;
+        _rules.UpdateRules();
+    }
+}

--- a/Content.Client/Info/RulesAndInfoWindow.cs
+++ b/Content.Client/Info/RulesAndInfoWindow.cs
@@ -13,6 +13,8 @@ namespace Content.Client.Info
     {
         [Dependency] private readonly IResourceCache _resourceManager = default!;
         [Dependency] private readonly IConfigurationManager _cfgManager = default!;
+        [Dependency] private readonly IEntitySystemManager _sysMan = default!;
+        [Dependency] private readonly RulesManager _rules = default!;
 
         private OptionsMenu optionsMenu;
 
@@ -35,17 +37,12 @@ namespace Content.Client.Info
             TabContainer.SetTabTitle(rulesList, Loc.GetString("ui-info-tab-rules"));
             TabContainer.SetTabTitle(tutorialList, Loc.GetString("ui-info-tab-tutorial"));
 
-            PopulateRules(rulesList);
+            AddSection(rulesList, _rules.RulesSection());
             PopulateTutorial(tutorialList);
 
             Contents.AddChild(rootContainer);
 
             SetSize = (650, 650);
-        }
-
-        private void PopulateRules(Info rulesList)
-        {
-            AddSection(rulesList, MakeRules(_cfgManager, _resourceManager));
         }
 
         private void PopulateTutorial(Info tutorialList)
@@ -74,9 +71,5 @@ namespace Content.Client.Info
             return new InfoSection(title, res.ContentFileReadAllText($"/Server Info/{path}"), markup);
         }
 
-        public static Control MakeRules(IConfigurationManager cfg, IResourceManager res)
-        {
-            return MakeSection(Loc.GetString(cfg.GetCVar(CCVars.RulesHeader)), cfg.GetCVar(CCVars.RulesFile), true, res);
-        }
     }
 }

--- a/Content.Client/Info/RulesControl.xaml.cs
+++ b/Content.Client/Info/RulesControl.xaml.cs
@@ -13,12 +13,13 @@ public sealed partial class RulesControl : BoxContainer
 {
     [Dependency] private readonly IResourceCache _resourceManager = default!;
     [Dependency] private readonly IConfigurationManager _cfgManager = default!;
+    [Dependency] private readonly IEntitySystemManager _sysMan = default!;
+    [Dependency] private readonly RulesManager _rules = default!;
 
     public RulesControl()
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
-
-        AddChild(RulesAndInfoWindow.MakeRules(_cfgManager, _resourceManager));
+        AddChild(_rules.RulesSection());
     }
 }

--- a/Content.Client/Info/RulesManager.cs
+++ b/Content.Client/Info/RulesManager.cs
@@ -17,7 +17,9 @@ public sealed class RulesManager : SharedRulesManager
     [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly IClientConsoleHost _consoleHost = default!;
     [Dependency] private readonly INetManager _netManager = default!;
+    [Dependency] private readonly IEntitySystemManager _sysMan = default!;
 
+    private InfoSection rulesSection = new InfoSection("", "", false);
     private bool _shouldShowRules;
 
     public void Initialize()
@@ -71,5 +73,21 @@ public sealed class RulesManager : SharedRulesManager
     {
         var message = _netManager.CreateNetMessage<RulesAcceptedMessage>();
         _netManager.ClientSendMessage(message);
+    }
+
+    public void UpdateRules()
+    {
+        var rules = _sysMan.GetEntitySystem<InfoSystem>().Rules;
+        rulesSection.SetText(rules.Title, rules.Text, true);
+    }
+
+    public Control RulesSection()
+    {
+        if (rulesSection.Disposed)
+        {
+            rulesSection = new InfoSection("", "", false);
+        }
+        UpdateRules();
+        return rulesSection;
     }
 }

--- a/Content.Server/Info/InfoSystem.cs
+++ b/Content.Server/Info/InfoSystem.cs
@@ -1,0 +1,36 @@
+﻿using Content.Shared.CCVar;
+using Content.Shared.Info;
+using Robust.Shared.Configuration;
+using Robust.Shared.ContentPack;
+using Robust.Shared.Log;
+
+namespace Content.Server.Info;
+
+public class InfoSystem : EntitySystem
+{
+    [Dependency] private readonly IResourceManager _res = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeNetworkEvent<RequestRulesMessage>(OnRequestRules);
+    }
+
+    protected void OnRequestRules(RequestRulesMessage message, EntitySessionEventArgs eventArgs)
+    {
+        Logger.DebugS("info", "Client requested rules.");
+        var title = Loc.GetString(_cfg.GetCVar(CCVars.RulesHeader));
+        var path = _cfg.GetCVar(CCVars.RulesFile);
+        var rules = "Server could not read its rules.";
+        try
+        {
+            rules = _res.ContentFileReadAllText($"/Server Info/{path}");
+        }
+        catch (System.Exception)
+        {
+            Logger.ErrorS("info", "Could not read server rules file.");
+        }
+        var response = new RulesMessage(title, rules);
+        RaiseNetworkEvent(response, eventArgs.SenderSession.ConnectedClient);
+    }
+}

--- a/Content.Shared/Info/SharedInfo.cs
+++ b/Content.Shared/Info/SharedInfo.cs
@@ -1,0 +1,28 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared.Info
+{
+    /// <summary>
+    ///     A client request for server rules.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed class RequestRulesMessage : EntityEventArgs
+    {
+    }
+
+    /// <summary>
+    ///     A server response with server rules.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed class RulesMessage : EntityEventArgs
+    {
+        public string Title;
+        public string Text;
+
+        public RulesMessage(string title, string rules)
+        {
+            Title = title;
+            Text = rules;
+        }
+    }
+}


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a new InfoSystem that sends SharedInfo from the server to client when requested. Currently, only the rule header and rule text is sent.

Previously, the rule header and rule text was bundled in the client, which means that the client would only display rules that it was built with, even if the server has different rules.

This allows servers all running the same build to send different rules. This could be useful, for example, for servers running the official builds to send different rulesets without a client rebuild.

**Screenshots**
N/A

**Changelog**
N/A