### PR TITLE
Remove Ratatouille

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -197,22 +197,11 @@ namespace Content.Shared.Movement.Systems
             {
                 // This should have its event run during island solver soooo
                 xform.DeferUpdates = true;
-                TransformComponent rotateXform;
-
-                // If we're in a container then relay rotation to the parent instead
-                if (_container.TryGetContainingContainer(xform.Owner, out var container))
-                {
-                    rotateXform = Transform(container.Owner);
-                }
-                else
-                {
-                    rotateXform = xform;
-                }
-
-                rotateXform.LocalRotation = xform.GridUid != null
+                
+                xform.LocalRotation = xform.GridUid != null
                     ? total.ToWorldAngle()
                     : worldTotal.ToWorldAngle();
-                rotateXform.DeferUpdates = false;
+                xform.DeferUpdates = false;
 
                 if (!weightless && TryComp<MobMoverComponent>(mover.Owner, out var mobMover) &&
                     TryGetSound(weightless, mover, mobMover, xform, out var sound))


### PR DESCRIPTION
Apparently this was required to band aid vehicles at some point, but AFAICT it is no longer needed and is causing issues.

:cl:
- fix: Removed ratatouille (held mice and holo parasites no longer affect what direction a player is facing)

