### PR TITLE
empty id card name fix

### DIFF
--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -29,9 +29,6 @@ namespace Content.Server.Access.Systems
 
         private void OnMapInit(EntityUid uid, IdCardComponent id, MapInitEvent args)
         {
-            // On one hand, these prototypes should default to having the correct name. On the other hand, id cards are
-            // rarely ever spawned in on their own without an owner, so this is fine.
-            id.OriginalEntityName ??= EntityManager.GetComponent<MetaDataComponent>(id.Owner).EntityName;
             UpdateEntityName(uid, id);
         }
 
@@ -80,21 +77,32 @@ namespace Content.Server.Access.Systems
         /// <remarks>
         /// If provided with a player's EntityUid to the player parameter, adds the change to the admin logs.
         /// </remarks>
-        public bool TryChangeJobTitle(EntityUid uid, string jobTitle, IdCardComponent? id = null, EntityUid? player = null)
+        public bool TryChangeJobTitle(EntityUid uid, string? jobTitle, IdCardComponent? id = null, EntityUid? player = null)
         {
             if (!Resolve(uid, ref id))
                 return false;
 
-            if (jobTitle.Length > SharedIdCardConsoleComponent.MaxJobTitleLength)
-                jobTitle = jobTitle[..SharedIdCardConsoleComponent.MaxJobTitleLength];
+            if (!string.IsNullOrWhiteSpace(jobTitle))
+            {
+                jobTitle = jobTitle.Trim();
+
+                if (jobTitle.Length > SharedIdCardConsoleComponent.MaxJobTitleLength)
+                    jobTitle = jobTitle[..SharedIdCardConsoleComponent.MaxJobTitleLength];
+            }
+            else
+            {
+                jobTitle = null;
+            }
 
             id.JobTitle = jobTitle;
             Dirty(id);
             UpdateEntityName(uid, id);
 
             if (player != null)
+            {
                 _adminLogger.Add(LogType.Identity, LogImpact.Low,
-                $"{ToPrettyString(player.Value):player} has changed the job title of {ToPrettyString(id.Owner):entity} to {jobTitle} ");
+                    $"{ToPrettyString(player.Value):player} has changed the job title of {ToPrettyString(id.Owner):entity} to {jobTitle} ");
+            }
             return true;
         }
 
@@ -105,21 +113,31 @@ namespace Content.Server.Access.Systems
         /// <remarks>
         /// If provided with a player's EntityUid to the player parameter, adds the change to the admin logs.
         /// </remarks>
-        public bool TryChangeFullName(EntityUid uid, string fullName, IdCardComponent? id = null, EntityUid? player = null)
+        public bool TryChangeFullName(EntityUid uid, string? fullName, IdCardComponent? id = null, EntityUid? player = null)
         {
             if (!Resolve(uid, ref id))
                 return false;
 
-            if (fullName.Length > SharedIdCardConsoleComponent.MaxFullNameLength)
-                fullName = fullName[..SharedIdCardConsoleComponent.MaxFullNameLength];
+            if (!string.IsNullOrWhiteSpace(fullName))
+            {
+                fullName = fullName.Trim();
+                if (fullName.Length > SharedIdCardConsoleComponent.MaxFullNameLength)
+                    fullName = fullName[..SharedIdCardConsoleComponent.MaxFullNameLength];
+            }
+            else
+            {
+                fullName = null;
+            }
 
             id.FullName = fullName;
             Dirty(id);
             UpdateEntityName(uid, id);
 
             if (player != null)
+            {
                 _adminLogger.Add(LogType.Identity, LogImpact.Low,
-                $"{ToPrettyString(player.Value):player} has changed the name of {ToPrettyString(id.Owner):entity} to {fullName} ");
+                    $"{ToPrettyString(player.Value):player} has changed the name of {ToPrettyString(id.Owner):entity} to {fullName} ");
+            }
             return true;
         }
 
@@ -135,17 +153,10 @@ namespace Content.Server.Access.Systems
             if (!Resolve(uid, ref id))
                 return;
 
-            if (string.IsNullOrWhiteSpace(id.FullName) && string.IsNullOrWhiteSpace(id.JobTitle))
-            {
-                EntityManager.GetComponent<MetaDataComponent>(id.Owner).EntityName = id.OriginalEntityName;
-                return;
-            }
-
             var jobSuffix = string.IsNullOrWhiteSpace(id.JobTitle) ? string.Empty : $" ({id.JobTitle})";
 
             var val = string.IsNullOrWhiteSpace(id.FullName)
                 ? Loc.GetString("access-id-card-component-owner-name-job-title-text",
-                    ("originalOwnerName", id.OriginalEntityName),
                     ("jobSuffix", jobSuffix))
                 : Loc.GetString("access-id-card-component-owner-full-name-job-title-text",
                     ("fullName", id.FullName),

--- a/Content.Server/Access/Systems/IdExaminableSystem.cs
+++ b/Content.Server/Access/Systems/IdExaminableSystem.cs
@@ -66,7 +66,6 @@ public sealed class IdExaminableSystem : EntitySystem
 
         var val = string.IsNullOrWhiteSpace(id.FullName)
             ? Loc.GetString("access-id-card-component-owner-name-job-title-text",
-                ("originalOwnerName", id.OriginalEntityName),
                 ("jobSuffix", jobSuffix))
             : Loc.GetString("access-id-card-component-owner-full-name-job-title-text",
                 ("fullName", id.FullName),

--- a/Content.Server/Mind/Commands/RenameCommand.cs
+++ b/Content.Server/Mind/Commands/RenameCommand.cs
@@ -58,15 +58,6 @@ public sealed class RenameCommand : IConsoleCommand
         {
             if (idCardSystem.TryFindIdCard(entityUid, out var idCard))
                 idCardSystem.TryChangeFullName(idCard.Owner, name, idCard);
-            else
-            {
-                foreach (var idCardComponent in entMan.EntityQuery<IdCardComponent>())
-                {
-                    if (idCardComponent.OriginalEntityName != oldName)
-                        continue;
-                    idCardSystem.TryChangeFullName(idCardComponent.Owner, name, idCardComponent);
-                }
-            }
         }
 
         // PDAs

--- a/Content.Shared/Access/Components/IdCardComponent.cs
+++ b/Content.Shared/Access/Components/IdCardComponent.cs
@@ -9,9 +9,6 @@ namespace Content.Shared.Access.Components
     [Access(typeof(SharedIdCardSystem), typeof(SharedPDASystem), typeof(SharedAgentIdCardSystem))]
     public sealed class IdCardComponent : Component
     {
-        [DataField("originalEntityName")]
-        public string OriginalEntityName = string.Empty;
-
         [DataField("fullName")]
         [Access(typeof(SharedIdCardSystem), typeof(SharedPDASystem), typeof(SharedAgentIdCardSystem),
             Other = AccessPermissions.ReadWrite)] // FIXME Friends

--- a/Resources/Locale/en-US/access/components/id-card-component.ftl
+++ b/Resources/Locale/en-US/access/components/id-card-component.ftl
@@ -1,7 +1,8 @@
 ## IdCardComponent
 
-access-id-card-component-owner-name-job-title-text = {$originalOwnerName}{$jobSuffix}
+access-id-card-component-owner-name-job-title-text = ID card{$jobSuffix}
 access-id-card-component-owner-full-name-job-title-text = {$fullName}'s ID card{$jobSuffix}
+access-id-card-component-default = ID card
 
 id-card-component-microwave-burnt = {$id}'s circuits pop loudly!
 id-card-component-microwave-bricked = {$id}'s circuits sizzle!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes #10831 

Refactors a bit of the id code so that cards without owners no longer display simply empty text. Also sanitizes id names and jobs to remove whitespace empty values.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed issues with ID cards displaying whitespace and empty names.

