### PR TITLE
Mark sandbox test as destructive

### DIFF
--- a/Content.IntegrationTests/Tests/Utility/SandboxTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/SandboxTest.cs
@@ -8,7 +8,7 @@ public sealed class SandboxTest
     [Test]
     public async Task Test()
     {
-        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoServer = true});
+        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings{NoServer = true, Destructive = true});
         var client = pairTracker.Pair.Client;
         await client.CheckSandboxed(typeof(Client.Entry.EntryPoint).Assembly);
         await pairTracker.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/Utility/TestTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/TestTest.cs
@@ -1,0 +1,6 @@
+namespace Content.IntegrationTests.Tests.Utility;
+
+public sealed class TestTest
+{
+    
+}

--- a/Content.IntegrationTests/Tests/Utility/TestTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/TestTest.cs
@@ -1,6 +1,0 @@
-namespace Content.IntegrationTests.Tests.Utility;
-
-public sealed class TestTest
-{
-    
-}


### PR DESCRIPTION
The sandbox check seems to damage the IoC. Marking this test as destructive so other tests don't use the client it messes up.