### PR TITLE
Adds implementation for Closed in CrewManifestEui

### DIFF
--- a/Content.Server/CrewManifest/CrewManifestEui.cs
+++ b/Content.Server/CrewManifest/CrewManifestEui.cs
@@ -40,8 +40,15 @@ public sealed class CrewManifestEui : BaseEui
         switch (msg)
         {
             case CrewManifestEuiClosed:
-                _crewManifest.CloseEui(_station, Player, Owner);
+                Closed();
                 break;
         }
+    }
+
+    public override void Closed()
+    {
+        base.Closed();
+
+        _crewManifest.CloseEui(_station, Player, Owner);
     }
 }

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -186,8 +186,8 @@ public sealed class CrewManifestSystem : EntitySystem
 
         if (eui.Owner == owner)
         {
-            eui.Close();
             euis.Remove(session);
+            eui.Close();
         }
 
         if (euis.Count == 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a missing implementation in CrewManifestEui. This might fix the current issue where rounds restart instantly due to an exception thrown by a missing key in the EUI manager.