### PR TITLE
Changes the walls bounding box slightly to avoid sprite clipping.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -35,7 +35,7 @@
     fixtures:
     - shape:
         !type:PhysShapeAabb
-        bounds: "-0.5,-0.5,0.5,0.5"
+        bounds: "-0.6,-0.6,0.6,0.6"
       mask:
       - FullTileMask
       layer:

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -187,7 +187,7 @@
     sprite: Structures/Windows/directional.rsi
     state: tinted_window
   - type: Occluder
-    boundingBox: "-0.5,-0.5,0.5,-0.5"
+    boundingBox: "-0.5,-0.5,0.5,-0.3"
   - type: StaticPrice
     price: 0.5
 

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -187,7 +187,7 @@
     sprite: Structures/Windows/directional.rsi
     state: tinted_window
   - type: Occluder
-    boundingBox: "-0.5,-0.5,0.5,-0.3"
+    boundingBox: "-0.5,-0.5,0.5,-0.5"
   - type: StaticPrice
     price: 0.5
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR 

This PR aims to make a small visual change to SS14's look by slightly extending the walls' bounding box to avoid sprite clipping. The goal is to get something that's visually more resembling to BYOND's SS13 look without removing pixel movement.

**Screenshots**

![image](https://user-images.githubusercontent.com/31417754/187086210-78eaec3f-67c6-46fd-8cb5-7388c9c6046d.png)

From what I could test, it's not affecting freedom of movement much and you can still slide through doors easily. It's also not having a pronounced visual effect on impacts on walls (I fired a disabler at walls) as the effect mostly happens on the tile adjacent to the wall already.

I do realise it's very subjective, low-effort, and maybe a bit self-serving for a fist PR, but I do think it helps a lot with immersion if characters are not constantly phasing through the edges of walls. I hope this PR is acceptable.

If it is so, then I aim to also tweak the bounding box of windows and game structures to reduce this clipping effect as much as possible.

**Changelog**

:cl:
- add: The collision box of walls has been slightly increased to reduce the likelihood of spacemen clipping through them.

