### PR TITLE
Improve test stability

### DIFF
--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -766,6 +766,7 @@ public sealed class PairTracker : IAsyncDisposable
         {
             Pair.Client.Dispose();
             Pair.Server.Dispose();
+            await PoolManager.ReallyBeIdle(Pair);
             var returnTime2 = cleanWatch.Elapsed;
             await TestContext.Out.WriteLineAsync($"{nameof(CleanReturnAsync)}: Clean disposed in {returnTime2.TotalMilliseconds} ms");
             return;

--- a/Content.Server/AI/Pathfinding/Accessible/AiReachableSystem.cs
+++ b/Content.Server/AI/Pathfinding/Accessible/AiReachableSystem.cs
@@ -445,10 +445,11 @@ namespace Content.Server.AI.Pathfinding.Accessible
             var parentChunk = node.ParentChunk;
 
             // No guarantee the node even has a region yet (if we're doing neighbor lookups)
-            if (!_regions[parentChunk.GridId].TryGetValue(parentChunk, out var regions))
-            {
+            if (!_regions.TryGetValue(parentChunk.GridId, out var chunk))
                 return null;
-            }
+
+            if (!chunk.TryGetValue(parentChunk, out var regions))
+                return null;
 
             foreach (var region in regions)
             {

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.TimedCollide.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.TimedCollide.cs
@@ -19,6 +19,8 @@ public sealed partial class TriggerSystem
         //Ensures the entity trigger will have an active component
         EnsureComp<ActiveTriggerOnTimedCollideComponent>(uid);
         var otherUID = args.OtherFixture.Body.Owner;
+        if (component.Colliding.ContainsKey(otherUID))
+            return;
         component.Colliding.Add(otherUID, 0);
     }
 

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -119,7 +119,8 @@ public sealed class StationSystem : EntitySystem
     private void OnStationDeleted(EntityUid uid, StationDataComponent component, ComponentShutdown args)
     {
         if (_stations.Contains(uid) && // Was not deleted via DeleteStation()
-            _gameTicker.RunLevel == GameRunLevel.InRound) // And not due to a round restart
+            _gameTicker.RunLevel == GameRunLevel.InRound && // And not due to a round restart
+            _gameTicker.LobbyEnabled) // If there isn't a lobby, this is probably sandbox, single player, or a test
         {
             // printing a stack trace, rather than throwing an exception so that entity deletion continues as normal.
             Logger.Error($"Station entity {ToPrettyString(uid)} is getting deleted mid-round. Trace: {Environment.StackTrace}");

--- a/Content.Shared/Body/Components/SharedBodyComponent.cs
+++ b/Content.Shared/Body/Components/SharedBodyComponent.cs
@@ -395,7 +395,8 @@ namespace Content.Shared.Body.Components
             var gibs = new HashSet<EntityUid>();
             foreach (var part in SlotParts.Keys)
             {
-                if (!metaQuery.HasComponent(part.Owner))
+                if (!metaQuery.TryGetComponent(part.Owner, out var meta) ||
+                    meta.EntityLifeStage >= EntityLifeStage.Terminating)
                 {
                     SlotParts.Remove(part);
                     continue;

--- a/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
@@ -94,6 +94,7 @@
     tags:
       - Debug
   - type: Clickable
+  - type: PowerNetworkBattery
   - type: InteractionOutline
   - type: Physics
   - type: Fixtures


### PR DESCRIPTION
- Replaces SpawnTest with two different tests
-- SpawnAndDeleteAllEntitiesOnDifferentMaps
-- SpawnAndDeleteAllEntitiesInTheSameSpot

- Fixes an AI crash, and trigger crash
- Stops station from logging an error on deletion if lobby is disabled, so the tests can delete/cleanup without thinking they failed.
- Gibbing will now skip a part if it's entity lifetime is terminating, so flushing the entity manager works better.
- Added PowerNetworkBattery to DebugBatteryDischarger so creating it doesn't crash