### PR TITLE
Fix reading rules multiple times

### DIFF
--- a/Content.Client/Info/RulesManager.cs
+++ b/Content.Client/Info/RulesManager.cs
@@ -83,10 +83,7 @@ public sealed class RulesManager : SharedRulesManager
 
     public Control RulesSection()
     {
-        if (rulesSection.Disposed)
-        {
-            rulesSection = new InfoSection("", "", false);
-        }
+        rulesSection = new InfoSection("", "", false);
         UpdateRules();
         return rulesSection;
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The client crashes when reading rules multiple times, because the InfoSection is re-used (and not deparented) when RuleSection is created. Fix by always constructing the InfoSection.

Pointyhat to myself for not testing this particular case earlier.

**Screenshots**
N/A

**Changelog**
N/A