### PR TITLE
Sort scanner "eject" verb first

### DIFF
--- a/Content.Server/Medical/MedicalScannerSystem.cs
+++ b/Content.Server/Medical/MedicalScannerSystem.cs
@@ -94,6 +94,7 @@ namespace Content.Server.Medical
                 verb.Act = () => EjectBody(uid, component);
                 verb.Category = VerbCategory.Eject;
                 verb.Text = Loc.GetString("medical-scanner-verb-noun-occupant");
+                verb.Priority = 1; // Promote to top to make ejecting the ALT-click action
                 args.Verbs.Add(verb);
             }
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
MED players know that they eject bodies more times than they need to vault cloners. Promote the "eject" verb so that it becomes the ALT-Click action.

Requested by a few notable MED players.

**Screenshots**
![scanner_eject](https://user-images.githubusercontent.com/3229565/187356707-1ebcf4c3-b15d-4cea-a7dc-f950ff6dcffe.png)

**Changelog**
N/A