### PR TITLE
Add InventoryRelayedEvent<TEvent>

### DIFF
--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Movement.Systems;
+using Content.Shared.Inventory;
+using Content.Shared.Movement.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 
@@ -15,7 +16,7 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
 
         SubscribeLocalEvent<ClothingSpeedModifierComponent, ComponentGetState>(OnGetState);
         SubscribeLocalEvent<ClothingSpeedModifierComponent, ComponentHandleState>(OnHandleState);
-        SubscribeLocalEvent<ClothingSpeedModifierComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMoveSpeed);
+        SubscribeLocalEvent<ClothingSpeedModifierComponent, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRefreshMoveSpeed);
     }
 
     // Public API
@@ -60,11 +61,11 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
         }
     }
 
-    private void OnRefreshMoveSpeed(EntityUid uid, ClothingSpeedModifierComponent component, RefreshMovementSpeedModifiersEvent args)
+    private void OnRefreshMoveSpeed(EntityUid uid, ClothingSpeedModifierComponent component, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
     {
         if (!component.Enabled)
             return;
 
-        args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+        args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -24,11 +24,31 @@ public partial class InventorySystem
     protected void RelayInventoryEvent<T>(EntityUid uid, InventoryComponent component, T args) where T : EntityEventArgs, IInventoryRelayEvent
     {
         var containerEnumerator = new ContainerSlotEnumerator(uid, component.TemplateId, _prototypeManager, this, args.TargetSlots);
-        while(containerEnumerator.MoveNext(out var container))
+        var ev = new InventoryRelayedEvent<T>(args);
+        while (containerEnumerator.MoveNext(out var container))
         {
-            if(!container.ContainedEntity.HasValue) continue;
-            RaiseLocalEvent(container.ContainedEntity.Value, args, false);
+            if (!container.ContainedEntity.HasValue) continue;
+            RaiseLocalEvent(container.ContainedEntity.Value, ev, false);
         }
+    }
+}
+
+/// <summary>
+///     Event wrapper for relayed events.
+/// </summary>
+/// <remarks>
+///      This avoids nested inventory relays, and makes it easy to have certain events only handled by the initial
+///      target entity. E.g. health based movement speed modifiers should not be handled by a hat, even if that hat
+///      happens to be a dead mouse. Clothing that wishes to modify movement speed must subscribe to
+///      InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent>
+/// </remarks>
+public sealed class InventoryRelayedEvent<TEvent> : EntityEventArgs where TEvent : EntityEventArgs, IInventoryRelayEvent
+{
+    public readonly TEvent Args;
+
+    public InventoryRelayedEvent(TEvent args)
+    {
+        Args = args;
     }
 }
 


### PR DESCRIPTION
Draft for an alternative to #10916 & general fix for #10917.

Basically, events that get relayed to inventory items now get wrapped in another event. So for example, instead of subscribing to `RefreshMovementSpeedModifiersEvent`, clothing based modifiers should subscribe to `InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent>`.

This both prevents unintentional recursion, and avoids accidentally applying effects to the wrong target without requiring an explicit check to be added.