### PR TITLE
Machine frame Examine shows board

### DIFF
--- a/Content.Server/Construction/MachineFrameSystem.cs
+++ b/Content.Server/Construction/MachineFrameSystem.cs
@@ -1,6 +1,7 @@
-﻿using Content.Server.Construction.Components;
+using Content.Server.Construction.Components;
 using Content.Server.Stack;
 using Content.Shared.Construction;
+using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Tag;
 using Robust.Shared.Containers;
@@ -22,6 +23,7 @@ public sealed class MachineFrameSystem : EntitySystem
         SubscribeLocalEvent<MachineFrameComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<MachineFrameComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<MachineFrameComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<MachineFrameComponent, ExaminedEvent>(OnMachineFrameExamined);
     }
 
     private void OnInit(EntityUid uid, MachineFrameComponent component, ComponentInit args)
@@ -294,5 +296,12 @@ public sealed class MachineFrameSystem : EntitySystem
                     component.TagProgress[tagName]++;
             }
         }
+    }
+    private void OnMachineFrameExamined(EntityUid uid, MachineFrameComponent component, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+        if (component.HasBoard)
+            args.PushMarkup(Loc.GetString("machine-frame-component-on-examine-label", ("board", EntityManager.GetComponent<MetaDataComponent>(component.BoardContainer.ContainedEntities[0]).EntityName)));
     }
 }

--- a/Resources/Locale/en-US/construction/components/machine-frame-component.ftl
+++ b/Resources/Locale/en-US/construction/components/machine-frame-component.ftl
@@ -1,0 +1,1 @@
+machine-frame-component-on-examine-label = [color=white]Current machine board:[/color] [color=cyan]{$board}[/color]


### PR DESCRIPTION
Machine frame Examine shows board, issue #10891 

##  Contents <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the current inserted machine board to the examine

**Screenshots**
![machineframe-commit](https://user-images.githubusercontent.com/45628623/187636153-ce879e84-d439-4d18-b07a-b70cd476fbac.png)

