### PR TITLE
Make Licoxide bypass insulated gloves

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -248,7 +248,7 @@ public sealed partial class AdminVerbSystem
                     }
 
                     _electrocutionSystem.TryDoElectrocution(args.Target, null, damageToDeal,
-                        TimeSpan.FromSeconds(30), true);
+                        TimeSpan.FromSeconds(30), refresh: true, ignoreInsulation: true);
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-smite-electrocute-description")

--- a/Content.Server/Chemistry/ReagentEffects/Electrocute.cs
+++ b/Content.Server/Chemistry/ReagentEffects/Electrocute.cs
@@ -19,7 +19,7 @@ public sealed class Electrocute : ReagentEffect
     public override void Effect(ReagentEffectArgs args)
     {
         EntitySystem.Get<ElectrocutionSystem>().TryDoElectrocution(args.SolutionEntity, null,
-            Math.Max((args.Quantity * ElectrocuteDamageScale).Int(), 1), TimeSpan.FromSeconds(ElectrocuteTime), Refresh);
+            Math.Max((args.Quantity * ElectrocuteDamageScale).Int(), 1), TimeSpan.FromSeconds(ElectrocuteTime), Refresh, ignoreInsulation: true);
 
         args.Source?.RemoveReagent(args.Reagent.ID, args.Quantity);
     }

--- a/Content.Server/Electrocution/ElectrocuteCommand.cs
+++ b/Content.Server/Electrocution/ElectrocuteCommand.cs
@@ -48,7 +48,7 @@ namespace Content.Server.Electrocution
             }
 
             entityManager.EntitySysManager.GetEntitySystem<ElectrocutionSystem>()
-                .TryDoElectrocution(uid, null, damage, TimeSpan.FromSeconds(seconds), true);
+                .TryDoElectrocution(uid, null, damage, TimeSpan.FromSeconds(seconds), refresh: true, ignoreInsulation: true);
         }
     }
 }

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.Database;
 using Content.Shared.Electrocution;
 using Content.Shared.Interaction;
+using Content.Shared.Inventory;
 using Content.Shared.Jittering;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
@@ -252,18 +253,25 @@ namespace Content.Server.Electrocution
             }
         }
 
+        /// <param name="uid">Entity being electrocuted.</param>
+        /// <param name="sourceUid">Source entity of the electrocution.</param>
+        /// <param name="shockDamage">How much shock damage the entity takes.</param>
+        /// <param name="time">How long the entity will be stunned.</param>
+        /// <param name="refresh">Should <paramref>time</paramref> be refreshed (instead of accumilated) if the entity is already electrocuted?</param>
+        /// <param name="siemensCoeffiecient">How insulated the entity is from the shock. 0 means completely insulated, and 1 means no insulation.</param>
+        /// <param name="statusEffect">Status effect to apply to the entity.</param>
+        /// <param name="ignoreInsulation">Should the electrocution bypass the Insulated component?</param>
         /// <returns>Whether the entity <see cref="uid"/> was stunned by the shock.</returns>
         public bool TryDoElectrocution(
             EntityUid uid, EntityUid? sourceUid, int shockDamage, TimeSpan time, bool refresh, float siemensCoefficient = 1f,
-            StatusEffectsComponent? statusEffects = null)
+            StatusEffectsComponent? statusEffects = null, bool ignoreInsulation = false)
         {
-            if (!DoCommonElectrocutionAttempt(uid, sourceUid, ref siemensCoefficient)
+            if (!DoCommonElectrocutionAttempt(uid, sourceUid, ref siemensCoefficient, ignoreInsulation)
                 || !DoCommonElectrocution(uid, sourceUid, shockDamage, time, refresh, siemensCoefficient, statusEffects))
                 return false;
 
             RaiseLocalEvent(uid, new ElectrocutedEvent(uid, sourceUid, siemensCoefficient), true);
             return true;
-
         }
 
         private bool TryDoElectrocutionPowered(
@@ -281,7 +289,7 @@ namespace Content.Server.Electrocution
                 return false;
 
             // Coefficient needs to be higher than this to do a powered electrocution!
-            if(siemensCoefficient <= 0.5f)
+            if (siemensCoefficient <= 0.5f)
                 return DoCommonElectrocution(uid, sourceUid, shockDamage, time, refresh, siemensCoefficient, statusEffects);
 
             if (!DoCommonElectrocution(uid, sourceUid, null, time, refresh, siemensCoefficient, statusEffects))
@@ -311,9 +319,11 @@ namespace Content.Server.Electrocution
             return true;
         }
 
-        private bool DoCommonElectrocutionAttempt(EntityUid uid, EntityUid? sourceUid, ref float siemensCoefficient)
+        private bool DoCommonElectrocutionAttempt(EntityUid uid, EntityUid? sourceUid, ref float siemensCoefficient, bool ignoreInsulation = false)
         {
-            var attemptEvent = new ElectrocutionAttemptEvent(uid, sourceUid, siemensCoefficient);
+
+            var attemptEvent = new ElectrocutionAttemptEvent(uid, sourceUid, siemensCoefficient,
+                ignoreInsulation ? SlotFlags.NONE : ~SlotFlags.POCKET);
             RaiseLocalEvent(uid, attemptEvent, true);
 
             // Cancel the electrocution early, so we don't recursively electrocute anything.

--- a/Content.Shared/Electrocution/ElectrocutionEvents.cs
+++ b/Content.Shared/Electrocution/ElectrocutionEvents.cs
@@ -4,15 +4,16 @@ namespace Content.Shared.Electrocution
 {
     public sealed class ElectrocutionAttemptEvent : CancellableEntityEventArgs, IInventoryRelayEvent
     {
-        public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
+        public SlotFlags TargetSlots { get; }
 
         public readonly EntityUid TargetUid;
         public readonly EntityUid? SourceUid;
         public float SiemensCoefficient = 1f;
 
-        public ElectrocutionAttemptEvent(EntityUid targetUid, EntityUid? sourceUid, float siemensCoefficient)
+        public ElectrocutionAttemptEvent(EntityUid targetUid, EntityUid? sourceUid, float siemensCoefficient, SlotFlags targetSlots)
         {
             TargetUid = targetUid;
+            TargetSlots = TargetSlots;
             SourceUid = sourceUid;
             SiemensCoefficient = siemensCoefficient;
         }


### PR DESCRIPTION
As well as the `electrocute` console command. ~~The admin electrocution smite is also changed to bypass insulated gloves, instead of removing the `InsulatedComponent` from them.~~ It now does both.

Also, the `TryDoElectrocution` function params are now documented, because I couldn't guess what some of them did just based on their names.

**Changelog**
:cl:
- fix: Insulated glove users are no longer safe from licoxide.


Closes #9650