### PR TITLE
Make t-rays, gas analyzers, and belts lathable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -71,6 +71,9 @@
       - Spade
       - CableStack
       - HandheldGPSBasic
+      - TRayScanner
+      - GasAnalyzer
+      - UtilityBelt
   - type: ActivatableUI
     key: enum.LatheUiKey.Key
   - type: ActivatableUIRequiresPower

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -142,6 +142,24 @@
     Glass: 300
 
 - type: latheRecipe
+  id: TRayScanner
+  icon: Objects/Tools/t-ray.rsi/tray-off.png
+  result: trayScanner
+  completetime: 2
+  materials:
+    Steel: 800
+    Glass: 300
+
+- type: latheRecipe
+  id: GasAnalyzer
+  icon: Objects/Specific/Atmos/gasanalyzer.rsi/icon.png
+  result: GasAnalyzer
+  completetime: 2
+  materials:
+    Steel: 800
+    Glass: 300
+
+- type: latheRecipe
   id: AirlockPainter
   icon: /Textures/Objects/Tools/airlock_painter.rsi/airlock_painter.png
   result: AirlockPainter
@@ -149,6 +167,15 @@
   materials:
     Steel: 300
     Plastic: 100
+
+- type: latheRecipe
+  id: UtilityBelt
+  icon: Clothing/Belt/utility.rsi/icon.png
+  result: ClothingBeltUtility
+  completetime: 2
+  materials:
+    Cloth: 100
+    Steel: 50
 
 - type: latheRecipe
   id: HolofanProjector


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds lathe recipes for t-ray scanners, gas analyzers, and utility belts. Make them craftable in the autolathe.

**Screenshots**
N/A

**Changelog**
:cl: notafet
- add: More tools are craftable in the autolathe.