### PR TITLE
Revert stripping menu order

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -1,12 +1,45 @@
 ﻿- type: inventoryTemplate
   id: human
   slots:
-    - name: head
-      slotTexture: head
-      slotFlags: HEAD
+    - name: shoes
+      slotTexture: shoes
+      slotFlags: FEET
+      stripTime: 2
       uiContainer: Top
-      uiWindowPos: 1,0
-      displayName: Head
+      uiWindowPos: 1,3
+      displayName: Shoes
+    - name: jumpsuit
+      slotTexture: uniform
+      slotFlags: INNERCLOTHING
+      stripTime: 5
+      uiContainer: Top
+      uiWindowPos: 0,2
+      displayName: Jumpsuit
+    - name: outerClothing
+      slotTexture: suit
+      slotFlags: OUTERCLOTHING
+      stripTime: 5
+      uiContainer: Top
+      uiWindowPos: 1,2
+      displayName: Suit
+    - name: gloves
+      slotTexture: gloves
+      slotFlags: GLOVES
+      uiContainer: Top
+      uiWindowPos: 2,2
+      displayName: Gloves
+    - name: neck
+      slotTexture: neck
+      slotFlags: NECK
+      uiContainer: Top
+      uiWindowPos: 0,1
+      displayName: Neck
+    - name: mask
+      slotTexture: mask
+      slotFlags: MASK
+      uiContainer: Top
+      uiWindowPos: 1,1
+      displayName: Mask
     - name: eyes
       slotTexture: glasses
       slotFlags: EYES
@@ -21,25 +54,12 @@
       uiContainer: Top
       uiWindowPos: 2,0
       displayName: Ears
-    - name: mask
-      slotTexture: mask
-      slotFlags: MASK
+    - name: head
+      slotTexture: head
+      slotFlags: HEAD
       uiContainer: Top
-      uiWindowPos: 1,1
-      displayName: Mask
-    - name: neck
-      slotTexture: neck
-      slotFlags: NECK
-      uiContainer: Top
-      uiWindowPos: 0,1
-      displayName: Neck
-    - name: jumpsuit
-      slotTexture: uniform
-      slotFlags: INNERCLOTHING
-      stripTime: 5
-      uiContainer: Top
-      uiWindowPos: 0,2
-      displayName: Jumpsuit
+      uiWindowPos: 1,0
+      displayName: Head
     - name: pocket1
       slotTexture: pocket
       slotFlags: POCKET
@@ -58,21 +78,6 @@
       dependsOn: jumpsuit
       displayName: Pocket 2
       stripHidden: true
-    - name: id
-      slotTexture: id
-      slotFlags: IDCARD
-      stripTime: 5
-      uiContainer: BottomRight
-      uiWindowPos: 2,1
-      dependsOn: jumpsuit
-      displayName: ID
-    - name: outerClothing
-      slotTexture: suit
-      slotFlags: OUTERCLOTHING
-      stripTime: 5
-      uiContainer: Top
-      uiWindowPos: 1,2
-      displayName: Suit
     - name: suitstorage
       slotTexture: suit_storage
       slotFlags:   SUITSTORAGE
@@ -81,12 +86,14 @@
       uiWindowPos: 2,0
       dependsOn: outerClothing
       displayName: Suit Storage
-    - name: gloves
-      slotTexture: gloves
-      slotFlags: GLOVES
-      uiContainer: Top
-      uiWindowPos: 2,2
-      displayName: Gloves
+    - name: id
+      slotTexture: id
+      slotFlags: IDCARD
+      stripTime: 5
+      uiContainer: BottomRight
+      uiWindowPos: 2,1
+      dependsOn: jumpsuit
+      displayName: ID
     - name: belt
       slotTexture: belt
       slotFlags: BELT
@@ -101,10 +108,3 @@
       uiContainer: BottomLeft
       uiWindowPos: 3,0
       displayName: Back
-    - name: shoes
-      slotTexture: shoes
-      slotFlags: FEET
-      stripTime: 2
-      uiContainer: Top
-      uiWindowPos: 1,3
-      displayName: Shoes


### PR DESCRIPTION
This partially reverts commit e4a7a0afe9164042f645c65fca02c62211c24292.

i dont think its objectively better than the old stripping order and it appears to have broken quickequip for unknown reasons so let's just revert this

