### PR TITLE
Mapping autosaves

### DIFF
--- a/Content.Server/Mapping/MappingCommand.cs
+++ b/Content.Server/Mapping/MappingCommand.cs
@@ -90,11 +90,17 @@ namespace Content.Server.Mapping
                 mapId = mapManager.NextMapId();
             }
 
+            string? toLoad = null;
             // either load a map or create a new one.
             if (args.Length <= 1)
+            {
                 shell.ExecuteCommand($"addmap {mapId} false");
+            }
             else
-                shell.ExecuteCommand($"loadmap {mapId} \"{CommandParsing.Escape(args[1])}\" 0 0 0 true");
+            {
+                toLoad = CommandParsing.Escape(args[1]);
+                shell.ExecuteCommand($"loadmap {mapId} \"{toLoad}\" 0 0 0 true");
+            }
 
             // was the map actually created?
             if (!mapManager.MapExists(mapId))
@@ -114,7 +120,7 @@ namespace Content.Server.Mapping
 
             shell.ExecuteCommand("sudo cvar events.enabled false");
             if (cfg.GetCVar(CCVars.AutosaveEnabled))
-                shell.ExecuteCommand($"toggleautosave {mapId}");
+                shell.ExecuteCommand($"toggleautosave {mapId} {toLoad ?? "NEWMAP"}");
             shell.ExecuteCommand($"tp 0 0 {mapId}");
             shell.RemoteExecuteCommand("mappingclientsidesetup");
             mapManager.SetMapPaused(mapId, true);

--- a/Content.Server/Mapping/MappingCommand.cs
+++ b/Content.Server/Mapping/MappingCommand.cs
@@ -1,17 +1,18 @@
 // ReSharper disable once RedundantUsingDirective
 // Used to warn the player in big red letters in debug mode
 
+using System.Linq;
 using Content.Server.Administration;
 using Content.Shared.Administration;
+using Content.Shared.CCVar;
 using Robust.Server.Player;
-using Robust.Server.Console.Commands;
+using Robust.Shared.Configuration;
 using Robust.Shared.Console;
+using Robust.Shared.ContentPack;
 using Robust.Shared.Map;
 using Robust.Shared.Utility;
-using Robust.Shared.ContentPack;
-using System.Linq;
 
-namespace Content.Server.GameTicking.Commands
+namespace Content.Server.Mapping
 {
     [AdminCommand(AdminFlags.Server | AdminFlags.Mapping)]
     sealed class MappingCommand : IConsoleCommand
@@ -109,7 +110,11 @@ namespace Content.Server.GameTicking.Commands
                 shell.ExecuteCommand("aghost");
             }
 
+            var cfg = IoCManager.Resolve<IConfigurationManager>();
+
             shell.ExecuteCommand("sudo cvar events.enabled false");
+            if (cfg.GetCVar(CCVars.AutosaveEnabled))
+                shell.ExecuteCommand($"toggleautosave {mapId}");
             shell.ExecuteCommand($"tp 0 0 {mapId}");
             shell.RemoteExecuteCommand("mappingclientsidesetup");
             mapManager.SetMapPaused(mapId, true);

--- a/Content.Server/Mapping/MappingSystem.cs
+++ b/Content.Server/Mapping/MappingSystem.cs
@@ -1,0 +1,155 @@
+﻿using System.Globalization;
+using System.IO;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Microsoft.Extensions.Configuration;
+using Robust.Server.Maps;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+using Robust.Shared.ContentPack;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Mapping;
+
+/// <summary>
+///     Handles autosaving maps.
+/// </summary>
+public sealed class MappingSystem : EntitySystem
+{
+    [Dependency] private readonly IConsoleHost _conHost = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IMapLoader _mapLoader = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IResourceManager _resMan = default!;
+
+    // Not a comp because I don't want to deal with this getting saved onto maps ever
+    /// <summary>
+    ///     map id -> next autosave timespan.
+    /// </summary>
+    /// <returns></returns>
+    private Dictionary<MapId, TimeSpan> _currentlyAutosaving = new();
+
+    private ISawmill _sawmill = default!;
+    private bool _autosaveEnabled;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _conHost.RegisterCommand("toggleautosave",
+            "Toggles autosaving for a map.",
+            "autosave <map>",
+            ToggleAutosaveCommand);
+
+        _sawmill = Logger.GetSawmill("autosave");
+        _cfg.OnValueChanged(CCVars.AutosaveEnabled, SetAutosaveEnabled, true);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _cfg.UnsubValueChanged(CCVars.AutosaveEnabled, SetAutosaveEnabled);
+    }
+
+    private void SetAutosaveEnabled(bool b)
+    {
+        if (!b)
+            _currentlyAutosaving.Clear();
+        _autosaveEnabled = b;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_autosaveEnabled)
+            return;
+
+        foreach (var (map, time) in _currentlyAutosaving.ToArray())
+        {
+            if (_timing.RealTime <= time)
+                continue;
+
+            if (!_mapManager.MapExists(map) || _mapManager.IsMapInitialized(map))
+            {
+                _sawmill.Warning($"Can't autosave map {map}; it doesn't exist, or is initialized. Removing from autosave.");
+                _currentlyAutosaving.Remove(map);
+                return;
+            }
+
+            var autosavesDir = _cfg.GetCVar(CCVars.AutosaveDirectory);
+            var dir = new ResourcePath(autosavesDir).ToRootedPath();
+            _resMan.UserData.CreateDir(dir);
+
+            var path = Path.Combine(autosavesDir, $"{DateTime.Now.ToString("yyyy-M-dd_HH.mm.ss")}-AUTO.yml");
+            _currentlyAutosaving[map] = CalculateNextTime();
+            _sawmill.Info($"Autosaving map {map} to {path}. Next save in {ReadableTimeLeft(map)} seconds.");
+            _mapLoader.SaveMap(map, path);
+        }
+    }
+
+    private TimeSpan CalculateNextTime()
+    {
+        return _timing.RealTime + TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.AutosaveInterval));
+    }
+
+    private double ReadableTimeLeft(MapId map)
+    {
+        return Math.Round(_currentlyAutosaving[map].TotalSeconds - _timing.RealTime.TotalSeconds);
+    }
+
+    #region Public API
+
+    public void ToggleAutosave(MapId map)
+    {
+        if (!_autosaveEnabled)
+            return;
+
+        if (_currentlyAutosaving.TryAdd(map, CalculateNextTime()))
+        {
+            if (!_mapManager.MapExists(map) || _mapManager.IsMapInitialized(map))
+            {
+                _sawmill.Warning("Tried to enable autosaving on non-existant or already initialized map!");
+                _currentlyAutosaving.Remove(map);
+                return;
+            }
+
+            _sawmill.Info($"Started autosaving map {map}. Next save in {ReadableTimeLeft(map)} seconds.");
+        }
+        else
+        {
+            _currentlyAutosaving.Remove(map);
+            _sawmill.Info($"Stopped autosaving on map {map}");
+        }
+    }
+
+    #endregion
+
+    #region Commands
+
+    [AdminCommand(AdminFlags.Server | AdminFlags.Mapping)]
+    private void ToggleAutosaveCommand(IConsoleShell shell, string argstr, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var intMapId))
+        {
+            shell.WriteError(Loc.GetString("cmd-mapping-failure-integer", ("arg", args[0])));
+            return;
+        }
+
+        var mapId = new MapId(intMapId);
+        ToggleAutosave(mapId);
+    }
+
+    #endregion
+}

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1092,7 +1092,7 @@ namespace Content.Shared.CCVar
             AutosaveInterval = CVarDef.Create("mapping.autosave_interval", 600f, CVar.SERVERONLY);
 
         /// <summary>
-        ///     Directory in server user data to save to.
+        ///     Directory in server user data to save to. Saves will be inside folders in this directory.
         /// </summary>
         public static readonly CVarDef<string>
             AutosaveDirectory = CVarDef.Create("mapping.autosave_dir", "Autosaves", CVar.SERVERONLY);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1076,6 +1076,28 @@ namespace Content.Shared.CCVar
             SalvageForced = CVarDef.Create("salvage.forced", "", CVar.SERVERONLY);
 
         /*
+         * Mapping
+         */
+
+        /// <summary>
+        ///     Will mapping mode enable autosaves when it's activated?
+        /// </summary>
+        public static readonly CVarDef<bool>
+            AutosaveEnabled = CVarDef.Create("mapping.autosave", true, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Autosave interval in seconds.
+        /// </summary>
+        public static readonly CVarDef<float>
+            AutosaveInterval = CVarDef.Create("mapping.autosave_interval", 600f, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Directory in server user data to save to.
+        /// </summary>
+        public static readonly CVarDef<string>
+            AutosaveDirectory = CVarDef.Create("mapping.autosave_dir", "Autosaves", CVar.SERVERONLY);
+
+        /*
          * Rules
          */
 

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -53,6 +53,7 @@
     - showsubfloor
     - showsubfloorforever
     - mapping
+    - toggleautosave
     - toggledecals
     - nodevis
     - nodevisfilter


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Does not clean the autosave dir at any point or keep a circular buffer. These files are like 1mb each and mappers can just delete the directory themselves, I don't want to have the game delete files that they actually want

Saves inside directories for the given filename when `mapping` is used

![image](https://user-images.githubusercontent.com/19853115/188048405-8775da36-40ea-4e2c-8f05-174353be28ac.png)

![image](https://user-images.githubusercontent.com/19853115/188048419-3af67909-3e2d-403a-b565-0ca8426d770f.png)

Fixes #4631
