### PR TITLE
Fix chem payloads not updating beaker appearance

### DIFF
--- a/Content.Server/Payload/EntitySystems/PayloadSystem.cs
+++ b/Content.Server/Payload/EntitySystems/PayloadSystem.cs
@@ -162,7 +162,7 @@ public sealed class PayloadSystem : EntitySystem
 
         solutionA.MaxVolume += solutionB.MaxVolume;
         _solutionSystem.TryAddSolution(beakerA, solutionA, solutionB);
-        solutionB.RemoveAllSolution();
+        _solutionSystem.RemoveAllSolution(beakerB, solutionB);
 
         // The grenade might be a dud. Redistribute solution:
         var tmpSol = _solutionSystem.SplitSolution(beakerA, solutionA, solutionA.CurrentVolume * solutionB.MaxVolume / solutionA.MaxVolume);


### PR DESCRIPTION
The `PayloadSystem` now always updates the appearance of the beaker in slot B of the chemical payload.
Closes #10958