### PR TITLE
Fix extra plasteel getting returned when deconstructing shuttle airlocks

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/shuttle.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/shuttle.yml
@@ -135,7 +135,7 @@
     - to: skeletonWelded
       completed:
       - !type:SpawnPrototype
-        prototype: SheetPlasteel1
+        prototype: IngotSilver1
         amount: 2
       steps:
       - tool: Prying


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Deconstructing a shuttle airlock returned plasteel instead of silver.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed shuttle airlock deconstruction returning plasteel instead of silver.
