### PR TITLE
Give filled jetpacks both O2 and N2

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -86,12 +86,13 @@
   suffix: Filled
   components:
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 42.6
     air:
       volume: 70
       temperature: 293.15
       moles:
-        - 22.6293856
+        - 11.315
+        - 11.315
 
 #Empty black
 - type: entity
@@ -115,12 +116,13 @@
   suffix: Filled
   components:
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 42.6
     air:
       volume: 70
       temperature: 293.15
       moles:
-        - 22.6293856
+        - 11.315
+        - 11.315
 
 #Empty captain
 - type: entity
@@ -146,12 +148,13 @@
   suffix: Filled
   components:
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 42.6
     air:
       volume: 70
       temperature: 293.15
       moles:
-        - 22.6293856
+        - 11.315
+        - 11.315
 
 #Empty mini
 - type: entity
@@ -176,12 +179,13 @@
   suffix: Filled
   components:
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 42.6
     air:
       temperature: 293.15
       volume: 2
       moles:
-      - 0.323460326
+      - 0.161
+      - 0.161
 
 #Empty security
 - type: entity
@@ -205,12 +209,13 @@
   suffix: Filled
   components:
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 42.6
     air:
       volume: 70
       temperature: 293.15
       moles:
-        - 22.6293856
+        - 11.315
+        - 11.315
 
 #Empty void
 - type: entity
@@ -234,9 +239,10 @@
   suffix: Filled
   components:
   - type: GasTank
-    outputPressure: 21.27825
+    outputPressure: 42.6
     air:
       volume: 70
       temperature: 293.15
       moles:
-        - 22.6293856
+        - 11.315
+        - 11.315


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Jetpacks were clearly designed to double as internals for their users. However, since we have different species that require N2 instead of O2, compromise by starting them with a 50/50 mix of O2 and N2.

To keep untrained users from gasping, set the default output pressure for filled jetpacks to 2x the unfilled default.

**Screenshots**
N/A

**Changelog**
N/A
