### PR TITLE
Start salvagers with a jetpack

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -7,8 +7,6 @@
     contents:
 # Should be moved to a suit storage unit when/if they are added.
       - id: ClothingOuterHardsuitSpatio
-      - id: YellowOxygenTankFilled
-      - id: NitrogenTankFilled
       - id: ClothingShoesBootsMag
       - id: ClothingMaskGasExplorer
 # Currently do not function as 'true' mesons, so they're useless for salvagers.
@@ -17,3 +15,4 @@
         prob: 0.8
       - id: SurvivalKnife
       - id: WeaponProtoKineticAccelerator
+      - id: JetpackBlueFilled


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
With the recent randomized salvage spawn change, it is really hard to do your job as salvage without jetpacks. Give salvagers jetpacks.

As a slight nerf, remove their extra O2 and N2 tanks, so that they'll most likely use the internals built-in to their jetpacks. This makes running out of air mid-salvage a real threat.

**Because we have multiple species, this should only be merged after #10981.**

**Screenshots**
N/A

**Changelog**
:cl: notafet
- add: Salvagers now start with jetpacks.
