### PR TITLE
Automatically TitleCase IC names

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1066,10 +1066,10 @@ namespace Content.Shared.CCVar
             CVarDef.Create("ic.punctuation", false, CVar.SERVER);
 
         /// <summary>
-        /// Makes IC character names TitleCase.
+        /// Enables automatically forcing IC name rules. Uppercases the first letter of the first and last words of the name
         /// </summary>
-        public static readonly CVarDef<bool> TitleCaseNames =
-            CVarDef.Create("ic.title_case_names", true, CVar.SERVER | CVar.REPLICATED);
+        public static readonly CVarDef<bool> ICNameCase =
+            CVarDef.Create("ic.name_case", true, CVar.SERVER | CVar.REPLICATED);
 
         /*
          * Salvage

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1065,6 +1065,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ChatPunctuation =
             CVarDef.Create("ic.punctuation", false, CVar.SERVER);
 
+        /// <summary>
+        /// Makes IC character names TitleCase.
+        /// </summary>
+        public static readonly CVarDef<bool> TitleCaseNames =
+            CVarDef.Create("ic.title_case_names", true, CVar.SERVER | CVar.REPLICATED);
+
         /*
          * Salvage
          */

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -304,9 +304,12 @@ namespace Content.Shared.Preferences
                 name = Regex.Replace(name, @"[^A-Z,a-z,0-9, -]", string.Empty);
             }
 
-            if (configManager.GetCVar(CCVars.TitleCaseNames))
+            if (configManager.GetCVar(CCVars.ICNameCase))
             {
-                name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name);
+                // This regex replaces the first character of the first and last words of the name with their uppercase version
+                name = Regex.Replace(name,
+                @"^(?<word>\w)|\b(?<word>\w)(?=\w*$)",
+                m => m.Groups["word"].Value.ToUpper());
             }
 
             if (string.IsNullOrEmpty(name))

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Content.Shared.CCVar;
 using Content.Shared.CharacterAppearance;
@@ -297,9 +298,15 @@ namespace Content.Shared.Preferences
 
             name = name.Trim();
 
-            if (IoCManager.Resolve<IConfigurationManager>().GetCVar(CCVars.RestrictedNames))
+            var configManager = IoCManager.Resolve<IConfigurationManager>();
+            if (configManager.GetCVar(CCVars.RestrictedNames))
             {
                 name = Regex.Replace(name, @"[^A-Z,a-z,0-9, -]", string.Empty);
+            }
+
+            if (configManager.GetCVar(CCVars.TitleCaseNames))
+            {
+                name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name);
             }
 
             if (string.IsNullOrEmpty(name))


### PR DESCRIPTION
## About the PR 
Its toggleable with a cvar and on by default. Could probably merge it with the `RestrictedNames` cvar but i think they serve different purposes.

**Changelog**

:cl:
- tweak: In-Character names now get proper casing automatically

