### PR TITLE
Fix: Drop plasteel when deconstructing reinforced walls

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/girders.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/girders.yml
@@ -50,3 +50,38 @@
         acts: [ "Destruction" ]
   - type: StaticPrice
     price: 0.5
+
+- type: entity
+  id: ReinforcedGirder
+  parent: Girder
+  name: reinforced girder
+  description: A large structural assembly made out of metal and plasteel; It requires a layer of plasteel before it can be considered a reinforced wall.
+  components:
+    - type: Sprite
+      sprite: Structures/Walls/solid.rsi
+      state: reinforced_wall_girder
+    - type: Construction
+      graph: Girder
+      node: reinforcedGirder
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 200
+          behaviors:
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+        - trigger:
+            !type:DamageTrigger
+            damage: 50
+          behaviors:
+            - !type:SpawnEntitiesBehavior
+              spawn:
+                SheetSteel1:
+                  min: 1
+                  max: 1
+                SheetPlasteel1:
+                  min: 1
+                  max: 1
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -219,11 +219,7 @@
               doAfter: 10
 
     - node: reinforcedGirder
-      actions:
-        - !type:SpriteChange
-          specifier:
-            sprite: /Textures/Structures/Walls/solid.rsi
-            state: reinforced_wall_girder
+      entity: ReinforcedGirder
       edges:
         - to: reinforcedWall
           completed:
@@ -240,20 +236,23 @@
           completed:
             - !type:SnapToGrid
               southRotation: true
+            - !type:SpawnPrototype
+              prototype: SheetPlasteel1
+              amount: 2
           conditions:
             - !type:EntityAnchored { }
           steps:
-            - tool: Welding
-              doAfter: 10
+            - tool: Cutting
+              doAfter: 2
 
     - node: reinforcedWall
       entity: WallReinforced
       edges:
-        - to: girder
+        - to: reinforcedGirder
           completed:
             - !type:SpawnPrototype
               prototype: SheetPlasteel1
-              amount: 4
+              amount: 2
           steps:
             - tool: Cutting
               doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -250,6 +250,10 @@
       entity: WallReinforced
       edges:
         - to: girder
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetPlasteel1
+              amount: 4
           steps:
             - tool: Cutting
               doAfter: 1
@@ -293,7 +297,7 @@
                   data: 0
             - tool: Cutting
               doAfter: 1
-              
+
     - node: wallrust
       entity: WallSolidRust
       edges:

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -17,6 +17,24 @@
     - !type:TileNotBlocked
 
 - type: construction
+  name: reinforced girder
+  id: ReinforcedGirder
+  graph: Girder
+  startNode: start
+  targetNode: reinforcedGirder
+  category: construction-category-structures
+  description: A large structural assembly made out of metal and plasteel.
+  icon:
+    sprite: /Textures/Structures/Walls/solid.rsi
+    state: reinforced_wall_girder
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: false
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
   name: wall
   id: Wall
   graph: Girder


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Carbonhell
- tweak: Deconstructing reinforced walls now leads to the creation of a reinforced girder instead of a normal one, and it drops 2 plasteel sheets.
- tweak: Deconstructing reinforced girders now only requires cutting for 2 seconds and drops 2 plasteel sheets.
