### PR TITLE
Tweak: Allows putting the seclite in a security belt

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -337,6 +337,7 @@
       tags:
         - CigPack
         - Taser
+        - SecBeltEquip
       components:
         - Stunbaton
         - FlashOnTrigger

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -59,6 +59,9 @@
   id: FlashlightSeclite
   description: A robust flashlight used by security.
   components:
+  - type: Tag
+    tags:
+      - SecBeltEquip
   - type: PowerCellSlot
     cellSlot:
       startingItem: PowerCellHigh

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -421,6 +421,9 @@
   id: Screwdriver
 
 - type: Tag
+  id: SecBeltEquip
+
+- type: Tag
   id: SecwayKeys
 
 - type: Tag


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Fixes #10995 

**Changelog**

:cl:
- tweak: The security belt can now hold seclites.

