### PR TITLE
DoAfter bar fixed y-offset

### DIFF
--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -74,7 +74,7 @@ public sealed class DoAfterOverlay : Overlay
                 float yOffset;
                 if (spriteQuery.TryGetComponent(comp.Owner, out var sprite))
                 {
-                    yOffset = sprite.Bounds.Height / 2f + 0.05f;
+                    yOffset = MathF.Pow(sprite.Bounds.Height,2) / 4f + 0.05f;
                 }
                 else
                 {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the height at which the DoAfter progress bar is shown, see #10965 and my comment there.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rolfero
- fix: The action progress bar is now shown at the correct height!

