### PR TITLE
Air alarm patches

### DIFF
--- a/Content.Server/Atmos/Monitor/Components/AtmosAlarmableComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AtmosAlarmableComponent.cs
@@ -31,7 +31,7 @@ public sealed class AtmosAlarmableComponent : Component
     [ViewVariables]
     public readonly Dictionary<string, AtmosAlarmType> NetworkAlarmStates = new();
 
-    [ViewVariables] public AtmosAlarmType LastAlarmState = AtmosAlarmType.Normal;
+    [ViewVariables] public AtmosAlarmType LastAlarmState = AtmosAlarmType.Invalid;
 
     [ViewVariables] public bool IgnoreAlarms { get; set; } = false;
 

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -178,19 +178,17 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private void OnPowerChanged(EntityUid uid, AirAlarmComponent component, PowerChangedEvent args)
     {
-        if (!args.Powered)
+        if (args.Powered)
         {
-            ForceCloseAllInterfaces(uid);
-            component.CurrentModeUpdater = null;
-            component.KnownDevices.Clear();
-            component.ScrubberData.Clear();
-            component.SensorData.Clear();
-            component.VentData.Clear();
+            return;
         }
-        else
-        {
-            SyncAllDevices(uid);
-        }
+
+        ForceCloseAllInterfaces(uid);
+        component.CurrentModeUpdater = null;
+        component.KnownDevices.Clear();
+        component.ScrubberData.Clear();
+        component.SensorData.Clear();
+        component.VentData.Clear();
     }
 
     private void OnClose(EntityUid uid, AirAlarmComponent component, BoundUIClosedEvent args)

--- a/Content.Server/Atmos/Monitor/Systems/AtmosAlarmableSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosAlarmableSystem.cs
@@ -18,6 +18,7 @@ public sealed class AtmosAlarmableSystem : EntitySystem
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly AudioSystem _audioSystem = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNet = default!;
+    [Dependency] private readonly AtmosDeviceNetworkSystem _atmosDevNetSystem = default!;
 
     /// <summary>
     ///     An alarm. Has three valid states: Normal, Warning, Danger.
@@ -41,13 +42,18 @@ public sealed class AtmosAlarmableSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<AtmosAlarmableComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<AtmosAlarmableComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<AtmosAlarmableComponent, DeviceNetworkPacketEvent>(OnPacketRecv);
         SubscribeLocalEvent<AtmosAlarmableComponent, PowerChangedEvent>(OnPowerChange);
     }
 
-    private void OnInit(EntityUid uid, AtmosAlarmableComponent component, ComponentInit args)
+    private void OnMapInit(EntityUid uid, AtmosAlarmableComponent component, MapInitEvent args)
     {
+        // Attempt to register and sync against any sensors already linked to this device.
+        // We do it here, because it avoids any boilerplate in any other systems that use alarmable.
+        _atmosDevNetSystem.Register(uid, null);
+        _atmosDevNetSystem.Sync(uid, null);
+
         TryUpdateAlert(
             uid,
             TryGetHighestAlert(uid, out var alarm) ? alarm.Value : AtmosAlarmType.Normal,

--- a/Content.Server/Atmos/Monitor/Systems/AtmosAlarmableSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosAlarmableSystem.cs
@@ -49,11 +49,6 @@ public sealed class AtmosAlarmableSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, AtmosAlarmableComponent component, MapInitEvent args)
     {
-        // Attempt to register and sync against any sensors already linked to this device.
-        // We do it here, because it avoids any boilerplate in any other systems that use alarmable.
-        _atmosDevNetSystem.Register(uid, null);
-        _atmosDevNetSystem.Sync(uid, null);
-
         TryUpdateAlert(
             uid,
             TryGetHighestAlert(uid, out var alarm) ? alarm.Value : AtmosAlarmType.Normal,
@@ -69,6 +64,10 @@ public sealed class AtmosAlarmableSystem : EntitySystem
         }
         else
         {
+            // sussy
+            _atmosDevNetSystem.Register(uid, null);
+            _atmosDevNetSystem.Sync(uid, null);
+
             TryUpdateAlert(
                 uid,
                 TryGetHighestAlert(uid, out var alarm) ? alarm.Value : AtmosAlarmType.Normal,

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -258,6 +258,11 @@ namespace Content.Server.DeviceNetwork.Systems
 
         private void SendToConnections(ReadOnlySpan<DeviceNetworkComponent> connections, DeviceNetworkPacketEvent packet)
         {
+            if (Deleted(packet.Sender))
+            {
+                return;
+            }
+
             var xform = Transform(packet.Sender);
 
             BeforePacketSentEvent beforeEv = new(packet.Sender, xform, _transformSystem.GetWorldPosition(xform));

--- a/Content.Shared/Atmos/Monitor/AtmosAlarmType.cs
+++ b/Content.Shared/Atmos/Monitor/AtmosAlarmType.cs
@@ -8,6 +8,6 @@ public enum AtmosAlarmType : sbyte
     Invalid = 0,
     Normal = 1,
     Warning = 2,
-    Danger = 3, // 1 << 1 is the exact same thing and we're not really doing **bitmasking** are we?
+    Danger = 3,
     Emagged = 4,
 }

--- a/Content.Shared/Atmos/Monitor/AtmosAlarmType.cs
+++ b/Content.Shared/Atmos/Monitor/AtmosAlarmType.cs
@@ -5,8 +5,9 @@ namespace Content.Shared.Atmos.Monitor;
 [Serializable, NetSerializable]
 public enum AtmosAlarmType : sbyte
 {
-    Normal = 0,
-    Warning = 1,
-    Danger = 2, // 1 << 1 is the exact same thing and we're not really doing **bitmasking** are we?
-    Emagged = 3,
+    Invalid = 0,
+    Normal = 1,
+    Warning = 2,
+    Danger = 3, // 1 << 1 is the exact same thing and we're not really doing **bitmasking** are we?
+    Emagged = 4,
 }

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -81,6 +81,8 @@
   - type: Construction
     graph: AirAlarm
     node: assembly
+  - type: Transform
+    anchored: true
   placement:
     mode: SnapgridCenter
     snap:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -91,6 +91,8 @@
   - type: Construction
     graph: FireAlarm
     node: assembly
+  - type: Transform
+    anchored: true
   placement:
     mode: SnapgridCenter
     snap:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Patches up atmos alarmable so that atmos alarmables attempt to register and sync against sensors upon power change, as well as update their current alarm, as well as device networks causing an exception upon packet sending if the `restartroundnow` command was used. This also fixes an issue where alarms could not be completely constructed, due to their transforms not being properly anchored. Thanks to @Partmedia for reporting some of these bugs.