### PR TITLE
Fixes secret only adding game rules, not starting them

### DIFF
--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -37,7 +37,7 @@ public sealed class SecretRuleSystem : GameRuleSystem
 
         foreach (var rule in _prototypeManager.Index<GamePresetPrototype>(preset).Rules)
         {
-            _ticker.AddGameRule(_prototypeManager.Index<GameRulePrototype>(rule));
+            _ticker.StartGameRule(_prototypeManager.Index<GameRulePrototype>(rule));
         }
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Why even have a playtest at this point

Fixes #10978
Fixes RANDOM EVENTS NOT WORKING FOR THE PAST 2 MONTHS

Test added fails on previous commits and passes with new commit.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixes nukeops being broken when run from secret.
- fix: Fixes random events being broken when run from secret. Are you serious? Not a single one of you reported this until now? It's been broken for 2 months.
