### PR TITLE
Fix alerts not showing up when attaching to a new entity.

### DIFF
--- a/Content.Client/Alerts/ClientAlertsSystem.cs
+++ b/Content.Client/Alerts/ClientAlertsSystem.cs
@@ -71,7 +71,7 @@ internal sealed class ClientAlertsSystem : AlertsSystem
 
         component.Alerts = new(componentAlerts);
 
-        if (_playerManager.LocalPlayer?.ControlledEntity != uid)
+        if (_playerManager.LocalPlayer?.ControlledEntity == uid)
             SyncAlerts?.Invoke(this, componentAlerts);
     }
 

--- a/Content.Client/Alerts/ClientAlertsSystem.cs
+++ b/Content.Client/Alerts/ClientAlertsSystem.cs
@@ -66,15 +66,13 @@ internal sealed class ClientAlertsSystem : AlertsSystem
 
     private void ClientAlertsHandleState(EntityUid uid, AlertsComponent component, ref ComponentHandleState args)
     {
-        if (_playerManager.LocalPlayer?.ControlledEntity != uid)
-            return;
-
         var componentAlerts = (args.Current as AlertsComponentState)?.Alerts;
         if (componentAlerts == null) return;
 
         component.Alerts = new(componentAlerts);
 
-        SyncAlerts?.Invoke(this, componentAlerts);
+        if (_playerManager.LocalPlayer?.ControlledEntity != uid)
+            SyncAlerts?.Invoke(this, componentAlerts);
     }
 
     private void OnPlayerAttached(EntityUid uid, AlertsComponent component, PlayerAttachedEvent args)


### PR DESCRIPTION
The server sends the first alerts state before the player gets attached, which previously resulted in the state not being applied. AFAICT this fixes the current disappearing alerts issue, unless there is also some other problem.