### PR TITLE
Fix docking adding comps to terminating entities

### DIFF
--- a/Content.Server/Shuttles/Systems/DockingSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.cs
@@ -461,13 +461,13 @@ namespace Content.Server.Shuttles.Systems
                 _doorSystem.TryClose(doorB.Owner, doorB);
             }
 
-            if (!Deleted(dock.Owner))
+            if (LifeStage(dock.Owner) < EntityLifeStage.Terminating)
             {
                 var recentlyDocked = EnsureComp<RecentlyDockedComponent>(dock.Owner);
                 recentlyDocked.LastDocked = dock.DockedWith.Value;
             }
 
-            if (!Deleted(dock.DockedWith.Value))
+            if (TryComp(dock.DockedWith.Value, out MetaDataComponent? meta) && meta.EntityLifeStage < EntityLifeStage.Terminating)
             {
                 var recentlyDocked = EnsureComp<RecentlyDockedComponent>(dock.DockedWith.Value);
                 recentlyDocked.LastDocked = dock.DockedWith.Value;


### PR DESCRIPTION
Prevents docking from adding components to terminating entities. Fixes a debug assert that sometimes causes tests to fail at random.
