### PR TITLE
Fix: ID card computer not showing privileged ID details

### DIFF
--- a/Content.Server/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Server/Access/Components/IdCardConsoleComponent.cs
@@ -151,8 +151,8 @@ namespace Content.Server.Access.Components
                     null,
                     null,
                     null,
-                    privilegedIdName,
                     string.Empty,
+                    privilegedIdName,
                     string.Empty);
             }
             else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #11000, the commit which caused this is https://github.com/space-wizards/space-station-14/commit/1b50928d5071ce257af5b4e815903e58d670245c#diff-d2b071b3b0033691b6ba447673779ed478bbcfc5dd573efb562b9ca36dbfda2bR155

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: When a privileged ID card is the only card inserted in an ID card computer, its details will now show.

