### PR TITLE
Adds a check for if a firelock is powered before auto-opening

### DIFF
--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -31,7 +31,7 @@ namespace Content.Server.Doors.Systems
 
         private void OnBeforeDoorOpened(EntityUid uid, FirelockComponent component, BeforeDoorOpenedEvent args)
         {
-            if (component.IsHoldingFire() || component.IsHoldingPressure())
+            if (!this.IsPowered(uid, EntityManager) || component.IsHoldingFire() || component.IsHoldingPressure())
                 args.Cancel();
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This was causing issues with firelocks auto-opening when connected to an atmospheric alarm receiver, and the power was shut off for the firelock and the atmospheric alarm receiver.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

