### PR TITLE
make randomHumanoidAppearance work when added at runtime

### DIFF
--- a/Content.Server/CharacterAppearance/Systems/RandomHumanoidAppearanceSystem.cs
+++ b/Content.Server/CharacterAppearance/Systems/RandomHumanoidAppearanceSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.CharacterAppearance.Components;
+using Content.Server.IdentityManagement;
 using Content.Shared.CharacterAppearance.Components;
 using Content.Shared.CharacterAppearance.Systems;
 using Content.Shared.Preferences;
@@ -8,15 +9,16 @@ namespace Content.Server.CharacterAppearance.Systems;
 public sealed class RandomHumanoidAppearanceSystem : EntitySystem
 {
     [Dependency] private readonly SharedHumanoidAppearanceSystem _humanoidAppearance = default!;
+    [Dependency] private readonly IdentitySystem _identity = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<RandomHumanoidAppearanceComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<RandomHumanoidAppearanceComponent, ComponentStartup>(OnStartup);
     }
 
-    private void OnMapInit(EntityUid uid, RandomHumanoidAppearanceComponent component, MapInitEvent args)
+    private void OnStartup(EntityUid uid, RandomHumanoidAppearanceComponent component, ComponentStartup args)
     {
         if (TryComp<HumanoidAppearanceComponent>(uid, out var appearance))
         {
@@ -29,5 +31,6 @@ public sealed class RandomHumanoidAppearanceSystem : EntitySystem
                 meta.EntityName = profile.Name;
             }
         }
+        _identity.QueueIdentityUpdate(uid);
     }
 }


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
previously, it only worked when added in prototypes.
it now works on component startup rather than on mapinit

it also now queues an identity update to avoid jank
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

no cl no fun

