### PR TITLE
fix zombie mispredicts

### DIFF
--- a/Content.Client/Zombies/ZombieSystem.cs
+++ b/Content.Client/Zombies/ZombieSystem.cs
@@ -1,0 +1,8 @@
+﻿using Content.Shared.Zombies;
+
+namespace Content.Client.Zombies;
+
+public sealed class ZombieSystem : SharedZombieSystem
+{
+
+}

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -13,12 +13,12 @@ using Content.Server.Inventory;
 using Robust.Shared.Prototypes;
 using Content.Server.Speech;
 using Content.Server.Chat.Systems;
-using Content.Shared.Movement.Systems;
 using Content.Shared.Damage;
+using Content.Shared.Zombies;
 
 namespace Content.Server.Zombies
 {
-    public sealed class ZombieSystem : EntitySystem
+    public sealed class ZombieSystem : SharedZombieSystem
     {
         [Dependency] private readonly DiseaseSystem _disease = default!;
         [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
@@ -36,7 +36,7 @@ namespace Content.Server.Zombies
             SubscribeLocalEvent<ZombieComponent, MeleeHitEvent>(OnMeleeHit);
             SubscribeLocalEvent<ZombieComponent, MobStateChangedEvent>(OnMobState);
             SubscribeLocalEvent<ActiveZombieComponent, DamageChangedEvent>(OnDamage);
-            SubscribeLocalEvent<ZombieComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshSpeed);
+
         }
 
         private void OnMobState(EntityUid uid, ZombieComponent component, MobStateChangedEvent args)
@@ -51,12 +51,6 @@ namespace Content.Server.Zombies
         {
             if (args.DamageIncreased)
                 DoGroan(uid, component);
-        }
-
-        private void OnRefreshSpeed(EntityUid uid, ZombieComponent component, RefreshMovementSpeedModifiersEvent args)
-        {
-            var mod = component.ZombieMovementSpeedDebuff;
-            args.ModifySpeed(mod, mod);
         }
 
         private float GetZombieInfectionChance(EntityUid uid, ZombieComponent component)

--- a/Content.Shared/Zombies/SharedZombieSystem.cs
+++ b/Content.Shared/Zombies/SharedZombieSystem.cs
@@ -1,0 +1,20 @@
+﻿using Content.Shared.Movement.Systems;
+
+namespace Content.Shared.Zombies;
+
+public abstract class SharedZombieSystem : EntitySystem
+{
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ZombieComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshSpeed);
+    }
+
+    private void OnRefreshSpeed(EntityUid uid, ZombieComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        var mod = component.ZombieMovementSpeedDebuff;
+        args.ModifySpeed(mod, mod);
+    }
+}

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -2,7 +2,7 @@ using Content.Shared.Roles;
 using Content.Shared.Weapons.Melee;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Server.Zombies
+namespace Content.Shared.Zombies
 {
     [RegisterComponent]
     public sealed class ZombieComponent : Component

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Roles;
 using Content.Shared.Weapons.Melee;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Zombies

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Zombies
 {
-    [RegisterComponent]
+    [RegisterComponent, NetworkedComponent]
     public sealed class ZombieComponent : Component
     {
         /// <summary>


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
moves a small part of zombie system to shared.
hopefully now they stop mispredicting out the ass and making me want to die.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Zombie move speed should no longer mispredict.

