### PR TITLE
add special job components back when cloning

### DIFF
--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -22,6 +22,7 @@ using Content.Server.Fluids.EntitySystems;
 using Content.Server.Chat.Systems;
 using Content.Server.Construction.Components;
 using Content.Server.Stack;
+using Content.Server.Jobs;
 using Robust.Server.GameObjects;
 using Robust.Server.Containers;
 using Robust.Server.Player;
@@ -233,6 +234,17 @@ namespace Content.Server.Cloning.Systems
             _euiManager.OpenEui(new AcceptCloningEui(mind, this), client);
 
             AddComp<ActiveCloningPodComponent>(uid);
+
+            // Add on special job components to the mob.
+            if (mind.CurrentJob != null)
+            {
+                foreach (var special in mind.CurrentJob.Prototype.Special)
+                {
+                    if (special.GetType() == typeof(AddComponentSpecial))
+                        special.AfterEquip(mob);
+                }
+            }
+
             return true;
         }
 

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -235,6 +235,8 @@ namespace Content.Server.Cloning.Systems
 
             AddComp<ActiveCloningPodComponent>(uid);
 
+            // TODO: Ideally, components like this should be on a mind entity so this isn't neccesary.
+            // Remove this when 'mind entities' are added.
             // Add on special job components to the mob.
             if (mind.CurrentJob != null)
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For chaplains, clowns, mimes, boxers, etc. Should save a lot of ahelps.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: Special job components like mime powers or the ability to use bibles are no longer lost on cloning.

