### PR TITLE
Add more networking options

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -54,6 +54,8 @@ namespace Content.Client.Entry
         [Dependency] private readonly IStateManager _stateManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
 
+        public const int NetBufferSizeOverride = 2;
+
         public override void Init()
         {
             var factory = IoCManager.Resolve<IComponentFactory>();
@@ -125,7 +127,7 @@ namespace Content.Client.Entry
 
 #if FULL_RELEASE
             // if FULL_RELEASE, because otherwise this breaks some integration tests.
-            IoCManager.Resolve<IConfigurationManager>().OverrideDefault(CVars.NetBufferSize, 2);
+            IoCManager.Resolve<IConfigurationManager>().OverrideDefault(CVars.NetBufferSize, NetBufferSizeOverride);
 #endif
 
             _escapeMenuOwner.Initialize();

--- a/Content.Client/EscapeMenu/UI/Tabs/NetworkTab.xaml
+++ b/Content.Client/EscapeMenu/UI/Tabs/NetworkTab.xaml
@@ -2,19 +2,61 @@
          xmlns:hudUi="clr-namespace:Content.Client.HUD.UI"
          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
          x:Class="Content.Client.EscapeMenu.UI.Tabs.NetworkTab">
-    <BoxContainer Orientation="Vertical">
+    <BoxContainer Orientation="Vertical" >
         <BoxContainer Orientation="Vertical" Margin="8 8 8 8" VerticalExpand="True">
-            <BoxContainer Orientation="Horizontal" Margin="5 0 0 0">
+            <BoxContainer Orientation="Horizontal" Margin="4 10 4 0">
                 <Label Text="{Loc 'ui-options-net-interp-ratio'}" />
                 <Control MinSize="8 0" />
                 <Slider Name="NetInterpRatioSlider"
                             ToolTip="{Loc 'ui-options-net-interp-ratio-tooltip'}"
-                            MaxValue="6"
+                            MaxValue="8"
                             HorizontalExpand="True"
                             MinSize="80 0"
                             Rounded="True" />
                 <Control MinSize="8 0" />
                 <Label Name="NetInterpRatioLabel" MinSize="48 0" Align="Right" />
+                <Control MinSize="4 0"/>
+            </BoxContainer>
+            <BoxContainer Orientation="Horizontal" Margin="4 10 4 0">
+                <Label Text="{Loc 'ui-options-net-predict-tick-bias'}" />
+                <Control MinSize="8 0" />
+                <Slider Name="NetPredictTickBiasSlider"
+                            ToolTip="{Loc 'ui-options-net-predict-tick-bias-tooltip'}"
+                            MaxValue="6"
+                            MinValue="0"
+                            HorizontalExpand="True"
+                            MinSize="80 0"
+                            Rounded="True" />
+                <Control MinSize="8 0" />
+                <Label Name="NetPredictTickBiasLabel" MinSize="48 0" Align="Right" />
+                <Control MinSize="4 0"/>
+            </BoxContainer>
+            <BoxContainer Orientation="Horizontal" Margin="4 10 4 0">
+                <Label Text="{Loc 'ui-options-net-pvs-entry'}" />
+                <Control MinSize="8 0" />
+                <Slider Name="NetPvsEntrySlider"
+                            ToolTip="{Loc 'ui-options-net-pvs-entry-tooltip'}"
+                            MaxValue="150"
+                            MinValue="20"
+                            HorizontalExpand="True"
+                            MinSize="80 0"
+                            Rounded="True" />
+                <Control MinSize="8 0" />
+                <Label Name="NetPvsEntryLabel" MinSize="48 0" Align="Right" />
+                <Control MinSize="4 0"/>
+            </BoxContainer>
+            <BoxContainer Orientation="Horizontal" Margin="4 10 4 10">
+                <Label Text="{Loc 'ui-options-net-pvs-leave'}" />
+                <Control MinSize="8 0" />
+                <Slider Name="NetPvsLeaveSlider"
+                            ToolTip="{Loc 'ui-options-net-pvs-leave-tooltip'}"
+                            MaxValue="300"
+                            MinValue="20"
+                            HorizontalExpand="True"
+                            MinSize="80 0"
+                            Rounded="True" />
+                <Control MinSize="8 0" />
+                <Label Name="NetPvsLeaveLabel" MinSize="48 0" Align="Right" />
                 <Control MinSize="4 0"/>
             </BoxContainer>
         </BoxContainer>
@@ -27,6 +69,10 @@
                         Text="{Loc 'ui-options-reset-all'}"
                         StyleClasses="Caution"
                         HorizontalExpand="True"
+                        HorizontalAlignment="Right" />
+                <Button Name="DefaultButton"
+                        Text="{Loc 'ui-options-default'}"
+                        TextAlign="Center"
                         HorizontalAlignment="Right" />
                 <Control MinSize="2 0" />
                 <Button Name="ApplyButton"

--- a/Content.Client/EscapeMenu/UI/Tabs/NetworkTab.xaml.cs
+++ b/Content.Client/EscapeMenu/UI/Tabs/NetworkTab.xaml.cs
@@ -5,6 +5,7 @@ using Robust.Client.UserInterface.XAML;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Client.GameStates;
+using Content.Client.Entry;
 
 namespace Content.Client.EscapeMenu.UI.Tabs
 {
@@ -16,13 +17,18 @@ namespace Content.Client.EscapeMenu.UI.Tabs
 
         public NetworkTab()
         {
+
             RobustXamlLoader.Load(this);
             IoCManager.InjectDependencies(this);
 
             ApplyButton.OnPressed += OnApplyButtonPressed;
             ResetButton.OnPressed += OnResetButtonPressed;
-            NetInterpRatioSlider.OnValueChanged += OnNetInterpRatioSliderChanged;
+            DefaultButton.OnPressed += OnDefaultButtonPressed;
+            NetInterpRatioSlider.OnValueChanged += OnSliderChanged;
             NetInterpRatioSlider.MinValue = _stateMan.MinBufferSize;
+            NetPredictTickBiasSlider.OnValueChanged += OnSliderChanged;
+            NetPvsEntrySlider.OnValueChanged += OnSliderChanged;
+            NetPvsLeaveSlider.OnValueChanged += OnSliderChanged;
 
             Reset();
         }
@@ -31,11 +37,15 @@ namespace Content.Client.EscapeMenu.UI.Tabs
         {
             ApplyButton.OnPressed -= OnApplyButtonPressed;
             ResetButton.OnPressed -= OnResetButtonPressed;
-            NetInterpRatioSlider.OnValueChanged -= OnNetInterpRatioSliderChanged;
+            DefaultButton.OnPressed -= OnDefaultButtonPressed;
+            NetInterpRatioSlider.OnValueChanged -= OnSliderChanged;
+            NetPredictTickBiasSlider.OnValueChanged -= OnSliderChanged;
+            NetPvsEntrySlider.OnValueChanged -= OnSliderChanged;
+            NetPvsLeaveSlider.OnValueChanged -= OnSliderChanged;
             base.Dispose(disposing);
         }
 
-        private void OnNetInterpRatioSliderChanged(Robust.Client.UserInterface.Controls.Range range)
+        private void OnSliderChanged(Robust.Client.UserInterface.Controls.Range range)
         {
             UpdateChanges();
         }
@@ -43,6 +53,10 @@ namespace Content.Client.EscapeMenu.UI.Tabs
         private void OnApplyButtonPressed(BaseButton.ButtonEventArgs args)
         {
             _cfg.SetCVar(CVars.NetBufferSize, (int) NetInterpRatioSlider.Value - _stateMan.MinBufferSize);
+            _cfg.SetCVar(CVars.NetPredictTickBias, (int) NetPredictTickBiasSlider.Value);
+            _cfg.SetCVar(CVars.NetPVSEntityBudget, (int) NetPvsEntrySlider.Value);
+            _cfg.SetCVar(CVars.NetPVSEntityExitBudget, (int) NetPvsLeaveSlider.Value);
+
             _cfg.SaveToFile();
             UpdateChanges();
         }
@@ -52,18 +66,41 @@ namespace Content.Client.EscapeMenu.UI.Tabs
             Reset();
         }
 
+        private void OnDefaultButtonPressed(BaseButton.ButtonEventArgs obj)
+        {
+            NetPredictTickBiasSlider.Value = CVars.NetPredictTickBias.DefaultValue;
+            NetPvsEntrySlider.Value = CVars.NetPVSEntityBudget.DefaultValue;
+            NetPvsLeaveSlider.Value = CVars.NetPVSEntityExitBudget.DefaultValue;
+
+            // Apparently default value doesn't get updated when using override defaults, so using a const
+            NetInterpRatioSlider.Value = EntryPoint.NetBufferSizeOverride + _stateMan.MinBufferSize;
+
+            UpdateChanges();
+        }
+
         private void Reset()
         {
             NetInterpRatioSlider.Value = _cfg.GetCVar(CVars.NetBufferSize) + _stateMan.MinBufferSize;
+            NetPredictTickBiasSlider.Value = _cfg.GetCVar(CVars.NetPredictTickBias);
+            NetPvsEntrySlider.Value = _cfg.GetCVar(CVars.NetPVSEntityBudget);
+            NetPvsLeaveSlider.Value = _cfg.GetCVar(CVars.NetPVSEntityExitBudget);
             UpdateChanges();
         }
 
         private void UpdateChanges()
         {
-            var isEverythingSame = NetInterpRatioSlider.Value == _cfg.GetCVar(CVars.NetBufferSize) + _stateMan.MinBufferSize;
+            var isEverythingSame =
+                NetInterpRatioSlider.Value == _cfg.GetCVar(CVars.NetBufferSize) + _stateMan.MinBufferSize &&
+                NetPredictTickBiasSlider.Value == _cfg.GetCVar(CVars.NetPredictTickBias) &&
+                NetPvsEntrySlider.Value == _cfg.GetCVar(CVars.NetPVSEntityBudget) &&
+                NetPvsLeaveSlider.Value == _cfg.GetCVar(CVars.NetPVSEntityExitBudget);
+
             ApplyButton.Disabled = isEverythingSame;
             ResetButton.Disabled = isEverythingSame;
             NetInterpRatioLabel.Text = NetInterpRatioSlider.Value.ToString();
+            NetPredictTickBiasLabel.Text = NetPredictTickBiasSlider.Value.ToString();
+            NetPvsEntryLabel.Text = NetPvsEntrySlider.Value.ToString();
+            NetPvsLeaveLabel.Text = NetPvsLeaveSlider.Value.ToString();
         }
     }
 }

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -8,6 +8,7 @@ ui-options-tab-network = Network
 
 ui-options-apply = Apply
 ui-options-reset-all = Reset All
+ui-options-default = Default
 
 ## Audio menu
 
@@ -175,7 +176,24 @@ ui-options-function-shuttle-brake = Brake
 ## Network menu
 
 ui-options-net-interp-ratio = State buffer size
-ui-options-net-interp-ratio-tooltip = Increasing this will generally make the game
-                                      more resistant to packet-loss, however in doing
-                                      so it effectively adds slightly more latency and
-                                      requires the client to predict more future ticks.
+ui-options-net-interp-ratio-tooltip = Increasing this will generally make the game more resistant 
+                                      to server->client packet-loss, however in doing so it 
+                                      effectively adds slightly more latency and requires the 
+                                      client to predict more future ticks.
+
+ui-options-net-predict-tick-bias = Prediction tick bias
+ui-options-net-predict-tick-bias-tooltip = Increasing this will generally make the game more resistant 
+                                           to client->server packet-loss, however in doing so it 
+                                           effectively adds slightly more latency and requires the 
+                                           client to predict more future ticks.
+
+ui-options-net-pvs-entry = PVS entity budget
+ui-options-net-pvs-entry-tooltip = This limits the rate at which the server will send new 
+                                       entities to the client. Lowering this can help reduce 
+                                       stuttering due to entity spawning, but can lead to pop-in.
+
+ui-options-net-pvs-leave = PVS detach rate
+ui-options-net-pvs-leave-tooltip = This limits the rate at which the client will remove 
+                                       out-of-view entities. Lowering this can help reduce 
+                                       stuttering when walking around, but could occasionally 
+                                       lead to mispredicts and other issues.


### PR DESCRIPTION
This just takes existing cvars and makes them accessible via the options window:

![ui](https://user-images.githubusercontent.com/60421075/188500566-bfcb640b-3b12-46a9-9602-573685630233.png)

The sliders have tooltips, but it would probably be nice if there was a clearer visual indicator that the option has a description.
But that should probably be somewhat standardized for options, so a problem for a future time.

:cl:
- add: Added some more networking options to the options window.

