### PR TITLE
remove stripping doafter

### DIFF
--- a/Content.Server/Strip/StrippableComponent.cs
+++ b/Content.Server/Strip/StrippableComponent.cs
@@ -10,20 +10,11 @@ namespace Content.Server.Strip
     public sealed class StrippableComponent : SharedStrippableComponent
     {
         /// <summary>
-        /// How long it takes to open the strip menu.
-        /// This should be relatively short so it's not a hassle
-        /// but so it also doesn't open immediately during melee combat
-        /// </summary>
-        [ViewVariables]
-        [DataField("openDelay")]
-        public float OpenDelay = 1f;
-
-        /// <summary>
         /// The strip delay for hands.
         /// </summary>
         [ViewVariables]
         [DataField("handDelay")]
-        public float HandStripDelay = 3f;
+        public float HandStripDelay = 4f;
 
         public override bool Drop(DragDropEvent args)
         {

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -21,7 +21,7 @@ public sealed class SlotDefinition
 
     [DataField("slotFlags")] public SlotFlags SlotFlags { get; } = SlotFlags.PREVENTEQUIP;
 
-    [DataField("stripTime")] public float StripTime { get; } = 3f;
+    [DataField("stripTime")] public float StripTime { get; } = 4f;
 
     [DataField("uiContainer")] public SlotUIContainer UIContainer { get; } = SlotUIContainer.None;
 

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -4,21 +4,21 @@
     - name: shoes
       slotTexture: shoes
       slotFlags: FEET
-      stripTime: 2
+      stripTime: 3
       uiContainer: Top
       uiWindowPos: 1,3
       displayName: Shoes
     - name: jumpsuit
       slotTexture: uniform
       slotFlags: INNERCLOTHING
-      stripTime: 5
+      stripTime: 6
       uiContainer: Top
       uiWindowPos: 0,2
       displayName: Jumpsuit
     - name: outerClothing
       slotTexture: suit
       slotFlags: OUTERCLOTHING
-      stripTime: 5
+      stripTime: 6
       uiContainer: Top
       uiWindowPos: 1,2
       displayName: Suit
@@ -43,14 +43,14 @@
     - name: eyes
       slotTexture: glasses
       slotFlags: EYES
-      stripTime: 2
+      stripTime: 3
       uiContainer: Top
       uiWindowPos: 0,0
       displayName: Eyes
     - name: ears
       slotTexture: ears
       slotFlags: EARS
-      stripTime: 2
+      stripTime: 3
       uiContainer: Top
       uiWindowPos: 2,0
       displayName: Ears
@@ -63,7 +63,7 @@
     - name: pocket1
       slotTexture: pocket
       slotFlags: POCKET
-      stripTime: 2
+      stripTime: 3
       uiContainer: BottomRight
       uiWindowPos: 0,3
       dependsOn: jumpsuit
@@ -72,7 +72,7 @@
     - name: pocket2
       slotTexture: pocket
       slotFlags: POCKET
-      stripTime: 2
+      stripTime: 3
       uiContainer: BottomRight
       uiWindowPos: 2,3
       dependsOn: jumpsuit
@@ -81,7 +81,7 @@
     - name: suitstorage
       slotTexture: suit_storage
       slotFlags:   SUITSTORAGE
-      stripTime: 2
+      stripTime: 3
       uiContainer: BottomLeft
       uiWindowPos: 2,0
       dependsOn: outerClothing
@@ -89,7 +89,7 @@
     - name: id
       slotTexture: id
       slotFlags: IDCARD
-      stripTime: 5
+      stripTime: 6
       uiContainer: BottomRight
       uiWindowPos: 2,1
       dependsOn: jumpsuit
@@ -97,14 +97,14 @@
     - name: belt
       slotTexture: belt
       slotFlags: BELT
-      stripTime: 5
+      stripTime: 6
       uiContainer: BottomLeft
       uiWindowPos: 3,1
       displayName: Belt
     - name: back
       slotTexture: back
       slotFlags: BACK
-      stripTime: 5
+      stripTime: 6
       uiContainer: BottomLeft
       uiWindowPos: 3,0
       displayName: Back


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mostly just makes things feel laggy and the problems it was attempting to fix have been fixed via different methods.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Opening the strip UI no longer has a doafter. All item stripping times have been increased by 1 second to account for this.
