### PR TITLE
Make events less frequent.

### DIFF
--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -117,8 +117,8 @@ namespace Content.Server.StationEvents
         /// </summary>
         private void ResetTimer()
         {
-            // 5 - 15 minutes. TG does 3-10 but that's pretty frequent
-            _timeUntilNextEvent = _random.Next(300, 900);
+            // 5 - 25 minutes. TG does 3-10 but that's pretty frequent
+            _timeUntilNextEvent = _random.Next(300, 1500);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reduces event frequency a decent bit to calm things down. Bit too hectic at the minute with default settings.

**Changelog**
:cl: moony
- tweak: Made events less frequent, from 5-15min to 5-25min.