### PR TITLE
Makes it so that all wires (except the bolt wire) have to be cut on airlocks/windoors

### DIFF
--- a/Content.Server/Construction/Conditions/AllWiresCut.cs
+++ b/Content.Server/Construction/Conditions/AllWiresCut.cs
@@ -15,6 +15,8 @@ namespace Content.Server.Construction.Conditions
     {
         [DataField("value")] public bool Value { get; private set; } = true;
 
+        [DataField("ignoreTypes")] public HashSet<Type> IgnoreTypes { get; } = new();
+
         public bool Condition(EntityUid uid, IEntityManager entityManager)
         {
             if (!entityManager.TryGetComponent(uid, out WiresComponent? wires))
@@ -22,6 +24,11 @@ namespace Content.Server.Construction.Conditions
 
             foreach (var wire in wires.WiresList)
             {
+                if (IgnoreTypes.Contains(wire.Action.GetType()))
+                {
+                    continue;
+                }
+
                 switch (Value)
                 {
                     case true when !wire.IsCut:

--- a/Content.Server/Construction/Conditions/AllWiresCut.cs
+++ b/Content.Server/Construction/Conditions/AllWiresCut.cs
@@ -1,7 +1,9 @@
-﻿using Content.Server.Wires;
+﻿using System.Linq;
+using Content.Server.Wires;
 using Content.Shared.Construction;
 using Content.Shared.Examine;
 using JetBrains.Annotations;
+using Robust.Shared.Reflection;
 
 namespace Content.Server.Construction.Conditions
 {
@@ -15,16 +17,18 @@ namespace Content.Server.Construction.Conditions
     {
         [DataField("value")] public bool Value { get; private set; } = true;
 
-        [DataField("ignoreTypes")] public HashSet<Type> IgnoreTypes { get; } = new();
+        [DataField("ignoreTypes")] public HashSet<IWireAction> IgnoreTypes { get; } = new();
 
         public bool Condition(EntityUid uid, IEntityManager entityManager)
         {
             if (!entityManager.TryGetComponent(uid, out WiresComponent? wires))
                 return true;
 
+            var ignoreTypes = IgnoreTypes.Select(t => t.GetType()).ToHashSet();
+
             foreach (var wire in wires.WiresList)
             {
-                if (IgnoreTypes.Contains(wire.Action.GetType()))
+                if (ignoreTypes.Contains(wire.Action.GetType()))
                 {
                     continue;
                 }

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -90,12 +90,13 @@
       - !type:AirlockBolted
         value: false
       - !type:WirePanel {}
+      - !type:AllWiresCut {}
       completed:
       - !type:EmptyAllContainers {}
       steps:
       - tool: Prying
         doAfter: 5
-        
+
   - node: glassElectronics
     entity: AirlockAssembly
     edges:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -90,7 +90,9 @@
       - !type:AirlockBolted
         value: false
       - !type:WirePanel {}
-      - !type:AllWiresCut {}
+      - !type:AllWiresCut
+        ignoreTypes:
+          - !type:DoorBoltWireAction
       completed:
       - !type:EmptyAllContainers {}
       steps:
@@ -128,6 +130,9 @@
       - !type:AirlockBolted
         value: false
       - !type:WirePanel {}
+      - !type:AllWiresCut
+        ignoreTypes:
+          - !type:DoorBoltWireAction
       completed:
       - !type:SpawnPrototype
         prototype: SheetRGlass1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
@@ -112,6 +112,7 @@
       - !type:AirlockBolted
         value: false
       - !type:WirePanel {}
+      - !type:AllWiresCut {}
       completed:
       - !type:EmptyAllContainers {}
       steps:
@@ -212,6 +213,7 @@
       - !type:WirePanel {}
       - !type:ContainerNotEmpty # TODO ShadowCommander: Remove when map gets updated
         container: board
+      - !type:AllWiresCut {}
       completed:
       - !type:EmptyAllContainers {}
       steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
@@ -112,7 +112,9 @@
       - !type:AirlockBolted
         value: false
       - !type:WirePanel {}
-      - !type:AllWiresCut {}
+      - !type:AllWiresCut
+        ignoreTypes:
+          - !type:DoorBoltWireAction
       completed:
       - !type:EmptyAllContainers {}
       steps:
@@ -213,7 +215,9 @@
       - !type:WirePanel {}
       - !type:ContainerNotEmpty # TODO ShadowCommander: Remove when map gets updated
         container: board
-      - !type:AllWiresCut {}
+      - !type:AllWiresCut
+        ignoreTypes:
+          - !type:DoorBoltWireAction
       completed:
       - !type:EmptyAllContainers {}
       steps:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

See title. This functionality has been missing for some time, allowing players to just unscrew and crowbar a door open in order to deconstruct it.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: The wires in airlocks and windoors are now more secure, and require you to actually cut wires in order to remove the board. Try not to bolt it!

