### PR TITLE
AirAlarms fixes

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class SensorInfo : BoxContainer
             var label = new Label();
             label.Text = Loc.GetString("air-alarm-ui-gases", ("gas", $"{gas}"),
                 ("amount", $"{amount:0.####}"),
-                ("percentage", $"{(amount / data.TotalMoles):0.##}"));
+                ("percentage", $"{(100 * amount / data.TotalMoles):0.##}"));
             GasContainer.AddChild(label);
             _gasLabels.Add(gas, label);
         }
@@ -87,7 +87,7 @@ public sealed partial class SensorInfo : BoxContainer
 
             label.Text = Loc.GetString("air-alarm-ui-gases", ("gas", $"{gas}"),
                 ("amount", $"{amount:0.####}"),
-                ("percentage", $"{(amount / data.TotalMoles):0.##}"));
+                ("percentage", $"{(100 * amount / data.TotalMoles):0.##}"));
         }
 
         _pressureThreshold.UpdateThresholdData(data.PressureThreshold);

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -300,7 +300,7 @@ public sealed class AirAlarmSystem : EntitySystem
         {
             SetMode(uid, addr, AirAlarmMode.None, true, false);
         }
-        else if (args.AlarmType == AtmosAlarmType.Normal)
+        else if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)
         {
             SetMode(uid, addr, AirAlarmMode.Filtering, true, false);
         }

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -298,7 +298,7 @@ public sealed class AirAlarmSystem : EntitySystem
 
         if (args.AlarmType == AtmosAlarmType.Danger)
         {
-            SetMode(uid, addr, AirAlarmMode.None, true, false);
+            SetMode(uid, addr, AirAlarmMode.Panic, true, false);
         }
         else if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)
         {

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -91,7 +91,7 @@ namespace Content.Server.Doors.Systems
         {
             if (!TryComp<DoorComponent>(uid, out var doorComponent)) return;
 
-            if (args.AlarmType == AtmosAlarmType.Normal)
+            if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)
             {
                 if (doorComponent.State == DoorState.Closed)
                     _doorSystem.TryOpen(uid);

--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -1,8 +1,8 @@
 - type: alarmThreshold
   id: stationTemperature
-  upperBound: 1465.75 # T20C * 5
+  upperBound: 393.15 # T20C + 200
   lowerBound: 193.15 # T20C - 100
-  upperWarnAround: 0.25
+  upperWarnAround: 0.7
   lowerWarnAround: 1.1
 
 - type: alarmThreshold
@@ -14,11 +14,21 @@
 
 - type: alarmThreshold
   id: stationOxygen
-  lowerBound: 0.0010
+  lowerBound: 0.10
   lowerWarnAround: 1.5
 
 - type: alarmThreshold
   id: stationCO2
+  upperBound: 0.0025
+  upperWarnAround: 0.5
+
+- type: alarmThreshold
+  id: stationNO
+  upperBound: 0.0025
+  upperWarnAround: 0.5
+
+- type: alarmThreshold
+  id: stationMiasma
   upperBound: 0.0025
   upperWarnAround: 0.5
 

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -45,8 +45,8 @@
         Plasma: danger # everything below is usually bad
         Tritium: danger
         WaterVapor: danger
-        Miasma: danger
-        NitrousOxide: danger
+        Miasma: stationMiasma
+        NitrousOxide: stationNO
         Frezon: danger
     - type: Tag
       tags:
@@ -134,8 +134,8 @@
         Plasma: danger # everything below is usually bad
         Tritium: danger
         WaterVapor: danger
-        Miasma: danger
-        NitrousOxide: danger
+        Miasma: stationMiasma
+        NitrousOxide: stationNO
         Frezon: danger
     - type: Tag
       tags:

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -52,8 +52,8 @@
         Plasma: danger # everything below is usually bad
         Tritium: danger
         WaterVapor: danger
-        Miasma: danger
-        NitrousOxide: danger
+        Miasma: stationMiasma
+        NitrousOxide: stationNO
         Frezon: danger
     - type: Tag
       tags:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Displays the actual gas percentage in the air alarms UI, not the ratio
- Modifies the gases thresholds for miasma and nitrous oxyde so the alarms are not always on Danger state
- Makes firedoors to reopen on Warning sate
- When on Danger state, put the vents/scrubbers on Panic mode instead of None

