### PR TITLE
Air alarm balancing

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -51,7 +51,16 @@ public sealed partial class AirAlarmWindow : DefaultWindow
 
         foreach (var mode in Enum.GetValues<AirAlarmMode>())
         {
-            _modes.AddItem($"{mode}", (int) mode);
+            var text = mode switch
+            {
+                AirAlarmMode.Filtering => "air-alarm-ui-mode-filtering",
+                AirAlarmMode.WideFiltering => "air-alarm-ui-mode-wide-filtering",
+                AirAlarmMode.Fill => "air-alarm-ui-mode-fill",
+                AirAlarmMode.Panic => "air-alarm-ui-mode-panic",
+                AirAlarmMode.None => "air-alarm-ui-mode-none",
+                _ => "error"
+            };
+            _modes.AddItem(Loc.GetString(text));
         }
 
         _modes.OnItemSelected += args =>

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmModes.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmModes.cs
@@ -56,6 +56,7 @@ public interface IAirAlarmModeUpdate
 public sealed class AirAlarmModeFactory
 {
     private static IAirAlarmMode _filterMode = new AirAlarmFilterMode();
+    private static IAirAlarmMode _wideFilterMode = new AirAlarmWideFilterMode();
     private static IAirAlarmMode _fillMode = new AirAlarmFillMode();
     private static IAirAlarmMode _panicMode = new AirAlarmPanicMode();
     private static IAirAlarmMode _noneMode = new AirAlarmNoneMode();
@@ -67,6 +68,7 @@ public sealed class AirAlarmModeFactory
         return mode switch
         {
             AirAlarmMode.Filtering => _filterMode,
+            AirAlarmMode.WideFiltering => _wideFilterMode,
             AirAlarmMode.Fill => _fillMode,
             AirAlarmMode.Panic => _panicMode,
             AirAlarmMode.None => _noneMode,
@@ -129,6 +131,20 @@ public sealed class AirAlarmFilterMode : AirAlarmModeExecutor
         foreach (var (addr, device) in alarm.ScrubberData)
         {
             AirAlarmSystem.SetData(uid, addr, GasVentScrubberData.FilterModePreset);
+        }
+    }
+}
+
+public sealed class AirAlarmWideFilterMode : AirAlarmModeExecutor
+{
+    public override void Execute(EntityUid uid)
+    {
+        if (!EntityManager.TryGetComponent(uid, out AirAlarmComponent? alarm))
+            return;
+
+        foreach (var (addr, device) in alarm.ScrubberData)
+        {
+            AirAlarmSystem.SetData(uid, addr, GasVentScrubberData.WideFilterModePreset);
         }
     }
 }

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmModes.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmModes.cs
@@ -142,6 +142,11 @@ public sealed class AirAlarmWideFilterMode : AirAlarmModeExecutor
         if (!EntityManager.TryGetComponent(uid, out AirAlarmComponent? alarm))
             return;
 
+        foreach (var (addr, device) in alarm.VentData)
+        {
+            AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FilterModePreset);
+        }
+
         foreach (var (addr, device) in alarm.ScrubberData)
         {
             AirAlarmSystem.SetData(uid, addr, GasVentScrubberData.WideFilterModePreset);

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -299,7 +299,7 @@ public sealed class AirAlarmSystem : EntitySystem
 
         if (args.AlarmType == AtmosAlarmType.Danger)
         {
-            SetMode(uid, addr, AirAlarmMode.None, true, false);
+            SetMode(uid, addr, AirAlarmMode.WideFiltering, true, false);
         }
         else if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)
         {

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -299,7 +299,7 @@ public sealed class AirAlarmSystem : EntitySystem
 
         if (args.AlarmType == AtmosAlarmType.Danger)
         {
-            SetMode(uid, addr, AirAlarmMode.Panic, true, false);
+            SetMode(uid, addr, AirAlarmMode.None, true, false);
         }
         else if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)
         {

--- a/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
+++ b/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
@@ -13,6 +13,7 @@ public enum AirAlarmMode
 {
     None,
     Filtering,
+    WideFiltering,
     Fill,
     Panic,
 }

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -36,6 +36,15 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             WideNet = false
         };
 
+        public static GasVentScrubberData WideFilterModePreset = new GasVentScrubberData
+        {
+            Enabled = true,
+            FilterGases = new(GasVentScrubberData.DefaultFilterGases),
+            PumpDirection = ScrubberPumpDirection.Scrubbing,
+            VolumeRate = 200f,
+            WideNet = true
+        };
+
         public static GasVentScrubberData FillModePreset = new GasVentScrubberData
         {
             Enabled = false,

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -24,6 +24,12 @@ air-alarm-ui-window-tab-sensors = Sensors
 
 air-alarm-ui-gases = {$gas}: {$amount} mol ({$percentage}%)
 
+air-alarm-ui-mode-filtering = Filtering
+air-alarm-ui-mode-wide-filtering = Filtering (wide)
+air-alarm-ui-mode-fill = Fill
+air-alarm-ui-mode-panic = Panic
+air-alarm-ui-mode-none = None
+
 ## Widgets
 
 ### General

--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -2,7 +2,7 @@
   id: stationTemperature
   upperBound: 393.15 # T20C + 200
   lowerBound: 193.15 # T20C - 100
-  upperWarnAround: 0.7
+  upperWarnAround: 0.8
   lowerWarnAround: 1.1
 
 - type: alarmThreshold
@@ -11,6 +11,11 @@
   lowerBound: 20 # as defined in Atmospherics.cs
   upperWarnAround: 0.7
   lowerWarnAround: 2.5
+
+# a reminder that all of these are percentages (where 1 is 100%),
+# so 0.10 is 1%,
+# 0.0001 is 0.01%
+# etc.
 
 - type: alarmThreshold
   id: stationOxygen
@@ -24,12 +29,12 @@
 
 - type: alarmThreshold
   id: stationNO
-  upperBound: 0.0025
+  upperBound: 0.1
   upperWarnAround: 0.5
 
 - type: alarmThreshold
   id: stationMiasma
-  upperBound: 0.0025
+  upperBound: 0.05
   upperWarnAround: 0.5
 
 - type: alarmThreshold

--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -13,7 +13,7 @@
   lowerWarnAround: 2.5
 
 # a reminder that all of these are percentages (where 1 is 100%),
-# so 0.10 is 1%,
+# so 0.01 is 1%,
 # 0.0001 is 0.01%
 # etc.
 
@@ -29,7 +29,7 @@
 
 - type: alarmThreshold
   id: stationNO
-  upperBound: 0.1
+  upperBound: 0.01
   upperWarnAround: 0.5
 
 - type: alarmThreshold


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Balances thresholds for air alarms, and adds a new air alarm mode, Filtering (wide), which sets widenet for every scrubber linked to an air alarm. Air alarms now default to this mode when it receives a danger-type atmos alarm.