### PR TITLE
Make ghost warp use `AttachToGridOrMap()`

### DIFF
--- a/Content.Server/Warps/WarpPointComponent.cs
+++ b/Content.Server/Warps/WarpPointComponent.cs
@@ -7,5 +7,11 @@ namespace Content.Server.Warps
     public sealed class WarpPointComponent : Component
     {
         [ViewVariables(VVAccess.ReadWrite)] [DataField("location")] public string? Location { get; set; }
+
+        /// <summary>
+        ///     If true, ghosts warping to this entity will begin following it.
+        /// </summary>
+        [DataField("follow")]
+        public readonly bool Follow = false;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -13,6 +13,7 @@
     price: 2000
   - type: CargoSellBlacklist
   - type: WarpPoint
+    follow: true
     location: nuke disk
 
 - type: entity


### PR DESCRIPTION
Ensures that ghost warping uses `AttachToGridOrMap()` to avoid getting stuck being parented to other entities. Also adds an option to warp points that will cause observers to follow the entity, rather than just warp to it. 

