### PR TITLE
Fix log component parenting issues

### DIFF
--- a/Content.Server/Botany/Components/LogComponent.cs
+++ b/Content.Server/Botany/Components/LogComponent.cs
@@ -4,6 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Server.Botany.Components;
 // TODO: This should probably be merged with SliceableFood somehow or made into a more generic Choppable.
+// Yeah this is pretty trash. also consolidating this type of behavior will avoid future transform parenting bugs (see #6090).
 
 [RegisterComponent]
 [Access(typeof(LogSystem))]

--- a/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
@@ -64,12 +64,16 @@ namespace Content.Server.Nutrition.EntitySystems
             // Fill new slice
             FillSlice(sliceUid, lostSolution);
 
-            if (EntityManager.TryGetComponent(user, out HandsComponent? handsComponent))
+            var inCont = _containerSystem.IsEntityInContainer(component.Owner);
+            if (inCont)
             {
-                if (_containerSystem.IsEntityInContainer(component.Owner))
-                {
-                    _handsSystem.PickupOrDrop(user, sliceUid, handsComp: handsComponent);
-                }
+                _handsSystem.PickupOrDrop(user, sliceUid);
+            }
+            else
+            {
+                var xform = Transform(sliceUid);
+                _containerSystem.AttachParentToContainerOrGrid(xform);
+                xform.LocalRotation = 0;
             }
 
             SoundSystem.Play(component.Sound.GetSound(), Filter.Pvs(uid),
@@ -84,15 +88,26 @@ namespace Content.Server.Nutrition.EntitySystems
             }
 
             // Split last slice
-            if (component.Count == 1) {
-                var lastSlice = EntityManager.SpawnEntity(component.Slice, transform.Coordinates);
+            if (component.Count > 1)
+                return true;
 
-                // Fill last slice with the rest of the solution
-                FillSlice(lastSlice, solution);
+            sliceUid = EntityManager.SpawnEntity(component.Slice, transform.Coordinates);
 
-                EntityManager.DeleteEntity(uid);
+            // Fill last slice with the rest of the solution
+            FillSlice(sliceUid, solution);
+
+            if (inCont)
+            {
+                _handsSystem.PickupOrDrop(user, sliceUid);
+            }
+            else
+            {
+                var xform = Transform(sliceUid);
+                _containerSystem.AttachParentToContainerOrGrid(xform);
+                xform.LocalRotation = 0;
             }
 
+            EntityManager.DeleteEntity(uid);
             return true;
         }
 


### PR DESCRIPTION
Fixes #6090. There may be more instances of this bug happening, but this + the old hands ECS fixed most of them. If there are more, a newer & more specific issue should be opened

:cl:
- fix: Fixed wood planks and sliceable food sometimes getting "stuck" to a player after cutting.

