### PR TITLE
Fix AdminTestArenaSystem

### DIFF
--- a/Content.Server/Administration/Systems/AdminTestArenaSystem.cs
+++ b/Content.Server/Administration/Systems/AdminTestArenaSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Robust.Server.Maps;
 using Robust.Server.Player;
 using Robust.Shared.Map;
@@ -17,16 +17,26 @@ public sealed class AdminTestArenaSystem : EntitySystem
     public const string ArenaMapPath = "/Maps/Test/admin_test_arena.yml";
 
     public Dictionary<NetUserId, EntityUid> ArenaMap { get; private set; } = new();
-    public Dictionary<NetUserId, EntityUid> ArenaGrid { get; private set; } = new();
+    public Dictionary<NetUserId, EntityUid?> ArenaGrid { get; private set; } = new();
 
-    public (EntityUid, EntityUid) AssertArenaLoaded(IPlayerSession admin)
+    public (EntityUid Map, EntityUid? Grid) AssertArenaLoaded(IPlayerSession admin)
     {
         if (ArenaMap.TryGetValue(admin.UserId, out var arenaMap) && !Deleted(arenaMap) && !Terminating(arenaMap))
-            return (arenaMap, ArenaGrid[admin.UserId]);
+        {
+            if (ArenaGrid.TryGetValue(admin.UserId, out var arenaGrid) && !Deleted(arenaGrid) && !Terminating(arenaGrid.Value))
+            {
+                return (arenaMap, arenaGrid);
+            }
+            else
+            {
+                ArenaGrid[admin.UserId] = null;
+                return (arenaMap, null);
+            }
+        }
 
         ArenaMap[admin.UserId] = _mapManager.GetMapEntityId(_mapManager.CreateMap());
-        var (grids, _) = _mapLoader.LoadMap(Comp<MapComponent>(ArenaMap[admin.UserId]).WorldMap, ArenaMapPath);
-        ArenaGrid[admin.UserId] = grids.First();
+        var (_, grids) = _mapLoader.LoadMap(Comp<MapComponent>(ArenaMap[admin.UserId]).WorldMap, ArenaMapPath);
+        ArenaGrid[admin.UserId] = grids.Count == 0 ? null : grids[0];
 
         return (ArenaMap[admin.UserId], ArenaGrid[admin.UserId]);
     }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -1,4 +1,3 @@
-﻿
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Administration.Commands;
@@ -376,11 +375,11 @@ public sealed partial class AdminVerbSystem
                 Text = "Send to test arena",
                 Category = VerbCategory.Tricks,
                 IconTexture = "/Textures/Interface/VerbIcons/eject.svg.192dpi.png",
+
                 Act = () =>
                 {
-                    var (_, arenaGrid) = _adminTestArenaSystem.AssertArenaLoaded(player);
-
-                    Transform(args.Target).Coordinates = new EntityCoordinates(arenaGrid, Vector2.One);
+                    var (mapUid, gridUid) = _adminTestArenaSystem.AssertArenaLoaded(player);
+                    Transform(args.Target).Coordinates = new EntityCoordinates(gridUid ?? mapUid, Vector2.One);
                 },
                 Impact = LogImpact.Medium,
                 Message = Loc.GetString("admin-trick-send-to-test-arena-description"),


### PR DESCRIPTION
The admin arena was parenting players to the first entity on the map, rather than the first grid. This is usually (always?) a LV wire, which when deleted will delete the player and render the test area inaccessible. This PR fixes this so it actually uses the first grid, but also allows the area to be accessible even when the grid gets deleted.

Fixes #11032