### PR TITLE
Command to get overall playtime of offline players

### DIFF
--- a/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
+++ b/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
@@ -1,5 +1,6 @@
 ﻿parse-minutes-fail = Unable to parse '{$minutes}' as minutes
 parse-session-fail = Did not find session for '{$username}'
+parse-username-fail = Could not parse guid for '{$username}'
 
 ## Role Timer Commands
 
@@ -54,3 +55,7 @@ cmd-playtime_flush-help = Usage: {$command} [user name]
 
 cmd-playtime_flush-error-args = Expected zero or one arguments
 cmd-playtime_flush-arg-user = [user name]
+
+## playtime_getoffline
+cmd-playtime_getoffline-desc = Get overall playtime from the username of an offline player.
+cmd-playtime_getoffline-failure = Failed to get overall playtime for {$username}.

--- a/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
+++ b/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
@@ -1,6 +1,7 @@
 ﻿parse-minutes-fail = Unable to parse '{$minutes}' as minutes
 parse-session-fail = Did not find session for '{$username}'
 parse-username-fail = Could not parse guid for '{$username}'
+playtime-netuserid-not-found = Unable to find '{$username}' netuserid
 
 ## Role Timer Commands
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Very useful for whitelisting, and other stuff too I imagine. I was able to use this to process like 50 whitelist applications on Nyano real quick, so it's been tested live and locally
