### PR TITLE
Add examines for damage values

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using Content.Client.Weapons.Melee.Components;
+using Content.Shared.Examine;
 using Content.Shared.Weapons.Melee;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;

--- a/Content.Server/Weapon/Ranged/Systems/GunSystem.Battery.cs
+++ b/Content.Server/Weapon/Ranged/Systems/GunSystem.Battery.cs
@@ -1,5 +1,12 @@
 using Content.Server.Power.Components;
+using Content.Server.Projectiles.Components;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Content.Shared.Verbs;
+using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Weapon.Ranged.Systems;
 
@@ -12,11 +19,15 @@ public sealed partial class GunSystem
         // Hitscan
         SubscribeLocalEvent<HitscanBatteryAmmoProviderComponent, ComponentStartup>(OnBatteryStartup);
         SubscribeLocalEvent<HitscanBatteryAmmoProviderComponent, ChargeChangedEvent>(OnBatteryChargeChange);
+        SubscribeLocalEvent<HitscanBatteryAmmoProviderComponent, GetVerbsEvent<ExamineVerb>>(OnBatteryExaminableVerb);
 
         // Projectile
         SubscribeLocalEvent<ProjectileBatteryAmmoProviderComponent, ComponentStartup>(OnBatteryStartup);
         SubscribeLocalEvent<ProjectileBatteryAmmoProviderComponent, ChargeChangedEvent>(OnBatteryChargeChange);
+        SubscribeLocalEvent<ProjectileBatteryAmmoProviderComponent, GetVerbsEvent<ExamineVerb>>(OnBatteryExaminableVerb);
     }
+
+
 
     private void OnBatteryStartup(EntityUid uid, BatteryAmmoProviderComponent component, ComponentStartup args)
     {
@@ -47,6 +58,77 @@ public sealed partial class GunSystem
         component.Shots = shots;
         component.Capacity = maxShots;
         UpdateBatteryAppearance(component.Owner, component);
+    }
+
+    private void OnBatteryExaminableVerb(EntityUid uid, BatteryAmmoProviderComponent component, GetVerbsEvent<ExamineVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        var damageSpec = GetDamage(component);
+
+        if (damageSpec == null)
+            return;
+
+        var verb = new ExamineVerb()
+        {
+            Act = () =>
+            {
+                var markup = GetBatteryMarkup(component);
+                Examine.SendExamineTooltip(args.User, uid, markup, false, false);
+            },
+            Text = Loc.GetString("damage-examinable-verb-text"),
+            Message = Loc.GetString("damage-examinable-verb-message"),
+            Category = VerbCategory.Examine,
+            IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png"
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private DamageSpecifier? GetDamage(BatteryAmmoProviderComponent component)
+    {
+        if (component is ProjectileBatteryAmmoProviderComponent battery)
+        {
+            if (ProtoManager.Index<EntityPrototype>(battery.Prototype).Components
+                .TryGetValue(_factory.GetComponentName(typeof(ProjectileComponent)), out var projectile))
+            {
+                var p = (ProjectileComponent) projectile.Component;
+
+                if (p.Damage.Total > FixedPoint2.Zero)
+                {
+                    return p.Damage;
+                }
+            }
+
+            return null;
+        }
+
+        if (component is HitscanBatteryAmmoProviderComponent hitscan)
+        {
+            return ProtoManager.Index<HitscanPrototype>(hitscan.Prototype).Damage;
+        }
+
+        return null;
+    }
+
+    private FormattedMessage GetBatteryMarkup(BatteryAmmoProviderComponent component)
+    {
+        var damageSpec = GetDamage(component);
+
+        if (damageSpec == null)
+            return new FormattedMessage();
+
+        var msg = new FormattedMessage();
+        msg.AddMarkup(Loc.GetString("damage-examine"));
+
+        foreach (var damage in damageSpec.DamageDict)
+        {
+            msg.PushNewline();
+            msg.AddMarkup(Loc.GetString("damage-value", ("type", damage.Key), ("amount", damage.Value)));
+        }
+
+        return msg;
     }
 
     protected override void TakeCharge(EntityUid uid, BatteryAmmoProviderComponent component)

--- a/Content.Server/Weapon/Ranged/Systems/GunSystem.Cartridges.cs
+++ b/Content.Server/Weapon/Ranged/Systems/GunSystem.Cartridges.cs
@@ -10,8 +10,6 @@ namespace Content.Server.Weapon.Ranged.Systems;
 
 public sealed partial class GunSystem
 {
-
-
     protected override void InitializeCartridge()
     {
         base.InitializeCartridge();
@@ -48,7 +46,7 @@ public sealed partial class GunSystem
     private ProjectileComponent? GetProjectile(string proto)
     {
         if (ProtoManager.Index<EntityPrototype>(proto).Components
-            .TryGetValue("Projectile", out var projectile))
+            .TryGetValue(_factory.GetComponentName(typeof(ProjectileComponent)), out var projectile))
         {
             var p = (ProjectileComponent) projectile.Component;
 

--- a/Content.Server/Weapon/Ranged/Systems/GunSystem.Cartridges.cs
+++ b/Content.Server/Weapon/Ranged/Systems/GunSystem.Cartridges.cs
@@ -1,0 +1,94 @@
+using Content.Server.Projectiles.Components;
+using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
+using Content.Shared.Verbs;
+using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Weapon.Ranged.Systems;
+
+public sealed partial class GunSystem
+{
+
+
+    protected override void InitializeCartridge()
+    {
+        base.InitializeCartridge();
+        SubscribeLocalEvent<CartridgeAmmoComponent, ExaminedEvent>(OnCartridgeExamine);
+        SubscribeLocalEvent<CartridgeAmmoComponent, GetVerbsEvent<ExamineVerb>>(OnCartridgeVerbExamine);
+    }
+
+    private void OnCartridgeVerbExamine(EntityUid uid, CartridgeAmmoComponent component, GetVerbsEvent<ExamineVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        var projectile = GetProjectile(component.Prototype);
+
+        if (projectile == null)
+            return;
+
+        var verb = new ExamineVerb()
+        {
+            Act = () =>
+            {
+                var markup = GetCartridgeMarkup(component.Prototype);
+                _examine.SendExamineTooltip(args.User, uid, markup, false, false);
+            },
+            Text = Loc.GetString("damage-examinable-verb-text"),
+            Message = Loc.GetString("damage-examinable-verb-message"),
+            Category = VerbCategory.Examine,
+            IconTexture = "/Textures/Interface/VerbIcons/smite.svg.192dpi.png"
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private ProjectileComponent? GetProjectile(string proto)
+    {
+        if (ProtoManager.Index<EntityPrototype>(proto).Components
+            .TryGetValue("Projectile", out var projectile))
+        {
+            var p = (ProjectileComponent) projectile.Component;
+
+            if (p.Damage.Total > FixedPoint2.Zero)
+            {
+                return p;
+            }
+        }
+
+        return null;
+    }
+
+    private FormattedMessage GetCartridgeMarkup(string proto)
+    {
+        var projectile = GetProjectile(proto);
+
+        if (projectile == null)
+            return new FormattedMessage();
+
+        var msg = new FormattedMessage();
+        msg.AddMarkup(Loc.GetString("damage-examine"));
+
+        foreach (var damage in projectile.Damage.DamageDict)
+        {
+            msg.PushNewline();
+            msg.AddMarkup(Loc.GetString("damage-value", ("type", damage.Key), ("amount", damage.Value)));
+        }
+
+        return msg;
+    }
+
+    private void OnCartridgeExamine(EntityUid uid, CartridgeAmmoComponent component, ExaminedEvent args)
+    {
+        if (component.Spent)
+        {
+            args.PushMarkup(Loc.GetString("gun-cartridge-spent"));
+        }
+        else
+        {
+            args.PushMarkup(Loc.GetString("gun-cartridge-unspent"));
+        }
+    }
+}

--- a/Content.Server/Weapon/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapon/Ranged/Systems/GunSystem.cs
@@ -24,6 +24,7 @@ namespace Content.Server.Weapon.Ranged.Systems;
 
 public sealed partial class GunSystem : SharedGunSystem
 {
+    [Dependency] private readonly IComponentFactory _factory = default!;
     [Dependency] private readonly ExamineSystem _examine = default!;
     [Dependency] private readonly StaminaSystem _stamina = default!;
 

--- a/Content.Server/Weapon/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapon/Ranged/Systems/GunSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Damage.Systems;
+using Content.Server.Examine;
 using Content.Server.Projectiles.Components;
 using Content.Server.Weapon.Melee;
 using Content.Server.Weapon.Ranged.Components;
@@ -23,6 +24,7 @@ namespace Content.Server.Weapon.Ranged.Systems;
 
 public sealed partial class GunSystem : SharedGunSystem
 {
+    [Dependency] private readonly ExamineSystem _examine = default!;
     [Dependency] private readonly StaminaSystem _stamina = default!;
 
     public const float DamagePitchVariation = MeleeWeaponSystem.DamagePitchVariation;

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.MobState.Components;
 using Content.Shared.Radiation.Events;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Damage
 {
@@ -20,6 +21,31 @@ namespace Content.Shared.Damage
             SubscribeLocalEvent<DamageableComponent, ComponentHandleState>(DamageableHandleState);
             SubscribeLocalEvent<DamageableComponent, ComponentGetState>(DamageableGetState);
             SubscribeLocalEvent<DamageableComponent, OnIrradiatedEvent>(OnIrradiated);
+        }
+
+        /// <summary>
+        /// Retrieves the damage examine values.
+        /// </summary>
+        public FormattedMessage GetDamageExamine(DamageSpecifier damageSpecifier, string? type = null)
+        {
+            var msg = new FormattedMessage();
+
+            if (string.IsNullOrEmpty(type))
+            {
+                msg.AddMarkup(Loc.GetString("damage-examine"));
+            }
+            else
+            {
+                msg.AddMarkup(Loc.GetString("damage-examine-type", ("type", type)));
+            }
+
+            foreach (var damage in damageSpecifier.DamageDict)
+            {
+                msg.PushNewline();
+                msg.AddMarkup(Loc.GetString("damage-value", ("type", damage.Key), ("amount", damage.Value)));
+            }
+
+            return msg;
         }
 
         /// <summary>

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Battery.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Battery.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.GameStates;
@@ -49,6 +50,18 @@ public abstract partial class SharedGunSystem
     private void OnBatteryExamine(EntityUid uid, BatteryAmmoProviderComponent component, ExaminedEvent args)
     {
         args.PushMarkup(Loc.GetString("gun-battery-examine", ("color", AmmoExamineColor), ("count", component.Shots)));
+
+        if (component is HitscanBatteryAmmoProviderComponent hitscanComp &&
+            ProtoManager.TryIndex<HitscanPrototype>(hitscanComp.Prototype, out var hitscan) &&
+            hitscan.Damage?.Total > FixedPoint2.Zero)
+        {
+            args.PushMarkup(Loc.GetString("damage-examine"));
+
+            foreach (var damage in hitscan.Damage.DamageDict)
+            {
+                args.PushMarkup(Loc.GetString("damage-value", ("type", damage.Key), ("amount", damage.Value)));
+            }
+        }
     }
 
     private void OnBatteryTakeAmmo(EntityUid uid, BatteryAmmoProviderComponent component, TakeAmmoEvent args)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Battery.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Battery.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Examine;
-using Content.Shared.FixedPoint;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.GameStates;
@@ -50,18 +49,6 @@ public abstract partial class SharedGunSystem
     private void OnBatteryExamine(EntityUid uid, BatteryAmmoProviderComponent component, ExaminedEvent args)
     {
         args.PushMarkup(Loc.GetString("gun-battery-examine", ("color", AmmoExamineColor), ("count", component.Shots)));
-
-        if (component is HitscanBatteryAmmoProviderComponent hitscanComp &&
-            ProtoManager.TryIndex<HitscanPrototype>(hitscanComp.Prototype, out var hitscan) &&
-            hitscan.Damage?.Total > FixedPoint2.Zero)
-        {
-            args.PushMarkup(Loc.GetString("damage-examine"));
-
-            foreach (var damage in hitscan.Damage.DamageDict)
-            {
-                args.PushMarkup(Loc.GetString("damage-value", ("type", damage.Key), ("amount", damage.Value)));
-            }
-        }
     }
 
     private void OnBatteryTakeAmmo(EntityUid uid, BatteryAmmoProviderComponent component, TakeAmmoEvent args)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Cartridges.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Cartridges.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Weapons.Ranged.Systems;
 
 public abstract partial class SharedGunSystem
 {
-    private void InitializeCartridge()
+    protected virtual void InitializeCartridge()
     {
         SubscribeLocalEvent<CartridgeAmmoComponent, ComponentGetState>(OnCartridgeGetState);
         SubscribeLocalEvent<CartridgeAmmoComponent, ComponentHandleState>(OnCartridgeHandleState);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -42,6 +42,7 @@ public abstract partial class SharedGunSystem : EntitySystem
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
     [Dependency] private   readonly SharedCombatModeSystem _combatMode = default!;
     [Dependency] protected readonly SharedContainerSystem Containers = default!;
+    [Dependency] protected readonly ExamineSystemShared Examine = default!;
     [Dependency] protected readonly SharedPhysicsSystem Physics = default!;
     [Dependency] protected readonly SharedPopupSystem PopupSystem = default!;
     [Dependency] protected readonly ThrowingSystem ThrowingSystem = default!;

--- a/Resources/Locale/en-US/damage/damage-examine.ftl
+++ b/Resources/Locale/en-US/damage/damage-examine.ftl
@@ -1,0 +1,10 @@
+# Damage examines
+damage-examinable-verb-text = Damage
+damage-examinable-verb-message = Examine the damage values.
+
+damage-hitscan = hitscan
+damage-projectile = projectile
+damage-melee = melee
+damage-examine = It does the following damage:
+damage-examine-type = It does the following {$type} damage:
+damage-value = - [color=red]{$amount}[/color] units of [color=yellow]{$type}[/color].

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -31,11 +31,3 @@ gun-revolver-full = Revolver full
 gun-revolver-insert = Inserted
 gun-revolver-spin = Spin revolver
 gun-revolver-spun = Spun
-
-
-# Damage examines
-damage-examinable-verb-text = Damage
-damage-examinable-verb-message = Examine the damage values.
-
-damage-examine = It does the following damage:
-damage-value = - [color=red]{$amount}[/color] units of [color=yellow]{$type}[/color].

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -15,8 +15,12 @@ gun-ballistic-cycle = Cycle
 gun-ballistic-cycled = Cycled
 gun-ballistic-cycled-empty = Cycled (empty)
 
+# CartridgeAmmo
+gun-cartridge-spent = It is [color=red]spent[/color].
+gun-cartridge-unspent = It is [color=lime]not spent[/color].
+
 # BatteryAmmoProvider
-gun-battery-examine = It has enough charge for [color={$color}]{$count} shots.
+gun-battery-examine = It has enough charge for [color={$color}]{$count}[/color] shots.
 
 # MagazineAmmoProvider
 gun-magazine-examine = It has [color={$color}]{$count}[/color] shots remaining.
@@ -27,3 +31,11 @@ gun-revolver-full = Revolver full
 gun-revolver-insert = Inserted
 gun-revolver-spin = Spin revolver
 gun-revolver-spun = Spun
+
+
+# Damage examines
+damage-examinable-verb-text = Damage
+damage-examinable-verb-message = Examine the damage values.
+
+damage-examine = It does the following damage:
+damage-value = - [color=red]{$amount}[/color] units of [color=yellow]{$type}[/color].


### PR DESCRIPTION
Even immersive sims still give you values.

We should also do this for armour so people don't have to yml dive and so the general public actually know the balance of things.

Forgor to paste screeny (this is under the examinable verb so won't show up under the regular examine)
![image](https://user-images.githubusercontent.com/31366439/188858317-97b2d05c-d5ee-493a-b0c4-6d8e2e12f8aa.png)


:cl:
- add: Hitscan guns, gun cartridges, and melee weapons are now examinable for their damage values.
