### PR TITLE
External airlock assembly rotation

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -9,6 +9,7 @@
   - type: Sprite
     netsync: false
     sprite: Structures/Doors/Airlocks/Standard/shuttle.rsi
+    snapCardinals: false
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
@@ -98,6 +99,10 @@
   suffix: Docking
   description: An incomplete structure necessary for connecting two space craft together.
   components:
+  - type: Transform
+    anchored: true
+    noRot: false
+  - type: Rotatable
   - type: Sprite
     netsync: false
     sprite: Structures/Doors/Airlocks/Glass/shuttle.rsi


### PR DESCRIPTION
Regarding the bugfix, apparently external airlocks, sprite wise, would always face south even if their rotation was different due to the snapCardinals flag snapping to south. I'm not sure what's the point of this flag, I assume it's for mono directional things such as walls, girders and so on?

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: External airlocks now show the correct direction relative to their rotation.
- tweak: External airlock assemblies can now be rotated. This is particularly useful when building shuttles, for docking: you can now have docks that face in any of the four cardinal directions.

