### PR TITLE
Adds examine values to armor

### DIFF
--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -1,19 +1,79 @@
 ﻿using Content.Shared.Damage;
+using Content.Server.Examine;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Armor
 {
     public sealed class ArmorSystem : EntitySystem
     {
+
+        [Dependency] private readonly ExamineSystem _examine = default!;
+
         public override void Initialize()
         {
             base.Initialize();
 
             SubscribeLocalEvent<ArmorComponent, DamageModifyEvent>(OnDamageModify);
+            SubscribeLocalEvent<ArmorComponent, GetVerbsEvent<ExamineVerb>>(OnArmorVerbExamine);
         }
 
         private void OnDamageModify(EntityUid uid, ArmorComponent component, DamageModifyEvent args)
         {
             args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, component.Modifiers);
+        }
+
+        private void OnArmorVerbExamine(EntityUid uid, ArmorComponent component, GetVerbsEvent<ExamineVerb> args)
+        {
+            if (!args.CanInteract || !args.CanAccess)
+                return;
+
+            var armorModifiers = component.Modifiers;
+
+            if (armorModifiers == null)
+                return;
+
+            var verb = new ExamineVerb()
+            {
+                Act = () =>
+                {
+                    var markup = GetArmorExamine(armorModifiers);
+                    _examine.SendExamineTooltip(args.User, uid, markup, false, false);
+                },
+                Text = Loc.GetString("armor-examinable-verb-text"),
+                Message = Loc.GetString("armor-examinable-verb-message"),
+                Category = VerbCategory.Examine,
+                IconTexture = "/Textures/Interface/VerbIcons/dot.svg.192dpi.png"
+            };
+
+            args.Verbs.Add(verb);
+        }
+
+        private static FormattedMessage GetArmorExamine(DamageModifierSet armorModifiers)
+        {
+            var msg = new FormattedMessage();
+
+            msg.AddMarkup(Loc.GetString("armor-examine"));
+
+            foreach (var coefficientArmor in armorModifiers.Coefficients)
+            {
+                msg.PushNewline();
+                msg.AddMarkup(Loc.GetString("armor-coefficient-value",
+                    ("type", coefficientArmor.Key),
+                    ("value", MathF.Round((1f - coefficientArmor.Value) * 100,1))
+                    ));
+            }
+
+            foreach (var flatArmor in armorModifiers.FlatReduction)
+            {
+                msg.PushNewline();
+                msg.AddMarkup(Loc.GetString("armor-reduction-value",
+                    ("type", flatArmor.Key),
+                    ("value", flatArmor.Value)
+                    ));
+            }
+
+            return msg;
         }
     }
 }

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -1,0 +1,6 @@
+# Armor examines
+armor-examinable-verb-text = Armor
+armor-examinable-verb-message = Examine the armor values.
+armor-examine = It provides the following protection:
+armor-coefficient-value = - [color=yellow]{$type}[/color] damage reduced by [color=orange]{$value}%[/color].
+armor-reduction-value = - [color=yellow]{$type}[/color] damage reduced by [color=red]{$value}[/color].

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -2,5 +2,5 @@
 armor-examinable-verb-text = Armor
 armor-examinable-verb-message = Examine the armor values.
 armor-examine = It provides the following protection:
-armor-coefficient-value = - [color=yellow]{$type}[/color] damage reduced by [color=orange]{$value}%[/color].
-armor-reduction-value = - [color=yellow]{$type}[/color] damage reduced by [color=red]{$value}[/color].
+armor-coefficient-value = - [color=yellow]{$type}[/color] damage reduced by [color=lightblue]{$value}%[/color].
+armor-reduction-value = - [color=yellow]{$type}[/color] damage reduced by [color=lightblue]{$value}[/color].


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

You can now examine armors to see their armor values

(Related to #11090, #11091)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

Edit: New screenshot, new color

![lightblue-comparison](https://user-images.githubusercontent.com/45628623/189012989-2eaf089b-67d8-4d5f-b8ff-59d883c853b1.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Armors shows their armor values when examined!

