### PR TITLE
Give emergency air tanks 50/50 N2/O2 mix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -23,11 +23,12 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 21.27825
+      outputPressure: 42.6
       air:
         volume: 2
         moles:
           - 0.323460326 # oxygen
+          - 0.323460326 # nitrogen
         temperature: 293.15
 
 - type: entity
@@ -36,11 +37,12 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 21.27825
+      outputPressure: 42.6
       air:
         volume: 6
         moles:
           - 0.969830813 # oxygen
+          - 0.969830813 # nitrogen
         temperature: 293.15
 
 - type: entity
@@ -49,11 +51,12 @@
   suffix: Filled
   components:
     - type: GasTank
-      outputPressure: 21.27825
+      outputPressure: 42.6
       air:
         volume: 10
         moles:
           - 1.61721219 # oxygen
+          - 1.61721219 # nitrogen
         temperature: 293.15
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -53,16 +53,6 @@
 - type: entity
   parent: OxygenTank
   id: YellowOxygenTank
-  name: oxygen tank
-  description: A tank of oxygen. This one is in yellow.
-  components:
-  - type: Sprite
-    sprite: Objects/Tanks/yellow.rsi
-  - type: Clothing
-    sprite: Objects/Tanks/yellow.rsi
-    slots:
-    - Back
-    - suitStorage
 
 - type: entity
   parent: OxygenTank
@@ -81,8 +71,8 @@
 - type: entity
   parent: OxygenTank
   id: EmergencyOxygenTank
-  name: emergency oxygen tank
-  description: Used for emergencies. Contains very little oxygen, so try to conserve it until you actually need it.
+  name: emergency air tank
+  description: Used for emergencies. Contains very little air, so try to conserve it until you actually need it.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency.rsi
@@ -103,8 +93,8 @@
 - type: entity
   parent: EmergencyOxygenTank
   id: ExtendedEmergencyOxygenTank
-  name: extended-capacity emergency oxygen tank
-  description: Used for emergencies. Contains little oxygen, so try to conserve it until you actually need it.
+  name: extended-capacity emergency air tank
+  description: Used for emergencies. Contains little air, so try to conserve it until you actually need it.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_yellow.rsi
@@ -126,7 +116,7 @@
 - type: entity
   parent: ExtendedEmergencyOxygenTank
   id: DoubleEmergencyOxygenTank
-  name: double emergency oxygen tank
+  name: double emergency air tank
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_double.rsi


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Emergency oxygen tanks spawn in survival boxes and can sometimes be found around the station. However, some species don't breathe oxygen.

Instead of adding content bloat, rename existing emergency _oxygen_ tanks to emergency _air_ tanks, preserving the prototype ID so that no changes are needed. Add a 50/50 N2/O2 mix to filled tanks and double regulator output so that users don't gasp by default. The amount of time that an emergency tanks lasts remains the same (double the gas, but also double the consumption rate).

While here, remove custom coloring from the large yellow oxygen tank. Large tanks should be consistently colored.

**Screenshots**
N/A

**Changelog**
:cl: notafet
- tweak: Emergency gas tanks now contain both oxygen and nitrogen.

