### PR TITLE
Adds speed modifier values to examine clothing

### DIFF
--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -1,6 +1,9 @@
-﻿using Content.Shared.Movement.Systems;
+﻿using Content.Shared.Examine;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Clothing;
 
@@ -8,6 +11,7 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
 {
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
 
     public override void Initialize()
     {
@@ -16,6 +20,7 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
         SubscribeLocalEvent<ClothingSpeedModifierComponent, ComponentGetState>(OnGetState);
         SubscribeLocalEvent<ClothingSpeedModifierComponent, ComponentHandleState>(OnHandleState);
         SubscribeLocalEvent<ClothingSpeedModifierComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMoveSpeed);
+        SubscribeLocalEvent<ClothingSpeedModifierComponent, GetVerbsEvent<ExamineVerb>>(OnClothingVerbExamine);
     }
 
     // Public API
@@ -66,5 +71,64 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
             return;
 
         args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+    }
+
+    private void OnClothingVerbExamine(EntityUid uid, ClothingSpeedModifierComponent component, GetVerbsEvent<ExamineVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        var walkModifierPercentage = MathF.Round((1.0f - component.WalkModifier) * 100f, 1);
+        var sprintModifierPercentage = MathF.Round((1.0f - component.SprintModifier) * 100f, 1);
+
+        if (walkModifierPercentage == 0.0f && sprintModifierPercentage == 0.0f)
+            return;
+
+        var msg = new FormattedMessage();
+
+        if (walkModifierPercentage == sprintModifierPercentage)
+        {
+            if (walkModifierPercentage < 0.0f)
+                msg.AddMarkup(Loc.GetString("clothing-speed-increase-equal-examine", ("walkSpeed", MathF.Abs(walkModifierPercentage)), ("runSpeed", MathF.Abs(sprintModifierPercentage))));
+            else
+                msg.AddMarkup(Loc.GetString("clothing-speed-decrease-equal-examine", ("walkSpeed", walkModifierPercentage), ("runSpeed", sprintModifierPercentage)));
+        }
+        else
+        {
+            if (sprintModifierPercentage < 0.0f)
+            {
+                msg.AddMarkup(Loc.GetString("clothing-speed-increase-run-examine", ("runSpeed", MathF.Abs(sprintModifierPercentage))));
+            }
+            else if (sprintModifierPercentage > 0.0f)
+            {
+                msg.AddMarkup(Loc.GetString("clothing-speed-decrease-run-examine", ("runSpeed", sprintModifierPercentage)));
+            }
+            if (walkModifierPercentage != 0.0f && sprintModifierPercentage != 0.0f)
+            {
+                msg.PushNewline();
+            }
+            if (walkModifierPercentage < 0.0f)
+            {
+                msg.AddMarkup(Loc.GetString("clothing-speed-increase-walk-examine", ("walkSpeed", MathF.Abs(walkModifierPercentage))));
+            }
+            else if (walkModifierPercentage > 0.0f)
+            {
+                msg.AddMarkup(Loc.GetString("clothing-speed-decrease-walk-examine", ("walkSpeed", walkModifierPercentage)));
+            }
+        }
+
+        var verb = new ExamineVerb()
+        {
+            Act = () =>
+            {
+                _examine.SendExamineTooltip(args.User, uid, msg, false, false);
+            },
+            Text = Loc.GetString("clothing-speed-examinable-verb-text"),
+            Message = Loc.GetString("clothing-speed-examinable-verb-message"),
+            Category = VerbCategory.Examine,
+            IconTexture = "/Textures/Interface/VerbIcons/outfit.svg.192dpi.png"
+        };
+
+        args.Verbs.Add(verb);
     }
 }

--- a/Resources/Locale/en-US/clothing/clothing-speed.ftl
+++ b/Resources/Locale/en-US/clothing/clothing-speed.ftl
@@ -1,0 +1,9 @@
+# Clothing speed examine
+clothing-speed-examinable-verb-text = Clothing
+clothing-speed-examinable-verb-message = Examine the clothing speed values.
+clothing-speed-increase-equal-examine = This increases your speed by [color=yellow]{$walkSpeed}%[/color].
+clothing-speed-decrease-equal-examine = This decreases your speed by [color=yellow]{$walkSpeed}%[/color].
+clothing-speed-increase-run-examine = This increases your running spead by [color=yellow]{$runSpeed}%[/color].
+clothing-speed-decrease-run-examine = This decreases your running spead by [color=yellow]{$runSpeed}%[/color].
+clothing-speed-increase-walk-examine = This increases your walking spead by [color=yellow]{$walkSpeed}%[/color].
+clothing-speed-decrease-walk-examine = This decreases your walking spead by [color=yellow]{$walkSpeed}%[/color].

--- a/Resources/Locale/en-US/clothing/clothing-speed.ftl
+++ b/Resources/Locale/en-US/clothing/clothing-speed.ftl
@@ -3,7 +3,7 @@ clothing-speed-examinable-verb-text = Clothing
 clothing-speed-examinable-verb-message = Examine the clothing speed values.
 clothing-speed-increase-equal-examine = This increases your speed by [color=yellow]{$walkSpeed}%[/color].
 clothing-speed-decrease-equal-examine = This decreases your speed by [color=yellow]{$walkSpeed}%[/color].
-clothing-speed-increase-run-examine = This increases your running spead by [color=yellow]{$runSpeed}%[/color].
-clothing-speed-decrease-run-examine = This decreases your running spead by [color=yellow]{$runSpeed}%[/color].
-clothing-speed-increase-walk-examine = This increases your walking spead by [color=yellow]{$walkSpeed}%[/color].
-clothing-speed-decrease-walk-examine = This decreases your walking spead by [color=yellow]{$walkSpeed}%[/color].
+clothing-speed-increase-run-examine = This increases your running speed by [color=yellow]{$runSpeed}%[/color].
+clothing-speed-decrease-run-examine = This decreases your running speed by [color=yellow]{$runSpeed}%[/color].
+clothing-speed-increase-walk-examine = This increases your walking speed by [color=yellow]{$walkSpeed}%[/color].
+clothing-speed-decrease-walk-examine = This decreases your walking speed by [color=yellow]{$walkSpeed}%[/color].


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

You can examine entities with the ClothingSpeedModifier component to get the speed modifier value

Related to #11092

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![clothing-examine](https://user-images.githubusercontent.com/45628623/189001277-9de9e43c-997c-4f75-9bb8-65de1d395b03.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: You can examine hardsuits, magboots, etc to find out how much your speed is decreased from them.

