### PR TITLE
Fix alerts clearing on PlayerDetached

### DIFF
--- a/Content.Client/Alerts/ClientAlertsSystem.cs
+++ b/Content.Client/Alerts/ClientAlertsSystem.cs
@@ -95,9 +95,6 @@ internal sealed class ClientAlertsSystem : AlertsSystem
 
     private void OnPlayerDetached(EntityUid uid, AlertsComponent component, PlayerDetachedEvent args)
     {
-        if (_playerManager.LocalPlayer?.ControlledEntity != uid)
-            return;
-
         ClearAlerts?.Invoke(this, EventArgs.Empty);
     }
 


### PR DESCRIPTION
Fixes #11068. Issue was introduced by space-wizards/RobustToolbox/pull/3181, as `ControlledEntity` is now set to null upon detaching.

> "AFAIK this doesn't cause any issues."

Welp, that was wrong.