### PR TITLE
Bound uploadfile to the relative path's extension

### DIFF
--- a/Content.Client/Administration/Commands/UploadFile.cs
+++ b/Content.Client/Administration/Commands/UploadFile.cs
@@ -30,9 +30,11 @@ public sealed class UploadFile : IConsoleCommand
             return;
         }
 
+        var path = new ResourcePath(args[0]).ToRelativePath();
+
         var dialog = IoCManager.Resolve<IFileDialogManager>();
 
-        var filters = new FileDialogFilters(new FileDialogFilters.Group("*"));
+        var filters = new FileDialogFilters(new FileDialogFilters.Group(path.Extension));
         await using var file = await dialog.OpenFile(filters);
 
         if (file == null)
@@ -54,7 +56,7 @@ public sealed class UploadFile : IConsoleCommand
         var netManager = IoCManager.Resolve<INetManager>();
         var msg = netManager.CreateNetMessage<NetworkResourceUploadMessage>();
 
-        msg.RelativePath = new ResourcePath(args[0]).ToRelativePath();
+        msg.RelativePath = path;
         msg.Data = data;
 
         netManager.ClientSendMessage(msg);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As said in title. I was having issues with file dialog filters in macOS, and I decided to just make it so that uploading files when using uploadfile is now bound to the extension that you give in the relative file path.



