### PR TITLE
Fixes air alarm mode propagation when a mode is set from an air alarm

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -416,7 +416,7 @@ public sealed class AirAlarmSystem : EntitySystem
             case AirAlarmSetMode:
                 if (!args.Data.TryGetValue(AirAlarmSetMode, out AirAlarmMode alarmMode)) break;
 
-                SetMode(uid, args.SenderAddress, alarmMode);
+                SetMode(uid, args.SenderAddress, alarmMode, uiOnly: false);
 
                 return;
         }


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

There was an issue where setting an air alarm's mode from one alarm in a set of alarms linked together wouldn't propagate the mode change to the devices linked to it. This should fix that.