### PR TITLE
Only ghosts can examine warps names

### DIFF
--- a/Content.Server/Warps/WarpPointSystem.cs
+++ b/Content.Server/Warps/WarpPointSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Ghost.Components;
 using Content.Shared.Examine;
 
 namespace Content.Server.Warps;
@@ -10,8 +11,11 @@ public sealed class WarpPointSystem : EntitySystem
         SubscribeLocalEvent<WarpPointComponent, ExaminedEvent>(OnWarpPointExamine);
     }
 
-    private static void OnWarpPointExamine(EntityUid uid, WarpPointComponent component, ExaminedEvent args)
+    private void OnWarpPointExamine(EntityUid uid, WarpPointComponent component, ExaminedEvent args)
     {
+        if (!HasComp<GhostComponent>(args.Examiner))
+            return;
+
         var loc = component.Location == null ? "<null>" : $"'{component.Location}'";
         args.PushText(Loc.GetString("warp-point-component-on-examine-success", ("location", loc)));
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10806

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Only ghosts can see warp point information while examining nuke disk.

