### PR TITLE
Add SQLitePCL provider dependency

### DIFF
--- a/Content.Server.Database/Content.Server.Database.csproj
+++ b/Content.Server.Database/Content.Server.Database.csproj
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.5" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Content.Server.Database depends on a Sqlite provider. Add this missing dependency. This is needed in case RobustToolbox decides to drop a transitive dependency (see [RobustToolbox#3240](https://github.com/space-wizards/RobustToolbox/pull/3240)).

**Screenshots**
N/A

**Changelog**
N/A