### PR TITLE
Fix item slot mispredict

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -11,6 +11,8 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Containers.ItemSlots
 {
@@ -19,6 +21,8 @@ namespace Content.Shared.Containers.ItemSlots
     /// </summary>
     public sealed class ItemSlotsSystem : EntitySystem
     {
+        [Dependency] private readonly IGameTiming _timing = default!;
+        [Dependency] private readonly INetManager _netManager = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
         [Dependency] private readonly SharedContainerSystem _containers = default!;
         [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
@@ -237,7 +241,7 @@ namespace Content.Shared.Containers.ItemSlots
 
             if (slot.Whitelist != null && !slot.Whitelist.IsValid(usedUid))
             {
-                if (popup.HasValue && !string.IsNullOrWhiteSpace(slot.WhitelistFailPopup))
+                if (_netManager.IsClient && _timing.IsFirstTimePredicted && popup.HasValue && !string.IsNullOrWhiteSpace(slot.WhitelistFailPopup))
                     _popupSystem.PopupEntity(Loc.GetString(slot.WhitelistFailPopup), uid, Filter.Entities(popup.Value));
                 return false;
             }


### PR DESCRIPTION
On master it replays it every tick so it gets spammed. The server also plays it to the client as well so you get a duplicate.

Thought I had an issue for this but I couldn't find it.

:cl:
- fix: Item slots (such as reagent dispensers) won't spam popups anymore.