### PR TITLE
Makes ahelp relay messages a little less disgusting to look at

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Server.Administration.Systems
             _config.OnValueChanged(CCVars.DiscordAHelpWebhook, OnWebhookChanged, true);
             _config.OnValueChanged(CVars.GameHostName, OnServerNameChanged, true);
             _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("AHELP");
-            _maxAdditionalChars = GenerateAHelpMessage("", "", true, true).Length + Header("").Length;
+            _maxAdditionalChars = GenerateAHelpMessage("", "", true, true).Length;
 
             SubscribeLocalEvent<RoundStartingEvent>(RoundStarting);
         }
@@ -70,8 +70,6 @@ namespace Content.Server.Administration.Systems
             _webhookUrl = obj;
         }
 
-        private string Header(string serverName) => $":desktop: **{serverName}**";
-
         private async void ProcessQueue(NetUserId channelId, Queue<string> messages)
         {
             if (!_relayMessages.TryGetValue(channelId, out var oldMessage) || messages.Sum(x => x.Length+2) + oldMessage.content.Length > MessageMax)
@@ -85,7 +83,7 @@ namespace Content.Server.Administration.Systems
                     return;
                 }
 
-                oldMessage = (string.Empty, lookup.Username, Header(_serverName));
+                oldMessage = (string.Empty, lookup.Username, "");
             }
 
             while (messages.TryDequeue(out var message))
@@ -95,7 +93,7 @@ namespace Content.Server.Administration.Systems
 
             var payload = new WebhookPayload()
             {
-                Username = $"{oldMessage.username} (round {_gameTicker.RoundId})",
+                Username = $"{oldMessage.username} on {_serverName} (round {_gameTicker.RoundId})",
                 Content = oldMessage.content
             };
 
@@ -236,8 +234,7 @@ namespace Content.Server.Administration.Systems
             var stringbuilder = new StringBuilder();
             if (noReceiver)
                 stringbuilder.Append(":sos:");
-            else
-                stringbuilder.Append(admin ? ":outbox_tray:" : ":inbox_tray:");
+            stringbuilder.Append(admin ? ":outbox_tray:" : ":inbox_tray:");
             stringbuilder.Append(" **");
             stringbuilder.Append(username);
             stringbuilder.Append(":** ");

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -70,7 +70,7 @@ namespace Content.Server.Administration.Systems
             _webhookUrl = obj;
         }
 
-        private string Header(string serverName) => $"Server: {serverName}";
+        private string Header(string serverName) => $":desktop: **{serverName}**";
 
         private async void ProcessQueue(NetUserId channelId, Queue<string> messages)
         {
@@ -95,7 +95,7 @@ namespace Content.Server.Administration.Systems
 
             var payload = new WebhookPayload()
             {
-                Username = $"R:{_gameTicker.RoundId}|N:{oldMessage.username}",
+                Username = $"{oldMessage.username} (round {_gameTicker.RoundId})",
                 Content = oldMessage.content
             };
 
@@ -236,10 +236,11 @@ namespace Content.Server.Administration.Systems
             var stringbuilder = new StringBuilder();
             if (noReceiver)
                 stringbuilder.Append(":sos:");
-            stringbuilder.Append(admin ? ":outbox_tray:" : ":inbox_tray:");
-            stringbuilder.Append(' ');
+            else
+                stringbuilder.Append(admin ? ":outbox_tray:" : ":inbox_tray:");
+            stringbuilder.Append(" **");
             stringbuilder.Append(username);
-            stringbuilder.Append(": ");
+            stringbuilder.Append(":** ");
             stringbuilder.Append(message);
             return stringbuilder.ToString();
         }


### PR DESCRIPTION
Bolds the username of the user. Server name is now included in the title of the webhook, and the title itself has been cleaned up too.

Before:

![image](https://user-images.githubusercontent.com/39844191/189465078-2c4fc4c1-9174-4330-8dfe-3ecc260e4598.png)

After:

![image](https://user-images.githubusercontent.com/39844191/189465152-5821cbbf-c7eb-4363-b0cd-80461ffeb2f2.png)
