### PR TITLE
Melee special examine

### DIFF
--- a/Content.Server/Abilities/Boxer/BoxingSystem.cs
+++ b/Content.Server/Abilities/Boxer/BoxingSystem.cs
@@ -20,7 +20,7 @@ namespace Content.Server.Abilities.Boxer
         {
             base.Initialize();
             SubscribeLocalEvent<BoxerComponent, ComponentInit>(OnInit);
-            SubscribeLocalEvent<BoxerComponent, MeleeHitEvent>(ApplyBoxerModifiers);
+            SubscribeLocalEvent<BoxerComponent, ItemMeleeDamageEvent>(GetDamageModifiers);
             SubscribeLocalEvent<BoxingGlovesComponent, StaminaMeleeHitEvent>(OnStamHit);
         }
 
@@ -29,7 +29,7 @@ namespace Content.Server.Abilities.Boxer
             if (TryComp<MeleeWeaponComponent>(uid, out var meleeComp))
                 meleeComp.Range *= boxer.RangeBonus;
         }
-        private void ApplyBoxerModifiers(EntityUid uid, BoxerComponent component, MeleeHitEvent args)
+        private void GetDamageModifiers(EntityUid uid, BoxerComponent component, ItemMeleeDamageEvent args)
         {
             if (component.UnarmedModifiers == default!)
             {

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -33,10 +33,10 @@ namespace Content.Server.Stunnable.Systems
             SubscribeLocalEvent<StunbatonComponent, UseInHandEvent>(OnUseInHand);
             SubscribeLocalEvent<StunbatonComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<StunbatonComponent, StaminaDamageOnHitAttemptEvent>(OnStaminaHitAttempt);
-            SubscribeLocalEvent<StunbatonComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<StunbatonComponent, ItemMeleeDamageEvent>(OnMeleeHit);
         }
 
-        private void OnMeleeHit(EntityUid uid, StunbatonComponent component, MeleeHitEvent args)
+        private void OnMeleeHit(EntityUid uid, StunbatonComponent component, ItemMeleeDamageEvent args)
         {
             if (!component.Activated) return;
 

--- a/Content.Server/Tools/ToolSystem.Welder.cs
+++ b/Content.Server/Tools/ToolSystem.Welder.cs
@@ -37,10 +37,10 @@ namespace Content.Server.Tools
             SubscribeLocalEvent<WelderComponent, ToolUseFinishAttemptEvent>(OnWelderToolUseFinishAttempt);
             SubscribeLocalEvent<WelderComponent, ComponentShutdown>(OnWelderShutdown);
             SubscribeLocalEvent<WelderComponent, ComponentGetState>(OnWelderGetState);
-            SubscribeLocalEvent<WelderComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<WelderComponent, ItemMeleeDamageEvent>(OnMeleeHit);
         }
 
-        private void OnMeleeHit(EntityUid uid, WelderComponent component, MeleeHitEvent args)
+        private void OnMeleeHit(EntityUid uid, WelderComponent component, ItemMeleeDamageEvent args)
         {
             if (!args.Handled && component.Lit)
                 args.BonusDamage += component.LitMeleeDamageBonus;

--- a/Content.Server/Weapon/Melee/Components/MeleeWeaponComponent.cs
+++ b/Content.Server/Weapon/Melee/Components/MeleeWeaponComponent.cs
@@ -47,6 +47,10 @@ namespace Content.Server.Weapon.Melee.Components
         [DataField("clickAttackEffect")]
         public bool ClickAttackEffect { get; set; } = true;
 
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("hidden")]
+        public bool HideFromExamine { get; set; } = false;
+
         public TimeSpan LastAttackTime;
         public TimeSpan CooldownEnd;
 

--- a/Content.Server/Weapon/Melee/EnergySword/Components/EnergySwordComponent.cs
+++ b/Content.Server/Weapon/Melee/EnergySword/Components/EnergySwordComponent.cs
@@ -16,6 +16,12 @@ namespace Content.Server.Weapon.Melee.EnergySword
         public bool IsSharp = true;
 
         /// <summary>
+        ///     Does this become hidden when deactivated
+        /// </summary>
+        [DataField("secret")]
+        public bool Secret { get; set; } = false;
+
+        /// <summary>
         ///     RGB cycle rate for hacked e-swords.
         /// </summary>
         [DataField("cycleRate")]

--- a/Content.Server/Weapon/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Server/Weapon/Melee/EnergySword/EnergySwordSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Weapon.Melee.EnergySword
             base.Initialize();
 
             SubscribeLocalEvent<EnergySwordComponent, MapInitEvent>(OnMapInit);
-            SubscribeLocalEvent<EnergySwordComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<EnergySwordComponent, ItemMeleeDamageEvent>(OnMeleeHit);
             SubscribeLocalEvent<EnergySwordComponent, UseInHandEvent>(OnUseInHand);
             SubscribeLocalEvent<EnergySwordComponent, InteractUsingEvent>(OnInteractUsing);
             SubscribeLocalEvent<EnergySwordComponent, IsHotEvent>(OnIsHotEvent);
@@ -38,7 +38,7 @@ namespace Content.Server.Weapon.Melee.EnergySword
                 comp.BladeColor = _random.Pick(comp.ColorOptions);
         }
 
-        private void OnMeleeHit(EntityUid uid, EnergySwordComponent comp, MeleeHitEvent args)
+        private void OnMeleeHit(EntityUid uid, EnergySwordComponent comp, ItemMeleeDamageEvent args)
         {
             if (!comp.Activated) return;
 
@@ -80,7 +80,11 @@ namespace Content.Server.Weapon.Melee.EnergySword
             }
 
             if(TryComp<MeleeWeaponComponent>(comp.Owner, out var weaponComp))
+            {
                 weaponComp.HitSound = comp.OnHitOff;
+                if (comp.Secret)
+                    weaponComp.HideFromExamine = true;
+            }
 
             if (comp.IsSharp)
                 RemComp<SharpComponent>(comp.Owner);
@@ -104,7 +108,11 @@ namespace Content.Server.Weapon.Melee.EnergySword
                 EnsureComp<SharpComponent>(comp.Owner);
 
             if(TryComp<MeleeWeaponComponent>(comp.Owner, out var weaponComp))
+            {
                 weaponComp.HitSound = comp.OnHitOn;
+                if (comp.Secret)
+                    weaponComp.HideFromExamine = false;
+            }
 
             SoundSystem.Play(comp.ActivateSound.GetSound(), Filter.Pvs(comp.Owner, entityManager: EntityManager), comp.Owner);
 

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -449,7 +449,7 @@ namespace Content.Server.Weapon.Melee
         public readonly DamageSpecifier BaseDamage = new();
 
         /// <summary>
-        ///     Modifier sets to apply to the hit event when it's all said and done.
+        ///     Modifier sets to apply to the damage when it's all said and done.
         ///     This should be modified by adding a new entry to the list.
         /// </summary>
         public List<DamageModifierSet> ModifiersList = new();

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -55,18 +55,18 @@ namespace Content.Server.Weapon.Melee
 
         private void OnMeleeExaminableVerb(EntityUid uid, MeleeWeaponComponent component, GetVerbsEvent<ExamineVerb> args)
         {
-            if (!args.CanInteract || !args.CanAccess)
+            if (!args.CanInteract || !args.CanAccess || component.HideFromExamine)
                 return;
 
-            var simulatedHitEvent = new MeleeHitEvent(new List<EntityUid>(), args.User, component.Damage);
-            RaiseLocalEvent(uid, simulatedHitEvent, false);
+            var getDamage = new ItemMeleeDamageEvent(component.Damage);
+            RaiseLocalEvent(uid, getDamage, false);
 
             var damageSpec = GetDamage(component);
 
             if (damageSpec == null)
                 damageSpec = new DamageSpecifier();
 
-            damageSpec += simulatedHitEvent.BonusDamage;
+            damageSpec += getDamage.BonusDamage;
 
             if (damageSpec.Total == FixedPoint2.Zero)
                 return;
@@ -133,7 +133,7 @@ namespace Content.Server.Weapon.Melee
 
             if (args.Target is {Valid: true} target)
             {
-                // Raise event before doing damage so we can cancel damage if the event is handled
+                // Raising a melee hit event which may handle combat for us
                 var hitEvent = new MeleeHitEvent(new List<EntityUid>() { target }, args.User, comp.Damage);
                 RaiseLocalEvent(owner, hitEvent, false);
 
@@ -142,9 +142,15 @@ namespace Content.Server.Weapon.Melee
                     var targets = new[] { target };
                     SendAnimation(comp.ClickArc, angle, args.User, owner, targets, comp.ClickAttackEffect, false);
 
+                    // Raising a GetMeleeDamage event which gets our damage
+                    var getDamageEvent = new ItemMeleeDamageEvent(comp.Damage);
+                    RaiseLocalEvent(owner, getDamageEvent, false);
+
                     RaiseLocalEvent(target, new AttackedEvent(args.Used, args.User, args.ClickLocation), true);
 
-                    var modifiedDamage = DamageSpecifier.ApplyModifierSets(comp.Damage + hitEvent.BonusDamage, hitEvent.ModifiersList);
+                    var modifiersList = getDamageEvent.ModifiersList;
+                    modifiersList.AddRange(hitEvent.ModifiersList);
+                    var modifiedDamage = DamageSpecifier.ApplyModifierSets(comp.Damage + hitEvent.BonusDamage + getDamageEvent.BonusDamage, modifiersList);
                     var damageResult = _damageable.TryChangeDamage(target, modifiedDamage);
 
                     if (damageResult != null && damageResult.Total > FixedPoint2.Zero)
@@ -226,15 +232,19 @@ namespace Content.Server.Weapon.Melee
                     hitEntities.Add(entity);
                 }
             }
-
-            // Raise event before doing damage so we can cancel damage if handled
+            // Raising a melee hit event which may handle combat for us
             var hitEvent = new MeleeHitEvent(hitEntities, args.User, comp.Damage);
             RaiseLocalEvent(owner, hitEvent, false);
             SendAnimation(comp.Arc, angle, args.User, owner, hitEntities);
 
             if (!hitEvent.Handled)
             {
-                var modifiedDamage = DamageSpecifier.ApplyModifierSets(comp.Damage + hitEvent.BonusDamage, hitEvent.ModifiersList);
+                var getDamageEvent = new ItemMeleeDamageEvent(comp.Damage);
+                RaiseLocalEvent(owner, getDamageEvent, false);
+
+                var modifiersList = getDamageEvent.ModifiersList;
+                modifiersList.AddRange(hitEvent.ModifiersList);
+                var modifiedDamage = DamageSpecifier.ApplyModifierSets(comp.Damage + hitEvent.BonusDamage + getDamageEvent.BonusDamage, modifiersList);
                 var appliedDamage = new DamageSpecifier();
 
                 foreach (var entity in hitEntities)
@@ -428,6 +438,33 @@ namespace Content.Server.Weapon.Melee
         public void SendLunge(Angle angle, EntityUid source)
         {
             RaiseNetworkEvent(new MeleeWeaponSystemMessages.PlayLungeAnimationMessage(angle, source), Filter.Pvs(source, 1f));
+        }
+    }
+
+    public sealed class ItemMeleeDamageEvent : HandledEntityEventArgs
+    {
+        /// <summary>
+        ///     The base amount of damage dealt by the melee hit.
+        /// </summary>
+        public readonly DamageSpecifier BaseDamage = new();
+
+        /// <summary>
+        ///     Modifier sets to apply to the hit event when it's all said and done.
+        ///     This should be modified by adding a new entry to the list.
+        /// </summary>
+        public List<DamageModifierSet> ModifiersList = new();
+
+        /// <summary>
+        ///     Damage to add to the default melee weapon damage. Applied before modifiers.
+        /// </summary>
+        /// <remarks>
+        ///     This might be required as damage modifier sets cannot add a new damage type to a DamageSpecifier.
+        /// </remarks>
+        public DamageSpecifier BonusDamage = new();
+
+        public ItemMeleeDamageEvent(DamageSpecifier baseDamage)
+        {
+            BaseDamage = baseDamage;
         }
     }
 

--- a/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapon/Melee/MeleeWeaponSystem.cs
@@ -58,9 +58,17 @@ namespace Content.Server.Weapon.Melee
             if (!args.CanInteract || !args.CanAccess)
                 return;
 
+            var simulatedHitEvent = new MeleeHitEvent(new List<EntityUid>(), args.User, component.Damage);
+            RaiseLocalEvent(uid, simulatedHitEvent, false);
+
             var damageSpec = GetDamage(component);
 
             if (damageSpec == null)
+                damageSpec = new DamageSpecifier();
+
+            damageSpec += simulatedHitEvent.BonusDamage;
+
+            if (damageSpec.Total == FixedPoint2.Zero)
                 return;
 
             var verb = new ExamineVerb()

--- a/Content.Server/Wieldable/Components/IncreaseDamageOnWieldComponent.cs
+++ b/Content.Server/Wieldable/Components/IncreaseDamageOnWieldComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Server.Wieldable.Components
     [RegisterComponent, Access(typeof(WieldableSystem))]
     public sealed class IncreaseDamageOnWieldComponent : Component
     {
-        [DataField("modifiers", required: true)]
-        public DamageModifierSet Modifiers = default!;
+        [DataField("damage", required: true)]
+        public DamageSpecifier BonusDamage = default!;
     }
 }

--- a/Content.Server/Wieldable/WieldableSystem.cs
+++ b/Content.Server/Wieldable/WieldableSystem.cs
@@ -37,7 +37,7 @@ namespace Content.Server.Wieldable
             SubscribeLocalEvent<WieldableComponent, GetVerbsEvent<InteractionVerb>>(AddToggleWieldVerb);
             SubscribeLocalEvent<WieldableComponent, DisarmAttemptEvent>(OnDisarmAttemptEvent);
 
-            SubscribeLocalEvent<IncreaseDamageOnWieldComponent, MeleeHitEvent>(OnMeleeHit);
+            SubscribeLocalEvent<IncreaseDamageOnWieldComponent, ItemMeleeDamageEvent>(OnMeleeHit);
         }
 
         private void OnDisarmAttemptEvent(EntityUid uid, WieldableComponent component, DisarmAttemptEvent args)
@@ -233,7 +233,7 @@ namespace Content.Server.Wieldable
                 AttemptUnwield(args.BlockingEntity, component, args.User);
         }
 
-        private void OnMeleeHit(EntityUid uid, IncreaseDamageOnWieldComponent component, MeleeHitEvent args)
+        private void OnMeleeHit(EntityUid uid, IncreaseDamageOnWieldComponent component, ItemMeleeDamageEvent args)
         {
             if (EntityManager.TryGetComponent<WieldableComponent>(uid, out var wield))
             {

--- a/Content.Server/Wieldable/WieldableSystem.cs
+++ b/Content.Server/Wieldable/WieldableSystem.cs
@@ -243,7 +243,7 @@ namespace Content.Server.Wieldable
             if (args.Handled)
                 return;
 
-            args.ModifiersList.Add(component.Modifiers);
+            args.BonusDamage += component.BonusDamage;
         }
     }
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -41,8 +41,11 @@ namespace Content.Shared.Damage
 
             foreach (var damage in damageSpecifier.DamageDict)
             {
-                msg.PushNewline();
-                msg.AddMarkup(Loc.GetString("damage-value", ("type", damage.Key), ("amount", damage.Value)));
+                if (damage.Value != FixedPoint2.Zero)
+                {
+                    msg.PushNewline();
+                    msg.AddMarkup(Loc.GetString("damage-value", ("type", damage.Key), ("amount", damage.Value)));
+                }
             }
 
             return msg;

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -74,10 +74,10 @@
         Slash: 8
   - type: Wieldable
   - type: IncreaseDamageOnWield #they don't call it an axe for nothing
-    modifiers:
-      flatReductions:
-        Blunt: -2
-        Slash: -6
+    damage:
+      types:
+        Blunt: 2
+        Slash: 6
 
 - type: entity
   parent: BaseHandheldInstrument

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -58,6 +58,7 @@
   description: 'A dark ink pen.'
   components:
   - type: EnergySword
+    secret: true
     litDamageBonus:
         types:
             Slash: 7.5
@@ -74,6 +75,7 @@
         shader: unshaded
         map: [ "blade" ]
   - type: MeleeWeapon
+    hidden: true
     damage:
       types:
         Blunt: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -20,11 +20,11 @@
         Structural: 5
   - type: Wieldable
   - type: IncreaseDamageOnWield
-    modifiers:
-      flatReductions:
-        Blunt: -2 # negative reductions = increases
-        Slash: -8
-        Structural: -45
+    damage:
+      types:
+        Blunt: 2
+        Slash: 8
+        Structural: 45
   - type: Item
     size: 150
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -45,9 +45,9 @@
     maxTransferAmount: 5
   - type: Wieldable
   - type: IncreaseDamageOnWield
-    modifiers:
-      flatReductions:
-        Piercing: -7
+    damage:
+      types:
+        Piercing: 7
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I noticed e-swords didnt show the correct damage upon examine when lit, and went about trying to change it. This also affects wielded weapons, and other weapons that turn on (welders, for example).

This is done by splitting the MeleeHitEvent into a MeleeHitEvent (which handles special interactions and is called whenever you actually use the item to attack) and an ItemMeleeDamageEvent (which gets the current damage from the item), and then whenever you examine a Melee weapon, the ItemMeleeDamageEvent is called on the entity, getting the damage
This also means it would catch if you somehow could improve weapons in the future with temporary buffs or upgrades as well.

This fixes #11154 and fixes #11153 as well - you can make MeleeWeaponComponents "Hidden = true", which means the examine wont show their damage.

The IncreaseDamageOnWieldComponent also is changed to add a DamageSpecifier as bonus damage, instead of a DamageModifierSet (which means they dont need a "Flat Damage Reduction of -8" to increase their damage by 8)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Melee weapons that change damage now show their damage correctly.
- fix: Syndicate E-pens is no longer shown to be a weapon upon examination.

