### PR TITLE
NoRot: true on cables

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -14,6 +14,7 @@
     netsync: false
     drawdepth: ThinWire
     visible: false
+    noRot: true
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -10,11 +10,11 @@
   - type: InteractionOutline
   - type: Transform
     anchored: true
+    noRot: true
   - type: Sprite
     netsync: false
     drawdepth: ThinWire
     visible: false
-    noRot: true
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
@@ -41,6 +41,7 @@
     lowVoltageNode: power
   - type: CableVis
     node: power
+   
 
 - type: entity
   parent: CableBase


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
basically just to help out mappers so they don't have to fucking keep spinning cables around while doing mapping and such.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

mappers around the world, rejoice.
another small annoyance fixed.
