### PR TITLE
Display gender and age when examining humanoids

### DIFF
--- a/Content.Shared/CharacterAppearance/Systems/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/CharacterAppearance/Systems/SharedHumanoidAppearanceSystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Body.Part;
+using Content.Shared.Examine;
 using Content.Shared.CharacterAppearance.Components;
 using Content.Shared.Preferences;
+using Content.Shared.IdentityManagement;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.GameStates;
@@ -14,6 +16,7 @@ namespace Content.Shared.CharacterAppearance.Systems
         {
             SubscribeLocalEvent<HumanoidAppearanceComponent, ComponentGetState>(OnAppearanceGetState);
             SubscribeLocalEvent<HumanoidAppearanceComponent, ComponentHandleState>(OnAppearanceHandleState);
+            SubscribeLocalEvent<HumanoidAppearanceComponent, ExaminedEvent>(OnExamined);
         }
 
         public void UpdateFromProfile(EntityUid uid, ICharacterProfile profile, HumanoidAppearanceComponent? appearance=null)
@@ -143,6 +146,20 @@ namespace Content.Shared.CharacterAppearance.Systems
                 Gender = gender;
                 Species = species;
             }
+        }
+
+        private void OnExamined(EntityUid uid, HumanoidAppearanceComponent component, ExaminedEvent args)
+        {
+            var identity = Identity.Entity(component.Owner, EntityManager);
+
+            var ageString = component.Age switch
+            {
+                <= 30 => Loc.GetString("identity-age-young"),
+                > 30 and <= 60 => Loc.GetString("identity-age-middle-aged"),
+                > 60 => Loc.GetString("identity-age-old")
+            };
+
+            args.PushText(Loc.GetString("humanoid-appearance-component-examine", ("user", identity), ("age", ageString), ("species", component.Species)));
         }
     }
 }

--- a/Content.Shared/CharacterAppearance/Systems/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/CharacterAppearance/Systems/SharedHumanoidAppearanceSystem.cs
@@ -14,6 +14,8 @@ namespace Content.Shared.CharacterAppearance.Systems
 {
     public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     {
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
         public override void Initialize()
         {
             SubscribeLocalEvent<HumanoidAppearanceComponent, ComponentGetState>(OnAppearanceGetState);
@@ -77,17 +79,20 @@ namespace Content.Shared.CharacterAppearance.Systems
         /// <summary>
         /// Takes ID of the species prototype, returns UI-friendly name of the species.
         /// </summary>
-        public string GetSpeciesRepresentation(string speciesId) {
-            var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-            if (prototypeManager.TryIndex<SpeciesPrototype>(speciesId, out var species)) {
+        public string GetSpeciesRepresentation(string speciesId)
+        {
+            if (_prototypeManager.TryIndex<SpeciesPrototype>(speciesId, out var species))
+            {
                 return Loc.GetString(species.Name);
             }
-            else {
-                return Loc.GetString("humanoid-appearance-component-unkown-species");
+            else
+            {
+                return Loc.GetString("humanoid-appearance-component-unknown-species");
             }
         }
 
-        public string GetAgeRepresentation(int age) {
+        public string GetAgeRepresentation(int age)
+        {
             return age switch
             {
                 <= 30 => Loc.GetString("identity-age-young"),

--- a/Resources/Locale/en-US/character-appearance/components/humanoid-appearance-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/humanoid-appearance-component.ftl
@@ -1,5 +1,2 @@
-humanoid-appearance-component-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } { INDEFINITE($age) } { $age } miserable pile of { $species ->
-     [Reptilian] scaly secrets
-     [SlimePerson] slimy secrets
-    *[Human] secrets
-    }.
+humanoid-appearance-component-unkown-species = Person
+humanoid-appearance-component-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } { INDEFINITE($age) } { $age } { $species }.

--- a/Resources/Locale/en-US/character-appearance/components/humanoid-appearance-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/humanoid-appearance-component.ftl
@@ -1,0 +1,5 @@
+humanoid-appearance-component-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } { INDEFINITE($age) } { $age } miserable pile of { $species ->
+     [Reptilian] scaly secrets
+     [SlimePerson] slimy secrets
+    *[Human] secrets
+    }.

--- a/Resources/Locale/en-US/character-appearance/components/humanoid-appearance-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/humanoid-appearance-component.ftl
@@ -1,2 +1,2 @@
-humanoid-appearance-component-unkown-species = Person
+humanoid-appearance-component-unknown-species = Person
 humanoid-appearance-component-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } { INDEFINITE($age) } { $age } { $species }.

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -3,7 +3,6 @@
   name: Urist McHands
   parent: BaseMobHuman
   id: MobHuman
-  description: A miserable pile of secrets.
   components:
   - type: CombatMode
     canDisarm: true

--- a/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
@@ -3,7 +3,6 @@
   name: Urisst' Mzhand
   parent: BaseMobReptilian
   id: MobReptilian
-  description: A miserable pile of scales.
   components:
     - type: CombatMode
       canDisarm: true

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -3,7 +3,6 @@
   save: false
   name: Urist McHands
   id: BaseMobOrganic
-  description: A miserable pile of secrets.
   noSpawn: true
   components:
   - type: RangedDamageSound

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -4,7 +4,6 @@
   parent: BaseMobOrganic
   id: BaseMobDwarf
   abstract: true
-  description: A miserable pile of secrets.
   components:
   - type: Hunger
   - type: Thirst

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -4,7 +4,6 @@
   parent: BaseMobOrganic
   id: BaseMobHuman
   abstract: true
-  description: A miserable pile of secrets.
   components:
   - type: Hunger
   - type: Thirst

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -4,7 +4,6 @@
   parent: BaseMobOrganic
   id: BaseMobReptilian
   abstract: true
-  description: A miserable pile of scales.
   components:
   - type: Hunger
   - type: Thirst

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -4,7 +4,6 @@
   parent: BaseMobOrganic
   id: BaseMobSkeletonPerson
   abstract: true
-  description: A miserable pile of bones.
   components:
   - type: Markings
   - type: Icon

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -3,7 +3,6 @@
   parent: BaseMobOrganic
   id: BaseMobSlimePerson
   abstract: true
-  description: A miserable pile of slime.
   components:
   - type: Hunger
   - type: Thirst


### PR DESCRIPTION
## About the PR
I personally struggle with telling what other player's character's genders and preferred pronouns are. Even if I could tell what their sex is, it may not correspond with the pronouns they use (especially in case of they/it); and names are very often ambiguous. There have also been requests for such feature, so I'm not alone in this.

**Screenshots**
![image](https://user-images.githubusercontent.com/80923370/189485841-159f2400-1adc-4049-a2d5-8d2a137f6668.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: och
- add: Examining people tells you their pronouns and approximate age
<!-- - remove: Removed fun! -->

