### PR TITLE
Keep windoors open if they are clicked

### DIFF
--- a/Content.Server/Doors/Components/AirlockComponent.cs
+++ b/Content.Server/Doors/Components/AirlockComponent.cs
@@ -50,6 +50,13 @@ namespace Content.Server.Doors.Components
         [DataField("openPanelVisible")]
         public bool OpenPanelVisible = false;
 
+        /// <summary>
+        /// Whether the airlock should stay open if the airlock was clicked.
+        /// If the airlock was bumped into it will still auto close.
+        /// </summary>
+        [DataField("keepOpenIfClicked")]
+        public bool KeepOpenIfClicked = false;
+
         private CancellationTokenSource _powerWiresPulsedTimerCancel = new();
         private bool _powerWiresPulsed;
 
@@ -104,6 +111,12 @@ namespace Content.Server.Doors.Components
                 UpdateBoltLightStatus();
             }
         }
+
+        /// <summary>
+        /// Whether the airlock should auto close. This value is reset every time the airlock closes.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool AutoClose = true;
 
         /// <summary>
         /// Delay until an open door automatically closes.

--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -71,6 +71,10 @@ namespace Content.Server.Doors.Systems
             component.UpdateBoltLightStatus();
 
             UpdateAutoClose(uid, component);
+
+            // Make sure the airlock auto closes again next time it is opened
+            if (args.State == DoorState.Closed)
+                component.AutoClose = true;
         }
 
         /// <summary>
@@ -82,6 +86,9 @@ namespace Content.Server.Doors.Systems
                 return;
 
             if (door.State != DoorState.Open)
+                return;
+
+            if (!airlock.AutoClose)
                 return;
 
             if (!airlock.CanChangeState())
@@ -133,6 +140,13 @@ namespace Content.Server.Doors.Systems
             {
                 _wiresSystem.OpenUserInterface(uid, actor.PlayerSession);
                 args.Handled = true;
+                return;
+            }
+
+            if (component.KeepOpenIfClicked)
+            {
+                // Disable auto close
+                component.AutoClose = false;
             }
         }
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -72,6 +72,7 @@
         acts: [ "Destruction" ]
   - type: AccessReader
   - type: Airlock
+    keepOpenIfClicked: true
     openPanelVisible: true
     # needed so that windoors will close regardless of whether there are people in it; it doesn't crush after all
     safety: false


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Windoors will now stay open if you click them. If you bump into them, they will still auto close after 5 seconds like airlocks. This makes for example HoP gameplay much nicer, as now you can just keep your windoors open while you are at your desk.

**Changelog**

:cl:
- tweak: Windoors will now stay open if you open them by clicking.