### PR TITLE
changes SpawnPrototype to GivePrototype where it makes sense

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -131,7 +131,7 @@
       edges:
         - to: girder
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 2
           steps:
@@ -143,7 +143,7 @@
       edges:
         - to: girder
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: MaterialWoodPlank1
               amount: 2
           steps:
@@ -155,7 +155,7 @@
       edges:
         - to: girder
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetUranium1
               amount: 2
           steps:
@@ -169,7 +169,7 @@
       edges:
         - to: girder
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: IngotSilver1
               amount: 2
           steps:
@@ -183,7 +183,7 @@
       edges:
         - to: girder
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 2
           steps:
@@ -195,7 +195,7 @@
       edges:
         - to: girder
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetPlasma1
               amount: 2
           steps:
@@ -209,7 +209,7 @@
       edges:
         - to: girder
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: IngotGold1
               amount: 2
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/air_alarms.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/air_alarms.yml
@@ -23,7 +23,7 @@
         doAfter: 1
     - to: start
       completed:
-      - !type:SpawnPrototype
+      - !type:GivePrototype
         prototype: SheetSteel1
         amount: 2
       - !type:DeleteEntity {}
@@ -45,7 +45,7 @@
         doAfter: 1
     - to: assembly
       completed:
-      - !type:SpawnPrototype
+      - !type:GivePrototype
         prototype: CableApcStack1
         amount: 2
       steps:
@@ -102,7 +102,7 @@
         doAfter: 1
     - to: start
       completed:
-      - !type:SpawnPrototype
+      - !type:GivePrototype
         prototype: SheetSteel1
         amount: 2
       - !type:DeleteEntity {}
@@ -124,7 +124,7 @@
         doAfter: 1
     - to: assembly
       completed:
-      - !type:SpawnPrototype
+      - !type:GivePrototype
         prototype: CableApcStack1
         amount: 2
       steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/cable_terminal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/cable_terminal.yml
@@ -15,7 +15,7 @@
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 10
             - !type:DeleteEntity

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_generator.yml
@@ -18,7 +18,7 @@
         - tool: Welding
           doAfter: 4
         completed:
-        - !type:SpawnPrototype
+        - !type:GivePrototype
           prototype: SheetSteel1
           amount: 5
       - to: parts
@@ -51,7 +51,7 @@
           doAfter: 1
       - to: frame
         completed:
-        - !type:SpawnPrototype
+        - !type:GivePrototype
           prototype: CableHVStack1
           amount: 5
         steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
@@ -18,7 +18,7 @@
         - tool: Welding
           doAfter: 4
         completed:
-        - !type:SpawnPrototype
+        - !type:GivePrototype
           prototype: SheetSteel1
           amount: 5
       - to: parts
@@ -42,7 +42,7 @@
           doAfter: 1
       - to: frame
         completed:
-        - !type:SpawnPrototype
+        - !type:GivePrototype
           prototype: CableHVStack1
           amount: 5
         steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_telemonitors.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_telemonitors.yml
@@ -22,7 +22,7 @@
               
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 2
             - !type:DeleteEntity {}
@@ -45,10 +45,10 @@
                 
         - to: TelescreenFrame
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SurveillanceCameraMonitorCircuitboard
               amount: 1
           steps:
@@ -69,7 +69,7 @@
 
         - to: Wired
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetGlass1
               amount: 2
           steps:
@@ -111,7 +111,7 @@
               
         - to: start
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetSteel1
               amount: 2
             - !type:DeleteEntity {}
@@ -134,10 +134,10 @@
                 
         - to: TelevisionFrame
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: CableApcStack1
               amount: 5
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: ComputerTelevisionCircuitboard
               amount: 1
           steps:
@@ -158,7 +158,7 @@
 
         - to: Wired
           completed:
-            - !type:SpawnPrototype
+            - !type:GivePrototype
               prototype: SheetGlass1
               amount: 2
           steps:


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the SpawnPrototype to GivePrototype in several construction recipes - the effect is that if you for example deconstruct something on the wall, the resulting prototype isnt stuck in the wall, it tries to put it in your hand instead.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Deconstructing certain things dont leave their materials stuck in the wall.

