### PR TITLE
Restrict ghost role speech/movement to component flags

### DIFF
--- a/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
@@ -63,6 +63,14 @@ namespace Content.Server.Ghost.Roles.Components
             }
         }
 
+        [DataField("allowSpeech")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool AllowSpeech { get; set; } = true;
+
+        [DataField("allowMovement")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool AllowMovement { get; set; }
+
         [ViewVariables(VVAccess.ReadOnly)]
         public bool Taken { get; set; }
 

--- a/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleMobSpawnerComponent.cs
@@ -46,7 +46,7 @@ namespace Content.Server.Ghost.Roles.Components
             _entMan.EventBus.RaiseLocalEvent(mob, spawnedEvent, false);
 
             if (MakeSentient)
-                MakeSentientCommand.MakeSentient(mob, _entMan);
+                MakeSentientCommand.MakeSentient(mob, _entMan, AllowMovement, AllowSpeech);
 
             mob.EnsureComponent<MindComponent>();
 

--- a/Content.Server/Ghost/Roles/Components/GhostTakeoverAvailableComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostTakeoverAvailableComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Ghost.Roles.Components
                 return false;
 
             if (MakeSentient)
-                MakeSentientCommand.MakeSentient(Owner, IoCManager.Resolve<IEntityManager>());
+                MakeSentientCommand.MakeSentient(Owner, IoCManager.Resolve<IEntityManager>(), AllowMovement, AllowSpeech);
 
             var ghostRoleSystem = EntitySystem.Get<GhostRoleSystem>();
             ghostRoleSystem.GhostRoleInternalCreateMindAndTransfer(session, Owner, Owner, this);

--- a/Content.Server/Mind/Commands/MakeSentientCommand.cs
+++ b/Content.Server/Mind/Commands/MakeSentientCommand.cs
@@ -39,7 +39,7 @@ namespace Content.Server.Mind.Commands
                 return;
             }
 
-            MakeSentient(entId, entityManager);
+            MakeSentient(entId, entityManager, true, true);
         }
 
         public static void MakeSentient(EntityUid uid, IEntityManager entityManager, bool allowMovement = true, bool allowSpeech = true)

--- a/Content.Server/Mind/Commands/MakeSentientCommand.cs
+++ b/Content.Server/Mind/Commands/MakeSentientCommand.cs
@@ -42,16 +42,24 @@ namespace Content.Server.Mind.Commands
             MakeSentient(entId, entityManager);
         }
 
-        public static void MakeSentient(EntityUid uid, IEntityManager entityManager)
+        public static void MakeSentient(EntityUid uid, IEntityManager entityManager, bool allowMovement = true, bool allowSpeech = true)
         {
             entityManager.RemoveComponent<NPCComponent>(uid);
 
             entityManager.EnsureComponent<MindComponent>(uid);
-            entityManager.EnsureComponent<InputMoverComponent>(uid);
-            entityManager.EnsureComponent<MobMoverComponent>(uid);
-            entityManager.EnsureComponent<MovementSpeedModifierComponent>(uid);
-            entityManager.EnsureComponent<SharedSpeechComponent>(uid);
-            entityManager.EnsureComponent<SharedEmotingComponent>(uid);
+            if (allowMovement)
+            {
+                entityManager.EnsureComponent<InputMoverComponent>(uid);
+                entityManager.EnsureComponent<MobMoverComponent>(uid);
+                entityManager.EnsureComponent<MovementSpeedModifierComponent>(uid);
+            }
+
+            if (allowSpeech)
+            {
+                entityManager.EnsureComponent<SharedSpeechComponent>(uid);
+                entityManager.EnsureComponent<SharedEmotingComponent>(uid);
+            }
+
             entityManager.EnsureComponent<ExaminerComponent>(uid);
         }
     }

--- a/Content.Server/StationEvents/Events/RandomSentience.cs
+++ b/Content.Server/StationEvents/Events/RandomSentience.cs
@@ -29,7 +29,6 @@ public sealed class RandomSentience : StationEventSystem
             if (toMakeSentient-- == 0)
                 break;
 
-            MakeSentientCommand.MakeSentient(target.Owner, EntityManager, false, true);
             EntityManager.RemoveComponent<SentienceTargetComponent>(target.Owner);
             var comp = EntityManager.AddComponent<GhostTakeoverAvailableComponent>(target.Owner);
             comp.RoleName = EntityManager.GetComponent<MetaDataComponent>(target.Owner).EntityName;

--- a/Content.Server/StationEvents/Events/RandomSentience.cs
+++ b/Content.Server/StationEvents/Events/RandomSentience.cs
@@ -29,7 +29,7 @@ public sealed class RandomSentience : StationEventSystem
             if (toMakeSentient-- == 0)
                 break;
 
-            MakeSentientCommand.MakeSentient(target.Owner, EntityManager);
+            MakeSentientCommand.MakeSentient(target.Owner, EntityManager, false, true);
             EntityManager.RemoveComponent<SentienceTargetComponent>(target.Owner);
             var comp = EntityManager.AddComponent<GhostTakeoverAvailableComponent>(target.Owner);
             comp.RoleName = EntityManager.GetComponent<MetaDataComponent>(target.Owner).EntityName;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -738,6 +738,8 @@
   components:
   - type: GhostTakeoverAvailable
     makeSentient: true
+    allowSpeech: true
+    allowMovement: true
     name: ghost-role-information-mouse-name
     description: ghost-role-information-mouse-description
   - type: Speech

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -138,6 +138,8 @@
     - type: GhostTakeoverAvailable
       prob: 0.33
       name: space carp on salvage wreck
+      allowMovement: true
+      allowSpeech: true
       description: |
         Defend the loot inside the salvage wreck!
     - type: SalvageMobRestrictions
@@ -149,6 +151,8 @@
   parent: BaseMobCarp
   components:
     - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
       makeSentient: true
       name: Sentient Carp
       description: Help the dragon flood the station with carps!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -86,6 +86,8 @@
     - id: FoodMeatXeno
       amount: 5
   - type: GhostTakeoverAvailable
+    allowMovement: true
+    allowSpeech: true
     makeSentient: true
     name: xeno
     description: You are a xeno, co-operate with your hive to kill all crewmembers!

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -6,6 +6,8 @@
   description: A flying leviathan, loosely related to space carps.
   components:
     - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
       makeSentient: true
       name: Space dragon
       description: Call in 3 carp rifts and take over this quadrant! You have only 5 minutes in between each rift before you will disappear.

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -6,6 +6,8 @@
   components:
   - type: GhostTakeoverAvailable
     makeSentient: true
+    allowMovement: true
+    allowSpeech: true
     name: Remilia, the chaplain's familiar
     description: Obey your master. Eat fruit.
     rules: You are an intelligent fruit bat. Follow the chaplain around. Don't cause any trouble unless the chaplain tells you to.
@@ -32,6 +34,8 @@
   components:
   - type: GhostTakeoverAvailable
     makeSentient: true
+    allowMovement: true
+    allowSpeech: true
     name: Cerberus, Evil Familiar
     description: Obey your master. Spread chaos.
     rules: You are an intelligent, demonic dog. Try to help the chaplain and any of his flock. As an antagonist, you're otherwise unrestrained.

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -7,6 +7,8 @@
   save: false
   components:
     - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
       makeSentient: true
       name: Guardian
       description: Listen to your owner. Don't tank damage. Punch people hard.
@@ -103,6 +105,8 @@
   description: A mesmerising whirl of hard-light patterns weaves a marvelous, yet oddly familiar visage. It stands proud, tuning into its owner's life to sustain itself.
   components:
     - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
       makeSentient: true
       name: Holoparasite
       description: Listen to your owner. Don't tank damage. Punch people hard.
@@ -127,6 +131,8 @@
   description: A corrupted jinn, ripped from fitra to serve the wizard's petty needs. It stands wicked, tuning into it's owner's life to sustain itself.
   components:
     - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
       makeSentient: true
       name: Ifrit
       description: Listen to your owner. Don't tank damage. Punch people hard.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Restricts ghost role speech/movement to component flags. By default, ghost roles can speak, but cannot move anymore. This should fix the issue with vending machines being able to move when unanchored.

:cl:
- fix: NanoTrasen has removed the wheels from vending machines. They should no longer be able to move, if your station suffers from a case of the sentient virus plaguing our networks.

