### PR TITLE
Add embeds to AHelp relay

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -112,7 +112,7 @@ namespace Content.Server.Administration.Systems
             var payload = new WebhookPayload
             {
                 Username = $"{oldMessage.username}",
-                AvaterUrl = _avatarUrl,
+                AvatarUrl = _avatarUrl,
                 Embeds = new List<Embed>
                 {
                     new Embed
@@ -178,11 +178,14 @@ namespace Content.Server.Administration.Systems
 
             foreach (var channelId in _messageQueues.Keys.ToArray())
             {
-                if(_processingChannels.Contains(channelId)) continue;
+                if (_processingChannels.Contains(channelId))
+                    continue;
 
                 var queue = _messageQueues[channelId];
                 _messageQueues.Remove(channelId);
-                if (queue.Count == 0) continue;
+                if (queue.Count == 0)
+                    continue;
+
                 _processingChannels.Add(channelId);
 
                 ProcessQueue(channelId, queue);
@@ -288,7 +291,7 @@ namespace Content.Server.Administration.Systems
             public string Username { get; set; } = "";
 
             [JsonPropertyName("avatar_url")]
-            public string AvaterUrl { get; set; } = "";
+            public string AvatarUrl { get; set; } = "";
 
             [JsonPropertyName("embeds")]
             public List<Embed>? Embeds { get; set; } = null;

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -30,20 +30,25 @@ namespace Content.Server.Administration.Systems
         private ISawmill _sawmill = default!;
         private readonly HttpClient _httpClient = new();
         private string _webhookUrl = string.Empty;
+        private string _iconUrl = string.Empty;
         private string _serverName = string.Empty;
-        private readonly Dictionary<NetUserId, (string id, string username, string content)> _relayMessages = new();
+        private readonly Dictionary<NetUserId, (string id, string username, string messages)> _relayMessages = new();
         private readonly Dictionary<NetUserId, Queue<string>> _messageQueues = new();
         private readonly HashSet<NetUserId> _processingChannels = new();
-        private const ushort MessageMax = 2000;
+
+        // Max embed description length is 4096, according to https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
+        // Keep small margin, just to be safe
+        private const ushort DescriptionMax = 4000;
         private int _maxAdditionalChars;
 
         public override void Initialize()
         {
             base.Initialize();
             _config.OnValueChanged(CCVars.DiscordAHelpWebhook, OnWebhookChanged, true);
+            _config.OnValueChanged(CCVars.DiscordAHelpIcon, OnIconChanged, true);
             _config.OnValueChanged(CVars.GameHostName, OnServerNameChanged, true);
             _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("AHELP");
-            _maxAdditionalChars = GenerateAHelpMessage("", "", true, true).Length;
+            _maxAdditionalChars = GenerateAHelpMessage("", "", true).Length;
 
             SubscribeLocalEvent<RoundStartingEvent>(RoundStarting);
         }
@@ -62,6 +67,7 @@ namespace Content.Server.Administration.Systems
         {
             base.Shutdown();
             _config.UnsubValueChanged(CCVars.DiscordAHelpWebhook, OnWebhookChanged);
+            _config.UnsubValueChanged(CCVars.DiscordAHelpIcon, OnIconChanged);
             _config.UnsubValueChanged(CVars.GameHostName, OnServerNameChanged);
         }
 
@@ -70,9 +76,14 @@ namespace Content.Server.Administration.Systems
             _webhookUrl = obj;
         }
 
+        private void OnIconChanged(string url)
+        {
+            _iconUrl = url;
+        }
+
         private async void ProcessQueue(NetUserId channelId, Queue<string> messages)
         {
-            if (!_relayMessages.TryGetValue(channelId, out var oldMessage) || messages.Sum(x => x.Length+2) + oldMessage.content.Length > MessageMax)
+            if (!_relayMessages.TryGetValue(channelId, out var oldMessage) || messages.Sum(x => x.Length + 2) + oldMessage.messages.Length > DescriptionMax)
             {
                 var lookup = await _playerLocator.LookupIdAsync(channelId);
 
@@ -83,18 +94,32 @@ namespace Content.Server.Administration.Systems
                     return;
                 }
 
-                oldMessage = (string.Empty, lookup.Username, "");
+                oldMessage = (string.Empty, lookup.Username, string.Empty);
             }
 
             while (messages.TryDequeue(out var message))
             {
-                oldMessage.content += $"\n{message}";
+                oldMessage.messages += $"\n{message}";
             }
 
-            var payload = new WebhookPayload()
+            var payload = new WebhookPayload
             {
-                Username = $"{oldMessage.username} on {_serverName} (round {_gameTicker.RoundId})",
-                Content = oldMessage.content
+                Username = $"{oldMessage.username}",
+                Embeds = new List<Embed>
+                {
+                    new Embed
+                    {
+                        Description = oldMessage.messages,
+                        // If no admins are online, set embed color to red. Otherwise green
+                        Color = GetTargetAdmins().Count > 0 ? 0x41F097 : 0xFF0000,
+                        Footer = new EmbedFooter
+                        {
+                            // Limit server name to 1500 characters, in case someone tries to be a little funny
+                            Text = $"{_serverName[..Math.Min(_serverName.Length, 1500)]} (round {_gameTicker.RoundId})",
+                            IconUrl = _iconUrl,
+                        },
+                    },
+                },
             };
 
             if (oldMessage.id == string.Empty)
@@ -105,7 +130,7 @@ namespace Content.Server.Administration.Systems
                 var content = await request.Content.ReadAsStringAsync();
                 if (!request.IsSuccessStatusCode)
                 {
-                    _sawmill.Log(LogLevel.Error, $"Discord returned bad status code when posting message: {request.StatusCode}\nResponse: {content}");
+                    _sawmill.Log(LogLevel.Error, $"Discord returned bad status code when posting message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
                     _relayMessages.Remove(channelId);
                     return;
                 }
@@ -128,7 +153,7 @@ namespace Content.Server.Administration.Systems
                 if (!request.IsSuccessStatusCode)
                 {
                     var content = await request.Content.ReadAsStringAsync();
-                    _sawmill.Log(LogLevel.Error, $"Discord returned bad status code when patching message: {request.StatusCode}\nResponse: {content}");
+                    _sawmill.Log(LogLevel.Error, $"Discord returned bad status code when patching message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
                     _relayMessages.Remove(channelId);
                     return;
                 }
@@ -188,20 +213,20 @@ namespace Content.Server.Administration.Systems
 
             LogBwoink(msg);
 
-            // Admins w/ AHelp access
-            var targets = _adminManager.ActiveAdmins
-                .Where(p => _adminManager.GetAdminData(p)?.HasFlag(AdminFlags.Adminhelp) ?? false)
-                .Select(p => p.ConnectedClient).ToList();
+            var admins = GetTargetAdmins();
 
-            // And involved player
-            if (_playerManager.TryGetSessionById(message.ChannelId, out var session))
-                if (!targets.Contains(session.ConnectedClient))
-                    targets.Add(session.ConnectedClient);
-
-            foreach (var channel in targets)
+            // Notify all admins
+            foreach (var channel in admins)
+            {
                 RaiseNetworkEvent(msg, channel);
+            }
 
-            var noReceivers = targets.Count == 1;
+            // Notify player
+            if (_playerManager.TryGetSessionById(message.ChannelId, out var session))
+            {
+                if (!admins.Contains(session.ConnectedClient))
+                    RaiseNetworkEvent(msg, session.ConnectedClient);
+            }
 
             var sendsWebhook = _webhookUrl != string.Empty;
             if (sendsWebhook)
@@ -212,52 +237,90 @@ namespace Content.Server.Administration.Systems
                 var str = message.Text;
                 var unameLength = senderSession.Name.Length;
 
-                if (unameLength+str.Length+_maxAdditionalChars > MessageMax)
+                if (unameLength + str.Length + _maxAdditionalChars > DescriptionMax)
                 {
-                    str = str[..(MessageMax - _maxAdditionalChars - unameLength)];
+                    str = str[..(DescriptionMax - _maxAdditionalChars - unameLength)];
                 }
-                _messageQueues[msg.ChannelId].Enqueue(GenerateAHelpMessage(senderSession.Name, str, !personalChannel, noReceivers));
+                _messageQueues[msg.ChannelId].Enqueue(GenerateAHelpMessage(senderSession.Name, str, !personalChannel));
             }
 
-            if (noReceivers)
-            {
-                var systemText = sendsWebhook ?
-                    Loc.GetString("bwoink-system-starmute-message-no-other-users-webhook") :
-                    Loc.GetString("bwoink-system-starmute-message-no-other-users");
-                var starMuteMsg = new BwoinkTextMessage(message.ChannelId, SystemUserId, systemText);
-                RaiseNetworkEvent(starMuteMsg, senderSession.ConnectedClient);
-            }
+            if (admins.Count != 0)
+                return;
+
+            // No admin online, let the player know
+            var systemText = sendsWebhook ?
+                Loc.GetString("bwoink-system-starmute-message-no-other-users-webhook") :
+                Loc.GetString("bwoink-system-starmute-message-no-other-users");
+            var starMuteMsg = new BwoinkTextMessage(message.ChannelId, SystemUserId, systemText);
+            RaiseNetworkEvent(starMuteMsg, senderSession.ConnectedClient);
         }
 
-        private string GenerateAHelpMessage(string username, string message, bool admin, bool noReceiver)
+        // Returns all online admins with AHelp access
+        private IList<INetChannel> GetTargetAdmins()
+        {
+            return _adminManager.ActiveAdmins
+               .Where(p => _adminManager.GetAdminData(p)?.HasFlag(AdminFlags.Adminhelp) ?? false)
+               .Select(p => p.ConnectedClient)
+               .ToList();
+        }
+
+        private static string GenerateAHelpMessage(string username, string message, bool admin)
         {
             var stringbuilder = new StringBuilder();
-            if (noReceiver)
-                stringbuilder.Append(":sos:");
             stringbuilder.Append(admin ? ":outbox_tray:" : ":inbox_tray:");
-            stringbuilder.Append(" **");
-            stringbuilder.Append(username);
-            stringbuilder.Append(":** ");
+            stringbuilder.Append($" **{username}:** ");
             stringbuilder.Append(message);
             return stringbuilder.ToString();
         }
 
+        // https://discord.com/developers/docs/resources/channel#message-object-message-structure
         private struct WebhookPayload
         {
             [JsonPropertyName("username")]
             public string Username { get; set; } = "";
 
-            [JsonPropertyName("content")]
-            public string Content { get; set; } = "";
+            [JsonPropertyName("embeds")]
+            public List<Embed>? Embeds { get; set; } = null;
 
             [JsonPropertyName("allowed_mentions")]
             public Dictionary<string, string[]> AllowedMentions { get; set; } =
                 new()
                 {
-                    { "parse", Array.Empty<string>() }
+                    { "parse", Array.Empty<string>() },
                 };
 
-            public WebhookPayload() {}
+            public WebhookPayload() { }
+        }
+
+        // https://discord.com/developers/docs/resources/channel#embed-object-embed-structure
+        private struct Embed
+        {
+            [JsonPropertyName("description")]
+            public string Description { get; set; } = "";
+
+            [JsonPropertyName("color")]
+            public int Color { get; set; } = 0;
+
+            [JsonPropertyName("footer")]
+            public EmbedFooter? Footer { get; set; } = null;
+
+            public Embed()
+            {
+            }
+        }
+
+        // https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure
+        private struct EmbedFooter
+        {
+            [JsonPropertyName("text")]
+            public string Text { get; set; } = "";
+
+            [JsonPropertyName("icon_url")]
+            public string IconUrl { get; set; } = "";
+
+            public EmbedFooter()
+            {
+            }
         }
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -257,11 +257,17 @@ namespace Content.Shared.CCVar
             CVarDef.Create("discord.ahelp_webhook", string.Empty, CVar.SERVERONLY);
 
         /// <summary>
-        /// The server icon to use in the Discord ahelp embeds.
+        /// The server icon to use in the Discord ahelp embed footer.
         /// Valid values are specified at https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure.
         /// </summary>
-        public static readonly CVarDef<string> DiscordAHelpIcon =
-            CVarDef.Create("discord.ahelp_icon", string.Empty, CVar.SERVERONLY);
+        public static readonly CVarDef<string> DiscordAHelpFooterIcon =
+            CVarDef.Create("discord.ahelp_footer_icon", string.Empty, CVar.SERVERONLY);
+
+        /// <summary>
+        /// The avatar to use for the webhook. Should be an URL.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordAHelpAvatar =
+            CVarDef.Create("discord.ahelp_avatar", string.Empty, CVar.SERVERONLY);
 
         /*
          * Suspicion

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -250,8 +250,18 @@ namespace Content.Shared.CCVar
          * Discord
          */
 
+        /// <summary>
+        /// URL of the Discord webhook which will relay all ahelp messages.
+        /// </summary>
         public static readonly CVarDef<string> DiscordAHelpWebhook =
             CVarDef.Create("discord.ahelp_webhook", string.Empty, CVar.SERVERONLY);
+
+        /// <summary>
+        /// The server icon to use in the Discord ahelp embeds.
+        /// Valid values are specified at https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordAHelpIcon =
+            CVarDef.Create("discord.ahelp_icon", string.Empty, CVar.SERVERONLY);
 
         /*
          * Suspicion


### PR DESCRIPTION
AHelp relay now uses embeds, which are much more readable. The footer contains the server name, the round ID and an icon which can be set with a CVar, so the server can more quickly be identified.

If no admin is online to receive the AHelp, the embed color is red:

![image](https://user-images.githubusercontent.com/39844191/189501678-4bbe6920-fedf-4700-b54c-ead411ad0751.png)

Otherwise the embed color is green:

![image](https://user-images.githubusercontent.com/39844191/189501680-b43a50b3-3c09-4c9f-b247-7ff3065c48c0.png)

This color depends on the last message received.

EDIT: Made it possible to set a webhook avatar with a CVar:

![image](https://user-images.githubusercontent.com/39844191/189502484-8fc76e25-299f-443b-b07a-a0399a86926b.png)

EDIT: Now shows character name as well, if the player has one.

![image](https://user-images.githubusercontent.com/39844191/189536070-9759c801-606f-4111-afce-ba3b44bdf00d.png)