### PR TITLE
Use Segments for RandomMetadata

### DIFF
--- a/Content.Server/RandomMetadata/RandomMetadataComponent.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataComponent.cs
@@ -1,7 +1,4 @@
-﻿using Content.Shared.Dataset;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
-
-namespace Content.Server.RandomMetadata;
+﻿namespace Content.Server.RandomMetadata;
 
 /// <summary>
 ///     Randomizes the description and/or the name for an entity by creating it from list of dataset prototypes or strings.
@@ -14,4 +11,10 @@ public sealed class RandomMetadataComponent : Component
 
     [DataField("nameSegments")]
     public List<string>? NameSegments;
+
+    [DataField("nameSeparator")]
+    public string NameSeparator = " ";
+
+    [DataField("descriptionSeparator")]
+    public string DescriptionSeparator = " ";
 }

--- a/Content.Server/RandomMetadata/RandomMetadataComponent.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataComponent.cs
@@ -4,14 +4,14 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server.RandomMetadata;
 
 /// <summary>
-///     Randomizes the description and/or the name for an entity by pulling from a dataset prototype.
+///     Randomizes the description and/or the name for an entity by creating it from list of dataset prototypes or strings.
 /// </summary>
 [RegisterComponent]
 public sealed class RandomMetadataComponent : Component
 {
-    [DataField("descriptionSet", customTypeSerializer:typeof(PrototypeIdSerializer<DatasetPrototype>))]
-    public string? DescriptionSet;
+    [DataField("descriptionSegments")]
+    public List<string>? DescriptionSegments;
 
-    [DataField("nameSet", customTypeSerializer:typeof(PrototypeIdSerializer<DatasetPrototype>))]
-    public string? NameSet;
+    [DataField("nameSegments")]
+    public List<string>? NameSegments;
 }

--- a/Content.Server/RandomMetadata/RandomMetadataSystem.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Dataset;
+using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -23,26 +24,31 @@ public sealed class RandomMetadataSystem : EntitySystem
 
         if (component.NameSegments != null)
         {
-            var outputSegments = new List<string>();
-            foreach (var segment in component.NameSegments)
-            {
-                outputSegments.Add(_prototype.TryIndex<DatasetPrototype>(segment, out var proto)
-                    ? _random.Pick(proto.Values)
-                    : segment);
-            }
-            meta.EntityName = string.Join(component.NameSeparator, outputSegments);
+            meta.EntityName = GetRandomFromSegments(component.NameSegments, component.NameSeparator);
         }
 
         if (component.DescriptionSegments != null)
         {
-            var outputSegments = new List<string>();
-            foreach (var segment in component.DescriptionSegments)
-            {
-                outputSegments.Add(_prototype.TryIndex<DatasetPrototype>(segment, out var proto)
-                    ? _random.Pick(proto.Values)
-                    : segment);
-            }
-            meta.EntityDescription = string.Join(component.DescriptionSeparator, outputSegments);
+            meta.EntityDescription = GetRandomFromSegments(component.DescriptionSegments, component.DescriptionSeparator);
         }
+    }
+
+    /// <summary>
+    /// Generates a random string from segments and a separator.
+    /// </summary>
+    /// <param name="segments">The segments that it will be generated from</param>
+    /// <param name="separator">The separator that will be inbetween each segment</param>
+    /// <returns>The newly generated string</returns>
+    [PublicAPI]
+    public string GetRandomFromSegments(List<string> segments, string? separator)
+    {
+        var outputSegments = new List<string>();
+        foreach (var segment in segments)
+        {
+            outputSegments.Add(_prototype.TryIndex<DatasetPrototype>(segment, out var proto)
+                ? _random.Pick(proto.Values)
+                : segment);
+        }
+        return string.Join(separator, outputSegments);
     }
 }

--- a/Content.Server/RandomMetadata/RandomMetadataSystem.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataSystem.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Content.Shared.Dataset;
+﻿using Content.Shared.Dataset;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -31,7 +30,7 @@ public sealed class RandomMetadataSystem : EntitySystem
                     ? _random.Pick(proto.Values)
                     : segment);
             }
-            meta.EntityName = string.Join(" ", outputSegments);
+            meta.EntityName = string.Join(component.NameSeparator, outputSegments);
         }
 
         if (component.DescriptionSegments != null)
@@ -43,7 +42,7 @@ public sealed class RandomMetadataSystem : EntitySystem
                     ? _random.Pick(proto.Values)
                     : segment);
             }
-            meta.EntityDescription = string.Join(" ", outputSegments);
+            meta.EntityDescription = string.Join(component.DescriptionSeparator, outputSegments);
         }
     }
 }

--- a/Content.Server/RandomMetadata/RandomMetadataSystem.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Dataset;
+﻿using System.Linq;
+using Content.Shared.Dataset;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -21,16 +22,28 @@ public sealed class RandomMetadataSystem : EntitySystem
     {
         var meta = MetaData(uid);
 
-        if (component.NameSet != null)
+        if (component.NameSegments != null)
         {
-            var nameProto = _prototype.Index<DatasetPrototype>(component.NameSet);
-            meta.EntityName = _random.Pick(nameProto.Values);
+            var outputSegments = new List<string>();
+            foreach (var segment in component.NameSegments)
+            {
+                outputSegments.Add(_prototype.TryIndex<DatasetPrototype>(segment, out var proto)
+                    ? _random.Pick(proto.Values)
+                    : segment);
+            }
+            meta.EntityName = string.Join(" ", outputSegments);
         }
 
-        if (component.DescriptionSet != null)
+        if (component.DescriptionSegments != null)
         {
-            var descProto = _prototype.Index<DatasetPrototype>(component.DescriptionSet);
-            meta.EntityDescription = _random.Pick(descProto.Values);
+            var outputSegments = new List<string>();
+            foreach (var segment in component.DescriptionSegments)
+            {
+                outputSegments.Add(_prototype.TryIndex<DatasetPrototype>(segment, out var proto)
+                    ? _random.Pick(proto.Values)
+                    : segment);
+            }
+            meta.EntityDescription = string.Join(" ", outputSegments);
         }
     }
 }

--- a/Content.Server/RatKing/RatKingComponent.cs
+++ b/Content.Server/RatKing/RatKingComponent.cs
@@ -1,6 +1,4 @@
 using Content.Shared.Actions.ActionTypes;
-using Content.Shared.Dataset;
-using Content.Shared.Disease;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
@@ -44,11 +42,5 @@ namespace Content.Server.RatKing
         /// </summary>
         [ViewVariables, DataField("molesMiasmaPerDomain")]
         public float MolesMiasmaPerDomain = 100f;
-
-        // Both of these are used to generate the random name for rat king.
-        [DataField("titleNameDataset", customTypeSerializer: typeof(PrototypeIdSerializer<DatasetPrototype>))]
-        public string TitleNameDataset = "RegalRatNameTitle";
-        [DataField("kingdomNameDataset", customTypeSerializer: typeof(PrototypeIdSerializer<DatasetPrototype>))]
-        public string KingdomNameDataset = "RegalRatNameKingdom";
     }
 };

--- a/Content.Server/RatKing/RatKingSystem.cs
+++ b/Content.Server/RatKing/RatKingSystem.cs
@@ -1,23 +1,16 @@
 using Content.Server.Actions;
 using Content.Server.Atmos.EntitySystems;
-using Content.Server.Disease;
-using Content.Server.Disease.Components;
 using Content.Server.Nutrition.Components;
 using Content.Server.Popups;
 using Content.Shared.Actions;
 using Content.Shared.Atmos;
-using Content.Shared.Dataset;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
 
 namespace Content.Server.RatKing
 {
     public sealed class RatKingSystem : EntitySystem
     {
-        [Dependency] private readonly IPrototypeManager _proto = default!;
-        [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly PopupSystem _popup = default!;
         [Dependency] private readonly ActionsSystem _action = default!;
         [Dependency] private readonly AtmosphereSystem _atmos = default!;
@@ -37,11 +30,6 @@ namespace Content.Server.RatKing
         {
             _action.AddAction(uid, component.ActionRaiseArmy, null);
             _action.AddAction(uid, component.ActionDomain, null);
-
-            var kingdom = _proto.Index<DatasetPrototype>(component.KingdomNameDataset);
-            var title = _proto.Index<DatasetPrototype>(component.TitleNameDataset);
-
-            MetaData(uid).EntityName = $"{_random.Pick(kingdom.Values)} {_random.Pick(title.Values)}";
         }
 
         /// <summary>

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -113,6 +113,10 @@
     - TongueTwister
   - type: MobPrice
     price: 2500 # rat wealth
+  - type: RandomMetadata
+    nameSegments:
+    - RegalRatNameKingdom
+    - RegalRatNameTitle
 
 - type: entity
   id: MobRatKingBuff

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -65,7 +65,7 @@
   - type: Loadout
     prototype: ERTLeaderGear
   - type: RandomMetadata
-    nameSet: NamesFirstMilitaryLeader
+    nameSegments: [NamesFirstMilitaryLeader]
   - type: RandomHumanoidAppearance
     randomizeName: false
 
@@ -198,7 +198,7 @@
   - type: Loadout
     prototype: SyndicateOperativeGearExtremelyBasic
   - type: RandomMetadata
-    nameSet: names_death_commando
+    nameSegments: [names_death_commando]
 
 # Nuclear Operative
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -236,7 +236,7 @@
     - Cargo
     - Maintenance
   - type: RandomMetadata
-    descriptionSet: ATVDescriptions
+    descriptionSegments: [ATVDescriptions]
   - type: MovementSpeedModifier
     acceleration: 1
     friction: 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
slight refactor to randommetadata that makes it use "segments" of prototypes/strings instead of simply a single prototype.
This means that you can have a list of multiple prototypes which are all chosen independently.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

no cl no fun

