### PR TITLE
Hide mob damage

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -54,6 +54,7 @@
   - type: ReplacementAccent
     accent: mouse
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     arc: bite
@@ -130,6 +131,7 @@
       autoPopulate: false
       name: action-name-disarm
   - type: MeleeWeapon
+    hidden: true
     range: 0.3
     arcwidth: 0
     arc: bite
@@ -655,6 +657,7 @@
       Dead:
         Base: kangaroo-boxing-dead
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     arc: claw
@@ -1180,6 +1183,7 @@
     - id: FoodMeatPenguin
       amount: 3
   - type: MeleeWeapon
+    hidden: true
     range: 0.5
     arcwidth: 0
     arc: bite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -1,4 +1,4 @@
-- type: entity
+﻿- type: entity
   name: space bear
   id: MobBearSpace
   parent: SimpleSpaceMobBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: space bear
   id: MobBearSpace
   parent: SimpleSpaceMobBase
@@ -57,6 +57,7 @@
     heatDamageThreshold: 500
     coldDamageThreshold: 0
   - type: MeleeWeapon
+    hidden: true
     range: 0.5
     arcwidth: 0
     arc: claw

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -65,6 +65,7 @@
         - id: FoodMeatFish
           amount: 2
     - type: MeleeWeapon
+      hidden: true
       range: 1.5
       arcwidth: 0
       arc: bite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -36,6 +36,7 @@
   - type: HumanoidAppearance
   - type: AnimationPlayer
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     arc: fist

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -75,6 +75,7 @@
       Dead:
         Base: narsian_dead
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     arc: bite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -41,6 +41,7 @@
       150: Critical
       200: Dead
   - type: MeleeWeapon
+    hidden: true
     range: 1
     arcwidth: 0
     arc: claw
@@ -132,6 +133,7 @@
       300: Critical
       350: Dead
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     arc: fist
@@ -198,6 +200,7 @@
       30: Critical
       60: Dead
   - type: MeleeWeapon
+    hidden: true
     range: 1
     arcwidth: 0
     arc: claw

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -116,6 +116,7 @@
     preset: AnimalPreset
   - type: Examiner
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     arc: bite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -54,6 +54,7 @@
       autoPopulate: false
       name: action-name-disarm
   - type: MeleeWeapon
+    hidden: true
     range: 0.5
     arcwidth: 0
     arc: bite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -61,6 +61,7 @@
         Bloodloss:
           -0.25
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     hitSound:
@@ -188,6 +189,7 @@
     baseWalkSpeed : 2.8
     baseSprintSpeed : 3.8
   - type: MeleeWeapon
+    hidden: true
     damage:
      groups:
        Brute: 40
@@ -226,6 +228,7 @@
     baseWalkSpeed : 2.3
     baseSprintSpeed : 4.2
   - type: MeleeWeapon
+    hidden: true
     damage:
      groups:
        Brute: 35
@@ -264,6 +267,7 @@
     baseWalkSpeed : 2.7
     baseSprintSpeed : 6.0
   - type: MeleeWeapon
+    hidden: true
     damage:
      groups:
        Brute: 15
@@ -355,6 +359,7 @@
     factions:
     - Xeno
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     arc: bite

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -89,6 +89,7 @@
         path: /Audio/Animals/space_dragon_roar.ogg
       soundPerceivedByOthers: false # A 75% chance for a loud roar would get old fast.
     - type: MeleeWeapon
+      hidden: true
       hitSound:
         path: /Audio/Effects/bite.ogg
       damage:

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -36,6 +36,7 @@
     description: Obey your master. Spread chaos.
     rules: You are an intelligent, demonic dog. Try to help the chaplain and any of his flock. As an antagonist, you're otherwise unrestrained.
   - type: MeleeWeapon
+    hidden: true
     range: 1.5
     arcwidth: 0
     arc: bite

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -77,6 +77,7 @@
       proto: guardian
     - type: Pullable
     - type: MeleeWeapon
+      hidden: true
       range: 2
       arcwidth: 30
       arc: fist

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -291,6 +291,7 @@
   - type: AnimationPlayer
   - type: Buckle
   - type: MeleeWeapon
+    hidden: true
     hitSound:
       collection: Punch
     range: 0.8

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -132,6 +132,7 @@
     damageContainer: Biological
     damageModifierSet: Scale
   - type: MeleeWeapon
+    hidden: true
     hitSound:
       path: /Audio/Weapons/pierce.ogg
     range: 0.8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When you examine mobs, their melee damage is hidden

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: You can no longer examine players and other mobs melee damage.
