### PR TITLE
locked cabinets actually cant be opened

### DIFF
--- a/Content.Server/Cabinet/ItemCabinetSystem.cs
+++ b/Content.Server/Cabinet/ItemCabinetSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Storage.Components;
 using Content.Shared.Audio;
 using Content.Shared.Cabinet;
 using Content.Shared.Containers.ItemSlots;
@@ -67,6 +68,9 @@ namespace Content.Server.Cabinet
             if (args.Hands == null || !args.CanAccess || !args.CanInteract)
                 return;
 
+            if (TryComp<LockComponent>(uid, out var lockComponent) && lockComponent.Locked)
+                return;
+
             // Toggle open verb
             ActivationVerb toggleVerb = new();
             toggleVerb.Act = () => ToggleItemCabinet(uid, cabinet);
@@ -98,6 +102,9 @@ namespace Content.Server.Cabinet
         private void ToggleItemCabinet(EntityUid uid, ItemCabinetComponent? cabinet = null)
         {
             if (!Resolve(uid, ref cabinet))
+                return;
+
+            if (TryComp<LockComponent>(uid, out var lockComponent) && lockComponent.Locked)
                 return;
 
             cabinet.Opened = !cabinet.Opened;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #11216

ItemCabinets actually checks for a lockcomponent and if its locked

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Locks on cabinets actually work.

