### PR TITLE
Fix pathfinding exception

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PickAccessibleComponentOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PickAccessibleComponentOperator.cs
@@ -77,6 +77,9 @@ public sealed class PickAccessibleComponentOperator : HTNOperator
             // TODO: God the path api sucks PLUS I need some fast way to get this.
             var job = _path.RequestPath(owner, target.Owner, CancellationToken.None);
 
+            if (job == null)
+                continue;
+
             await job.AsTask;
 
             if (job.Result == null || !_entManager.TryGetComponent<TransformComponent>(target.Owner, out var targetXform))

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -37,7 +37,7 @@ namespace Content.Server.NPC.Pathfinding
             return job;
         }
 
-        public Job<Queue<TileRef>> RequestPath(EntityUid source, EntityUid target, CancellationToken cancellationToken)
+        public Job<Queue<TileRef>>? RequestPath(EntityUid source, EntityUid target, CancellationToken cancellationToken)
         {
             var collisionMask = 0;
 
@@ -46,17 +46,16 @@ namespace Content.Server.NPC.Pathfinding
                 collisionMask = body.CollisionMask;
             }
 
-            var start = TileRef.Zero;
-            var end = TileRef.Zero;
-
-            if (TryComp<TransformComponent>(source, out var xform) &&
-                _mapManager.TryGetGrid(xform.GridUid, out var grid) &&
-                TryComp<TransformComponent>(target, out var targetXform) &&
-                _mapManager.TryGetGrid(targetXform.GridUid, out var targetGrid))
+            if (!TryComp<TransformComponent>(source, out var xform) ||
+                !_mapManager.TryGetGrid(xform.GridUid, out var grid) ||
+                !TryComp<TransformComponent>(target, out var targetXform) ||
+                !_mapManager.TryGetGrid(targetXform.GridUid, out var targetGrid))
             {
-                start = grid.GetTileRef(xform.Coordinates);
-                end = grid.GetTileRef(targetXform.Coordinates);
+                return null;
             }
+
+            var start = grid.GetTileRef(xform.Coordinates);
+            var end = targetGrid.GetTileRef(targetXform.Coordinates);
 
             var args = new PathfindingArgs(source, _access.FindAccessTags(source), collisionMask, start, end);
 


### PR DESCRIPTION
Fix a grafana exception due to calling `GetNode(TileRef.Zero)`. Also makes `end` use `targetGrid`.
```
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Entity 0 does not have a component of type Content.Server.NPC.Pathfinding.GridPathfindingComponent)
 ---> System.Collections.Generic.KeyNotFoundException: Entity 0 does not have a component of type Content.Server.NPC.Pathfinding.GridPathfindingComponent
   at Content.Server.NPC.Pathfinding.PathfindingSystem.GetOrCreateChunk(TileRef tile) in /home/runner/work/space-station-14/space-station-14/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs:line 85
   at Content.Server.NPC.Pathfinding.PathfindingSystem.RequestPath(EntityUid source, EntityUid target, CancellationToken cancellationToken) in /home/runner/work/space-station-14/space-station-14/Content.Server/NPC/Pathfinding/PathfindingSystem.cs:line 63
   at Content.Server.NPC.HTN.PrimitiveTasks.Operators.PickAccessibleComponentOperator.Plan(NPCBlackboard blackboard) in /home/runner/work/space-station-14/space-station-14/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PickAccessibleComponentOperator.cs:line 78
   at Content.Server.NPC.HTN.HTNPlanJob.PrimitiveConditionMet(HTNPrimitiveTask primitive, NPCBlackboard blackboard, List`1 appliedStates) in /home/runner/work/space-station-14/space-station-14/Content.Server/NPC/HTN/HTNPlanJob.cs:line 134
   at Content.Server.CPUJob.JobQueues.Job`1.WaitAsyncTask[TTask](Task`1 task) in /home/runner/work/space-station-14/space-station-14/Content.Server/CPUJob/JobQueues/Job.cs:line 96
   at Content.Server.NPC.HTN.HTNPlanJob.Process() in /home/runner/work/space-station-14/space-station-14/Content.Server/NPC/HTN/HTNPlanJob.cs:line 98
   at Content.Server.CPUJob.JobQueues.Job`1.ProcessWrap()
   --- End of inner exception stack trace ---
```
