### PR TITLE
Remove buyer from store messages

### DIFF
--- a/Content.Client/Store/Ui/StoreBoundUserInterface.cs
+++ b/Content.Client/Store/Ui/StoreBoundUserInterface.cs
@@ -26,21 +26,18 @@ public sealed class StoreBoundUserInterface : BoundUserInterface
 
         _menu.OnListingButtonPressed += (_, listing) =>
         {
-            if (_menu.CurrentBuyer != null)
-              SendMessage(new StoreBuyListingMessage(_menu.CurrentBuyer.Value, listing));
+            SendMessage(new StoreBuyListingMessage(listing));
         };
 
         _menu.OnCategoryButtonPressed += (_, category) =>
         {
             _menu.CurrentCategory = category;
-            if (_menu.CurrentBuyer != null)
-                SendMessage(new StoreRequestUpdateInterfaceMessage(_menu.CurrentBuyer.Value));
+            SendMessage(new StoreRequestUpdateInterfaceMessage());
         };
 
         _menu.OnWithdrawAttempt += (_, type, amount) =>
         {
-            if (_menu.CurrentBuyer != null)
-                SendMessage(new StoreRequestWithdrawMessage(_menu.CurrentBuyer.Value, type, amount));
+            SendMessage(new StoreRequestWithdrawMessage(type, amount));
         };
     }
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -53,8 +50,6 @@ public sealed class StoreBoundUserInterface : BoundUserInterface
         switch (state)
         {
             case StoreUpdateState msg:
-                if (msg.Buyer != null)
-                    _menu.CurrentBuyer = msg.Buyer;
                 _menu.UpdateBalance(msg.Balance);
                 _menu.PopulateStoreCategoryButtons(msg.Listings);
                 _menu.UpdateListing(msg.Listings.ToList());

--- a/Content.Client/Store/Ui/StoreMenu.xaml.cs
+++ b/Content.Client/Store/Ui/StoreMenu.xaml.cs
@@ -25,7 +25,6 @@ public sealed partial class StoreMenu : DefaultWindow
     public event Action<BaseButton.ButtonEventArgs, string>? OnCategoryButtonPressed;
     public event Action<BaseButton.ButtonEventArgs, string, int>? OnWithdrawAttempt;
 
-    public EntityUid? CurrentBuyer;
     public Dictionary<string, FixedPoint2> Balance = new();
     public string CurrentCategory = string.Empty;
 
@@ -212,7 +211,6 @@ public sealed partial class StoreMenu : DefaultWindow
     public override void Close()
     {
         base.Close();
-        CurrentBuyer = null;
         _withdrawWindow?.Close();
     }
 

--- a/Content.Server/Store/Systems/StoreSystem.Listings.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Listings.cs
@@ -63,23 +63,23 @@ public sealed partial class StoreSystem : EntitySystem
     /// <summary>
     /// Gets the available listings for a store
     /// </summary>
-    /// <param name="user">The person getting the listings.</param>
+    /// <param name="buyer">Either the account owner, user, or an inanimate object (e.g., surplus bundle)</param>
     /// <param name="component">The store the listings are coming from.</param>
     /// <returns>The available listings.</returns>
-    public IEnumerable<ListingData> GetAvailableListings(EntityUid user, StoreComponent component)
+    public IEnumerable<ListingData> GetAvailableListings(EntityUid buyer, StoreComponent component)
     {
-        return GetAvailableListings(user, component.Listings, component.Categories, component.Owner);
+        return GetAvailableListings(buyer, component.Listings, component.Categories, component.Owner);
     }
 
     /// <summary>
     /// Gets the available listings for a user given an overall set of listings and categories to filter by.
     /// </summary>
-    /// <param name="user">The person getting the listings.</param>
+    /// <param name="buyer">Either the account owner, user, or an inanimate object (e.g., surplus bundle)</param>
     /// <param name="listings">All of the listings that are available. If null, will just get all listings from the prototypes.</param>
     /// <param name="categories">What categories to filter by.</param>
     /// <param name="storeEntity">The physial entity of the store. Can be null.</param>
     /// <returns>The available listings.</returns>
-    public IEnumerable<ListingData> GetAvailableListings(EntityUid user, HashSet<ListingData>? listings, HashSet<string> categories, EntityUid? storeEntity = null)
+    public IEnumerable<ListingData> GetAvailableListings(EntityUid buyer, HashSet<ListingData>? listings, HashSet<string> categories, EntityUid? storeEntity = null)
     {
         if (listings == null)
             listings = GetAllListings();
@@ -91,7 +91,7 @@ public sealed partial class StoreSystem : EntitySystem
 
             if (listing.Conditions != null)
             {
-                var args = new ListingConditionArgs(user, storeEntity, listing, EntityManager);
+                var args = new ListingConditionArgs(buyer, storeEntity, listing, EntityManager);
                 var conditionsMet = true;
 
                 foreach (var condition in listing.Conditions)

--- a/Content.Shared/Store/ListingCondition.cs
+++ b/Content.Shared/Store/ListingCondition.cs
@@ -17,7 +17,7 @@ public abstract class ListingCondition
     public abstract bool Condition(ListingConditionArgs args);
 }
 
-/// <param name="Buyer">The person purchasing the listing</param>
-/// <param name="Listing">The liting itself</param>
+/// <param name="Buyer">Either the account owner, user, or an inanimate object (e.g., surplus bundle)</param>
+/// <param name="Listing">The listing itself</param>
 /// <param name="EntityManager">An entitymanager for sane coding</param>
 public readonly record struct ListingConditionArgs(EntityUid Buyer, EntityUid? StoreEntity, ListingData Listing, IEntityManager EntityManager);

--- a/Content.Shared/Store/StoreUi.cs
+++ b/Content.Shared/Store/StoreUi.cs
@@ -1,5 +1,4 @@
 using Content.Shared.FixedPoint;
-using Content.Shared.MobState;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Store;
@@ -13,15 +12,12 @@ public enum StoreUiKey : byte
 [Serializable, NetSerializable]
 public sealed class StoreUpdateState : BoundUserInterfaceState
 {
-    public readonly EntityUid? Buyer;
-
     public readonly HashSet<ListingData> Listings;
 
     public readonly Dictionary<string, FixedPoint2> Balance;
 
-    public StoreUpdateState(EntityUid? buyer, HashSet<ListingData> listings, Dictionary<string, FixedPoint2> balance)
+    public StoreUpdateState(HashSet<ListingData> listings, Dictionary<string, FixedPoint2> balance)
     {
-        Buyer = buyer;
         Listings = listings;
         Balance = balance;
     }
@@ -44,24 +40,18 @@ public sealed class StoreInitializeState : BoundUserInterfaceState
 [Serializable, NetSerializable]
 public sealed class StoreRequestUpdateInterfaceMessage : BoundUserInterfaceMessage
 {
-    public EntityUid CurrentBuyer;
-
-    public StoreRequestUpdateInterfaceMessage(EntityUid currentBuyer)
+    public StoreRequestUpdateInterfaceMessage()
     {
-        CurrentBuyer = currentBuyer;
     }
 }
 
 [Serializable, NetSerializable]
 public sealed class StoreBuyListingMessage : BoundUserInterfaceMessage
 {
-    public EntityUid Buyer;
-
     public ListingData Listing;
 
-    public StoreBuyListingMessage(EntityUid buyer, ListingData listing)
+    public StoreBuyListingMessage(ListingData listing)
     {
-        Buyer = buyer;
         Listing = listing;
     }
 }
@@ -69,15 +59,12 @@ public sealed class StoreBuyListingMessage : BoundUserInterfaceMessage
 [Serializable, NetSerializable]
 public sealed class StoreRequestWithdrawMessage : BoundUserInterfaceMessage
 {
-    public EntityUid Buyer;
-
     public string Currency;
 
     public int Amount;
 
-    public StoreRequestWithdrawMessage(EntityUid buyer, string currency, int amount)
+    public StoreRequestWithdrawMessage(string currency, int amount)
     {
-        Buyer = buyer;
         Currency = currency;
         Amount = amount;
     }


### PR DESCRIPTION
Currently the server accepts arbitrary buyer UIDs from clients. This replaces buyer with either a server-side user performing an interaction or the entity attached to the session that is sending a BUI message.

This also changes some of the store listing/buying condition logic slightly. Currently the shown listings are based on the buyer being `component.AccountOwner ?? user`, but buying is based on just `user`. This changes them all to consistently use the former, so if the listing is shown a user can buy the item. If that's not desirable, or if there should be extra restrictions like requiring `user == actOwner` to buy stuff, I can change that.