### PR TITLE
Content changes for session specific entity states

### DIFF
--- a/Content.Server/Actions/ActionsSystem.cs
+++ b/Content.Server/Actions/ActionsSystem.cs
@@ -16,33 +16,6 @@ namespace Content.Server.Actions
         public override void Initialize()
         {
             base.Initialize();
-
-            SubscribeLocalEvent<ActionsComponent, PlayerAttachedEvent>(OnPlayerAttached);
-            SubscribeLocalEvent<ActionsComponent, ComponentStartup>(OnStartup);
-            SubscribeLocalEvent<ActionsComponent, ComponentShutdown>(OnShutdown);
-            SubscribeLocalEvent<ActionsComponent, MetaFlagRemoveAttemptEvent>(OnMetaFlagRemoval);
-        }
-
-        private void OnMetaFlagRemoval(EntityUid uid, ActionsComponent component, ref MetaFlagRemoveAttemptEvent args)
-        {
-            if (component.LifeStage == ComponentLifeStage.Running)
-                args.ToRemove &= ~MetaDataFlags.EntitySpecific;
-        }
-
-        private void OnStartup(EntityUid uid, ActionsComponent component, ComponentStartup args)
-        {
-            _metaSystem.AddFlag(uid, MetaDataFlags.EntitySpecific);
-        }
-
-        private void OnShutdown(EntityUid uid, ActionsComponent component, ComponentShutdown args)
-        {
-            _metaSystem.RemoveFlag(uid, MetaDataFlags.EntitySpecific);
-        }
-
-        private void OnPlayerAttached(EntityUid uid, ActionsComponent component, PlayerAttachedEvent args)
-        {
-            // need to send state to new player.
-            Dirty(component);
         }
 
         protected override bool PerformBasicActions(EntityUid user, ActionType action)

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -39,32 +39,6 @@ namespace Content.Server.Flash
             SubscribeLocalEvent<InventoryComponent, FlashAttemptEvent>(OnInventoryFlashAttempt);
 
             SubscribeLocalEvent<FlashImmunityComponent, FlashAttemptEvent>(OnFlashImmunityFlashAttempt);
-
-            SubscribeLocalEvent<FlashableComponent, ComponentStartup>(OnFlashableStartup);
-            SubscribeLocalEvent<FlashableComponent, ComponentShutdown>(OnFlashableShutdown);
-            SubscribeLocalEvent<FlashableComponent, MetaFlagRemoveAttemptEvent>(OnMetaFlagRemoval);
-            SubscribeLocalEvent<FlashableComponent, PlayerAttachedEvent>(OnPlayerAttached);
-        }
-
-        private void OnPlayerAttached(EntityUid uid, FlashableComponent component, PlayerAttachedEvent args)
-        {
-            Dirty(component);
-        }
-
-        private void OnMetaFlagRemoval(EntityUid uid, FlashableComponent component, ref MetaFlagRemoveAttemptEvent args)
-        {
-            if (component.LifeStage == ComponentLifeStage.Running)
-                args.ToRemove &= ~MetaDataFlags.EntitySpecific;
-        }
-
-        private void OnFlashableStartup(EntityUid uid, FlashableComponent component, ComponentStartup args)
-        {
-            _metaSystem.AddFlag(uid, MetaDataFlags.EntitySpecific);
-        }
-
-        private void OnFlashableShutdown(EntityUid uid, FlashableComponent component, ComponentShutdown args)
-        {
-            _metaSystem.RemoveFlag(uid, MetaDataFlags.EntitySpecific);
         }
 
         private void OnFlashMeleeHit(EntityUid uid, FlashComponent comp, MeleeHitEvent args)

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -45,13 +45,6 @@ namespace Content.Server.Shuttles.Systems
 
             SubscribeLocalEvent<PilotComponent, MoveEvent>(HandlePilotMove);
             SubscribeLocalEvent<PilotComponent, ComponentGetState>(OnGetState);
-            SubscribeLocalEvent<PilotComponent, ComponentGetStateAttemptEvent>(OnGetStateAttempt);
-        }
-
-        private void OnGetStateAttempt(EntityUid uid, PilotComponent component, ref ComponentGetStateAttemptEvent args)
-        {
-            if (args.Cancelled || !TryComp<ActorComponent>(uid, out var actor) || actor.PlayerSession != args.Player)
-                args.Cancelled = true;
         }
 
         private void OnDestinationMessage(EntityUid uid, ShuttleConsoleComponent component, ShuttleConsoleDestinationMessage args)

--- a/Content.Server/Vehicle/VehicleSystem.Rider.cs
+++ b/Content.Server/Vehicle/VehicleSystem.Rider.cs
@@ -11,36 +11,10 @@ namespace Content.Server.Vehicle
     {
         private void InitializeRider()
         {
-            SubscribeLocalEvent<RiderComponent, ComponentStartup>(OnRiderStartup);
-            SubscribeLocalEvent<RiderComponent, ComponentShutdown>(OnRiderShutdown);
-            SubscribeLocalEvent<RiderComponent, MetaFlagRemoveAttemptEvent>(OnRiderRemoval);
             SubscribeLocalEvent<RiderComponent, ComponentGetState>(OnRiderGetState);
-            SubscribeLocalEvent<RiderComponent, ComponentGetStateAttemptEvent>(OnRiderGetStateAttempt);
             SubscribeLocalEvent<RiderComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
             SubscribeLocalEvent<RiderComponent, FellDownEvent>(OnFallDown);
             SubscribeLocalEvent<RiderComponent, MobStateChangedEvent>(OnMobStateChanged);
-        }
-
-        private void OnRiderRemoval(EntityUid uid, RiderComponent component, ref MetaFlagRemoveAttemptEvent args)
-        {
-            if ((args.ToRemove & MetaDataFlags.EntitySpecific) != 0x0)
-                args.ToRemove = MetaDataFlags.None;
-        }
-
-        private void OnRiderStartup(EntityUid uid, RiderComponent component, ComponentStartup args)
-        {
-            _metadata.AddFlag(uid, MetaDataFlags.EntitySpecific);
-        }
-
-        private void OnRiderShutdown(EntityUid uid, RiderComponent component, ComponentShutdown args)
-        {
-            _metadata.RemoveFlag(uid, MetaDataFlags.EntitySpecific);
-        }
-
-        private void OnRiderGetStateAttempt(EntityUid uid, RiderComponent component, ref ComponentGetStateAttemptEvent args)
-        {
-            if (uid != args.Player.AttachedEntity)
-                args.Cancelled = true;
         }
 
         private void OnRiderGetState(EntityUid uid, RiderComponent component, ref ComponentGetState args)

--- a/Content.Shared/Actions/ActionsComponent.cs
+++ b/Content.Shared/Actions/ActionsComponent.cs
@@ -12,6 +12,8 @@ public sealed class ActionsComponent : Component
     [ViewVariables]
     [Access(typeof(SharedActionsSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
     public SortedSet<ActionType> Actions = new();
+
+    public override bool SendOnlyToOwner => true;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -37,7 +37,6 @@ public abstract class SharedActionsSystem : EntitySystem
         SubscribeLocalEvent<ActionsComponent, DidUnequipHandEvent>(OnHandUnequipped);
 
         SubscribeLocalEvent<ActionsComponent, ComponentGetState>(GetState);
-        SubscribeLocalEvent<ActionsComponent, ComponentGetStateAttemptEvent>(OnCanGetState);
 
         SubscribeAllEvent<RequestPerformActionEvent>(OnActionRequest);
     }
@@ -89,12 +88,6 @@ public abstract class SharedActionsSystem : EntitySystem
         args.State = new ActionsComponentState(component.Actions.ToList());
     }
 
-    private void OnCanGetState(EntityUid uid, ActionsComponent component, ref ComponentGetStateAttemptEvent args)
-    {
-        // Only send action state data to the relevant player.
-        if (args.Player.AttachedEntity != uid)
-            args.Cancelled = true;
-    }
     #endregion
 
     #region Execution

--- a/Content.Shared/Alert/AlertsComponent.cs
+++ b/Content.Shared/Alert/AlertsComponent.cs
@@ -11,4 +11,6 @@ namespace Content.Shared.Alert;
 public sealed class AlertsComponent : Component
 {
     [ViewVariables] public Dictionary<AlertKey, AlertState> Alerts = new();
+
+    public override bool SendOnlyToOwner => true;
 }

--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -158,38 +158,21 @@ public abstract class AlertsSystem : EntitySystem
         SubscribeLocalEvent<AlertsComponent, ComponentStartup>(HandleComponentStartup);
         SubscribeLocalEvent<AlertsComponent, ComponentShutdown>(HandleComponentShutdown);
 
-        SubscribeLocalEvent<AlertsComponent, MetaFlagRemoveAttemptEvent>(OnMetaFlagRemoval);
         SubscribeLocalEvent<AlertsComponent, ComponentGetState>(ClientAlertsGetState);
-        SubscribeLocalEvent<AlertsComponent, ComponentGetStateAttemptEvent>(OnCanGetState);
         SubscribeNetworkEvent<ClickAlertEvent>(HandleClickAlert);
 
         LoadPrototypes();
         _prototypeManager.PrototypesReloaded += HandlePrototypesReloaded;
     }
 
-    private void OnMetaFlagRemoval(EntityUid uid, AlertsComponent component, ref MetaFlagRemoveAttemptEvent args)
-    {
-        if (component.LifeStage == ComponentLifeStage.Running)
-            args.ToRemove &= ~MetaDataFlags.EntitySpecific;
-    }
-
-    private void OnCanGetState(EntityUid uid, AlertsComponent component, ref ComponentGetStateAttemptEvent args)
-    {
-        // Only send alert state data to the relevant player.
-        if (args.Player.AttachedEntity != uid)
-            args.Cancelled = true;
-    }
-
     protected virtual void HandleComponentShutdown(EntityUid uid, AlertsComponent component, ComponentShutdown args)
     {
         RaiseLocalEvent(uid, new AlertSyncEvent(uid), true);
-        _metaSystem.RemoveFlag(uid, MetaDataFlags.EntitySpecific);
     }
 
     private void HandleComponentStartup(EntityUid uid, AlertsComponent component, ComponentStartup args)
     {
         RaiseLocalEvent(uid, new AlertSyncEvent(uid), true);
-        _metaSystem.AddFlag(uid, MetaDataFlags.EntitySpecific);
     }
 
     public override void Shutdown()

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -9,14 +9,6 @@ namespace Content.Shared.Flash
             base.Initialize();
 
             SubscribeLocalEvent<SharedFlashableComponent, ComponentGetState>(OnFlashableGetState);
-            SubscribeLocalEvent<SharedFlashableComponent, ComponentGetStateAttemptEvent>(OnGetStateAttempt);
-        }
-
-        private static void OnGetStateAttempt(EntityUid uid, SharedFlashableComponent component, ref ComponentGetStateAttemptEvent args)
-        {
-            // Only send state to the player attached to the entity.
-            if (args.Player.AttachedEntity != uid)
-                args.Cancelled = true;
         }
 
         private static void OnFlashableGetState(EntityUid uid, SharedFlashableComponent component, ref ComponentGetState args)

--- a/Content.Shared/Flash/SharedFlashableComponent.cs
+++ b/Content.Shared/Flash/SharedFlashableComponent.cs
@@ -8,6 +8,8 @@ namespace Content.Shared.Flash
     {
         public float Duration { get; set; }
         public TimeSpan LastFlash { get; set; }
+
+        public override bool SendOnlyToOwner => true;
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Shuttles/Components/PilotComponent.cs
+++ b/Content.Shared/Shuttles/Components/PilotComponent.cs
@@ -29,5 +29,7 @@ namespace Content.Shared.Shuttles.Components
 
         [ViewVariables]
         public ShuttleButtons HeldButtons = ShuttleButtons.None;
+
+        public override bool SendOnlyToOwner => true;
     }
 }

--- a/Content.Shared/Vehicle/Components/RiderComponent.cs
+++ b/Content.Shared/Vehicle/Components/RiderComponent.cs
@@ -13,5 +13,7 @@ namespace Content.Shared.Vehicle.Components
         /// The vehicle this rider is currently riding.
         /// </summary>
         [ViewVariables] public EntityUid? Vehicle;
+
+        public override bool SendOnlyToOwner => true;
     }
 }


### PR DESCRIPTION
Required changes for an engine PR + boilerplate removal.
Requires space-wizards/RobustToolbox/pull/3249


