### PR TITLE
Increase breathable air canister capacity by 10x

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -4,7 +4,7 @@
     sprite: Structures/Storage/canister.rsi
     state: grey
   product: AirCanister
-  cost: 2700
+  cost: 6200
   category: Atmospherics
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 2300
+  cost: 4300
   category: Atmospherics
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 3200
+  cost: 4300
   category: Atmospherics
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 2600
+  cost: 1800
   category: Atmospherics
   group: market
 

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -128,10 +128,10 @@
       - state: grey
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 10000
       moles:
-        - 393.0592071 # oxygen 21%
-        - 1478.6513029 # nitrogen 79%
+        - 3930.0592071 # oxygen 21%
+        - 14780.6513029 # nitrogen 79%
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -159,9 +159,9 @@
       - state: blue
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 10000
       moles:
-        - 1871.71051 # oxygen
+        - 18710.71051 # oxygen
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -189,10 +189,10 @@
         - state: red
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles:
           - 0 # oxygen
-          - 1871.71051 # nitrogen
+          - 18710.71051 # nitrogen
         temperature: 293.15
     - type: Destructible
       thresholds:


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The current default gas content (about 1800 moles) is enough to fill 18 tiles (because each tile contains about 100 moles at STP). This makes it impractical for players to use canisters to re-pressurize a station.

This PR fills air, N2, and O2 canisters with 10x more air, so that each canister can re-pressurize 180 tiles. This might sound like a lot, but for comparison, atmos on Omega is 91 tiles. After this change, one canister would only be able to refill a de-pressurized atmos twice.

Increase effective gas canister volume by 10x as well to prevent max-capping. The "physics-based" reason for this is that gases turn into liquids at high pressures; real cryogenic gas tanks only output about 400 kPa despite having a lot of gas stored.

Adjust cargo gas canister prices to reflect the higher quantity of gas. While here, adjust the CO2 canister price to reflect how much it should be actually worth after the recent change to gas prices (#10948).

See also: #8311

**Screenshots**
N/A

**Changelog**
:cl: notafet
- add: Air, oxygen, and nitrogen gas canisters now contain significantly more gas.