### PR TITLE
Use paralyze for table bonks

### DIFF
--- a/Content.Server/Climbing/ClimbSystem.cs
+++ b/Content.Server/Climbing/ClimbSystem.cs
@@ -144,8 +144,7 @@ public sealed class ClimbSystem : SharedClimbSystem
         // BONK!
 
         _audioSystem.PlayPvs(component.BonkSound, component.Owner);
-
-        _stunSystem.TryKnockdown(user, TimeSpan.FromSeconds(component.BonkTime), true);
+        _stunSystem.TryParalyze(user, TimeSpan.FromSeconds(component.BonkTime), true);
 
         if (component.BonkDamage is { } bonkDmg)
             _damageableSystem.TryChangeDamage(user, bonkDmg, true);

--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -41,7 +41,7 @@ namespace Content.Shared.ActionBlocker
                 return false;
 
             var ev = new UpdateCanMoveEvent(uid);
-            RaiseLocalEvent(uid, ev, true);
+            RaiseLocalEvent(uid, ev);
 
             if (component.CanMove == ev.Cancelled && component is Component comp)
                 Dirty(comp);


### PR DESCRIPTION
Originally I was going to have knockdowns block movement but we might want crawling I guess.
Fixes https://github.com/space-wizards/space-station-14/issues/11116

:cl:
- fix: Clowns bonking on a table no longer get free movement.
