### PR TITLE
Fix appearance being lost on cloning

### DIFF
--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -219,8 +219,7 @@ namespace Content.Server.Cloning.Systems
             // end of genetic damage checks
 
             var mob = Spawn(speciesPrototype.Prototype, Transform(clonePod.Owner).MapPosition);
-            _appearanceSystem.UpdateAppearance(mob, humanoid.Appearance);
-            _appearanceSystem.UpdateSexGender(mob, humanoid.Sex, humanoid.Gender);
+            _appearanceSystem.UpdateAppearance(mob, humanoid.Appearance, humanoid.Sex, humanoid.Gender, humanoid.Species, humanoid.Age);
 
             MetaData(mob).EntityName = MetaData(bodyToClone).EntityName;
 

--- a/Content.Shared/CharacterAppearance/Systems/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/CharacterAppearance/Systems/SharedHumanoidAppearanceSystem.cs
@@ -36,7 +36,7 @@ namespace Content.Shared.CharacterAppearance.Systems
             component.Dirty();
         }
 
-        private void UpdateAppearance(EntityUid uid, HumanoidCharacterAppearance appearance, Sex sex, Gender gender, string species, int age, HumanoidAppearanceComponent? component = null)
+        public void UpdateAppearance(EntityUid uid, HumanoidCharacterAppearance appearance, Sex sex, Gender gender, string species, int age, HumanoidAppearanceComponent? component = null)
         {
             if (!Resolve(uid, ref component)) return;
 


### PR DESCRIPTION
## About the PR
Due to my previous PR it became apparent that clones did not update their `HumanoidAppearance` to match the original body. This PR (_hopefully_) fixes that.
I don't actually know what was causing it, maybe two calls to `Component.Dirty` or two `ChangedHumanoidAppearanceEvent`s, but I'm just guessing. And the previously private `SharedHumanoidAppearanceSystem.UpdateAppearance` is better for this than calling those two methods anyway, so whatever.

**Screenshots**
Before:
![image](https://user-images.githubusercontent.com/80923370/189932341-a5c0dc9a-fd1d-4cac-aac7-d3344bf3a273.png)
^ original body

![image](https://user-images.githubusercontent.com/80923370/189932364-cf9ee67f-841c-4215-8c70-de599b6e0ffd.png)
^ clone

After:
![image](https://user-images.githubusercontent.com/80923370/189937110-1bbeb82a-4213-4c91-80e1-13366a244907.png)
^ original body

![image](https://user-images.githubusercontent.com/80923370/189937143-696883ca-ef43-4da0-9b71-562547a7d6b9.png)
^ clone

**Changelog**
:cl: och
- fix: Fix all clones being young neuter humans

