### PR TITLE
Allowed stunbaton for Wall Recharger

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -76,3 +76,4 @@
         components:
         - HitscanBatteryAmmoProvider
         - ProjectileBatteryAmmoProvider
+        - Stunbaton


### PR DESCRIPTION
-Wall Recharger now accepts Stunbatons when it previously could not.

NT need better inventors or I'll take their knees