### PR TITLE
Empty fuel tanks won't explode. Fuel tank explosion scales with remaining fuel.

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -11,6 +11,8 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Shared.Destructible;
+using Content.Server.Chemistry.EntitySystems;
+using Content.Server.Fluids.EntitySystems;
 
 namespace Content.Server.Destructible
 {
@@ -25,6 +27,8 @@ namespace Content.Server.Destructible
         [Dependency] public readonly ExplosionSystem ExplosionSystem = default!;
         [Dependency] public readonly StackSystem StackSystem = default!;
         [Dependency] public readonly TriggerSystem TriggerSystem = default!;
+        [Dependency] public readonly SolutionContainerSystem SolutionContainerSystem = default!;
+        [Dependency] public readonly SpillableSystem SpillableSystem = default!;
         [Dependency] public readonly IPrototypeManager PrototypeManager = default!;
         [Dependency] public readonly IComponentFactory ComponentFactory = default!;
 

--- a/Content.Server/Destructible/Thresholds/Behaviors/SolutionExplosionBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SolutionExplosionBehavior.cs
@@ -1,0 +1,46 @@
+using Content.Server.Chemistry.EntitySystems;
+using Content.Server.Fluids.Components;
+using Content.Server.Fluids.EntitySystems;
+using Content.Server.Explosion.Components;
+using JetBrains.Annotations;
+
+namespace Content.Server.Destructible.Thresholds.Behaviors
+{
+    /// <summary>
+    /// Works like a SpillBehavior combined with an ExplodeBehavior
+    /// </summary>
+    [UsedImplicitly]
+    [DataDefinition]
+    public sealed class SolutionExplosionBehavior : IThresholdBehavior
+    {
+        [DataField("solution", required: true)]
+        public string Solution = default!;
+
+        public void Execute(EntityUid owner, DestructibleSystem system)
+        {
+            if (system.SolutionContainerSystem.TryGetSolution(owner, Solution, out var explodingSolution)
+                && system.EntityManager.TryGetComponent(owner, out ExplosiveComponent? explosiveComponent))
+            {
+                // Don't explode if there's no solution
+                if (explodingSolution.CurrentVolume == 0)
+                    return;
+
+                // Scale the explosion intensity based on the remaining volume of solution
+                var explosionScaleFactor = (explodingSolution.CurrentVolume.Float() / explodingSolution.MaxVolume.Float());
+
+                // TODO: Perhaps some of the liquid should be discarded as if it's being consumed by the explosion
+
+                // Spill the solution out into the world
+                // Spill before exploding in anticipation of a future where the explosion can light the solution on fire.
+                var coordinates = system.EntityManager.GetComponent<TransformComponent>(owner).Coordinates;
+                system.SpillableSystem.SpillAt(explodingSolution, coordinates, "PuddleSmear", combine: true);
+
+                // Explode
+                // Don't delete the object here - let other processes like physical damage from the
+                // explosion clean up the exploding object(s)
+                var explosiveTotalIntensity = explosiveComponent.TotalIntensity * explosionScaleFactor;
+                system.ExplosionSystem.TriggerExplosive(owner, explosiveComponent, false, explosiveTotalIntensity);
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
@@ -30,17 +30,17 @@
         damageType: Heat
         damage: 5
       behaviors:
-      #spill BEFORE exploding, so that one day explosions can ignite puddles
-      - !type:SpillBehavior
+      - !type:SolutionExplosionBehavior
         solution: tank
-      - !type:ExplodeBehavior
-        #note: only actually explodes if entity has ExplosiveComponent.
     - trigger:
         !type:DamageTrigger
         damage: 10
       behaviors:
       - !type:SpillBehavior
         solution: tank
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/metalbreak.ogg
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: SolutionContainerManager


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds `SolutionExplosionBehavior` which combines elements of `SpillBehavior` and `ExplodeBehavior`. It's necessary to create this combined behavior so that we can 1: Prevent the explosion from happening if the solution is empty and 2: Provide a foundation for some more fun down the line involving exploding solutions.

Fixes #10924


### Empty Fuel Tanks won't explode

yeah

### Fuel tank explosion scales with remaining fuel.
Here is a normal full tank for reference
![tank_normal](https://user-images.githubusercontent.com/6798456/190075505-1b85938f-35fe-48d4-bfd2-7d2e54b01b87.gif)

Here is a tank with 250 fuel remaining
![tank_almostempty](https://user-images.githubusercontent.com/6798456/190075516-ecca6589-bbd7-4ac1-94da-31c7a09cd381.gif)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Empty Fuel Tank wont explode.
- add: Fuel Tank explosion scales with remaining fuel.

