### PR TITLE
CE and Captain jetpack tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -140,6 +140,7 @@
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     slots:
       - Back
+      - suitStorage
   - type: Item
     size: 30
 
@@ -233,6 +234,9 @@
     sprite: Objects/Tanks/Jetpacks/void.rsi
     slots:
       - Back
+      - suitStorage
+  - type: Item
+    size: 50
 
 # Filled void
 - type: entity


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR 
Both Void and Captain's jetpacks can fit in suit storage now, and the Void Jetpack now has a size of 50 to make it more convenient to store in a bag.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Nanotrasen engineers have optimized the physical profile of the captain and void jetpacks, allowing them to fit in suit storage. Additionally, the void jetpack has had its weight significantly reduced, making it easier to store in bags.

