### PR TITLE
Add trash tags to some items

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -39,6 +39,8 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkBottleBaseFull

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
@@ -114,6 +114,9 @@
     sprite: Objects/Consumable/Food/plates.rsi
     state: plate-plastic
     netsync: false
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   name: plastic plate
@@ -125,6 +128,9 @@
     sprite: Objects/Consumable/Food/plates.rsi
     state: plate-small-plastic
     netsync: false
+  - type: Tag
+    tags:
+    - Trash
 
 # Pie Tin
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -98,6 +98,8 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: TrashOnEmpty
+    solution: food
 
 - type: entity
   parent: ReagentContainerBase


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds Trash tag or TrashOnEmpty component to some of the items requested in #10988
- Bottles from the Booze-o-mat (on empty)
- Plastic plates (trash)
- Kitchen ingredient containers like milk carton/flour bag (on empty)

As far as I can tell, empty coffee/tea, empty soda cans, and empty sauce packets get trashed correctly.
Might need discussion as per if lighters/rolling packs should be marked as trash. (not touching for now)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Trash bags can pick up empty booze bottles, empty ingredient packs, and plastic plates
