### PR TITLE
Load prototype command

### DIFF
--- a/Content.Client/Administration/Commands/LoadPrototypeCommand.cs
+++ b/Content.Client/Administration/Commands/LoadPrototypeCommand.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using Content.Shared.Administration;
+using Robust.Client.UserInterface;
+using Robust.Shared.Console;
+
+namespace Content.Client.Administration.Commands;
+
+public sealed class LoadPrototypeCommand : IConsoleCommand
+{
+    public string Command { get; } = "loadprototype";
+    public string Description { get; } = "Load a prototype file into the server.";
+    public string Help => Command;
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        LoadPrototype();
+    }
+
+    public static async void LoadPrototype()
+    {
+        var dialogManager = IoCManager.Resolve<IFileDialogManager>();
+        var loadManager = IoCManager.Resolve<IGamePrototypeLoadManager>();
+
+        var stream = await dialogManager.OpenFile();
+        if (stream is null)
+            return;
+
+        // ew oop
+        var reader = new StreamReader(stream);
+        var proto = await reader.ReadToEndAsync();
+        loadManager.SendGamePrototype(proto);
+    }
+}

--- a/Content.Client/Administration/UI/Tabs/AdminbusTab/AdminbusTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/AdminbusTab/AdminbusTab.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Content.Client.Administration.Commands;
 using Content.Client.Administration.Managers;
 using Content.Client.Sandbox;
 using Content.Shared.Administration;
@@ -29,19 +30,9 @@ namespace Content.Client.Administration.UI.Tabs.AdminbusTab
             LoadBlueprintsButton.Disabled = !adminManager.HasFlag(AdminFlags.Mapping);
         }
 
-        private async void LoadGamePrototypeButtonOnPressed(BaseButton.ButtonEventArgs obj)
+        private void LoadGamePrototypeButtonOnPressed(BaseButton.ButtonEventArgs obj)
         {
-            var dialogManager = IoCManager.Resolve<IFileDialogManager>();
-            var loadManager = IoCManager.Resolve<IGamePrototypeLoadManager>();
-
-            var stream = await dialogManager.OpenFile();
-            if (stream is null)
-                return;
-
-            // ew oop
-            var reader = new StreamReader(stream);
-            var proto = await reader.ReadToEndAsync();
-            loadManager.SendGamePrototype(proto);
+            LoadPrototypeCommand.LoadPrototype();
         }
 
         private void SpawnEntitiesButtonOnPressed(BaseButton.ButtonEventArgs obj)

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -66,3 +66,4 @@
 - Flags: QUERY
   Commands:
     - uploadfile
+    - loadprototype


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Turns the 'Load Prototype' button in the admin menu into a command, allowing users that have +QUERY but do not have +ADMIN to load a prototype into the server. This mirrors the flag limitation of prototype loading server-side, where it checks if the user has +QUERY for loading a prototype - but does not check if they have +ADMIN.
