### PR TITLE
Toggle windoors open with a click

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -57,7 +57,7 @@ public sealed class DoorSystem : SharedDoorSystem
         if (args.Handled || !door.ClickOpen)
             return;
 
-        TryToggleDoor(uid, door, args.User);
+        TryToggleDoor(uid, door, args.User, default, true);
         args.Handled = true;
     }
 
@@ -314,7 +314,7 @@ public sealed class DoorSystem : SharedDoorSystem
         }
     }
 
-    public override void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    public override void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false, bool clickedOpen = false)
     {
         if (!Resolve(uid, ref door))
             return;
@@ -322,6 +322,9 @@ public sealed class DoorSystem : SharedDoorSystem
         var lastState = door.State;
 
         SetState(uid, DoorState.Opening, door);
+
+        // Only set this here after all checks have been done.
+        door.ClickedOpen = clickedOpen;
 
         if (door.OpenSound != null)
             PlaySound(uid, door.OpenSound, AudioParams.Default.WithVolume(-5), user, predicted);

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -205,6 +205,19 @@ public sealed class DoorComponent : Component, ISerializationHooks
     [DataField("clickOpen")]
     public bool ClickOpen = true;
 
+    /// <summary>
+    /// Whether the door will stay open when it is activated or clicked.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("stayOpenOnClick")]
+    public bool StayOpenOnClick = false;
+
+    /// <summary>
+    ///     Whether the door is being manually opened
+    /// </summary>
+    [DataField("clickedOpen")]
+    public bool ClickedOpen = false;
+
     [DataField("openDrawDepth", customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
     public int OpenDrawDepth = (int) DrawDepth.DrawDepth.Doors;
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -85,6 +85,7 @@
       path: /Audio/Machines/windoor_open.ogg
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
+    stayOpenOnClick: true
   - type: Electrified
     enabled: false
     usesApcPower: true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Clicking or activating a windoor manually will cause it to remain open instead of auto-closing.
This could be used in places like botany, kitchen, or chemistry where you often need it open longer.

Implements #10462

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

<video src='https://user-images.githubusercontent.com/89101928/190271109-a1c446d1-9f46-4982-b6f5-17614ce801a5.mp4'></video>


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak; Windoors will stay open when manually clicked or activated

