### PR TITLE
Fix ChemMaster labelling behavior

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Chemistry.Components;
+using Content.Server.Labels;
 using Content.Server.Labels.Components;
 using Content.Server.Popups;
 using Content.Server.Storage.Components;
@@ -33,6 +34,7 @@ namespace Content.Server.Chemistry.EntitySystems
         [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
         [Dependency] private readonly UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private readonly StorageSystem _storageSystem = default!;
+        [Dependency] private readonly LabelSystem _labelSystem = default!;
         
         private const string PillPrototypeId = "Pill";
 
@@ -191,13 +193,13 @@ namespace Content.Server.Chemistry.EntitySystems
             if (!WithdrawFromBuffer(chemMaster, needed, user, out var withdrawal))
                 return;
             
-            Label(container, message.Label);
+            _labelSystem.Label(container, message.Label);
             
             for (var i = 0; i < message.Number; i++)
             {
                 var item = Spawn(PillPrototypeId, Transform(container).Coordinates);
                 _storageSystem.Insert(container, item, storage);
-                Label(item, message.Label);
+                _labelSystem.Label(item, message.Label);
 
                 var itemSolution = _solutionContainerSystem.EnsureSolution(item, SharedChemMaster.PillSolutionName);
                 
@@ -231,7 +233,7 @@ namespace Content.Server.Chemistry.EntitySystems
             if (!WithdrawFromBuffer(chemMaster, message.Dosage, user, out var withdrawal))
                 return;
 
-            Label(container, message.Label);
+            _labelSystem.Label(container, message.Label);
             _solutionContainerSystem.TryAddSolution(
                 container, solution, withdrawal);
 
@@ -268,18 +270,6 @@ namespace Content.Server.Chemistry.EntitySystems
 
             outputSolution = solution.SplitSolution(neededVolume);
             return true;
-        }
-
-        private void Label(EntityUid ent, string label)
-        {
-            if (string.IsNullOrEmpty(label)) 
-                return;
-            var labelComponent = EnsureComp<LabelComponent>(ent);
-            
-            labelComponent.OriginalName = Name(ent);
-            var val = Name(ent) + $" ({label})";
-            MetaData(ent).EntityName = val;
-            labelComponent.CurrentLabel = label;
         }
 
         private void ClickSound(ChemMasterComponent chemMaster)

--- a/Content.Server/Labels/Label/HandLabelerSystem.cs
+++ b/Content.Server/Labels/Label/HandLabelerSystem.cs
@@ -15,6 +15,7 @@ namespace Content.Server.Labels
     public sealed class HandLabelerSystem : EntitySystem
     {
         [Dependency] private readonly UserInterfaceSystem _userInterfaceSystem = default!;
+        [Dependency] private readonly LabelSystem _labelSystem = default!;
 
         public override void Initialize()
         {
@@ -44,23 +45,14 @@ namespace Content.Server.Labels
                 return;
             }
 
-            LabelComponent label = target.EnsureComponent<LabelComponent>();
-
-            if (label.OriginalName != null)
-                EntityManager.GetComponent<MetaDataComponent>(target).EntityName = label.OriginalName;
-            label.OriginalName = null;
-
             if (handLabeler.AssignedLabel == string.Empty)
             {
-                label.CurrentLabel = null;
+                _labelSystem.Label(target, null);
                 result = Loc.GetString("hand-labeler-successfully-removed");
                 return;
             }
 
-            label.OriginalName = EntityManager.GetComponent<MetaDataComponent>(target).EntityName;
-            string val = EntityManager.GetComponent<MetaDataComponent>(target).EntityName + $" ({handLabeler.AssignedLabel})";
-            EntityManager.GetComponent<MetaDataComponent>(target).EntityName = val;
-            label.CurrentLabel = handLabeler.AssignedLabel;
+            _labelSystem.Label(target, handLabeler.AssignedLabel);
             result = Loc.GetString("hand-labeler-successfully-applied");
         }
 

--- a/Content.Server/Labels/Label/LabelSystem.cs
+++ b/Content.Server/Labels/Label/LabelSystem.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Labels
             if (!Resolve(uid, ref metadata))
                 return;
             if (!Resolve(uid, ref label, false))
-                label = uid.EnsureComponent<LabelComponent>();
+                label = EnsureComp<LabelComponent>(uid);
 
             if (string.IsNullOrEmpty(text))
             {

--- a/Content.Server/Labels/Label/LabelSystem.cs
+++ b/Content.Server/Labels/Label/LabelSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Examine;
 using Content.Shared.Labels;
 using JetBrains.Annotations;
-using Npgsql.Internal.TypeHandlers.LTreeHandlers;
 using Robust.Shared.Containers;
 using Robust.Shared.Utility;
 


### PR DESCRIPTION
The labelling code extracted from the old ChemMaster's CreatePillsAndBottles didn't correctly handle applying a label to something that was already labelled.

This commit cleans up and extracts to LabelSystem the labelling code from the hand labeller and uses it inside the ChemMaster.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: illiux
- fix: The ChemMaster 4000 applies labels correctly

