### PR TITLE
Adds another check in the Nukeops system

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -101,6 +101,20 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
     }
 
     private WinType _winType = WinType.Neutral;
+
+    private WinType RuleWinType
+    {
+        get => _winType;
+        set
+        {
+            _winType = value;
+
+            if (value == WinType.CrewMajor || value == WinType.OpsMajor)
+            {
+                _roundEndSystem.EndRound();
+            }
+        }
+    }
     private List<WinCondition> _winConditions = new ();
 
     private MapId? _nukiePlanet;
@@ -175,28 +189,27 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         {
             if (ev.OwningStation == _nukieOutpost)
             {
-                _winType = WinType.CrewMajor;
                 _winConditions.Add(WinCondition.NukeExplodedOnNukieOutpost);
+                RuleWinType = WinType.CrewMajor;
+                return;
             }
-            else
+
+            if (TryComp(_targetStation, out StationDataComponent? data))
             {
-                if (TryComp(_targetStation, out StationDataComponent? data))
+                foreach (var grid in data.Grids)
                 {
-                    foreach (var grid in data.Grids)
+                    if (grid != ev.OwningStation)
                     {
-                        if (grid != ev.OwningStation)
-                        {
-                            continue;
-                        }
-
-                        _winType = WinType.OpsMajor;
-                        _winConditions.Add(WinCondition.NukeExplodedOnCorrectStation);
-                        return;
+                        continue;
                     }
-                }
 
-                _winConditions.Add(WinCondition.NukeExplodedOnIncorrectLocation);
+                    _winConditions.Add(WinCondition.NukeExplodedOnCorrectStation);
+                    RuleWinType = WinType.OpsMajor;
+                    return;
+                }
             }
+
+            _winConditions.Add(WinCondition.NukeExplodedOnIncorrectLocation);
         }
         else
         {
@@ -246,7 +259,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
     private void OnRoundEnd()
     {
         // If the win condition was set to operative/crew major win, ignore.
-        if (_winType == WinType.OpsMajor || _winType == WinType.CrewMajor)
+        if (RuleWinType == WinType.OpsMajor || RuleWinType == WinType.CrewMajor)
         {
             return;
         }
@@ -261,8 +274,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
             // UH OH
             if (nukeTransform.MapID == _shuttleSystem.CentComMap)
             {
-                _winType = WinType.OpsMajor;
                 _winConditions.Add(WinCondition.NukeActiveAtCentCom);
+                RuleWinType = WinType.OpsMajor;
                 return;
             }
 
@@ -283,8 +296,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
                     continue;
                 }
 
-                _winType = WinType.OpsMajor;
                 _winConditions.Add(WinCondition.NukeActiveInStation);
+                RuleWinType = WinType.OpsMajor;
                 return;
             }
         }
@@ -305,7 +318,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         // running away the moment nuke ops appear.
         if (allAlive)
         {
-            _winType = WinType.OpsMinor;
+            RuleWinType = WinType.OpsMinor;
             _winConditions.Add(WinCondition.AllNukiesAlive);
             return;
         }
@@ -327,13 +340,13 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         // This also implies that some nuclear operatives have died.
         if (diskAtCentCom)
         {
-            _winType = WinType.CrewMinor;
+            RuleWinType = WinType.CrewMinor;
             _winConditions.Add(WinCondition.NukeDiskOnCentCom);
         }
         // Otherwise, the nuke ops win.
         else
         {
-            _winType = WinType.OpsMinor;
+            RuleWinType = WinType.OpsMinor;
             _winConditions.Add(WinCondition.NukeDiskNotOnCentCom);
         }
     }
@@ -363,7 +376,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     private void CheckRoundShouldEnd()
     {
-        if (!RuleAdded || _winType == WinType.CrewMajor || _winType == WinType.OpsMajor)
+        if (!RuleAdded || RuleWinType == WinType.CrewMajor || RuleWinType == WinType.OpsMajor)
             return;
 
         // If there are any nuclear bombs that are active, immediately return. We're not over yet.
@@ -401,8 +414,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         if (operativesAlive)
             return; // There are living operatives than can access the shuttle, or are still on the station's map.
 
-        _winType = WinType.CrewMajor;
-
         // Check that there are spawns available and that they can access the shuttle.
         var spawnsAvailable = EntityQuery<NukeOperativeSpawnerComponent>(true).Any();
         if (spawnsAvailable && shuttleMapId == _nukiePlanet)
@@ -419,7 +430,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
             _winConditions.Add(WinCondition.AllNukiesDead);
         }
 
-        _roundEndSystem.EndRound();
+        RuleWinType = WinType.CrewMajor;
     }
 
     private void OnNukeDisarm(NukeDisarmSuccessEvent ev)
@@ -790,7 +801,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     public override void Started()
     {
-        _winType = WinType.Neutral;
+        RuleWinType = WinType.Neutral;
         _winConditions.Clear();
         _nukieOutpost = null;
         _nukiePlanet = null;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -363,7 +363,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     private void CheckRoundShouldEnd()
     {
-        if (!RuleAdded)
+        if (!RuleAdded || _winType == WinType.CrewMajor || _winType == WinType.OpsMajor)
             return;
 
         // If there are any nuclear bombs that are active, immediately return. We're not over yet.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

CheckRoundShouldEnd in NukeopsRuleSystem managed to give the crew a victory (since all nukeops died) when the entire station exploded. This should enforce that if the win type was set to any major type, the function should return. This also makes it so that if the round's win conditions lead to a major win, the round should end immediately via the property setter.