### PR TITLE
Cargo price tweaks 2

### DIFF
--- a/Content.Server/Cargo/Components/StationBankAccountComponent.cs
+++ b/Content.Server/Cargo/Components/StationBankAccountComponent.cs
@@ -15,5 +15,5 @@ public sealed class StationBankAccountComponent : Component
     /// How much the bank balance goes up per second, every Delay period. Rounded down when multiplied.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("increasePerSecond")]
-    public int IncreasePerSecond = 2;
+    public int IncreasePerSecond = 1;
 }

--- a/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Cargo.Components;
 using Content.Server.Labels.Components;
+using Content.Server.MobState;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.UserInterface;
@@ -39,6 +40,7 @@ public sealed partial class CargoSystem
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly PricingSystem _pricing = default!;
     [Dependency] private readonly ShuttleConsoleSystem _console = default!;
     [Dependency] private readonly ShuttleSystem _shuttle = default!;
@@ -534,8 +536,8 @@ public sealed partial class CargoSystem
 
         while (childEnumerator.MoveNext(out var child))
         {
-            if (mobQuery.HasComponent(child.Value) ||
-                FoundOrganics(child.Value, mobQuery, xformQuery)) return true;
+            if ((mobQuery.TryGetComponent(child.Value, out var mobState) && !_mobState.IsDead(child.Value, mobState))
+                || FoundOrganics(child.Value, mobQuery, xformQuery)) return true;
         }
 
         return false;

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
     state: icon
   product: CrateArmorySMG
-  cost: 8000
+  cost: 3000
   category: Armory
   group: market
 
@@ -14,6 +14,6 @@
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
     state: icon
   product: CrateArmoryShotgun
-  cost: 8000
+  cost: 2500
   category: Armory
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_botany.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_botany.yml
@@ -14,7 +14,7 @@
     sprite: Objects/Specific/Hydroponics/galaxythistle.rsi
     state: seed
   product: CrateHydroponicsSeedsMedicinal
-  cost: 1000
+  cost: 500
   category: Hydroponics
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Tools/Hydroponics/hoe.rsi
     state: icon
   product: CrateHydroponicsTools
-  cost: 1500
+  cost: 500
   category: Hydroponics
   group: market
 
@@ -34,6 +34,6 @@
     sprite: Objects/Specific/Hydroponics/apple.rsi
     state: seed
   product: CrateHydroponicsSeeds
-  cost: 1000
+  cost: 500
   category: Hydroponics
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
@@ -4,7 +4,7 @@
     sprite: Clothing/Head/Helmets/bombsuit.rsi
     state: icon
   product: CrateEmergencyExplosive
-  cost: 1500
+  cost: 500
   category: Emergency
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Clothing/Mask/breath.rsi
     state: icon
   product: CrateEmergencyInternals
-  cost: 1000
+  cost: 500
   category: Emergency
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Structures/Wallmounts/signs.rsi
     state: radiation
   product: CrateEmergencyRadiation
-  cost: 1000
+  cost: 500
   category: Emergency
   group: market
 
@@ -44,6 +44,6 @@
     sprite: Objects/Misc/inflatable_wall.rsi
     state: item_wall
   product: CrateEmergencyInflatablewall
-  cost: 1000
+  cost: 500
   category: Emergency
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coillv-30
   product: CrateEngineeringCableLV
-  cost: 1000
+  cost: 300
   category: Engineering
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilmv-30
   product: CrateEngineeringCableMV
-  cost: 1500
+  cost: 300
   category: Engineering
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilhv-30
   product: CrateEngineeringCableHV
-  cost: 2000
+  cost: 300
   category: Engineering
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilall-30
   product: CrateEngineeringCableBulk
-  cost: 3000
+  cost: 500
   category: Engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Power/AME/ame_part.rsi
     state: box
   product: CrateEngineeringAMEShielding
-  cost: 10000
+  cost: 6000
   category: Engineering
   group: market
 
@@ -76,7 +76,7 @@
     sprite: Structures/Power/Generation/PA/control_box.rsi
     state: boxc
   product: CrateEngineeringParticleAccelerator
-  cost: 10000
+  cost: 2000
   category: Engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita
   product: CrateFoodPizza
-  cost: 1000
+  cost: 500
   category: Food
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     state: nutribrick
   product: CrateFoodMRE
-  cost: 4000
+  cost: 1000
   category: Food
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Consumable/Food/ingredients.rsi
     state: flour-big
   product: CrateFoodCooking
-  cost: 5000
+  cost: 1500
   category: Food
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Fun/Instruments/accordion.rsi
     state: icon
   product: CrateFunInstruments
-  cost: 5000
+  cost: 3000
   category: Fun
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Fun/Instruments/structureinstruments.rsi
     state: tuba
   product: CrateFunBrass
-  cost: 3500
+  cost: 2500
   category: Fun
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Fun/crayons.rsi
     state: box
   product: CrateFunArtSupplies
-  cost: 1000
+  cost: 500
   category: Fun
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Fun/toys.rsi
     state: plushie_h
   product: CrateFunPlushie
-  cost: 5000
+  cost: 1000
   category: Fun
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -94,7 +94,7 @@
     sprite: Mobs/Animals/gorilla.rsi
     state: icon
   product: CrateNPCGorilla
-  cost: 2000
+  cost: 1000
   category: Livestock
   group: market
 
@@ -104,7 +104,7 @@
     sprite: Mobs/Animals/monkey.rsi
     state: monkey
   product: CrateNPCMonkeyCube
-  cost: 1500
+  cost: 2000
   category: Livestock
   group: market
 
@@ -134,7 +134,7 @@
     sprite: Mobs/Animals/penguin.rsi
     state: penguin
   product: CrateNPCPenguin
-  cost: 2000
+  cost: 1500
   category: Livestock
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Materials/Sheets/glass.rsi
     state: glass_3
   product: CrateMaterialGlass
-  cost: 1500
+  cost: 1000
   category: Materials
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: steel_3
   product: CrateMaterialSteel
-  cost: 1500
+  cost: 1000
   category: Materials
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: plasteel_3
   product: CrateMaterialPlasteel
-  cost: 6000
+  cost: 3000
   category: Materials
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: plasma_3
   product: CrateMaterialPlasma
-  cost: 5000
+  cost: 2000
   category: Materials
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_science.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_science.yml
@@ -4,6 +4,6 @@
     sprite: Structures/Storage/Crates/artifact.rsi
     state: artifact_container_icon
   product: CrateArtifactContainer
-  cost: 2000
+  cost: 500
   category: Science
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -4,7 +4,7 @@
     sprite: Clothing/OuterClothing/Vests/oldarmor.rsi
     state: icon
   product: CrateSecurityArmor
-  cost: 1500
+  cost: 500
   category: Security
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Clothing/Head/Helmets/security.rsi
     state: icon
   product: CrateSecurityHelmet
-  cost: 1000
+  cost: 500
   category: Security
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
     state: icon
   product: CrateSecurityLaser
-  cost: 2000
+  cost: 1600
   category: Security
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
     state: icon
   product: CrateSecurityRiot
-  cost: 10000
+  cost: 2000
   category: Security
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Objects/Storage/boxes.rsi
     state: box_security
   product: CrateSecuritySupplies
-  cost: 1500
+  cost: 500
   category: Security
   group: market
 
@@ -64,6 +64,6 @@
     sprite: Objects/Misc/handcuffs.rsi
     state: handcuff
   product: CrateRestraints
-  cost: 1500
+  cost: 1000
   category: Security
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Specific/Janitorial/janitorial.rsi
     state: cleaner
   product: CrateServiceJanitorialSupplies
-  cost: 1000
+  cost: 500
   category: Service
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Power/light_bulb.rsi
     state: normal
   product: CrateServiceReplacementLights
-  cost: 1000
+  cost: 600
   category: Service
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Devices/mousetrap.rsi
     state: mousetrap
   product: CrateMousetrapBoxes
-  cost: 1000
+  cost: 500
   category: Service
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Consumable/Smokeables/Cigarettes/Cartons/green.rsi
     state: closed
   product: CrateServiceSmokeables
-  cost: 2000
+  cost: 1500
   category: Service
   group: market
 

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -66,6 +66,8 @@
         useDelay: 1.0
         event: !type:ToggleJetpackEvent
     - type: Appearance
+    - type: StaticPrice
+      price: 100
 
 #Empty blue
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -71,6 +71,8 @@
     # Gravity generator is a large machine, not casting shadows is fine within the radius set above.
     castShadows: false
     color: "#a8ffd9"
+  - type: StaticPrice
+    price: 5000
 
 - type: entity
   id: GravityGeneratorMini
@@ -106,3 +108,5 @@
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
+  - type: StaticPrice
+    price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -69,6 +69,8 @@
   - type: Actions
   - type: SentienceTarget
     flavorKind: mechanical
+  - type: StaticPrice
+    price: 200
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -16,6 +16,8 @@
           nodeGroupID: Pipe
           pipeDirection: South
     - type: CollideOnAnchor
+    - type: StaticPrice
+      price: 200
 
 - type: entity
   parent: GasUnaryBase

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -53,6 +53,8 @@
   - type: ContainerContainer
     containers:
       DisposalTube: !type:Container
+  - type: StaticPrice
+    price: 100
 
 - type: entity
   id: DisposalHolder

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -36,6 +36,8 @@
         behaviors:
           - !type:DoActsBehavior
             acts: ["Destruction"]
+    - type: StaticPrice
+      price: 1000
   placement:
     mode: SnapgridCenter
 
@@ -111,6 +113,8 @@
     autoRot: true
     offset: "0, 0.1" # shine from the top, not bottom of the computer
     color: "#4246b3"
+  - type: StaticPrice
+    price: 2000
 
 - type: entity
   id: DebugGyroscope

--- a/Resources/Prototypes/Entities/Structures/Storage/storage.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/storage.yml
@@ -50,3 +50,5 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Climbable
+  - type: StaticPrice
+    price: 150

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -682,8 +682,6 @@
   - type: IconSmooth
     key: walls
     base: solid
-  - type: StaticPrice
-    price: 1 # total material cost. If you change the recipe for the wall you should recalculate this.
 
 - type: entity
   parent: BaseWall


### PR DESCRIPTION
:cl:
- tweak: Most cargo crate prices have been tweaked down to reflect the value of the crate. Security items in particular are much cheaper.
- tweak: Cargo passive income reduced from 2 to 1 per second.
- tweak: Pipes, racks, and walls should be worth a token amount of money.
- tweak: Dead organics can be sold.