### PR TITLE
Break joints on entering vehicle

### DIFF
--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -12,6 +12,8 @@ using Content.Shared.Tag;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
 
@@ -20,10 +22,10 @@ namespace Content.Server.Vehicle
     public sealed partial class VehicleSystem : SharedVehicleSystem
     {
         [Dependency] private readonly HandVirtualItemSystem _virtualItemSystem = default!;
-        [Dependency] private readonly MetaDataSystem _metadata = default!;
         [Dependency] private readonly MovementSpeedModifierSystem _modifier = default!;
         [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
         [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
+        [Dependency] private readonly SharedJointSystem _joints = default!;
         [Dependency] private readonly SharedMoverController _mover = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
 
@@ -110,6 +112,11 @@ namespace Content.Server.Vehicle
                 if (component.HornSound != null)
                 {
                     _actionsSystem.AddAction(args.BuckledEntity, component.HornAction, uid, actions);
+                }
+
+                if (TryComp<JointComponent>(args.BuckledEntity, out var joints))
+                {
+                    _joints.ClearJoints(joints);
                 }
 
                 return;


### PR DESCRIPTION
The issue is that both bodies go to sleep on the server-side so it mispredicts like crazy on the client then when you unbuckle it snaps.

This is just a bandaid until buckling + vehicles get some more love in future.

:cl:
- fix: Joints will break upon buckling to a vehicle.
