### PR TITLE
Allow players to spend 3x more time as an intern role (Technical Assistant, Medical Intern, Security Cadet)

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -5,7 +5,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 5400
+      time: 7200
       inverted: true # stop playing intern if you're good at engineering!
   startingGear: TechnicalAssistantGear
   icon: "TechnicalAssistant"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -5,7 +5,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 1800
+      time: 5400
       inverted: true # stop playing intern if you're good at engineering!
   startingGear: TechnicalAssistantGear
   icon: "TechnicalAssistant"

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -5,7 +5,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 1800
+      time: 5400
       inverted: true # stop playing intern if you're good at med!
   startingGear: MedicalInternGear
   icon: "MedicalIntern"

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -5,7 +5,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 5400
+      time: 7200
       inverted: true # stop playing intern if you're good at med!
   startingGear: MedicalInternGear
   icon: "MedicalIntern"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -5,7 +5,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 5400
+      time: 7200
       inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "SecurityCadet"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -5,7 +5,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 1800
+      time: 5400
       inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "SecurityCadet"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The intern roles are a nice and (mostly) stress-free introduction to their respective departments, but you can only spend 30 minutes as them, which is usually a single round. As a result beginners may not be comfortable enough to play an actual role in the department by the time they cannot play as it anymore; especially if the round was uneventful.

I made this pull request to try and solve this problem by allowing beginners more time as an intern.
EDIT: Forgot to clarify, originally I was going to change the maximum time to 90 minutes, but I decided to change it to 120 minutes instead shortly after.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Jukereise
- tweak: Beginners can now spend up to 2 hours (90 extra minutes after unlocking the non-beginner jobs) as an intern (originally 30 minutes)

