### PR TITLE
Add jetpack to cargo

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-engineering.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-engineering.ftl
@@ -12,3 +12,6 @@ ent-EngineeringCableBulk = { ent-CrateEngineeringCableBulk }
 
 ent-EngineeringElectricalSupplies = { ent-CrateEngineeringElectricalSupplies }
     .desc = { ent-CrateEngineeringElectricalSupplies.desc }
+
+ent-EngineeringJetpack = { ent-CrateEngineeringJetpack }
+    .desc = { ent-CrateEngineeringJetpack.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/engineering-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/engineering-crates.ftl
@@ -21,3 +21,6 @@ ent-CrateEngineeringCableBulk = Bulk cable crate
 
 ent-CrateEngineeringElectricalSupplies = Electrical Supplies Crate
     .desc = NT is not responsible for any workplace infighting relating to the insulated gloves included within these crates.
+
+ent-CrateEngineeringJetpack = Jetpack crate
+    .desc = Two jetpacks for those who don't know how to use fire extinguishers.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -52,7 +52,7 @@
   id: EngineeringJetpack
   icon:
     sprite: Objects/Tanks/Jetpacks/blue.rsi
-    state: base
+    state: icon
   product: CrateEngineeringJetpack
   cost: 1000
   category: Engineering

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -47,3 +47,13 @@
   cost: 4500
   category: Engineering
   group: market
+
+- type: cargoProduct
+  id: EngineeringJetpack
+  icon:
+    sprite: Objects/Tanks/Jetpacks/blue.rsi
+    state: base
+  product: CrateEngineeringJetpack
+  cost: 1000
+  category: Engineering
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -94,5 +94,5 @@
   components:
   - type: StorageFill
     contents:
-      - id: JetpackBlueFilled
+      - id: JetpackBlue
         amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -87,3 +87,12 @@
         amount: 2
       - id: ClothingHandsGlovesColorYellow
         amount: 2
+
+- type: entity
+  id: CrateEngineeringJetpack
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: JetpackBlueFilled
+        amount: 2


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #11306
Adds a crate containing 2 jetpacks to the cargo catalog.

**Changelog**

:cl:
- add: You can now buy jetpacks from cargo.

