### PR TITLE
Multitool examine wires on click

### DIFF
--- a/Content.Server/Power/EntitySystems/CableMultitoolSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableMultitoolSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Power.Components;
 using Content.Server.Power.NodeGroups;
 using Content.Server.Tools;
 using Content.Shared.Examine;
+using Content.Shared.Interaction;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Shared.Utility;
@@ -21,6 +22,17 @@ namespace Content.Server.Power.EntitySystems
             base.Initialize();
 
             SubscribeLocalEvent<CableComponent, GetVerbsEvent<ExamineVerb>>(OnGetExamineVerbs);
+            SubscribeLocalEvent<CableComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
+        }
+
+        private void OnAfterInteractUsing(EntityUid uid, CableComponent component, AfterInteractUsingEvent args)
+        {
+            if (args.Handled || args.Target == null || !args.CanReach || !_toolSystem.HasQuality(args.Used, "Pulsing"))
+                return;
+
+            var markup = FormattedMessage.FromMarkup(GenerateCableMarkup(uid));
+            _examineSystem.SendExamineTooltip(args.User, uid, markup, false, false);
+            args.Handled = true;
         }
 
         private void OnGetExamineVerbs(EntityUid uid, CableComponent component, GetVerbsEvent<ExamineVerb> args)

--- a/Content.Server/Power/EntitySystems/CableMultitoolSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableMultitoolSystem.cs
@@ -1,13 +1,10 @@
-using Content.Server.Examine;
 using Content.Server.NodeContainer;
 using Content.Server.Power.Components;
 using Content.Server.Power.NodeGroups;
 using Content.Server.Tools;
 using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
-using Robust.Shared.Log;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Power.EntitySystems
@@ -18,48 +15,12 @@ namespace Content.Server.Power.EntitySystems
         [Dependency] private readonly ToolSystem _toolSystem = default!;
         [Dependency] private readonly PowerNetSystem _pnSystem = default!;
         [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
-        [Dependency] private readonly SharedVerbSystem _verbSystem = default!;
 
         public override void Initialize()
         {
             base.Initialize();
 
             SubscribeLocalEvent<CableComponent, GetVerbsEvent<ExamineVerb>>(OnGetExamineVerbs);
-            SubscribeLocalEvent<CableComponent, AfterInteractUsingEvent>(OnAfterInteract);
-        }
-
-        private void OnAfterInteract(EntityUid uid, CableComponent component, AfterInteractUsingEvent args)
-        {
-            Logger.DebugS("debug","OnAfterInteract, is target equal to null?");
-            if (args.Target == null)
-                return;
-            Logger.DebugS("debug", "Target not null! Is it in details range?");
-            if (_examineSystem.IsInDetailsRange(args.User, args.Target.Value))
-            {
-                Logger.DebugS("debug", "Within details range! Does the tool have pulsing?");
-                if (_toolSystem.HasQuality(args.Used, "Pulsing"))
-                {
-                    Logger.DebugS("debug", "Tool has pulsing! Create verb.");
-                    var verb = new ExamineVerb
-                    {
-                        Message = Loc.GetString("cable-multitool-system-verb-tooltip"),
-                        Text = Loc.GetString("cable-multitool-system-verb-name"),
-                        Category = VerbCategory.Examine,
-                        IconTexture = "/Textures/Interface/VerbIcons/zap.svg.192dpi.png",
-                        Act = () =>
-                        {
-                            Logger.DebugS("debug", "Verb acted out, apparently.");
-                            var markup = FormattedMessage.FromMarkup(GenerateCableMarkup(uid));
-                            _examineSystem.SendExamineTooltip(args.User, uid, markup, true, false);
-                        }
-                    };
-                    Logger.DebugS("debug", "Verb created, executing it...");
-                    _verbSystem.ExecuteVerb(verb, args.User, args.Target.Value, true);
-                    Logger.DebugS("debug", "Verb executed.");
-                    //var markup = FormattedMessage.FromMarkup(GenerateCableMarkup(uid));
-                    //_examineSystem.SendExamineTooltip(args.User, uid, markup, true, false);
-                }
-            }
         }
 
         private void OnGetExamineVerbs(EntityUid uid, CableComponent component, GetVerbsEvent<ExamineVerb> args)

--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -36,8 +36,7 @@ public sealed partial class CableSystem : EntitySystem
             return;
 
         var ev = new CuttingFinishedEvent(args.User);
-        _toolSystem.UseTool(args.Used, args.User, uid, 0, cable.CuttingDelay, new[] { cable.CuttingQuality }, doAfterCompleteEvent: ev, doAfterEventTarget: uid);
-        args.Handled = true;
+        args.Handled = _toolSystem.UseTool(args.Used, args.User, uid, 0, cable.CuttingDelay, new[] { cable.CuttingQuality }, doAfterCompleteEvent: ev, doAfterEventTarget: uid);
     }
 
     private void OnCableCut(EntityUid uid, CableComponent cable, CuttingFinishedEvent args)

--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -1,11 +1,17 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Electrocution;
+using Content.Server.Examine;
+using Content.Server.NodeContainer;
 using Content.Server.Power.Components;
+using Content.Server.Power.NodeGroups;
 using Content.Server.Stack;
 using Content.Server.Tools;
 using Content.Shared.Database;
+using Content.Shared.Examine;
 using Content.Shared.Interaction;
+using Content.Shared.Verbs;
 using Robust.Shared.Map;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Power.EntitySystems;
 
@@ -17,6 +23,9 @@ public sealed partial class CableSystem : EntitySystem
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly ElectrocutionSystem _electrocutionSystem = default!;
     [Dependency] private readonly IAdminLogManager _adminLogs = default!;
+    [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
+    [Dependency] private readonly SharedVerbSystem _verbSystem = default!;
+    [Dependency] private readonly PowerNetSystem _pnSystem = default!;
 
     public override void Initialize()
     {
@@ -32,12 +41,67 @@ public sealed partial class CableSystem : EntitySystem
 
     private void OnInteractUsing(EntityUid uid, CableComponent cable, InteractUsingEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || _examineSystem.IsInDetailsRange(args.User, args.Target))
             return;
+
+        if (_toolSystem.HasQuality(args.Used, "Pulsing"))
+        {
+            var verb = new ExamineVerb
+            {
+                Message = Loc.GetString("cable-multitool-system-verb-tooltip"),
+                Text = Loc.GetString("cable-multitool-system-verb-name"),
+                Category = VerbCategory.Examine,
+                IconTexture = "/Textures/Interface/VerbIcons/zap.svg.192dpi.png",
+                Act = () =>
+                {
+                    Logger.DebugS("debug", "Verb acted out, apparently.");
+                    var markup = FormattedMessage.FromMarkup(GenerateCableMarkup(uid));
+                    _examineSystem.SendExamineTooltip(args.User, uid, markup, true, false);
+                }
+            };
+            Logger.DebugS("debug", "Verb created, executing it...");
+            _verbSystem.ExecuteVerb(verb, args.User, args.Target, true);
+            Logger.DebugS("debug", "Verb executed.");
+
+            //var markup = FormattedMessage.FromMarkup(GenerateCableMarkup(uid));
+            //_examineSystem.SendExamineTooltip(args.User, uid, markup, true, false);
+
+            args.Handled = true;
+            return;
+        }
 
         var ev = new CuttingFinishedEvent(args.User);
         _toolSystem.UseTool(args.Used, args.User, uid, 0, cable.CuttingDelay, new[] { cable.CuttingQuality }, doAfterCompleteEvent: ev, doAfterEventTarget: uid);
         args.Handled = true;
+    }
+    private string GenerateCableMarkup(EntityUid uid, NodeContainerComponent? nodeContainer = null)
+    {
+        if (!Resolve(uid, ref nodeContainer))
+            return Loc.GetString("cable-multitool-system-internal-error-missing-component");
+
+        foreach (var node in nodeContainer.Nodes)
+        {
+            if (!(node.Value.NodeGroup is IBasePowerNet))
+                continue;
+            var p = (IBasePowerNet) node.Value.NodeGroup;
+            var ps = _pnSystem.GetNetworkStatistics(p.NetworkNode);
+
+            float storageRatio = ps.InStorageCurrent / Math.Max(ps.InStorageMax, 1.0f);
+            float outStorageRatio = ps.OutStorageCurrent / Math.Max(ps.OutStorageMax, 1.0f);
+            return Loc.GetString("cable-multitool-system-statistics",
+                ("supplyc", ps.SupplyCurrent),
+                ("supplyb", ps.SupplyBatteries),
+                ("supplym", ps.SupplyTheoretical),
+                ("consumption", ps.Consumption),
+                ("storagec", ps.InStorageCurrent),
+                ("storager", storageRatio),
+                ("storagem", ps.InStorageMax),
+                ("storageoc", ps.OutStorageCurrent),
+                ("storageor", outStorageRatio),
+                ("storageom", ps.OutStorageMax)
+            );
+        }
+        return Loc.GetString("cable-multitool-system-internal-error-no-power-node");
     }
 
     private void OnCableCut(EntityUid uid, CableComponent cable, CuttingFinishedEvent args)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows you to click a wire with a multitool in your hand to bring up the detailed power usage examine tooltip.

Fixes #10755 