### PR TITLE
Entity storage now holds air

### DIFF
--- a/Content.Server/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Server/Storage/Components/EntityStorageComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server.Atmos;
 using Content.Shared.Physics;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
@@ -6,9 +7,10 @@ using Robust.Shared.Containers;
 namespace Content.Server.Storage.Components;
 
 [RegisterComponent]
-public sealed class EntityStorageComponent : Component
+public sealed class EntityStorageComponent : Component, IGasMixtureHolder
 {
     public readonly float MaxSize = 1.0f; // maximum width or height of an entity allowed inside the storage.
+    public const float GasMixVolume = 70f;
 
     public static readonly TimeSpan InternalOpenAttemptDelay = TimeSpan.FromSeconds(0.5);
     public TimeSpan LastInternalOpenAttempt;
@@ -35,7 +37,7 @@ public sealed class EntityStorageComponent : Component
     [DataField("isCollidableWhenOpen")]
     public bool IsCollidableWhenOpen;
 
-    //The offset for where items are emptied/vacuumed for the EntityStorage. 
+    //The offset for where items are emptied/vacuumed for the EntityStorage.
     [DataField("enteringOffset")]
     public Vector2 EnteringOffset = new(0, 0);
 
@@ -77,6 +79,13 @@ public sealed class EntityStorageComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite)]
     public bool IsWeldedShut;
+
+    /// <summary>
+    ///     Gas currently contained in this entity storage.
+    ///     None while open. Grabs gas from the atmosphere when closed, and exposes any entities inside to it.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public GasMixture Air { get; set; } = new (GasMixVolume);
 }
 
 public sealed class InsertIntoEntityStorageAttemptEvent : CancellableEntityEventArgs { }

--- a/Content.Server/Storage/Components/InsideEntityStorageComponent.cs
+++ b/Content.Server/Storage/Components/InsideEntityStorageComponent.cs
@@ -1,0 +1,10 @@
+﻿namespace Content.Server.Storage.Components;
+
+/// <summary>
+///     Added to entities contained within entity storage, for directed event purposes.
+/// </summary>
+[RegisterComponent]
+public sealed class InsideEntityStorageComponent : Component
+{
+    public EntityUid Storage;
+}

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -61,6 +61,17 @@ public sealed class EntityStorageSystem : EntitySystem
 
         if (TryComp<PlaceableSurfaceComponent>(uid, out var placeable))
             _placeableSurface.SetPlaceable(uid, component.Open, placeable);
+
+        if (!component.Open)
+        {
+            // If we're closed on spawn, we need to pull some air into our environment from where we spawned,
+            // so that we have -something-. For example, if you bought an animal crate or something.
+
+            if (_atmos.GetContainingMixture(uid, false, true) is {} environment)
+            {
+                _atmos.Merge(component.Air, environment.RemoveVolume(EntityStorageComponent.GasMixVolume));
+            }
+        }
     }
 
     private void OnInteract(EntityUid uid, EntityStorageComponent component, ActivateInWorldEvent args)

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Construction;
 using Content.Server.Construction.Components;
 using Content.Server.Popups;
@@ -29,6 +30,7 @@ public sealed class EntityStorageSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private readonly PlaceableSurfaceSystem _placeableSurface = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly AtmosphereSystem _atmos = default!;
 
     public const string ContainerName = "entity_storage";
 
@@ -41,6 +43,11 @@ public sealed class EntityStorageSystem : EntitySystem
         SubscribeLocalEvent<EntityStorageComponent, WeldableAttemptEvent>(OnWeldableAttempt);
         SubscribeLocalEvent<EntityStorageComponent, WeldableChangedEvent>(OnWelded);
         SubscribeLocalEvent<EntityStorageComponent, DestructionEventArgs>(OnDestroy);
+
+        SubscribeLocalEvent<InsideEntityStorageComponent, InhaleLocationEvent>(OnInsideInhale);
+        SubscribeLocalEvent<InsideEntityStorageComponent, ExhaleLocationEvent>(OnInsideExhale);
+        SubscribeLocalEvent<InsideEntityStorageComponent, AtmosExposedGetAirEvent>(OnInsideExposed);
+
     }
 
     private void OnInit(EntityUid uid, EntityStorageComponent component, ComponentInit args)
@@ -117,11 +124,12 @@ public sealed class EntityStorageSystem : EntitySystem
         var containedArr = component.Contents.ContainedEntities.ToArray();
         foreach (var contained in containedArr)
         {
-            if (component.Contents.Remove(contained))
-            {
-                Transform(contained).WorldPosition =
-                    uidXform.WorldPosition + uidXform.WorldRotation.RotateVec(component.EnteringOffset);
-            }
+            if (!component.Contents.Remove(contained))
+                continue;
+
+            RemComp<InsideEntityStorageComponent>(contained);
+            Transform(contained).WorldPosition =
+                uidXform.WorldPosition + uidXform.WorldRotation.RotateVec(component.EnteringOffset);
         }
     }
 
@@ -134,6 +142,13 @@ public sealed class EntityStorageSystem : EntitySystem
         EmptyContents(uid, component);
         ModifyComponents(uid, component);
         SoundSystem.Play(component.OpenSound.GetSound(), Filter.Pvs(component.Owner), component.Owner);
+
+        if (_atmos.GetContainingMixture(uid, false, true) is {} environment)
+        {
+            _atmos.Merge(environment, component.Air);
+            component.Air.Clear();
+        }
+
         RaiseLocalEvent(uid, new StorageAfterOpenEvent());
     }
 
@@ -161,9 +176,17 @@ public sealed class EntityStorageSystem : EntitySystem
             if (!AddToContents(entity, uid, component))
                 continue;
 
+            var inside = EnsureComp<InsideEntityStorageComponent>(entity);
+            inside.Storage = uid;
+
             count++;
             if (count >= component.Capacity)
                 break;
+        }
+
+        if (_atmos.GetContainingMixture(uid, false, true) is {} environment)
+        {
+            _atmos.Merge(component.Air, environment.RemoveVolume(EntityStorageComponent.GasMixVolume));
         }
 
         ModifyComponents(uid, component);
@@ -365,4 +388,37 @@ public sealed class EntityStorageSystem : EntitySystem
             appearance.SetData(StorageVisuals.HasContents, component.Contents.ContainedEntities.Any());
         }
     }
+
+    #region Gas mix event handlers
+
+    private void OnInsideInhale(EntityUid uid, InsideEntityStorageComponent component, InhaleLocationEvent args)
+    {
+        if (TryComp<EntityStorageComponent>(component.Storage, out var storage))
+        {
+            args.Gas = storage.Air;
+        }
+    }
+
+    private void OnInsideExhale(EntityUid uid, InsideEntityStorageComponent component, ExhaleLocationEvent args)
+    {
+        if (TryComp<EntityStorageComponent>(component.Storage, out var storage))
+        {
+            args.Gas = storage.Air;
+        }
+    }
+
+    private void OnInsideExposed(EntityUid uid, InsideEntityStorageComponent component, ref AtmosExposedGetAirEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (TryComp<EntityStorageComponent>(component.Storage, out var storage))
+        {
+            args.Gas = storage.Air;
+        }
+
+        args.Handled = true;
+    }
+
+    #endregion
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Takes in some air on close, releases it on open. Entities inside are exposed to the air inside. This does make storage into mini-canisters but their volume is so low that it's effectively useless for that purpose. People will eventually suffocate to death from their own carbon dioxide if left for long enough, as you do. This does imply all entity storage is hermetically sealed but whatever.

https://user-images.githubusercontent.com/19853115/190708616-1399f841-7fb9-481d-8c3c-1f381c01c6e3.mp4

:cl:
- add: Entity storage (lockers, animal crates, etc) now hold some air inside them when closed. Entities inside will be exposed to that air instead of the environment surrounding the storage. Now you can take animals on spacewalks!
