### PR TITLE
Fix drobes and lockers contents

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -17,3 +17,25 @@
         prob: 0.8
       - id: SurvivalKnife
       - id: WeaponProtoKineticAccelerator
+
+- type: entity
+  id: LockerCargoTechnicianFilled
+  suffix: Filled
+  parent: LockerCargoTechnician
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingHeadHatCargosoft
+        amount: 1
+      - id: ClothingUniformJumpsuitCargo
+        amount: 1
+      - id: ClothingBackpack
+        amount: 1
+      - id: ClothingShoesColorBlack
+        amount: 1
+      - id: ClothingUniformJumpskirtCargo
+        amount: 1
+      - id: ClothingHandsGlovesFingerless
+        amount: 1
+      - id: AppraisalTool
+        amount: 1

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -56,6 +56,7 @@
       - id: ForensicScanner
       - id: BoxForensicPad
       - id: WeaponRevolverInspector
+      - id: DrinkDetFlask
 
 - type: entity
   id: ClosetBombFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -15,6 +15,8 @@
         prob: 0.5
       - id: DrinkBottleBeer
         prob: 0.5
+      - id: BoxBeanbag
+        amount: 2
 
 #- type: entity
 #  id: LockerFormalFilled
@@ -53,6 +55,7 @@
   - type: StorageFill
     contents:
       - id: MopItem
+        amount: 2
       - id: BoxMousetrap
         amount: 2
       - id: WetFloorSign
@@ -63,6 +66,12 @@
         amount: 1
       - id: BoxLightMixed
         amount: 1
+      - id: Holoprojector
+        amount: 1
+      - id: SoapNT
+        amount: 2
+      - id: FlashlightLantern
+        amount: 2
 
 - type: entity
   id: ClosetLegalFilled

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
@@ -12,4 +12,3 @@
     ClothingOuterVestKevlar: 2
     ClothingBeltBandolier: 2
     ClothingEyesGlassesSunglasses: 2
-    BoxBeanbag: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cargodrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cargodrobe.yml
@@ -1,7 +1,6 @@
 - type: vendingMachineInventory
   id: CargoDrobeInventory
   startingInventory:
-    AppraisalTool: 3
     ClothingUniformJumpsuitCargo: 3
     ClothingUniformJumpskirtCargo: 3
     ClothingShoesColorBlack: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -13,5 +13,4 @@
     ClothingHeadHatFedoraGrey: 2
     ClothingHandsGlovesColorBlack: 2
     ClothingHandsGlovesLatex: 2
-    DrinkDetFlask: 2
     ClothingHeadsetSecurity: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
@@ -11,6 +11,5 @@
     ClothingOuterVestHazard: 3
     ClothingShoesBootsWork: 3
     ClothingHeadHatHardhatYellow: 3
-    ClothingHeadHatWelding: 3
     ClothingHeadsetEngineering: 3
     ClothingOuterWinterEngi: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -2,7 +2,7 @@
   id: EngiVendInventory
   startingInventory:
     ClothingEyesGlassesMeson: 4
-    ClothingHeadHatWelding: 4
+    ClothingHeadHatWelding: 6
     Multitool: 4
     PowerCellMedium: 5
     ClothingHandsGlovesColorYellow: 6

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
@@ -5,14 +5,10 @@
     ClothingUniformJumpskirtJanitor: 2
     ClothingShoesColorBlack: 2
     ClothingHeadHatPurplesoft: 2
-    FlashlightLantern: 2
-    LightReplacer: 2
-    SoapNT: 2
-    TrashBag: 2
     ClothingShoesGaloshes: 2
     ClothingBeltJanitor: 2
     ClothingHeadsetService: 2
     ClothingOuterWinterJani: 2
-    Holoprojector: 1
+
   emaggedInventory:
     ClothingUniformJumpskirtJanimaid: 2

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -49,6 +49,21 @@
   - type: AccessReader
     access: [["Salvage"]]
 
+- type: entity
+  id: LockerCargoTechnician
+  parent: LockerBase
+  name: cargo technician's equipment
+  description: All the basics for a Cargonian resident.
+  components:
+    - type: Appearance
+      visuals:
+      - type: StorageVisualizer
+        state: cargo
+        state_open: cargo_open
+        state_closed: cargo_door
+    - type: AccessReader
+      access: [["Cargo"]]
+
 # Command
 - type: entity
   id: LockerCaptain


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This removes non-clothing items from all drobes and puts them into lockers where they should be.

* Removed bean bag boxes from BarDrobe. They are now in the booze locker
* Removed appraisal tool from CargoDrobe. It's now in the cargo tech's locker
* Added cargo technicians locker. It has some basic clothing for them and an appraisal tool. Sorry mappers, a new thing to add.
* Removed detective's flask from the DetDrobe. It's now in the detective's locker.
* Removed flashlight, light replacer, soap, trash bags, and holoprojector from the JaniDrobe. These items are now in the custodial closet.
* Custodial closet now has 2 mops. Also mappers should make sure this closet is mapped in, I didn't see it in some of the map screenshots. It's not in Saltern for sure. Once again, sorry mappers :(
* Removed welding mask from EngiDrobe. EngiVend has two more to compensate.

Should resolve  #11348
at least until people put more non-clothing items in drobes >:(

closes #11291
the extra mop was added to custodial closets

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: ashtronaut
- tweak: Due to a mix-up in the NanoTrasen Standardized Equipment Logistics Warehouse, non-clothing items were getting stocked in 'Drobe machines. We've corrected this issue and ensured said equipment should be available in the appropriate lockers instead. 

