### PR TITLE
Adds a power check to OnAtmosAlarm for firelocks

### DIFF
--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -30,6 +30,7 @@ namespace Content.Server.Doors.Systems
             base.Initialize();
 
             SubscribeLocalEvent<FirelockComponent, BeforeDoorOpenedEvent>(OnBeforeDoorOpened);
+            SubscribeLocalEvent<FirelockComponent, BeforeDoorClosedEvent>(OnBeforeDoorClose);
             SubscribeLocalEvent<FirelockComponent, DoorGetPryTimeModifierEvent>(OnDoorGetPryTimeModifier);
             SubscribeLocalEvent<FirelockComponent, DoorStateChangedEvent>(OnUpdateState);
 
@@ -154,6 +155,12 @@ namespace Content.Server.Doors.Systems
                 args.Cancel();
         }
 
+        private void OnBeforeDoorClose(EntityUid uid, FirelockComponent component, BeforeDoorClosedEvent args)
+        {
+            if (!this.IsPowered(uid, EntityManager))
+                args.Cancel();
+        }
+
         private void OnAtmosAlarm(EntityUid uid, FirelockComponent component, AtmosAlarmEvent args)
         {
             if (!TryComp<DoorComponent>(uid, out var doorComponent)) return;
@@ -165,7 +172,7 @@ namespace Content.Server.Doors.Systems
             }
             else if (args.AlarmType == AtmosAlarmType.Danger)
             {
-                EmergencyPressureStop(uid, component, doorComponent);
+                _doorSystem.TryClose(uid, doorComponent);
             }
         }
 

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -159,7 +159,8 @@ namespace Content.Server.Doors.Systems
             if (!this.IsPowered(uid, EntityManager))
                 return;
 
-            if (!TryComp<DoorComponent>(uid, out var doorComponent)) return;
+            if (!TryComp<DoorComponent>(uid, out var doorComponent))
+                return;
 
             if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)
             {
@@ -168,7 +169,7 @@ namespace Content.Server.Doors.Systems
             }
             else if (args.AlarmType == AtmosAlarmType.Danger)
             {
-                _doorSystem.TryClose(uid, doorComponent);
+                EmergencyPressureStop(uid, component, doorComponent);
             }
         }
 

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -30,7 +30,6 @@ namespace Content.Server.Doors.Systems
             base.Initialize();
 
             SubscribeLocalEvent<FirelockComponent, BeforeDoorOpenedEvent>(OnBeforeDoorOpened);
-            SubscribeLocalEvent<FirelockComponent, BeforeDoorClosedEvent>(OnBeforeDoorClose);
             SubscribeLocalEvent<FirelockComponent, DoorGetPryTimeModifierEvent>(OnDoorGetPryTimeModifier);
             SubscribeLocalEvent<FirelockComponent, DoorStateChangedEvent>(OnUpdateState);
 
@@ -155,14 +154,11 @@ namespace Content.Server.Doors.Systems
                 args.Cancel();
         }
 
-        private void OnBeforeDoorClose(EntityUid uid, FirelockComponent component, BeforeDoorClosedEvent args)
-        {
-            if (!this.IsPowered(uid, EntityManager))
-                args.Cancel();
-        }
-
         private void OnAtmosAlarm(EntityUid uid, FirelockComponent component, AtmosAlarmEvent args)
         {
+            if (!this.IsPowered(uid, EntityManager))
+                return;
+
             if (!TryComp<DoorComponent>(uid, out var doorComponent)) return;
 
             if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)


### PR DESCRIPTION
## About the PR

There were firelocks closing the moment they got an alarm, even when unpowered - this should fix that behavior.