### PR TITLE
Adds a component to require an entity to be powered to receive DeviceNetwork packets.

### DIFF
--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkRequiresPowerComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkRequiresPowerComponent.cs
@@ -1,5 +1,10 @@
 namespace Content.Server.DeviceNetwork.Components;
 
+/// <summary>
+///     Component that indicates that this device networked entity requires power
+///     in order to receive a packet. Having this component will cancel all packet events
+///     if the entity is not powered.
+/// </summary>
 [RegisterComponent]
 public sealed class DeviceNetworkRequiresPowerComponent : Component
 {

--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkRequiresPowerComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkRequiresPowerComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Server.DeviceNetwork.Components;
+
+[RegisterComponent]
+public sealed class DeviceNetworkRequiresPowerComponent : Component
+{
+}

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkRequiresPowerSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkRequiresPowerSystem.cs
@@ -1,0 +1,22 @@
+using Content.Server.DeviceNetwork.Components;
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+
+namespace Content.Server.DeviceNetwork.Systems;
+
+public sealed class DeviceNetworkRequiresPowerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<DeviceNetworkRequiresPowerComponent, BeforePacketSentEvent>(OnBeforePacketSent);
+    }
+
+    private void OnBeforePacketSent(EntityUid uid, DeviceNetworkRequiresPowerComponent component,
+        BeforePacketSentEvent args)
+    {
+        if (!this.IsPowered(uid, EntityManager))
+        {
+            args.Cancel();
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -13,6 +13,7 @@
     - type: DeviceNetwork
       deviceNetId: AtmosDevices
       receiveFrequencyId: AtmosMonitor
+    - type: DeviceNetworkRequiresPower
     - type: InteractionOutline
     - type: Damageable
       damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -640,6 +640,7 @@
       receiveFrequencyId: SurveillanceCamera
       transmitFrequencyId: SurveillanceCamera
     - type: WiredNetworkConnection
+    - type: DeviceNetworkRequiresPower
     - type: SurveillanceCameraMonitor
     - type: ActivatableUI
       key: enum.SurveillanceCameraMonitorUiKey.Key
@@ -670,6 +671,7 @@
       transmitFrequencyId: SurveillanceCamera
     - type: WirelessNetworkConnection
       range: 200
+    - type: DeviceNetworkRequiresPower
     - type: SurveillanceCameraMonitor
     - type: ActivatableUI
       key: enum.SurveillanceCameraMonitorUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Machines/surveillance_camera_routers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/surveillance_camera_routers.yml
@@ -10,6 +10,7 @@
       receiveFrequencyId: SurveillanceCamera
       transmitFrequencyId: SurveillanceCamera
     - type: WiredNetworkConnection
+    - type: DeviceNetworkRequiresPower
     - type: UserInterface
       interfaces:
         - key: enum.SurveillanceCameraSetupUiKey.Router
@@ -114,6 +115,7 @@
       transmitFrequencyId: SurveillanceCamera
     - type: WirelessNetworkConnection
       range: 200
+    - type: DeviceNetworkRequiresPower
     - type: UserInterface
       interfaces:
         - key: enum.SurveillanceCameraSetupUiKey.Router

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -34,6 +34,7 @@
       prefix: device-address-prefix-vent
       sendBroadcastAttemptEvent: true
     - type: WiredNetworkConnection
+    - type: DeviceNetworkRequiresPower
     - type: AtmosDevice
     - type: AtmosMonitor
       temperatureThreshold: stationTemperature
@@ -124,6 +125,7 @@
       receiveFrequencyId: AtmosMonitor
       transmitFrequencyId: AtmosMonitor
       prefix: device-address-prefix-scrubber
+    - type: DeviceNetworkRequiresPower
     - type: AtmosMonitor
       temperatureThreshold: stationTemperature
       pressureThreshold: stationPressure

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -41,6 +41,7 @@
       prefix: device-address-prefix-sensor
       sendBroadcastAttemptEvent: true
     - type: WiredNetworkConnection
+    - type: DeviceNetworkRequiresPower
     - type: AtmosDevice
     - type: AtmosMonitor
       temperatureThreshold: stationTemperature

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -16,6 +16,7 @@
     sendBroadcastAttemptEvent: true
   - type: WiredNetworkConnection
   - type: DeviceList
+  - type: DeviceNetworkRequiresPower
   - type: AtmosAlarmable
     syncWith:
       - AirAlarm

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -16,6 +16,7 @@
     sendBroadcastAttemptEvent: true
   - type: DeviceList
   - type: WiredNetworkConnection
+  - type: DeviceNetworkRequiresPower
   - type: AtmosDevice
   - type: AtmosAlarmable
     syncWith:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
@@ -82,6 +82,7 @@
       receiveFrequencyId: SurveillanceCamera
       transmitFrequencyId: SurveillanceCamera
     - type: WiredNetworkConnection
+    - type: DeviceNetworkRequiresPower
     - type: SurveillanceCameraMonitor
     - type: ActivatableUI
       key: enum.SurveillanceCameraMonitorUiKey.Key
@@ -157,6 +158,7 @@
       transmitFrequencyId: SurveillanceCamera
     - type: WirelessNetworkConnection
       range: 200
+    - type: DeviceNetworkRequiresPower
     - type: SurveillanceCameraMonitor
     - type: ActivatableUI
       key: enum.SurveillanceCameraMonitorUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -17,6 +17,7 @@
   - type: ExtensionCableReceiver
   - type: Eye
   - type: WiredNetworkConnection
+  - type: DeviceNetworkRequiresPower
   - type: Transform
     anchored: true
   - type: Wires


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As said in the title. This should avoid having to do manual power checks within the packet receive event handler, and instead it'll just be an added component in a given entity.