### PR TITLE
Clear and reregister devices for atmos alarms

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -168,9 +168,10 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private void OnDeviceListUpdate(EntityUid uid, AirAlarmComponent component, DeviceListUpdateEvent args)
     {
+        var query = GetEntityQuery<DeviceNetworkComponent>();
         foreach (var device in args.OldDevices)
         {
-            if (!TryComp<DeviceNetworkComponent>(device, out var deviceNet))
+            if (!query.TryGetComponent(device, out var deviceNet))
             {
                 continue;
             }

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -168,6 +168,13 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private void OnDeviceListUpdate(EntityUid uid, AirAlarmComponent component, DeviceListUpdateEvent args)
     {
+        _atmosDevNetSystem.Deregister(uid, null);
+
+        component.ScrubberData.Clear();
+        component.SensorData.Clear();
+        component.VentData.Clear();
+        component.KnownDevices.Clear();
+
         SyncRegisterAllDevices(uid);
     }
 
@@ -294,8 +301,8 @@ public sealed class AirAlarmSystem : EntitySystem
         }
 
         var addr = string.Empty;
-        if (EntityManager.TryGetComponent(uid, out DeviceNetworkComponent? netConn)) addr = netConn.Address;
-
+        if (EntityManager.TryGetComponent(uid, out DeviceNetworkComponent? netConn))
+            addr = netConn.Address;
 
         if (args.AlarmType == AtmosAlarmType.Danger)
         {

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -168,7 +168,15 @@ public sealed class AirAlarmSystem : EntitySystem
 
     private void OnDeviceListUpdate(EntityUid uid, AirAlarmComponent component, DeviceListUpdateEvent args)
     {
-        _atmosDevNetSystem.Deregister(uid, null);
+        foreach (var device in args.OldDevices)
+        {
+            if (!TryComp<DeviceNetworkComponent>(device, out var deviceNet))
+            {
+                continue;
+            }
+
+            _atmosDevNetSystem.Deregister(uid, deviceNet.Address);
+        }
 
         component.ScrubberData.Clear();
         component.SensorData.Clear();

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -183,6 +183,8 @@ public sealed class AirAlarmSystem : EntitySystem
         component.VentData.Clear();
         component.KnownDevices.Clear();
 
+        UpdateUI(uid, component);
+
         SyncRegisterAllDevices(uid);
     }
 

--- a/Content.Server/Atmos/Monitor/Systems/AtmosDeviceNetwork.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosDeviceNetwork.cs
@@ -16,6 +16,11 @@ public sealed class AtmosDeviceNetworkSystem : EntitySystem
     public const string RegisterDevice = "atmos_register_device";
 
     /// <summary>
+    ///     Deregister a device's address on this device.
+    /// </summary>
+    public const string DeregisterDevice = "atmos_deregister_device";
+
+    /// <summary>
     ///     Synchronize the data this device has with the sender.
     /// </summary>
     public const string SyncData = "atmos_sync_data";
@@ -30,6 +35,16 @@ public sealed class AtmosDeviceNetworkSystem : EntitySystem
         };
 
         _deviceNet.QueuePacket(uid, address, registerPayload);
+    }
+
+    public void Deregister(EntityUid uid, string? address)
+    {
+        var deregisterPayload = new NetworkPayload
+        {
+            [DeviceNetworkConstants.Command] = DeregisterDevice
+        };
+
+        _deviceNet.QueuePacket(uid, address, deregisterPayload);
     }
 
     public void Sync(EntityUid uid, string? address)

--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -98,6 +98,9 @@ public sealed class AtmosMonitorSystem : EntitySystem
             case AtmosDeviceNetworkSystem.RegisterDevice:
                 component.RegisteredDevices.Add(args.SenderAddress);
                 break;
+            case AtmosDeviceNetworkSystem.DeregisterDevice:
+                component.RegisteredDevices.Remove(args.SenderAddress);
+                break;
             case AtmosAlarmableSystem.ResetAll:
                 Reset(uid);
                 // Don't clear alarm states here.

--- a/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.AlertLevel;
 using Content.Server.Atmos.Monitor.Components;
+using Content.Server.DeviceNetwork.Components;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
@@ -32,7 +33,16 @@ public sealed class FireAlarmSystem : EntitySystem
 
     private void OnDeviceListSync(EntityUid uid, FireAlarmComponent component, DeviceListUpdateEvent args)
     {
-        _atmosDevNet.Deregister(uid, null);
+        foreach (var device in args.OldDevices)
+        {
+            if (!TryComp<DeviceNetworkComponent>(device, out var deviceNet))
+            {
+                continue;
+            }
+
+            _atmosDevNet.Deregister(uid, deviceNet.Address);
+        }
+
         _atmosDevNet.Register(uid, null);
         _atmosDevNet.Sync(uid, null);
     }

--- a/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
@@ -33,9 +33,10 @@ public sealed class FireAlarmSystem : EntitySystem
 
     private void OnDeviceListSync(EntityUid uid, FireAlarmComponent component, DeviceListUpdateEvent args)
     {
+        var query = GetEntityQuery<DeviceNetworkComponent>();
         foreach (var device in args.OldDevices)
         {
-            if (!TryComp<DeviceNetworkComponent>(device, out var deviceNet))
+            if (!query.TryGetComponent(device, out var deviceNet))
             {
                 continue;
             }

--- a/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/FireAlarmSystem.cs
@@ -32,6 +32,7 @@ public sealed class FireAlarmSystem : EntitySystem
 
     private void OnDeviceListSync(EntityUid uid, FireAlarmComponent component, DeviceListUpdateEvent args)
     {
+        _atmosDevNet.Deregister(uid, null);
         _atmosDevNet.Register(uid, null);
         _atmosDevNet.Sync(uid, null);
     }

--- a/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
+++ b/Content.Shared/DeviceNetwork/Systems/SharedDeviceListSystem.cs
@@ -24,6 +24,7 @@ public abstract class SharedDeviceListSystem : EntitySystem
         if (!Resolve(uid, ref deviceList))
             return DeviceListUpdateResult.NoComponent;
 
+        var oldDevices = deviceList.Devices.ToList();
         var newDevices = merge ? new HashSet<EntityUid>(deviceList.Devices) : new();
         var devicesList = devices.ToList();
 
@@ -35,7 +36,7 @@ public abstract class SharedDeviceListSystem : EntitySystem
 
         deviceList.Devices = newDevices;
 
-        RaiseLocalEvent(uid, new DeviceListUpdateEvent(devicesList));
+        RaiseLocalEvent(uid, new DeviceListUpdateEvent(oldDevices, devicesList));
 
         Dirty(deviceList);
 
@@ -71,11 +72,13 @@ public abstract class SharedDeviceListSystem : EntitySystem
 
 public sealed class DeviceListUpdateEvent : EntityEventArgs
 {
-    public DeviceListUpdateEvent(List<EntityUid> devices)
+    public DeviceListUpdateEvent(List<EntityUid> oldDevices, List<EntityUid> devices)
     {
+        OldDevices = oldDevices;
         Devices = devices;
     }
 
+    public List<EntityUid> OldDevices { get; }
     public List<EntityUid> Devices { get; }
 }
 


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Upon a device list update, the air alarm and fire alarm should now deregister from all connected devices, clear out any data (in the case of air alarms), and then re-register to any connected devices. This addresses an issue raised in #11375.