### PR TITLE
Add power selling price

### DIFF
--- a/Content.Server/Power/Components/BatteryComponent.cs
+++ b/Content.Server/Power/Components/BatteryComponent.cs
@@ -30,6 +30,13 @@ namespace Content.Server.Power.Components
         [ViewVariables] public bool IsFullyCharged => MathHelper.CloseToPercent(CurrentCharge, MaxCharge);
 
         /// <summary>
+        /// The price per one joule. Default is 1 credit for 10kJ.
+        /// </summary>
+        [DataField("pricePerJoule")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float PricePerJoule = 0.0001f;
+
+        /// <summary>
         ///     If sufficient charge is avaiable on the battery, use it. Otherwise, don't.
         /// </summary>
         public virtual bool TryUseCharge(float chargeToUse)

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Cargo.Systems;
 using Content.Server.Power.Components;
 using Content.Shared.Examine;
 using JetBrains.Annotations;
@@ -7,11 +8,14 @@ namespace Content.Server.Power.EntitySystems
     [UsedImplicitly]
     public sealed class BatterySystem : EntitySystem
     {
+        private const float PricePerJoule = 0.0001f;
+
         public override void Initialize()
         {
             base.Initialize();
 
             SubscribeLocalEvent<ExaminableBatteryComponent, ExaminedEvent>(OnExamine);
+            SubscribeLocalEvent<BatteryComponent, PriceCalculationEvent>(CalculateBatteryPrice);
 
             SubscribeLocalEvent<NetworkBatteryPreSync>(PreSync);
             SubscribeLocalEvent<NetworkBatteryPostSync>(PostSync);
@@ -63,6 +67,14 @@ namespace Content.Server.Power.EntitySystems
                 if (batt.IsFullyCharged) continue;
                 batt.CurrentCharge += comp.AutoRechargeRate * frameTime;
             }
+        }
+
+        /// <summary>
+        /// Gets the price for the power contained in an entity's battery.
+        /// </summary>
+        private void CalculateBatteryPrice(EntityUid uid, BatteryComponent component, ref PriceCalculationEvent args)
+        {
+            args.Price += component.CurrentCharge * PricePerJoule;
         }
     }
 }

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -8,7 +8,6 @@ namespace Content.Server.Power.EntitySystems
     [UsedImplicitly]
     public sealed class BatterySystem : EntitySystem
     {
-        private const float PricePerJoule = 0.0001f;
 
         public override void Initialize()
         {
@@ -74,7 +73,7 @@ namespace Content.Server.Power.EntitySystems
         /// </summary>
         private void CalculateBatteryPrice(EntityUid uid, BatteryComponent component, ref PriceCalculationEvent args)
         {
-            args.Price += component.CurrentCharge * PricePerJoule;
+            args.Price += component.CurrentCharge * component.PricePerJoule;
         }
     }
 }

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -8,7 +8,6 @@ namespace Content.Server.Power.EntitySystems
     [UsedImplicitly]
     public sealed class BatterySystem : EntitySystem
     {
-
         public override void Initialize()
         {
             base.Initialize();

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -4,6 +4,7 @@
   parent: BaseItem
   components:
   - type: Battery
+    pricePerJoule: 0.15
   - type: PowerCell
   - type: Explosive
     explosionType: Default
@@ -28,8 +29,6 @@
       - DroneUsable
   - type: Appearance
   - type: PowerCellVisuals
-  - type: StaticPrice
-    price: 100
 
 - type: entity
   name: potato battery

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -36,6 +36,7 @@
     - type: PowerSink
     - type: Battery
       maxCharge: 7500000
+      pricePerJoule: 0.0003
     - type: ExaminableBattery
     - type: PowerConsumer
       voltage: High

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -58,8 +58,6 @@
     - type: Machine
       board: SMESMachineCircuitboard
     - type: StationInfiniteBatteryTarget
-    - type: StaticPrice
-      price: 750
 
 # SMES' in use
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When selling stuff through cargo shuttle there is now a specific price for the power contained in SMES, substations and anything having a BatteryComponent.

With this PR : 

- an empty SMES can be sold for 300 (parts and board) while a full one is worth 1300
- a substation is worth 200/600
- a medium power cells is worth 20/126
- a fully loaded, unanchored before exploding, powersink could be sold for 1500

closes #11302

**Changelog**

:cl:
- add: Selling prices of SMES, substations and power-cells now depends on their filling level

