### PR TITLE
Cleanup and re-parenting of wallmount/door electronics

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/atmos_alarms.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/atmos_alarms.yml
@@ -1,27 +1,25 @@
 - type: entity
   id: AirAlarmElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: air alarm electronics
   description: An electronics board used in air alarms
   components:
   - type: Tag
     tags:
     - AirAlarmElectronics
-    - DroneUsable
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: airalarm_electronics
 
 - type: entity
   id: FireAlarmElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: fire alarm electronics
   description: An electronics board used in fire alarms
   components:
   - type: Tag
     tags:
     - FireAlarmElectronics
-    - DroneUsable
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: airalarm_electronics

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/atmos_alarms.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/atmos_alarms.yml
@@ -4,9 +4,6 @@
   name: air alarm electronics
   description: An electronics board used in air alarms
   components:
-  - type: Tag
-    tags:
-    - AirAlarmElectronics
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: airalarm_electronics
@@ -17,9 +14,6 @@
   name: fire alarm electronics
   description: An electronics board used in fire alarms
   components:
-  - type: Tag
-    tags:
-    - FireAlarmElectronics
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: airalarm_electronics

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: BaseElectronics
+  parent: BaseItem
+  name: base electronics
+  abstract: true
+  suffix: Electronics
+  components:
+    - type: Sprite
+      sprite: Objects/Misc/module.rsi
+      state: generic
+    - type: Tag
+      tags:
+        - DroneUsable
+    - type: StaticPrice
+      price: 100

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
@@ -8,6 +8,7 @@
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: generic
+      netsync: false
     - type: Tag
       tags:
         - DroneUsable

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/disposal.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/disposal.yml
@@ -1,13 +1,12 @@
 ﻿- type: entity
   id: MailingUnitElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: mailing unit electronics
   description: An electronics board used in mailing units
   components:
     - type: Tag
       tags:
         - MailingUnitElectronics
-        - DroneUsable
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: net_wired

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/disposal.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/disposal.yml
@@ -4,9 +4,6 @@
   name: mailing unit electronics
   description: An electronics board used in mailing units
   components:
-    - type: Tag
-      tags:
-        - MailingUnitElectronics
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: net_wired

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -4,9 +4,6 @@
   name: door electronics
   description: An electronics board used in doors and airlocks
   components:
-    - type: Tag
-      tags:
-      - DoorElectronics
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: door_electronics

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -1,13 +1,12 @@
 - type: entity
   id: DoorElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: door electronics
   description: An electronics board used in doors and airlocks
   components:
     - type: Tag
       tags:
       - DoorElectronics
-      - DroneUsable
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: door_electronics

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
@@ -1,16 +1,13 @@
 ﻿- type: entity
   id: FirelockElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: firelock electronics
   description: An electronics board used to detect differences in pressure, temperature and gas concentrations between the two sides of the door.
   components:
     - type: Tag
       tags:
       - FirelockElectronics
-      - DroneUsable
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: mainboard
       netsync: false
-    - type: StaticPrice
-      price: 100

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
@@ -4,9 +4,6 @@
   name: firelock electronics
   description: An electronics board used to detect differences in pressure, temperature and gas concentrations between the two sides of the door.
   components:
-    - type: Tag
-      tags:
-      - FirelockElectronics
     - type: Sprite
       sprite: Objects/Misc/module.rsi
       state: mainboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/power_electronics.yml
@@ -1,7 +1,7 @@
 ﻿# APC
 - type: entity
   id: APCElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: APC electronics
   description: Circuit used in APC construction.
   components:
@@ -10,13 +10,11 @@
       sprite: Objects/Misc/module.rsi
       state: charger_APC
       netsync: false
-    - type: StaticPrice
-      price: 100
 
 # Wallmount Substation
 - type: entity
   id: WallmountSubstationElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: wallmount substation electronics
   description: Circuit used to construct a wallmount substation.
   components:
@@ -24,13 +22,11 @@
       sprite: Objects/Misc/module.rsi
       state: charger_APC
       netsync: false
-    - type: StaticPrice
-      price: 100
 
 # Wallmount Generator
 - type: entity
   id: WallmountGeneratorElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: wallmount generator electronics
   description: Circuit used to construct a wallmount generator.
   components:
@@ -38,13 +34,11 @@
       sprite: Objects/Misc/module.rsi
       state: charger_APC
       netsync: false
-    - type: StaticPrice
-      price: 100
 
 # APU
 - type: entity
   id: WallmountGeneratorAPUElectronics
-  parent: BaseItem
+  parent: BaseElectronics
   name: wallmount APU electronics
   description: Circuit used to construct a wallmount APU.
   components:
@@ -52,12 +46,10 @@
       sprite: Objects/Misc/module.rsi
       state: charger_APC
       netsync: false
-    - type: StaticPrice
-      price: 100
 
 # Solar Tracker Electronics
 - type: entity
-  parent: BaseItem
+  parent: BaseElectronics
   id: SolarTrackerElectronics
   name: solar tracker electronics
   description: Advanced circuit board used to detect differences in pressure, temperature and gas concentrations between the two sides of the door.
@@ -66,5 +58,3 @@
       sprite: Objects/Misc/module.rsi
       state: generic
       netsync: false
-    - type: StaticPrice
-      price: 100

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -48,7 +48,7 @@
       conditions:
       - !type:EntityAnchored {}
       steps:
-      - tag: DoorElectronics
+      - prototype: DoorElectronics
         store: board
         name: "door electronics circuit board"
         icon:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/shutter.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/shutter.yml
@@ -44,7 +44,7 @@
             - !type:EntityAnchored
               anchored: true
           steps:
-            - tag: DoorElectronics
+            - prototype: DoorElectronics
               name: Door Electronics
               icon:
                 sprite: "Objects/Misc/module.rsi"

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/shuttle.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/shuttle.yml
@@ -25,7 +25,7 @@
       conditions:
       - !type:EntityAnchored {}
       steps:
-      - tag: DoorElectronics
+      - prototype: DoorElectronics
         store: board
         name: "door electronics circuit board"
         icon:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
@@ -77,7 +77,7 @@
       conditions:
       - !type:EntityAnchored {}
       steps:
-      - tag: DoorElectronics
+      - prototype: DoorElectronics
         store: board
         name: "door electronics circuit board"
         icon:
@@ -178,7 +178,7 @@
       conditions:
       - !type:EntityAnchored { }
       steps:
-      - tag: DoorElectronics
+      - prototype: DoorElectronics
         store: board
         name: "door electronics circuit board"
         icon:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/air_alarms.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/air_alarms.yml
@@ -36,7 +36,7 @@
     edges:
     - to: electronics
       steps:
-      - tag: AirAlarmElectronics
+      - prototype: AirAlarmElectronics
         store: board
         name: "air alarm electronics"
         icon:
@@ -115,7 +115,7 @@
     edges:
     - to: electronics
       steps:
-      - tag: FireAlarmElectronics
+      - prototype: FireAlarmElectronics
         store: board
         name: "fire alarm electronics"
         icon:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/disposal_machines.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/disposal_machines.yml
@@ -70,7 +70,7 @@
               doAfter: 0.25
         - to: frame_mailing
           steps:
-            - tag: MailingUnitElectronics
+            - prototype: MailingUnitElectronics
               name: Mailing Unit Electronics
               icon:
                 sprite: "Objects/Misc/module.rsi"

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -4,9 +4,6 @@
   id: AirAlarm
 
 - type: Tag
-  id: AirAlarmElectronics
-
-- type: Tag
   id: AirSensor
 
 - type: Tag
@@ -166,9 +163,6 @@
   id: DoorBumpOpener
 
 - type: Tag
-  id: DoorElectronics
-
-- type: Tag
   id: DonkPocket
 
 - type: Tag
@@ -191,9 +185,6 @@
 
 - type: Tag
   id: FireAlarm
-
-- type: Tag
-  id: FireAlarmElectronics
 
 - type: Tag
   id: FireAxe
@@ -328,9 +319,6 @@
 
 - type: Tag
   id: Matchstick
-
-- type: Tag
-  id: MailingUnitElectronics
 
 - type: Tag
   id: Medkit


### PR DESCRIPTION
closes #11155

This PR also delete some Tags that were used only in construction graphs. It replace the tags by the prototypes in these graphs.