### PR TITLE
Fix nukie bug

### DIFF
--- a/Content.Server/GameTicking/Rules/Configurations/NukeopsRuleConfiguration.cs
+++ b/Content.Server/GameTicking/Rules/Configurations/NukeopsRuleConfiguration.cs
@@ -16,6 +16,9 @@ public sealed class NukeopsRuleConfiguration : GameRuleConfiguration
     [DataField("minPlayers")]
     public int MinPlayers = 15;
 
+    /// <summary>
+    ///     This INCLUDES the operatives. So a value of 3 is satisfied by 2 players & 1 operative
+    /// </summary>
     [DataField("playersPerOperative")]
     public int PlayersPerOperative = 5;
 


### PR DESCRIPTION
The nuke rule system was trying to resolve a station from a previous round as the target station when first spawning players. This is now behind a `GameTicker.RunLevel` check.

