### PR TITLE
Construction error handling changes

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -460,12 +460,24 @@ namespace Content.Server.Construction
                 if (!Exists(uid) || !TryComp(uid, out ConstructionComponent? construction))
                     continue;
 
+#if EXCEPTION_TOLERANCE
+                try
+                {
+#endif
                 // Handle all queued interactions!
                 while (construction.InteractionQueue.TryDequeue(out var interaction))
                 {
                     // We set validation to false because we actually want to perform the interaction here.
                     HandleEvent(uid, interaction, false, construction);
                 }
+#if EXCEPTION_TOLERANCE
+                }
+                catch (Exception e)
+                {
+                    _sawmill.Error($"Caught exception while processing construction queue. Entity {ToPrettyString(uid)}, graph: {construction.Graph}, exception: {e}");
+                    Del(uid);
+                }
+#endif
             }
 
             _constructionUpdateQueue.Clear();


### PR DESCRIPTION
Adds a try-catch to construction interaction processing, so that the current graph prototype gets logged.

This is to try help fix construction errors, where the entity is seemingly deleted while processing the interactions:
```
Can't resolve "Robust.Shared.GameObjects.TransformComponent" on entity 228!
   at Content.Server.Construction.ConstructionSystem.ChangeEntity(EntityUid uid, Nullable`1 userUid, String newEntity, ConstructionComponent construction, MetaDataComponent metaData, TransformComponent transform, ContainerManagerComponent containerManager) in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Graph.cs:line 270
   at Content.Server.Construction.ConstructionSystem.ChangeNode(EntityUid uid, Nullable`1 userUid, String id, Boolean performActions, ConstructionComponent construction) in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Graph.cs:line 236
   at Content.Server.Construction.ConstructionSystem.HandleEdge(EntityUid uid, Object ev, ConstructionGraphEdge edge, Boolean validation, ConstructionComponent construction) in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Interactions.cs:line 166
   at Content.Server.Construction.ConstructionSystem.HandleEvent(EntityUid uid, Object ev, Boolean validation, ConstructionComponent construction, InteractUsingEvent args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Interactions.cs:line 59
   at Content.Server.Construction.ConstructionSystem.UpdateInteractions() in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Interactions.cs:line 460
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 302
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 133
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 144
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 673
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 213
   at Robust.Server.BaseServer.MainLoop() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 520
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 75
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 46
   at Robust.Server.Program.Main(String[] args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 25
```

