### PR TITLE
SMES are no longer filled when constructed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -318,7 +318,7 @@
       sprite: Objects/Misc/module.rsi
       state: power_mod
     - type: MachineBoard
-      prototype: SMESBasic
+      prototype: SMESBasicEmpty
       requirements:
         Capacitor: 10
 
@@ -329,7 +329,7 @@
   description: A machine printed circuit board for a substation
   components:
     - type: MachineBoard
-      prototype: SubstationBasic
+      prototype: SubstationBasicEmpty
       requirements:
         Capacitor: 3
       materialRequirements:

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -71,3 +71,11 @@
   - type: Battery
     maxCharge: 10000000
     startingCharge: 10000000
+
+- type: entity
+  parent: SMESBasic
+  id: SMESBasicEmpty
+  suffix: Empty
+  components:
+  - type: Battery
+    startingCharge: 0

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -170,6 +170,14 @@
     startingCharge: 4000000
 
 - type: entity
+  parent: SubstationBasic
+  id: SubstationBasicEmpty
+  suffix: Empty
+  components:
+  - type: Battery
+    startingCharge: 0
+
+- type: entity
   parent: BaseSubstationWall
   id: SubstationWallBasic
   suffix: Basic, 2MW


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, when you build a new SMES from scratch it is filled when finished.
So if your power goes out because e.g. you forgot to refill AME, you just have to partially deconstruct and then reconstruct your SMES (this is done in 3 simple steps : screwdriver, crowbar, screwdriver) and you get power without any power source !
The same apply to substations.

This PR change the final entity of the construction to unfilled SMES and substation.

<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- remove: SMES's and substations are no longer filled upon construction

