### PR TITLE
Use IRuntimeLog in ConstructionSystem

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -7,12 +7,18 @@ using Content.Shared.Construction.Steps;
 using Content.Shared.Database;
 using Content.Shared.Interaction;
 using Robust.Shared.Containers;
+#if EXCEPTION_TOLERANCE
+using Robust.Shared.Exceptions;
+#endif
 
 namespace Content.Server.Construction
 {
     public sealed partial class ConstructionSystem
     {
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+#if EXCEPTION_TOLERANCE
+        [Dependency] private readonly IRuntimeLog _runtimeLog = default!;
+#endif
 
         private readonly HashSet<EntityUid> _constructionUpdateQueue = new();
 
@@ -474,7 +480,8 @@ namespace Content.Server.Construction
                 }
                 catch (Exception e)
                 {
-                    _sawmill.Error($"Caught exception while processing construction queue. Entity {ToPrettyString(uid)}, graph: {construction.Graph}, exception: {e}");
+                    _sawmill.Error($"Caught exception while processing construction queue. Entity {ToPrettyString(uid)}, graph: {construction.Graph}");
+                    _runtimeLog.LogException(e, $"{nameof(ConstructionSystem)}.{nameof(UpdateInteractions)}");
                     Del(uid);
                 }
 #endif


### PR DESCRIPTION
Does what the title says, though I'm not sure about the `IRuntimeLog` convention for the "catcher" argument.
Some usages just use the name of the class, others just use some text with spacing, while others include information in the catcher name (e.g., entity UIDs), effectively treating it like a general error message field. I've just changed this to use both a descriptive error log and an exception log.