### PR TITLE
Ambience no longer plays in the lobby

### DIFF
--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -151,8 +151,8 @@ namespace Content.Client.Audio
             Timer.Spawn(1500, () =>
             {
                 // If we traverse a few times then don't interrupt an existing song.
-                // If we are in the Lobby, don't start Ambience because of a player movement
-                if (_playingCollection == _currentCollection || _stateManager.CurrentState is LobbyState)
+                // If we are not in gameplay, don't call StartAmbience because of player movement
+                if (_playingCollection == _currentCollection || _stateManager.CurrentState is not GameplayState)
                     return;
                 StartAmbience();
             }, _timerCancelTokenSource.Token);

--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -134,8 +134,7 @@ namespace Content.Client.Audio
         private void EntParentChanged(ref EntParentChangedMessage message)
         {
             if(_playMan.LocalPlayer is null || _playMan.LocalPlayer.ControlledEntity != message.Entity ||
-               !_timing.IsFirstTimePredicted)
-                return;
+               !_timing.IsFirstTimePredicted) return;
 
             // Check if we traversed to grid.
             CheckAmbience(message.Transform);
@@ -143,8 +142,7 @@ namespace Content.Client.Audio
 
         private void ChangeAmbience(SoundCollectionPrototype newAmbience)
         {
-            if (_currentCollection == newAmbience)
-                return;
+            if (_currentCollection == newAmbience) return;
             _timerCancelTokenSource.Cancel();
             _currentCollection = newAmbience;
             _timerCancelTokenSource = new();
@@ -152,8 +150,7 @@ namespace Content.Client.Audio
             {
                 // If we traverse a few times then don't interrupt an existing song.
                 // If we are in the Lobby, don't start Ambience because of a player movement
-                if (_playingCollection == _currentCollection || _stateManager.CurrentState is LobbyState)
-                    return;
+                if (_playingCollection == _currentCollection || _stateManager.CurrentState is LobbyState) return;
                 StartAmbience();
             }, _timerCancelTokenSource.Token);
         }
@@ -300,8 +297,7 @@ namespace Content.Client.Audio
 
         public void StartLobbyMusic()
         {
-            if (_lobbyStream != null || !_configManager.GetCVar(CCVars.LobbyMusicEnabled))
-                return;
+            if (_lobbyStream != null || !_configManager.GetCVar(CCVars.LobbyMusicEnabled)) return;
 
             var file = _gameTicker.LobbySong;
             if (file == null) // We have not received the lobby song yet.

--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -149,8 +149,8 @@ namespace Content.Client.Audio
             Timer.Spawn(1500, () =>
             {
                 // If we traverse a few times then don't interrupt an existing song.
-                if (_playingCollection == _currentCollection) return;
-                EndAmbience();
+                // If we are in the Lobby, don't start Ambience because of a player movement
+                if (_playingCollection == _currentCollection || _stateManager.CurrentState is LobbyState) return;
                 StartAmbience();
             }, _timerCancelTokenSource.Token);
         }

--- a/Content.Client/Audio/BackgroundAudioSystem.cs
+++ b/Content.Client/Audio/BackgroundAudioSystem.cs
@@ -134,7 +134,8 @@ namespace Content.Client.Audio
         private void EntParentChanged(ref EntParentChangedMessage message)
         {
             if(_playMan.LocalPlayer is null || _playMan.LocalPlayer.ControlledEntity != message.Entity ||
-               !_timing.IsFirstTimePredicted) return;
+               !_timing.IsFirstTimePredicted)
+                return;
 
             // Check if we traversed to grid.
             CheckAmbience(message.Transform);
@@ -142,7 +143,8 @@ namespace Content.Client.Audio
 
         private void ChangeAmbience(SoundCollectionPrototype newAmbience)
         {
-            if (_currentCollection == newAmbience) return;
+            if (_currentCollection == newAmbience)
+                return;
             _timerCancelTokenSource.Cancel();
             _currentCollection = newAmbience;
             _timerCancelTokenSource = new();
@@ -150,7 +152,8 @@ namespace Content.Client.Audio
             {
                 // If we traverse a few times then don't interrupt an existing song.
                 // If we are in the Lobby, don't start Ambience because of a player movement
-                if (_playingCollection == _currentCollection || _stateManager.CurrentState is LobbyState) return;
+                if (_playingCollection == _currentCollection || _stateManager.CurrentState is LobbyState)
+                    return;
                 StartAmbience();
             }, _timerCancelTokenSource.Token);
         }
@@ -297,7 +300,8 @@ namespace Content.Client.Audio
 
         public void StartLobbyMusic()
         {
-            if (_lobbyStream != null || !_configManager.GetCVar(CCVars.LobbyMusicEnabled)) return;
+            if (_lobbyStream != null || !_configManager.GetCVar(CCVars.LobbyMusicEnabled))
+                return;
 
             var file = _gameTicker.LobbySong;
             if (file == null) // We have not received the lobby song yet.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Ambience does no longer play in the lobby <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

A check prevents ChangeAmbience from calling StartAmbience after the player entity is moved during lobby creation. Also removed unnecessary function call to EndAmbience. 

fixes #11198
doesn't implement the second part of the issue ("Ideally we should have more ways of controlling ambient music like space wind too so we can have it per tile?") though.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Sheppard
- fix: Ambience no longer plays in the lobby.

