### PR TITLE
Armor price calculations

### DIFF
--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -27,47 +27,47 @@ namespace Content.Server.Armor
 
             double price = 0;
 
-            double coefDefaultPrice = 1; //default price of 1% protection against a certain type of damage
+            double coefDefaultPrice = 2; //default price of 1% protection against a certain type of damage
             var coefPriceList = new Dictionary<string, double>()
             {
-                {"Brute", 3 }, //Group: Blunt, Slash, Piercing
-                {"Blunt", 1 },
-                {"Slash", 1 },
-                {"Piercing", 1 },
-                {"Burn", 3.6 }, //Group: Heat, Cold, Shock
-                {"Heat", 1.2 },
-                {"Cold", 1.2 },
-                {"Shock", 1.2 },
-                {"Toxin", 6.7 }, //Group: Radiation, Poison
-                {"Radiation", 1.2 }, 
-                {"Poison", 5 }, //  Armor stopping poison damage? Sounds strong
-                {"Genetic", 2 }, //Group: Cellular
-                {"Cellular", 2 }, //idk
-                {"Airloss", 6 }, //Group: Bloodloss, Asphyxiation
-                {"Bloodloss", 3 }, 
-                {"Asphyxiation", 3 },
-                {"Caustic", 6.2 } //Group: Heat, Poison
+                {"Brute", 6 }, //Group: Blunt, Slash, Piercing
+                {"Blunt", 2 },
+                {"Slash", 2 },
+                {"Piercing", 2 },
+                {"Burn", 7.5 }, //Group: Heat, Cold, Shock
+                {"Heat", 2.5 },
+                {"Cold", 2.5 },
+                {"Shock", 2.5 },
+                {"Toxin", 12.5 }, //Group: Radiation, Poison
+                {"Radiation", 2.5 }, 
+                {"Poison", 10 }, //  Armor stopping poison damage? Sounds strong
+                {"Genetic", 5 }, //Group: Cellular
+                {"Cellular", 5 }, //idk
+                {"Airloss", 10 }, //Group: Bloodloss, Asphyxiation
+                {"Bloodloss", 5 }, 
+                {"Asphyxiation", 5 },
+                {"Caustic", 12.5 } //Group: Heat, Poison
             };
             double flatDefaultPrice = 5; //default price of 1 damage protection against a certain type of damage
             var flatPriceList = new Dictionary<string, double>()
             {
-                {"Brute", 15 }, //Group: Blunt, Slash, Piercing
-                {"Blunt", 5 },
-                {"Slash", 5 },
-                {"Piercing", 5 },
-                {"Burn", 30 }, //Group: Heat, Cold, Shock
-                {"Heat", 10 },
-                {"Cold", 10 },
-                {"Shock", 10 },
-                {"Toxin", 62 }, //Group: Radiation, Poison
-                {"Radiation", 12 },
-                {"Poison", 50 }, //  Armor stopping poison damage? Sounds strong
-                {"Genetic", 20 }, //Group: Cellular
-                {"Cellular", 20 }, //idk
-                {"Airloss", 60 }, //Group: Bloodloss, Asphyxiation
-                {"Bloodloss", 30 },
-                {"Asphyxiation", 30 },
-                {"Caustic", 60 } //Group: Heat, Poison
+                {"Brute", 30 }, //Group: Blunt, Slash, Piercing
+                {"Blunt", 10 },
+                {"Slash", 10 },
+                {"Piercing", 10 },
+                {"Burn", 60 }, //Group: Heat, Cold, Shock
+                {"Heat", 20 },
+                {"Cold", 20 },
+                {"Shock", 20 },
+                {"Toxin", 76 }, //Group: Radiation, Poison
+                {"Radiation", 16 },
+                {"Poison", 60 }, //  Armor stopping poison damage? Sounds strong
+                {"Genetic", 30 }, //Group: Cellular
+                {"Cellular", 30 }, //idk
+                {"Airloss", 100 }, //Group: Bloodloss, Asphyxiation
+                {"Bloodloss", 50 },
+                {"Asphyxiation", 50 },
+                {"Caustic", 80 } //Group: Heat, Poison
             };
 
             foreach (var modifier in component.Modifiers.Coefficients)

--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.Examine;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
+using Content.Server.Cargo.Systems;
 
 namespace Content.Server.Armor
 {
@@ -16,8 +17,83 @@ namespace Content.Server.Armor
 
             SubscribeLocalEvent<ArmorComponent, DamageModifyEvent>(OnDamageModify);
             SubscribeLocalEvent<ArmorComponent, GetVerbsEvent<ExamineVerb>>(OnArmorVerbExamine);
+            SubscribeLocalEvent<ArmorComponent, PriceCalculationEvent>(GetArmorPrice);
         }
 
+        private void GetArmorPrice(EntityUid uid, ArmorComponent component, ref PriceCalculationEvent args)
+        {
+            if (component.Modifiers == null)
+                return;
+
+            double price = 0;
+
+            double coefDefaultPrice = 1; //default price of 1% protection against a certain type of damage
+            var coefPriceList = new Dictionary<string, double>()
+            {
+                {"Brute", 3 }, //Group: Blunt, Slash, Piercing
+                {"Blunt", 1 },
+                {"Slash", 1 },
+                {"Piercing", 1 },
+                {"Burn", 3.6 }, //Group: Heat, Cold, Shock
+                {"Heat", 1.2 },
+                {"Cold", 1.2 },
+                {"Shock", 1.2 },
+                {"Toxin", 6.7 }, //Group: Radiation, Poison
+                {"Radiation", 1.2 }, 
+                {"Poison", 5 }, //  Armor stopping poison damage? Sounds strong
+                {"Genetic", 2 }, //Group: Cellular
+                {"Cellular", 2 }, //idk
+                {"Airloss", 6 }, //Group: Bloodloss, Asphyxiation
+                {"Bloodloss", 3 }, 
+                {"Asphyxiation", 3 },
+                {"Caustic", 6.2 } //Group: Heat, Poison
+            };
+            double flatDefaultPrice = 5; //default price of 1 damage protection against a certain type of damage
+            var flatPriceList = new Dictionary<string, double>()
+            {
+                {"Brute", 15 }, //Group: Blunt, Slash, Piercing
+                {"Blunt", 5 },
+                {"Slash", 5 },
+                {"Piercing", 5 },
+                {"Burn", 30 }, //Group: Heat, Cold, Shock
+                {"Heat", 10 },
+                {"Cold", 10 },
+                {"Shock", 10 },
+                {"Toxin", 62 }, //Group: Radiation, Poison
+                {"Radiation", 12 },
+                {"Poison", 50 }, //  Armor stopping poison damage? Sounds strong
+                {"Genetic", 20 }, //Group: Cellular
+                {"Cellular", 20 }, //idk
+                {"Airloss", 60 }, //Group: Bloodloss, Asphyxiation
+                {"Bloodloss", 30 },
+                {"Asphyxiation", 30 },
+                {"Caustic", 60 } //Group: Heat, Poison
+            };
+
+            foreach (var modifier in component.Modifiers.Coefficients)
+            {
+                if (coefPriceList.ContainsKey(modifier.Key))
+                {
+                    price += coefPriceList[modifier.Key] * 100 * (1-modifier.Value);
+                }
+                else
+                {
+                    price += coefDefaultPrice * 100 * (1 - modifier.Value);
+                }
+            }
+            foreach (var modifier in component.Modifiers.FlatReduction)
+            {
+                if (flatPriceList.ContainsKey(modifier.Key))
+                {
+                    price += flatPriceList[modifier.Key] * modifier.Value;
+                }
+                else
+                {
+                    price += flatDefaultPrice * modifier.Value;
+                }
+            }
+            args.Price += price;
+        }
         private void OnDamageModify(EntityUid uid, ArmorComponent component, DamageModifyEvent args)
         {
             args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, component.Modifiers);

--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -27,8 +27,8 @@ namespace Content.Server.Armor
 
             double price = 0;
 
-            double coefDefaultPrice = 2; //default price of 1% protection against a certain type of damage
-            var coefPriceList = new Dictionary<string, double>()
+            double coefDefaultPrice = 2; // default price of 1% protection against any type of damage
+            var coefPriceList = new Dictionary<string, double>() // List of damage type and cost per 1% of protection
             {
                 {"Brute", 6 }, //Group: Blunt, Slash, Piercing
                 {"Blunt", 2 },
@@ -40,16 +40,16 @@ namespace Content.Server.Armor
                 {"Shock", 2.5 },
                 {"Toxin", 12.5 }, //Group: Radiation, Poison
                 {"Radiation", 2.5 }, 
-                {"Poison", 10 }, //  Armor stopping poison damage? Sounds strong
+                {"Poison", 10 }, 
                 {"Genetic", 5 }, //Group: Cellular
-                {"Cellular", 5 }, //idk
+                {"Cellular", 5 }, 
                 {"Airloss", 10 }, //Group: Bloodloss, Asphyxiation
                 {"Bloodloss", 5 }, 
                 {"Asphyxiation", 5 },
                 {"Caustic", 12.5 } //Group: Heat, Poison
             };
-            double flatDefaultPrice = 5; //default price of 1 damage protection against a certain type of damage
-            var flatPriceList = new Dictionary<string, double>()
+            double flatDefaultPrice = 10; //default price of 1 damage protection against a certain type of damage
+            var flatPriceList = new Dictionary<string, double>() // List of damage type and cost per 1 damage reduction
             {
                 {"Brute", 30 }, //Group: Blunt, Slash, Piercing
                 {"Blunt", 10 },
@@ -61,9 +61,9 @@ namespace Content.Server.Armor
                 {"Shock", 20 },
                 {"Toxin", 76 }, //Group: Radiation, Poison
                 {"Radiation", 16 },
-                {"Poison", 60 }, //  Armor stopping poison damage? Sounds strong
+                {"Poison", 60 },
                 {"Genetic", 30 }, //Group: Cellular
-                {"Cellular", 30 }, //idk
+                {"Cellular", 30 },
                 {"Airloss", 100 }, //Group: Bloodloss, Asphyxiation
                 {"Bloodloss", 50 },
                 {"Asphyxiation", 50 },

--- a/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
@@ -4,7 +4,7 @@
     sprite: Clothing/Head/Helmets/bombsuit.rsi
     state: icon
   product: CrateEmergencyExplosive
-  cost: 500
+  cost: 650
   category: Emergency
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Structures/Wallmounts/signs.rsi
     state: radiation
   product: CrateEmergencyRadiation
-  cost: 500
+  cost: 900
   category: Emergency
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -4,7 +4,7 @@
     sprite: Clothing/OuterClothing/Vests/oldarmor.rsi
     state: icon
   product: CrateSecurityArmor
-  cost: 500
+  cost: 700
   category: Security
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -44,7 +44,7 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
     state: icon
   product: CrateSecurityRiot
-  cost: 2000
+  cost: 2800
   category: Security
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -14,7 +14,7 @@
     sprite: Clothing/Head/Helmets/security.rsi
     state: icon
   product: CrateSecurityHelmet
-  cost: 500
+  cost: 550
   category: Security
   group: market
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds automatic calculation of prices to armors, fixes #11299 (altho not logarithmic)

It currently works through assigning a value to each 1% reduction per type, or for each 1 damage flat reduction. The basic prices are 2$ per 1% of brute damage reduction, and 2.5$ per 1% of burn damage reduction.

Not sure about the balance of the prices, but I assume it'll have to be balanced again later somehow.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Armor prices are calculated based on damage reduction.

