### PR TITLE
Some ID card layers fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -496,8 +496,8 @@
   components:
   - type: Sprite
     layers:
-    - state: idpsychologist
     - state: default
+    - state: idpsychologist
   - type: PresetIdCard
     job: Psychologist
 
@@ -508,8 +508,8 @@
   components:
   - type: Sprite
     layers:
-    - state: idreporter
     - state: default
+    - state: idreporter
   - type: PresetIdCard
     job: Reporter
 
@@ -532,8 +532,8 @@
   components:
   - type: Sprite
     layers:
-    - state: iddetective
     - state: default
+    - state: iddetective
   - type: PresetIdCard
     job: Detective
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/100279397/191142602-7b65dfb0-619a-46b3-9871-4071960041cd.png)
->
![image](https://user-images.githubusercontent.com/100279397/191142388-6c82d94c-ee99-4cc4-87e8-26b68e3d7561.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: psychologist, detective, and reporter ID cards now display correct layers

