### PR TITLE
Forensic pad is now tagged as a document

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Forensics/forensics.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Forensics/forensics.yml
@@ -13,3 +13,6 @@
     layers:
     - state: paper
       color: yellow
+  - type: Tag
+    tags:
+    - Document


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Forensic pad is now tagged as a document

Fixes #10941 

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Forensic pad is now tagged as a document. They can be stored in filling cabinets and folders.

