### PR TITLE
Fix cargo computer boards

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -16,8 +16,9 @@
         prob: 0.7
       - id: ClothingHeadHatQMsoft
         prob: 0.8
-      - id: SupplyRequestComputerCircuitboard
-      - id: SupplyComputerCircuitboard
+      - id: CargoRequestComputerCircuitboard
+      - id: CargoShuttleComputerCircuitboard
+      - id: CargoShuttleConsoleCircuitboard
       - id: CigPackGreen
         prob: 0.50
       - id: DoorRemoteCargo

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -58,9 +58,9 @@
 
 - type: entity
   parent: BaseComputerCircuitboard
-  id: SupplyComputerCircuitboard
-  name: supply ordering computer board
-  description: A computer printed circuit board for a supply ordering console.
+  id: CargoRequestComputerCircuitboard
+  name: cargo request computer board
+  description: A computer printed circuit board for a cargo request computer.
   components:
     - type: Sprite
       state: cpu_supply
@@ -71,14 +71,23 @@
 
 - type: entity
   parent: BaseComputerCircuitboard
-  id: SupplyRequestComputerCircuitboard
-  name: supply request computer board
-  description: A computer printed circuit board for a supply request console.
+  id: CargoShuttleComputerCircuitboard
+  name: cargo shuttle computer board
+  description: A computer printed circuit board for a cargo shuttle computer.
   components:
     - type: Sprite
       state: cpu_supply
     - type: ComputerBoard
-      prototype: ComputerCargoOrders
+      prototype: ComputerCargoShuttle
+
+- type: entity
+  parent: BaseComputerCircuitboard
+  id: CargoShuttleConsoleCircuitboard
+  name: supply shuttle console board
+  description: A computer printed circuit board for a cargo shuttle console.
+  components:
+    - type: ComputerBoard
+      prototype: ComputerShuttleCargo
 
 - type: entity
   parent: BaseComputerCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -115,6 +115,8 @@
       radius: 1.5
       energy: 1.6
       color: "#c94242"
+    - type: Computer
+      board: CargoShuttleConsoleCircuitboard
 
 - type: entity
   parent: BaseComputer
@@ -548,7 +550,7 @@
     - key: enum.CargoConsoleUiKey.Shuttle
       type: CargoShuttleConsoleBoundUserInterface
   - type: Computer
-    board: SupplyComputerCircuitboard
+    board: CargoShuttleComputerCircuitboard
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -576,7 +578,7 @@
     - key: enum.CargoConsoleUiKey.Orders
       type: CargoOrderConsoleBoundUserInterface
   - type: Computer
-    board: SupplyComputerCircuitboard
+    board: CargoRequestComputerCircuitboard
   - type: PointLight
     radius: 1.5
     energy: 1.6

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -170,7 +170,7 @@
       roleId: Quartermaster
   conditions:
     - !type:StealCondition
-      prototype: SupplyComputerCircuitboard
+      prototype: CargoRequestComputerCircuitboard
       owner: job-name-qm
 
 - type: objective


### PR DESCRIPTION
Closes #11429

IDs of all 3 cargo boards were changed. Mappers need to update their maps if they have them mapped in somewhere. None of the maps in this repo are affected.

**Changelog**
:cl:
- add: Added a computer board for the cargo shuttle console, found in QM's locker
- fix: Fixed a bug that made it impossible to construct a cargo shuttle computer
- fix: Cargo computer board names now match their corresponding computer