### PR TITLE
Air alarm mode sent to all linked air alarms from a single air alarm

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -248,7 +248,7 @@ public sealed class AirAlarmSystem : EntitySystem
         var addr = string.Empty;
         if (EntityManager.TryGetComponent(uid, out DeviceNetworkComponent? netConn)) addr = netConn.Address;
         if (AccessCheck(uid, args.Session.AttachedEntity, component))
-            SetMode(uid, addr, args.Mode, true, false);
+            SetMode(uid, addr, args.Mode, false);
         else
             UpdateUI(uid, component);
     }
@@ -299,11 +299,11 @@ public sealed class AirAlarmSystem : EntitySystem
 
         if (args.AlarmType == AtmosAlarmType.Danger)
         {
-            SetMode(uid, addr, AirAlarmMode.WideFiltering, true, false);
+            SetMode(uid, addr, AirAlarmMode.WideFiltering, false);
         }
         else if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)
         {
-            SetMode(uid, addr, AirAlarmMode.Filtering, true, false);
+            SetMode(uid, addr, AirAlarmMode.Filtering, false);
         }
 
         UpdateUI(uid, component);
@@ -320,9 +320,13 @@ public sealed class AirAlarmSystem : EntitySystem
     /// <param name="mode">The mode to set the alarm to.</param>
     /// <param name="sync">Whether to sync this mode change to the network or not. Defaults to false.</param>
     /// <param name="uiOnly">Whether this change is for the UI only, or if it changes the air alarm's operating mode. Defaults to true.</param>
-    public void SetMode(EntityUid uid, string origin, AirAlarmMode mode, bool sync = false, bool uiOnly = true, AirAlarmComponent? controller = null)
+    public void SetMode(EntityUid uid, string origin, AirAlarmMode mode, bool uiOnly = true, AirAlarmComponent? controller = null)
     {
-        if (!Resolve(uid, ref controller)) return;
+        if (!Resolve(uid, ref controller) || controller.CurrentMode == mode)
+        {
+            return;
+        }
+
         controller.CurrentMode = mode;
 
         // setting it to UI only means we don't have
@@ -359,7 +363,7 @@ public sealed class AirAlarmSystem : EntitySystem
         // setting sync deals with the issue of air alarms
         // in the same network needing to have the same mode
         // as other alarms
-        if (sync) SyncMode(uid, mode);
+        SyncMode(uid, mode);
     }
 
     /// <summary>

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -318,7 +318,6 @@ public sealed class AirAlarmSystem : EntitySystem
     /// </summary>
     /// <param name="origin">The origin address of this mode set. Used for network sync.</param>
     /// <param name="mode">The mode to set the alarm to.</param>
-    /// <param name="sync">Whether to sync this mode change to the network or not. Defaults to false.</param>
     /// <param name="uiOnly">Whether this change is for the UI only, or if it changes the air alarm's operating mode. Defaults to true.</param>
     public void SetMode(EntityUid uid, string origin, AirAlarmMode mode, bool uiOnly = true, AirAlarmComponent? controller = null)
     {

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -418,7 +418,8 @@ public sealed class AirAlarmSystem : EntitySystem
 
                 return;
             case AirAlarmSetMode:
-                if (!args.Data.TryGetValue(AirAlarmSetMode, out AirAlarmMode alarmMode)) break;
+                if (!args.Data.TryGetValue(AirAlarmSetMode, out AirAlarmMode alarmMode))
+                    break;
 
                 SetMode(uid, args.SenderAddress, alarmMode, uiOnly: false);
 

--- a/Content.Server/Atmos/Monitor/WireActions/AirAlarmPanicWire.cs
+++ b/Content.Server/Atmos/Monitor/WireActions/AirAlarmPanicWire.cs
@@ -44,7 +44,7 @@ public sealed class AirAlarmPanicWire : BaseWireAction
     {
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet))
         {
-            _airAlarmSystem.SetMode(wire.Owner, devNet.Address, AirAlarmMode.Panic, true, false);
+            _airAlarmSystem.SetMode(wire.Owner, devNet.Address, AirAlarmMode.Panic, false);
         }
 
         return true;
@@ -56,7 +56,7 @@ public sealed class AirAlarmPanicWire : BaseWireAction
             && EntityManager.TryGetComponent<AirAlarmComponent>(wire.Owner, out var alarm)
             && alarm.CurrentMode == AirAlarmMode.Panic)
         {
-            _airAlarmSystem.SetMode(wire.Owner, devNet.Address, AirAlarmMode.Filtering, true, false, alarm);
+            _airAlarmSystem.SetMode(wire.Owner, devNet.Address, AirAlarmMode.Filtering, false, alarm);
         }
 
 
@@ -67,7 +67,7 @@ public sealed class AirAlarmPanicWire : BaseWireAction
     {
         if (EntityManager.TryGetComponent<DeviceNetworkComponent>(wire.Owner, out var devNet))
         {
-            _airAlarmSystem.SetMode(wire.Owner, devNet.Address, AirAlarmMode.Panic, true, false);
+            _airAlarmSystem.SetMode(wire.Owner, devNet.Address, AirAlarmMode.Panic, false);
         }
 
         return true;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As said in title. This addresses an issue told to me by another user where air alarm modes were only synced to the next air alarm, rather than all air alarms linked to the single air alarm.

(yes, this was referenced in the air alarm issue - I may have mixed it up, as the same user who made that issue told me this bug as well)