### PR TITLE
Adds device network addresses to the examine tooltip as an option

### DIFF
--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
@@ -81,6 +81,13 @@ namespace Content.Server.DeviceNetwork.Components
         public bool ReceiveAll;
 
         /// <summary>
+        ///     If the device should show its address upon an examine. Useful for devices
+        ///     that do not have a visible UI.
+        /// </summary>
+        [DataField("examinableAddress")]
+        public bool ExaminableAddress;
+
+        /// <summary>
         ///     Whether the device should attempt to join the network on map init.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Examine;
 using static Content.Server.DeviceNetwork.Components.DeviceNetworkComponent;
 
 namespace Content.Server.DeviceNetwork.Systems
@@ -28,6 +29,7 @@ namespace Content.Server.DeviceNetwork.Systems
         {
             SubscribeLocalEvent<DeviceNetworkComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<DeviceNetworkComponent, ComponentShutdown>(OnNetworkShutdown);
+            SubscribeLocalEvent<DeviceNetworkComponent, ExaminedEvent>(OnExamine);
         }
 
         public override void Update(float frameTime)
@@ -59,6 +61,15 @@ namespace Content.Server.DeviceNetwork.Systems
             if (frequency != null)
                 _packets.Enqueue(new DeviceNetworkPacketEvent(device.DeviceNetId, address, frequency.Value, device.Address, uid, data));
         }
+
+        private void OnExamine(EntityUid uid, DeviceNetworkComponent device, ExaminedEvent args)
+        {
+            if (device.ExaminableAddress)
+            {
+                args.PushText(Loc.GetString("device-address-examine-message", ("address", device.Address)));
+            }
+        }
+
         /// <summary>
         /// Automatically attempt to connect some devices when a map starts.
         /// </summary>

--- a/Resources/Locale/en-US/devices/device-network.ftl
+++ b/Resources/Locale/en-US/devices/device-network.ftl
@@ -20,3 +20,7 @@ device-frequency-prototype-name-surveillance-camera-entertainment = Entertainmen
 device-address-prefix-vent = Vnt-
 device-address-prefix-scrubber = Scr-
 device-address-prefix-sensor = Sns-
+device-address-prefix-fire-alarm = Fir-
+device-address-prefix-air-alarm = Air-
+
+device-address-examine-message = The device's address is {$address}.

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -35,6 +35,7 @@
       transmitFrequencyId: AtmosMonitor
       prefix: device-address-prefix-vent
       sendBroadcastAttemptEvent: true
+      examinableAddress: true
     - type: WiredNetworkConnection
     - type: DeviceNetworkRequiresPower
     - type: AtmosDevice
@@ -127,6 +128,7 @@
       receiveFrequencyId: AtmosMonitor
       transmitFrequencyId: AtmosMonitor
       prefix: device-address-prefix-scrubber
+      examinableAddress: true
     - type: DeviceNetworkRequiresPower
     - type: AtmosMonitor
       temperatureThreshold: stationTemperature

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -40,6 +40,7 @@
       transmitFrequencyId: AtmosMonitor
       prefix: device-address-prefix-sensor
       sendBroadcastAttemptEvent: true
+      examinableAddress: true
     - type: WiredNetworkConnection
     - type: DeviceNetworkRequiresPower
     - type: AtmosDevice

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -13,6 +13,7 @@
     deviceNetId: AtmosDevices
     receiveFrequencyId: AtmosMonitor
     transmitFrequencyId: AtmosMonitor
+    prefix: device-address-prefix-air-alarm
     sendBroadcastAttemptEvent: true
   - type: WiredNetworkConnection
   - type: DeviceList

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -13,7 +13,9 @@
     deviceNetId: AtmosDevices
     receiveFrequencyId: AtmosMonitor
     transmitFrequencyId: AtmosMonitor
+    prefix: device-address-prefix-fire-alarm
     sendBroadcastAttemptEvent: true
+    examinableAddress: true
   - type: DeviceList
   - type: WiredNetworkConnection
   - type: DeviceNetworkRequiresPower


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds device network addresses to the examine tooltip as an optional flag. This is mostly useful for quickly referencing devices when you only have them by address.

:cl:
- add: We have added a little sticker to some of your devices that should make it easier for you to figure out what that device's local address is.

