### PR TITLE
Ensures that a network configurator always has a visible address

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceListSystem.cs
@@ -25,6 +25,9 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
     /// <summary>
     /// Gets the given device list as a dictionary
     /// </summary>
+    /// <remarks>
+    /// If any entity in the device list is pre-map init, it will show the entity UID of the device instead.
+    /// </remarks>
     public Dictionary<string, EntityUid> GetDeviceList(EntityUid uid, DeviceListComponent? deviceList = null)
     {
         if (!Resolve(uid, ref deviceList))
@@ -37,7 +40,11 @@ public sealed class DeviceListSystem : SharedDeviceListSystem
             if (!TryComp(deviceUid, out DeviceNetworkComponent? deviceNet))
                 continue;
 
-            devices.Add(deviceNet.Address, deviceUid);
+            var address = MetaData(deviceUid).EntityLifeStage == EntityLifeStage.MapInitialized
+                ? deviceNet.Address
+                : $"UID: {deviceUid.ToString()}";
+
+            devices.Add(address, deviceUid);
 
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #11456, as device-networked entities before mapinit did not have an address, causing the function that crashes the server in mapping mode to try and add all addresses to an empty string key.