### PR TITLE
Add some latejoin spawns to Pillar

### DIFF
--- a/Resources/Maps/newpillar.yml
+++ b/Resources/Maps/newpillar.yml
@@ -175041,4 +175041,28 @@ entities:
   - pos: -99.5,8.5
     parent: 8
     type: Transform
+- uid: 21391
+  type: SpawnPointLatejoin
+  components:
+  - pos: -58.5,31.5
+    parent: 8
+    type: Transform
+- uid: 21392
+  type: SpawnPointLatejoin
+  components:
+  - pos: -59.5,31.5
+    parent: 8
+    type: Transform
+- uid: 21393
+  type: SpawnPointLatejoin
+  components:
+  - pos: -60.5,31.5
+    parent: 8
+    type: Transform
+- uid: 21394
+  type: SpawnPointLatejoin
+  components:
+  - pos: -61.5,31.5
+    parent: 8
+    type: Transform
 ...


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Pillar had no latejoin spawnpoints nor an arrivals shuttle, and so was spawning latejoins randomly. I've added a few latejoin spawns to Pillar, right next to the existing assistant spawns in arrivals.

fixes: #11440

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![latejoin](https://user-images.githubusercontent.com/451390/191886760-f3d19c6f-cf8b-4a4a-966b-e93ff2688c88.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: illiux
- add: Latejoin spawns to Pillar

