### PR TITLE
Adds a meteor gun and rod gun for admeme use

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -128,7 +128,16 @@
       tags:
         - CartridgeRocket
     proto: MeteorLarge
-  - type: ContainerContainer
-    containers:
-      gun_magazine: !type:ContainerSlot
-      gun_chamber: !type:ContainerSlot
+      
+- type: entity
+  name: immovable rod launcher
+  parent: WeaponLauncherAdmemeMeteorLarge
+  id: WeaponLauncherAdmemeImmovableRodSlow
+  suffix: Admeme
+  description: It fires slow immovable rods.
+  components:
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+        - CartridgeRocket
+    proto: ImmovableRodSlow

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -128,7 +128,10 @@
       tags:
         - CartridgeRocket
     proto: MeteorLarge
-      
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container
+
 - type: entity
   name: immovable rod launcher
   parent: WeaponLauncherAdmemeMeteorLarge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -128,3 +128,7 @@
       tags:
         - CartridgeRocket
     proto: MeteorLarge
+  - type: ContainerContainer
+    containers:
+      gun_magazine: !type:ContainerSlot
+      gun_chamber: !type:ContainerSlot

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -114,3 +114,17 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+
+# Admeme
+- type: entity
+  name: meteor launcher
+  parent: WeaponLauncherMultipleRocket
+  id: WeaponLauncherAdmemeMeteorLarge
+  suffix: Admeme
+  description: It fires large meteors
+  components:
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+        - CartridgeRocket
+    proto: MeteorLarge


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So I've often felt we should be able to fire meteors at specific parts of the station for events etc, and increasingly now to get rid of "bugs" on the "windscreen" of the shuttle.

I wanted to make one for the null rod and a micro meteor pistol for hitting individuals but kept getting errors and couldn't find the null rod so here it is.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![Content Client_9ZSBKDZhey](https://user-images.githubusercontent.com/78795277/191915129-be13d8e3-ddeb-4403-abd4-3af584d3c162.gif)
