### PR TITLE
Fix exception with miasma system

### DIFF
--- a/Content.Server/Atmos/Miasma/MiasmaSystem.cs
+++ b/Content.Server/Atmos/Miasma/MiasmaSystem.cs
@@ -238,7 +238,7 @@ namespace Content.Server.Atmos.Miasma
 
         private void OnFliesShutdown(EntityUid uid, FliesComponent component, ComponentShutdown args)
         {
-            if (!Terminating(uid))
+            if (!Terminating(uid) && !Deleted(uid))
                 Del(component.VirtFlies);
         }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Try fix error from logs:
```
Called Delete on an entity already being deleted. Entity:  (1964121, AmbientSoundSourceFlies). Stack:    at System.Environment.get_StackTrace()
   at Robust.Shared.GameObjects.EntityManager.DeleteEntity(EntityUid e) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 312
   at Content.Server.Atmos.Miasma.MiasmaSystem.OnFliesShutdown(EntityUid uid, FliesComponent component, ComponentShutdown args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Atmos/Miasma/MiasmaSystem.cs:line 241
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass47_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 252
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass58_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 390
   at Robust.Shared.GameObjects.EntityEventBus.DispatchComponent[TEvent](EntityUid euid, IComponent component, CompIdx baseType, Unit& args, Boolean dispatchByReference) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 592
   at Robust.Shared.GameObjects.EntityEventBus.Robust.Shared.GameObjects.IDirectedEventBus.RaiseComponentEvent[TEvent](IComponent component, TEvent args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 132
   at Robust.Shared.GameObjects.Component.LifeShutdown(IEntityManager entManager) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/Component.cs:line 124
   at Robust.Shared.GameObjects.EntityManager.RemoveComponentImmediate(Component component, EntityUid uid, Boolean removeProtected) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.Components.cs:line 528
   at Content.Server.Atmos.Miasma.MiasmaSystem.OnShutdown(EntityUid uid, RottingComponent component, ComponentShutdown args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Atmos/Miasma/MiasmaSystem.cs:line 152
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass47_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 252
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass58_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 390
   at Robust.Shared.GameObjects.EntityEventBus.DispatchComponent[TEvent](EntityUid euid, IComponent component, CompIdx baseType, Unit& args, Boolean dispatchByReference) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 592
   at Robust.Shared.GameObjects.EntityEventBus.Robust.Shared.GameObjects.IDirectedEventBus.RaiseComponentEvent[TEvent](IComponent component, TEvent args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 132
   at Robust.Shared.GameObjects.Component.LifeShutdown(IEntityManager entManager) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/Component.cs:line 124
   at Robust.Shared.GameObjects.EntityManager.RecursiveDeleteEntity(MetaDataComponent metadata, EntityQuery`1 metaQuery, EntityQuery`1 xformQuery, SharedTransformSystem xformSys) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 370
   at Robust.Shared.GameObjects.EntityManager.RecursiveDeleteEntity(MetaDataComponent metadata, EntityQuery`1 metaQuery, EntityQuery`1 xformQuery, SharedTransformSystem xformSys) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 352
   at Robust.Shared.GameObjects.EntityManager.DeleteEntity(EntityUid e) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 324
   at Content.Server.Cargo.Systems.CargoSystem.SellPallets(CargoShuttleComponent component, StationBankAccountComponent bank) in /home/runner/work/space-station-14/space-station-14/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs:line 342
   at Content.Server.Cargo.Systems.CargoSystem.RecallCargoShuttle(EntityUid uid, CargoShuttleConsoleComponent component, CargoRecallShuttleMessage args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs:line 514
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass47_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 252
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass58_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 390
   at Robust.Server.GameObjects.UserInterfaceSystem.OnMessageReceived(BoundUIWrapMessage msg, EntitySessionEventArgs args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/EntitySystems/UserInterfaceSystem.cs:line 73
   at Robust.Shared.GameObjects.EventBusExt.HandlerWrapper`1.Invoke(EntitySessionMessage`1 msg) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EventBusExt.cs:line 46
   at Robust.Shared.GameObjects.EntityEventBus.ProcessSingleEventCore(EventSource source, Unit& unitRef, EventData subs, Boolean byRef) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 324
   at Robust.Server.GameObjects.ServerEntityManager.<Initialize>b__9_0(Object _, Object systemMsg) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 40
   at Robust.Server.GameObjects.ServerEntityManager.DispatchEntityNetworkMessage(MsgEntity message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 285
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 136
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 673
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 213
   at Robust.Server.BaseServer.MainLoop() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 520
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 75
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 46
   at Robust.Server.Program.Main(String[] args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 25
   ````

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

