### PR TITLE
Keep collidable items from getting stuck at conveyor corners

### DIFF
--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -219,7 +219,10 @@ namespace Content.Server.Physics.Controllers
             }
             else
             {
-                var velocity = r.Normalized * speed;
+                // Give a slight nudge in the direction of the conveyor to prevent
+                // to collidable objects (e.g. crates) on the locker from getting stuck
+                // pushing each other when rounding a corner.
+                var velocity = (r + direction*0.2f).Normalized * speed;
                 return velocity * frameTime;
             }
         }


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This fixes the issue of (exactly) two collidable objects getting stuck at the corner of a conveyor.

**Screenshots**
![2022-09-24_20-40](https://user-images.githubusercontent.com/3229565/192127250-c42cd905-69dd-49c2-8a90-262da01b356e.png)

In this setup, neither crates move because the left crate is trying to move right, but the right crate is trying to move left because it's trying to re-center itself. The red vectors sum to zero.

Fix by changing the right crate's vector to the new green vector by adding a component in the conveyor's direction.

Thanks to @keronshb and @metalgearsloth for reporting the issue.

**Changelog**
N/A