### PR TITLE
Fixes asleep entities not colliding with conveyor belts.

### DIFF
--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -141,7 +141,7 @@ namespace Content.Server.Physics.Controllers
             if (!xformQuery.TryGetComponent(component.Owner, out var xform))
                 return;
 
-            var beltTileRef = xform.Coordinates.GetTileRef();
+            var beltTileRef = xform.Coordinates.GetTileRef(EntityManager, _mapManager);
 
             if (beltTileRef != null)
             {

--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -31,6 +31,7 @@ namespace Content.Server.Physics.Controllers
         [Dependency] private readonly GravitySystem _gravity = default!;
         [Dependency] private readonly RecyclerSystem _recycler = default!;
         [Dependency] private readonly SignalLinkerSystem _signalSystem = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
         public const string ConveyorFixture = "conveyor";
 
@@ -152,7 +153,7 @@ namespace Content.Server.Physics.Controllers
                     if (!bodyQuery.TryGetComponent(entity, out var physics))
                         continue;
 
-                    physics.Awake = true;
+                    _physics.WakeBody(physics);
                 }
             }
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Please merge #11508 first as that fixes a different issue (collidable items getting stuck on belts)

This PR fixes an issue where if a belt is turned off and on again, any non-collidable and/or non-hard entities will stop moving on belts. That's because they go to sleep and can't collide with the belt when it's turned back on.

I also did some slight cleanup with single-line if statements.

closes #11511
closes #10688

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixes an issue where items would stop moving on conveyor belts.