### PR TITLE
Recycler Now Accepts All Trash

### DIFF
--- a/Content.Server/Recycling/RecyclerSystem.cs
+++ b/Content.Server/Recycling/RecyclerSystem.cs
@@ -92,8 +92,8 @@ namespace Content.Server.Recycling
         {
             RecyclableComponent? recyclable = null;
 
-            // Can only recycle things that are recyclable... And also check the safety of the thing to recycle.
-            if (!_tags.HasTag(entity, "Recyclable") &&
+            // Can only recycle things that are trash or recyclable... And also check the safety of the thing to recycle.
+            if (!_tags.HasTag(entity, "Trash") &&
                 (!TryComp(entity, out recyclable) || !recyclable.Safe && component.Safe))
             {
                 return;

--- a/Content.Server/Recycling/RecyclerSystem.cs
+++ b/Content.Server/Recycling/RecyclerSystem.cs
@@ -92,8 +92,8 @@ namespace Content.Server.Recycling
         {
             RecyclableComponent? recyclable = null;
 
-            // Can only recycle things that are trash or recyclable... And also check the safety of the thing to recycle.
-            if (!_tags.HasTag(entity, "Trash") &&
+            // Can only recycle things that are tagged trash or recyclable... And also check the safety of the thing to recycle.
+            if (!_tags.HasAnyTag(entity, "Trash", "Recyclable") &&
                 (!TryComp(entity, out recyclable) || !recyclable.Safe && component.Safe))
             {
                 return;

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -184,8 +184,7 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 4
     fillBaseName: icon-
-  - type: TrashOnEmpty
-    solution: drink
+  - type: Recyclable
 
 - type: entity
   parent: DrinkBaseCup
@@ -210,8 +209,7 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 4
     fillBaseName: icon-
-  - type: TrashOnEmpty
-    solution: drink
+  - type: Recyclable
 
 - type: entity
   parent: DrinkBaseCup
@@ -231,8 +229,7 @@
     state: icon
   - type: Item
     sprite: Objects/Consumable/Drinks/lean.rsi
-  - type: TrashOnEmpty
-    solution: drink
+  - type: Recyclable
 
 - type: entity
   parent: DrinkBaseCup
@@ -251,5 +248,4 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/water_cup.rsi
     state: icon-1
-  - type: TrashOnEmpty
-    solution: drink
+  - type: Recyclable

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -184,7 +184,8 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 4
     fillBaseName: icon-
-  - type: Recyclable
+  - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkBaseCup
@@ -209,7 +210,8 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 4
     fillBaseName: icon-
-  - type: Recyclable
+  - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkBaseCup
@@ -229,7 +231,8 @@
     state: icon
   - type: Item
     sprite: Objects/Consumable/Drinks/lean.rsi
-  - type: Recyclable
+  - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkBaseCup
@@ -248,4 +251,5 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/water_cup.rsi
     state: icon-1
-  - type: Recyclable
+  - type: TrashOnEmpty
+    solution: drink


### PR DESCRIPTION
## About the PR 
Makes objects tagged "Trash" by the "TrashOnEmpty" component be recycled by the Recycler.
In practice, this means that every object that a Trash Bag can contain is recyclable.

Has been tested, but might cause issues with objects that have the "Recyclable" tag (not component, tag) and NOT the "Trash" tag.

**Changelog**
:cl: civilCornball
- fix: Fixes the recycler not recycling some trash.

