### PR TITLE
Permit ReagentEffect PopupMessage to access the solutionEntity it occurs in.

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/PopupMessage.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PopupMessage.cs
@@ -22,10 +22,14 @@ namespace Content.Server.Chemistry.ReagentEffects
             var random = IoCManager.Resolve<IRobustRandom>();
 
             var msg = random.Pick(Messages);
+            var msgArgs = new (string, object)[] {
+                ("entity", args.SolutionEntity),
+                ("organ", args.OrganEntity.GetValueOrDefault()),
+            };
             if (Type == PopupRecipients.Local)
-                popupSys.PopupEntity(Loc.GetString(msg), args.SolutionEntity, Filter.Entities(args.SolutionEntity), VisualType);
+                popupSys.PopupEntity(Loc.GetString(msg, msgArgs), args.SolutionEntity, Filter.Entities(args.SolutionEntity), VisualType);
             else if (Type == PopupRecipients.Pvs)
-                popupSys.PopupEntity(Loc.GetString(msg), args.SolutionEntity, Filter.Pvs(args.SolutionEntity), VisualType);
+                popupSys.PopupEntity(Loc.GetString(msg, msgArgs), args.SolutionEntity, Filter.Pvs(args.SolutionEntity), VisualType);
         }
     }
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This patch allows the PopupMessage ReagentEffect to make use of the SolutionEntity (and possibly the OrganEntity) where it happens in, allowing for messages like `{ $entity } sweats.` when a reagent is present within a person.

With this, you could have:

```
      - !type:PopupMessage
        type: Pvs
        visualType: Small
        messages: [ "sweat" ]
```

```
sweat = {CAPITALIZE($entity)} sweats!
```

And this will work. It'll be like DiseasePopUp, except for reagents.
