### PR TITLE
fix some machines being unable to be deconstructed.

### DIFF
--- a/Content.Server/Construction/Conditions/WirePanel.cs
+++ b/Content.Server/Construction/Conditions/WirePanel.cs
@@ -13,8 +13,9 @@ namespace Content.Server.Construction.Conditions
 
         public bool Condition(EntityUid uid, IEntityManager entityManager)
         {
+            //if it doesn't have a wire panel, then just let it work.
             if (!entityManager.TryGetComponent(uid, out WiresComponent? wires))
-                return false;
+                return true;
 
             return wires.IsPanelOpen == Open;
         }

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
@@ -101,7 +101,7 @@
             - !type:WirePanel
           steps:
             - tool: Prying
-              doAfter: 0.25
+              doAfter: 2
 
     - node: destroyedMachineFrame
       entity: MachineFrameDestroyed


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
basically, all machines about wire panels couldn't be deconstructed, which is really lame and stupid. This just fixes it super quickly (and rebalances a value so you can't deconstruct something in 0.25 seconds)
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed some machines being unable to be deconstructed.
