### PR TITLE
Biomass Reclaimer cleanup

### DIFF
--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
@@ -28,14 +28,14 @@ namespace Content.Server.Medical.BiomassReclaimer
         /// When it hits 0, spit out biomass.
         /// </summary>
         [ViewVariables]
-        public float ProcessingTimer = default!;
+        public float ProcessingTimer = default;
 
         /// <summary>
         /// Amount of biomass that the mob being processed will yield.
         /// This is calculated from the YieldPerUnitMass.
         /// </summary>
         [ViewVariables]
-        public uint CurrentExpectedYield = default!;
+        public uint CurrentExpectedYield = default;
 
         /// <summary>
         /// The reagent that will be spilled while processing a mob.
@@ -52,7 +52,7 @@ namespace Content.Server.Medical.BiomassReclaimer
         /// How many units of biomass it produces for each unit of mass.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float YieldPerUnitMass = default!;
+        public float YieldPerUnitMass = default;
 
         /// <summary>
         /// The base yield per mass unit when no components are upgraded.
@@ -77,7 +77,7 @@ namespace Content.Server.Medical.BiomassReclaimer
         /// The time it takes to process a mob, per mass.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float ProcessingTimePerUnitMass = default!;
+        public float ProcessingTimePerUnitMass = default;
 
         /// <summary>
         /// The base time per mass unit that it takes to process a mob

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
@@ -10,39 +10,54 @@ namespace Content.Server.Medical.BiomassReclaimer
     {
         public CancellationTokenSource? CancelToken;
 
-        [DataField("accumulator")]
-        public float Accumulator = 0f;
+        /// <summary>
+        /// This gets set for each mob it processes.
+        /// When it hits 0, there is a chance for the reclaimer to either spill blood or throw an item.
+        /// </summary>
+        [ViewVariables]
+        public float RandomMessTimer = 0f;
 
-        [DataField("randomMessAccumulator")]
-        public float RandomMessAccumulator = 0f;
+        /// <summary>
+        /// The interval for <see cref="RandomMessTimer"/>.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite), DataField("randomMessInterval")]
         public TimeSpan RandomMessInterval = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// This gets set for each mob it processes.
-        /// When accumulator hits this, spit out biomass.
+        /// When it hits 0, spit out biomass.
         /// </summary>
-        public float CurrentProcessingTime = 70f;
+        [ViewVariables]
+        public float ProcessingTimer = default!;
 
         /// <summary>
-        /// This is calculated from the YieldPerUnitMass
-        /// and adjusted for genetic damage too.
+        /// Amount of biomass that the mob being processed will yield.
+        /// This is calculated from the YieldPerUnitMass.
         /// </summary>
-        public float CurrentExpectedYield = 28f;
+        [ViewVariables]
+        public uint CurrentExpectedYield = default!;
 
-        public string BloodReagent = "Blood";
+        /// <summary>
+        /// The reagent that will be spilled while processing a mob.
+        /// </summary>
+        [ViewVariables]
+        public string? BloodReagent;
 
+        /// <summary>
+        /// Entities that can be randomly spawned while processing a mob.
+        /// </summary>
         public List<EntitySpawnEntry> SpawnedEntities = new();
 
         /// <summary>
         /// How many units of biomass it produces for each unit of mass.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float YieldPerUnitMass = 0.4f;
+        public float YieldPerUnitMass = default!;
 
         /// <summary>
-        /// The base yield when no components are upgraded
+        /// The base yield per mass unit when no components are upgraded.
         /// </summary>
-        [DataField("baseYieldPerUnitMass")]
+        [ViewVariables, DataField("baseYieldPerUnitMass")]
         public float BaseYieldPerUnitMass = 0.4f;
 
         /// <summary>
@@ -52,18 +67,24 @@ namespace Content.Server.Medical.BiomassReclaimer
         public string MachinePartYieldAmount = "Manipulator";
 
         /// <summary>
-        /// Lower number = faster processing.
-        /// Good for machine upgrading I guess.
+        /// How much the machine part quality affects the yield.
+        /// Going up a tier will multiply the yield by this amount.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float ProcessingSpeedMultiplier = 0.4f;
+        [DataField("partRatingYieldAmountMultiplier")]
+        public float PartRatingYieldAmountMultiplier = 1.25f;
 
         /// <summary>
-        /// The base multiplier of processing speed with no upgrades
-        /// that is used with the weight to calculate the yield
+        /// The time it takes to process a mob, per mass.
         /// </summary>
-        [DataField("baseProcessingSpeedMultiplier")]
-        public float BaseProcessingSpeedMultiplier = 0.4f;
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float ProcessingTimePerUnitMass = default!;
+
+        /// <summary>
+        /// The base time per mass unit that it takes to process a mob
+        /// when no components are upgraded.
+        /// </summary>
+        [ViewVariables, DataField("baseProcessingTimePerUnitMass")]
+        public float BaseProcessingTimePerUnitMass = 0.5f;
 
         /// <summary>
         /// The machine part that increses the processing speed.
@@ -72,9 +93,16 @@ namespace Content.Server.Medical.BiomassReclaimer
         public string MachinePartProcessingSpeed = "Laser";
 
         /// <summary>
+        /// How much the machine part quality affects the yield.
+        /// Going up a tier will multiply the speed by this amount.
+        /// </summary>
+        [ViewVariables, DataField("partRatingSpeedMultiplier")]
+        public float PartRatingSpeedMultiplier = 1.35f;
+
+        /// <summary>
         /// Will this refuse to gib a living mob?
         /// </summary>
-        [DataField("safetyEnabled")]
+        [ViewVariables(VVAccess.ReadWrite), DataField("safetyEnabled")]
         public bool SafetyEnabled = true;
     }
 }

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -49,37 +49,34 @@ namespace Content.Server.Medical.BiomassReclaimer
 
             foreach (var (_, reclaimer) in EntityQuery<ActiveBiomassReclaimerComponent, BiomassReclaimerComponent>())
             {
-                reclaimer.Accumulator += frameTime;
-                reclaimer.RandomMessAccumulator += frameTime;
+                reclaimer.ProcessingTimer -= frameTime;
+                reclaimer.RandomMessTimer -= frameTime;
 
-                if (reclaimer.RandomMessAccumulator >= reclaimer.RandomMessInterval.TotalSeconds)
+                if (reclaimer.RandomMessTimer <= 0)
                 {
-                    if (_robustRandom.Prob(0.3f))
+                    if (_robustRandom.Prob(0.2f) && reclaimer.BloodReagent is not null)
                     {
-                        if (_robustRandom.Prob(0.7f))
-                        {
-                            Solution blood = new();
-                            blood.AddReagent(reclaimer.BloodReagent, 50);
-                            _spillableSystem.SpillAt(reclaimer.Owner, blood, "PuddleBlood");
-                        }
-                        if (_robustRandom.Prob(0.1f) && reclaimer.SpawnedEntities.Count > 0)
-                        {
-                            var thrown = Spawn(_robustRandom.Pick(reclaimer.SpawnedEntities).PrototypeId, Transform(reclaimer.Owner).Coordinates);
-                            Vector2 direction = (_robustRandom.Next(-30, 30), _robustRandom.Next(-30, 30));
-                            _throwing.TryThrow(thrown, direction, _robustRandom.Next(1, 10));
-                        }
+                        Solution blood = new();
+                        blood.AddReagent(reclaimer.BloodReagent, 50);
+                        _spillableSystem.SpillAt(reclaimer.Owner, blood, "PuddleBlood");
                     }
-                    reclaimer.RandomMessAccumulator -= (float) reclaimer.RandomMessInterval.TotalSeconds;
+                    if (_robustRandom.Prob(0.03f) && reclaimer.SpawnedEntities.Count > 0)
+                    {
+                        var thrown = Spawn(_robustRandom.Pick(reclaimer.SpawnedEntities).PrototypeId, Transform(reclaimer.Owner).Coordinates);
+                        Vector2 direction = (_robustRandom.Next(-30, 30), _robustRandom.Next(-30, 30));
+                        _throwing.TryThrow(thrown, direction, _robustRandom.Next(1, 10));
+                    }
+                    reclaimer.RandomMessTimer += (float) reclaimer.RandomMessInterval.TotalSeconds;
                 }
 
-                if (reclaimer.Accumulator < reclaimer.CurrentProcessingTime)
+                if (reclaimer.ProcessingTimer > 0)
                 {
                     continue;
                 }
-                reclaimer.Accumulator = 0;
 
                 _stackSystem.SpawnMultiple((int) reclaimer.CurrentExpectedYield, 100, "Biomass", Transform(reclaimer.Owner).Coordinates);
 
+                reclaimer.BloodReagent = null;
                 reclaimer.SpawnedEntities.Clear();
                 RemCompDeferred<ActiveBiomassReclaimerComponent>(reclaimer.Owner);
             }
@@ -155,12 +152,13 @@ namespace Content.Server.Medical.BiomassReclaimer
             var laserRating = args.PartRatings[component.MachinePartProcessingSpeed];
             var manipRating = args.PartRatings[component.MachinePartYieldAmount];
 
-            //sloping down from 1/2 multiplier
-            component.ProcessingSpeedMultiplier =
-                component.BaseProcessingSpeedMultiplier * MathF.Pow(0.65f, laserRating - 1) + 0.1f;
+            // Processing time slopes downwards with part rating.
+            component.ProcessingTimePerUnitMass =
+                component.BaseProcessingTimePerUnitMass / MathF.Pow(component.PartRatingSpeedMultiplier, laserRating - 1);
 
-            //linear increase by .1 per rating
-            component.YieldPerUnitMass = component.BaseYieldPerUnitMass + (manipRating - 1) * 0.1f;
+            // Yield slopes upwards with part rating.
+            component.YieldPerUnitMass =
+                component.BaseYieldPerUnitMass * MathF.Pow(component.PartRatingYieldAmountMultiplier, manipRating - 1);
         }
 
         private void OnReclaimSuccessful(ReclaimSuccessfulEvent args)
@@ -181,6 +179,12 @@ namespace Content.Server.Medical.BiomassReclaimer
         }
         private void StartProcessing(EntityUid toProcess, BiomassReclaimerComponent component)
         {
+            if (!TryComp<PhysicsComponent>(toProcess, out var physics))
+            {
+                Logger.Error("Somehow tried to extract biomass from {0}, which has no physics component.", toProcess);
+                return;
+            }
+
             AddComp<ActiveBiomassReclaimerComponent>(component.Owner);
 
             if (TryComp<BloodstreamComponent>(toProcess, out var stream))
@@ -192,19 +196,9 @@ namespace Content.Server.Medical.BiomassReclaimer
                 component.SpawnedEntities = butcherableComponent.SpawnedEntities;
             }
 
-            component.CurrentExpectedYield = CalculateYield(toProcess, component);
-            component.CurrentProcessingTime = component.CurrentExpectedYield / component.YieldPerUnitMass * component.ProcessingSpeedMultiplier;
+            component.CurrentExpectedYield = (uint) Math.Max(0, physics.FixturesMass * component.YieldPerUnitMass);
+            component.ProcessingTimer = physics.FixturesMass * component.ProcessingTimePerUnitMass;
             EntityManager.QueueDeleteEntity(toProcess);
-        }
-        private float CalculateYield(EntityUid uid, BiomassReclaimerComponent component)
-        {
-            if (!TryComp<PhysicsComponent>(uid, out var physics))
-            {
-                Logger.Error("Somehow tried to extract biomass from " + uid +  ", which has no physics component.");
-                return 0f;
-            }
-
-            return (physics.FixturesMass * component.YieldPerUnitMass);
         }
 
         private bool CanGib(EntityUid uid, EntityUid dragged, BiomassReclaimerComponent component)

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -179,11 +179,9 @@ namespace Content.Server.Medical.BiomassReclaimer
         }
         private void StartProcessing(EntityUid toProcess, BiomassReclaimerComponent component)
         {
-            if (!TryComp<PhysicsComponent>(toProcess, out var physics))
-            {
-                Logger.Error("Somehow tried to extract biomass from {0}, which has no physics component.", toProcess);
+            PhysicsComponent? physics = null;
+            if (!Resolve(toProcess, ref physics))
                 return;
-            }
 
             AddComp<ActiveBiomassReclaimerComponent>(component.Owner);
 

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -177,9 +177,9 @@ namespace Content.Server.Medical.BiomassReclaimer
                 return;
             reclaimer.CancelToken = null;
         }
-        private void StartProcessing(EntityUid toProcess, BiomassReclaimerComponent component)
+
+        private void StartProcessing(EntityUid toProcess, BiomassReclaimerComponent component, PhysicsComponent? physics = null)
         {
-            PhysicsComponent? physics = null;
             if (!Resolve(toProcess, ref physics))
                 return;
 

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -196,7 +196,7 @@ namespace Content.Server.Medical.BiomassReclaimer
 
             component.CurrentExpectedYield = (uint) Math.Max(0, physics.FixturesMass * component.YieldPerUnitMass);
             component.ProcessingTimer = physics.FixturesMass * component.ProcessingTimePerUnitMass;
-            EntityManager.QueueDeleteEntity(toProcess);
+            QueueDel(toProcess);
         }
 
         private bool CanGib(EntityUid uid, EntityUid dragged, BiomassReclaimerComponent component)


### PR DESCRIPTION
#11545 got merged while I was reviewing it. This PR addresses my review comments, plus some other minor changes.

- Document all the properties.
- Data fields for how much the part ratings affect speed/yield, instead of hardcoded values.
- The timers now count down instead of up (gets rid of `Accumulator` field).
- Make `BloodReagent` nullable.
- Make `CurrentExpectedYield` uint instead of float.
- More `ViewVariables` attributes and made some existing ones RW.
- Decouple speed and yield so they no longer affect the other, instead both are based on mass.
- Change formula for yield to be the same as for speed: multiplier^(partRating-1)