### PR TITLE
Allow aghost to accept order from cargo request console

### DIFF
--- a/Content.Shared/Cargo/CargoOrderData.cs
+++ b/Content.Shared/Cargo/CargoOrderData.cs
@@ -36,11 +36,7 @@ namespace Content.Shared.Cargo
             {
                 sb.Append($"({idCard.JobTitle})");
             }
-
-            if (sb.Length > 0)
-            {
-                Approver = sb.ToString();
-            }
+            Approver = sb.ToString();
         }
     }
 }


### PR DESCRIPTION
fixes #11130
Orders wasn't approved because Approver was still null since aghost don't have idcard.