### PR TITLE
SmartFridge now contains chemistry equipment

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/smartfridge.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/smartfridge.yml
@@ -1,2 +1,6 @@
 - type: vendingMachineInventory
   id: SmartFridgeInventory
+  startingInventory:
+    BoxBottle: 3
+    BoxPillCanister: 3
+    BoxBeaker: 3


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Added 3 boxes of bottles, 3 boxes of pill canisters, and 3 boxes of beakers to the Smart Fridge. Eventually I want chemists to be able to dump bottles and pills into the fridge so doctors can come over and dispense them, but I think this is a good change to make it useful for now.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: SmartFridge now contains chemistry equipment.

