### PR TITLE
Allow gas analyzers to continue operation after the user moves without a target.

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -81,7 +81,10 @@ namespace Content.Server.Atmos.EntitySystems
         {
             component.Target = target;
             component.User = user;
-            component.LastPosition = Transform(target ?? user).Coordinates;
+            if (target != null)
+                component.LastPosition = Transform(target.Value).Coordinates;
+            else
+                component.LastPosition = null;
             component.Enabled = true;
             Dirty(component);
             UpdateAppearance(component);


### PR DESCRIPTION
## About the PR

Monitoring the environment's gas is tedious if you're moving, because you have to re-activate the analyzer and move the window any time you get too far from the original position you stood upon when you activated it.

With this change, the analyzer will only store `LastPosition` if you had an actual target.

This should make an Atmospheric Technician's job easier as far as keeping an analyzer open and patrolling the station for gas leaks goes.

It seems like this was the intended functionality to begin with, since `LastPosition` is checked if it has a value in `UpdateAnalyzer`, but that condition should always be true, since it was setting either the target or the user's co-ordinates any time the analyzer was activated.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Gas analyzers no longer close when you move, if you're only monitoring the environment.

