### PR TITLE
scale reagent damage when under metabolism rate

### DIFF
--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -172,7 +172,7 @@ namespace Content.Server.Body.Systems
 
                     var actualEntity = bodyEntityUid != null ? bodyEntityUid.Value : solutionEntityUid.Value;
                     var args = new ReagentEffectArgs(actualEntity, (meta).Owner, solution, proto, mostToRemove,
-                        EntityManager, null);
+                        EntityManager, null, entry);
 
                     // do all effects, if conditions apply
                     foreach (var effect in entry.Effects)

--- a/Content.Server/Chemistry/ReagentEffects/HealthChange.cs
+++ b/Content.Server/Chemistry/ReagentEffects/HealthChange.cs
@@ -34,6 +34,8 @@ namespace Content.Server.Chemistry.ReagentEffects
         public override void Effect(ReagentEffectArgs args)
         {
             var scale = ScaleByQuantity ? args.Quantity : FixedPoint2.New(1);
+            if (args.MetabolismEffects != null)
+                scale *= (args.Quantity / args.MetabolismEffects.MetabolismRate);
             EntitySystem.Get<DamageableSystem>().TryChangeDamage(args.SolutionEntity, Damage * scale, IgnoreResistances);
         }
     }

--- a/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
@@ -192,7 +192,7 @@ namespace Content.Shared.Chemistry.Reaction
         {
             var args = new ReagentEffectArgs(owner, null, solution,
                 randomReagent,
-                unitReactions, EntityManager, null);
+                unitReactions, EntityManager, null, null);
 
             foreach (var effect in reaction.Effects)
             {

--- a/Content.Shared/Chemistry/ReactiveSystem.cs
+++ b/Content.Shared/Chemistry/ReactiveSystem.cs
@@ -39,7 +39,7 @@ namespace Content.Shared.Chemistry
 
             // If we have a source solution, use the reagent quantity we have left. Otherwise, use the reaction volume specified.
             var args = new ReagentEffectArgs(uid, null, source, reagent,
-                source?.GetReagentQuantity(reagent.ID) ?? reactVolume, EntityManager, method);
+                source?.GetReagentQuantity(reagent.ID) ?? reactVolume, EntityManager, method, null);
 
             // First, check if the reagent wants to apply any effects.
             if (reagent.ReactiveEffects != null && reactive.ReactiveGroups != null)

--- a/Content.Shared/Chemistry/Reagent/ReagentEffect.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentEffect.cs
@@ -82,6 +82,7 @@ namespace Content.Shared.Chemistry.Reagent
         ReagentPrototype Reagent,
         FixedPoint2 Quantity,
         IEntityManager EntityManager,
-        ReactionMethod? Method
+        ReactionMethod? Method,
+        ReagentEffectsEntry? MetabolismEffects
     );
 }

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -130,7 +130,7 @@ namespace Content.Shared.Chemistry.Reagent
 
             var entMan = IoCManager.Resolve<IEntityManager>();
             var random = IoCManager.Resolve<IRobustRandom>();
-            var args = new ReagentEffectArgs(plantHolder.Value, null, solution, this, amount.Quantity, entMan, null);
+            var args = new ReagentEffectArgs(plantHolder.Value, null, solution, this, amount.Quantity, entMan, null, null);
             foreach (var plantMetabolizable in PlantMetabolisms)
             {
                 if (!plantMetabolizable.ShouldApply(args, random))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I don't know about you guys, I would like to reintroduce cigarettes at some point. This adds a decent way to balance slow drips under 0.5u (or whatever other metabolism rate). I started with just health change because that's the main problematic one. It can easily be expanded to any other problematic reagent effect.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: Healing ticks when you metabolize less reagent than each tick takes away are now scaled accordingly. In other words, 0.1u of omnizine is no longer identical to 0.5u of omnizine, and will heal 5 times less.