### PR TITLE
Layer bucked sprites based on direction

### DIFF
--- a/Content.Client/Buckle/BuckleComponent.cs
+++ b/Content.Client/Buckle/BuckleComponent.cs
@@ -49,11 +49,20 @@ namespace Content.Client.Buckle
             // TODO when ECSing, make this a visualizer
             if (_buckled &&
                 LastEntityBuckledTo != null &&
-                EntMan.GetComponent<TransformComponent>(LastEntityBuckledTo.Value).LocalRotation.GetCardinalDir() == Direction.North &&
                 EntMan.TryGetComponent<SpriteComponent>(LastEntityBuckledTo, out var buckledSprite))
             {
                 _originalDrawDepth ??= ownerSprite.DrawDepth;
-                ownerSprite.DrawDepth = buckledSprite.DrawDepth - 1;
+
+                // Properly render sprite layering depending on direction
+                if (EntMan.GetComponent<TransformComponent>(LastEntityBuckledTo.Value).LocalRotation.GetCardinalDir() ==
+                    Direction.North)
+                {
+                    ownerSprite.DrawDepth = buckledSprite.DrawDepth - 1;
+                }
+                else
+                {
+                    ownerSprite.DrawDepth = buckledSprite.DrawDepth + 1;
+                }
                 return;
             }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is to fix layering issues when someone rotates from north to another direction when bucked to stuff.

Fixes #10326
Fixes #11478 

**Video**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
https://user-images.githubusercontent.com/37940282/193037508-c8d68af1-bbe9-4390-97a5-41425a1a9d0d.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: DeathCamel57
- fix: Fixed chair layering

