### PR TITLE
Cap passive research points so people spend points more

### DIFF
--- a/Content.Server/Research/Components/ResearchServerComponent.cs
+++ b/Content.Server/Research/Components/ResearchServerComponent.cs
@@ -11,8 +11,13 @@ namespace Content.Server.Research.Components
         [ViewVariables(VVAccess.ReadWrite)] [DataField("points")]
         public int Points = 0;
 
+        /// <summary>
+        /// To encourage people to spend points,
+        /// will not accept passive points gain above this number for each source.
+        /// </summary
+        [DataField("passiveLimitPerSource")]
+        public int PassiveLimitPerSource = 30000;
         [ViewVariables(VVAccess.ReadOnly)] public int Id { get; set; }
-
         [ViewVariables(VVAccess.ReadOnly)]
         public List<ResearchPointSourceComponent> PointSources { get; } = new();
 

--- a/Content.Server/Research/Components/ResearchServerComponent.cs
+++ b/Content.Server/Research/Components/ResearchServerComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Research.Components
         /// <summary>
         /// To encourage people to spend points,
         /// will not accept passive points gain above this number for each source.
-        /// </summary
+        /// </summary>
         [DataField("passiveLimitPerSource")]
         public int PassiveLimitPerSource = 30000;
         [ViewVariables(VVAccess.ReadOnly)] public int Id { get; set; }

--- a/Content.Server/Research/Components/ResearchServerComponent.cs
+++ b/Content.Server/Research/Components/ResearchServerComponent.cs
@@ -18,6 +18,7 @@ namespace Content.Server.Research.Components
         [DataField("passiveLimitPerSource")]
         public int PassiveLimitPerSource = 30000;
         [ViewVariables(VVAccess.ReadOnly)] public int Id { get; set; }
+
         [ViewVariables(VVAccess.ReadOnly)]
         public List<ResearchPointSourceComponent> PointSources { get; } = new();
 

--- a/Content.Server/Research/Systems/ResearchSystem.Server.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Server.cs
@@ -96,7 +96,8 @@ public sealed partial class ResearchSystem
     {
         var points = 0;
 
-        if (CanRun(component))
+        // Is our machine powered, and are we below our limit of passive point gain?
+        if (CanRun(component) && component.Points < (component.PassiveLimitPerSource * component.PointSources.Count))
         {
             foreach (var source in component.PointSources)
             {

--- a/Content.Server/Research/Systems/ResearchSystem.Server.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Server.cs
@@ -1,4 +1,5 @@
 using Content.Server.Power.EntitySystems;
+using Content.Server.Station.Systems;
 using Content.Server.Research.Components;
 using Content.Shared.Research.Prototypes;
 
@@ -6,6 +7,7 @@ namespace Content.Server.Research;
 
 public sealed partial class ResearchSystem
 {
+    [Dependency] private readonly StationSystem _stationSystem = default!;
     private void InitializeServer()
     {
         SubscribeLocalEvent<ResearchServerComponent, ComponentStartup>(OnServerStartup);
@@ -35,6 +37,10 @@ public sealed partial class ResearchSystem
 
     public bool RegisterServerClient(ResearchServerComponent component, ResearchClientComponent clientComponent)
     {
+        // Has to be on the same station
+        if (_stationSystem.GetOwningStation(component.Owner) != _stationSystem.GetOwningStation(clientComponent.Owner))
+            return false;
+
         // TODO: This is shit but I'm just trying to fix RND for now until it gets bulldozed
         if (TryComp<ResearchPointSourceComponent>(clientComponent.Owner, out var source))
         {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is not really a 'nerf', but it encourages people to check what techs are available rather than going AFK and unlocking them all at once. Should be a very small change with decent impacts on how invested people are in science. It's based on the count of point sources because my research design lets people build more, although it's less relevant here.

You can bikeshed the 30,000 a bit, the intent is just to avoid people going afk for 45 minutes and coming back to 2 million points

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Passive research points will not generate above 30,000 stored points. Rate or total available research is not affected. All this means is you have to actively spend them, rather than let them accumulate the whole round and unlock all techs at once.

