### PR TITLE
Lock all command roles to 30 hours total of playtime

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -9,6 +9,8 @@
     - !type:DepartmentTimeRequirement
       department: Cargo
       time: 18000
+    - !type:OverallPlaytimeRequirement
+      time: 108000
   weight: 10
   startingGear: QuartermasterGear
   icon: "QuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -13,7 +13,7 @@
       department: Security
       time: 3600
     - !type:OverallPlaytimeRequirement
-      time: 54000
+      time: 108000
   weight: 20
   startingGear: HoPGear
   icon: "HeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -9,6 +9,8 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 18000
+    - !type:OverallPlaytimeRequirement
+      time: 108000
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "ChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -8,6 +8,8 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 18000
+    - !type:OverallPlaytimeRequirement
+      time: 108000
   weight: 10
   startingGear: CMOGear
   icon: "ChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -6,6 +6,8 @@
     - !type:DepartmentTimeRequirement
       department: Science
       time: 18000
+    - !type:OverallPlaytimeRequirement
+      time: 108000
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "ResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -9,6 +9,8 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 18000
+    - !type:OverallPlaytimeRequirement
+      time: 108000
   weight: 10
   startingGear: HoSGear
   icon: "HeadOfSecurity"


### PR DESCRIPTION
locks every command role to 30 hours of playtime as well as their miniscule departmental requirements. morale and round quality will improve after this merge.

:cl: Emisse
- add: All command roles now take 30 hours of total playtime on top of other requirements.

