### PR TITLE
Add delay to dumping mop bucket

### DIFF
--- a/Content.Server/Fluids/Components/SpillableComponent.cs
+++ b/Content.Server/Fluids/Components/SpillableComponent.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Content.Server.Fluids.Components;
 
 [RegisterComponent]
@@ -12,4 +14,9 @@ public sealed class SpillableComponent : Component
     /// </summary>
     [DataField("spillWorn")]
     public bool SpillWorn = true;
+
+    [DataField("delay")]
+    public float? Delay;
+
+    public CancellationTokenSource? CancelToken;
 }

--- a/Content.Server/Fluids/Components/SpillableComponent.cs
+++ b/Content.Server/Fluids/Components/SpillableComponent.cs
@@ -15,8 +15,8 @@ public sealed class SpillableComponent : Component
     [DataField("spillWorn")]
     public bool SpillWorn = true;
 
-    [DataField("delay")]
-    public float? Delay;
+    [DataField("spillDelay")]
+    public float? SpillDelay;
 
     public CancellationTokenSource? CancelToken;
 }

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -152,6 +152,7 @@ public sealed class SpillableSystem : EntitySystem
                         BreakOnUserMove = true,
                         BreakOnDamage = true,
                         BreakOnStun = true,
+                        NeedHand = true,
                         TargetFinishedEvent = new SpillFinishedEvent(args.User, component.Owner, solution),
                         TargetCancelledEvent = new SpillCancelledEvent(component.Owner)
                     });

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using Content.Server.Administration.Logs;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Clothing.Components;
+using Content.Server.DoAfter;
 using Content.Server.Fluids.Components;
 using Content.Server.Nutrition.Components;
 using Content.Server.Nutrition.EntitySystems;
@@ -28,6 +30,7 @@ public sealed class SpillableSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger= default!;
+    [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
 
     public override void Initialize()
     {
@@ -36,6 +39,8 @@ public sealed class SpillableSystem : EntitySystem
         SubscribeLocalEvent<SpillableComponent, GetVerbsEvent<Verb>>(AddSpillVerb);
         SubscribeLocalEvent<SpillableComponent, GotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<SpillableComponent, SolutionSpikeOverflowEvent>(OnSpikeOverflow);
+        SubscribeLocalEvent<SpillableComponent, SpillFinishedEvent>(OnSpillFinished);
+        SubscribeLocalEvent<SpillableComponent, SpillCancelledEvent>(OnSpillCancelled);
     }
 
     private void OnSpikeOverflow(EntityUid uid, SpillableComponent component, SolutionSpikeOverflowEvent args)
@@ -125,12 +130,34 @@ public sealed class SpillableSystem : EntitySystem
         Verb verb = new();
         verb.Text = Loc.GetString("spill-target-verb-get-data-text");
         // TODO VERB ICONS spill icon? pouring out a glass/beaker?
-        verb.Act = () =>
+        if (component.Delay == null)
         {
-            var puddleSolution = _solutionContainerSystem.SplitSolution(args.Target,
-                solution, solution.DrainAvailable);
-            SpillAt(puddleSolution, Transform(args.Target).Coordinates, "PuddleSmear");
-        };
+            verb.Act = () =>
+            {
+                var puddleSolution = _solutionContainerSystem.SplitSolution(args.Target,
+                    solution, solution.DrainAvailable);
+                SpillAt(puddleSolution, Transform(args.Target).Coordinates, "PuddleSmear");
+            };
+        }
+        else
+        {
+            verb.Act = () =>
+            {
+                if (component.CancelToken == null)
+                {
+                    component.CancelToken = new CancellationTokenSource();
+                    _doAfterSystem.DoAfter(new DoAfterEventArgs(args.User, component.Delay.Value, component.CancelToken.Token, component.Owner)
+                    {
+                        BreakOnTargetMove = true,
+                        BreakOnUserMove = true,
+                        BreakOnDamage = true,
+                        BreakOnStun = true,
+                        TargetFinishedEvent = new SpillFinishedEvent(args.User, component.Owner, solution),
+                        TargetCancelledEvent = new SpillCancelledEvent(component.Owner)
+                    });
+                }
+            };
+        }
         verb.Impact = LogImpact.Medium; // dangerous reagent reaction are logged separately.
         args.Verbs.Add(verb);
     }
@@ -233,5 +260,48 @@ public sealed class SpillableSystem : EntitySystem
         _puddleSystem.TryAddSolution(startEntity, solution, sound, overflow);
 
         return puddleComponent;
+    }
+
+    private void OnSpillFinished(EntityUid uid, SpillableComponent component, SpillFinishedEvent ev)
+    {
+        component.CancelToken = null;
+
+        //solution gone by other means before doafter completes
+        if (ev.Solution == null || ev.Solution.CurrentVolume == 0)
+            return;
+
+        var puddleSolution = _solutionContainerSystem.SplitSolution(uid,
+            ev.Solution, ev.Solution.DrainAvailable);
+
+        SpillAt(puddleSolution, Transform(component.Owner).Coordinates, "PuddleSmear");
+    }
+
+    private void OnSpillCancelled(EntityUid uid, SpillableComponent component, SpillCancelledEvent ev)
+    {
+        component.CancelToken = null;
+    }
+
+    internal sealed class SpillFinishedEvent : EntityEventArgs
+    {
+        public SpillFinishedEvent(EntityUid user, EntityUid spillable, Solution solution)
+        {
+            User = user;
+            Spillable = spillable;
+            Solution = solution;
+        }
+
+        public EntityUid User { get; }
+        public EntityUid Spillable { get; }
+        public Solution Solution { get; }
+    }
+
+    private sealed class SpillCancelledEvent : EntityEventArgs
+    {
+        public EntityUid Spillable;
+
+        public SpillCancelledEvent(EntityUid spillable)
+        {
+            Spillable = spillable;
+        }
     }
 }

--- a/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpillableSystem.cs
@@ -130,7 +130,7 @@ public sealed class SpillableSystem : EntitySystem
         Verb verb = new();
         verb.Text = Loc.GetString("spill-target-verb-get-data-text");
         // TODO VERB ICONS spill icon? pouring out a glass/beaker?
-        if (component.Delay == null)
+        if (component.SpillDelay == null)
         {
             verb.Act = () =>
             {
@@ -146,7 +146,7 @@ public sealed class SpillableSystem : EntitySystem
                 if (component.CancelToken == null)
                 {
                     component.CancelToken = new CancellationTokenSource();
-                    _doAfterSystem.DoAfter(new DoAfterEventArgs(args.User, component.Delay.Value, component.CancelToken.Token, component.Owner)
+                    _doAfterSystem.DoAfter(new DoAfterEventArgs(args.User, component.SpillDelay.Value, component.CancelToken.Token, component.Owner)
                     {
                         BreakOnTargetMove = true,
                         BreakOnUserMove = true,

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -46,7 +46,7 @@
         - ReagentId: Water
           Quantity: 250 # half-full at roundstart to leave room for puddles
   - type: Spillable
-    delay: 3.0
+    spillDelay: 3.0
   - type: DrainableSolution
     solution: bucket
   - type: RefillableSolution
@@ -142,7 +142,7 @@
         mask:
         - MobMask
     - type: Spillable
-      delay: 3.0
+      spillDelay: 3.0
     - type: SolutionContainerManager
       solutions:
         bucket:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -46,6 +46,7 @@
         - ReagentId: Water
           Quantity: 250 # half-full at roundstart to leave room for puddles
   - type: Spillable
+    delay: 3.0
   - type: DrainableSolution
     solution: bucket
   - type: RefillableSolution
@@ -141,6 +142,7 @@
         mask:
         - MobMask
     - type: Spillable
+      delay: 3.0
     - type: SolutionContainerManager
       solutions:
         bucket:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a DoAfter to spilling a mop bucket/trolly to avoid misclicks and give janies a moment to react before the clown dumps out the blood they just finished mopping _again_.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Dumping a mop bucket now has a short delay

