### PR TITLE
Small chat sanitization tweak.

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -57,9 +57,13 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { ":/", "chatsan-uncertain" },
         { ":\\", "chatsan-uncertain" },
         { "lmao", "chatsan-laughs" },
+        { "lmao.", "chatsan-laughs" },
         { "lol", "chatsan-laughs" },
+        { "lol.", "chatsan-laughs" },
         { "lel", "chatsan-laughs" },
+        { "lel.", "chatsan-laughs" },
         { "kek", "chatsan-laughs" },
+        { "kek.", "chatsan-laughs" },
         { "o7", "chatsan-salutes" },
         { ";_;7", "chatsan-tearfully-salutes"},
         { "idk", "chatsan-shrugs" }


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that the chat sanitization shortcuts such as "lol" "lmao" etc that convert to @laughs can now work with "lol." or "lmao.".

no cl because stupid small change