### PR TITLE
Surveillance camera listening/speaking

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AtmosAlarmableSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosAlarmableSystem.cs
@@ -243,7 +243,7 @@ public sealed class AtmosAlarmableSystem : EntitySystem
     /// <param name="alarmable"></param>
     public void Reset(EntityUid uid, AtmosAlarmableComponent? alarmable = null, TagComponent? tags = null)
     {
-        if (!Resolve(uid, ref alarmable, ref tags) || alarmable.LastAlarmState == AtmosAlarmType.Normal)
+        if (!Resolve(uid, ref alarmable, ref tags, false) || alarmable.LastAlarmState == AtmosAlarmType.Normal)
         {
             return;
         }
@@ -285,7 +285,7 @@ public sealed class AtmosAlarmableSystem : EntitySystem
     {
         alarm = null;
 
-        if (!Resolve(uid, ref alarmable))
+        if (!Resolve(uid, ref alarmable, false))
         {
             return false;
         }

--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -334,7 +334,7 @@ public sealed class AtmosMonitorSystem : EntitySystem
     {
         if (!monitor.NetEnabled) return;
 
-        if (!Resolve(monitor.Owner, ref tags))
+        if (!Resolve(monitor.Owner, ref tags, false))
         {
             return;
         }

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
@@ -10,6 +10,7 @@ namespace Content.Server.SurveillanceCamera;
 ///     environment. All surveillance camera monitors have speakers for this.
 /// </summary>
 [RegisterComponent]
+[ComponentReference(typeof(IListen))]
 public sealed class SurveillanceCameraMicrophoneComponent : Component, IListen
 {
     public bool Enabled { get; set; } = true;

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
@@ -23,16 +23,23 @@ public sealed class SurveillanceCameraMicrophoneComponent : Component, IListen
     public EntityWhitelist BlacklistedComponents { get; } = new();
 
     // TODO: Once IListen is removed, **REMOVE THIS**
-    public int ListenRange { get; }
+
+    private SurveillanceCameraMicrophoneSystem? _microphoneSystem;
+    protected override void Initialize()
+    {
+        base.Initialize();
+
+        _microphoneSystem = EntitySystem.Get<SurveillanceCameraMicrophoneSystem>();
+    }
+
+    public int ListenRange { get; } = 10;
     public bool CanListen(string message, EntityUid source, RadioChannelPrototype? channelPrototype)
     {
-        return Enabled
-               && !BlacklistedComponents.IsValid(source)
-               && EntitySystem.Get<SharedInteractionSystem>().InRangeUnobstructed(Owner, source, range: ListenRange);
+        return _microphoneSystem?.CanListen(Owner, speaker, this);
     }
 
     public void Listen(string message, EntityUid speaker, RadioChannelPrototype? channel)
     {
-        EntitySystem.Get<SurveillanceCameraMicrophoneSystem>().RelayEntityMessage(Owner, speaker, message);
+        _microphoneSystem?.RelayEntityMessage(Owner, speaker, message);
     }
 }

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
@@ -1,3 +1,6 @@
+using Content.Server.Radio.Components;
+using Content.Shared.Interaction;
+using Content.Shared.Radio;
 using Content.Shared.Whitelist;
 
 namespace Content.Server.SurveillanceCamera;
@@ -7,7 +10,7 @@ namespace Content.Server.SurveillanceCamera;
 ///     environment. All surveillance camera monitors have speakers for this.
 /// </summary>
 [RegisterComponent]
-public sealed class SurveillanceCameraMicrophoneComponent : Component
+public sealed class SurveillanceCameraMicrophoneComponent : Component, IListen
 {
     public bool Enabled { get; set; } = true;
 
@@ -16,5 +19,20 @@ public sealed class SurveillanceCameraMicrophoneComponent : Component
     ///     messages from these entities over the surveillance camera.
     ///     Used to avoid things like feedback loops, or radio spam.
     /// </summary>
+    [DataField("blacklist")]
     public EntityWhitelist BlacklistedComponents { get; } = new();
+
+    // TODO: Once IListen is removed, **REMOVE THIS**
+    public int ListenRange { get; }
+    public bool CanListen(string message, EntityUid source, RadioChannelPrototype? channelPrototype)
+    {
+        return Enabled
+               && !BlacklistedComponents.IsValid(source)
+               && EntitySystem.Get<SharedInteractionSystem>().InRangeUnobstructed(Owner, source, range: ListenRange);
+    }
+
+    public void Listen(string message, EntityUid speaker, RadioChannelPrototype? channel)
+    {
+        EntitySystem.Get<SurveillanceCameraMicrophoneSystem>().RelayEntityMessage(Owner, speaker, message);
+    }
 }

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
@@ -35,7 +35,8 @@ public sealed class SurveillanceCameraMicrophoneComponent : Component, IListen
     public int ListenRange { get; } = 10;
     public bool CanListen(string message, EntityUid source, RadioChannelPrototype? channelPrototype)
     {
-        return _microphoneSystem?.CanListen(Owner, speaker, this);
+        return _microphoneSystem != null
+            && _microphoneSystem.CanListen(Owner, source, this);
     }
 
     public void Listen(string message, EntityUid speaker, RadioChannelPrototype? channel)

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMicrophoneComponent.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Whitelist;
+
+namespace Content.Server.SurveillanceCamera;
+
+/// <summary>
+///     Component that allows surveillance cameras to listen to the local
+///     environment. All surveillance camera monitors have speakers for this.
+/// </summary>
+[RegisterComponent]
+public sealed class SurveillanceCameraMicrophoneComponent : Component
+{
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    ///     Components that the microphone checks for to avoid transmitting
+    ///     messages from these entities over the surveillance camera.
+    ///     Used to avoid things like feedback loops, or radio spam.
+    /// </summary>
+    public EntityWhitelist BlacklistedComponents { get; } = new();
+}

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMonitorComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMonitorComponent.cs
@@ -41,4 +41,10 @@ public sealed class SurveillanceCameraMonitorComponent : Component
     [ViewVariables]
     // The subnets known by this camera monitor.
     public Dictionary<string, string> KnownSubnets { get; } = new();
+
+    // mostly copied from Speech
+    [ViewVariables] public bool SpeechEnabled = false;
+    [ViewVariables] public float SpeechSoundCooldown = 0.5f;
+
+    public TimeSpan LastSoundPlayed = TimeSpan.Zero;
 }

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMonitorComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMonitorComponent.cs
@@ -43,6 +43,7 @@ public sealed class SurveillanceCameraMonitorComponent : Component
     public Dictionary<string, string> KnownSubnets { get; } = new();
 
     // mostly copied from Speech
+    [DataField("speechEnabled")]
     [ViewVariables] public bool SpeechEnabled = false;
     [ViewVariables] public float SpeechSoundCooldown = 0.5f;
 

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMonitorComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraMonitorComponent.cs
@@ -41,11 +41,4 @@ public sealed class SurveillanceCameraMonitorComponent : Component
     [ViewVariables]
     // The subnets known by this camera monitor.
     public Dictionary<string, string> KnownSubnets { get; } = new();
-
-    // mostly copied from Speech
-    [DataField("speechEnabled")]
-    [ViewVariables] public bool SpeechEnabled = false;
-    [ViewVariables] public float SpeechSoundCooldown = 0.5f;
-
-    public TimeSpan LastSoundPlayed = TimeSpan.Zero;
 }

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraSpeakerComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraSpeakerComponent.cs
@@ -1,0 +1,17 @@
+namespace Content.Server.SurveillanceCamera;
+
+/// <summary>
+/// This is used for...
+/// </summary>
+[RegisterComponent]
+public sealed class SurveillanceCameraSpeakerComponent : Component
+{
+    // mostly copied from Speech
+    [DataField("speechEnabled")] public bool SpeechEnabled = false;
+
+    [ViewVariables] public float SpeechSoundCooldown = 0.5f;
+
+    [ViewVariables] public Queue<string> LastSpokenNames = new();
+
+    public TimeSpan LastSoundPlayed = TimeSpan.Zero;
+}

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraSpeakerComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraSpeakerComponent.cs
@@ -1,7 +1,8 @@
 namespace Content.Server.SurveillanceCamera;
 
 /// <summary>
-/// This is used for...
+///     This allows surveillance cameras to speak, if the camera in question
+///     has a microphone that listens to speech.
 /// </summary>
 [RegisterComponent]
 public sealed class SurveillanceCameraSpeakerComponent : Component
@@ -11,7 +12,7 @@ public sealed class SurveillanceCameraSpeakerComponent : Component
 
     [ViewVariables] public float SpeechSoundCooldown = 0.5f;
 
-    [ViewVariables] public Queue<string> LastSpokenNames = new();
+    [ViewVariables] public readonly Queue<string> LastSpokenNames = new();
 
     public TimeSpan LastSoundPlayed = TimeSpan.Zero;
 }

--- a/Content.Server/SurveillanceCamera/Components/SurveillanceCameraSpeakerComponent.cs
+++ b/Content.Server/SurveillanceCamera/Components/SurveillanceCameraSpeakerComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Server.SurveillanceCamera;
 public sealed class SurveillanceCameraSpeakerComponent : Component
 {
     // mostly copied from Speech
-    [DataField("speechEnabled")] public bool SpeechEnabled = false;
+    [DataField("speechEnabled")] public bool SpeechEnabled = true;
 
     [ViewVariables] public float SpeechSoundCooldown = 0.5f;
 

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
@@ -25,8 +25,8 @@ public sealed class SurveillanceCameraMicrophoneSystem : EntitySystem
             return;
         }
 
-        message = Loc.GetString("surveillance-camera-microphone-message", ("speaker", speaker), ("message", message));
-        var ev = new SurveillanceCameraSpeechSendEvent(message);
+        var wrapped = Loc.GetString("surveillance-camera-microphone-message", ("speaker", speaker), ("message", message));
+        var ev = new SurveillanceCameraSpeechSendEvent(speaker, message, wrapped);
 
         foreach (var monitor in camera.ActiveMonitors)
         {
@@ -37,11 +37,15 @@ public sealed class SurveillanceCameraMicrophoneSystem : EntitySystem
 
 public sealed class SurveillanceCameraSpeechSendEvent : EntityEventArgs
 {
-    public string Message { get; }
+    public EntityUid Speaker { get; }
+    public string OriginalMessage { get; }
+    public string WrappedMessage { get; }
 
-    public SurveillanceCameraSpeechSendEvent(string message)
+    public SurveillanceCameraSpeechSendEvent(EntityUid speaker, string originalMessage, string wrappedMessage)
     {
-        Message = message;
+        Speaker = speaker;
+        OriginalMessage = originalMessage;
+        WrappedMessage = wrappedMessage;
     }
 }
 

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
@@ -4,24 +4,14 @@ namespace Content.Server.SurveillanceCamera;
 
 public sealed class SurveillanceCameraMicrophoneSystem : EntitySystem
 {
-    public override void Initialize()
+    public void RelayEntityMessage(EntityUid source, EntityUid speaker, string message, SurveillanceCameraComponent? camera = null)
     {
-
-    }
-
-    private void OnEntitySpeak()
-    {
-        // check if the speaking entity has an offending component,
-        // and if it does, disregard
-    }
-
-    private void RelayEntityMessage(EntityUid source, EntityUid speaker, string message, SurveillanceCameraComponent? camera)
-    {
-        if (!Resolve(speaker, ref camera))
+        if (!Resolve(source, ref camera))
         {
             return;
         }
 
+        message = Loc.GetString("surveillance-camera-microphone-message", ("speaker", speaker), ("message", message));
         var ev = new SurveillanceCameraSpeechSendEvent(message);
 
         foreach (var monitor in camera.ActiveMonitors)

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
@@ -25,8 +25,7 @@ public sealed class SurveillanceCameraMicrophoneSystem : EntitySystem
             return;
         }
 
-        var wrapped = Loc.GetString("surveillance-camera-microphone-message", ("speaker", speaker), ("message", message));
-        var ev = new SurveillanceCameraSpeechSendEvent(speaker, message, wrapped);
+        var ev = new SurveillanceCameraSpeechSendEvent(speaker, message);
 
         foreach (var monitor in camera.ActiveMonitors)
         {
@@ -38,14 +37,12 @@ public sealed class SurveillanceCameraMicrophoneSystem : EntitySystem
 public sealed class SurveillanceCameraSpeechSendEvent : EntityEventArgs
 {
     public EntityUid Speaker { get; }
-    public string OriginalMessage { get; }
-    public string WrappedMessage { get; }
+    public string Message { get; }
 
-    public SurveillanceCameraSpeechSendEvent(EntityUid speaker, string originalMessage, string wrappedMessage)
+    public SurveillanceCameraSpeechSendEvent(EntityUid speaker, string message)
     {
         Speaker = speaker;
-        OriginalMessage = originalMessage;
-        WrappedMessage = wrappedMessage;
+        Message = message;
     }
 }
 

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
@@ -1,9 +1,23 @@
 using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
 
 namespace Content.Server.SurveillanceCamera;
 
 public sealed class SurveillanceCameraMicrophoneSystem : EntitySystem
 {
+    [Dependency] private SharedInteractionSystem _interactionSystem = default!;
+
+    public bool CanListen(EntityUid source, EntityUid speaker, SurveillanceCameraMicrophoneComponent? microphone = null)
+    {
+        if (!Resolve(source, ref microphone))
+        {
+            return false;
+        }
+
+        return microphone.Enabled
+               && !microphone.BlacklistedComponents.IsValid(speaker)
+               && _interactionSystem.InRangeUnobstructed(source, speaker, range: microphone.ListenRange);
+    }
     public void RelayEntityMessage(EntityUid source, EntityUid speaker, string message, SurveillanceCameraComponent? camera = null)
     {
         if (!Resolve(source, ref camera))

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMicrophoneSystem.cs
@@ -1,0 +1,43 @@
+using Content.Shared.IdentityManagement;
+
+namespace Content.Server.SurveillanceCamera;
+
+public sealed class SurveillanceCameraMicrophoneSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+
+    }
+
+    private void OnEntitySpeak()
+    {
+        // check if the speaking entity has an offending component,
+        // and if it does, disregard
+    }
+
+    private void RelayEntityMessage(EntityUid source, EntityUid speaker, string message, SurveillanceCameraComponent? camera)
+    {
+        if (!Resolve(speaker, ref camera))
+        {
+            return;
+        }
+
+        var ev = new SurveillanceCameraSpeechSendEvent(message);
+
+        foreach (var monitor in camera.ActiveMonitors)
+        {
+            RaiseLocalEvent(monitor, ev);
+        }
+    }
+}
+
+public sealed class SurveillanceCameraSpeechSendEvent : EntityEventArgs
+{
+    public string Message { get; }
+
+    public SurveillanceCameraSpeechSendEvent(string message)
+    {
+        Message = message;
+    }
+}
+

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server.Chat.Systems;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Power.Components;
@@ -16,6 +17,7 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
     [Dependency] private readonly SurveillanceCameraSystem _surveillanceCameras = default!;
     [Dependency] private readonly UserInterfaceSystem _userInterface = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetworkSystem = default!;
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
 
     public override void Initialize()
     {
@@ -30,6 +32,7 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
         SubscribeLocalEvent<SurveillanceCameraMonitorComponent, SurveillanceCameraRefreshCamerasMessage>(OnRefreshCamerasMessage);
         SubscribeLocalEvent<SurveillanceCameraMonitorComponent, SurveillanceCameraRefreshSubnetsMessage>(OnRefreshSubnetsMessage);
         SubscribeLocalEvent<SurveillanceCameraMonitorComponent, SurveillanceCameraDisconnectMessage>(OnDisconnectMessage);
+        SubscribeLocalEvent<SurveillanceCameraMonitorComponent, SurveillanceCameraSpeechSendEvent>(OnSpeechSent);
     }
 
     private const float _maxHeartbeatTime = 300f;
@@ -211,6 +214,12 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
         }
 
         RemoveViewer(uid, args.Session.AttachedEntity.Value, component);
+    }
+
+    private void OnSpeechSent(EntityUid uid, SurveillanceCameraMonitorComponent component,
+        SurveillanceCameraSpeechSendEvent args)
+    {
+        _chatSystem.TrySendInGameICMessage(uid, args.Message, InGameICChatType.Speak, false);
     }
     #endregion
 

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -22,7 +22,6 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
     [Dependency] private readonly UserInterfaceSystem _userInterface = default!;
     [Dependency] private readonly DeviceNetworkSystem _deviceNetworkSystem = default!;
 
-
     public override void Initialize()
     {
         SubscribeLocalEvent<SurveillanceCameraMonitorComponent, SurveillanceCameraDeactivateEvent>(OnSurveillanceCameraDeactivate);
@@ -218,8 +217,6 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
 
         RemoveViewer(uid, args.Session.AttachedEntity.Value, component);
     }
-
-
     #endregion
 
     private void SendHeartbeat(EntityUid uid, SurveillanceCameraMonitorComponent? monitor = null)

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.SurveillanceCamera;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
 namespace Content.Server.SurveillanceCamera;
@@ -24,6 +25,7 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()
     {
@@ -241,8 +243,13 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
                 _ => speechProto.SaySound
             };
 
-            _audioSystem.PlayPvs(sound, uid);
+            var scale = (float) _random.NextGaussian(1, speechProto.Variation);
+            var param = speech.AudioParams.WithPitchScale(scale);
+            _audioSystem.PlayPvs(sound, uid, param);
+
+            component.LastSoundPlayed = time;
         }
+
 
         _chatSystem.TrySendInGameICMessage(uid, args.WrappedMessage, InGameICChatType.Speak, false);
     }

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -227,6 +227,11 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
     private void OnSpeechSent(EntityUid uid, SurveillanceCameraMonitorComponent component,
         SurveillanceCameraSpeechSendEvent args)
     {
+        if (!component.SpeechEnabled)
+        {
+            return;
+        }
+
         var time = _gameTiming.CurTime;
         var cd = TimeSpan.FromSeconds(component.SpeechSoundCooldown);
 
@@ -242,6 +247,20 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
                 '!' => speechProto.ExclaimSound,
                 _ => speechProto.SaySound
             };
+
+            var uppercase = 0;
+            for (var i = 0; i < args.OriginalMessage.Length; i++)
+            {
+                if (char.IsUpper(args.OriginalMessage[i]))
+                {
+                    uppercase++;
+                }
+            }
+
+            if (uppercase > args.OriginalMessage.Length / 2)
+            {
+                sound = speechProto.ExclaimSound;
+            }
 
             var scale = (float) _random.NextGaussian(1, speechProto.Variation);
             var param = speech.AudioParams.WithPitchScale(scale);

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -430,8 +430,7 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
 
         if (monitor.ActiveCamera != null)
         {
-            EntityUid? monitorUid = monitor.Viewers.Count == 0 ? uid : null;
-            _surveillanceCameras.RemoveActiveViewer(monitor.ActiveCamera.Value, player, monitorUid);
+            _surveillanceCameras.RemoveActiveViewer(monitor.ActiveCamera.Value, player);
         }
     }
 

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSpeakerSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSpeakerSystem.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Timing;
 namespace Content.Server.SurveillanceCamera;
 
 /// <summary>
-/// This handles speech for surveillance camera monitors.
+///     This handles speech for surveillance camera monitors.
 /// </summary>
 public sealed class SurveillanceCameraSpeakerSystem : EntitySystem
 {

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSpeakerSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSpeakerSystem.cs
@@ -1,0 +1,85 @@
+using Content.Server.Chat.Systems;
+using Content.Shared.Speech;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server.SurveillanceCamera;
+
+/// <summary>
+/// This handles speech for surveillance camera monitors.
+/// </summary>
+public sealed class SurveillanceCameraSpeakerSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<SurveillanceCameraSpeakerComponent, SurveillanceCameraSpeechSendEvent>(OnSpeechSent);
+        SubscribeLocalEvent<SurveillanceCameraSpeakerComponent, TransformSpeakerNameEvent>(OnTransformSpeech);
+    }
+
+    private void OnSpeechSent(EntityUid uid, SurveillanceCameraSpeakerComponent component,
+        SurveillanceCameraSpeechSendEvent args)
+    {
+        if (!component.SpeechEnabled)
+        {
+            return;
+        }
+
+        var time = _gameTiming.CurTime;
+        var cd = TimeSpan.FromSeconds(component.SpeechSoundCooldown);
+
+        // this part's mostly copied from speech
+        if (time - component.LastSoundPlayed < cd
+            && TryComp<SharedSpeechComponent>(args.Speaker, out var speech)
+            && speech.SpeechSounds != null
+            && _prototypeManager.TryIndex(speech.SpeechSounds, out SpeechSoundsPrototype? speechProto))
+        {
+            var sound = args.Message[^1] switch
+            {
+                '?' => speechProto.AskSound,
+                '!' => speechProto.ExclaimSound,
+                _ => speechProto.SaySound
+            };
+
+            var uppercase = 0;
+            for (var i = 0; i < args.Message.Length; i++)
+            {
+                if (char.IsUpper(args.Message[i]))
+                {
+                    uppercase++;
+                }
+            }
+
+            if (uppercase > args.Message.Length / 2)
+            {
+                sound = speechProto.ExclaimSound;
+            }
+
+            var scale = (float) _random.NextGaussian(1, speechProto.Variation);
+            var param = speech.AudioParams.WithPitchScale(scale);
+            _audioSystem.PlayPvs(sound, uid, param);
+
+            component.LastSoundPlayed = time;
+        }
+
+        var nameEv = new TransformSpeakerNameEvent(args.Speaker, Name(args.Speaker));
+        RaiseLocalEvent(args.Speaker, nameEv);
+        component.LastSpokenNames.Enqueue(nameEv.Name);
+
+        _chatSystem.TrySendInGameICMessage(uid, args.Message, InGameICChatType.Speak, false);
+    }
+
+    private void OnTransformSpeech(EntityUid uid, SurveillanceCameraSpeakerComponent component,
+        TransformSpeakerNameEvent args)
+    {
+        args.Name = Loc.GetString("surveillance-camera-microphone-message", ("speaker", Name(uid)),
+            ("originalName", component.LastSpokenNames.Dequeue()));
+    }
+}

--- a/Resources/Locale/en-US/surveillance-camera/surveillance-camera-speaker.ftl
+++ b/Resources/Locale/en-US/surveillance-camera/surveillance-camera-speaker.ftl
@@ -1,0 +1,1 @@
+surveillance-camera-microphone-message = {$speaker} [{$originalName}]

--- a/Resources/Locale/en-US/surveillance-camera/surveillance-camera-speaker.ftl
+++ b/Resources/Locale/en-US/surveillance-camera/surveillance-camera-speaker.ftl
@@ -1,1 +1,1 @@
-surveillance-camera-microphone-message = {$speaker} [{$originalName}]
+surveillance-camera-microphone-message = {$speaker} ({$originalName})

--- a/Resources/Locale/en-US/surveillance-camera/surveillance-camera-ui.ftl
+++ b/Resources/Locale/en-US/surveillance-camera/surveillance-camera-ui.ftl
@@ -11,4 +11,3 @@ surveillance-camera-monitor-ui-no-subnets = No Subnets
 surveillance-camera-setup = Setup
 surveillance-camera-setup-ui-set = Set
 
-surveillance-camera-microphone-message = {$speaker} says, "{$message}"

--- a/Resources/Locale/en-US/surveillance-camera/surveillance-camera-ui.ftl
+++ b/Resources/Locale/en-US/surveillance-camera/surveillance-camera-ui.ftl
@@ -10,3 +10,5 @@ surveillance-camera-monitor-ui-no-subnets = No Subnets
 
 surveillance-camera-setup = Setup
 surveillance-camera-setup-ui-set = Set
+
+surveillance-camera-microphone-message = {$speaker} says, {$message}

--- a/Resources/Locale/en-US/surveillance-camera/surveillance-camera-ui.ftl
+++ b/Resources/Locale/en-US/surveillance-camera/surveillance-camera-ui.ftl
@@ -11,4 +11,4 @@ surveillance-camera-monitor-ui-no-subnets = No Subnets
 surveillance-camera-setup = Setup
 surveillance-camera-setup-ui-set = Set
 
-surveillance-camera-microphone-message = {$speaker} says, {$message}
+surveillance-camera-microphone-message = {$speaker} says, "{$message}"

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -675,6 +675,7 @@
       range: 200
     - type: DeviceNetworkRequiresPower
     - type: SurveillanceCameraMonitor
+      speechEnabled: true
     - type: ActivatableUI
       key: enum.SurveillanceCameraMonitorUiKey.Key
     - type: ActivatableUIRequiresPower

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -675,6 +675,7 @@
       range: 200
     - type: DeviceNetworkRequiresPower
     - type: Speech
+    - type: SurveillanceCameraSpeaker
     - type: SurveillanceCameraMonitor
       speechEnabled: true
     - type: ActivatableUI

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -674,6 +674,7 @@
     - type: WirelessNetworkConnection
       range: 200
     - type: DeviceNetworkRequiresPower
+    - type: Speech
     - type: SurveillanceCameraMonitor
       speechEnabled: true
     - type: ActivatableUI

--- a/Resources/Prototypes/Entities/Structures/Machines/wireless_surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/wireless_surveillance_camera.yml
@@ -22,6 +22,11 @@
           mass: 50
           mask:
             - MachineMask
+    - type: SurveillanceCameraMicrophone
+      blacklist:
+        components:
+          - SurveillanceCamera
+          - SurveillanceCameraMonitor
     - type: UserInterface
       interfaces:
         - key: enum.SurveillanceCameraSetupUiKey.Camera

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
@@ -83,8 +83,6 @@
       transmitFrequencyId: SurveillanceCamera
     - type: WiredNetworkConnection
     - type: DeviceNetworkRequiresPower
-    - type: Speech
-    - type: SurveillanceCameraSpeaker
     - type: SurveillanceCameraMonitor
     - type: ActivatableUI
       key: enum.SurveillanceCameraMonitorUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
@@ -83,6 +83,8 @@
       transmitFrequencyId: SurveillanceCamera
     - type: WiredNetworkConnection
     - type: DeviceNetworkRequiresPower
+    - type: Speech
+    - type: SurveillanceCameraSpeaker
     - type: SurveillanceCameraMonitor
     - type: ActivatableUI
       key: enum.SurveillanceCameraMonitorUiKey.Key
@@ -159,6 +161,8 @@
     - type: WirelessNetworkConnection
       range: 200
     - type: DeviceNetworkRequiresPower
+    - type: Speech
+    - type: SurveillanceCameraSpeaker
     - type: SurveillanceCameraMonitor
     - type: ActivatableUI
       key: enum.SurveillanceCameraMonitorUiKey.Key


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the ability for surveillance cameras to listen to entities in close range, and relay them to all surveillance camera monitors connected to the camera in question.

:cl:
- add: NanoTrasen has given some of your television cameras microphones. Now you can actually hear the news, instead of having to either lip read the newscasters, or have them ring in your headset all the events of the station!
