### PR TITLE
Butchered objects use MapPosition for spawning, spawn with small offsets. Objects cannot be butchered inside containers.

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -85,7 +85,7 @@ public sealed class SharpSystem : EntitySystem
         foreach (var proto in spawnEntities)
         {
             // distribute the spawned items randomly in a small radius around the origin
-            popupEnt = Spawn(proto, coords.Offset(_robustRandom.NextVector2(0.25f));
+            popupEnt = Spawn(proto, coords.Offset(_robustRandom.NextVector2(0.25f)));
         }
 
         _popupSystem.PopupEntity(Loc.GetString("butcherable-knife-butchered-success", ("target", ev.Entity), ("knife", ev.Sharp)),

--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -92,7 +92,7 @@ public sealed class SharpSystem : EntitySystem
             popupEnt, Filter.Entities(ev.User), PopupType.LargeCaution);
 
         if (TryComp<SharedBodyComponent>(ev.Entity, out var body))
-        { 
+        {
             body.Gib();
         }
         else

--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -85,7 +85,7 @@ public sealed class SharpSystem : EntitySystem
         foreach (var proto in spawnEntities)
         {
             // distribute the spawned items randomly in a small radius around the origin
-            popupEnt = Spawn(proto, coords.Offset(_robustRandom.NextAngle().ToVec() * 0.25f));
+            popupEnt = Spawn(proto, coords.Offset(_robustRandom.NextVector2(0.25f));
         }
 
         _popupSystem.PopupEntity(Loc.GetString("butcherable-knife-butchered-success", ("target", ev.Entity), ("knife", ev.Sharp)),

--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -80,18 +80,19 @@ public sealed class SharpSystem : EntitySystem
         sharp.Butchering.Remove(ev.Entity);
 
         var spawnEntities = EntitySpawnCollection.GetSpawns(butcher.SpawnedEntities, _robustRandom);
-        var coords = Transform(ev.Entity).Coordinates;
+        var coords = Transform(ev.Entity).MapPosition;
         EntityUid popupEnt = default;
         foreach (var proto in spawnEntities)
         {
-            popupEnt = Spawn(proto, coords);
+            // distribute the spawned items randomly in a small radius around the origin
+            popupEnt = Spawn(proto, coords.Offset(_robustRandom.NextAngle().ToVec() * 0.25f));
         }
 
         _popupSystem.PopupEntity(Loc.GetString("butcherable-knife-butchered-success", ("target", ev.Entity), ("knife", ev.Sharp)),
             popupEnt, Filter.Entities(ev.User), PopupType.LargeCaution);
 
         if (TryComp<SharedBodyComponent>(ev.Entity, out var body))
-        {
+        { 
             body.Gib();
         }
         else

--- a/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
@@ -1,4 +1,4 @@
 ﻿butcherable-knife-butchered-success = You butcher { THE($target) } with { THE($knife) }.
-butcherable-need-knife = Use a sharp object to butcher this creature.
+butcherable-need-knife = Use a sharp object to butcher { THE($target) }.
 butcherable-mob-isnt-dead = Needs to be dead.
 butcherable-verb-name = Butcher


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Closes #10838

- You cannot butcher an object inside a container.
- Butchered objects use `MapPosition` for spawning.
- I added a small offset to each spawned object so they don't weirdly all spawn to precisely the same spot.
- `butcherable-need-knife` uses the target object name, since both living and non-living things can be butchered.
- When butchering a non-living thing, the success alert is less intrusive.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Objects to be butchered must not be worn or be in a container.
- tweak: Items dropped by butchering now drop within a tight circle around the butchered object.

