### PR TITLE
Add description tooltips to traits, jobs and antagonists

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -1099,6 +1099,7 @@ namespace Content.Client.Preferences.UI
 
             private StripeBack _lockStripe;
             private Label _requirementsLabel;
+            private Label _jobTitle;
 
             public JobPrioritySelector(JobPrototype job)
             {
@@ -1156,13 +1157,25 @@ namespace Content.Client.Preferences.UI
                     }
                 };
 
+                _jobTitle = new Label()
+                {
+                    Text = job.LocalizedName,
+                    MinSize = (175, 0)
+                };
+
+                if (job.Description != null)
+                {
+                    _jobTitle.ToolTip = job.Description;
+                    _jobTitle.TooltipDelay = 0.2f;
+                }
+
                 AddChild(new BoxContainer
                 {
                     Orientation = LayoutOrientation.Horizontal,
                     Children =
                     {
                         icon,
-                        new Label {Text = job.LocalizedName, MinSize = (175, 0)},
+                        _jobTitle,
                         _optionButton,
                         _lockStripe,
                     }
@@ -1227,6 +1240,12 @@ namespace Content.Client.Preferences.UI
                 _checkBox = new CheckBox {Text = $"{antag.Name}"};
                 _checkBox.OnToggled += OnCheckBoxToggled;
 
+                if (antag.Description != null)
+                {
+                    _checkBox.ToolTip = antag.Description;
+                    _checkBox.TooltipDelay = 0.2f;
+                }
+
                 AddChild(new BoxContainer
                 {
                     Orientation = LayoutOrientation.Horizontal,
@@ -1262,6 +1281,12 @@ namespace Content.Client.Preferences.UI
 
                 _checkBox = new CheckBox {Text = $"{trait.Name}"};
                 _checkBox.OnToggled += OnCheckBoxToggled;
+
+                if (trait.Description != null)
+                {
+                    _checkBox.ToolTip = trait.Description;
+                    _checkBox.TooltipDelay = 0.2f;
+                }
 
                 AddChild(new BoxContainer
                 {

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -1163,9 +1163,9 @@ namespace Content.Client.Preferences.UI
                     MinSize = (175, 0)
                 };
 
-                if (job.Description != null)
+                if (job.LocalizedDescription != null)
                 {
-                    _jobTitle.ToolTip = job.Description;
+                    _jobTitle.ToolTip = job.LocalizedDescription;
                     _jobTitle.TooltipDelay = 0.2f;
                 }
 

--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -10,6 +10,7 @@ namespace Content.Shared.Roles
     {
         private string _name = string.Empty;
         private string _objective = string.Empty;
+        private string? _description = string.Empty;
 
         [ViewVariables]
         [IdDataFieldAttribute]
@@ -23,6 +24,16 @@ namespace Content.Shared.Roles
         {
             get => _name;
             private set => _name = Loc.GetString(value);
+        }
+
+        /// <summary>
+        ///     The description of this antag shown in a tooltip.
+        /// </summary>
+        [DataField("description")]
+        public string? Description
+        {
+            get => _description;
+            private set => _description = value is null ? null : Loc.GetString(value);
         }
 
         /// <summary>

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -28,6 +28,12 @@ namespace Content.Shared.Roles
         [DataField("name")]
         public string Name { get; } = string.Empty;
 
+        /// <summary>
+        ///     The name of this job as displayed to players.
+        /// </summary>
+        [DataField("description")]
+        public string? Description { get; }
+
         [ViewVariables(VVAccess.ReadOnly)]
         public string LocalizedName => Loc.GetString(Name);
 

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -28,6 +28,9 @@ namespace Content.Shared.Roles
         [DataField("name")]
         public string Name { get; } = string.Empty;
 
+        [ViewVariables(VVAccess.ReadOnly)]
+        public string LocalizedName => Loc.GetString(Name);
+
         /// <summary>
         ///     The name of this job as displayed to players.
         /// </summary>
@@ -35,7 +38,7 @@ namespace Content.Shared.Roles
         public string? Description { get; }
 
         [ViewVariables(VVAccess.ReadOnly)]
-        public string LocalizedName => Loc.GetString(Name);
+        public string? LocalizedDescription => Description is null ? null : Loc.GetString(Description);
 
         [DataField("requirements")]
         public HashSet<JobRequirement>? Requirements;

--- a/Content.Shared/Traits/TraitPrototype.cs
+++ b/Content.Shared/Traits/TraitPrototype.cs
@@ -20,6 +20,12 @@ namespace Content.Shared.Traits
         public string Name { get; } = string.Empty;
 
         /// <summary>
+        ///     The description of this trait.
+        /// </summary>
+        [DataField("description")]
+        public string? Description { get; }
+
+        /// <summary>
         ///     The components that get added to the player, when they pick this trait.
         /// </summary>
         [DataField("components")]

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -1,12 +1,14 @@
 ﻿- type: trait
   id: Blindness
   name: Blindness
+  description: You lack vision
   components:
     - type: PermanentBlindness
 
 - type: trait
   id: Narcolepsy
   name: Narcolepsy
+  description: You fall asleep randomly
   components:
     - type: Narcolepsy
       timeBetweenIncidents: 300, 600

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -1,6 +1,7 @@
 ﻿- type: trait
   id: UncontrollableSneezing
   name: Runny nose
+  description: You sneeze and cough uncontrollably
   components:
     - type: UncontrollableSnough
       snoughSound:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

You can now add descriptions to jobs, antags and traits that should show as a tooltip when you hover over them during character creation.

Includes very short descriptions on blind, runny nose, and narcolepsy.

It's just a "description: " addition to the prototype