### PR TITLE
Butcher verb now only visible when wielding a sharp object

### DIFF
--- a/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
@@ -1,4 +1,3 @@
 ﻿butcherable-knife-butchered-success = You butcher { THE($target) } with { THE($knife) }.
-butcherable-need-knife = Use a sharp object to butcher this creature.
 butcherable-mob-isnt-dead = Needs to be dead.
 butcherable-verb-name = Butcher


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Butcher verb will now only be visible when wielding a sharp object. This might make it slightly harder for newbies to discover how to do butchering, but personally I like keeping the verb menu as short as possible. Discuss.

Additionally, butchering non-living things dosen't generate such an intrusive message.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Butcher verb will now only be visible when wielding a sharp object

