### PR TITLE
view ghosts on round end

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -10,6 +10,7 @@ using Content.Server.Warps;
 using Content.Shared.Actions;
 using Content.Shared.Examine;
 using Content.Shared.Follower;
+using Content.Shared.GameTicking;
 using Content.Shared.Ghost;
 using Content.Shared.MobState.Components;
 using Content.Shared.Movement.Events;
@@ -53,6 +54,8 @@ namespace Content.Server.Ghost
 
             SubscribeLocalEvent<GhostComponent, BooActionEvent>(OnActionPerform);
             SubscribeLocalEvent<GhostComponent, InsertIntoEntityStorageAttemptEvent>(OnEntityStorageInsertAttempt);
+
+            SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
         }
         private void OnActionPerform(EntityUid uid, GhostComponent component, BooActionEvent args)
         {
@@ -246,6 +249,18 @@ namespace Content.Server.Ghost
         public void OnEntityStorageInsertAttempt(EntityUid uid, GhostComponent comp, InsertIntoEntityStorageAttemptEvent args)
         {
             args.Cancel();
+        }
+
+        /// <summary>
+        /// When the round ends, make all players able to see ghosts.
+        /// </summary>
+        /// <param name="args"></param>
+        private void OnRoundEnd(RoundEndTextAppendEvent args)
+        {
+            foreach (var component in EntityQuery<EyeComponent>())
+            {
+                component.VisibilityMask |= (uint) VisibilityFlags.Ghost;
+            }
         }
 
         public bool DoGhostBooEvent(EntityUid target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes ghosts visible to players when the round ends.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Ghosts are now visible in the post-round period.

