### PR TITLE
Some vehicle bugfixes

### DIFF
--- a/Content.Client/Vehicle/VehicleSystem.cs
+++ b/Content.Client/Vehicle/VehicleSystem.cs
@@ -1,72 +1,43 @@
-using Content.Client.Eye;
 using Content.Shared.Vehicle;
 using Content.Shared.Vehicle.Components;
 using Robust.Client.GameObjects;
-using Robust.Client.Graphics;
-using Robust.Client.Player;
 using Robust.Shared.GameStates;
 
 namespace Content.Client.Vehicle
 {
     public sealed class VehicleSystem : SharedVehicleSystem
     {
-        [Dependency] private readonly IEyeManager _eyeManager = default!;
-        [Dependency] private readonly IPlayerManager _playerManager = default!;
-        [Dependency] private readonly EyeLerpingSystem _lerpSys = default!;
-
         public override void Initialize()
         {
             base.Initialize();
+            SubscribeLocalEvent<RiderComponent, ComponentStartup>(OnRiderStartup);
             SubscribeLocalEvent<RiderComponent, ComponentShutdown>(OnRiderShutdown);
             SubscribeLocalEvent<RiderComponent, ComponentHandleState>(OnRiderHandleState);
-            SubscribeLocalEvent<RiderComponent, PlayerAttachedEvent>(OnRiderAttached);
-            SubscribeLocalEvent<RiderComponent, PlayerDetachedEvent>(OnRiderDetached);
+        }
+
+        private void OnRiderStartup(EntityUid uid, RiderComponent component, ComponentStartup args)
+        {
+            // Center the player's eye on the vehicle
+            if (TryComp(uid, out EyeComponent? eyeComp))
+                eyeComp.Target ??= component.Vehicle;
         }
 
         private void OnRiderShutdown(EntityUid uid, RiderComponent component, ComponentShutdown args)
         {
-            if (component.Vehicle != null)
-                _lerpSys.RemoveEye(component.Vehicle.Value);
-
-            if (uid == _playerManager.LocalPlayer?.ControlledEntity
-                && TryComp(uid, out EyeComponent? eye)
-                && eye.Eye != null)
-            {
-                _eyeManager.CurrentEye = eye.Eye;
-            }
-
-            component.Vehicle = null;
-        }
-
-        private void OnRiderAttached(EntityUid uid, RiderComponent component, PlayerAttachedEvent args)
-        {
-            UpdateEye(component);
-        }
-
-        private void OnRiderDetached(EntityUid uid, RiderComponent component, PlayerDetachedEvent args)
-        {
-            if (component.Vehicle != null)
-                _lerpSys.RemoveEye(component.Vehicle.Value);
-        }
-
-        private void UpdateEye(RiderComponent component)
-        {
-            if (!TryComp(component.Vehicle, out EyeComponent? eyeComponent) || eyeComponent.Eye == null)
-                return;
-
-            _lerpSys.AddEye(component.Vehicle.Value, eyeComponent);
-            _eyeManager.CurrentEye = eyeComponent.Eye;
+            // reset the riders eye centering.
+            if (TryComp(uid, out EyeComponent? eyeComp) && eyeComp.Target == component.Vehicle)
+                eyeComp.Target = null;
         }
 
         private void OnRiderHandleState(EntityUid uid, RiderComponent component, ref ComponentHandleState args)
         {
-            if (uid != _playerManager.LocalPlayer?.ControlledEntity)
+            if (args.Current is not RiderComponentState state)
                 return;
 
-            if (args.Current is not RiderComponentState state) return;
-            component.Vehicle = state.Entity;
+            if (TryComp(uid, out EyeComponent? eyeComp) && eyeComp.Target == component.Vehicle)
+                eyeComp.Target = state.Entity;
 
-            UpdateEye(component);
+            component.Vehicle = state.Entity;
         }
     }
 }

--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -22,14 +22,9 @@ namespace Content.Server.Vehicle
     public sealed partial class VehicleSystem : SharedVehicleSystem
     {
         [Dependency] private readonly HandVirtualItemSystem _virtualItemSystem = default!;
-        [Dependency] private readonly MovementSpeedModifierSystem _modifier = default!;
         [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
-        [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
         [Dependency] private readonly SharedJointSystem _joints = default!;
         [Dependency] private readonly SharedMoverController _mover = default!;
-        [Dependency] private readonly TagSystem _tagSystem = default!;
-
-        private const string KeySlot = "key_slot";
 
         public override void Initialize()
         {
@@ -39,8 +34,6 @@ namespace Content.Server.Vehicle
 
             SubscribeLocalEvent<VehicleComponent, HonkActionEvent>(OnHonk);
             SubscribeLocalEvent<VehicleComponent, BuckleChangeEvent>(OnBuckleChange);
-            SubscribeLocalEvent<VehicleComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
-            SubscribeLocalEvent<VehicleComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
         }
 
         /// <summary>
@@ -96,9 +89,8 @@ namespace Content.Server.Vehicle
                 component.Rider = args.BuckledEntity;
 
                 var relay = EnsureComp<RelayInputMoverComponent>(args.BuckledEntity);
-                relay.RelayEntity = uid;
+                _mover.SetRelay(args.BuckledEntity, uid, relay);
                 rider.Vehicle = uid;
-                component.HasRider = true;
 
                 // Update appearance stuff, add actions
                 UpdateBuckleOffset(Transform(uid), component);
@@ -114,10 +106,7 @@ namespace Content.Server.Vehicle
                     _actionsSystem.AddAction(args.BuckledEntity, component.HornAction, uid, actions);
                 }
 
-                if (TryComp<JointComponent>(args.BuckledEntity, out var joints))
-                {
-                    _joints.ClearJoints(joints);
-                }
+                _joints.ClearJoints(args.BuckledEntity);
 
                 return;
             }
@@ -133,43 +122,7 @@ namespace Content.Server.Vehicle
             RemComp<RelayInputMoverComponent>(args.BuckledEntity);
 
             // Reset component
-            component.HasRider = false;
             component.Rider = null;
-        }
-
-        /// <summary>
-        /// Handle adding keys to the ignition, give stuff the InVehicleComponent so it can't be picked
-        /// up by people not in the vehicle.
-        /// </summary>
-        private void OnEntInserted(EntityUid uid, VehicleComponent component, EntInsertedIntoContainerMessage args)
-        {
-            if (args.Container.ID != KeySlot ||
-                !_tagSystem.HasTag(args.Entity, "VehicleKey")) return;
-
-            // Enable vehicle
-            var inVehicle = AddComp<InVehicleComponent>(args.Entity);
-            inVehicle.Vehicle = component;
-
-            component.HasKey = true;
-
-            // Audiovisual feedback
-            _ambientSound.SetAmbience(uid, true);
-            _tagSystem.AddTag(uid, "DoorBumpOpener");
-            _modifier.RefreshMovementSpeedModifiers(uid);
-        }
-
-        /// <summary>
-        /// Turn off the engine when key is removed.
-        /// </summary>
-        private void OnEntRemoved(EntityUid uid, VehicleComponent component, EntRemovedFromContainerMessage args)
-        {
-            if (args.Container.ID != KeySlot || !RemComp<InVehicleComponent>(args.Entity)) return;
-
-            // Disable vehicle
-            component.HasKey = false;
-            _ambientSound.SetAmbience(uid, false);
-            _tagSystem.RemoveTag(uid, "DoorBumpOpener");
-            _modifier.RefreshMovementSpeedModifiers(uid);
         }
     }
 }

--- a/Content.Shared/Movement/Components/RelayInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/RelayInputMoverComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Movement.Systems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Movement.Components;
@@ -6,6 +7,7 @@ namespace Content.Shared.Movement.Components;
 /// Raises the engine movement inputs for a particular entity onto the designated entity
 /// </summary>
 [RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedMoverController))]
 public sealed class RelayInputMoverComponent : Component
 {
     [ViewVariables]

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
-using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
@@ -22,6 +21,7 @@ public abstract class SharedJetpackSystem : EntitySystem
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
     [Dependency] protected readonly SharedContainerSystem Container = default!;
     [Dependency] private readonly SharedPopupSystem _popups = default!;
+    [Dependency] private readonly SharedMoverController _mover = default!;
 
     public override void Initialize()
     {
@@ -102,7 +102,7 @@ public abstract class SharedJetpackSystem : EntitySystem
     {
         var user = EnsureComp<JetpackUserComponent>(uid);
         var relay = EnsureComp<RelayInputMoverComponent>(uid);
-        relay.RelayEntity = component.Owner;
+        _mover.SetRelay(uid, component.Owner, relay);
         user.Jetpack = component.Owner;
     }
 

--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -13,6 +13,19 @@ public abstract partial class SharedMoverController
         SubscribeLocalEvent<RelayInputMoverComponent, ComponentShutdown>(OnRelayShutdown);
     }
 
+    /// <summary>
+    ///     Sets the relay entity and marks the component as dirty. This only exists because people have previously
+    ///     forgotten to Dirty(), so fuck you, you have to use this method now.
+    /// </summary>
+    public void SetRelay(EntityUid uid, EntityUid relayEntity, RelayInputMoverComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        component.RelayEntity = relayEntity;
+        Dirty(component);
+    }
+
     private void OnRelayShutdown(EntityUid uid, RelayInputMoverComponent component, ComponentShutdown args)
     {
         // If relay is removed then cancel all inputs.

--- a/Content.Shared/Vehicle/Components/VehicleComponent.cs
+++ b/Content.Shared/Vehicle/Components/VehicleComponent.cs
@@ -16,7 +16,7 @@ namespace Content.Shared.Vehicle.Components
         /// <summary>
         /// Whether someone is currently riding the vehicle
         /// </summary>
-        public bool HasRider = false;
+        public bool HasRider => Rider != null;
 
         /// <summary>
         /// The entity currently riding the vehicle.
@@ -58,6 +58,7 @@ namespace Content.Shared.Vehicle.Components
         /// <summary>
         /// Whether the vehicle has a key currently inside it or not.
         /// </summary>
+        [ViewVariables]
         public bool HasKey = false;
 
         // TODO: Fix this

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -22,7 +22,6 @@
     frictionNoInput: 6
     baseWalkSpeed: 4.5
     baseSprintSpeed: 6
-  - type: Eye
   - type: Tag
   - type: Pullable
   - type: Physics


### PR DESCRIPTION
- Vehicle system no longer modified `IEyeManager.CurrentEye` and instead just modifies the rider's eye's target/centre. Should fix #11655
- Moved the key insertion/removal logic from the server to the shared system. Avoids some client mispredicts
- Changed the `RelayInputMover` component/system to ensure that the component gets dirtied whenever the rider relay entity gets modified.