### PR TITLE
Unify melee ranges

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -83,11 +83,12 @@ public sealed class MeleeWeaponComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     public FixedPoint2 BluntStaminaDamageFactor { get; set; } = 0.5f;
 
+    // TODO: Temporarily 1.5 until interactionoutline is adjusted to use melee, then probably drop to 1.2
     /// <summary>
     /// Nearest edge range to hit an entity.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
-    public float Range = 1f;
+    public float Range = 1.5f;
 
     /// <summary>
     /// Total width of the angle for wide attacks.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -55,7 +55,6 @@
     accent: mouse
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     animation: WeaponArcBite
     damage:
@@ -132,7 +131,6 @@
       name: action-name-disarm
   - type: MeleeWeapon
     hidden: true
-    range: 0.3
     angle: 0
     animation: WeaponArcBite
     damage:
@@ -658,7 +656,6 @@
         Base: kangaroo-boxing-dead
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     animation: WeaponArcClaw
     damage:
@@ -1186,7 +1183,6 @@
       amount: 3
   - type: MeleeWeapon
     hidden: true
-    range: 0.5
     angle: 0
     animation: WeaponArcBite
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -58,7 +58,6 @@
     coldDamageThreshold: 0
   - type: MeleeWeapon
     hidden: true
-    range: 0.5
     angle: 0
     animation: WeaponArcClaw
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -56,7 +56,6 @@
           amount: 2
     - type: MeleeWeapon
       hidden: true
-      range: 1.5
       angle: 0
       animation: WeaponArcBite
       soundHit:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -37,7 +37,6 @@
   - type: AnimationPlayer
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     animation: WeaponArcFist
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -76,7 +76,6 @@
         Base: narsian_dead
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     animation: WeaponArcBite
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -42,7 +42,6 @@
       200: Dead
   - type: MeleeWeapon
     hidden: true
-    range: 1
     angle: 0
     animation: WeaponArcClaw
     damage:
@@ -134,7 +133,6 @@
       350: Dead
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     attackRate: 0.75
     animation: WeaponArcFist
@@ -202,7 +200,6 @@
       60: Dead
   - type: MeleeWeapon
     hidden: true
-    range: 1
     angle: 0
     animation: WeaponArcClaw
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -117,7 +117,6 @@
   - type: Examiner
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     animation: WeaponArcBite
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -55,7 +55,6 @@
       name: action-name-disarm
   - type: MeleeWeapon
     hidden: true
-    range: 0.5
     angle: 0
     animation: WeaponArcBite
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -67,7 +67,6 @@
           -0.25
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     soundHit:
      collection: AlienClaw
@@ -364,7 +363,6 @@
     - Xeno
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     animation: WeaponArcBite
     damage:

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -41,7 +41,6 @@
     rules: You are an intelligent, demonic dog. Try to help the chaplain and any of his flock. As an antagonist, you're otherwise unrestrained.
   - type: MeleeWeapon
     hidden: true
-    range: 1.5
     angle: 0
     animation: WeaponArcBite
     damage:

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -80,7 +80,6 @@
     - type: Pullable
     - type: MeleeWeapon
       hidden: true
-      range: 2
       angle: 30
       animation: WeaponArcFist
       attackRate: 1.5

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -246,7 +246,6 @@
     hidden: true
     soundHit:
       collection: Punch
-    range: 1.5
     angle: 30
     animation: WeaponArcFist
     attackRate: 1

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -27,7 +27,6 @@
     hidden: true
     soundHit:
       path: /Audio/Weapons/pierce.ogg
-    range: 0.8
     angle: 30
     animation: WeaponArcFist
     damage:

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -550,7 +550,6 @@
     state: foamblade
   - type: MeleeWeapon
     attackRate: 1.5
-    range: 2.0
     angle: 0
     animation: WeaponArcThrust
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -16,7 +16,6 @@
     damage:
       types:
         Piercing: 10
-    range: 1.5
     angle: 0
     animation: WeaponArcThrust
   - type: DamageOtherOnHit

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -17,7 +17,6 @@
       types:
         Blunt: 7
     bluntStaminaDamageFactor: 2.0
-    range: 1.5
     angle: 60
     animation: WeaponArcSlash
   - type: StaminaDamageOnHit
@@ -61,7 +60,6 @@
       damage:
         types:
           Blunt: 0 # why is this classed as a melee weapon? Is it needed for some interaction?
-      range: 1
       angle: 10
     - type: Item
       size: 5


### PR DESCRIPTION
Temporary measure until interactionoutline reflects melee range. Merge after https://github.com/space-wizards/space-station-14/pull/11660

:cl:
- tweak: Melee range has been temporarily standardised from 1m centre distance up to 1.5m nearest edge distance until interaction outline reflects melee weapon ranges.