### PR TITLE
Fixes conveyor belts enabling collisions of opened blast doors when turning on

### DIFF
--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -152,8 +152,13 @@ namespace Content.Server.Physics.Controllers
                 {
                     if (!bodyQuery.TryGetComponent(entity, out var physics))
                         continue;
+                    if (!xformQuery.TryGetComponent(entity, out var intersectingXform))
+                        continue;
 
-                    _physics.WakeBody(physics);
+                    if (!intersectingXform.Anchored)
+                    {
+                        _physics.WakeBody(physics);
+                    }
                 }
             }
         }

--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -152,10 +152,8 @@ namespace Content.Server.Physics.Controllers
                 {
                     if (!bodyQuery.TryGetComponent(entity, out var physics))
                         continue;
-                    if (!xformQuery.TryGetComponent(entity, out var intersectingXform))
-                        continue;
 
-                    if (!intersectingXform.Anchored)
+                    if (physics.BodyType != BodyType.Static)
                     {
                         _physics.WakeBody(physics);
                     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #11672
The root cause is due to the AwakenEntities method on ConveyorController: https://github.com/space-wizards/space-station-14/blob/master/Content.Server/Physics/Controllers/ConveyorController.cs#L156
Basically what happened is that turning conveyor belts on causes the body of any entity on the same tile to awake. Awakening results in collisions being turned on. This seems to have been introduced by the PR #11521. The issue is that this is called for any entity with a physics component, including anchored components such as blast doors and shutters. This results in opened blast doors/shutters to act as if they were closed due to WakeBody turning collisions on again. This also explains why simply closing and reopening them worked as an ingame workaround.
The idea behind my fix is to simply avoid waking bodies of anchored entities, since they shouldn't be moving in the first place.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixes supply blast doors not letting crates pass when the underlying conveyor belts get turned on.

