### PR TITLE
Fix incorrect gender on humanoid appearance cloning

### DIFF
--- a/Content.Server/Humanoid/Systems/HumanoidSystem.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidSystem.cs
@@ -110,7 +110,6 @@ public sealed partial class HumanoidSystem : SharedHumanoidSystem
         EnsureDefaultMarkings(uid, humanoid);
 
         humanoid.Gender = profile.Gender;
-
         if (TryComp<GrammarComponent>(uid, out var grammar))
         {
             grammar.Gender = profile.Gender;
@@ -143,6 +142,12 @@ public sealed partial class HumanoidSystem : SharedHumanoidSystem
         targetHumanoid.Sex = sourceHumanoid.Sex;
         targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
         targetHumanoid.CurrentMarkings = new(sourceHumanoid.CurrentMarkings);
+
+        targetHumanoid.Gender = sourceHumanoid.Gender;
+        if (TryComp<GrammarComponent>(target, out var grammar))
+        {
+            grammar.Gender = sourceHumanoid.Gender;
+        }
 
         Synchronize(target, targetHumanoid);
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes pronouns / gender not being assigned correctly to a humanoid upon cloning a humanoid's settings to another humanoid entity. This should fix #11744.
