### PR TITLE
Make surveillance camera static shorter

### DIFF
--- a/Content.Client/SurveillanceCamera/ActiveSurveillanceCameraMonitor.cs
+++ b/Content.Client/SurveillanceCamera/ActiveSurveillanceCameraMonitor.cs
@@ -3,7 +3,7 @@ namespace Content.Client.SurveillanceCamera;
 [RegisterComponent]
 public sealed class ActiveSurveillanceCameraMonitorVisualsComponent : Component
 {
-    public float TimeLeft = 30f;
+    public float TimeLeft = 10f;
 
     public Action? OnFinish;
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes surveillance camera static shorter. This is mostly to see if shorter static will still mask the effect of loading in entities, since the intent of the effect is to mask the pop in.

:cl:
- tweak: NanoTrasen has supplied your stations with better routers! The static you see will now disappear much more faster than before!
