### PR TITLE
Respect USE_SYSTEM_SQLITE

### DIFF
--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -661,6 +661,9 @@ namespace Content.Server.Database
             var configPreferencesDbPath = _cfg.GetCVar(CCVars.DatabaseSqliteDbPath);
             var inMemory = _res.UserData.RootDir == null;
 
+#if USE_SYSTEM_SQLITE
+            SQLitePCL.raw.SetProvider(new SQLitePCL.SQLite3Provider_sqlite3());
+#endif
             SqliteConnection connection;
             if (!inMemory)
             {


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

RobustToolbox was updated with a USE_SYSTEM_SQLITE definition in https://github.com/space-wizards/RobustToolbox/pull/3298. Update Content.Server to respect this definition.

While an engine update is needed for this to be effective, nothing bad will happen without an engine update; this flag will simply be ignored, which matches current behavior. The flag will be respected on the next engine update.

This is required for the server to run on FreeBSD.

**Screenshots**
N/A

**Changelog**
N/A