### PR TITLE
Fix firelock construction

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
@@ -8,3 +8,7 @@
       sprite: Objects/Misc/module.rsi
       state: mainboard
       netsync: false
+    - type: Tag
+      tags:
+      - DroneUsable
+      - FirelockElectronics

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/firelock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/firelock.yml
@@ -51,6 +51,7 @@
               anchored: true
           steps:
             - tag: FirelockElectronics
+              store: board
               name: Firelock Electronics
               icon:
                 sprite: "Objects/Misc/module.rsi"
@@ -82,9 +83,7 @@
               doAfter: 0.25
         - to: frame2
           completed:
-            - !type:SpawnPrototype
-              prototype: FirelockElectronics
-              amount: 1
+            - !type:EmptyAllContainers {}
           conditions:
             - !type:EntityAnchored
               anchored: true


### PR DESCRIPTION
Fixes #11715
Fixes #11567

This will partially break firelock deconstruction as existing firelocks don't currently spawn with a board, but I'll fix that separately.

:cl:
- fix: Fixed firelock construction not working. Deconstructing existing firelocks is still bugged.

