### PR TITLE
new social traitor objective + fix targeting for other traitor alive

### DIFF
--- a/Content.Server/Objectives/Conditions/RandomTraitorAliveCondition.cs
+++ b/Content.Server/Objectives/Conditions/RandomTraitorAliveCondition.cs
@@ -1,9 +1,6 @@
-using Content.Server.Mind.Components;
 using Content.Server.Objectives.Interfaces;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Server.Traitor;
-using Content.Server.Mind;
 using Content.Server.GameTicking.Rules;
 
 namespace Content.Server.Objectives.Conditions
@@ -17,8 +14,28 @@ namespace Content.Server.Objectives.Conditions
         {
             var entityMgr = IoCManager.Resolve<IEntityManager>();
             var traitors = EntitySystem.Get<TraitorRuleSystem>().Traitors;
+            List<Traitor.TraitorRole> removeList = new();
 
-            if (traitors.Count == 0) return new RandomTraitorAliveCondition { _target = mind }; //You were made a traitor by admins, and are the first/only.
+            foreach (var traitor in traitors)
+            {
+                if (traitor.Mind == null)
+                {
+                    removeList.Add(traitor);
+                    continue;
+                }
+                if (traitor.Mind == mind) // we have different objectives for defending ourselves.
+                {
+                    removeList.Add(traitor);
+                    continue;
+                }
+            }
+
+            foreach (var traitor in removeList)
+            {
+                traitors.Remove(traitor);
+            }
+
+            if (traitors.Count == 0) return new EscapeShuttleCondition{}; //You were made a traitor by admins, and are the first/only.
             return new RandomTraitorAliveCondition { _target = IoCManager.Resolve<IRobustRandom>().Pick(traitors).Mind };
         }
 

--- a/Content.Server/Objectives/Conditions/RandomTraitorProgressCondition.cs
+++ b/Content.Server/Objectives/Conditions/RandomTraitorProgressCondition.cs
@@ -1,0 +1,102 @@
+using Content.Server.Objectives.Interfaces;
+using Robust.Shared.Random;
+using Robust.Shared.Utility;
+using Content.Server.GameTicking.Rules;
+
+namespace Content.Server.Objectives.Conditions
+{
+    [DataDefinition]
+    public sealed class RandomTraitorProgressCondition : IObjectiveCondition
+    {
+        private Mind.Mind? _target;
+
+        public IObjectiveCondition GetAssigned(Mind.Mind mind)
+        {
+            var entityMgr = IoCManager.Resolve<IEntityManager>();
+            var traitors = EntitySystem.Get<TraitorRuleSystem>().Traitors;
+
+            if (traitors.Count == 0) return new EscapeShuttleCondition{}; //You were made a traitor by admins, and are the first/only.
+            return new RandomTraitorProgressCondition { _target = IoCManager.Resolve<IRobustRandom>().Pick(traitors).Mind };
+        }
+
+        public string Title
+        {
+            get
+            {
+                var targetName = string.Empty;
+                var jobName = _target?.CurrentJob?.Name ?? "Unknown";
+
+                if (_target == null)
+                    return Loc.GetString("objective-condition-other-traitor-progress-title", ("targetName", targetName), ("job", jobName));
+
+                if (_target.CharacterName != null)
+                    targetName = _target.CharacterName;
+                else if (_target.OwnedEntity is {Valid: true} owned)
+                    targetName = IoCManager.Resolve<IEntityManager>().GetComponent<MetaDataComponent>(owned).EntityName;
+
+                return Loc.GetString("objective-condition-other-traitor-progress-title", ("targetName", targetName), ("job", jobName));
+            }
+        }
+
+        public string Description => Loc.GetString("objective-condition-other-traitor-progress-description");
+
+        public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Objects/Misc/bureaucracy.rsi"), "folder-white");
+
+        public float Progress
+        {
+            get {
+                var entMan = IoCManager.Resolve<IEntityManager>();
+
+                float total = 0f; // how much progress they have
+                float max = 0f; // how much progress is needed for 100%
+
+                if (_target == null)
+                {
+                    Logger.Error("Null target on RandomTraitorProgressCondition.");
+                    return 1f;
+                }
+
+                foreach (var objective in _target.AllObjectives)
+                {
+                    foreach (var condition in objective.Conditions)
+                    {
+                        max++; // things can only be up to 100% complete yeah
+                        total += condition.Progress;
+                    }
+                }
+
+                if (max == 0f)
+                {
+                    Logger.Error("RandomTraitorProgressCondition assigned someone with no objectives to be helped.");
+                    return 1f;
+                }
+
+                var completion = total / max;
+                Logger.Error("completion: " + completion);
+                if (completion >= 0.5f)
+                    return 1f;
+                else
+                    return completion / 0.5f;
+            }
+        }
+
+        public float Difficulty => 2.5f;
+
+        public bool Equals(IObjectiveCondition? other)
+        {
+            return other is RandomTraitorProgressCondition kpc && Equals(_target, kpc._target);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is RandomTraitorProgressCondition alive && alive.Equals(this);
+        }
+
+        public override int GetHashCode()
+        {
+            return _target?.GetHashCode() ?? 0;
+        }
+    }
+}

--- a/Content.Server/Objectives/Conditions/RandomTraitorProgressCondition.cs
+++ b/Content.Server/Objectives/Conditions/RandomTraitorProgressCondition.cs
@@ -86,8 +86,6 @@ namespace Content.Server.Objectives.Conditions
                     return 1f;
                 }
 
-                Logger.Error("Target: " + _target.CurrentEntity);
-
                 foreach (var objective in _target.AllObjectives)
                 {
                     foreach (var condition in objective.Conditions)
@@ -104,7 +102,7 @@ namespace Content.Server.Objectives.Conditions
                 }
 
                 var completion = total / max;
-                Logger.Error("completion: " + completion);
+
                 if (completion >= 0.5f)
                     return 1f;
                 else

--- a/Resources/Locale/en-US/objectives/conditions/other-traitor-progress-condition.ftl
+++ b/Resources/Locale/en-US/objectives/conditions/other-traitor-progress-condition.ftl
@@ -1,0 +1,2 @@
+objective-condition-other-traitor-progress-title = Ensure fellow traitor {$targetName}, {CAPITALIZE($job)} achieves at least half their objectives.
+objective-condition-other-traitor-progress-description = Identify yourself at your own risk. We just need them to succeed.

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -52,164 +52,164 @@
   conditions:
     - !type:DieCondition {}
 
-- type: objective
-  id: CMOHyposprayStealObjective
-  issuer: syndicate
-  difficultyOverride: 2.75
-  prob: 0.2
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: ChiefMedicalOfficer
-  conditions:
-    - !type:StealCondition
-      prototype: Hypospray
-      owner: job-name-cmo
+# - type: objective
+#   id: CMOHyposprayStealObjective
+#   issuer: syndicate
+#   difficultyOverride: 2.75
+#   prob: 0.2
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: ChiefMedicalOfficer
+#   conditions:
+#     - !type:StealCondition
+#       prototype: Hypospray
+#       owner: job-name-cmo
 
-- type: objective
-  id: RDHardsuitStealObjective
-  issuer: syndicate
-  difficultyOverride: 2.75
-  prob: 0.2
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: ResearchDirector
-  conditions:
-    - !type:StealCondition
-      prototype: ClothingOuterHardsuitRd
-      owner: job-name-rd
+# - type: objective
+#   id: RDHardsuitStealObjective
+#   issuer: syndicate
+#   difficultyOverride: 2.75
+#   prob: 0.2
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: ResearchDirector
+#   conditions:
+#     - !type:StealCondition
+#       prototype: ClothingOuterHardsuitRd
+#       owner: job-name-rd
 
-- type: objective
-  id: NukeDiskStealObjective
-  issuer: syndicate
-  prob: 0.2
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: Captain
-    - !type:NotRoleRequirement
-      roleId: HeadOfSecurity
-    - !type:NotRoleRequirement
-      roleId: HeadOfPersonnel
-    - !type:NotRoleRequirement
-      roleId: ChiefEngineer
-    - !type:NotRoleRequirement
-      roleId: ChiefMedicalOfficer
-    - !type:NotRoleRequirement
-      roleId: ResearchDirector
-  conditions:
-    - !type:StealCondition
-      prototype: NukeDisk
-      owner: objective-condition-steal-station
+# - type: objective
+#   id: NukeDiskStealObjective
+#   issuer: syndicate
+#   prob: 0.2
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: Captain
+#     - !type:NotRoleRequirement
+#       roleId: HeadOfSecurity
+#     - !type:NotRoleRequirement
+#       roleId: HeadOfPersonnel
+#     - !type:NotRoleRequirement
+#       roleId: ChiefEngineer
+#     - !type:NotRoleRequirement
+#       roleId: ChiefMedicalOfficer
+#     - !type:NotRoleRequirement
+#       roleId: ResearchDirector
+#   conditions:
+#     - !type:StealCondition
+#       prototype: NukeDisk
+#       owner: objective-condition-steal-station
 
 
-- type: objective
-  id: IDComputerBoardStealObjective
-  issuer: syndicate
-  prob: 0.2
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: HeadOfPersonnel
-  conditions:
-    - !type:StealCondition
-      prototype: IDComputerCircuitboard
-      owner: job-name-hop
+# - type: objective
+#   id: IDComputerBoardStealObjective
+#   issuer: syndicate
+#   prob: 0.2
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: HeadOfPersonnel
+#   conditions:
+#     - !type:StealCondition
+#       prototype: IDComputerCircuitboard
+#       owner: job-name-hop
 
-- type: objective
-  id: MagbootsStealObjective
-  issuer: syndicate
-  difficultyOverride: 2.75
-  prob: 0.2
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: ChiefEngineer
-  conditions:
-    - !type:StealCondition
-      prototype: ClothingShoesBootsMagAdv
-      owner: job-name-ce
+# - type: objective
+#   id: MagbootsStealObjective
+#   issuer: syndicate
+#   difficultyOverride: 2.75
+#   prob: 0.2
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: ChiefEngineer
+#   conditions:
+#     - !type:StealCondition
+#       prototype: ClothingShoesBootsMagAdv
+#       owner: job-name-ce
 
-- type: objective
-  id: SupplyConsoleBoardStealObjective
-  issuer: syndicate
-  prob: 0.2
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: Quartermaster
-  conditions:
-    - !type:StealCondition
-      prototype: CargoRequestComputerCircuitboard
-      owner: job-name-qm
+# - type: objective
+#   id: SupplyConsoleBoardStealObjective
+#   issuer: syndicate
+#   prob: 0.2
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: Quartermaster
+#   conditions:
+#     - !type:StealCondition
+#       prototype: CargoRequestComputerCircuitboard
+#       owner: job-name-qm
 
-- type: objective
-  id: CorgiMeatStealObjective
-  issuer: syndicate
-  prob: 0.2
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: HeadOfPersonnel
-  conditions:
-    - !type:StealCondition
-      prototype: FoodMeatCorgi
-      owner: objective-condition-steal-Ian
+# - type: objective
+#   id: CorgiMeatStealObjective
+#   issuer: syndicate
+#   prob: 0.2
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: HeadOfPersonnel
+#   conditions:
+#     - !type:StealCondition
+#       prototype: FoodMeatCorgi
+#       owner: objective-condition-steal-Ian
 
-- type: objective
-  id: CaptainGunStealObjective
-  issuer: syndicate
-  difficultyOverride: 2.75
-  prob: 0.1
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: Captain
-  conditions:
-    - !type:StealCondition
-      prototype: WeaponAntiqueLaser
-      owner: job-name-captain
+# - type: objective
+#   id: CaptainGunStealObjective
+#   issuer: syndicate
+#   difficultyOverride: 2.75
+#   prob: 0.1
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: Captain
+#   conditions:
+#     - !type:StealCondition
+#       prototype: WeaponAntiqueLaser
+#       owner: job-name-captain
 
-- type: objective
-  id: CaptainJetpackStealObjective
-  issuer: syndicate
-  difficultyOverride: 2.75
-  prob: 0.1
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - DieCondition
-    - !type:NotRoleRequirement
-      roleId: Captain
-  conditions:
-    - !type:StealCondition
-      prototype: JetpackCaptainFilled
+# - type: objective
+#   id: CaptainJetpackStealObjective
+#   issuer: syndicate
+#   difficultyOverride: 2.75
+#   prob: 0.1
+#   requirements:
+#     - !type:TraitorRequirement {}
+#     - !type:IncompatibleConditionsRequirement
+#       conditions:
+#         - DieCondition
+#     - !type:NotRoleRequirement
+#       roleId: Captain
+#   conditions:
+#     - !type:StealCondition
+#       prototype: JetpackCaptainFilled
 
 - type: objective
   id: EscapeShuttleObjective
@@ -221,3 +221,13 @@
         - DieCondition
   conditions:
     - !type:EscapeShuttleCondition {}
+
+- type: objective
+  id: RandomTraitorProgressObjective
+  issuer: syndicate
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:MultipleTraitorsRequirement
+  conditions:
+    - !type:RandomTraitorProgressCondition {}
+  canBeDuplicate: true

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -52,164 +52,164 @@
   conditions:
     - !type:DieCondition {}
 
-# - type: objective
-#   id: CMOHyposprayStealObjective
-#   issuer: syndicate
-#   difficultyOverride: 2.75
-#   prob: 0.2
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: ChiefMedicalOfficer
-#   conditions:
-#     - !type:StealCondition
-#       prototype: Hypospray
-#       owner: job-name-cmo
+- type: objective
+  id: CMOHyposprayStealObjective
+  issuer: syndicate
+  difficultyOverride: 2.75
+  prob: 0.2
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: ChiefMedicalOfficer
+  conditions:
+    - !type:StealCondition
+      prototype: Hypospray
+      owner: job-name-cmo
 
-# - type: objective
-#   id: RDHardsuitStealObjective
-#   issuer: syndicate
-#   difficultyOverride: 2.75
-#   prob: 0.2
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: ResearchDirector
-#   conditions:
-#     - !type:StealCondition
-#       prototype: ClothingOuterHardsuitRd
-#       owner: job-name-rd
+- type: objective
+  id: RDHardsuitStealObjective
+  issuer: syndicate
+  difficultyOverride: 2.75
+  prob: 0.2
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: ResearchDirector
+  conditions:
+    - !type:StealCondition
+      prototype: ClothingOuterHardsuitRd
+      owner: job-name-rd
 
-# - type: objective
-#   id: NukeDiskStealObjective
-#   issuer: syndicate
-#   prob: 0.2
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: Captain
-#     - !type:NotRoleRequirement
-#       roleId: HeadOfSecurity
-#     - !type:NotRoleRequirement
-#       roleId: HeadOfPersonnel
-#     - !type:NotRoleRequirement
-#       roleId: ChiefEngineer
-#     - !type:NotRoleRequirement
-#       roleId: ChiefMedicalOfficer
-#     - !type:NotRoleRequirement
-#       roleId: ResearchDirector
-#   conditions:
-#     - !type:StealCondition
-#       prototype: NukeDisk
-#       owner: objective-condition-steal-station
+- type: objective
+  id: NukeDiskStealObjective
+  issuer: syndicate
+  prob: 0.2
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: Captain
+    - !type:NotRoleRequirement
+      roleId: HeadOfSecurity
+    - !type:NotRoleRequirement
+      roleId: HeadOfPersonnel
+    - !type:NotRoleRequirement
+      roleId: ChiefEngineer
+    - !type:NotRoleRequirement
+      roleId: ChiefMedicalOfficer
+    - !type:NotRoleRequirement
+      roleId: ResearchDirector
+  conditions:
+    - !type:StealCondition
+      prototype: NukeDisk
+      owner: objective-condition-steal-station
 
 
-# - type: objective
-#   id: IDComputerBoardStealObjective
-#   issuer: syndicate
-#   prob: 0.2
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: HeadOfPersonnel
-#   conditions:
-#     - !type:StealCondition
-#       prototype: IDComputerCircuitboard
-#       owner: job-name-hop
+- type: objective
+  id: IDComputerBoardStealObjective
+  issuer: syndicate
+  prob: 0.2
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: HeadOfPersonnel
+  conditions:
+    - !type:StealCondition
+      prototype: IDComputerCircuitboard
+      owner: job-name-hop
 
-# - type: objective
-#   id: MagbootsStealObjective
-#   issuer: syndicate
-#   difficultyOverride: 2.75
-#   prob: 0.2
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: ChiefEngineer
-#   conditions:
-#     - !type:StealCondition
-#       prototype: ClothingShoesBootsMagAdv
-#       owner: job-name-ce
+- type: objective
+  id: MagbootsStealObjective
+  issuer: syndicate
+  difficultyOverride: 2.75
+  prob: 0.2
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: ChiefEngineer
+  conditions:
+    - !type:StealCondition
+      prototype: ClothingShoesBootsMagAdv
+      owner: job-name-ce
 
-# - type: objective
-#   id: SupplyConsoleBoardStealObjective
-#   issuer: syndicate
-#   prob: 0.2
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: Quartermaster
-#   conditions:
-#     - !type:StealCondition
-#       prototype: CargoRequestComputerCircuitboard
-#       owner: job-name-qm
+- type: objective
+  id: SupplyConsoleBoardStealObjective
+  issuer: syndicate
+  prob: 0.2
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: Quartermaster
+  conditions:
+    - !type:StealCondition
+      prototype: CargoRequestComputerCircuitboard
+      owner: job-name-qm
 
-# - type: objective
-#   id: CorgiMeatStealObjective
-#   issuer: syndicate
-#   prob: 0.2
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: HeadOfPersonnel
-#   conditions:
-#     - !type:StealCondition
-#       prototype: FoodMeatCorgi
-#       owner: objective-condition-steal-Ian
+- type: objective
+  id: CorgiMeatStealObjective
+  issuer: syndicate
+  prob: 0.2
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: HeadOfPersonnel
+  conditions:
+    - !type:StealCondition
+      prototype: FoodMeatCorgi
+      owner: objective-condition-steal-Ian
 
-# - type: objective
-#   id: CaptainGunStealObjective
-#   issuer: syndicate
-#   difficultyOverride: 2.75
-#   prob: 0.1
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: Captain
-#   conditions:
-#     - !type:StealCondition
-#       prototype: WeaponAntiqueLaser
-#       owner: job-name-captain
+- type: objective
+  id: CaptainGunStealObjective
+  issuer: syndicate
+  difficultyOverride: 2.75
+  prob: 0.1
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: Captain
+  conditions:
+    - !type:StealCondition
+      prototype: WeaponAntiqueLaser
+      owner: job-name-captain
 
-# - type: objective
-#   id: CaptainJetpackStealObjective
-#   issuer: syndicate
-#   difficultyOverride: 2.75
-#   prob: 0.1
-#   requirements:
-#     - !type:TraitorRequirement {}
-#     - !type:IncompatibleConditionsRequirement
-#       conditions:
-#         - DieCondition
-#     - !type:NotRoleRequirement
-#       roleId: Captain
-#   conditions:
-#     - !type:StealCondition
-#       prototype: JetpackCaptainFilled
+- type: objective
+  id: CaptainJetpackStealObjective
+  issuer: syndicate
+  difficultyOverride: 2.75
+  prob: 0.1
+  requirements:
+    - !type:TraitorRequirement {}
+    - !type:IncompatibleConditionsRequirement
+      conditions:
+        - DieCondition
+    - !type:NotRoleRequirement
+      roleId: Captain
+  conditions:
+    - !type:StealCondition
+      prototype: JetpackCaptainFilled
 
 - type: objective
   id: EscapeShuttleObjective


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- fix: You'll no longer be tasked to keep 'fellow traitor' yourself alive. That objective now checks that you aren't getting yourself as a target.
- add: New objective: Ensure another traitor completes at like half of their objectives.

