### PR TITLE
Revert "Remove references to obsolete GridId"

### DIFF
--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -45,15 +45,17 @@ public sealed class PricingSystem : EntitySystem
 
         foreach (var gid in args)
         {
-            if (!EntityUid.TryParse(gid, out var gridId) || !gridId.IsValid())
+            if (!int.TryParse(gid, out var i) || i <= 0)
             {
                 shell.WriteError($"Invalid grid ID \"{gid}\".");
                 continue;
             }
 
+            var gridId = new GridId(i);
+
             if (!_mapManager.TryGetGrid(gridId, out var mapGrid))
             {
-                shell.WriteError($"Grid \"{gridId}\" doesn't exist.");
+                shell.WriteError($"Grid \"{i}\" doesn't exist.");
                 continue;
             }
 

--- a/Content.Server/Coordinates/Helpers/SnapgridHelper.cs
+++ b/Content.Server/Coordinates/Helpers/SnapgridHelper.cs
@@ -15,11 +15,11 @@ namespace Content.Server.Coordinates.Helpers
         {
             IoCManager.Resolve(ref entMan, ref mapManager);
 
-            var gridIdOpt = coordinates.GetGridUid(entMan);
+            var gridId = coordinates.GetGridId(entMan);
 
             var tileSize = 1f;
 
-            if (gridIdOpt is EntityUid gridId && gridId.IsValid())
+            if (gridId.IsValid())
             {
                 var grid = mapManager.GetGrid(gridId);
                 tileSize = grid.TileSize;

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
@@ -18,7 +18,7 @@ public sealed partial class ExplosionSystem : EntitySystem
     /// </summary>
     private void OnGridStartup(GridStartupEvent ev)
     {
-        var grid = _mapManager.GetGrid(ev.EntityUid);
+        var grid = _mapManager.GetGrid(ev.GridId);
 
         Dictionary<Vector2i, NeighborFlag> edges = new();
         _gridEdges[ev.EntityUid] = edges;

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -27,7 +27,7 @@ public sealed class ImmovableRodSystem : EntitySystem
         {
             if (!rod.DestroyTiles)
                 continue;
-            if (!_map.TryGetGrid(trans.GridUid, out var grid))
+            if (!_map.TryGetGrid(trans.GridID, out var grid))
                 continue;
 
             grid.SetTile(trans.Coordinates, Tile.Empty);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -97,7 +97,7 @@ public sealed partial class ShuttleSystem
 
         foreach (var other in _mapManager.FindGridsIntersecting(xform.MapID, bounds))
         {
-            if (grid.Owner == other.GridEntityId ||
+            if (grid.GridIndex == other.Index ||
                 !bodyQuery.TryGetComponent(other.GridEntityId, out var body) ||
                 body.Mass < ShuttleFTLMassThreshold) continue;
 


### PR DESCRIPTION
Reverts space-wizards/space-station-14#11531

Requires https://github.com/space-wizards/RobustToolbox/pull/3308

This broke maploading because mapgrids no longer get serialized.