### PR TITLE
Fix rules popup

### DIFF
--- a/Content.Client/Info/RulesManager.cs
+++ b/Content.Client/Info/RulesManager.cs
@@ -73,7 +73,10 @@ public sealed class RulesManager : SharedRulesManager
         _activePopup.OnQuitPressed += OnQuitPressed;
         _activePopup.OnAcceptPressed += OnAcceptPressed;
         _userInterfaceManager.StateRoot.AddChild(_activePopup);
-        LayoutContainer.SetAnchorAndMarginPreset(_activePopup, LayoutContainer.LayoutPreset.Wide);
+        _activePopup.SetValue(LayoutContainer.AnchorBottomProperty, 1.0f);
+        _activePopup.SetValue(LayoutContainer.AnchorTopProperty, 0.0f);
+        _activePopup.SetValue(LayoutContainer.AnchorLeftProperty, 0.0f);
+        _activePopup.SetValue(LayoutContainer.AnchorRightProperty, 1.0f);
     }
 
     private void OnQuitPressed()


### PR DESCRIPTION
I'm kinda happy about fixing this, I didn't really get how anchors, and margins work in the robust universe. Now that my brain gets it, I don't think the helper methods do the correct thing. I'm not going to try to fix them at this time.

The rules popup doesn't need to set margins to work, so it shouldn't be using this method anyways.

The key part to understanding how anchors, and margins work for me was this code. (with variables renamed to make it readable without the rest of the code).
```c#
var childLeftSide = childAnchorLeft * parentSizeX + childMarginLeft;
var childTopSide = childAnchorTop * parentSizeY + childMarginTop;
var childRightSide = childAnchorRight* parentSizeX + childMarginRight;
var childBottomSide = childAnchorBottom * parentSizeY + childMarginBottom;

return new UIBox2(childLeftSide, childTopSide, childRightSide, childBottomSide);
```