### PR TITLE
Drill buff so they're worth mapping

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -39,8 +39,9 @@
   - type: GatheringTool
     damage:
       types:
-        Piercing: 25
-    gatheringTime: 0.75
+        Piercing: 35
+    gatheringTime: 0.50
+    MaxGatheringEntities: 2
   - type: ItemCooldown
   - type: MeleeWeapon
     damage:


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Made drills actually better than just a small mining speed increase, not mapped or vended anywhere.
I'd like R&D to be able to make these eventually if they've required tech and something like plasteel in a protolathe, but current R&D tech tree sucks so thats postponed for Emo's job content suffering.

They now:
Deal more damage to rocks.
Can mine 2 rocks at once.
Mine faster than pickaxes.
(P.S please pester #cartography to map these ill inevitably forget)
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: BurninDreamer
- tweak: Nanotrasen has finally invested into better drills for their miners, rock and stone!

