### PR TITLE
Stop reducing output pressure of gastank when low pressure

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -168,13 +168,6 @@ namespace Content.Server.Atmos.EntitySystems
             if (component.Air == null)
                 return new GasMixture(volume);
 
-            var tankPressure = component.Air.Pressure;
-            if (tankPressure < component.OutputPressure)
-            {
-                component.OutputPressure = tankPressure;
-                UpdateUserInterface(component);
-            }
-
             var molesNeeded = component.OutputPressure * volume / (Atmospherics.R * component.Air.Temperature);
 
             var air = RemoveAir(component, molesNeeded);

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -113,8 +113,9 @@ public sealed class InternalsSystem : EntitySystem
     {
         if (component.BreathToolEntity == null || !AreInternalsWorking(component)) return 2;
 
+        // What we are checking here is if there is more moles in tank than we need.
         if (TryComp<GasTankComponent>(component.GasTankEntity, out var gasTank)
-            && gasTank.OutputPressure * Atmospherics.BreathVolume > gasTank.Air.TotalMoles * Atmospherics.R * gasTank.Air.Temperature)
+            && (gasTank.OutputPressure * Atmospherics.BreathVolume / Atmospherics.R * gasTank.Air.Temperature) >= gasTank.Air.TotalMoles)
             return 0;
 
         return 1;

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -113,7 +113,8 @@ public sealed class InternalsSystem : EntitySystem
     {
         if (component.BreathToolEntity == null || !AreInternalsWorking(component)) return 2;
 
-        if (TryComp<GasTankComponent>(component.GasTankEntity, out var gasTank) && gasTank.Air.Volume < Atmospherics.BreathVolume)
+        if (TryComp<GasTankComponent>(component.GasTankEntity, out var gasTank)
+            && gasTank.OutputPressure * Atmospherics.BreathVolume > gasTank.Air.TotalMoles * Atmospherics.R * gasTank.Air.Temperature)
             return 0;
 
         return 1;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title says it. No more need to re-set the output pressure after refilling your gas tank. Which is un-intuitive to newcomers because you don't know you have to do it and you don't know what value to put.

Also, fixes the alert display when your tank has not enough gas for you to breath.

closes

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Your gas tank's output pressure will not decrease anymore when the tank is almost empty
- fix: The internals alert will blink again when your gas tank need to be refilled

