### PR TITLE
Reordered item insertion checks

### DIFF
--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -522,17 +522,9 @@ namespace Content.Server.Storage.EntitySystems
                 return false;
             }
 
-            if (TryComp(insertEnt, out ServerStorageComponent? storage) &&
-                storage.StorageCapacityMax >= storageComp.StorageCapacityMax)
+            if (TryComp(insertEnt, out TransformComponent? transformComp) && transformComp.Anchored)
             {
-                reason = "comp-storage-insufficient-capacity";
-                return false;
-            }
-
-            if (TryComp(insertEnt, out ItemComponent? itemComp) &&
-                itemComp.Size > storageComp.StorageCapacityMax - storageComp.StorageUsed)
-            {
-                reason = "comp-storage-insufficient-capacity";
+                reason = "comp-storage-anchored-failure";
                 return false;
             }
 
@@ -548,9 +540,17 @@ namespace Content.Server.Storage.EntitySystems
                 return false;
             }
 
-            if (TryComp(insertEnt, out TransformComponent? transformComp) && transformComp.Anchored)
+            if (TryComp(insertEnt, out ServerStorageComponent? storage) &&
+                storage.StorageCapacityMax >= storageComp.StorageCapacityMax)
             {
-                reason = "comp-storage-anchored-failure";
+                reason = "comp-storage-insufficient-capacity";
+                return false;
+            }
+
+            if (TryComp(insertEnt, out ItemComponent? itemComp) &&
+                itemComp.Size > storageComp.StorageCapacityMax - storageComp.StorageUsed)
+            {
+                reason = "comp-storage-insufficient-capacity";
                 return false;
             }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
tweaks one interaction described in #11234

reordered the insert failure checks so they are checked in this order:
- item is anchored
- invalid container for item
- insufficient space

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Improved error pop-up when failing to insert an item into storage containers.

