### PR TITLE
Fix changelog button in escape menu not working

### DIFF
--- a/Content.Client/UserInterface/Systems/EscapeMenu/EscapeUIController.cs
+++ b/Content.Client/UserInterface/Systems/EscapeMenu/EscapeUIController.cs
@@ -20,6 +20,9 @@ public sealed class EscapeUIController : UIController, IOnStateEntered<GameplayS
 {
     [Dependency] private readonly IClientConsoleHost _console = default!;
     [Dependency] private readonly IUriOpener _uri = default!;
+    [Dependency] private readonly ChangelogUIController _changelog = default!;
+    [Dependency] private readonly InfoUIController _info = default!;
+    [Dependency] private readonly OptionsUIController _options = default!;
 
     private Options.UI.EscapeMenu? _escapeWindow;
 
@@ -38,14 +41,13 @@ public sealed class EscapeUIController : UIController, IOnStateEntered<GameplayS
         _escapeWindow.ChangelogButton.OnPressed += _ =>
         {
             CloseEscapeWindow();
-            // Put this back when changelog button no longer controls the window
-            // UIManager.GetUIController<ChangelogUIController>().ToggleWindow();
+            _changelog.ToggleWindow();
         };
 
         _escapeWindow.RulesButton.OnPressed += _ =>
         {
             CloseEscapeWindow();
-            UIManager.GetUIController<InfoUIController>().OpenWindow();
+            _info.OpenWindow();
         };
 
         _escapeWindow.DisconnectButton.OnPressed += _ =>
@@ -57,7 +59,7 @@ public sealed class EscapeUIController : UIController, IOnStateEntered<GameplayS
         _escapeWindow.OptionsButton.OnPressed += _ =>
         {
             CloseEscapeWindow();
-            UIManager.GetUIController<OptionsUIController>().OpenWindow();
+            _options.OpenWindow();
         };
 
         _escapeWindow.QuitButton.OnPressed += _ =>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

looks like a missed wrexbe todo

:cl:
- fix: The changelog button in the escape menu now functions again.