### PR TITLE
Hide the action button label if it's empty.

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -163,6 +163,7 @@ public sealed class ActionButton : Control
     public void UpdateData(IEntityManager entityManager, ActionType action)
     {
         Action = action;
+        Label.Visible = true;
 
         if (action.Icon != null)
         {
@@ -188,6 +189,7 @@ public sealed class ActionButton : Control
         Sprite.Sprite = null;
         Cooldown.Visible = false;
         Cooldown.Progress = 1;
+        Label.Visible = false;
     }
 
     private Texture? GetIcon()


### PR DESCRIPTION
Reduces visual clutter just slightly, by avoiding bright white text in an otherwise empty and dark space.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: moony
- tweak: The action bar no longer shows the keybind for empty slots.