### PR TITLE
Add announcement wrap to department radio messages for non-player sources (salvage magnet)

### DIFF
--- a/Content.Server/Ghost/Components/IntrinsicRadioComponent.cs
+++ b/Content.Server/Ghost/Components/IntrinsicRadioComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Ghost.Components
         [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>), required: true)]
         private HashSet<string> _channels = new();
 
-        public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker)
+        public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker, bool announcement = false)
         {
             if (!_channels.Contains(channel.ID) || !_entMan.TryGetComponent(Owner, out ActorComponent? actor))
                 return;

--- a/Content.Server/Radio/Components/HandheldRadioComponent.cs
+++ b/Content.Server/Radio/Components/HandheldRadioComponent.cs
@@ -86,7 +86,7 @@ namespace Content.Server.Radio.Components
                    && EntitySystem.Get<SharedInteractionSystem>().InRangeUnobstructed(Owner, source, range: ListenRange);
         }
 
-        public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker)
+        public void Receive(string message, RadioChannelPrototype channel, EntityUid speaker, bool announcement = false)
         {
             if (_channels.Contains(channel.ID) && RadioOn)
             {

--- a/Content.Server/Radio/Components/IRadio.cs
+++ b/Content.Server/Radio/Components/IRadio.cs
@@ -4,7 +4,7 @@ namespace Content.Server.Radio.Components
 {
     public interface IRadio : IComponent
     {
-        void Receive(string message, RadioChannelPrototype channel, EntityUid speaker);
+        void Receive(string message, RadioChannelPrototype channel, EntityUid speaker, bool announcement = false);
 
         void Broadcast(string message, EntityUid speaker, RadioChannelPrototype channel);
     }

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Radio.EntitySystems
             args.PushMarkup(Loc.GetString("handheld-radio-component-on-examine",("frequency", component.BroadcastFrequency)));
         }
 
-        public void SpreadMessage(IRadio source, EntityUid speaker, string message, RadioChannelPrototype channel)
+        public void SpreadMessage(IRadio source, EntityUid speaker, string message, RadioChannelPrototype channel, bool announcement = false)
         {
             if (_messages.Contains(message)) return;
 
@@ -43,7 +43,7 @@ namespace Content.Server.Radio.EntitySystems
 
             foreach (var radio in EntityManager.EntityQuery<IRadio>(true))
             {
-                radio.Receive(message, channel, speaker);
+                radio.Receive(message, channel, speaker, announcement);
             }
 
             _messages.Remove(message);

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -322,7 +322,7 @@ namespace Content.Server.Salvage
 
             var message = args.Length == 0 ? Loc.GetString(messageKey) : Loc.GetString(messageKey, args);
             var channel = _prototypeManager.Index<RadioChannelPrototype>(channelName);
-            _radioSystem.SpreadMessage(radio, source, message, channel);
+            _radioSystem.SpreadMessage(radio, source, message, channel, true);
         }
 
         private void Transition(SalvageMagnetComponent magnet, TimeSpan currentTime)

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -1,5 +1,6 @@
 # Chat window radio wrap (prefix and postfix)
 chat-radio-message-wrap = [color={$color}]{$channel} {$name} says: "{"{"}0{"}"}"[/color]
+announcement-radio-message-wrap = [color={$color}]{$channel} Announcement: {"{"}0{"}"}[/color]
 
 examine-radio-frequency = It's set to broadcast over the {$frequency} frequency.
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The salvage magnet no longer "says" anything. This PR provides a way to define a radio message as an announcement, so that the message is a lot cleaner looking over the radio.
This also accounts for the requested change in #10001 (if-else)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/1261392/195759985-60b69249-715f-4f63-a71f-2c058fdba61e.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Salvage magnet can no longer speak