### PR TITLE
Disable gamemode vote if only one available

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -103,21 +103,7 @@ namespace Content.Server.Voting.Managers
 
         private void CreatePresetVote(IPlayerSession? initiator)
         {
-            var presets = new Dictionary<string, string>();
-
-            foreach (var preset in _prototypeManager.EnumeratePrototypes<GamePresetPrototype>())
-            {
-                if(!preset.ShowInVote)
-                    continue;
-
-                if(_playerManager.PlayerCount < (preset.MinPlayers ?? int.MinValue))
-                    continue;
-
-                if(_playerManager.PlayerCount > (preset.MaxPlayers ?? int.MaxValue))
-                    continue;
-
-                presets[preset.ID] = preset.ModeTitle;
-            }
+            var presets = GetGamePresets();
 
             var alone = _playerManager.PlayerCount == 1 && initiator != null;
             var options = new VoteOptions
@@ -210,6 +196,26 @@ namespace Content.Server.Voting.Managers
             var timeout = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteSameTypeTimeout));
             _standardVoteTimeout[type] = _timing.RealTime + timeout;
             DirtyCanCallVoteAll();
+        }
+
+        private Dictionary<string, string> GetGamePresets()
+        {
+            var presets = new Dictionary<string, string>();
+
+            foreach (var preset in _prototypeManager.EnumeratePrototypes<GamePresetPrototype>())
+            {
+                if(!preset.ShowInVote)
+                    continue;
+
+                if(_playerManager.PlayerCount < (preset.MinPlayers ?? int.MinValue))
+                    continue;
+
+                if(_playerManager.PlayerCount > (preset.MaxPlayers ?? int.MaxValue))
+                    continue;
+
+                presets[preset.ID] = preset.ModeTitle;
+            }
+            return presets;
         }
     }
 }

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -6,6 +6,7 @@ using Content.Server.Administration;
 using Content.Server.Administration.Managers;
 using Content.Server.Afk;
 using Content.Server.Chat.Managers;
+using Content.Server.GameTicking;
 using Content.Server.Maps;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
@@ -326,9 +327,14 @@ namespace Content.Server.Voting.Managers
             if (voteType == StandardVoteType.Restart && _cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
                 return false;
 
-            // If only one (or less) Preset available thats not really a vote
-            if (voteType == StandardVoteType.Preset && GetGamePresets().Count() <= 1)
-                return false;
+            // If only one Preset available thats not really a vote
+            // Still allow vote if availbable one is different from current one
+            if (voteType == StandardVoteType.Preset)
+            {
+                var presets = GetGamePresets();
+                if (presets.Count() == 1 && presets.Select(x => x.Key).Single() == EntitySystem.Get<GameTicker>().Preset?.ID)
+                    return false;
+            }
 
             return !_voteTimeout.TryGetValue(initiator.UserId, out timeSpan);
         }

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -326,6 +326,10 @@ namespace Content.Server.Voting.Managers
             if (voteType == StandardVoteType.Restart && _cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
                 return false;
 
+            // If only one (or less) Preset available thats not really a vote
+            if (voteType == StandardVoteType.Preset && GetGamePresets().Count() <= 1)
+                return false;
+
             return !_voteTimeout.TryGetValue(initiator.UserId, out timeSpan);
         }
 


### PR DESCRIPTION
## About the PR
See the title.
It is about getting rid of the vote for the Secret mode that no one cares about.

**Changelog**

:cl:
- remove: You can no longer call a vote for gamemode if only one is available.

