### PR TITLE
QoL for the MapRenderer tool

### DIFF
--- a/Content.MapRenderer/Program.cs
+++ b/Content.MapRenderer/Program.cs
@@ -27,6 +27,8 @@ namespace Content.MapRenderer
         {
             if (args.Length == 0)
             {
+                Console.WriteLine("Didn't specify any maps to paint! Loading the map list...");
+                
                 await using var server = await PoolManager.GetServerClient();
                 var mapIds = server.Pair.Server
                     .ResolveDependency<IPrototypeManager>()
@@ -36,8 +38,10 @@ namespace Content.MapRenderer
 
                 Array.Sort(mapIds);
 
-                Console.WriteLine("Didn't specify any maps to paint, select one, multiple separated by commas or \"all\":");
-                Console.WriteLine(string.Join('\n', mapIds.Select((id, i) => $"({i}): {id}")));
+                Console.WriteLine("Map List");
+                Console.WriteLine(string.Join('\n', mapIds.Select((id, i) => $"{i,3}: {id}")));
+                Console.WriteLine("Select one, multiple separated by commas or \"all\":");
+                Console.Write("> ");
                 var input = Console.ReadLine();
                 if (input == null)
                 {
@@ -119,44 +123,52 @@ namespace Content.MapRenderer
 
                 mapViewerData.ParallaxLayers.Add(LayerGroup.DefaultParallax());
                 var directory = Path.Combine(arguments.OutputPath, map);
-                Directory.CreateDirectory(directory);
-
+                
                 var i = 0;
-                await foreach (var renderedGrid in MapPainter.Paint(map))
+                try
                 {
-                    var grid = renderedGrid.Image;
-                    Directory.CreateDirectory(directory);
-
-                    var fileName = Path.GetFileNameWithoutExtension(map);
-                    var savePath = $"{directory}{Path.DirectorySeparatorChar}{fileName}-{i}.{arguments.Format.ToString()}";
-
-                    Console.WriteLine($"Writing grid of size {grid.Width}x{grid.Height} to {savePath}");
-
-                    switch (arguments.Format)
+                    await foreach (var renderedGrid in MapPainter.Paint(map))
                     {
-                        case OutputFormat.webp:
-                            var encoder = new WebpEncoder
-                            {
-                                Method = WebpEncodingMethod.BestQuality,
-                                FileFormat = WebpFileFormatType.Lossless,
-                                TransparentColorMode = WebpTransparentColorMode.Preserve
-                            };
+                        var grid = renderedGrid.Image;
+                        Directory.CreateDirectory(directory);
 
-                            await grid.SaveAsync(savePath, encoder);
-                            break;
+                        var fileName = Path.GetFileNameWithoutExtension(map);
+                        var savePath = $"{directory}{Path.DirectorySeparatorChar}{fileName}-{i}.{arguments.Format.ToString()}";
 
-                        default:
-                        case OutputFormat.png:
-                            await grid.SaveAsPngAsync(savePath);
-                            break;
+                        Console.WriteLine($"Writing grid of size {grid.Width}x{grid.Height} to {savePath}");
+
+                        switch (arguments.Format)
+                        {
+                            case OutputFormat.webp:
+                                var encoder = new WebpEncoder
+                                {
+                                    Method = WebpEncodingMethod.BestQuality,
+                                    FileFormat = WebpFileFormatType.Lossless,
+                                    TransparentColorMode = WebpTransparentColorMode.Preserve
+                                };
+
+                                await grid.SaveAsync(savePath, encoder);
+                                break;
+
+                            default:
+                            case OutputFormat.png:
+                                await grid.SaveAsPngAsync(savePath);
+                                break;
+                        }
+
+                        grid.Dispose();
+
+                        mapViewerData.Grids.Add(new GridLayer(renderedGrid, Path.Combine(map, Path.GetFileName(savePath))));
+
+                        mapNames.Add(fileName);
+                        i++;
                     }
-
-                    grid.Dispose();
-
-                    mapViewerData.Grids.Add(new GridLayer(renderedGrid,  Path.Combine(map, Path.GetFileName(savePath))));
-
-                    mapNames.Add(fileName);
-                    i++;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Painting map {map} failed due to an internal exception:");
+                    Console.WriteLine(ex);
+                    continue;
                 }
 
                 if (arguments.ExportViewerJson)
@@ -168,7 +180,8 @@ namespace Content.MapRenderer
 
             var mapNamesString = $"[{string.Join(',', mapNames.Select(s => $"\"{s}\""))}]";
             Console.WriteLine($@"::set-output name=map_names::{mapNamesString}");
-            Console.WriteLine($"Created {arguments.Maps.Count} map images.");
+            Console.WriteLine($"Processed {arguments.Maps.Count} maps.");
+            Console.WriteLine($"It's now safe to manually exit the process (automatic exit in a few moments...)");
         }
     }
 }


### PR DESCRIPTION
```
Didn't specify any maps to paint! Loading the map list...
Map List
  0: Bagel
  1: Box
  2: CentComm
  3: Dart
  4: Empty
  5: Infiltrator
  6: Kettle
  7: Lighthouse
  8: Marathon
  9: Omega
 10: Packed
 11: Pillar
 12: Pirate
 13: Saltern
 14: Split
Select one, multiple separated by commas or "all":
>
```

When run without arguments:
- Write the warning immediately and say that we're now loading the map list. Helps to know what's going on.
- Move the instructions right next to the input
- Add the little input expected caret so my empty brain is reminded that the program wants input

General:
- Only create directories for successfully generated images
- `Try/Catch` the paint method, to facilitate the `all` option
- Also when running with `all`, quite a few pairs can be opened in parallel and it takes a hot minuite for all of them to close, so I added a message about it being safe to just kill the process (it's safe to just kill the process right?).
  - I mildly looked into doing the shutdown properly, but decided it's out of scope 🙃 