### PR TITLE
Fix inventory containers

### DIFF
--- a/Content.Client/Clothing/ClothingVisualsSystem.cs
+++ b/Content.Client/Clothing/ClothingVisualsSystem.cs
@@ -172,7 +172,8 @@ public sealed class ClothingVisualsSystem : EntitySystem
 
     public void InitClothing(EntityUid uid, ClientInventoryComponent? component = null, SpriteComponent? sprite = null)
     {
-        if (!_inventorySystem.TryGetSlots(uid, out var slots, component) || !Resolve(uid, ref sprite, ref component)) return;
+        if (!Resolve(uid, ref sprite, ref component) || !_inventorySystem.TryGetSlots(uid, out var slots, component))
+            return;
 
         foreach (var slot in slots)
         {

--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -43,7 +43,6 @@ namespace Content.Client.Inventory
             SubscribeLocalEvent<ClientInventoryComponent, PlayerAttachedEvent>(OnPlayerAttached);
             SubscribeLocalEvent<ClientInventoryComponent, PlayerDetachedEvent>(OnPlayerDetached);
 
-            SubscribeLocalEvent<ClientInventoryComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<ClientInventoryComponent, ComponentShutdown>(OnShutdown);
 
             SubscribeLocalEvent<ClientInventoryComponent, DidEquipEvent>((_, comp, args) =>
@@ -145,16 +144,17 @@ namespace Content.Client.Inventory
             base.Shutdown();
         }
 
-        private void OnInit(EntityUid uid, ClientInventoryComponent component, ComponentInit args)
+        protected override void OnInit(EntityUid uid, InventoryComponent component, ComponentInit args)
         {
-            _clothingVisualsSystem.InitClothing(uid, component);
+            base.OnInit(uid, component, args);
+            _clothingVisualsSystem.InitClothing(uid, (ClientInventoryComponent) component);
 
             if (!_prototypeManager.TryIndex(component.TemplateId, out InventoryTemplatePrototype? invTemplate))
                 return;
 
             foreach (var slot in invTemplate.Slots)
             {
-                TryAddSlotDef(uid, component, slot);
+                TryAddSlotDef(uid, (ClientInventoryComponent)component, slot);
             }
         }
 
@@ -190,7 +190,6 @@ namespace Content.Client.Inventory
             SlotData newSlotData = newSlotDef; //convert to slotData
             if (!component.SlotData.TryAdd(newSlotDef.Name, newSlotData))
                 return false;
-
 
             if (owner == _playerManager.LocalPlayer?.ControlledEntity)
                 OnSlotAdded?.Invoke(newSlotData);
@@ -283,6 +282,8 @@ namespace Content.Client.Inventory
             public EntityUid? HeldEntity => Container?.ContainedEntity;
             public bool Blocked;
             public bool Highlighted;
+
+            [ViewVariables]
             public ContainerSlot? Container;
             public bool HasSlotGroup => SlotDef.SlotGroup != "Default";
             public Vector2i ButtonOffset => SlotDef.UIWindowPosition;

--- a/Content.IntegrationTests/Tests/DeleteInventoryTest.cs
+++ b/Content.IntegrationTests/Tests/DeleteInventoryTest.cs
@@ -33,11 +33,11 @@ namespace Content.IntegrationTests.Tests
 
                 var entMgr = IoCManager.Resolve<IEntityManager>();
                 var container = entMgr.SpawnEntity(null, MapCoordinates.Nullspace);
-                entMgr.AddComponent<ServerInventoryComponent>(container);
-                entMgr.AddComponent<ContainerManagerComponent>(container);
+                entMgr.EnsureComponent<ServerInventoryComponent>(container);
+                entMgr.EnsureComponent<ContainerManagerComponent>(container);
 
                 var child = entMgr.SpawnEntity(null, MapCoordinates.Nullspace);
-                var item = entMgr.AddComponent<ClothingComponent>(child);
+                var item = entMgr.EnsureComponent<ClothingComponent>(child);
 
                 IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ClothingSystem>().SetSlots(item.Owner, SlotFlags.HEAD, item);
 

--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -37,7 +37,8 @@ public partial class InventorySystem : EntitySystem
 
         if (!containerComp.TryGetContainer(slotDefinition.Name, out var container))
         {
-            Logger.Error($"Missing inventory container {slot} on entity {ToPrettyString(uid)}");
+            if (inventory.LifeStage >= ComponentLifeStage.Initialized)
+                Logger.Error($"Missing inventory container {slot} on entity {ToPrettyString(uid)}");
             return false;
         }
 

--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 
@@ -7,6 +7,22 @@ namespace Content.Shared.Inventory;
 public partial class InventorySystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    private void InitializeSlots()
+    {
+        SubscribeLocalEvent<InventoryComponent, ComponentInit>(OnInit);
+    }
+
+    protected virtual void OnInit(EntityUid uid, InventoryComponent component, ComponentInit args)
+    {
+        if (!_prototypeManager.TryIndex(component.TemplateId, out InventoryTemplatePrototype? invTemplate))
+            return;
+
+        foreach (var slot in invTemplate.Slots)
+        {
+            _containerSystem.EnsureContainer<ContainerSlot>(uid, slot.Name).OccludesLight = false;
+        }
+    }
 
     public bool TryGetSlotContainer(EntityUid uid, string slot, [NotNullWhen(true)] out ContainerSlot? containerSlot, [NotNullWhen(true)] out SlotDefinition? slotDefinition,
         InventoryComponent? inventory = null, ContainerManagerComponent? containerComp = null)
@@ -21,9 +37,8 @@ public partial class InventorySystem : EntitySystem
 
         if (!containerComp.TryGetContainer(slotDefinition.Name, out var container))
         {
-            containerSlot = containerComp.MakeContainer<ContainerSlot>(slotDefinition.Name);
-            containerSlot.OccludesLight = false;
-            return true;
+            Logger.Error($"Missing inventory container {slot} on entity {ToPrettyString(uid)}");
+            return false;
         }
 
         if (container is not ContainerSlot containerSlotChecked) return false;

--- a/Content.Shared/Inventory/InventorySystem.cs
+++ b/Content.Shared/Inventory/InventorySystem.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Shared.Inventory;
+namespace Content.Shared.Inventory;
 
 public partial class InventorySystem
 {
@@ -8,5 +8,6 @@ public partial class InventorySystem
         base.Initialize();
         InitializeEquip();
         InitializeRelay();
+        InitializeSlots();
     }
 }


### PR DESCRIPTION
Currently inventory containers only get added on init by clients, with deferred adding by the server. This leads to issues where the client can then end up deleting those containers when receiving server states, which messes with the inventory UI as it cached the (now deleted) containers.

This PR just makes sure the containers are added on init in shared code.

:cl:
- fix: Fixed a bug that was preventing the inventory UI from properly updating in some situations.

