### PR TITLE
Adds logging to stripping and construction starting

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Content.Server.Administration.Logs;
 using Content.Server.Construction.Components;
 using Content.Server.DoAfter;
 using Content.Server.Hands.Components;
@@ -10,6 +11,7 @@ using Content.Shared.Construction;
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Construction.Steps;
 using Content.Shared.Coordinates;
+using Content.Shared.Database;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
@@ -481,7 +483,7 @@ namespace Content.Server.Construction
             EntityManager.GetComponent<TransformComponent>(structure).Anchored = wasAnchored;
 
             RaiseNetworkEvent(new AckStructureConstructionMessage(ev.Ack));
-
+            _adminLogger.Add(LogType.Construction, LogImpact.Low, $"{ToPrettyString(user):player} has started construction on the ghost of a {ev.PrototypeName}");
             Cleanup();
         }
     }

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -172,7 +172,7 @@ namespace Content.Server.Construction
                 ChangeNode(uid, user, edge.Target, true, construction);
 
                 if (ev is ConstructionDoAfterComplete event1 && event1.WrappedEvent is InteractUsingEvent event2)
-                    _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(event2.User):player} changed {ToPrettyString(uid):entity}'s node to {edge.Target}");
+                    _adminLogger.Add(LogType.Construction, LogImpact.Low, $"{ToPrettyString(event2.User):player} changed {ToPrettyString(uid):entity}'s node to {edge.Target}");
             }
 
             return HandleResult.True;

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -206,7 +206,7 @@ namespace Content.Server.Strip
             {
                 _inventorySystem.TryEquip(user, component.Owner, held, slot);
 
-                _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):player} has placed the item {ToPrettyString(held):item} in {ToPrettyString(component.Owner):player}'s {slot} slot");
+                _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):user} has placed the item {ToPrettyString(held):item} in {ToPrettyString(component.Owner):target}'s {slot} slot");
             }
 
 
@@ -271,7 +271,7 @@ namespace Content.Server.Strip
 
             _handsSystem.TryDrop(user, checkActionBlocker: false, handsComp: userHands);
             _handsSystem.TryPickup(component.Owner, held, handName, checkActionBlocker: false, animateUser: true, handsComp: hands);
-            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):player} has placed the item {ToPrettyString(held):item} in {ToPrettyString(component.Owner):player}'s hands");
+            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):user} has placed the item {ToPrettyString(held):item} in {ToPrettyString(component.Owner):target}'s hands");
             // hand update will trigger strippable update
         }
 
@@ -342,7 +342,7 @@ namespace Content.Server.Strip
                 RaiseLocalEvent(item.Value, new DroppedEvent(user), true);
 
                 _handsSystem.PickupOrDrop(user, item.Value);
-                _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):player} has stripped the item {ToPrettyString(item.Value):item} from {ToPrettyString(component.Owner):player}");
+                _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):user} has stripped the item {ToPrettyString(item.Value):item} from {ToPrettyString(component.Owner):target}");
             }
         }
 
@@ -404,7 +404,7 @@ namespace Content.Server.Strip
             _handsSystem.TryDrop(component.Owner, hand, checkActionBlocker: false, handsComp: hands);
             _handsSystem.PickupOrDrop(user, held, handsComp: userHands);
             // hand update will trigger strippable update
-            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):player} has stripped the item {ToPrettyString(held):item} from {ToPrettyString(component.Owner):player}");
+            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):user} has stripped the item {ToPrettyString(held):item} from {ToPrettyString(component.Owner):target}");
         }
 
         private sealed class OpenStrippingCompleteEvent

--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -15,6 +15,8 @@ using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using System.Threading;
+using Content.Server.Administration.Logs;
+using Content.Shared.Database;
 
 namespace Content.Server.Strip
 {
@@ -26,6 +28,7 @@ namespace Content.Server.Strip
         [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
         [Dependency] private readonly EnsnareableSystem _ensnaring = default!;
         [Dependency] private readonly UserInterfaceSystem _userInterfaceSystem = default!;
+        [Dependency] private readonly IAdminLogManager _adminLogger = default!;
 
         // TODO: ECS popups. Not all of these have ECS equivalents yet.
 
@@ -202,7 +205,11 @@ namespace Content.Server.Strip
                 && _handsSystem.TryDrop(user, userHands.ActiveHand, handsComp: userHands))
             {
                 _inventorySystem.TryEquip(user, component.Owner, held, slot);
+
+                _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):player} has placed the item {ToPrettyString(held):item} in {ToPrettyString(component.Owner):player}'s {slot} slot");
             }
+
+
         }
 
         /// <summary>
@@ -264,6 +271,7 @@ namespace Content.Server.Strip
 
             _handsSystem.TryDrop(user, checkActionBlocker: false, handsComp: userHands);
             _handsSystem.TryPickup(component.Owner, held, handName, checkActionBlocker: false, animateUser: true, handsComp: hands);
+            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):player} has placed the item {ToPrettyString(held):item} in {ToPrettyString(component.Owner):player}'s hands");
             // hand update will trigger strippable update
         }
 
@@ -334,6 +342,7 @@ namespace Content.Server.Strip
                 RaiseLocalEvent(item.Value, new DroppedEvent(user), true);
 
                 _handsSystem.PickupOrDrop(user, item.Value);
+                _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):player} has stripped the item {ToPrettyString(item.Value):item} from {ToPrettyString(component.Owner):player}");
             }
         }
 
@@ -395,6 +404,7 @@ namespace Content.Server.Strip
             _handsSystem.TryDrop(component.Owner, hand, checkActionBlocker: false, handsComp: hands);
             _handsSystem.PickupOrDrop(user, held, handsComp: userHands);
             // hand update will trigger strippable update
+            _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):player} has stripped the item {ToPrettyString(held):item} from {ToPrettyString(component.Owner):player}");
         }
 
         private sealed class OpenStrippingCompleteEvent

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -77,4 +77,5 @@ public enum LogType
     CableCut = 72,
     StorePurchase = 73,
     LatticeCut = 74,
+    Stripping = 75,
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title is pretty descriptive!
Fix #11900

I've created a new log filter (in attempts to make Admin Logs searching easier to navigate) called "Stripping", which will log all stripping events.
New logs will be added everytime someone takes something from someone's hand OR inventory, and also when someone PLACES something to someone else's hands or inventory.

I've also solved an issue with construction logging, where the first step of a construction did not get logged and, in constructions that only have one step, such as Griles, they wouldn't get logged due to that.

No pics because tired 3 AM coding, pls forgib.