### PR TITLE
Update construction exception logging

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -268,7 +268,11 @@ namespace Content.Server.Construction
             ContainerManagerComponent? containerManager = null)
         {
             if (!Resolve(uid, ref construction, ref metaData, ref transform))
-                return null;
+            {
+                // Failed resolve logs an error, but we want to actually log information about the failed construction
+                // graph. So lets let the UpdateInteractions() try-catch log that info for us.
+                throw new Exception("Missing construction components");
+            }
 
             if (newEntity == metaData.EntityPrototype?.ID || !_prototypeManager.HasIndex<EntityPrototype>(newEntity))
                 return null;


### PR DESCRIPTION
There are a bunch of grafana errors like this:
```
Can't resolve "Robust.Shared.GameObjects.TransformComponent" on entity 178595!
   at Content.Server.Construction.ConstructionSystem.ChangeEntity(EntityUid uid, Nullable`1 userUid, String newEntity, ConstructionComponent construction, MetaDataComponent metaData, TransformComponent transform, ContainerManagerComponent containerManager) in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Graph.cs:line 270
   at Content.Server.Construction.ConstructionSystem.ChangeNode(EntityUid uid, Nullable`1 userUid, String id, Boolean performActions, ConstructionComponent construction) in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Graph.cs:line 236
   at Content.Server.Construction.ConstructionSystem.HandleEdge(EntityUid uid, Object ev, ConstructionGraphEdge edge, Boolean validation, ConstructionComponent construction) in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Interactions.cs:line 172
   at Content.Server.Construction.ConstructionSystem.HandleEvent(EntityUid uid, Object ev, Boolean validation, ConstructionComponent construction, InteractUsingEvent args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Interactions.cs:line 65
   at Content.Server.Construction.ConstructionSystem.UpdateInteractions() in /home/runner/work/space-station-14/space-station-14/Content.Server/Construction/ConstructionSystem.Interactions.cs:line 466
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 302
   at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 133
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 147
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 673
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 213
   at Robust.Server.BaseServer.MainLoop() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 520
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 75
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 46
   at Robust.Server.Program.Main(String[] args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/Program.cs:line 25
```

This isn't very graceful, but at least this should change these errors so that the construction graph type gets logged to help identify the problematic entities/graphs.