### PR TITLE
Seed extractor construction + upgrading

### DIFF
--- a/Content.Server/Botany/Components/SeedExtractorComponent.cs
+++ b/Content.Server/Botany/Components/SeedExtractorComponent.cs
@@ -1,4 +1,7 @@
 using Content.Server.Botany.Systems;
+using Content.Server.Construction;
+using Content.Shared.Construction.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Botany.Components;
 
@@ -6,8 +9,27 @@ namespace Content.Server.Botany.Components;
 [Access(typeof(SeedExtractorSystem))]
 public sealed class SeedExtractorComponent : Component
 {
-    // TODO: Upgradeable machines.
-    [DataField("minSeeds")] public int MinSeeds = 1;
+    /// <summary>
+    /// The minimum amount of seed packets dropped with no machine upgrades.
+    /// </summary>
+    [DataField("baseMinSeeds"), ViewVariables(VVAccess.ReadWrite)]
+    public int BaseMinSeeds = 1;
 
-    [DataField("maxSeeds")] public int MaxSeeds = 4;
+    /// <summary>
+    /// The maximum amount of seed packets dropped with no machine upgrades.
+    /// </summary>
+    [DataField("baseMaxSeeds"), ViewVariables(VVAccess.ReadWrite)]
+    public int BaseMaxSeeds = 3;
+
+    /// <summary>
+    /// Modifier to the amount of seeds outputted, set on <see cref="RefreshPartsEvent"/>.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int SeedAmountModifier;
+
+    /// <summary>
+    /// Machine part whose rating modifies the amount of seed packets dropped.
+    /// </summary>
+    [DataField("machinePartYieldAmount", customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>))]
+    public string MachinePartSeedAmount = "Manipulator";
 }

--- a/Content.Server/Botany/Components/SeedExtractorComponent.cs
+++ b/Content.Server/Botany/Components/SeedExtractorComponent.cs
@@ -25,11 +25,18 @@ public sealed class SeedExtractorComponent : Component
     /// Modifier to the amount of seeds outputted, set on <see cref="RefreshPartsEvent"/>.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public int SeedAmountModifier;
+    public float SeedAmountMultiplier;
 
     /// <summary>
     /// Machine part whose rating modifies the amount of seed packets dropped.
     /// </summary>
     [DataField("machinePartYieldAmount", customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>))]
     public string MachinePartSeedAmount = "Manipulator";
+
+    /// <summary>
+    /// How much the machine part quality affects the amount of seeds outputted.
+    /// Going up a tier will multiply the seed output by this amount.
+    /// </summary>
+    [DataField("partRatingSeedAmountMultiplier"), ViewVariables]
+    public float PartRatingSeedAmountMultiplier = 1.5f;
 }

--- a/Content.Server/Botany/Systems/SeedExtractorSystem.cs
+++ b/Content.Server/Botany/Systems/SeedExtractorSystem.cs
@@ -1,6 +1,6 @@
 using Content.Server.Botany.Components;
+using Content.Server.Construction;
 using Content.Server.Popups;
-using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
@@ -20,9 +20,10 @@ public sealed class SeedExtractorSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SeedExtractorComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<SeedExtractorComponent, RefreshPartsEvent>(OnRefreshParts);
     }
 
-    private void OnInteractUsing(EntityUid uid, SeedExtractorComponent component, InteractUsingEvent args)
+    private void OnInteractUsing(EntityUid uid, SeedExtractorComponent seedExtractor, InteractUsingEvent args)
     {
         if (!this.IsPowered(uid, EntityManager))
             return;
@@ -40,15 +41,20 @@ public sealed class SeedExtractorSystem : EntitySystem
 
         QueueDel(args.Used);
 
-        var random = _random.Next(component.MinSeeds, component.MaxSeeds);
+        var amount = _random.Next(seedExtractor.BaseMinSeeds, seedExtractor.BaseMaxSeeds + 1) + seedExtractor.SeedAmountModifier;
         var coords = Transform(uid).Coordinates;
 
-        if (random > 1)
+        if (amount > 1)
             seed.Unique = false;
 
-        for (var i = 0; i < random; i++)
+        for (var i = 0; i < amount; i++)
         {
             _botanySystem.SpawnSeedPacket(seed, coords);
         }
+    }
+
+    private void OnRefreshParts(EntityUid uid, SeedExtractorComponent seedExtractor, RefreshPartsEvent args)
+    {
+        seedExtractor.SeedAmountModifier = (int) args.PartRatings[seedExtractor.MachinePartSeedAmount] - 1;
     }
 }

--- a/Content.Server/Botany/Systems/SeedExtractorSystem.cs
+++ b/Content.Server/Botany/Systems/SeedExtractorSystem.cs
@@ -41,7 +41,7 @@ public sealed class SeedExtractorSystem : EntitySystem
 
         QueueDel(args.Used);
 
-        var amount = _random.Next(seedExtractor.BaseMinSeeds, seedExtractor.BaseMaxSeeds + 1) + seedExtractor.SeedAmountModifier;
+        var amount = (int) _random.NextFloat(seedExtractor.BaseMinSeeds, seedExtractor.BaseMaxSeeds + 1) * seedExtractor.SeedAmountMultiplier;
         var coords = Transform(uid).Coordinates;
 
         if (amount > 1)
@@ -55,6 +55,7 @@ public sealed class SeedExtractorSystem : EntitySystem
 
     private void OnRefreshParts(EntityUid uid, SeedExtractorComponent seedExtractor, RefreshPartsEvent args)
     {
-        seedExtractor.SeedAmountModifier = (int) args.PartRatings[seedExtractor.MachinePartSeedAmount] - 1;
+        var manipulatorQuality = args.PartRatings[seedExtractor.MachinePartSeedAmount];
+        seedExtractor.SeedAmountMultiplier = MathF.Pow(seedExtractor.PartRatingSeedAmountMultiplier, manipulatorQuality - 1);
     }
 }

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -66,6 +66,7 @@
     - Shovel
     - ButchCleaver
     - MicrowaveMachineCircuitboard
+    - SeedExtractorMachineCircuitboard
 
 - type: technology
   name: technologies-advanced-surgery

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -309,6 +309,26 @@
           ExamineName: Glass Beaker
 
 - type: entity
+  id: SeedExtractorMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: seed extractor machine board
+  description: A machine printed circuit board for a seed extractor
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: SeedExtractor
+      # See: https://github.com/vgstation-coders/vgstation13/blob/e9a806f30b4db0efa2a68b9eb42e3120d2321b6a/code/modules/hydroponics/seed_extractor.dm#L21
+      requirements:
+        Manipulator: 2
+        MatterBin: 1
+        Laser: 1
+        ScanningModule: 1
+      materialRequirements:
+        # replacing the console screen
+        Glass: 1
+
+- type: entity
   id: SMESMachineCircuitboard
   parent: BaseMachineCircuitboard
   name: SMES machine board

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -318,15 +318,13 @@
       state: service
     - type: MachineBoard
       prototype: SeedExtractor
-      # See: https://github.com/vgstation-coders/vgstation13/blob/e9a806f30b4db0efa2a68b9eb42e3120d2321b6a/code/modules/hydroponics/seed_extractor.dm#L21
       requirements:
         Manipulator: 2
-        MatterBin: 1
-        Laser: 1
-        ScanningModule: 1
+        Capacitor: 1
       materialRequirements:
         # replacing the console screen
         Glass: 1
+        Cable: 2
 
 - type: entity
   id: SMESMachineCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -288,6 +288,7 @@
       - WallmountSubstationElectronics
       - EmitterCircuitboard
       - GasRecyclerMachineCircuitboard
+      - SeedExtractorMachineCircuitboard
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/seed_extractor.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/seed_extractor.yml
@@ -27,3 +27,6 @@
   - type: SeedExtractor
   - type: Machine
     board: SeedExtractorMachineCircuitboard
+  - type: UpgradePowerDraw
+    powerDrawMultiplier: 0.75
+    scaling: Exponential

--- a/Resources/Prototypes/Entities/Structures/Machines/seed_extractor.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/seed_extractor.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: SeedExtractor
   name: seed extractor
-  parent: BaseMachinePowered
+  parent: [ BaseMachinePowered, ConstructibleMachine ]
   description: Extracts seeds from produce.
   components:
   - type: Sprite
@@ -25,3 +25,5 @@
       layer:
       - MachineLayer
   - type: SeedExtractor
+  - type: Machine
+    board: SeedExtractorMachineCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -404,11 +404,20 @@
   materials:
     Steel: 100
     Glass: 900
-    
+
 - type: latheRecipe
   id: GasRecyclerMachineCircuitboard
   icon: Objects/Misc/module.rsi/id_mod.png
   result: GasRecyclerMachineCircuitboard
+  completetime: 4
+  materials:
+    Steel: 100
+    Glass: 900
+
+- type: latheRecipe
+  id: SeedExtractorMachineCircuitboard
+  icon: Objects/Misc/module.rsi/id_mod.png
+  result: SeedExtractorMachineCircuitboard
   completetime: 4
   materials:
     Steel: 100


### PR DESCRIPTION
- Add construction, circuit board printable after unlocking adv botany.
- Add upgrading, each manipulator tier ~~increases seed output by 1~~ **increases seed output by 50%**. (#11530)
- It may look like I nerfed seed extractors by changing `MaxSeeds` from 4 to 3, but it was actually 3 before also because `MaxSeeds` was directly passed as second arg to `Random.Next` which is an exclusive limit. Now it passes `MaxSeeds + 1` instead which fixes this bug.
- Add `UpgradePowerDrawComponent`.

**Changelog**
:cl:
- add: Sci can now print seed extractor machine boards after unlocking advanced botany. They can be upgraded with better manipulators (seed output) and capacitors (power efficiency).