### PR TITLE
Adds DiseaseProtection to SimpleMobs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -207,4 +207,4 @@
   - type: MobPrice
     price: 150
   - type: DiseaseProtection
-    protection: 1
+    protection: 0.9

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -207,4 +207,4 @@
   - type: MobPrice
     price: 150
   - type: DiseaseProtection
-    protection: 0.9
+    protection: 1

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -206,4 +206,5 @@
     bloodMaxVolume: 150
   - type: MobPrice
     price: 150
-
+  - type: DiseaseProtection
+    protection: 1


### PR DESCRIPTION
The idea is that insects/animals don't commonly share diseases with humans, so to me, not having this doesn't make much sense.

It also allows for some balancing, as fully populated stations with a pandemic are a big problem to deal with. If SimpleMobs can continue the spread, it kinda exacerbates things.

Prevents this:
![image](https://user-images.githubusercontent.com/52474532/196045815-d32bff1b-86e8-40fa-8a22-37eaf0214035.png)


:cl:
- tweak: Simple Mobs cannot get diseases anymore!