### PR TITLE
Airlock bolt and deconstruction fixes

### DIFF
--- a/Content.Client/Doors/AirlockComponent.cs
+++ b/Content.Client/Doors/AirlockComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Doors.Components;
-using Robust.Shared.GameObjects;
 
 namespace Content.Client.Doors;
 

--- a/Content.Server/Construction/Conditions/AllWiresCut.cs
+++ b/Content.Server/Construction/Conditions/AllWiresCut.cs
@@ -1,9 +1,7 @@
-﻿using System.Linq;
-using Content.Server.Wires;
+﻿using Content.Server.Wires;
 using Content.Shared.Construction;
 using Content.Shared.Examine;
 using JetBrains.Annotations;
-using Robust.Shared.Reflection;
 
 namespace Content.Server.Construction.Conditions
 {
@@ -17,22 +15,13 @@ namespace Content.Server.Construction.Conditions
     {
         [DataField("value")] public bool Value { get; private set; } = true;
 
-        [DataField("ignoreTypes")] public HashSet<IWireAction> IgnoreTypes { get; } = new();
-
         public bool Condition(EntityUid uid, IEntityManager entityManager)
         {
             if (!entityManager.TryGetComponent(uid, out WiresComponent? wires))
                 return true;
 
-            var ignoreTypes = IgnoreTypes.Select(t => t.GetType()).ToHashSet();
-
             foreach (var wire in wires.WiresList)
             {
-                if (ignoreTypes.Contains(wire.Action.GetType()))
-                {
-                    continue;
-                }
-
                 switch (Value)
                 {
                     case true when !wire.IsCut:
@@ -46,6 +35,9 @@ namespace Content.Server.Construction.Conditions
 
         public bool DoExamine(ExaminedEvent args)
         {
+            if (Condition(args.Examined, IoCManager.Resolve<IEntityManager>()))
+                return false;
+
             args.PushMarkup(Loc.GetString(Value
                 ? "construction-examine-condition-all-wires-cut"
                 : "construction-examine-condition-all-wires-intact"));

--- a/Content.Server/Doors/Components/AirlockComponent.cs
+++ b/Content.Server/Doors/Components/AirlockComponent.cs
@@ -113,6 +113,12 @@ namespace Content.Server.Doors.Components
         }
 
         /// <summary>
+        /// True if the bolt wire is cut, which will force the airlock to always be bolted as long as it has power.
+        /// </summary>
+        [ViewVariables]
+        public bool BoltWireCut;
+
+        /// <summary>
         /// Whether the airlock should auto close. This value is reset every time the airlock closes.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -48,6 +48,8 @@ namespace Content.Server.Doors.Systems
             }
             else
             {
+                if (component.BoltWireCut)
+                    component.SetBoltsWithAudio(true);
                 UpdateAutoClose(uid, door: door);
             }
 

--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.Access;
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Construction;
-using Content.Server.Construction.Components;
 using Content.Server.Doors.Components;
 using Content.Server.Tools;
 using Content.Server.Tools.Systems;
@@ -271,7 +270,6 @@ public sealed class DoorSystem : SharedDoorSystem
         if (Tags.HasTag(otherUid, "DoorBumpOpener"))
             TryOpen(uid, door, otherUid);
     }
-
     private void OnEmagged(EntityUid uid, DoorComponent door, GotEmaggedEvent args)
     {
         if(TryComp<AirlockComponent>(uid, out var airlockComponent))

--- a/Content.Server/Doors/WireActions/DoorBoltWireAction.cs
+++ b/Content.Server/Doors/WireActions/DoorBoltWireAction.cs
@@ -38,18 +38,19 @@ public sealed class DoorBoltWireAction : BaseWireAction
     {
         if (EntityManager.TryGetComponent<AirlockComponent>(wire.Owner, out var door))
         {
-            if (!door.BoltsDown)
-            {
+            door.BoltWireCut = true;
+            if (!door.BoltsDown && IsPowered(wire.Owner))
                 door.SetBoltsWithAudio(true);
-            }
         }
 
         return true;
     }
 
-    // does nothing
     public override bool Mend(EntityUid user, Wire wire)
     {
+        if (EntityManager.TryGetComponent<AirlockComponent>(wire.Owner, out var door))
+            door.BoltWireCut = false;
+
         return true;
     }
 

--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -84,8 +84,8 @@ namespace Content.Server.Remotes
                     _doorSystem.TryToggleDoor(doorComp.Owner, doorComp, args.Used);
                     break;
                 case OperatingMode.ToggleBolts:
-                    //TODO: What about cut wires...?
-                    airlockComp.SetBoltsWithAudio(!airlockComp.IsBolted());
+                    if (!airlockComp.BoltWireCut)
+                        airlockComp.SetBoltsWithAudio(!airlockComp.IsBolted());
                     break;
                 case OperatingMode.ToggleEmergencyAccess:
                     _sharedAirlockSystem.ToggleEmergencyAccess(airlockComp);

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -91,8 +91,6 @@
         value: false
       - !type:WirePanel {}
       - !type:AllWiresCut
-        ignoreTypes:
-          - !type:DoorBoltWireAction
       completed:
       - !type:EmptyAllContainers {}
       steps:
@@ -131,8 +129,6 @@
         value: false
       - !type:WirePanel {}
       - !type:AllWiresCut
-        ignoreTypes:
-          - !type:DoorBoltWireAction
       completed:
       - !type:SpawnPrototype
         prototype: SheetRGlass1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/windoor.yml
@@ -113,8 +113,6 @@
         value: false
       - !type:WirePanel {}
       - !type:AllWiresCut
-        ignoreTypes:
-          - !type:DoorBoltWireAction
       completed:
       - !type:EmptyAllContainers {}
       steps:
@@ -216,8 +214,6 @@
       - !type:ContainerNotEmpty # TODO ShadowCommander: Remove when map gets updated
         container: board
       - !type:AllWiresCut
-        ignoreTypes:
-          - !type:DoorBoltWireAction
       completed:
       - !type:EmptyAllContainers {}
       steps:


### PR DESCRIPTION
Deconstructing airlocks is currently bugged, as pointed out by someone on discord. The "all of it's wires must be cut" examine text does not go away even when you meet the condition, thus hiding the next step of the deconstruction process. The condition also didn't match the text, because the condition is "cut all but the bolt wire."

- Airlock can no longer be unbolted with a remote if the bolt wire has been cut.
- Airlock no longer bolts if the bolt wire is cut while it has no power.
- All wires, including the bolt wire, now have to be cut to remove the door electronics from an airlock.
- Fix `AllWiresCut.DoExamine` always returning true and hiding the next deconstruction step.


**Changelog**
:cl:
- fix: Door remotes can no longer unbolt airlocks if the bolt wire is cut.
- tweak: Airlocks will no longer bolt if the bolt wire is cut while it has no power.
- tweak: All wires, including the bolt wire, now have to be cut to remove the door electronics from an airlock.
- fix: Fix a bug where airlock deconstruction examine text wouldn't update after cutting the wires.