### PR TITLE
Disable shadow casting for bioluminescent plants

### DIFF
--- a/Content.Server/Botany/Components/PlantHolderComponent.cs
+++ b/Content.Server/Botany/Components/PlantHolderComponent.cs
@@ -588,6 +588,8 @@ namespace Content.Server.Botany.Components
                 var light = _entMan.EnsureComponent<PointLightComponent>(Owner);
                 light.Radius = Seed.BioluminescentRadius;
                 light.Color = Seed.BioluminescentColor;
+                light.CastShadows = false; // this is expensive, and botanists make lots of plants
+                light.Dirty();
             }
             else
             {

--- a/Content.Server/Botany/Systems/BotanySystem.Seed.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Seed.cs
@@ -167,6 +167,8 @@ public sealed partial class BotanySystem
                 var light = EnsureComp<PointLightComponent>(entity);
                 light.Radius = proto.BioluminescentRadius;
                 light.Color = proto.BioluminescentColor;
+                light.CastShadows = false; // this is expensive, and botanists make lots of plants
+                light.Dirty();
             }
 
             if (proto.Slip)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Shadow casting is relatively expensive compared to point lights, and botanists can produce lots of plants.

Tested with over 1000 bioluminescent wheat bushels on Intel Integrated UHD Graphics 620 (on Kaby Lake GT2) with negligible rise in render time.

Requires https://github.com/space-wizards/RobustToolbox/pull/3346

**Screenshots**
N/A

**Changelog**
N/A