### PR TITLE
No UI Autoclose for books, handheld crew monitor, health analyzer, papers, and PDA when swapping hands

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
@@ -17,7 +17,6 @@
     - Belt
   - type: ActivatableUI
     key: enum.ForensicScannerUiKey.Key
-    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
     - key: enum.ForensicScannerUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
@@ -17,6 +17,7 @@
     - Belt
   - type: ActivatableUI
     key: enum.ForensicScannerUiKey.Key
+    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
     - key: enum.ForensicScannerUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -44,6 +44,7 @@
   - type: ActivatableUI
     key: enum.PDAUiKey.Key
     singleUser: true
+    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
     - key: enum.PDAUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -13,6 +13,7 @@
   - type: Paper
   - type: ActivatableUI
     key: enum.PaperUiKey.Key
+    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
     - key: enum.PaperUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -18,6 +18,7 @@
   - type: Paper
   - type: ActivatableUI
     key: enum.PaperUiKey.Key
+    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
     - key: enum.PaperUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -9,6 +9,7 @@
     state: scanner
   - type: ActivatableUI
     key: enum.CrewMonitoringUIKey.Key
+    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
       - key: enum.CrewMonitoringUIKey.Key

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -10,6 +10,7 @@
     state: analyzer
   - type: ActivatableUI
     key: enum.HealthAnalyzerUiKey.Key
+    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
       - key: enum.HealthAnalyzerUiKey.Key


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Books, handheld crew monitor, health analyzer, papers, and PDA UI no longer close if you swap hands

A bit ago I added the ability for ActivatableUI to not force close a UI when you switch hands. I've added this feature to BaseBook (so any books from that), the handheld crew monitor, health analyzer, papers, and the PDA. This means you can have the UI open as long as the thing remains in your hand. If you get disarmed/knocked down and the item leaves you hand, the UI closes as expected.

I know there is a PDA refactor, if the one line change somehow impacts that, or if there was a general PDA freeze, I can remove the line from the PDA yml. Just lmk!

Note: I originally added it to the forensics scanner, but it turns out that UI stays when swapping hands. It also stays when knocked down. It just stays up until you close it. Not sure if intended, didn't have time to figure out why it was different. My cursory glance at the differences didn't come up with any obvious cause. Probably should be fixed at some point, but I didn't have the time to dive into this deeper.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: ashtronaut
tweak: You can now continue to read books, the handheld crew monitor, health analyzer readouts, papers, and your PDA screen after swapping your active hand as long as they remain in your one of your hands. Remember, multitasking is an efficient use of company time.