### PR TITLE
Sleep NPCs on attach

### DIFF
--- a/Content.Server/Mind/Commands/MakeSentientCommand.cs
+++ b/Content.Server/Mind/Commands/MakeSentientCommand.cs
@@ -44,8 +44,6 @@ namespace Content.Server.Mind.Commands
 
         public static void MakeSentient(EntityUid uid, IEntityManager entityManager, bool allowMovement = true, bool allowSpeech = true)
         {
-            entityManager.RemoveComponent<NPCComponent>(uid);
-
             entityManager.EnsureComponent<MindComponent>(uid);
             if (allowMovement)
             {


### PR DESCRIPTION
Rather than having every caller handle it NPCs will just handle it internally. This also means when controlmob stops they can gracefully resume.

Fixes https://github.com/space-wizards/space-station-14/issues/11587

:cl:
- tweak: NPCs will now always sleep when a player attaches and wake when they leave.