### PR TITLE
Fix chat sanitization and entity name escaping

### DIFF
--- a/Content.Client/Chat/StoredChatMessage.cs
+++ b/Content.Client/Chat/StoredChatMessage.cs
@@ -23,9 +23,9 @@ namespace Content.Client.Chat
         public ChatChannel Channel { get; set; }
 
         /// <summary>
-        ///     What to "wrap" the message contents with. Example is stuff like 'Joe says: "{0}"'
+        ///     Modified message with some wrapping text. E.g. 'Joe says: "HELP!"'
         /// </summary>
-        public string MessageWrap { get; set; }
+        public string WrappedMessage { get; set; }
 
         /// <summary>
         /// The override color of the message
@@ -44,7 +44,7 @@ namespace Content.Client.Chat
         {
             Message = netMsg.Message;
             Channel = netMsg.Channel;
-            MessageWrap = netMsg.MessageWrap;
+            WrappedMessage = netMsg.WrappedMessage;
             MessageColorOverride = netMsg.MessageColorOverride;
         }
     }

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -46,13 +46,7 @@ public partial class ChatBox : UIWidget
 
     private void OnMessageAdded(StoredChatMessage msg)
     {
-        var text = FormattedMessage.EscapeText(msg.Message);
-        if (!string.IsNullOrEmpty(msg.MessageWrap))
-        {
-            text = string.Format(msg.MessageWrap, text);
-        }
-
-        Logger.DebugS("chat", $"{msg.Channel}: {text}");
+        Logger.DebugS("chat", $"{msg.Channel}: {msg.Message}");
         if (!ChatInput.FilterButton.ChatFilterPopup.IsActive(msg.Channel))
         {
             return;
@@ -64,7 +58,7 @@ public partial class ChatBox : UIWidget
             ? msg.MessageColorOverride
             : msg.Channel.TextColor();
 
-        AddLine(text, color);
+        AddLine(msg.WrappedMessage, color);
     }
 
     private void OnChannelSelect(ChatSelectChannel channel)

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -77,8 +77,8 @@ namespace Content.Server.Chat.Managers
 
         public void DispatchServerAnnouncement(string message, Color? colorOverride = null)
         {
-            var messageWrap = Loc.GetString("chat-manager-server-wrap-message");
-            ChatMessageToAll(ChatChannel.Server, message, messageWrap, colorOverride);
+            var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", FormattedMessage.EscapeText(message)));
+            ChatMessageToAll(ChatChannel.Server, message, wrappedMessage, colorOverride);
             Logger.InfoS("SERVER", message);
 
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Server announcement: {message}");
@@ -86,8 +86,8 @@ namespace Content.Server.Chat.Managers
 
         public void DispatchServerMessage(IPlayerSession player, string message)
         {
-            var messageWrap = Loc.GetString("chat-manager-server-wrap-message");
-            ChatMessageToOne(ChatChannel.Server, message, messageWrap, default, false, player.ConnectedClient);
+            var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", FormattedMessage.EscapeText(message)));
+            ChatMessageToOne(ChatChannel.Server, message, wrappedMessage, default, false, player.ConnectedClient);
 
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Server message to {player:Player}: {message}");
         }
@@ -95,12 +95,11 @@ namespace Content.Server.Chat.Managers
         public void SendAdminAnnouncement(string message)
         {
             var clients = _adminManager.ActiveAdmins.Select(p => p.ConnectedClient);
-            message = FormattedMessage.EscapeText(message);
 
-            var messageWrap = Loc.GetString("chat-manager-send-admin-announcement-wrap-message",
-                ("adminChannelName", Loc.GetString("chat-manager-admin-channel-name")));
+            var wrappedMessage = Loc.GetString("chat-manager-send-admin-announcement-wrap-message",
+                ("adminChannelName", Loc.GetString("chat-manager-admin-channel-name")), ("message", FormattedMessage.EscapeText(message)));
 
-            ChatMessageToMany(ChatChannel.Admin, message, messageWrap, default, false, clients.ToList());
+            ChatMessageToMany(ChatChannel.Admin, message, wrappedMessage, default, false, clients.ToList());
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Admin announcement from {message}: {message}");
         }
 
@@ -110,9 +109,8 @@ namespace Content.Server.Chat.Managers
             {
                 return;
             }
-            message = FormattedMessage.EscapeText(message);
-            var messageWrap = Loc.GetString("chat-manager-send-hook-ooc-wrap-message", ("senderName", sender));
-            ChatMessageToAll(ChatChannel.OOC, message, messageWrap);
+            var wrappedMessage = Loc.GetString("chat-manager-send-hook-ooc-wrap-message", ("senderName", sender), ("message", FormattedMessage.EscapeText(message)));
+            ChatMessageToAll(ChatChannel.OOC, message, wrappedMessage);
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Hook OOC from {sender}: {message}");
         }
 
@@ -134,8 +132,6 @@ namespace Content.Server.Chat.Managers
                 DispatchServerMessage(player, Loc.GetString("chat-manager-max-message-length-exceeded-message", ("limit", MaxMessageLength)));
                 return;
             }
-
-            message = FormattedMessage.EscapeText(message);
 
             switch (type)
             {
@@ -167,7 +163,7 @@ namespace Content.Server.Chat.Managers
             }
 
             Color? colorOverride = null;
-            var messageWrap = Loc.GetString("chat-manager-send-ooc-wrap-message", ("playerName",player.Name));
+            var wrappedMessage = Loc.GetString("chat-manager-send-ooc-wrap-message", ("playerName",player.Name), ("message", FormattedMessage.EscapeText(message)));
             if (_adminManager.HasAdminFlag(player, AdminFlags.Admin))
             {
                 var prefs = _preferencesManager.GetPreferences(player.UserId);
@@ -176,11 +172,11 @@ namespace Content.Server.Chat.Managers
             if (player.ConnectedClient.UserData.PatronTier is { } patron &&
                      PatronOocColors.TryGetValue(patron, out var patronColor))
             {
-                messageWrap = Loc.GetString("chat-manager-send-ooc-patron-wrap-message", ("patronColor", patronColor),("playerName", player.Name));
+                wrappedMessage = Loc.GetString("chat-manager-send-ooc-patron-wrap-message", ("patronColor", patronColor),("playerName", player.Name), ("message", FormattedMessage.EscapeText(message)));
             }
 
             //TODO: player.Name color, this will need to change the structure of the MsgChatMessage
-            ChatMessageToAll(ChatChannel.OOC, message, messageWrap, colorOverride);
+            ChatMessageToAll(ChatChannel.OOC, message, wrappedMessage, colorOverride);
             _mommiLink.SendOOCMessage(player.Name, message);
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"OOC from {player:Player}: {message}");
         }
@@ -194,10 +190,10 @@ namespace Content.Server.Chat.Managers
             }
 
             var clients = _adminManager.ActiveAdmins.Select(p => p.ConnectedClient);
-            var messageWrap = Loc.GetString("chat-manager-send-admin-chat-wrap-message",
+            var wrappedMessage = Loc.GetString("chat-manager-send-admin-chat-wrap-message",
                                             ("adminChannelName", Loc.GetString("chat-manager-admin-channel-name")),
-                                            ("playerName", player.Name));
-            ChatMessageToMany(ChatChannel.Admin, message, messageWrap, default, false, clients.ToList());
+                                            ("playerName", player.Name), ("message", FormattedMessage.EscapeText(message)));
+            ChatMessageToMany(ChatChannel.Admin, message, wrappedMessage, default, false, clients.ToList());
 
             _adminLogger.Add(LogType.Chat, $"Admin chat from {player:Player}: {message}");
         }
@@ -206,12 +202,12 @@ namespace Content.Server.Chat.Managers
 
         #region Utility
 
-        public void ChatMessageToOne(ChatChannel channel, string message, string messageWrap, EntityUid source, bool hideChat, INetChannel client, Color? colorOverride = null)
+        public void ChatMessageToOne(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, INetChannel client, Color? colorOverride = null)
         {
             var msg = new MsgChatMessage();
             msg.Channel = channel;
             msg.Message = message;
-            msg.MessageWrap = messageWrap;
+            msg.WrappedMessage = wrappedMessage;
             msg.SenderEntity = source;
             msg.HideChat = hideChat;
             if (colorOverride != null)
@@ -221,12 +217,12 @@ namespace Content.Server.Chat.Managers
             _netManager.ServerSendMessage(msg, client);
         }
 
-        public void ChatMessageToMany(ChatChannel channel, string message, string messageWrap, EntityUid source, bool hideChat, List<INetChannel> clients, Color? colorOverride = null)
+        public void ChatMessageToMany(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, List<INetChannel> clients, Color? colorOverride = null)
         {
             var msg = new MsgChatMessage();
             msg.Channel = channel;
             msg.Message = message;
-            msg.MessageWrap = messageWrap;
+            msg.WrappedMessage = wrappedMessage;
             msg.SenderEntity = source;
             msg.HideChat = hideChat;
             if (colorOverride != null)
@@ -236,7 +232,7 @@ namespace Content.Server.Chat.Managers
             _netManager.ServerSendToMany(msg, clients);
         }
 
-        public void ChatMessageToManyFiltered(Filter filter, ChatChannel channel, string message, string messageWrap, EntityUid source,
+        public void ChatMessageToManyFiltered(Filter filter, ChatChannel channel, string message, string wrappedMessage, EntityUid source,
             bool hideChat, Color? colorOverride = null)
         {
             if (!filter.Recipients.Any()) return;
@@ -247,15 +243,15 @@ namespace Content.Server.Chat.Managers
                 clients.Add(recipient.ConnectedClient);
             }
 
-            ChatMessageToMany(channel, message, messageWrap, source, hideChat, clients, colorOverride);
+            ChatMessageToMany(channel, message, wrappedMessage, source, hideChat, clients, colorOverride);
         }
 
-        public void ChatMessageToAll(ChatChannel channel, string message, string messageWrap, Color? colorOverride = null)
+        public void ChatMessageToAll(ChatChannel channel, string message, string wrappedMessage, Color? colorOverride = null)
         {
             var msg = new MsgChatMessage();
             msg.Channel = channel;
             msg.Message = message;
-            msg.MessageWrap = messageWrap;
+            msg.WrappedMessage = wrappedMessage;
             if (colorOverride != null)
             {
                 msg.MessageColorOverride = colorOverride.Value;

--- a/Content.Server/Chat/Managers/IChatManager.cs
+++ b/Content.Server/Chat/Managers/IChatManager.cs
@@ -23,12 +23,12 @@ namespace Content.Server.Chat.Managers
         void SendHookOOC(string sender, string message);
         void SendAdminAnnouncement(string message);
 
-        void ChatMessageToOne(ChatChannel channel, string message, string messageWrap, EntityUid source, bool hideChat,
+        void ChatMessageToOne(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat,
             INetChannel client, Color? colorOverride = null);
-        void ChatMessageToMany(ChatChannel channel, string message, string messageWrap, EntityUid source, bool hideChat,
+        void ChatMessageToMany(ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat,
             List<INetChannel> clients, Color? colorOverride = null);
-        void ChatMessageToManyFiltered(Filter filter, ChatChannel channel, string message, string messageWrap, EntityUid source, bool hideChat, Color? colorOverride);
-        void ChatMessageToAll(ChatChannel channel, string message, string messageWrap, Color? colorOverride = null);
+        void ChatMessageToManyFiltered(Filter filter, ChatChannel channel, string message, string wrappedMessage, EntityUid source, bool hideChat, Color? colorOverride);
+        void ChatMessageToAll(ChatChannel channel, string message, string wrappedMessage, Color? colorOverride = null);
 
         bool MessageCharacterLimit(IPlayerSession player, string message);
     }

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -299,15 +299,16 @@ public sealed class ZombieRuleSystem : GameRuleSystem
 
             if (mind.Session != null)
             {
-                var messageWrapper = Loc.GetString("chat-manager-server-wrap-message");
+                var message = Loc.GetString("zombie-patientzero-role-greeting");
+                var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", message));
 
                 //gets the names now in case the players leave.
                 //this gets unhappy if people with the same name get chose. Probably shouldn't happen.
                 _initialInfectedNames.Add(inCharacterName, mind.Session.Name);
 
                 // I went all the way to ChatManager.cs and all i got was this lousy T-shirt
-                _chatManager.ChatMessageToOne(Shared.Chat.ChatChannel.Server, Loc.GetString("zombie-patientzero-role-greeting"),
-                   messageWrapper, default, false, mind.Session.ConnectedClient, Color.Plum);
+                _chatManager.ChatMessageToOne(Shared.Chat.ChatChannel.Server, message,
+                   wrappedMessage, default, false, mind.Session.ConnectedClient, Color.Plum);
             }
         }
     }

--- a/Content.Server/Ghost/Components/IntrinsicRadioComponent.cs
+++ b/Content.Server/Ghost/Components/IntrinsicRadioComponent.cs
@@ -6,6 +6,7 @@ using Content.Shared.Radio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Ghost.Components
 {
@@ -37,12 +38,14 @@ namespace Content.Server.Ghost.Components
                 name = Identity.Name(speaker, _entMan);
             }
 
+            message = FormattedMessage.EscapeText(message);
+            name = FormattedMessage.EscapeText(name);
+
             var msg = new MsgChatMessage
             {
                 Channel = ChatChannel.Radio,
                 Message = message,
-                //Square brackets are added here to avoid issues with escaping
-                MessageWrap = Loc.GetString("chat-radio-message-wrap", ("color", channel.Color), ("channel", $"\\[{channel.LocalizedName}\\]"), ("name", name))
+                WrappedMessage = Loc.GetString("chat-radio-message-wrap", ("color", channel.Color), ("channel", $"\\[{channel.LocalizedName}\\]"), ("name", name), ("message", message))
             };
 
             _netManager.ServerSendMessage(msg, playerChannel);

--- a/Content.Server/Headset/HeadsetComponent.cs
+++ b/Content.Server/Headset/HeadsetComponent.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Headset
 {
@@ -71,12 +72,14 @@ namespace Content.Server.Headset
             if (message.Length == 0)
                 return;
 
+            message = FormattedMessage.EscapeText(message);
+            name = FormattedMessage.EscapeText(name);
+
             var msg = new MsgChatMessage
             {
                 Channel = ChatChannel.Radio,
                 Message = message,
-                //Square brackets are added here to avoid issues with escaping
-                MessageWrap = Loc.GetString("chat-radio-message-wrap", ("color", channel.Color), ("channel", $"\\[{channel.LocalizedName}\\]"), ("name", name))
+                WrappedMessage = Loc.GetString("chat-radio-message-wrap", ("color", channel.Color), ("channel", $"\\[{channel.LocalizedName}\\]"), ("name", name), ("message", message))
             };
 
             _netManager.ServerSendMessage(msg, playerChannel);

--- a/Content.Shared/Chat/MsgChatMessage.cs
+++ b/Content.Shared/Chat/MsgChatMessage.cs
@@ -24,9 +24,9 @@ namespace Content.Shared.Chat
         public string Message { get; set; } = string.Empty;
 
         /// <summary>
-        ///     What to "wrap" the message contents with. Example is stuff like 'Joe says: "{0}"'
+        ///     Modified message with some wrapping text. E.g. 'Joe says: "HELP!"'
         /// </summary>
-        public string MessageWrap { get; set; } = string.Empty;
+        public string WrappedMessage { get; set; } = string.Empty;
 
         /// <summary>
         ///     The sending entity.
@@ -46,7 +46,7 @@ namespace Content.Shared.Chat
         {
             Channel = (ChatChannel) buffer.ReadInt16();
             Message = buffer.ReadString();
-            MessageWrap = buffer.ReadString();
+            WrappedMessage = buffer.ReadString();
 
             switch (Channel)
             {
@@ -66,7 +66,7 @@ namespace Content.Shared.Chat
         {
             buffer.Write((short)Channel);
             buffer.Write(Message);
-            buffer.Write(MessageWrap);
+            buffer.Write(WrappedMessage);
 
             switch (Channel)
             {

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -13,20 +13,20 @@ chat-manager-max-message-length-exceeded-message = Your message exceeded {$limit
 chat-manager-no-headset-on-message = You don't have a headset on!
 chat-manager-no-such-channel = There is no such channel!
 chat-manager-whisper-headset-on-message = You can't whisper on the radio!
-chat-manager-server-wrap-message = SERVER: {"{0}"}
+chat-manager-server-wrap-message = SERVER: {$message}
 chat-manager-sender-announcement-wrap-message = {$sender} Announcement:
-                                                {"{0}"}
-chat-manager-entity-say-wrap-message = {$entityName} says: "{"{0}"}"
-chat-manager-entity-whisper-wrap-message = {$entityName} whispers: "{"{0}"}"
-chat-manager-entity-me-wrap-message = {$entityName} {"{0}"}
-chat-manager-entity-looc-wrap-message = LOOC: {$entityName}: {"{0}"}
-chat-manager-send-ooc-wrap-message = OOC: {$playerName}: {"{0}"}
-chat-manager-send-ooc-patron-wrap-message = OOC: [color={$patronColor}]{$playerName}[/color]: {"{0}"}
-chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: {$playerName}: {"{0}"}
-chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}:({$userName}): {"{0}"}
-chat-manager-send-admin-chat-wrap-message = {$adminChannelName}: {$playerName}: {"{0}"}
-chat-manager-send-admin-announcement-wrap-message = {$adminChannelName}: {"{0}"}
-chat-manager-send-hook-ooc-wrap-message = OOC: (D){$senderName}: {"{0}"}
+                                                {$message}
+chat-manager-entity-say-wrap-message = {$entityName} says: "{$message}"
+chat-manager-entity-whisper-wrap-message = {$entityName} whispers: "{$message}"
+chat-manager-entity-me-wrap-message = {$entityName} {$message}
+chat-manager-entity-looc-wrap-message = LOOC: {$entityName}: {$message}
+chat-manager-send-ooc-wrap-message = OOC: {$playerName}: {$message}
+chat-manager-send-ooc-patron-wrap-message = OOC: [color={$patronColor}]{$playerName}[/color]: {$message}
+chat-manager-send-dead-chat-wrap-message = {$deadChannelName}: {$playerName}: {$message}
+chat-manager-send-admin-dead-chat-wrap-message = {$adminChannelName}:({$userName}): {$message}
+chat-manager-send-admin-chat-wrap-message = {$adminChannelName}: {$playerName}: {$message}
+chat-manager-send-admin-announcement-wrap-message = {$adminChannelName}: {$message}
+chat-manager-send-hook-ooc-wrap-message = OOC: (D){$senderName}: {$message}
 
 chat-manager-dead-channel-name = DEAD
 chat-manager-admin-channel-name = ADMIN

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -1,5 +1,5 @@
 # Chat window radio wrap (prefix and postfix)
-chat-radio-message-wrap = [color={$color}]{$channel} {$name} says: "{"{"}0{"}"}"[/color]
+chat-radio-message-wrap = [color={$color}]{$channel} {$name} says: "{$message}"[/color]
 
 examine-radio-frequency = It's set to broadcast over the {$frequency} frequency.
 


### PR DESCRIPTION
fixes #11002

Currently you can use methods that change an entity's name (e.g. agent id, voice changer, or labeller) to either add "rich" text markup or mess with the chat message wrapping.

This PR fixes that by just getting rid of the client-side `string.Format()` call in favour of using fluent to format the message on the server-side, and by adding several `FormattedMessage.EscapeText()` calls. Main downside of this change is that the "original" message now effectively gets sent twice, given that it is generally also present in the formatted/wrapped message. But I can't think of a nicer way of doing this without just splitting the wrapper loc strings into a prefix & postfix, which I CBF doing.

:cl:
- fix: Fixed some chat sanitization issues that allowed some invalid entity names to mess with the chat window.

