### PR TITLE
Jetpack in-hand sprite fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -37,6 +37,7 @@
       state: icon
       netsync: false
     - type: Item
+      sprite: Objects/Tanks/Jetpacks/blue.rsi
       size: 100
     - type: UserInterface
       interfaces:
@@ -106,6 +107,8 @@
   name: jetpack
   suffix: Empty
   components:
+  - type: Item
+    sprite: Objects/Tanks/Jetpacks/black.rsi
   - type: Sprite
     sprite: Objects/Tanks/Jetpacks/black.rsi
   - type: Clothing
@@ -143,6 +146,7 @@
     slots:
       - Back
   - type: Item
+    sprite: Objects/Tanks/Jetpacks/captain.rsi
     size: 30
 
 # Filled captain
@@ -168,6 +172,8 @@
   name: mini jetpack
   suffix: Empty
   components:
+    - type: Item
+      sprite: Objects/Tanks/Jetpacks/mini.rsi
     - type: Sprite
       sprite: Objects/Tanks/Jetpacks/mini.rsi
     - type: Clothing
@@ -199,6 +205,8 @@
   name: security jetpack
   suffix: Empty
   components:
+  - type: Item
+    sprite: Objects/Tanks/Jetpacks/security.rsi
   - type: Sprite
     sprite: Objects/Tanks/Jetpacks/security.rsi
   - type: Clothing
@@ -229,6 +237,8 @@
   name: void jetpack
   suffix: Empty
   components:
+  - type: Item
+    sprite: Objects/Tanks/Jetpacks/void.rsi
   - type: Sprite
     sprite: Objects/Tanks/Jetpacks/void.rsi
   - type: Clothing


### PR DESCRIPTION
## About the PR
Fixes the in-hand sprite for all types of jetpacks.


**Screenshots**
![image](https://user-images.githubusercontent.com/110078045/196450243-3229d78c-e02d-4676-a22d-82c438476207.png)
![image](https://user-images.githubusercontent.com/110078045/196450325-20654643-55cb-4d4f-b770-bffc2c85c7df.png)
![image](https://user-images.githubusercontent.com/110078045/196450274-f07ca827-9a91-498e-884b-69885e29c0bc.png)


**Changelog**
:cl:  #Nairod
- fix: Fixed in-hand sprites for all jetpacks.

