### PR TITLE
Remove debug message

### DIFF
--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -80,9 +80,6 @@ public sealed class StationSystem : EntitySystem
             return;
 
         stationData.Grids.Remove(uid);
-
-        // TODO: Remove this when we find out what's mysteriously pulling the rug under us maps wise.
-        _sawmill.Debug($"Station grid is being deleted, trace is: {Environment.StackTrace}");
     }
 
     public override void Shutdown()


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There was once a time during which the station grid was being mysteriously deleted. This backtrace was added to debug this issue.

Since this issue has since been resolved (a salvage map was saved as a map, not a grid), this debug message can now go away.

**Screenshots**
N/A

**Changelog**
N/A