### PR TITLE
Adjust case of shuttle parts

### DIFF
--- a/Resources/Locale/en-US/prototypes/entities/structures/shuttles/thrusters.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/structures/shuttles/thrusters.ftl
@@ -1,14 +1,14 @@
-ent-BaseThruster = Thruster
+ent-BaseThruster = thruster
     .desc = A thruster that allows a shuttle to move.
 
 ent-Thruster = { ent-BaseThruster }
     .desc = { ent-BaseThruster.desc }
 
-ent-DebugThruster = Debug thruster
+ent-DebugThruster = debug thruster
     .desc = It goes nyooooooom. It doesn't need power nor space.
 
-ent-Gyroscope = Gyroscope
+ent-Gyroscope = gyroscope
     .desc = Increases the shuttle's potential angular rotation.
 
-ent-DebugGyroscope = Debug gyroscope
+ent-DebugGyroscope = debug gyroscope
     .desc = { ent-Gyroscope.desc }


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Convention is to use all lowercase for name fields, unless they are proper nouns. Apply these conventions to shuttle parts.

**Screenshots**
N/A

**Changelog**
N/A