### PR TITLE
Maybe fix pathfinding nullref

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathPoly.cs
+++ b/Content.Server/NPC/Pathfinding/PathPoly.cs
@@ -14,11 +14,6 @@ public sealed class PathPoly : IEquatable<PathPoly>
 
     public readonly HashSet<PathPoly> Neighbors;
 
-    public PathPoly()
-    {
-        Neighbors = new HashSet<PathPoly>();
-    }
-
     public PathPoly(EntityUid graphUid, Vector2i chunkOrigin, byte tileIndex, Box2 vertices, PathfindingData data, HashSet<PathPoly> neighbors)
     {
         GraphUid = graphUid;

--- a/Content.Server/NPC/Pathfinding/PathPoly.cs
+++ b/Content.Server/NPC/Pathfinding/PathPoly.cs
@@ -14,6 +14,11 @@ public sealed class PathPoly : IEquatable<PathPoly>
 
     public readonly HashSet<PathPoly> Neighbors;
 
+    public PathPoly()
+    {
+        Neighbors = new HashSet<PathPoly>();
+    }
+
     public PathPoly(EntityUid graphUid, Vector2i chunkOrigin, byte tileIndex, Box2 vertices, PathfindingData data, HashSet<PathPoly> neighbors)
     {
         GraphUid = graphUid;

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -628,6 +628,7 @@ public sealed partial class PathfindingSystem
 
         // If any paths have a ref to it let them know that the class is no longer a valid node.
         poly.Data.Flags = PathfindingBreadcrumbFlag.Invalid;
+        poly.Neighbors.Clear();
     }
 
     private void BuildNavmesh(GridPathfindingChunk chunk, GridPathfindingComponent component)

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -31,11 +31,6 @@ public sealed partial class PathfindingSystem
 
     // Probably can't pool polys as there might be old pathfinding refs to them.
 
-    private readonly ObjectPool<HashSet<PathPoly>> _neighborPolyPool =
-        new DefaultObjectPool<HashSet<PathPoly>>(new SetPolicy<PathPoly>(), MaxPoolSize);
-
-    private static int MaxPoolSize = Environment.ProcessorCount * 2 * ChunkSize * ChunkSize;
-
     private void InitializeGrid()
     {
         SubscribeLocalEvent<GridInitializeEvent>(OnGridInit);
@@ -561,7 +556,7 @@ public sealed partial class PathfindingSystem
                         (Vector2) (poly.TopRight + Vector2i.One) / SubStep + polyOffset);
                     var polyData = points[x * SubStep + poly.Left, y * SubStep + poly.Bottom].Data;
 
-                    var neighbors = _neighborPolyPool.Get();
+                    var neighbors = new HashSet<PathPoly>();
                     tilePoly.Add(new PathPoly(grid.GridEntityId, chunk.Origin, GetIndex(x, y), box, polyData, neighbors));
                 }
             }
@@ -633,7 +628,6 @@ public sealed partial class PathfindingSystem
 
         // If any paths have a ref to it let them know that the class is no longer a valid node.
         poly.Data.Flags = PathfindingBreadcrumbFlag.Invalid;
-        _neighborPolyPool.Return(poly.Neighbors);
     }
 
     private void BuildNavmesh(GridPathfindingChunk chunk, GridPathfindingComponent component)

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -32,7 +32,7 @@ public sealed partial class PathfindingSystem
     // Probably can't pool polys as there might be old pathfinding refs to them.
 
     private readonly ObjectPool<HashSet<PathPoly>> _neighborPolyPool =
-        new DefaultObjectPool<HashSet<PathPoly>>(new DefaultPooledObjectPolicy<HashSet<PathPoly>>(), MaxPoolSize);
+        new DefaultObjectPool<HashSet<PathPoly>>(new SetPolicy<PathPoly>(), MaxPoolSize);
 
     private static int MaxPoolSize = Environment.ProcessorCount * 2 * ChunkSize * ChunkSize;
 
@@ -574,7 +574,7 @@ public sealed partial class PathfindingSystem
             {
                 var index = x * ChunkSize + y;
                 var polys = chunkPolys[index];
-                ref var existing = ref chunk.Polygons[index];
+                var existing = chunk.Polygons[index];
 
                 var isEquivalent = true;
 
@@ -629,12 +629,10 @@ public sealed partial class PathfindingSystem
         foreach (var neighbor in poly.Neighbors)
         {
             neighbor.Neighbors.Remove(poly);
-            poly.Neighbors.Remove(neighbor);
         }
 
         // If any paths have a ref to it let them know that the class is no longer a valid node.
         poly.Data.Flags = PathfindingBreadcrumbFlag.Invalid;
-        poly.Neighbors.Clear();
         _neighborPolyPool.Return(poly.Neighbors);
     }
 


### PR DESCRIPTION
The only way neighbors could possibly be null that I can tell is from the default ctor being used but this shouldn't even be being used.

Edit: Okay so when I return the neighbors to pool that might be doing it so instead of trying to be clever and fucking it up I'm just going to increase allocs and not fuck it up.