### PR TITLE
Nukie lockers now contain magboots and no-slips

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -11,6 +11,8 @@
       - id: ClothingUniformJumpsuitOperative
       - id: ClothingUniformJumpskirtOperative
       - id: ClothingHeadsetAltSyndicate
+      - id: ClothingShoesBootsMagSyndie
+      - id: ClothingShoesChameleonNoSlips
 
 - type: entity
   id: ClosetEmergencyFilledRandom


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

#11652 removed the no-slips nukies started with and replaced them with combat boots. This adds the no-slips back, and puts them in the nukie lockers. I also threw magboots in there since nobody ever buys them, which means that nukies are at a massive disadvantage if grav gets turned off.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Nuclear Operatives now have no-slips and magboots available as starting gear. Check your lockers to find them.

