### PR TITLE
Show the station name on spawn

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -209,6 +209,12 @@ namespace Content.Server.GameTicking
                 _chatManager.DispatchServerMessage(player, Loc.GetString("job-greet-crew-shortages"));
             }
 
+            if (TryComp(station, out MetaDataComponent? metaData))
+            {
+                _chatManager.DispatchServerMessage(player,
+                    Loc.GetString("job-greet-station-name", ("stationName", metaData.EntityName)));
+            }
+
             // We raise this event directed to the mob, but also broadcast it so game rules can do something now.
             PlayersJoinedRoundNormally++;
             var aev = new PlayerSpawnCompleteEvent(mob, player, jobId, lateJoin, PlayersJoinedRoundNormally, station, character);

--- a/Content.Server/Roles/Job.cs
+++ b/Content.Server/Roles/Job.cs
@@ -1,7 +1,7 @@
 using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Shared.Roles;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using System.Globalization;
 
 namespace Content.Server.Roles
 {
@@ -39,24 +39,13 @@ namespace Content.Server.Roles
             if (Mind.TryGetSession(out var session))
             {
                 var chatMgr = IoCManager.Resolve<IChatManager>();
-                var chatSys = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>();
-                chatMgr.DispatchServerMessage(session, Loc.GetString("job-greet-introduce-job-name", ("jobName", Name)));
+                chatMgr.DispatchServerMessage(session, Loc.GetString("job-greet-introduce-job-name",
+                    ("jobName", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Name))));
 
                 if(Prototype.RequireAdminNotify)
                     chatMgr.DispatchServerMessage(session, Loc.GetString("job-greet-important-disconnect-admin-notify"));
 
                 chatMgr.DispatchServerMessage(session, Loc.GetString("job-greet-supervisors-warning", ("jobName", Name), ("supervisors", Loc.GetString(Prototype.Supervisors))));
-
-                if(Prototype.JoinNotifyCrew && Mind.CharacterName != null)
-                {
-                    if (Mind.OwnedEntity != null)
-                    {
-                        chatSys.DispatchStationAnnouncement(Mind.OwnedEntity.Value,
-                            Loc.GetString("job-greet-join-notify-crew", ("jobName", Name),
-                                ("characterName", Mind.CharacterName)),
-                            Loc.GetString("job-greet-join-notify-crew-announcer"), false);
-                    }
-                }
             }
         }
     }

--- a/Resources/Locale/en-US/job/job.ftl
+++ b/Resources/Locale/en-US/job/job.ftl
@@ -1,6 +1,5 @@
-job-greet-introduce-job-name = You are the {$jobName}.
+job-greet-station-name = Welcome aboard {$stationName}.
+job-greet-introduce-job-name = Your role is: {$jobName}.
 job-greet-important-disconnect-admin-notify = You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via ahelp.
 job-greet-supervisors-warning = As the {$jobName} you answer directly to {$supervisors}. Special circumstances may change this.
-job-greet-join-notify-crew = { CAPITALIZE($jobName)} {$characterName} on deck!
-job-greet-join-notify-crew-announcer = Station
 job-greet-crew-shortages = As this station was initially staffed with a skeleton crew, additional access has been added to your ID card.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Show the station name on spawn. I also tweaked the verbage a bit to make the role assignment text not have a 'the' in it, since roles with a single member are in the minority. The `supervisors-warning` text still contains a clunky 'the' but I decided it's outside scope 🙃

Fixes #12089

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![2022-10-21 16_52_44-Space Station 14](https://user-images.githubusercontent.com/6798456/197306242-1cf4888f-a08b-4290-9156-00f4f64ea678.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: You will now see a message at spawn telling you what station you're on.

