### PR TITLE
Mass scanner and power monitor boards in the circuit imprinter

### DIFF
--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -290,6 +290,7 @@
   unlockedRecipes:
     - ShuttleConsoleCircuitboard
     - Drone
+    - RadarConsoleCircuitboard
 
 # Electromagnetic Theory Technology Tree
 
@@ -316,6 +317,7 @@
     - SubstationMachineCircuitboard
     - HydroponicsTrayMachineCircuitboard
     - SolarControlComputerCircuitboard
+    - PowerComputerCircuitboard
     - GeneratorPlasmaMachineCircuitboard
     - Signaller
     - SignalTrigger

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -271,12 +271,14 @@
       - SurveillanceWirelessCameraAnchoredCircuitboard
       - HydroponicsTrayMachineCircuitboard
       - SolarControlComputerCircuitboard
+      - PowerComputerCircuitboard
       - AutolatheMachineCircuitboard
       - ProtolatheMachineCircuitboard
       - ReagentGrinderMachineCircuitboard
       - MicrowaveMachineCircuitboard
       - UniformPrinterMachineCircuitboard
       - ShuttleConsoleCircuitboard
+      - RadarConsoleCircuitboard
       - CircuitImprinterMachineCircuitboard
       - DawInstrumentMachineCircuitboard
       - CloningConsoleComputerCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -206,6 +206,15 @@
      Gold: 100
 
 - type: latheRecipe
+  id: RadarConsoleCircuitboard
+  icon: Objects/Misc/module.rsi/id_mod.png
+  result: RadarConsoleCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 900
+
+- type: latheRecipe
   id: DawInstrumentMachineCircuitboard
   icon: Objects/Misc/module.rsi/id_mod.png
   result: DawInstrumentMachineCircuitboard
@@ -310,6 +319,15 @@
   id: SolarControlComputerCircuitboard
   icon: Objects/Misc/module.rsi/id_mod.png
   result: SolarControlComputerCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 900
+
+- type: latheRecipe
+  id: PowerComputerCircuitboard
+  icon: Objects/Misc/module.rsi/id_mod.png
+  result: PowerComputerCircuitboard
   completetime: 4
   materials:
      Steel: 100


### PR DESCRIPTION
## About the PR
Allows the mass scanner and power monitoring computer boards to be produced in the circuit imprinter

**Changelog**
:cl: Nairod
- add: Added the mass scanner and power monitoring computer boards to the circuit imprinter.

