### PR TITLE
Fix LED lights.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -108,8 +108,8 @@
   - type: LightBulb
     bulb: Tube
     color: "#EEEEFF"
-    lightEnergy: 2.5
-    lightRadius: 10
+    lightEnergy: 1
+    lightRadius: 15
     lightSoftness: 0.9
     BurningTemperature: 350
     PowerUse: 12


### PR DESCRIPTION
Changes their energy level and range so that while they're higher power lights, they don't burn out your eyeballs.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Screenshots**
![image](https://user-images.githubusercontent.com/7806367/197328322-b5b47916-0d8a-4b6b-8429-beeaa990fd7a.png)

:cl: moony
- fix: LED lights no longer burn your eyes out (fixed their overly high brightness/energy)
