### PR TITLE
Head mantles in the uniform printer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -475,6 +475,12 @@
       - ClothingOuterWinterHoS
       - ClothingOuterWinterQM
       - ClothingOuterWinterRD
+      - ClothingNeckMantleCap
+      - ClothingNeckMantleCE
+      - ClothingNeckMantleCMO
+      - ClothingNeckMantleHOP
+      - ClothingNeckMantleHOS
+      - ClothingNeckMantleRD
       - ClothingOuterWinterMusician
       - ClothingOuterWinterClown
       - ClothingOuterWinterMime

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -630,6 +630,72 @@
     Durathread: 300
 
 - type: latheRecipe
+  id: ClothingNeckMantleCap
+  icon:
+    sprite: Clothing/Neck/mantles/capmantle.rsi
+    state: icon
+  result: ClothingNeckMantleCap
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingNeckMantleCE
+  icon:
+    sprite: Clothing/Neck/mantles/cemantle.rsi
+    state: icon
+  result: ClothingNeckMantleCE
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingNeckMantleCMO
+  icon:
+    sprite: Clothing/Neck/mantles/cmomantle.rsi
+    state: icon
+  result: ClothingNeckMantleCMO
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingNeckMantleHOP
+  icon:
+    sprite: Clothing/Neck/mantles/hopmantle.rsi
+    state: icon
+  result: ClothingNeckMantleHOP
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingNeckMantleHOS
+  icon:
+    sprite: Clothing/Neck/mantles/hosmantle.rsi
+    state: icon
+  result: ClothingNeckMantleHOS
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingNeckMantleRD
+  icon:
+    sprite: Clothing/Neck/mantles/rdmantle.rsi
+    state: icon
+  result: ClothingNeckMantleRD
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
   id: ClothingOuterWinterMusician
   icon:
     sprite: Clothing/OuterClothing/WinterCoats/coatnomi.rsi


### PR DESCRIPTION
## About the PR
Allows all the head mantles to be produced in the HoP's uniform printer, since they were all unused before unless mapped.

**Screenshots**
![image](https://user-images.githubusercontent.com/110078045/197363291-bf6099d0-c675-43cb-9ba2-1ae02898877c.png)

**Changelog**
:cl: Nairod
- add: Added the head's mantles to the uniform printer.