### PR TITLE
service vending machine updates

### DIFF
--- a/Resources/Locale/en-US/advertisements/vending/nutrimax.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/nutrimax.ftl
@@ -3,3 +3,4 @@ advertisement-nutrimax-2 = Don't you want some?
 advertisement-nutrimax-3 = The greenest thumbs ever.
 advertisement-nutrimax-4 = We like big plants.
 advertisement-nutrimax-5 = Soft soil...
+advertisement-nutrimax-6 = Buckets now included!

--- a/Resources/Prototypes/Catalog/VendingMachines/Advertisements/nutrimax.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Advertisements/nutrimax.yml
@@ -6,3 +6,4 @@
     - advertisement-nutrimax-3
     - advertisement-nutrimax-4
     - advertisement-nutrimax-5
+    - advertisement-nutrimax-6

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/dinnerware.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/dinnerware.yml
@@ -8,7 +8,9 @@
     FoodPlateSmall: 10
     FoodPlateTin: 5
     FoodKebabSkewer: 5
-    DrinkGlass: 10
+    DrinkGlass: 5
+    Beaker: 5
+    LargeBeaker: 5
     DrinkMug: 5
     DrinkMugBlack: 2
     DrinkMugBlue: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
@@ -12,6 +12,8 @@
     PestSpray: 20
     Syringe: 5
     RobustHarvestChemistryBottle: 3
+    Bucket: 3
+    DiseaseSwab: 20
     #TO DO:
     #plant analyzer
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
@@ -1,12 +1,12 @@
 - type: vendingMachineInventory
   id: NutriMaxInventory
   startingInventory:
-    HydroponicsToolSpade: 2
-    HydroponicsToolMiniHoe: 2
-    HydroponicsToolClippers: 2
-    HydroponicsToolScythe: 2
-    HydroponicsToolHatchet: 2
-    PlantBag: 2
+    HydroponicsToolSpade: 3
+    HydroponicsToolMiniHoe: 3
+    HydroponicsToolClippers: 3
+    HydroponicsToolScythe: 3
+    HydroponicsToolHatchet: 3
+    PlantBag: 3
     PlantBGoneSpray: 20
     WeedSpray: 20
     PestSpray: 20

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
@@ -10,6 +10,7 @@
     ChiliSeeds: 5
     CornSeeds: 5
     EggplantSeeds: 5
+    EggySeeds: 5
     GalaxythistleSeeds: 3
     LemonSeeds: 5
     LingzhiSeeds: 3


### PR DESCRIPTION
- egg-plant seeds added to seed vendor since they are available in botany locker at roundstart 
- botany tool number increased to match the increased botany staff count of most stations and also now has buckets
- dinnerware now has large beakers so they dont have to rob the bartender's shaker to have 100u containers

:cl:
- add: Added wares to the Nutrimax and Kitchenware machines.

