### PR TITLE
Don't predict body init

### DIFF
--- a/Content.Client/Body/Systems/BodySystem.cs
+++ b/Content.Client/Body/Systems/BodySystem.cs
@@ -1,7 +1,13 @@
-﻿using Content.Shared.Body.Systems;
+﻿using Content.Shared.Body.Components;
+using Content.Shared.Body.Prototypes;
+using Content.Shared.Body.Systems;
 
 namespace Content.Client.Body.Systems;
 
 public sealed class BodySystem : SharedBodySystem
 {
+    protected override void InitBody(BodyComponent body, BodyPrototype prototype)
+    {
+        return;
+    }
 }

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -6,7 +6,9 @@ using Content.Server.Kitchen.Components;
 using Content.Server.Mind.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
+using Content.Shared.Body.Prototypes;
 using Content.Shared.Body.Systems;
+using Content.Shared.Coordinates;
 using Content.Shared.Humanoid;
 using Content.Shared.MobState.Components;
 using Content.Shared.Movement.Events;
@@ -111,6 +113,21 @@ public sealed class BodySystem : SharedBodySystem
         var layers = HumanoidVisualLayersExtension.Sublayers(layer.Value);
         _humanoidSystem.SetLayersVisibility(oldBody.Value, layers, false, true, humanoid);
         return true;
+    }
+
+    protected override void InitBody(BodyComponent body, BodyPrototype prototype)
+    {
+        var root = prototype.Slots[prototype.Root];
+        var bodyId = Spawn(root.Part, body.Owner.ToCoordinates());
+        var partComponent = Comp<BodyPartComponent>(bodyId);
+        var slot = new BodyPartSlot(root.Part, body.Owner, partComponent.PartType);
+        body.Root = slot;
+        partComponent.Body = bodyId;
+
+        Containers.EnsureContainer<Container>(body.Owner, BodyContainerId);
+
+        AttachPart(bodyId, slot, partComponent);
+        InitPart(partComponent, prototype, prototype.Root);
     }
 
     public override HashSet<EntityUid> GibBody(EntityUid? bodyId, bool gibOrgans = false, BodyComponent? body = null)

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -14,13 +14,13 @@ public partial class SharedBodySystem
 {
     public void InitializeBody()
     {
-        SubscribeLocalEvent<BodyComponent, MapInitEvent>(OnBodyMapInit);
+        SubscribeLocalEvent<BodyComponent, ComponentInit>(OnBodyInit);
 
         SubscribeLocalEvent<BodyComponent, ComponentGetState>(OnBodyGetState);
         SubscribeLocalEvent<BodyComponent, ComponentHandleState>(OnBodyHandleState);
     }
 
-    private void OnBodyMapInit(EntityUid bodyId, BodyComponent body, MapInitEvent args)
+    private void OnBodyInit(EntityUid bodyId, BodyComponent body, ComponentInit args)
     {
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (body.Prototype == null || body.Root != null)

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -15,23 +15,12 @@ public partial class SharedBodySystem
     public void InitializeBody()
     {
         SubscribeLocalEvent<BodyComponent, MapInitEvent>(OnBodyMapInit);
-        SubscribeLocalEvent<BodyComponent, ComponentInit>(OnBodyInit);
 
         SubscribeLocalEvent<BodyComponent, ComponentGetState>(OnBodyGetState);
         SubscribeLocalEvent<BodyComponent, ComponentHandleState>(OnBodyHandleState);
     }
 
     private void OnBodyMapInit(EntityUid bodyId, BodyComponent body, MapInitEvent args)
-    {
-        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-        if (body.Prototype == null || body.Root != null)
-            return;
-
-        var prototype = Prototypes.Index<BodyPrototype>(body.Prototype);
-        InitBody(body, prototype);
-    }
-
-    private void OnBodyInit(EntityUid bodyId, BodyComponent body, ComponentInit args)
     {
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (body.Prototype == null || body.Root != null)
@@ -75,22 +64,9 @@ public partial class SharedBodySystem
         return true;
     }
 
-    private void InitBody(BodyComponent body, BodyPrototype prototype)
-    {
-        var root = prototype.Slots[prototype.Root];
-        var bodyId = Spawn(root.Part, body.Owner.ToCoordinates());
-        var partComponent = Comp<BodyPartComponent>(bodyId);
-        var slot = new BodyPartSlot(root.Part, body.Owner, partComponent.PartType);
-        body.Root = slot;
-        partComponent.Body = bodyId;
+    protected abstract void InitBody(BodyComponent body, BodyPrototype prototype);
 
-        Containers.EnsureContainer<Container>(body.Owner, BodyContainerId);
-
-        AttachPart(bodyId, slot, partComponent);
-        InitPart(partComponent, prototype, prototype.Root);
-    }
-
-    private void InitPart(BodyPartComponent parent, BodyPrototype prototype, string slotId, HashSet<string>? initialized = null)
+    protected void InitPart(BodyPartComponent parent, BodyPrototype prototype, string slotId, HashSet<string>? initialized = null)
     {
         initialized ??= new HashSet<string>();
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Body.Systems;
 
 public abstract partial class SharedBodySystem : EntitySystem
 {
-    private const string BodyContainerId = "BodyContainer";
+    protected const string BodyContainerId = "BodyContainer";
 
     [Dependency] protected readonly IPrototypeManager Prototypes = default!;
 


### PR DESCRIPTION
Client doesn't handle predicted entity spawning so the organs hang around.
Fixes https://github.com/space-wizards/space-station-14/issues/12162

:cl:
- fix: Fix clientside organs being left around.
