### PR TITLE
Forensic pads, zipties and glasses in the secfab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -324,8 +324,10 @@
       - Flash
       - FlashPayload
       - Handcuffs
+      - Zipties
       - Stunbaton
       - ForensicPad
+      - ClothingEyesGlassesSecurity
       - RiotShield
       - CartridgePistol
       - CartridgeMagnum

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -325,6 +325,7 @@
       - FlashPayload
       - Handcuffs
       - Stunbaton
+      - ForensicPad
       - RiotShield
       - CartridgePistol
       - CartridgeMagnum

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -9,6 +9,16 @@
     Steel: 300
 
 - type: latheRecipe
+  id: Zipties
+  icon:
+    sprite: Objects/Misc/zipties.rsi
+    state: cuff
+  result: Zipties
+  completetime: 2
+  materials:
+    Plastic: 200
+
+- type: latheRecipe
   id: Stunbaton
   icon:
     sprite: Objects/Weapons/Melee/stunbaton.rsi
@@ -28,6 +38,17 @@
   completetime: 4
   materials:
     Plastic: 100
+
+- type: latheRecipe
+  id: ClothingEyesGlassesSecurity
+  icon:
+    sprite: Clothing/Eyes/Glasses/secglasses.rsi
+    state: icon
+  result: ClothingEyesGlassesSecurity
+  completetime: 2
+  materials:
+    Steel: 300
+    Glass: 200
 
 - type: latheRecipe
   id: RiotShield

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -20,6 +20,16 @@
     Plastic: 300
 
 - type: latheRecipe
+  id: ForensicPad
+  icon:
+    sprite: Objects/Misc/bureaucracy.rsi
+    state: paper
+  result: ForensicPad
+  completetime: 4
+  materials:
+    Plastic: 100
+
+- type: latheRecipe
   id: RiotShield
   icon:
     sprite: Objects/Weapons/Melee/shields.rsi


### PR DESCRIPTION
## About the PR
Extends the range of sec gear inside the secfab with the addition of the forensic pads, zipties and sec glasses.

**Screenshots**
![image](https://user-images.githubusercontent.com/110078045/197415417-63adaf32-cfe4-4cb5-bd6c-aeecfe156e05.png)

**Changelog**
:cl: Nairod
- add: Added forensic pads, zipties and glasses to the secfab

