### PR TITLE
allow syringes to set transfer amount

### DIFF
--- a/Content.Server/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Server/Chemistry/Components/InjectorComponent.cs
@@ -1,6 +1,9 @@
 using System.Threading;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.FixedPoint;
+using Content.Server.UserInterface;
+using Robust.Server.GameObjects;
+using Content.Shared.Chemistry;
 
 namespace Content.Server.Chemistry.Components
 {
@@ -21,6 +24,20 @@ namespace Content.Server.Chemistry.Components
         [ViewVariables]
         [DataField("injectOnly")]
         public bool InjectOnly;
+
+        /// <summary>
+        ///     The minimum amount of solution that can be transferred at once from this solution.
+        /// </summary>
+        [DataField("minTransferAmount")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public FixedPoint2 MinimumTransferAmount { get; set; } = FixedPoint2.New(5);
+
+        /// <summary>
+        ///     The maximum amount of solution that can be transferred at once from this solution.
+        /// </summary>
+        [DataField("maxTransferAmount")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public FixedPoint2 MaximumTransferAmount { get; set; } = FixedPoint2.New(50);
 
         /// <summary>
         /// Amount to inject or draw on each usage. If the injector is inject only, it will
@@ -64,5 +81,7 @@ namespace Content.Server.Chemistry.Components
                 Dirty();
             }
         }
+
+        [ViewVariables] public BoundUserInterface? UserInterface => Owner.GetUIOrNull(TransferAmountUiKey.Key);
     }
 }

--- a/Content.Server/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Server/Chemistry/Components/InjectorComponent.cs
@@ -81,7 +81,5 @@ namespace Content.Server.Chemistry.Components
                 Dirty();
             }
         }
-
-        [ViewVariables] public BoundUserInterface? UserInterface => Owner.GetUIOrNull(TransferAmountUiKey.Key);
     }
 }

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
@@ -50,14 +50,6 @@ public sealed partial class ChemistrySystem
             if (!EntityManager.TryGetComponent<ActorComponent?>(args.User, out var actor))
                 return;
 
-            // Custom transfer verb
-            AlternativeVerb custom = new();
-            custom.Text = Loc.GetString("comp-solution-transfer-verb-custom-amount");
-            custom.Category = VerbCategory.SetTransferAmount;
-            custom.Act = () => component.UserInterface?.Open(actor.PlayerSession);
-            custom.Priority = 1;
-            args.Verbs.Add(custom);
-
             // Add specific transfer verbs according to the container's size
             var priority = 0;
             foreach (var amount in DefaultTransferAmounts)
@@ -246,6 +238,10 @@ public sealed partial class ChemistrySystem
             return;
 
         var actualDelay = MathF.Max(component.Delay, 1f);
+
+        // Injections take 1 second longer per additional 5u
+        actualDelay += (float) component.TransferAmount / component.Delay - 1;
+
         if (user != target)
         {
             // Create a pop-up for the target

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
@@ -74,7 +74,6 @@ public sealed partial class ChemistrySystem
         }
     }
 
-
     private static void OnInjectionCancelled(InjectionCancelledEvent ev)
     {
         ev.Component.CancelToken = null;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So I decided to try out playing as the sole chemist with only using syringes. Making the stuff was a breeze and was more engaging than the current pill meta (where you just scatter a massive amount of pills on the table for the public to use all willy-nilly). I was able to give out precise doses and was happy with the results.

The crew, on the other hand, were not happy. They wanted their pills and they wanted them badly, to the point of breaking into my lab making them themselves. I would ask them why they didn't want to bother with the syringes and the major pain point was the speed in administering the drugs. Crew are limited to only 15u per syringe and could only inject 5u per doafter.

Solution I've come up with is to allow syringes to have their solution transfer amount to be configurable just like any other container. It still defaults to 5u, but can be set to 10 or 15u as necessary. This in my opinion buffs syringes just enough to make them more palatable for crew to use.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![syringe](https://user-images.githubusercontent.com/8183999/197418804-5906cdf4-82a4-40dd-bded-9dda3a9aa480.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Syringes can now set how much solution to transfer.

