### PR TITLE
Laser crate changes

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-armory.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-armory.ftl
@@ -3,3 +3,6 @@ ent-ArmorySmg = { ent-CrateArmorySMG }
 
 ent-ArmoryShotgun = { ent-CrateArmoryShotgun }
     .desc = { ent-CrateArmoryShotgun.desc }
+
+ent-ArmoryLaser = { ent-CrateArmoryLaser }
+    .desc = { ent-CrateArmoryLaser.desc }

--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-security.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargo-security.ftl
@@ -7,9 +7,6 @@ ent-SecurityHelmet = { ent-CrateSecurityHelmet }
 ent-SecurityNonLethal = { ent-CrateSecurityNonlethal }
     .desc = { ent-CrateSecurityNonlethal.desc }
 
-ent-SecurityLaser = { ent-CrateSecurityLaser }
-    .desc = { ent-CrateSecurityLaser.desc }
-
 ent-SecurityRiot = { ent-CrateSecurityRiot }
     .desc = { ent-CrateSecurityRiot.desc }
 

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
@@ -3,3 +3,6 @@ ent-CrateArmorySMG = SMG crate
 
 ent-CrateArmoryShotgun = Shotgun crate
     .desc = For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer Combat Shotguns, and some standard shotgun shells. Requires Armory access to open.
+
+ent-CrateArmoryLaser = lasers crate
+    .desc = Contains three lethal, high-energy laser guns. Requires Armory access to open.

--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/security-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/security-crates.ftl
@@ -7,9 +7,6 @@ ent-CrateSecurityHelmet = helmet crate
 ent-CrateSecurityNonlethal = nonlethals crate
     .desc = Disabler weapons. Requires Security access to open.
 
-ent-CrateSecurityLaser = lasers crate
-    .desc = Contains three lethal, high-energy laser guns. Requires Security access to open.
-
 ent-CrateSecurityRiot = swat crate
     .desc = Contains two sets of heavy body armor and helmets and 2 shotguns with 6 rounds of beanbag shells each. Requires Armory access to open.
 

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -50496,7 +50496,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 6533
-  type: CrateSecurityLaser
+  type: CrateArmoryLaser
   components:
   - pos: -7.5,22.5
     parent: 0

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -17,3 +17,13 @@
   cost: 2500
   category: Armory
   group: market
+
+- type: cargoProduct
+  id: ArmoryLaser
+  icon:
+    sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi
+    state: icon
+  product: CrateArmoryLaser
+  cost: 1600
+  category: Armory
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -29,16 +29,6 @@
   group: market
 
 - type: cargoProduct
-  id: SecurityLaser
-  icon:
-    sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
-    state: icon
-  product: CrateSecurityLaser
-  cost: 1600
-  category: Security
-  group: market
-
-- type: cargoProduct
   id: SecurityRiot
   icon:
     sprite: Clothing/OuterClothing/Armor/riot.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -19,3 +19,12 @@
         amount: 2
       - id: BoxLethalshot
         amount: 3
+
+- type: entity
+  id: CrateArmoryLaser
+  parent: CrateWeaponSecure
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponLaserGun
+        amount: 3

--- a/Resources/Prototypes/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/security.yml
@@ -34,15 +34,6 @@
 #      - GrenadeTeargas
 
 - type: entity
-  id: CrateSecurityLaser
-  parent: CrateSecgear
-  components:
-  - type: StorageFill
-    contents:
-      - id: WeaponLaserGun
-        amount: 3
-
-- type: entity
   id: CrateSecurityRiot
   parent: CrateSecgear
   components:


### PR DESCRIPTION
## About the PR
Changes the laser crate access lock to armory instead of security.
Changes the laser crate's icon to the retro laser gun instead of the laser cannon.
Moves the category of the laser crate to armory instead of security.

**Screenshots**
![image](https://user-images.githubusercontent.com/110078045/197642993-a3842ae8-d73f-4637-aa29-3227b44b8c03.png)
![image](https://user-images.githubusercontent.com/110078045/197643006-dc23904f-d362-4d82-b65b-4d32ca7fa480.png)

**Changelog**
:cl: Nairod
- tweak: Changed the laser crate to now require armory access.

