### PR TITLE
Add hud-chatbox-info reads keybinds

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChatInputBox.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChatInputBox.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Chat;
+using Content.Shared.Input;
 using Robust.Client.UserInterface.Controls;
 
 namespace Content.Client.UserInterface.Systems.Chat.Controls;
@@ -32,7 +33,7 @@ public class ChatInputBox : PanelContainer
         Input = new HistoryLineEdit
         {
             Name = "Input",
-            PlaceHolder = Loc.GetString("hud-chatbox-info"),
+            PlaceHolder = Loc.GetString("hud-chatbox-info", ("talk-key", BoundKeyHelper.ShortKeyName(ContentKeyFunctions.FocusChat)), ("cycle-key", BoundKeyHelper.ShortKeyName(ContentKeyFunctions.CycleChatChannelForward))),
             HorizontalExpand = true,
             StyleClasses = {"chatLineEdit"}
         };

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -1,4 +1,4 @@
-hud-chatbox-info = T to talk, Tab to cycle channels.
+hud-chatbox-info = {$talk-key} to talk, {$cycle-key} to cycle channels.
 
 hud-chatbox-select-name-prefixed = {$prefix} {$name}
 hud-chatbox-select-channel-Admin = Admin


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The `hud-chatbox-info` localization assumes the user's keyboard layout has no modifications from QWERTY and that the typing and channel cycling keys are not rebound. This changes said localization as well as `ChatInputBox.cs` to use `BoundKeyHelper.ShortKeyName` with `ContentKeyFunctions` to display the user's accurate keybind to type or cycle channels.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![Screenshot from 2022-10-24 16-37-19](https://user-images.githubusercontent.com/44628275/197642939-27f09f1d-870b-45c4-96e7-f7674e8ea2a1.png)

![Screenshot from 2022-10-24 15-41-52](https://user-images.githubusercontent.com/44628275/197642620-458dd8e8-94e8-4075-8408-40cc209b3336.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: added keybind awareness to chatbox hint

