### PR TITLE
Vending machines properly show their current state after an animation

### DIFF
--- a/Content.Client/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Client/VendingMachines/VendingMachineSystem.cs
@@ -7,6 +7,7 @@ namespace Content.Client.VendingMachines;
 public sealed class VendingMachineSystem : SharedVendingMachineSystem
 {
     [Dependency] private readonly AnimationPlayerSystem _animationPlayer = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
 
     public override void Initialize()
     {
@@ -21,7 +22,14 @@ public sealed class VendingMachineSystem : SharedVendingMachineSystem
         if (!TryComp<SpriteComponent>(uid, out var sprite))
             return;
 
-        UpdateAppearance(uid, VendingMachineVisualState.Normal, component, sprite);
+        if (!TryComp<AppearanceComponent>(uid, out var appearance) ||
+            !_appearanceSystem.TryGetData(uid, VendingMachineVisuals.VisualState, out var visualStateObject, appearance) ||
+            visualStateObject is not VendingMachineVisualState visualState)
+        {
+            visualState = VendingMachineVisualState.Normal;
+        }
+
+        UpdateAppearance(uid, visualState, component, sprite);
     }
 
     private void OnAppearanceChange(EntityUid uid, VendingMachineComponent component, ref AppearanceChangeEvent args)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes and issue from discord where damaging an unpowered vending machine would make it look powered again. This bug was also blocking vending machines from showing their broken sprite in almost all cases.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed Vending Machines not showing their damage sprite in most cases.
