### PR TITLE
fixed windoor hacking

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -95,7 +95,7 @@
     usesApcPower: true
   - type: Wires
     BoardName: "Windoor Control"
-    LayoutId: Windoors
+    LayoutId: Airlock
   - type: UserInterface
     interfaces:
     - key: enum.WiresUiKey.Key
@@ -147,8 +147,6 @@
     - state: panel_open
       map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       visible: false
-  - type: Wires
-    LayoutId: Secure Windoors
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -20,7 +20,7 @@
   components:
   - type: AccessReader
     access: [["Bar"]]
-    
+
 - type: entity
   parent: Windoor
   id: WindoorBarKitchenLocked
@@ -28,7 +28,7 @@
   components:
   - type: AccessReader
     access: [["Bar"], ["Kitchen"]]
-    
+
 - type: entity
   parent: Windoor
   id: WindoorCargoLocked
@@ -68,7 +68,7 @@
   components:
   - type: AccessReader
     access: [["Kitchen"]]
-    
+
 - type: entity
   parent: Windoor
   id: WindoorKitchenHydroponicsLocked
@@ -76,7 +76,7 @@
   components:
   - type: AccessReader
     access: [["Kitchen"], ["Hydroponics"]]
-    
+
 - type: entity
   parent: Windoor
   id: WindoorServiceLocked
@@ -84,7 +84,7 @@
   components:
   - type: AccessReader
     access: [["Service"]]
-    
+
 - type: entity
   parent: Windoor
   id: WindoorTheatreLocked
@@ -134,7 +134,7 @@
   components:
   - type: AccessReader
     access: [["Chemistry"]]
-    
+
 - type: entity
   parent: WindoorSecure
   id: WindoorCommandLocked
@@ -142,8 +142,6 @@
   components:
   - type: AccessReader
     access: [["Command"]]
-  - type: Wires
-    LayoutId: WindoorCommand
 
 - type: entity
   parent: WindoorSecure
@@ -152,7 +150,7 @@
   components:
   - type: AccessReader
     access: [["Engineering"]]
-    
+
 - type: entity
   parent: WindoorSecure
   id: WindoorExternalLocked
@@ -200,8 +198,6 @@
   components:
   - type: AccessReader
     access: [["Security"]]
-  - type: Wires
-    LayoutId: WindoorSecurity
 
 - type: entity
   parent: WindoorSecure

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -22,10 +22,6 @@
   id: AirlockArmory
 
 - type: wireLayout
-  parent: Airlock
-  id: Windoors
-
-- type: wireLayout
   id: HighSec
   wires:
   - !type:PowerWireAction


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes: #12104

Side note: I've noticed that parenting a wire layout doesn't work as intended. As it stands now, parenting a layout will stack the number of wires for each parent. For example, command and armory airlocks are having their wires compounded on the normal airlock wires resulting in a total of 12 wires!. On some maps this happens where the Warden's airlock has 12 wires while HoS's airlock only has 6. Since most of the station's non-vault airlocks only have six wires, I've opted to use the Airlock wirelayout for all windoors. There is not vault windoor as far as I know. Fixing the layout parenting issue is out of scope for this fix and would also require extensive map changes throughout.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: fixed windoor hacking

