### PR TITLE
Add command to profile entity spawning

### DIFF
--- a/Content.Client/Commands/ProfileEntitySpawningCommand.cs
+++ b/Content.Client/Commands/ProfileEntitySpawningCommand.cs
@@ -1,0 +1,52 @@
+﻿using JetBrains.Profiler.Api;
+using Robust.Shared.Console;
+using Robust.Shared.Map;
+
+namespace Content.Client.Commands;
+
+#if !FULL_RELEASE
+public sealed class ProfileEntitySpawningCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entities = default!;
+
+    public string Command => "profileEntitySpawning";
+    public string Description => "Profiles entity spawning with n entities";
+    public string Help => $"Usage: {Command} | {Command} <amount> <prototype>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var amount = 10000;
+        string? prototype = null;
+
+        switch (args.Length)
+        {
+            case 0:
+                break;
+            case 2:
+                if (!int.TryParse(args[0], out amount))
+                {
+                    shell.WriteError($"First argument is not an integer: {args[0]}");
+                    return;
+                }
+
+                prototype = args[1];
+
+                break;
+            default:
+                shell.WriteError(Help);
+                return;
+        }
+
+        MeasureProfiler.StartCollectingData();
+
+        for (var i = 0; i < amount; i++)
+        {
+            _entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
+
+        }
+
+        MeasureProfiler.SaveData($"Client: Spawning {amount} entities");
+        shell.WriteLine($"Client: Profiled spawning {amount} entities");
+    }
+}
+#endif

--- a/Content.Client/Commands/ProfileEntitySpawningCommand.cs
+++ b/Content.Client/Commands/ProfileEntitySpawningCommand.cs
@@ -1,11 +1,12 @@
-﻿// ReSharper disable RedundantUsingDirective
+﻿#if !FULL_RELEASE
+// ReSharper disable RedundantUsingDirective
 using JetBrains.Profiler.Api;
 using Robust.Shared.Console;
 using Robust.Shared.Map;
+// ReSharper disable NotAccessedVariable
 
 namespace Content.Client.Commands;
 
-#if !FULL_RELEASE
 public sealed class ProfileEntitySpawningCommand : IConsoleCommand
 {
 #pragma warning disable CS0414
@@ -18,7 +19,7 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var amount = 10000;
+        var amount = 1000;
         string? prototype = null;
 
         switch (args.Length)
@@ -49,7 +50,7 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
         //     _entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
         // }
         //
-        // MeasureProfiler.SaveData($"Client: Spawning {amount} entities");
+        // MeasureProfiler.SaveData();
         // shell.WriteLine($"Client: Profiled spawning {amount} entities");
     }
 }

--- a/Content.Client/Commands/ProfileEntitySpawningCommand.cs
+++ b/Content.Client/Commands/ProfileEntitySpawningCommand.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Profiler.Api;
+﻿// ReSharper disable RedundantUsingDirective
+using JetBrains.Profiler.Api;
 using Robust.Shared.Console;
 using Robust.Shared.Map;
 
@@ -7,7 +8,9 @@ namespace Content.Client.Commands;
 #if !FULL_RELEASE
 public sealed class ProfileEntitySpawningCommand : IConsoleCommand
 {
+#pragma warning disable CS0414
     [Dependency] private readonly IEntityManager _entities = default!;
+#pragma warning restore CS0414
 
     public string Command => "profileEntitySpawning";
     public string Description => "Profiles entity spawning with n entities";
@@ -37,16 +40,17 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
                 return;
         }
 
-        MeasureProfiler.StartCollectingData();
+        // Disable sandbox and uncomment to use
 
-        for (var i = 0; i < amount; i++)
-        {
-            _entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
-
-        }
-
-        MeasureProfiler.SaveData($"Client: Spawning {amount} entities");
-        shell.WriteLine($"Client: Profiled spawning {amount} entities");
+        // MeasureProfiler.StartCollectingData();
+        //
+        // for (var i = 0; i < amount; i++)
+        // {
+        //     _entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
+        // }
+        //
+        // MeasureProfiler.SaveData($"Client: Spawning {amount} entities");
+        // shell.WriteLine($"Client: Profiled spawning {amount} entities");
     }
 }
 #endif

--- a/Content.Client/Commands/ProfileEntitySpawningCommand.cs
+++ b/Content.Client/Commands/ProfileEntitySpawningCommand.cs
@@ -40,7 +40,7 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
                 return;
         }
 
-        // Disable sandbox and uncomment to use
+        // Disable sandboxing and uncomment to use
 
         // MeasureProfiler.StartCollectingData();
         //

--- a/Content.Client/Content.Client.csproj
+++ b/Content.Client/Content.Client.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <Import Project="..\RobustToolbox\MSBuild\Robust.DefineConstants.targets" />
   <ItemGroup>
+    <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" PrivateAssets="All" />
   </ItemGroup>

--- a/Content.Server/Administration/Commands/AdminLogBulkCommand.cs
+++ b/Content.Server/Administration/Commands/AdminLogBulkCommand.cs
@@ -9,7 +9,7 @@ namespace Content.Server.Administration.Commands;
 
 #if DEBUG
 [AdminCommand(AdminFlags.Host)]
-public sealed class AdminLogBulk : IConsoleCommand
+public sealed class AdminLogBulkCommand : IConsoleCommand
 {
     public string Command => "adminlogbulk";
     public string Description => "Adds debug logs to the database.";

--- a/Content.Server/Administration/Commands/ProfileEntitySpawningCommand.cs
+++ b/Content.Server/Administration/Commands/ProfileEntitySpawningCommand.cs
@@ -1,0 +1,50 @@
+﻿using Content.Shared.Administration;
+using JetBrains.Profiler.Api;
+using Robust.Shared.Console;
+using Robust.Shared.Map;
+
+namespace Content.Server.Administration.Commands;
+
+#if !FULL_RELEASE
+[AdminCommand(AdminFlags.Host)]
+public sealed class ProfileEntitySpawningCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entities = default!;
+
+    public string Command => "profileEntitySpawning";
+    public string Description => "Profiles entity spawning with n entities";
+    public string Help => $"Usage: {Command} | {Command} <amount>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var amount = 10000;
+        switch (args.Length)
+        {
+            case 0:
+                break;
+            case 1:
+                if (!int.TryParse(args[0], out amount))
+                {
+                    shell.WriteError($"First argument is not an integer: {args[0]}");
+                    return;
+                }
+
+                break;
+            default:
+                shell.WriteError(Help);
+                return;
+        }
+
+        MeasureProfiler.StartCollectingData();
+
+        for (var i = 0; i < amount; i++)
+        {
+            _entities.SpawnEntity(null, MapCoordinates.Nullspace);
+
+        }
+
+        MeasureProfiler.SaveData($"Server: Spawning {amount} entities");
+        shell.WriteLine($"Server: Profiled spawning {amount} entities");
+    }
+}
+#endif

--- a/Content.Server/Administration/Commands/ProfileEntitySpawningCommand.cs
+++ b/Content.Server/Administration/Commands/ProfileEntitySpawningCommand.cs
@@ -1,11 +1,11 @@
-﻿using Content.Shared.Administration;
+﻿#if !FULL_RELEASE
+using Content.Shared.Administration;
 using JetBrains.Profiler.Api;
 using Robust.Shared.Console;
 using Robust.Shared.Map;
 
 namespace Content.Server.Administration.Commands;
 
-#if !FULL_RELEASE
 [AdminCommand(AdminFlags.Host)]
 public sealed class ProfileEntitySpawningCommand : IConsoleCommand
 {
@@ -17,17 +17,21 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var amount = 10000;
+        var amount = 1000;
+        string? prototype = null;
+
         switch (args.Length)
         {
             case 0:
                 break;
-            case 1:
+            case 2:
                 if (!int.TryParse(args[0], out amount))
                 {
                     shell.WriteError($"First argument is not an integer: {args[0]}");
                     return;
                 }
+
+                prototype = args[1];
 
                 break;
             default:
@@ -39,10 +43,10 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
 
         for (var i = 0; i < amount; i++)
         {
-            _entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            _entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
         }
 
-        MeasureProfiler.SaveData($"Server: Spawning {amount} entities");
+        MeasureProfiler.SaveData();
         shell.WriteLine($"Server: Profiled spawning {amount} entities");
     }
 }

--- a/Content.Server/Administration/Commands/ProfileEntitySpawningCommand.cs
+++ b/Content.Server/Administration/Commands/ProfileEntitySpawningCommand.cs
@@ -40,7 +40,6 @@ public sealed class ProfileEntitySpawningCommand : IConsoleCommand
         for (var i = 0; i < amount; i++)
         {
             _entities.SpawnEntity(null, MapCoordinates.Nullspace);
-
         }
 
         MeasureProfiler.SaveData($"Server: Spawning {amount} entities");

--- a/Content.Server/Content.Server.csproj
+++ b/Content.Server/Content.Server.csproj
@@ -16,6 +16,7 @@
   <Import Project="..\RobustToolbox\MSBuild\Robust.DefineConstants.targets" />
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" PrivateAssets="All" />
+    <PackageReference Condition="'$(FullRelease)' != 'True'" Include="JetBrains.Profiler.Api" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Content.Packaging\Content.Packaging.csproj" />

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -68,3 +68,7 @@
   Commands:
     - uploadfile
     - loadprototype
+
+- Flags: HOST
+  Commands:
+  - profileEntitySpawning


### PR DESCRIPTION
We finally do have the technology.

To use:
- **On Visual Studio:** good luck look into `ReSharper | Profile | Run Application Performance Profiling` or something
- **On Rider:** create a new profiling configuration in Rider
![image](https://user-images.githubusercontent.com/10968691/197686904-3c213695-1348-4190-90d6-cf424582412b.png)
- Make sure to mark "Control profiling with API" 
![image](https://user-images.githubusercontent.com/10968691/197686804-34149174-71ed-478b-8eb5-3c7c3d03bda3.png)
- Run client and/or server with that configuration (in the case of the client disable sandboxing and uncomment the block of code that calls MeasureProfiler
- Run the command, examples:
  - profileEntitySpawning 
  - profileEntitySpawning 500
  - profileEntitySpawning 1000 MobHuman