### PR TITLE
Fix gun ItemStatus

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
-using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
@@ -19,6 +17,7 @@ public abstract partial class SharedGunSystem
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, TakeAmmoEvent>(OnChamberMagazineTakeAmmo);
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, GetVerbsEvent<Verb>>(OnMagazineVerb);
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, EntInsertedIntoContainerMessage>(OnMagazineSlotChange);
+        SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, EntRemovedFromContainerMessage>(OnMagazineSlotChange);
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, UseInHandEvent>(OnMagazineUse);
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, ExaminedEvent>(OnChamberMagazineExamine);
     }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Magazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Magazine.cs
@@ -1,6 +1,4 @@
-using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
@@ -18,6 +16,7 @@ public abstract partial class SharedGunSystem
         SubscribeLocalEvent<MagazineAmmoProviderComponent, TakeAmmoEvent>(OnMagazineTakeAmmo);
         SubscribeLocalEvent<MagazineAmmoProviderComponent, GetVerbsEvent<Verb>>(OnMagazineVerb);
         SubscribeLocalEvent<MagazineAmmoProviderComponent, EntInsertedIntoContainerMessage>(OnMagazineSlotChange);
+        SubscribeLocalEvent<MagazineAmmoProviderComponent, EntRemovedFromContainerMessage>(OnMagazineSlotChange);
         SubscribeLocalEvent<MagazineAmmoProviderComponent, UseInHandEvent>(OnMagazineUse);
         SubscribeLocalEvent<MagazineAmmoProviderComponent, ExaminedEvent>(OnMagazineExamine);
     }
@@ -37,7 +36,7 @@ public abstract partial class SharedGunSystem
 
         if (magEnt == null) return;
 
-        RaiseLocalEvent(magEnt.Value, args, false);
+        RaiseLocalEvent(magEnt.Value, args);
         UpdateAmmoCount(uid);
         UpdateMagazineAppearance(component, magEnt.Value);
     }
@@ -50,13 +49,16 @@ public abstract partial class SharedGunSystem
 
         if (magEnt != null)
         {
-            RaiseLocalEvent(magEnt.Value, args, false);
+            RaiseLocalEvent(magEnt.Value, args);
             UpdateMagazineAppearance(component, magEnt.Value);
         }
     }
 
-    private void OnMagazineSlotChange(EntityUid uid, MagazineAmmoProviderComponent component, EntInsertedIntoContainerMessage args)
+    protected virtual void OnMagazineSlotChange(EntityUid uid, MagazineAmmoProviderComponent component, ContainerModifiedMessage args)
     {
+        if (MagazineSlot != args.Container.ID)
+            return;
+
         UpdateAmmoCount(uid);
         if (!TryComp<AppearanceComponent>(uid, out var appearance))
             return;


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/12224

Issue is that it wasn't handling removals anymore (e.g. when bullets shot).

:cl:
- fix: Fix the item status for chambered guns flickering.