### PR TITLE
Fix lamps not spawning with power cells

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -35,6 +35,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellSmall
   - type: ContainerContainer
     containers:
       cell_slot: !type:ContainerSlot


### PR DESCRIPTION
## About the PR
Makes all lamps spawn with a small power cell inside them.

**Changelog**
:cl: Nairod
- tweak: Changed it so lamps now spawn with power cells.