### PR TITLE
Make context menu use FrameUpdate() instead of Update()

### DIFF
--- a/Content.Client/Gameplay/GameplayStateBase.cs
+++ b/Content.Client/Gameplay/GameplayStateBase.cs
@@ -56,17 +56,14 @@ namespace Content.Client.Gameplay
         public IList<EntityUid> GetEntitiesUnderPosition(MapCoordinates coordinates)
         {
             // Find all the entities intersecting our click
-            var entities = EntitySystem.Get<EntityLookupSystem>().GetEntitiesIntersecting(coordinates.MapId,
-                Box2.CenteredAround(coordinates.Position, (1, 1)));
-
-            var containerSystem = _entitySystemManager.GetEntitySystem<SharedContainerSystem>();
+            var entities = _entityManager.EntitySysManager.GetEntitySystem<EntityLookupSystem>().GetEntitiesIntersecting(coordinates.MapId,
+                Box2.CenteredAround(coordinates.Position, (1, 1)), LookupFlags.Uncontained | LookupFlags.Approximate);
 
             // Check the entities against whether or not we can click them
             var foundEntities = new List<(EntityUid clicked, int drawDepth, uint renderOrder)>();
             foreach (var entity in entities)
             {
                 if (_entityManager.TryGetComponent<ClickableComponent?>(entity, out var component)
-                    && !containerSystem.IsEntityInContainer(entity)
                     && component.CheckClick(coordinates.Position, out var drawDepthClicked, out var renderOrder))
                 {
                     foundEntities.Add((entity, drawDepthClicked, renderOrder));

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -73,7 +73,7 @@ namespace Content.Client.Verbs
 
         public override void FrameUpdate(float frameTime)
         {
-            base.Update(frameTime);
+            base.FrameUpdate(frameTime);
             EntityMenu?.Update();
         }
 

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -1,14 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Content.Client.CombatMode;
 using Content.Client.ContextMenu.UI;
 using Content.Client.Examine;
 using Content.Client.Gameplay;
 using Content.Client.Popups;
 using Content.Client.Verbs.UI;
-using Content.Client.Viewport;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Tag;
@@ -18,11 +13,10 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Client.State;
-using Robust.Shared.Containers;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Utility;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Content.Client.Verbs
 {
@@ -77,7 +71,7 @@ namespace Content.Client.Verbs
             VerbMenu?.Dispose();
         }
 
-        public override void Update(float frameTime)
+        public override void FrameUpdate(float frameTime)
         {
             base.Update(frameTime);
             EntityMenu?.Update();


### PR DESCRIPTION
Now you should be able to look at 10,000 bananas before you get to 1fps (#8967). Its still shit though.