### PR TITLE
Don't log missing inventory.

### DIFF
--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -163,7 +163,7 @@ namespace Content.Client.Inventory
         public void ReloadInventory(ClientInventoryComponent? component = null)
         {
             var player = _playerManager.LocalPlayer?.ControlledEntity;
-            if (player == null || !Resolve(player.Value, ref component))
+            if (player == null || !Resolve(player.Value, ref component, false))
             {
                 return;
             }


### PR DESCRIPTION
Fixes error that appears when joining the game as a spectator.