### PR TITLE
Cap ChemMaster label length

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -79,6 +79,9 @@ namespace Content.Client.Chemistry.UI
             PillNumber.InitDefaultButtons();
             BottleDosage.InitDefaultButtons();
 
+            // Ensure label length is within the character limit.
+            LabelLineEdit.IsValid = s => s.Length <= SharedChemMaster.LabelMaxLength;
+
             Tabs.SetTabTitle(0, Loc.GetString("chem-master-window-input-tab"));
             Tabs.SetTabTitle(1, Loc.GetString("chem-master-window-output-tab"));
         }

--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -186,6 +186,10 @@ namespace Content.Server.Chemistry.EntitySystems
             if (message.Dosage == 0 || message.Dosage > chemMaster.PillDosageLimit)
                 return;
 
+            // Ensure label length is within the character limit.
+            if (message.Label.Length > SharedChemMaster.LabelMaxLength)
+                return;
+
             var needed = message.Dosage * message.Number;
             if (!WithdrawFromBuffer(chemMaster, needed, user, out var withdrawal))
                 return;
@@ -225,6 +229,10 @@ namespace Content.Server.Chemistry.EntitySystems
 
             // Ensure the amount is valid.
             if (message.Dosage == 0 || message.Dosage > solution.AvailableVolume)
+                return;
+
+            // Ensure label length is within the character limit.
+            if (message.Label.Length > SharedChemMaster.LabelMaxLength)
                 return;
 
             if (!WithdrawFromBuffer(chemMaster, message.Dosage, user, out var withdrawal))

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -15,6 +15,7 @@ namespace Content.Shared.Chemistry
         public const string OutputSlotName = "outputSlot";
         public const string PillSolutionName = "food";
         public const string BottleSolutionName = "drink";
+        public const uint LabelMaxLength = 50;
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
Context: this screenshot was posted on discord:
![image](https://user-images.githubusercontent.com/48867431/198547557-b1ddddb5-9b40-43f5-b877-92bb81617d16.png)

This pr limits it to 50 characters like the hand labeler.