### PR TITLE
Fix rotated chair draw depth

### DIFF
--- a/Content.Client/Buckle/BuckleComponent.cs
+++ b/Content.Client/Buckle/BuckleComponent.cs
@@ -49,6 +49,9 @@ namespace Content.Client.Buckle
             // Adjust draw depth when the chair faces north so that the seat back is drawn over the player.
             // Reset the draw depth when rotated in any other direction.
             // TODO when ECSing, make this a visualizer
+            // This code was written before rotatable viewports were introduced, so hard-coding Direction.North
+            // and comparing it against LocalRotation now breaks this in other rotations. This is a FIXME, but
+            // better to get it working for most people before we look at a more permanent solution.
             if (_buckled &&
                 LastEntityBuckledTo != null &&
                 EntMan.GetComponent<TransformComponent>(LastEntityBuckledTo.Value).LocalRotation.GetCardinalDir() == Direction.North &&

--- a/Content.Client/Buckle/BuckleComponent.cs
+++ b/Content.Client/Buckle/BuckleComponent.cs
@@ -46,6 +46,8 @@ namespace Content.Client.Buckle
                 return;
             }
 
+            // Adjust draw depth when the chair faces north so that the seat back is drawn over the player.
+            // Reset the draw depth when rotated in any other direction.
             // TODO when ECSing, make this a visualizer
             if (_buckled &&
                 LastEntityBuckledTo != null &&
@@ -57,7 +59,8 @@ namespace Content.Client.Buckle
                 return;
             }
 
-            if (_originalDrawDepth.HasValue && !_buckled)
+            // If here, we're not turning north and should restore the saved draw depth.
+            if (_originalDrawDepth.HasValue)
             {
                 ownerSprite.DrawDepth = _originalDrawDepth.Value;
                 _originalDrawDepth = null;


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Chair draw depth is adjusted on the client to draw the seat back over the player when the chair is facing north. However, a logic error exists in the code that restores the original draw depth that causes the chair to be drawn on top of the player.

Reproduction: sit in a chair, face north, then face any other direction. Player will be drawn under chair.

This PR fixes this (issues #11478 and #10326).

**Screenshots**

https://user-images.githubusercontent.com/3229565/198815216-c5570db3-a447-4482-96cf-d404531ee5d7.mp4

**Changelog**
:cl: notafet
- fix: Chairs are drawn correctly when rotated.
