### PR TITLE
More newlines in syndicate agent briefing

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
@@ -1,7 +1,7 @@
 ﻿nukeops-title = Nuclear Operatives
 nukeops-description = Nuclear operatives have targeted the station. Try to keep them from arming and detonating the nuke by protecting the nuke disk!
 
-nukeops-welcome = You are a nuclear operative. Your goal is to blow up {$station}, and ensure that it is nothing but a pile of rubble. Your bosses, the Syndicate, have provided you with the tools you'll need for the task.
+nukeops-welcome = You are a nuclear operative. Your goal is to blow up {$station}, and ensure that it is nothing but a pile of rubble. Your bosses, the Syndicate, have provided you with the tools you'll need for the task. Death to Nanotrasen!
 
 nukeops-opsmajor = Syndicate major victory!
 nukeops-opsminor = Syndicate minor victory!

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
@@ -1,7 +1,8 @@
 ﻿nukeops-title = Nuclear Operatives
 nukeops-description = Nuclear operatives have targeted the station. Try to keep them from arming and detonating the nuke by protecting the nuke disk!
 
-nukeops-welcome = You are a nuclear operative. Your goal is to blow up {$station}, and ensure that it is nothing but a pile of rubble. Your bosses, the Syndicate, have provided you with the tools you'll need for the task. Death to Nanotrasen!
+nukeops-welcome = You are a nuclear operative. Your goal is to blow up {$station}, and ensure that it is nothing but a pile of rubble. Your bosses, the Syndicate, have provided you with the tools you'll need for the task.
+ Death to Nanotrasen!
 
 nukeops-opsmajor = Syndicate major victory!
 nukeops-opsminor = Syndicate minor victory!

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
@@ -1,8 +1,9 @@
 ﻿nukeops-title = Nuclear Operatives
 nukeops-description = Nuclear operatives have targeted the station. Try to keep them from arming and detonating the nuke by protecting the nuke disk!
 
-nukeops-welcome = You are a nuclear operative. Your goal is to blow up {$station}, and ensure that it is nothing but a pile of rubble. Your bosses, the Syndicate, have provided you with the tools you'll need for the task.
- Death to Nanotrasen!
+nukeops-welcome =
+    You are a nuclear operative. Your goal is to blow up {$station}, and ensure that it is nothing but a pile of rubble. Your bosses, the Syndicate, have provided you with the tools you'll need for the task.
+    Death to Nanotrasen!
 
 nukeops-opsmajor = Syndicate major victory!
 nukeops-opsminor = Syndicate minor victory!

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -39,5 +39,11 @@ traitor-death-match-end-round-description-entry = {$originalName}'s PDA, with {$
 ## TraitorRole
 
 # TraitorRole
-traitor-role-greeting = You are a syndicate agent. Your objectives and codewords are listed in the character menu. Use the uplink loaded into your PDA to buy the tools you'll need for this mission.
-traitor-role-codewords = Codewords can be used in regular conversation to identify yourself discretely to other syndicate agents. The syndicate codewords are: {$codewords}
+traitor-role-greeting = You are a syndicate agent.
+ Your objectives and codewords are listed in the character menu.
+ Use the uplink loaded into your PDA to buy the tools you'll need for this mission.
+ Death to Nanotrasen!
+traitor-role-codewords = The codewords are:
+ {$codewords}.
+ Codewords can be used in regular conversation to identify yourself discretely to other syndicate agents.
+ Listen for them, and keep them secret.

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -39,11 +39,13 @@ traitor-death-match-end-round-description-entry = {$originalName}'s PDA, with {$
 ## TraitorRole
 
 # TraitorRole
-traitor-role-greeting = You are a syndicate agent.
- Your objectives and codewords are listed in the character menu.
- Use the uplink loaded into your PDA to buy the tools you'll need for this mission.
- Death to Nanotrasen!
-traitor-role-codewords = The codewords are:
- {$codewords}.
- Codewords can be used in regular conversation to identify yourself discretely to other syndicate agents.
- Listen for them, and keep them secret.
+traitor-role-greeting =
+    You are a syndicate agent.
+    Your objectives and codewords are listed in the character menu.
+    Use the uplink loaded into your PDA to buy the tools you'll need for this mission.
+    Death to Nanotrasen!
+traitor-role-codewords =
+    The codewords are:
+    {$codewords}.
+    Codewords can be used in regular conversation to identify yourself discretely to other syndicate agents.
+    Listen for them, and keep them secret.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Puts a newline into the syndicate traitor briefing.
Also changed a couple words in it.
Also added "Death to Nanotrasen!" into both the traitor and nukie briefings.
I might have went overboard with the newlines, tell me if any should be removed.

Based on https://discord.com/channels/310555209753690112/1035204807050416159
Thanks to Ygg01 on Discord for telling me how to make newlines in ftl files

**Screenshots**
### BEFORE:
![image](https://user-images.githubusercontent.com/113810873/198816036-3d6b5525-9641-45d7-ba34-fce0d0373bc6.png)

### AFTER:
![image](https://user-images.githubusercontent.com/113810873/198815844-f30b8ded-70b7-4f8b-86e6-51218f43986b.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Made it easier to see codewords in the character menu and syndicate agent briefing.
- tweak: The Syndicate hates Nanotrasen slightly more.
