### PR TITLE
Flying mob step trigger fix

### DIFF
--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -2,7 +2,6 @@ using Content.Shared.StepTrigger.Components;
 using Robust.Shared.Collections;
 using Robust.Shared.GameStates;
 using Robust.Shared.Physics.Components;
-using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 
 namespace Content.Shared.StepTrigger.Systems;
@@ -102,6 +101,9 @@ public sealed class StepTriggerSystem : EntitySystem
     private void HandleCollide(EntityUid uid, StepTriggerComponent component, ref StartCollideEvent args)
     {
         var otherUid = args.OtherFixture.Body.Owner;
+
+        if (!args.OtherFixture.Hard)
+            return;
 
         if (!CanTrigger(uid, otherUid, component))
             return;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disables collisions with non-Hard fixtures in StepTrigger.

~~Adds a new component called "NoStep" which is similar to NoSlip. Some mobs fly or are ghosts, and as such don't actually step anywhere. They shouldn't hit StepTriggers, but currently they run into mousetraps, glass shards, etc.~~

The problem with flying mobs hitting StepTriggers is actually caused by the Flammable fixture, but instead of redesigning that entire system or introducing workarounds I think it's better to ~~add a component that could also be used for other purposes.~~ disable collisions with non-Hard fixtures.

~~The only real solution for the collision itself, as I see it, is to somehow have FlammableSystem not reliant on fixtures at all.~~

Resolves [#9864](https://github.com/space-wizards/space-station-14/issues/9864).


**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/8189043/198836992-9a187373-05e8-4fb1-a504-ebf1bd620402.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Flying mobs no longer run into mousetraps and glass shards

