### PR TITLE
Fixes middle aged humanoids not showing the correct description when examined

### DIFF
--- a/Content.Server/Humanoid/Systems/HumanoidSystem.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidSystem.cs
@@ -509,10 +509,14 @@ public sealed partial class HumanoidSystem : SharedHumanoidSystem
         }
 
         if (age < speciesPrototype.YoungAge)
+        {
             return Loc.GetString("identity-age-young");
+        }
 
         if (age < speciesPrototype.OldAge)
-            Loc.GetString("identity-age-middle-aged");
+        {
+            return Loc.GetString("identity-age-middle-aged");
+        }
 
         return Loc.GetString("identity-age-old");
     }


### PR DESCRIPTION
This is for Helmsley, 34 is indeed not enough to be considered old.

:cl:
- fix: Examining a humanoid with an age between 30 and 60 years old now properly shows them as middle-aged instead of old.

