### PR TITLE
fix syringe overdrawing

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
@@ -394,8 +394,8 @@ public sealed partial class ChemistrySystem
             return;
         }
 
-        // Get transfer amount. May be smaller than _transferAmount if not enough room
-        var realTransferAmount = FixedPoint2.Min(component.TransferAmount, targetSolution.DrawAvailable);
+        // Get transfer amount. May be smaller than _transferAmount if not enough room, also make sure there's room in the injector
+        var realTransferAmount = FixedPoint2.Min(component.TransferAmount, targetSolution.DrawAvailable, solution.AvailableVolume);
 
         if (realTransferAmount <= 0)
         {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Someone in discord reported an edge case where if you try drawing 15u from a solution into a partially filled syringe then it would just eat the drawn amount without filling the syringe. This is because the realTransferAmount wasn't accounting for the amount available space in the injector. Easy fix.

Steps to reproduce:

1. spawn in a syringe
2. spawn in a beaker
3. spawn in a can of space cola
4. pour 10u of cola into the beaker
5. set syringe to draw and transfer amount to 15u
6. draw from the beaker with the syringe
7. syringe should have 10u
8. pour 10u of cola into the beaker
9. draw from the beaker with the syringe

bugged result: the 10u from the beaker is destroyed and the syringe still only has 10u in it
expected result: syringe draws 5u from the beaker, leaving 5u remaining in it

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Overdrawing with a syringe no longer destroys the transferred solution

