### PR TITLE
fix traitor game mode

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -71,13 +71,6 @@ public sealed class TraitorRuleSystem : GameRuleSystem
         if (!RuleAdded)
             return;
 
-        // If the current preset doesn't explicitly contain the traitor game rule, just carry on and remove self.
-        if (_gameTicker.Preset?.Rules.Contains(Prototype) ?? false)
-        {
-            _gameTicker.EndGameRule(_prototypeManager.Index<GameRulePrototype>(Prototype));
-            return;
-        }
-
         var minPlayers = _cfg.GetCVar(CCVars.TraitorMinPlayers);
         if (!ev.Forced && ev.Players.Length < minPlayers)
         {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For some reason it had a check to only start if the preset did NOT contain the traitor rule, which is... something...
Reversing the check with a ! would break secret because secret does not contain traitor
The solution is to remove it because any consequences from game modes that aren't traitor being able to start traitor would have been seen by now because that's the current situation; every gamemode EXCEPT traitor could start traitor
Closes https://github.com/space-wizards/space-station-14/issues/8952

:cl: Rane
- fix: Traitor mode will now work on its own rather than only in secret.
