### PR TITLE
pass on food digestion

### DIFF
--- a/Resources/Prototypes/Diseases/infectious.yml
+++ b/Resources/Prototypes/Diseases/infectious.yml
@@ -300,6 +300,7 @@
       min: 420 ## Reachable with a flamer
     - !type:DiseaseReagentCure
       reagent: Theobromine
+      min: 4
 
 - type: disease
   id: TongueTwister

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -1,5 +1,6 @@
-﻿- type: reagent
-  id: Nutriment
+﻿# End points - the eventual goal is that almost all foods and drinks metabolize into either these, or reagents that build up (e.g. theobromine, caffeine,... )
+- type: reagent
+  id: Nutriment #Anything that isn't better suited to vitamin, protein, or sugar. we aren't doing a super in-depth simulator.
   name: reagent-name-nutriment
   group: Foods
   desc: reagent-desc-nutriment
@@ -17,7 +18,7 @@
     amount: 0.5
 
 - type: reagent
-  id: Vitamin
+  id: Vitamin #Anything "healthy"
   name: reagent-name-vitamin
   group: Foods
   desc: reagent-desc-vitamin
@@ -39,7 +40,7 @@
       - !type:SatiateHunger #Numbers are balanced with this in mind + it helps limit how much healing you can get from food
 
 - type: reagent
-  id: Protein
+  id: Protein #Meat and beans
   name: reagent-name-protein
   group: Foods
   desc: reagent-desc-protein
@@ -58,3 +59,24 @@
         amount: 1 # weaker than iron but pretty good all things considered
       - !type:SatiateHunger
 
+- type: reagent
+  id: Sugar #Candy and grains
+  name: reagent-name-sugar
+  group: Foods
+  desc: reagent-desc-sugar
+  physicalDesc: reagent-physical-desc-sweet
+  flavor: sweet
+  color: white
+  meltingPoint: 146.0
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 1
+  plantMetabolism:
+  - !type:PlantAdjustNutrition
+    amount: 0.1
+  - !type:PlantAdjustWeeds
+    amount: 2
+  - !type:PlantAdjustPests
+    amount: 2

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -72,6 +72,10 @@
     Food:
       effects:
       - !type:SatiateHunger
+        conditions:
+        - !type:ReagentThreshold #Only satiates when eaten with nutriment
+          reagent: Nutriment
+          min: 0.1
         factor: 1
   plantMetabolism:
   - !type:PlantAdjustNutrition

--- a/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
@@ -9,8 +9,12 @@
   metabolisms:
     Food:
       effects:
-      - !type:SatiateHunger
-        factor: 1
+      - !type:AdjustReagent
+        reagent: Sugar
+        amount: 0.4
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.1
 
 - type: reagent
   id: Oats
@@ -23,8 +27,12 @@
   metabolisms:
     Food:
       effects:
-      - !type:SatiateHunger
-        factor: 1
+      - !type:AdjustReagent
+        reagent: Sugar
+        amount: 0.2
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.3
 
 - type: reagent
   id: Enzyme
@@ -34,11 +42,6 @@
   physicalDesc: reagent-physical-desc-chalky
   flavor: bitter
   color: "#009900"
-  metabolisms:
-    Food:
-      effects:
-      - !type:SatiateHunger
-        nutritionFactor: 1
 
 - type: reagent
   id: Egg
@@ -51,31 +54,9 @@
   metabolisms:
     Food:
       effects:
-      - !type:SatiateHunger
-        factor: 1
-
-- type: reagent
-  id: Sugar
-  name: reagent-name-sugar
-  group: Foods
-  desc: reagent-desc-sugar
-  physicalDesc: reagent-physical-desc-sweet
-  flavor: sweet
-  color: white
-  meltingPoint: 146.0
-  metabolisms:
-    Food:
-      effects:
-      - !type:SatiateHunger
-        factor: 1
-  plantMetabolism:
-  - !type:PlantAdjustNutrition
-    amount: 0.1
-  - !type:PlantAdjustWeeds
-    amount: 2
-  - !type:PlantAdjustPests
-    amount: 2
-
+      - !type:AdjustReagent
+        reagent: Protein
+        amount: 0.5
 
 - type: reagent
   id: Blackpepper
@@ -85,11 +66,6 @@
   physicalDesc: reagent-physical-desc-grainy
   flavor: peppery
   color: black
-  metabolisms:
-    Food:
-      effects:
-      - !type:SatiateHunger
-        factor: 1
 
 - type: reagent
   id: Vinegar
@@ -102,8 +78,17 @@
   metabolisms:
     Food:
       effects:
-      - !type:SatiateHunger
-        factor: 1
+      - !type:AdjustReagent
+        reagent: Water
+        amount: 0.4
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.1
+      - !type:ChemVomit
+        probability: 0.1
+        conditions:
+          - !type:ReagentThreshold
+            min: 6
 
 - type: reagent
   id: Rice
@@ -116,7 +101,12 @@
   metabolisms:
     Food:
       effects:
-      - !type:SatiateHunger
+      - !type:AdjustReagent
+        reagent: Sugar
+        amount: 0.4
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.1
 
 - type: reagent
   id: OilOlive
@@ -129,8 +119,9 @@
   metabolisms:
     Food:
       effects:
-      - !type:SatiateHunger
-        factor: 1
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.75
 
 - type: reagent
   id: Oil
@@ -157,8 +148,9 @@
   metabolisms:
     Food:
       effects:
-        - !type:SatiateHunger # spicy foods satiate hunger better
-          factor: 1.5
+      - !type:AdjustReagent
+        reagent: Nutriment #Oils enhance nutrition
+        amount: 0.75
     Poison:
       effects:
         - !type:AdjustTemperature

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -342,6 +342,7 @@
   boilingPoint: 554 # I'm not a chemist, but it boils at 295, lower than melting point, idk how it works so I gave it higher value
   metabolisms:
     Poison:
+      metabolismRate: 0.05
       effects:
       - !type:HealthChange
         conditions:
@@ -351,9 +352,9 @@
           type: Animal # Applying damage to the mobs with lower metabolism capabilities
         damage:
           types:
-            Poison: 4
+            Poison: 0.4
       - !type:ChemVomit
-        probability: 0.04
+        probability: 0.04 #Scaled for time, not metabolismrate.
         conditions:
           - !type:ReagentThreshold
             min: 3
@@ -444,6 +445,7 @@
   color: "#F2E9D2"
   metabolisms:
     Poison:
+      metabolismRate: 0.05
       effects:
       - !type:HealthChange
         conditions:
@@ -453,7 +455,7 @@
           type: Animal
         damage:
           types:
-            Poison: 6
+            Poison: 0.06
 
 - type: reagent
   id: Pax


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mostly gathering some feedback on this idea. This does particularly impact a lot of the current gameplay with animal metabolism, and would be good if someone wanted to revive https://github.com/space-wizards/space-station-14/pull/9124.

Needs a second pass later on the actual foods, I just messed with ingredients.

Also what this is working towards is good for chef gameplay :tm: because dietary needs will be more intuitive.

Closes https://github.com/space-wizards/space-station-14/issues/8889

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Rane
- tweak: Digesting most food will take a bit longer, as your body breaks things down. This also means OwOnavirus is easier to cure.
- fix: Creatures with animal metabolisms will build up allicin and theobromine more rapidly, making the intended toxin behavior actually work.
- fix: Sugar pills don't satiate anymore. Foods with sugar still do.

