### PR TITLE
Fix disposal tube deconstruction

### DIFF
--- a/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
+++ b/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
@@ -1,18 +1,16 @@
-using System.Text;
+using Content.Server.Construction.Completions;
 using Content.Server.Disposal.Tube.Components;
-using Content.Server.UserInterface;
 using Content.Server.Hands.Components;
+using Content.Server.UserInterface;
 using Content.Shared.Destructible;
 using Content.Shared.Disposal.Components;
-using Content.Shared.Movement;
 using Content.Shared.Movement.Events;
-using Content.Shared.Verbs;
 using Content.Shared.Popups;
-using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using System.Text;
 
 namespace Content.Server.Disposal.Tube
 {
@@ -32,6 +30,12 @@ namespace Content.Server.Disposal.Tube
             SubscribeLocalEvent<DisposalRouterComponent, ActivatableUIOpenAttemptEvent>(OnOpenRouterUIAttempt);
             SubscribeLocalEvent<DisposalTaggerComponent, ActivatableUIOpenAttemptEvent>(OnOpenTaggerUIAttempt);
             SubscribeLocalEvent<DisposalTubeComponent, ComponentStartup>(OnStartup);
+            SubscribeLocalEvent<DisposalTubeComponent, ConstructionBeforeDeleteEvent>(OnDeconstruct);
+        }
+
+        private void OnDeconstruct(EntityUid uid, DisposalTubeComponent component, ConstructionBeforeDeleteEvent args)
+        {
+            component.Disconnect();
         }
 
         private void OnStartup(EntityUid uid, DisposalTubeComponent component, ComponentStartup args)

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
@@ -65,7 +65,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
                 if (duc != null)
                     duc.Container.Insert(entity, EntityManager, xform, meta: meta);
                 else
-                    xform.AttachParentToContainerOrGrid(EntityManager);
+                    xform.AttachToGridOrMap();
             }
 
             if (duc != null)


### PR DESCRIPTION
:cl:
- fix: Deconstructing disposal tubes should no longer delete contained entities.
- fix: Fixed people getting trapped in disposal trunks.
