### PR TITLE
Add toggle ghost visibility button to ghost GUI

### DIFF
--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -155,5 +155,10 @@ namespace Content.Client.Ghost
         {
             _console.RemoteExecuteCommand(null, "ghostroles");
         }
+
+        public void ToggleGhostVisibility()
+        {
+            _console.RemoteExecuteCommand(null, "toggleghostvisibility");
+        }
     }
 }

--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -158,7 +158,7 @@ namespace Content.Client.Ghost
 
         public void ToggleGhostVisibility()
         {
-            _console.RemoteExecuteCommand(null, "toggleghostvisibility");
+            _console.RemoteExecuteCommand(null, "toggleghosts");
         }
     }
 }

--- a/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
@@ -99,6 +99,7 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         Gui.RequestWarpsPressed += RequestWarps;
         Gui.ReturnToBodyPressed += ReturnToBody;
         Gui.GhostRolesPressed += GhostRolesPressed;
+        Gui.ToggleGhostVisibility += ToggleGhostVisibility;
         Gui.TargetWindow.WarpClicked += OnWarpClicked;
 
         UpdateGui();
@@ -112,6 +113,7 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         Gui.RequestWarpsPressed -= RequestWarps;
         Gui.ReturnToBodyPressed -= ReturnToBody;
         Gui.GhostRolesPressed -= GhostRolesPressed;
+        Gui.ToggleGhostVisibility -= ToggleGhostVisibility;
         Gui.TargetWindow.WarpClicked -= OnWarpClicked;
 
         Gui.Hide();
@@ -132,5 +134,10 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
     private void GhostRolesPressed()
     {
         _system?.OpenGhostRoles();
+    }
+
+    private void ToggleGhostVisibility()
+    {
+        _system?.ToggleGhostVisibility();
     }
 }

--- a/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml
+++ b/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml
@@ -5,5 +5,6 @@
         <Button Name="ReturnToBodyButton" Text="{Loc ghost-gui-return-to-body-button}" />
         <Button Name="GhostWarpButton" Text="{Loc ghost-gui-ghost-warp-button}" />
         <Button Name="GhostRolesButton" />
+        <Button Name="ToggleGhostVisibilityButton" Text="{Loc ghost-gui-toggle-ghost-visibility-button}" />
     </BoxContainer>
 </widgets:GhostGui>

--- a/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
@@ -14,6 +14,7 @@ public sealed partial class GhostGui : UIWidget
     public event Action? RequestWarpsPressed;
     public event Action? ReturnToBodyPressed;
     public event Action? GhostRolesPressed;
+    public event Action? ToggleGhostVisibility;
 
     public GhostGui()
     {
@@ -26,6 +27,7 @@ public sealed partial class GhostGui : UIWidget
         GhostWarpButton.OnPressed += _ => RequestWarpsPressed?.Invoke();
         ReturnToBodyButton.OnPressed += _ => ReturnToBodyPressed?.Invoke();
         GhostRolesButton.OnPressed += _ => GhostRolesPressed?.Invoke();
+        ToggleGhostVisibilityButton.OnPressed += _ => ToggleGhostVisibility?.Invoke();
     }
 
     public void Hide()

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.Storage.Components;
 using Content.Server.Visible;
 using Content.Server.Warps;
 using Content.Shared.Actions;
+using Content.Shared.Administration;
 using Content.Shared.Examine;
 using Content.Shared.Follower;
 using Content.Shared.Ghost;
@@ -17,6 +18,7 @@ using Content.Shared.Movement.Events;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
+using Robust.Shared.Console;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
 
@@ -294,6 +296,29 @@ namespace Content.Server.Ghost
             RaiseLocalEvent(target, ghostBoo, true);
 
             return ghostBoo.Handled;
+        }
+    }
+    
+    [AnyCommand]
+    public sealed class ToggleGhostVisibility : IConsoleCommand
+    {
+        public string Command => "toggleghostvisibility";
+        public string Description => "Toggles ghost visibility";
+        public string Help => $"{Command}";
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (shell.Player == null)
+                shell.WriteLine("You can only open the ghost roles UI on a client.");
+
+            var entityManager = IoCManager.Resolve<IEntityManager>();
+            
+            var uid = shell.Player?.AttachedEntity;
+            if (uid == null
+                || !entityManager.HasComponent<GhostComponent>(uid)
+                || !entityManager.TryGetComponent<EyeComponent>(uid, out var eyeComponent))
+                return;
+
+            eyeComponent.VisibilityMask ^= (uint) VisibilityFlags.Ghost;
         }
     }
 }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -302,7 +302,7 @@ namespace Content.Server.Ghost
     [AnyCommand]
     public sealed class ToggleGhostVisibility : IConsoleCommand
     {
-        public string Command => "toggleghostvisibility";
+        public string Command => "toggleghosts";
         public string Description => "Toggles ghost visibility";
         public string Help => $"{Command}";
         public void Execute(IConsoleShell shell, string argStr, string[] args)

--- a/Resources/Locale/en-US/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-gui.ftl
@@ -1,6 +1,7 @@
 ghost-gui-return-to-body-button = Return to body
 ghost-gui-ghost-warp-button = Ghost Warp
 ghost-gui-ghost-roles-button = Ghost Roles ({$count})
+ghost-gui-toggle-ghost-visibility-button = Toggle Ghosts
 
 ghost-target-window-title = Ghost Warp
 ghost-target-window-current-button = Warp: {$name}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Added a `toggleghosts` command that changes the visibility of other player ghosts.
Added a button to the ghost GUI that runs the command.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/10494922/199148874-3294fc81-f6b1-45ce-bfd8-27bf57e2c5b8.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added a Toggle Ghosts button on the ghost GUI to get rid of those pesky apparitions.

