### PR TITLE
Fix medibot exception

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/MedibotInjectOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/MedibotInjectOperator.cs
@@ -44,7 +44,7 @@ public sealed class MedibotInjectOperator : HTNOperator
         // TODO: Wat
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
 
-        if (!blackboard.TryGetValue<EntityUid>(TargetKey, out var target))
+        if (!blackboard.TryGetValue<EntityUid>(TargetKey, out var target) || _entManager.Deleted(target))
             return HTNOperatorStatus.Failed;
 
         if (!_entManager.TryGetComponent<MedibotComponent>(owner, out var botComp))


### PR DESCRIPTION
If there were a lot of NPCs it's possible that the deferral from setting the target to now means it's deleted.