### PR TITLE
HoP starting access tweak

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -31,6 +31,7 @@
   - Kitchen
   - Chapel
   - Hydroponics
+  - External
   # I mean they'll give themselves the rest of the access levels *anyways*.
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -23,11 +23,8 @@
   access:
   - Command
   - HeadOfPersonnel
-  - Brig
+  - Bar
   - Service
-  - Quartermaster
-  - Salvage
-  - Cargo
   - Maintenance
   - Janitor
   - Theatre


### PR DESCRIPTION
## About the PR
Makes the HoP's starting access more uniform, more geared towards them being the head of the service department.

Grants them bar and external access.
Removes their brig access.
Removes their cargo, salvage and quartermaster access due to QM being a head now.

**Changelog**
:cl: Nairod
- tweak: Tweaked the HoP's starting access to be more uniform.