### PR TITLE
Parallelize BatteryRampPegSolver

### DIFF
--- a/Content.IntegrationTests/Tests/Power/PowerTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerTest.cs
@@ -11,6 +11,8 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
 using Robust.Shared.Timing;
+using TerraFX.Interop.Windows;
+using static Content.Server.Power.Pow3r.PowerState;
 
 namespace Content.IntegrationTests.Tests.Power
 {
@@ -713,6 +715,101 @@ namespace Content.IntegrationTests.Tests.Power
         }
 
         /// <summary>
+        ///     Checks that if there is insufficient supply to meet demand, generators will run at full power instead of
+        ///     having generators and batteries sharing the load. 
+        /// </summary>
+        [Test]
+        public async Task TestSupplyPrioritized()
+        {
+            await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings { NoClient = true, ExtraPrototypes = Prototypes });
+            var server = pairTracker.Pair.Server;
+            var mapManager = server.ResolveDependency<IMapManager>();
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var gameTiming = server.ResolveDependency<IGameTiming>();
+            PowerConsumerComponent consumer = default!;
+            PowerSupplierComponent supplier1 = default!;
+            PowerSupplierComponent supplier2 = default!;
+            PowerNetworkBatteryComponent netBattery1 = default!;
+            PowerNetworkBatteryComponent netBattery2 = default!;
+            BatteryComponent battery1 = default!;
+            BatteryComponent battery2 = default!;
+
+            await server.WaitAssertion(() =>
+            {
+                var map = mapManager.CreateMap();
+                var grid = mapManager.CreateGrid(map);
+
+                // Layout is two generators, two batteries, and one load. As to why two: because previously this test
+                // would fail ONLY if there were more than two batteries present, because each of them tries to supply
+                // the unmet load, leading to a double-battery supply attempt and ramping down of power generation from
+                // supplies.
+
+                // Actual layout is Battery Supply, Load, Supply,  Battery
+
+                // Place cables
+                for (var i = -2; i <= 2; i++)
+                {
+                    grid.SetTile(new Vector2i(0, i), new Tile(1));
+                    entityManager.SpawnEntity("CableHV", grid.ToCoordinates(0, i));
+                }
+
+                var batteryEnt1 = entityManager.SpawnEntity("FullBatteryDummy", grid.ToCoordinates(0, 2));
+                var batteryEnt2 = entityManager.SpawnEntity("FullBatteryDummy", grid.ToCoordinates(0, -2));
+
+                var supplyEnt1 = entityManager.SpawnEntity("GeneratorDummy", grid.ToCoordinates(0, 1));
+                var supplyEnt2 = entityManager.SpawnEntity("GeneratorDummy", grid.ToCoordinates(0, -1));
+
+                var consumerEnt = entityManager.SpawnEntity("ConsumerDummy", grid.ToCoordinates(0, 0));
+
+                consumer = entityManager.GetComponent<PowerConsumerComponent>(consumerEnt);
+                supplier1 = entityManager.GetComponent<PowerSupplierComponent>(supplyEnt1);
+                supplier2 = entityManager.GetComponent<PowerSupplierComponent>(supplyEnt2);
+                netBattery1 = entityManager.GetComponent<PowerNetworkBatteryComponent>(batteryEnt1);
+                netBattery2 = entityManager.GetComponent<PowerNetworkBatteryComponent>(batteryEnt2);
+                battery1 = entityManager.GetComponent<BatteryComponent>(batteryEnt1);
+                battery2 = entityManager.GetComponent<BatteryComponent>(batteryEnt2);
+
+                // Consumer wants 2k, supplies can only provide 1k (500 each). Expectation is that batteries will only provide the necessary remaining 1k (500 each).
+                // Previously this failed with a 2x 333 w supplies and 2x 666 w batteries.
+
+                consumer.DrawRate = 2000;
+
+                supplier1.MaxSupply = 500;
+                supplier2.MaxSupply = 500;
+                supplier1.SupplyRampTolerance = 500;
+                supplier2.SupplyRampTolerance = 500;
+
+                netBattery1.MaxSupply = 1000;
+                netBattery2.MaxSupply = 1000;
+                netBattery1.SupplyRampTolerance = 1000;
+                netBattery2.SupplyRampTolerance = 1000;
+                netBattery1.SupplyRampRate = 100_000;
+                netBattery2.SupplyRampRate = 100_000;
+                battery1.MaxCharge = 100_000;
+                battery2.MaxCharge = 100_000;
+                battery1.CurrentCharge = 100_000;
+                battery2.CurrentCharge = 100_000;
+            });
+
+            // Run some ticks so everything is stable.
+            server.RunTicks(60);
+
+            await server.WaitAssertion(() =>
+            {
+                Assert.That(consumer.ReceivedPower, Is.EqualTo(consumer.DrawRate).Within(0.1));
+                Assert.That(supplier1.CurrentSupply, Is.EqualTo(supplier1.MaxSupply).Within(0.1));
+                Assert.That(supplier2.CurrentSupply, Is.EqualTo(supplier2.MaxSupply).Within(0.1));
+
+                Assert.That(netBattery1.CurrentSupply, Is.EqualTo(500).Within(0.1));
+                Assert.That(netBattery2.CurrentSupply, Is.EqualTo(500).Within(0.1));
+                Assert.That(netBattery2.SupplyRampPosition, Is.EqualTo(500).Within(0.1));
+                Assert.That(netBattery2.SupplyRampPosition, Is.EqualTo(500).Within(0.1));
+            });
+
+            await pairTracker.CleanReturnAsync();
+        }
+
+        /// <summary>
         ///     Test that power is distributed proportionally, even through batteries.
         /// </summary>
         [Test]
@@ -833,7 +930,6 @@ namespace Content.IntegrationTests.Tests.Power
                 netBattery = entityManager.GetComponent<PowerNetworkBatteryComponent>(batteryEnt);
                 var battery = entityManager.GetComponent<BatteryComponent>(batteryEnt);
 
-                // Consumer needs 1000 W, supplier can only provide 800, battery fills in the remaining 200.
                 consumer.DrawRate = 1000;
                 supplier.MaxSupply = 1000;
                 supplier.SupplyRampTolerance = 1000;

--- a/Content.IntegrationTests/Tests/Power/PowerTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerTest.cs
@@ -430,7 +430,6 @@ namespace Content.IntegrationTests.Tests.Power
             await pairTracker.CleanReturnAsync();
         }
 
-
         [Test]
         public async Task TestNoDemandRampdown()
         {
@@ -440,7 +439,6 @@ namespace Content.IntegrationTests.Tests.Power
             var server = pairTracker.Pair.Server;
             var mapManager = server.ResolveDependency<IMapManager>();
             var entityManager = server.ResolveDependency<IEntityManager>();
-            var gameTiming = server.ResolveDependency<IGameTiming>();
             PowerSupplierComponent supplier = default!;
             PowerNetworkBatteryComponent netBattery = default!;
             BatteryComponent battery = default!;
@@ -496,7 +494,6 @@ namespace Content.IntegrationTests.Tests.Power
 
             await server.WaitAssertion(() =>
             {
-                // After 15 ticks (0.25 seconds), supply ramp pos should be at 100 W and supply at 100, approx.
                 Assert.That(supplier.CurrentSupply, Is.EqualTo(draw/2).Within(0.1));
                 Assert.That(supplier.SupplyRampPosition, Is.EqualTo(draw/2).Within(0.1));
                 Assert.That(netBattery.CurrentSupply, Is.EqualTo(draw / 2).Within(0.1));
@@ -511,7 +508,6 @@ namespace Content.IntegrationTests.Tests.Power
 
             await server.WaitAssertion(() =>
             {
-                // After 1 second total, ramp should be at 400 and supply should be at 400, everybody happy.
                 Assert.That(supplier.CurrentSupply, Is.EqualTo(0).Within(0.1));
                 Assert.That(supplier.SupplyRampPosition, Is.EqualTo(0).Within(0.1));
                 Assert.That(netBattery.CurrentSupply, Is.EqualTo(0).Within(0.1));
@@ -521,8 +517,6 @@ namespace Content.IntegrationTests.Tests.Power
 
             await pairTracker.CleanReturnAsync();
         }
-
-
 
         [Test]
         public async Task TestSimpleBatteryChargeDeficit()

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -246,7 +246,7 @@ namespace Content.Server.Electrocution
             Node? TryNode(string? id)
             {
                 if (id != null && nodeContainer.TryGetNode<Node>(id, out var tryNode)
-                               && tryNode.NodeGroup is IBasePowerNet { NetworkNode: { LastAvailableSupplySum: >0 } })
+                               && tryNode.NodeGroup is IBasePowerNet { NetworkNode: { LastCombinedSupply: >0 } })
                 {
                     return tryNode;
                 }

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -178,7 +178,7 @@ namespace Content.Server.Power.EntitySystems
                 return ApcExternalPowerState.None;
             }
 
-            var delta = netBat.CurrentReceiving - netBat.LoadingNetworkDemand;
+            var delta = netBat.CurrentReceiving - netBat.CurrentSupply;
             if (!MathHelper.CloseToPercent(delta, 0, 0.1f) && delta < 0)
             {
                 return ApcExternalPowerState.Low;

--- a/Content.Server/Power/NodeGroups/PowerNet.cs
+++ b/Content.Server/Power/NodeGroups/PowerNet.cs
@@ -5,6 +5,8 @@ using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Power.Pow3r;
 using JetBrains.Annotations;
+using Prometheus.DotNetRuntime;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Power.NodeGroups
 {
@@ -59,6 +61,7 @@ namespace Content.Server.Power.NodeGroups
 
         public void AddSupplier(PowerSupplierComponent supplier)
         {
+            DebugTools.Assert(supplier.NetworkSupply.LinkedNetwork == default);
             supplier.NetworkSupply.LinkedNetwork = default;
             Suppliers.Add(supplier);
             _powerNetSystem?.QueueReconnectPowerNet(this);
@@ -66,6 +69,7 @@ namespace Content.Server.Power.NodeGroups
 
         public void RemoveSupplier(PowerSupplierComponent supplier)
         {
+            DebugTools.Assert(supplier.NetworkSupply.LinkedNetwork == NetworkNode.Id);
             supplier.NetworkSupply.LinkedNetwork = default;
             Suppliers.Remove(supplier);
             _powerNetSystem?.QueueReconnectPowerNet(this);
@@ -73,6 +77,7 @@ namespace Content.Server.Power.NodeGroups
 
         public void AddConsumer(PowerConsumerComponent consumer)
         {
+            DebugTools.Assert(consumer.NetworkLoad.LinkedNetwork == default);
             consumer.NetworkLoad.LinkedNetwork = default;
             Consumers.Add(consumer);
             _powerNetSystem?.QueueReconnectPowerNet(this);
@@ -80,6 +85,7 @@ namespace Content.Server.Power.NodeGroups
 
         public void RemoveConsumer(PowerConsumerComponent consumer)
         {
+            DebugTools.Assert(consumer.NetworkLoad.LinkedNetwork == NetworkNode.Id);
             consumer.NetworkLoad.LinkedNetwork = default;
             Consumers.Remove(consumer);
             _powerNetSystem?.QueueReconnectPowerNet(this);
@@ -88,7 +94,8 @@ namespace Content.Server.Power.NodeGroups
         public void AddDischarger(BatteryDischargerComponent discharger)
         {
             var battery = IoCManager.Resolve<IEntityManager>().GetComponent<PowerNetworkBatteryComponent>(discharger.Owner);
-            battery.NetworkBattery.LinkedNetworkCharging = default;
+            DebugTools.Assert(battery.NetworkBattery.LinkedNetworkDischarging == default);
+            battery.NetworkBattery.LinkedNetworkDischarging = default;
             Dischargers.Add(discharger);
             _powerNetSystem?.QueueReconnectPowerNet(this);
         }
@@ -97,7 +104,10 @@ namespace Content.Server.Power.NodeGroups
         {
             // Can be missing if the entity is being deleted, not a big deal.
             if (IoCManager.Resolve<IEntityManager>().TryGetComponent(discharger.Owner, out PowerNetworkBatteryComponent? battery))
-                battery.NetworkBattery.LinkedNetworkCharging = default;
+            {
+                DebugTools.Assert(battery.NetworkBattery.LinkedNetworkDischarging == NetworkNode.Id);
+                battery.NetworkBattery.LinkedNetworkDischarging = default;
+            }
 
             Dischargers.Remove(discharger);
             _powerNetSystem?.QueueReconnectPowerNet(this);
@@ -106,6 +116,7 @@ namespace Content.Server.Power.NodeGroups
         public void AddCharger(BatteryChargerComponent charger)
         {
             var battery = IoCManager.Resolve<IEntityManager>().GetComponent<PowerNetworkBatteryComponent>(charger.Owner);
+            DebugTools.Assert(battery.NetworkBattery.LinkedNetworkCharging == default);
             battery.NetworkBattery.LinkedNetworkCharging = default;
             Chargers.Add(charger);
             _powerNetSystem?.QueueReconnectPowerNet(this);
@@ -115,7 +126,10 @@ namespace Content.Server.Power.NodeGroups
         {
             // Can be missing if the entity is being deleted, not a big deal.
             if (IoCManager.Resolve<IEntityManager>().TryGetComponent(charger.Owner, out PowerNetworkBatteryComponent? battery))
+            {
+                DebugTools.Assert(battery.NetworkBattery.LinkedNetworkCharging == NetworkNode.Id);
                 battery.NetworkBattery.LinkedNetworkCharging = default;
+            }
 
             Chargers.Remove(charger);
             _powerNetSystem?.QueueReconnectPowerNet(this);

--- a/Content.Server/Power/NodeGroups/PowerNet.cs
+++ b/Content.Server/Power/NodeGroups/PowerNet.cs
@@ -1,12 +1,11 @@
-using System.Linq;
 using Content.Server.NodeContainer.NodeGroups;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Power.Pow3r;
 using JetBrains.Annotations;
-using Prometheus.DotNetRuntime;
 using Robust.Shared.Utility;
+using System.Linq;
 
 namespace Content.Server.Power.NodeGroups
 {

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -1,4 +1,7 @@
-﻿using Robust.Shared.Utility;
+using Robust.Shared.Utility;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using static Content.Server.Power.Pow3r.PowerState;
 
 namespace Content.Server.Power.Pow3r
@@ -17,11 +20,36 @@ namespace Content.Server.Power.Pow3r
             }
         }
 
-        private readonly PriorityQueue<int, Network> _sortBuffer = new(new HeightComparer());
-
-        public void Tick(float frameTime, PowerState state)
+        public void Tick(float frameTime, PowerState state, int parallel)
         {
-            // Clear loads and supplies.
+            ClearLoadsAndSupplies(state);
+
+            state.GroupedNets ??= GroupByNetworkDepth(state);
+            DebugTools.Assert(state.GroupedNets.Select(x => x.Count).Sum() == state.Networks.Count);
+
+            // Each network height layer can be run in parallel without issues.
+            var opts = new ParallelOptions { MaxDegreeOfParallelism = parallel };
+            for (var i = state.GroupedNets.Count - 1; i >= 0; i--)
+            {
+                // Note that many net-layers only have a handful of networks.
+                // E.g., the number of nets from lowest to heights for box and saltern are:
+                // Saltern: 1477, 11, 2, 2, 3.
+                // Box:     3308, 20, 1, 5.
+                //
+                // I have NFI what the overhead for a Parallel.ForEach is, and how it compares to computing differently sized nets.
+                //
+                // TODO make GroupByNetworkDepth evaluate the TOTAL size of each layer (i.e. loads + chargers + suppliers + discharger)
+                // Then decide based on total layer size whether its worth parallelizing that layer?
+                Parallel.ForEach(state.GroupedNets[i], opts, net => UpdateNetwork(net, state, frameTime));
+            }
+
+            ClearBatteries(state);
+
+            PowerSolverShared.UpdateRampPositions(frameTime, state);
+        }
+
+        private void ClearLoadsAndSupplies(PowerState state)
+        {
             foreach (var load in state.Loads.Values)
             {
                 if (load.Paused)
@@ -38,105 +66,89 @@ namespace Content.Server.Power.Pow3r
                 supply.CurrentSupply = 0;
                 supply.SupplyRampTarget = 0;
             }
+        }
 
-            // Run a pass to estimate network tree graph height.
-            // This is so that we can run networks before their children,
-            // to avoid draining batteries for a tick if their passing-supply gets cut off.
-            // It's not a big loss if this doesn't work (it won't, in some scenarios), but it's a nice-to-have.
-            foreach (var network in state.Networks.Values)
-            {
-                network.HeightTouched = false;
-                network.Height = -1;
-            }
+        private void UpdateNetwork(Network network, PowerState state, float frameTime)
+        {
+            // TODO Look at SIMD.
+            // a lot of this is performing very basic math on arrays of data objects like batteries
+            // this really shouldn't be hard to do.
+            // except for maybe the paused/enabled guff. If its mostly false, I guess they could just be 0 multipliers?
 
-            foreach (var network in state.Networks.Values)
+            // Add up demand in network.
+            var demand = 0f;
+            foreach (var loadId in network.Loads)
             {
-                if (network.BatteriesDischarging.Count != 0)
+                var load = state.Loads[loadId];
+
+                if (!load.Enabled || load.Paused)
                     continue;
 
-                EstimateNetworkDepth(state, network);
+                DebugTools.Assert(load.DesiredPower >= 0);
+                demand += load.DesiredPower;
             }
 
-            foreach (var network in state.Networks.Values)
+            // TODO: Consider having battery charge loads be processed "after" pass-through loads.
+            // This would mean that charge rate would have no impact on throughput rate like it does currently.
+            // Would require a second pass over the network, or something. Not sure.
+
+            // Loading batteries.
+            foreach (var batteryId in network.BatteriesCharging)
             {
-                _sortBuffer.Enqueue(network.Height, network);
+                var battery = state.Batteries[batteryId];
+                if (!battery.Enabled || !battery.CanCharge || battery.Paused)
+                    continue;
+
+                var batterySpace = (battery.Capacity - battery.CurrentStorage) * (1 / battery.Efficiency);
+                batterySpace = Math.Max(0, batterySpace);
+                var scaledSpace = batterySpace / frameTime;
+
+                var chargeRate = battery.MaxChargeRate + battery.LoadingNetworkDemand / battery.Efficiency;
+
+                var batDemand = Math.Min(chargeRate, scaledSpace);
+
+                DebugTools.Assert(batDemand >= 0);
+
+                battery.DesiredPower = batDemand;
+                demand += batDemand;
             }
 
-            // Go over every network.
-            while (_sortBuffer.TryDequeue(out _, out var network))
+            DebugTools.Assert(demand >= 0);
+
+            // Add up supply in network.
+            var availableSupplySum = 0f;
+            var maxSupplySum = 0f;
+            foreach (var supplyId in network.Supplies)
             {
-                // Add up demand in network.
-                var demand = 0f;
-                foreach (var loadId in network.Loads)
-                {
-                    var load = state.Loads[loadId];
+                var supply = state.Supplies[supplyId];
+                if (!supply.Enabled || supply.Paused)
+                    continue;
 
-                    if (!load.Enabled || load.Paused)
-                        continue;
+                var rampMax = supply.SupplyRampPosition + supply.SupplyRampTolerance;
+                var effectiveSupply = Math.Min(rampMax, supply.MaxSupply);
 
-                    DebugTools.Assert(load.DesiredPower >= 0);
-                    demand += load.DesiredPower;
-                }
+                DebugTools.Assert(effectiveSupply >= 0);
+                DebugTools.Assert(supply.MaxSupply >= 0);
 
-                // TODO: Consider having battery charge loads be processed "after" pass-through loads.
-                // This would mean that charge rate would have no impact on throughput rate like it does currently.
-                // Would require a second pass over the network, or something. Not sure.
+                supply.EffectiveMaxSupply = effectiveSupply;
+                availableSupplySum += effectiveSupply;
+                maxSupplySum += supply.MaxSupply;
+            }
 
-                // Loading batteries.
-                foreach (var batteryId in network.BatteriesCharging)
-                {
-                    var battery = state.Batteries[batteryId];
-                    if (!battery.Enabled || !battery.CanCharge || battery.Paused)
-                        continue;
+            var unmet = Math.Max(0, demand - availableSupplySum);
 
-                    var batterySpace = (battery.Capacity - battery.CurrentStorage) * (1 / battery.Efficiency);
-                    batterySpace = Math.Max(0, batterySpace);
-                    var scaledSpace = batterySpace / frameTime;
+            DebugTools.Assert(availableSupplySum >= 0);
+            DebugTools.Assert(maxSupplySum >= 0);
 
-                    var chargeRate = battery.MaxChargeRate + battery.LoadingNetworkDemand / battery.Efficiency;
-
-                    var batDemand = Math.Min(chargeRate, scaledSpace);
-
-                    DebugTools.Assert(batDemand >= 0);
-
-                    battery.DesiredPower = batDemand;
-                    demand += batDemand;
-                }
-
-                DebugTools.Assert(demand >= 0);
-
-                // Add up supply in network.
-                var availableSupplySum = 0f;
-                var maxSupplySum = 0f;
-                foreach (var supplyId in network.Supplies)
-                {
-                    var supply = state.Supplies[supplyId];
-                    if (!supply.Enabled || supply.Paused)
-                        continue;
-
-                    var rampMax = supply.SupplyRampPosition + supply.SupplyRampTolerance;
-                    var effectiveSupply = Math.Min(rampMax, supply.MaxSupply);
-
-                    DebugTools.Assert(effectiveSupply >= 0);
-                    DebugTools.Assert(supply.MaxSupply >= 0);
-
-                    supply.EffectiveMaxSupply = effectiveSupply;
-                    availableSupplySum += effectiveSupply;
-                    maxSupplySum += supply.MaxSupply;
-                }
-
-                var unmet = Math.Max(0, demand - availableSupplySum);
-
-                DebugTools.Assert(availableSupplySum >= 0);
-                DebugTools.Assert(maxSupplySum >= 0);
-
-                // Supplying batteries.
-                // Batteries need to go after local supplies so that local supplies are prioritized.
-                // Also, it makes demand-pulling of batteries
-                // Because all batteries will will desire the unmet demand of their loading network,
-                // there will be a "rush" of input current when a network powers on,
-                // before power stabilizes in the network.
-                // This is fine.
+            // Supplying batteries.
+            // Batteries need to go after local supplies so that local supplies are prioritized.
+            // Also, it makes demand-pulling of batteries
+            // Because all batteries will will desire the unmet demand of their loading network,
+            // there will be a "rush" of input current when a network powers on,
+            // before power stabilizes in the network.
+            // This is fine.
+            if (unmet > 0)
+            {
                 foreach (var batteryId in network.BatteriesDischarging)
                 {
                     var battery = state.Batteries[batteryId];
@@ -161,89 +173,105 @@ namespace Content.Server.Power.Pow3r
                     battery.LoadingNetworkDemand = unmet;
                     battery.LoadingDemandMarked = true;
                 }
-
-                network.LastAvailableSupplySum = availableSupplySum;
-                network.LastMaxSupplySum = maxSupplySum;
-
-                var met = Math.Min(demand, availableSupplySum);
-
-                if (met != 0)
+            }
+            else
+            {
+                foreach (var batteryId in network.BatteriesDischarging)
                 {
-                    // Distribute supply to loads.
-                    foreach (var loadId in network.Loads)
-                    {
-                        var load = state.Loads[loadId];
-                        if (!load.Enabled || load.DesiredPower == 0 || load.Paused)
-                            continue;
+                    var battery = state.Batteries[batteryId];
+                    if (!battery.Enabled || !battery.CanDischarge || battery.Paused)
+                        continue;
 
-                        var ratio = load.DesiredPower / demand;
-                        load.ReceivingPower = ratio * met;
-                    }
-
-                    // Loading batteries
-                    foreach (var batteryId in network.BatteriesCharging)
-                    {
-                        var battery = state.Batteries[batteryId];
-
-                        if (!battery.Enabled || battery.DesiredPower == 0 || battery.Paused)
-                            continue;
-
-                        var ratio = battery.DesiredPower / demand;
-                        battery.CurrentReceiving = ratio * met;
-                        var receivedPower = frameTime * battery.CurrentReceiving;
-                        receivedPower *= battery.Efficiency;
-                        battery.CurrentStorage = Math.Min(
-                            battery.Capacity,
-                            battery.CurrentStorage + receivedPower);
-                        battery.LoadingMarked = true;
-                    }
-
-                    // Load to supplies
-                    foreach (var supplyId in network.Supplies)
-                    {
-                        var supply = state.Supplies[supplyId];
-                        if (!supply.Enabled || supply.EffectiveMaxSupply == 0 || supply.Paused)
-                            continue;
-
-                        var ratio = supply.EffectiveMaxSupply / availableSupplySum;
-                        supply.CurrentSupply = ratio * met;
-
-                        if (supply.MaxSupply != 0)
-                        {
-                            var maxSupplyRatio = supply.MaxSupply / maxSupplySum;
-
-                            supply.SupplyRampTarget = maxSupplyRatio * demand;
-                        }
-                        else
-                        {
-                            supply.SupplyRampTarget = 0;
-                        }
-                    }
-
-                    // Supplying batteries
-                    foreach (var batteryId in network.BatteriesDischarging)
-                    {
-                        var battery = state.Batteries[batteryId];
-                        if (!battery.Enabled || battery.TempMaxSupply == 0 || battery.Paused)
-                            continue;
-
-                        var ratio = battery.TempMaxSupply / availableSupplySum;
-                        battery.CurrentSupply = ratio * met;
-
-                        battery.CurrentStorage = Math.Max(
-                            0,
-                            battery.CurrentStorage - frameTime * battery.CurrentSupply);
-
-                        battery.SupplyRampTarget = battery.CurrentSupply - battery.CurrentReceiving * battery.Efficiency;
-
-                        /*var maxSupplyRatio = supply.MaxSupply / maxSupplySum;
-
-                        supply.SupplyRampTarget = maxSupplyRatio * demand;*/
-                        battery.SupplyingMarked = true;
-                    }
+                    battery.TempMaxSupply = 0;
+                    battery.LoadingNetworkDemand = 0;
+                    battery.LoadingDemandMarked = true;
                 }
             }
 
+            network.LastAvailableSupplySum = availableSupplySum;
+            network.LastMaxSupplySum = maxSupplySum;
+
+            var met = Math.Min(demand, availableSupplySum);
+
+            if (met == 0)
+                return;
+
+            // Distribute supply to loads.
+            foreach (var loadId in network.Loads)
+            {
+                var load = state.Loads[loadId];
+                if (!load.Enabled || load.DesiredPower == 0 || load.Paused)
+                    continue;
+
+                var ratio = load.DesiredPower / demand;
+                load.ReceivingPower = ratio * met;
+            }
+
+            // Loading batteries
+            foreach (var batteryId in network.BatteriesCharging)
+            {
+                var battery = state.Batteries[batteryId];
+
+                if (!battery.Enabled || battery.DesiredPower == 0 || battery.Paused)
+                    continue;
+
+                var ratio = battery.DesiredPower / demand;
+                battery.CurrentReceiving = ratio * met;
+                var receivedPower = frameTime * battery.CurrentReceiving;
+                receivedPower *= battery.Efficiency;
+                battery.CurrentStorage = Math.Min(
+                    battery.Capacity,
+                    battery.CurrentStorage + receivedPower);
+                battery.LoadingMarked = true;
+            }
+
+            // Load to supplies
+            foreach (var supplyId in network.Supplies)
+            {
+                var supply = state.Supplies[supplyId];
+                if (!supply.Enabled || supply.EffectiveMaxSupply == 0 || supply.Paused)
+                    continue;
+
+                var ratio = supply.EffectiveMaxSupply / availableSupplySum;
+                supply.CurrentSupply = ratio * met;
+
+                if (supply.MaxSupply != 0)
+                {
+                    var maxSupplyRatio = supply.MaxSupply / maxSupplySum;
+
+                    supply.SupplyRampTarget = maxSupplyRatio * demand;
+                }
+                else
+                {
+                    supply.SupplyRampTarget = 0;
+                }
+            }
+
+            // Load to supplying batteries
+            foreach (var batteryId in network.BatteriesDischarging)
+            {
+                var battery = state.Batteries[batteryId];
+                if (!battery.Enabled || battery.TempMaxSupply == 0 || battery.Paused)
+                    continue;
+
+                var ratio = battery.TempMaxSupply / availableSupplySum;
+                battery.CurrentSupply = ratio * met;
+
+                battery.CurrentStorage = Math.Max(
+                    0,
+                    battery.CurrentStorage - frameTime * battery.CurrentSupply);
+
+                battery.SupplyRampTarget = battery.CurrentSupply - battery.CurrentReceiving * battery.Efficiency;
+
+                /*var maxSupplyRatio = supply.MaxSupply / maxSupplySum;
+
+                supply.SupplyRampTarget = maxSupplyRatio * demand;*/
+                battery.SupplyingMarked = true;
+            }
+        }
+
+        private void ClearBatteries(PowerState state)
+        {
             // Clear supplying/loading on any batteries that haven't been marked by usage.
             // Because we need this data while processing ramp-pegging, we can't clear it at the start.
             foreach (var battery in state.Batteries.Values)
@@ -264,36 +292,55 @@ namespace Content.Server.Power.Pow3r
                 battery.LoadingMarked = false;
                 battery.LoadingDemandMarked = false;
             }
-
-            PowerSolverShared.UpdateRampPositions(frameTime, state);
         }
 
-        private static void EstimateNetworkDepth(PowerState state, Network network)
+        private List<List<Network>> GroupByNetworkDepth(PowerState state)
         {
-            network.HeightTouched = true;
-
-            if (network.BatteriesCharging.Count == 0)
+            List<List<Network>> groupedNetworks = new() { new() };
+            foreach (var network in state.Networks.Values)
             {
-                network.Height = 1;
-                return;
+                network.Height = -1;
             }
 
-            var max = 0;
+            foreach (var network in state.Networks.Values)
+            {
+                if (network.Height == -1)
+                    RecursivelyEstimateNetworkDepth(state, network, groupedNetworks);
+            }
+
+            return groupedNetworks;
+        }
+
+        private static void RecursivelyEstimateNetworkDepth(PowerState state, Network network, List<List<Network>> groupedNetworks)
+        {
+            network.Height = -2;
+            var height = -1;
+
             foreach (var batteryId in network.BatteriesCharging)
             {
                 var battery = state.Batteries[batteryId];
 
-                if (battery.LinkedNetworkDischarging == default)
+                if (battery.LinkedNetworkDischarging == default || battery.LinkedNetworkDischarging == network.Id)
                     continue;
 
                 var subNet = state.Networks[battery.LinkedNetworkDischarging];
-                if (!subNet.HeightTouched)
-                    EstimateNetworkDepth(state, subNet);
+                if (subNet.Height == -1)
+                    RecursivelyEstimateNetworkDepth(state, subNet, groupedNetworks);
+                else if (subNet.Height == -2)
+                {
+                    // this network is currently computing its own height (we encountered a loop).
+                    continue;
+                }
 
-                max = Math.Max(subNet.Height, max);
+                height = Math.Max(subNet.Height, height);
             }
 
-            network.Height = 1 + max;
+            network.Height = 1 + height;
+
+            if (network.Height >= groupedNetworks.Count)
+                groupedNetworks.Add(new() { network });
+            else
+                groupedNetworks[network.Height].Add(network);
         }
     }
 }

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -29,7 +29,7 @@ namespace Content.Server.Power.Pow3r
 
             // Each network height layer can be run in parallel without issues.
             var opts = new ParallelOptions { MaxDegreeOfParallelism = parallel };
-            for (var i = state.GroupedNets.Count - 1; i >= 0; i--)
+            foreach (var group in state.GroupedNets)
             {
                 // Note that many net-layers only have a handful of networks.
                 // E.g., the number of nets from lowest to heights for box and saltern are:
@@ -40,7 +40,7 @@ namespace Content.Server.Power.Pow3r
                 //
                 // TODO make GroupByNetworkDepth evaluate the TOTAL size of each layer (i.e. loads + chargers + suppliers + discharger)
                 // Then decide based on total layer size whether its worth parallelizing that layer?
-                Parallel.ForEach(state.GroupedNets[i], opts, net => UpdateNetwork(net, state, frameTime));
+                Parallel.ForEach(group, opts, net => UpdateNetwork(net, state, frameTime));
             }
 
             ClearBatteries(state);

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -241,8 +241,10 @@ namespace Content.Server.Power.Pow3r
                 battery.CurrentStorage -= frameTime * battery.CurrentSupply;
                 DebugTools.Assert(battery.CurrentStorage >= 0 || MathHelper.CloseTo(battery.CurrentStorage, 0));
 
-                // Each battery tries to ramp to meet the whole unmet supply all on its own (minus throughput from the source net)
-                battery.SupplyRampTarget = Math.Max(0, unmet - battery.CurrentReceiving * battery.Efficiency);
+                // TODO calculate this properly. Currently this is only initially non-zero if the ramp tolerance is
+                // non-zero then the ramp target grows as the ramp position does. Instead, batteries should just try to
+                // ramp to satisfy the demand.
+                battery.SupplyRampTarget = battery.CurrentSupply - battery.CurrentReceiving * battery.Efficiency;
             }
         }
 

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -279,7 +279,7 @@ namespace Content.Server.Power.Pow3r
 
         private List<List<Network>> GroupByNetworkDepth(PowerState state)
         {
-            List<List<Network>> groupedNetworks = new() { new() };
+            List<List<Network>> groupedNetworks = new();
             foreach (var network in state.Networks.Values)
             {
                 network.Height = -1;

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -37,10 +37,13 @@ namespace Content.Server.Power.Pow3r
                 // Saltern: 1477, 11, 2, 2, 3.
                 // Box:     3308, 20, 1, 5.
                 //
-                // I have NFI what the overhead for a Parallel.ForEach is, and how it compares to computing differently sized nets.
+                // I have NFI what the overhead for a Parallel.ForEach is, and how it compares to computing differently
+                // sized nets. Basic benchmarking shows that this is better, but maybe the highest-tier nets should just
+                // be run sequentially? But then again, maybe they are 2-3 very BIG networks at the top? So maybe:
                 //
-                // TODO make GroupByNetworkDepth evaluate the TOTAL size of each layer (i.e. loads + chargers + suppliers + discharger)
-                // Then decide based on total layer size whether its worth parallelizing that layer?
+                // TODO make GroupByNetworkDepth evaluate the TOTAL size of each layer (i.e. loads + chargers +
+                // suppliers + discharger) Then decide based on total layer size whether its worth parallelizing that
+                // layer?
                 Parallel.ForEach(group, opts, net => UpdateNetwork(net, state, frameTime));
             }
 

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -164,6 +164,7 @@ namespace Content.Server.Power.Pow3r
                     battery.AvailableSupply = Math.Min(scaledSpace, supplyAndPassthrough);
                     battery.LoadingNetworkDemand = unmet;
 
+                    battery.MaxEffectiveSupply = Math.Min(battery.CurrentStorage / frameTime, battery.MaxSupply + battery.CurrentReceiving * battery.Efficiency); 
                     totalBatterySupply += battery.AvailableSupply;
                     totalMaxBatterySupply += battery.MaxEffectiveSupply;
                 }
@@ -231,6 +232,7 @@ namespace Content.Server.Power.Pow3r
 
             // Target output capacity for batteries
             var relativeBatteryOutput = Math.Min(unmet, totalBatterySupply) / totalBatterySupply;
+            var relativeTargetBatteryOutput = Math.Min(unmet, totalMaxBatterySupply) / totalMaxBatterySupply;
 
             // Apply load to supplying batteries
             foreach (var batteryId in network.BatterySupplies)
@@ -241,13 +243,18 @@ namespace Content.Server.Power.Pow3r
 
                 battery.SupplyingMarked = true;
                 battery.CurrentSupply = battery.AvailableSupply * relativeBatteryOutput;
+                // Note that because available supply is always greater than or equal to the current ramp target, if you
+                // have multiple batteries running at less than 100% output, then batteries with greater ramp tolerances
+                // will contribute a larger relative fraction of output power as they have a larger available supply.
+                // IMO this is undesirable, but I can't think of an easy fix ATM.
+
                 battery.CurrentStorage -= frameTime * battery.CurrentSupply;
                 DebugTools.Assert(battery.CurrentStorage >= 0 || MathHelper.CloseTo(battery.CurrentStorage, 0));
 
-                // TODO calculate this properly. Currently this is only initially non-zero if the ramp tolerance is
-                // non-zero then the ramp target grows as the ramp position does. Instead, batteries should just try to
-                // ramp to satisfy the demand.
-                battery.SupplyRampTarget = battery.CurrentSupply - battery.CurrentReceiving * battery.Efficiency;
+                battery.SupplyRampTarget = battery.MaxEffectiveSupply * relativeTargetBatteryOutput - battery.CurrentReceiving * battery.Efficiency;
+
+                DebugTools.Assert(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency <= battery.LoadingNetworkDemand
+                    || MathHelper.CloseTo(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency, battery.LoadingNetworkDemand));
             }
         }
 

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -245,8 +245,9 @@ namespace Content.Server.Power.Pow3r
                 battery.CurrentSupply = battery.AvailableSupply * relativeBatteryOutput;
                 // Note that because available supply is always greater than or equal to the current ramp target, if you
                 // have multiple batteries running at less than 100% output, then batteries with greater ramp tolerances
-                // will contribute a larger relative fraction of output power as they have a larger available supply.
-                // IMO this is undesirable, but I can't think of an easy fix ATM.
+                // will contribute a larger relative fraction of output power. This is because while they will both ramp
+                // to the same relative maximum output, the larger tolerance will mean that one will have a larger
+                // available supply. IMO this is undesirable, but I can't think of an easy fix ATM.
 
                 battery.CurrentStorage -= frameTime * battery.CurrentSupply;
                 DebugTools.Assert(battery.CurrentStorage >= 0 || MathHelper.CloseTo(battery.CurrentStorage, 0));
@@ -254,7 +255,7 @@ namespace Content.Server.Power.Pow3r
                 battery.SupplyRampTarget = battery.MaxEffectiveSupply * relativeTargetBatteryOutput - battery.CurrentReceiving * battery.Efficiency;
 
                 DebugTools.Assert(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency <= battery.LoadingNetworkDemand
-                    || MathHelper.CloseTo(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency, battery.LoadingNetworkDemand));
+                    || MathHelper.CloseTo(battery.SupplyRampTarget + battery.CurrentReceiving * battery.Efficiency, battery.LoadingNetworkDemand, 0.01));
             }
         }
 

--- a/Content.Server/Power/Pow3r/IPowerSolver.cs
+++ b/Content.Server/Power/Pow3r/IPowerSolver.cs
@@ -1,7 +1,7 @@
-﻿namespace Content.Server.Power.Pow3r
+namespace Content.Server.Power.Pow3r
 {
     public interface IPowerSolver
     {
-        void Tick(float frameTime, PowerState state);
+        void Tick(float frameTime, PowerState state, int parallel);
     }
 }

--- a/Content.Server/Power/Pow3r/NoOpSolver.cs
+++ b/Content.Server/Power/Pow3r/NoOpSolver.cs
@@ -1,8 +1,8 @@
-﻿namespace Content.Server.Power.Pow3r
+namespace Content.Server.Power.Pow3r
 {
     public sealed class NoOpSolver : IPowerSolver
     {
-        public void Tick(float frameTime, PowerState state)
+        public void Tick(float frameTime, PowerState state, int parallel)
         {
             // Literally nothing.
         }

--- a/Content.Server/Power/Pow3r/PowerState.cs
+++ b/Content.Server/Power/Pow3r/PowerState.cs
@@ -171,6 +171,7 @@ namespace Content.Server.Power.Pow3r
                 storage._nextFree = nextFree;
 
                 // I think there is some issue with Pow3er's Save & Load to json leading to it constructing invalid GenIdStorages from json?
+                // If you get this error, clear out your data.json
                 DebugTools.Assert(storage.Values.Count() == storage.Count);
 
                 return storage;

--- a/Content.Server/Power/Pow3r/PowerState.cs
+++ b/Content.Server/Power/Pow3r/PowerState.cs
@@ -410,7 +410,15 @@ namespace Content.Server.Power.Pow3r
             [ViewVariables(VVAccess.ReadWrite)] public float MaxChargeRate;
             [ViewVariables(VVAccess.ReadWrite)] public float MaxThroughput; // 0 = infinite cuz imgui
             [ViewVariables(VVAccess.ReadWrite)] public float MaxSupply;
+
+            /// <summary>
+            ///     The batteries supply ramp tolerance. This is an always available supply added to the ramped supply.
+            /// </summary>
+            /// <remarks>
+            ///     Note that this MUST BE GREATER THAN ZERO, otherwise the current battery ramping calculation will not work.
+            /// </remarks>
             [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampTolerance = 5000;
+
             [ViewVariables(VVAccess.ReadWrite)] public float SupplyRampRate = 5000;
             [ViewVariables(VVAccess.ReadWrite)] public float Efficiency = 1;
 
@@ -449,8 +457,8 @@ namespace Content.Server.Power.Pow3r
             ///  Theoretical maximum effective supply, assuming the network providing power to this battery continues to supply it
             ///  at the same rate.
             /// </summary>
-            [ViewVariables] [JsonIgnore]
-            public float MaxEffectiveSupply => MaxSupply + CurrentReceiving * Efficiency;
+            [ViewVariables]
+            public float MaxEffectiveSupply;
         }
 
         // Readonly breaks json serialization.

--- a/Content.Server/Power/Pow3r/PowerState.cs
+++ b/Content.Server/Power/Pow3r/PowerState.cs
@@ -170,6 +170,9 @@ namespace Content.Server.Power.Pow3r
                 storage.Count = cache.Length;
                 storage._nextFree = nextFree;
 
+                // I think there is some issue with Pow3er's Save & Load to json leading to it constructing invalid GenIdStorages from json?
+                DebugTools.Assert(storage.Values.Count() == storage.Count);
+
                 return storage;
             }
 

--- a/Content.Server/Power/Pow3r/PowerState.cs
+++ b/Content.Server/Power/Pow3r/PowerState.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -20,6 +20,7 @@ namespace Content.Server.Power.Pow3r
         public GenIdStorage<Network> Networks = new();
         public GenIdStorage<Load> Loads = new();
         public GenIdStorage<Battery> Batteries = new();
+        public List<List<Network>>? GroupedNets;
 
         public readonly struct NodeId : IEquatable<NodeId>
         {
@@ -448,11 +449,17 @@ namespace Content.Server.Power.Pow3r
             // "Supplying" means the network is connected to the OUTPUT port of the battery.
             [ViewVariables] public List<NodeId> BatteriesDischarging = new();
 
+            /// <summary>
+            ///     Available supply from sources WITHOUT discharging batteries.
+            /// </summary>
             [ViewVariables] public float LastAvailableSupplySum = 0f;
+
+            /// <summary>
+            ///     Available supply from sources INCLUDING discharging batteries.
+            /// </summary>
             [ViewVariables] public float LastMaxSupplySum = 0f;
 
             [ViewVariables] [JsonIgnore] public int Height;
-            [JsonIgnore] public bool HeightTouched;
         }
     }
 }

--- a/Pow3r/Program.Simulation.cs
+++ b/Pow3r/Program.Simulation.cs
@@ -111,13 +111,13 @@ namespace Pow3r
                     supply.LinkedNetwork = network.Id;
                 }
 
-                foreach (var batteryId in network.BatteriesCharging)
+                foreach (var batteryId in network.BatteryLoads)
                 {
                     var battery = _state.Batteries[batteryId];
                     battery.LinkedNetworkCharging = network.Id;
                 }
 
-                foreach (var batteryId in network.BatteriesDischarging)
+                foreach (var batteryId in network.BatterySupplies)
                 {
                     var battery = _state.Batteries[batteryId];
                     battery.LinkedNetworkDischarging = network.Id;

--- a/Pow3r/Program.Simulation.cs
+++ b/Pow3r/Program.Simulation.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Content.Server.Power.Pow3r;
 using static Content.Server.Power.Pow3r.PowerState;
@@ -45,7 +45,7 @@ namespace Pow3r
             _simStopwatch.Restart();
             _tickDataIdx = (_tickDataIdx + 1) % MaxTickData;
 
-            _solvers[_currentSolver].Tick(frameTime, _state);
+            _solvers[_currentSolver].Tick(frameTime, _state, 1);
 
             // Update tick history.
             foreach (var load in _state.Loads.Values)

--- a/Pow3r/Program.UI.cs
+++ b/Pow3r/Program.UI.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using ImGuiNET;
 using Robust.Shared.Maths;
@@ -52,6 +52,7 @@ namespace Pow3r
             {
                 var network = new Network();
                 _state.Networks.Allocate(out network.Id) = network;
+                _state.GroupedNets = null;
                 _displayNetworks.Add(network.Id, new DisplayNetwork());
             }
 
@@ -60,6 +61,7 @@ namespace Pow3r
                 var battery = new Battery();
                 _state.Batteries.Allocate(out battery.Id) = battery;
                 _displayBatteries.Add(battery.Id, new DisplayBattery());
+                _state.GroupedNets = null;
             }
 
             Checkbox("Paused", ref _paused);
@@ -271,6 +273,7 @@ namespace Pow3r
                     if (battery.LinkedNetworkCharging == default && Button("Link as load"))
                     {
                         _linking.BatteryLoads.Add(battery.Id);
+                        _state.GroupedNets = null;
                         _linking = null;
                         RefreshLinks();
                     }
@@ -280,6 +283,7 @@ namespace Pow3r
                         if (battery.LinkedNetworkDischarging == default && Button("Link as supply"))
                         {
                             _linking.BatterySupplies.Add(battery.Id);
+                            _state.GroupedNets = null;
                             _linking = null;
                             RefreshLinks();
                         }
@@ -291,6 +295,7 @@ namespace Pow3r
                     {
                         var net = _state.Networks[battery.LinkedNetworkCharging];
                         net.BatteryLoads.Remove(battery.Id);
+                        _state.GroupedNets = null;
                         battery.LinkedNetworkCharging = default;
                     }
                     else
@@ -300,6 +305,7 @@ namespace Pow3r
                         {
                             var net = _state.Networks[battery.LinkedNetworkDischarging];
                             net.BatterySupplies.Remove(battery.Id);
+                            _state.GroupedNets = null;
                             battery.LinkedNetworkDischarging = default;
                         }
                     }
@@ -357,6 +363,7 @@ namespace Pow3r
                     case Network n:
                         _state.Networks.Free(n.Id);
                         _displayNetworks.Remove(n.Id);
+                        _state.GroupedNets = null;
                         reLink = true;
                         break;
 
@@ -377,6 +384,7 @@ namespace Pow3r
                         _state.Networks.Values.ForEach(n => n.BatteryLoads.Remove(b.Id));
                         _state.Networks.Values.ForEach(n => n.BatterySupplies.Remove(b.Id));
                         _displayBatteries.Remove(b.Id);
+                        _state.GroupedNets = null;
                         break;
                 }
             }

--- a/Pow3r/Program.UI.cs
+++ b/Pow3r/Program.UI.cs
@@ -270,7 +270,7 @@ namespace Pow3r
                 {
                     if (battery.LinkedNetworkCharging == default && Button("Link as load"))
                     {
-                        _linking.BatteriesCharging.Add(battery.Id);
+                        _linking.BatteryLoads.Add(battery.Id);
                         _linking = null;
                         RefreshLinks();
                     }
@@ -279,7 +279,7 @@ namespace Pow3r
                         SameLine();
                         if (battery.LinkedNetworkDischarging == default && Button("Link as supply"))
                         {
-                            _linking.BatteriesDischarging.Add(battery.Id);
+                            _linking.BatterySupplies.Add(battery.Id);
                             _linking = null;
                             RefreshLinks();
                         }
@@ -290,7 +290,7 @@ namespace Pow3r
                     if (battery.LinkedNetworkCharging != default && Button("Unlink loading"))
                     {
                         var net = _state.Networks[battery.LinkedNetworkCharging];
-                        net.BatteriesCharging.Remove(battery.Id);
+                        net.BatteryLoads.Remove(battery.Id);
                         battery.LinkedNetworkCharging = default;
                     }
                     else
@@ -299,7 +299,7 @@ namespace Pow3r
                         if (battery.LinkedNetworkDischarging != default && Button("Unlink supplying"))
                         {
                             var net = _state.Networks[battery.LinkedNetworkDischarging];
-                            net.BatteriesDischarging.Remove(battery.Id);
+                            net.BatterySupplies.Remove(battery.Id);
                             battery.LinkedNetworkDischarging = default;
                         }
                     }
@@ -331,13 +331,13 @@ namespace Pow3r
                     DrawArrowLine(bgDrawList, load.CurrentWindowPos, displayNet.CurrentWindowPos, Color.Red);
                 }
 
-                foreach (var batteryId in network.BatteriesCharging)
+                foreach (var batteryId in network.BatteryLoads)
                 {
                     var battery = _displayBatteries[batteryId];
                     DrawArrowLine(bgDrawList, battery.CurrentWindowPos, displayNet.CurrentWindowPos, Color.Purple);
                 }
 
-                foreach (var batteryId in network.BatteriesDischarging)
+                foreach (var batteryId in network.BatterySupplies)
                 {
                     var battery = _displayBatteries[batteryId];
                     DrawArrowLine(bgDrawList, displayNet.CurrentWindowPos, battery.CurrentWindowPos, Color.Cyan);
@@ -374,8 +374,8 @@ namespace Pow3r
 
                     case Battery b:
                         _state.Batteries.Free(b.Id);
-                        _state.Networks.Values.ForEach(n => n.BatteriesCharging.Remove(b.Id));
-                        _state.Networks.Values.ForEach(n => n.BatteriesDischarging.Remove(b.Id));
+                        _state.Networks.Values.ForEach(n => n.BatteryLoads.Remove(b.Id));
+                        _state.Networks.Values.ForEach(n => n.BatterySupplies.Remove(b.Id));
                         _displayBatteries.Remove(b.Id);
                         break;
                 }


### PR DESCRIPTION
- Makes network depth sorting lazy (only update networks when they change, instead of every tick)
- Changes how network sorting works. It now groups networks by depth.
- Each depth layer is now solved in parallel.
- Fixed some battery logic and adds a new test to ensure supplies are prioritized over draining batteries.
- Fixed batteries not ramping down when there is no load.

Basic benchmarking with dottrace on my machine shows that a passive box station with 1 client moves from spending half of the power system update in BatteryRampPegSolverindicate() to less than 10% (so around ~10x faster).

I couldn't figure out how to equally distribute load to batteries with different ramp tolerances, but that's not a new problem and relatively minor.