### PR TITLE
Aurora Australis

### DIFF
--- a/Content.Client/Light/RgbLightControllerSystem.cs
+++ b/Content.Client/Light/RgbLightControllerSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Light;
 using Content.Shared.Light.Component;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Timing;
 using static Robust.Client.GameObjects.SpriteComponent;
 
@@ -14,8 +15,8 @@ namespace Content.Client.Light
 {
     public sealed class RgbLightControllerSystem : SharedRgbLightControllerSystem
     {
-        [Dependency] private IGameTiming _gameTiming = default!;
-        [Dependency] private ItemSystem _itemSystem = default!;
+        [Dependency] private readonly IGameTiming _gameTiming = default!;
+        [Dependency] private readonly ItemSystem _itemSystem = default!;
 
         public override void Initialize()
         {
@@ -189,6 +190,12 @@ namespace Content.Client.Light
                 {
                     holderSprite.LayerSetColor(layer, color);
                 }
+            }
+
+            foreach (var (rgb, map) in EntityQuery<RgbLightControllerComponent, MapLightComponent>())
+            {
+                var color = GetCurrentRgbColor(_gameTiming.RealTime, rgb.CreationTick.Value * _gameTiming.TickPeriod, rgb);
+                map.AmbientLightColor = color;
             }
         }
 

--- a/Content.Shared/Light/SharedRgbLightControllerSystem.cs
+++ b/Content.Shared/Light/SharedRgbLightControllerSystem.cs
@@ -23,7 +23,7 @@ public abstract class SharedRgbLightControllerSystem : EntitySystem
             return;
 
         rgb.Layers = layers;
-        rgb.Dirty();
+        Dirty(rgb);
     }
 
     public void SetCycleRate(EntityUid uid, float rate, RgbLightControllerComponent? rgb = null)
@@ -32,6 +32,6 @@ public abstract class SharedRgbLightControllerSystem : EntitySystem
             return;
 
         rgb.CycleRate = Math.Clamp(0.01f, rate, 1); // lets not give people seizures
-        rgb.Dirty();
+        Dirty(rgb);
     }
 }

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -78,6 +78,7 @@
   - mapinit
   - savegrid
   - savemap
+  - setambientlight
   - tpgrid
   - gridtc
   - togglespritenetsync


### PR DESCRIPTION
RGBLightController support for MapLightComponent.

Requires https://github.com/space-wizards/RobustToolbox/pull/3433

:cl:
- add: Map ambient lighting can now be controlled by admins via RGBLightController.