### PR TITLE
Aghost tweaks

### DIFF
--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -245,7 +245,12 @@ namespace Content.Server.Strip
                 return true;
             }
 
-            var doAfterArgs = new DoAfterEventArgs(user, component.HandStripDelay, CancellationToken.None, component.Owner)
+            var userEv = new BeforeStripEvent(component.HandStripDelay);
+            RaiseLocalEvent(user, userEv);
+            var ev = new BeforeGettingStrippedEvent(userEv.Time, userEv.Stealth);
+            RaiseLocalEvent(component.Owner, ev);
+
+            var doAfterArgs = new DoAfterEventArgs(user, ev.Time, CancellationToken.None, component.Owner)
             {
                 ExtraCheck = Check,
                 BreakOnStun = true,
@@ -292,9 +297,9 @@ namespace Content.Server.Strip
                     return false;
                 }
 
-                if (!_inventorySystem.CanUnequip(user, component.Owner, slot, out _))
+                if (!_inventorySystem.CanUnequip(user, component.Owner, slot, out var reason))
                 {
-                    user.PopupMessageCursor(Loc.GetString("strippable-component-cannot-unequip-message", ("owner", component.Owner)));
+                    user.PopupMessageCursor(reason);
                     return false;
                 }
 
@@ -375,7 +380,6 @@ namespace Content.Server.Strip
 
                 return true;
             }
-
 
             var userEv = new BeforeStripEvent(component.HandStripDelay);
             RaiseLocalEvent(user, userEv);

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -240,8 +240,8 @@ public abstract partial class InventorySystem
             return true;
 
         // Is the actor currently stripping the target? Here we could check if the actor has the stripping UI open, but
-        // that requires server/client specific code. so lets just check if they **could** open the stripping UI.
-        // Note that this doesn't check that the item is equipped by the target, as this is done elsewhere.
+        // that requires server/client specific code.
+        // Uhhh TODO, fix this. This doesn't even fucking check if the target item is IN the targets inventory.
         return actor != target &&
             HasComp<SharedStrippableComponent>(target) &&
             HasComp<SharedStrippingComponent>(actor) &&

--- a/Content.Shared/Strip/Components/ThievingComponent.cs
+++ b/Content.Shared/Strip/Components/ThievingComponent.cs
@@ -1,7 +1,7 @@
-﻿namespace Content.Shared.Strip.Components;
+namespace Content.Shared.Strip.Components;
 
 /// <summary>
-/// Give this to an entity when you want to increase their stripping times
+/// Give this to an entity when you want to decrease stripping times
 /// </summary>
 [RegisterComponent]
 public sealed class ThievingComponent : Component
@@ -10,8 +10,8 @@ public sealed class ThievingComponent : Component
     /// How much the strip time should be shortened by
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("stealTime")]
-    public float StealTime = 0.5f;
+    [DataField("stripTimeReduction")]
+    public float StripTimeReduction = 0.5f;
 
     /// <summary>
     /// Should it notify the user if they're stripping a pocket?

--- a/Content.Shared/Strip/ThievingSystem.cs
+++ b/Content.Shared/Strip/ThievingSystem.cs
@@ -17,6 +17,6 @@ public sealed class ThievingSystem : EntitySystem
     private void OnBeforeStrip(EntityUid uid, ThievingComponent component, BeforeStripEvent args)
     {
         args.Stealth |= component.Stealthy;
-        args.Additive -= component.StealTime;
+        args.Additive -= component.StripTimeReduction;
     }
 }

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -202,7 +202,7 @@
     fiberMaterial: fibers-nanomachines
   - type: FingerprintMask
   - type: Thieving
-    stealTime: 1
+    stripTimeReduction: 1
     stealthy: true
 
 - type: entity
@@ -251,7 +251,7 @@
     - type: Clothing
       sprite: Clothing/Hands/Gloves/Color/black.rsi
     - type: Thieving
-      stealTime: 1.5
+      stripTimeReduction: 1.5
       stealthy: true
     - type: Fiber
       fiberMaterial: fibers-synthetic

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -101,3 +101,7 @@
     receiveFrequencyId: SuitSensor
   - type: WirelessNetworkConnection
     range: 500
+  - type: Thieving
+    stripTimeReduction: 9999
+    stealthy: true
+  - type: Stripping


### PR DESCRIPTION
~~Improves admin ERP Experience~~ Allows Aghosts to strip players, and sets the do-after delay to 0. Also fixes a stripping pop-up, renames a thieving component data-field, and makes it apply the reduction when inserting into a players hands. 