### PR TITLE
Better pinpointer accuracy + small cleanup

### DIFF
--- a/Content.Client/Pinpointer/ClientPinpointerSystem.cs
+++ b/Content.Client/Pinpointer/ClientPinpointerSystem.cs
@@ -58,7 +58,7 @@ namespace Content.Client.Pinpointer
             if (!Resolve(uid, ref pinpointer, ref appearance))
                 return;
 
-            _appearance.SetData(uid, PinpointerVisuals.TargetDirection, angle, appearance);
+            _appearance.SetData(uid, PinpointerVisuals.ArrowAngle, angle, appearance);
         }
 
         /// <summary>

--- a/Content.Client/Pinpointer/ClientPinpointerSystem.cs
+++ b/Content.Client/Pinpointer/ClientPinpointerSystem.cs
@@ -37,9 +37,9 @@ namespace Content.Client.Pinpointer
             if (args.Current is not PinpointerComponentState state)
                 return;
 
-            SetActive(uid, state.IsActive, pinpointer);
-            TrySetArrowAngle(uid, state.ArrowAngle, pinpointer);
-            SetDistance(uid, state.DistanceToTarget, pinpointer);
+            pinpointer.IsActive = state.IsActive;
+            pinpointer.ArrowAngle = state.ArrowAngle;
+            pinpointer.DistanceToTarget = state.DistanceToTarget;
         }
 
         private void UpdateAppearance(EntityUid uid, PinpointerComponent? pinpointer = null,

--- a/Content.Client/Pinpointer/ClientPinpointerSystem.cs
+++ b/Content.Client/Pinpointer/ClientPinpointerSystem.cs
@@ -1,10 +1,7 @@
 using Content.Shared.Pinpointer;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
-using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 
 namespace Content.Client.Pinpointer
 {
@@ -41,7 +38,7 @@ namespace Content.Client.Pinpointer
                 return;
 
             SetActive(uid, state.IsActive, pinpointer);
-            SetDirection(uid, state.DirectionToTarget, pinpointer);
+            TrySetArrowAngle(uid, state.ArrowAngle, pinpointer);
             SetDistance(uid, state.DistanceToTarget, pinpointer);
         }
 
@@ -55,13 +52,13 @@ namespace Content.Client.Pinpointer
             _appearance.SetData(uid, PinpointerVisuals.TargetDistance, pinpointer.DistanceToTarget, appearance);
         }
 
-        private void UpdateDirAppearance(EntityUid uid, Direction dir,PinpointerComponent? pinpointer = null,
+        private void UpdateArrowAngle(EntityUid uid, Angle angle, PinpointerComponent? pinpointer = null,
             AppearanceComponent? appearance = null)
         {
             if (!Resolve(uid, ref pinpointer, ref appearance))
                 return;
 
-            _appearance.SetData(uid, PinpointerVisuals.TargetDirection, dir, appearance);
+            _appearance.SetData(uid, PinpointerVisuals.TargetDirection, angle, appearance);
         }
 
         /// <summary>
@@ -70,20 +67,12 @@ namespace Content.Client.Pinpointer
         /// </summary>
         private void UpdateEyeDir(EntityUid uid, PinpointerComponent? pinpointer = null)
         {
-            if (!Resolve(uid, ref pinpointer))
+            if (!Resolve(uid, ref pinpointer) || !pinpointer.HasTarget)
                 return;
-
-            var worldDir = pinpointer.DirectionToTarget;
-            if (worldDir == Direction.Invalid)
-            {
-                UpdateDirAppearance(uid, Direction.Invalid, pinpointer);
-                return;
-            }
 
             var eye = _eyeManager.CurrentEye;
-            var angle = worldDir.ToAngle() + eye.Rotation;
-            var eyeDir = angle.GetDir();
-            UpdateDirAppearance(uid, eyeDir, pinpointer);
+            var angle = pinpointer.ArrowAngle + eye.Rotation;
+            UpdateArrowAngle(uid, angle, pinpointer);
         }
     }
 }

--- a/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
+++ b/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
@@ -21,24 +21,22 @@ namespace Content.Client.Pinpointer
                 return;
             }
 
-            // check if it has direction to target
             sprite.LayerSetVisible(PinpointerLayers.Screen, true);
-            sprite.LayerSetRotation(PinpointerLayers.Screen, Angle.Zero);
 
-            if (!args.Component.TryGetData(PinpointerVisuals.TargetDirection, out Angle angle))
+            // check distance and direction to target
+            if (!args.Component.TryGetData(PinpointerVisuals.TargetDistance, out Distance dis) ||
+                !args.Component.TryGetData(PinpointerVisuals.ArrowAngle, out Angle angle))
             {
                 sprite.LayerSetState(PinpointerLayers.Screen, "pinonnull");
+                sprite.LayerSetRotation(PinpointerLayers.Screen, Angle.Zero);
                 return;
             }
-
-            // check distance to target
-            if (!args.Component.TryGetData(PinpointerVisuals.TargetDistance, out Distance dis))
-                dis = Distance.Unknown;
 
             switch (dis)
             {
                 case Distance.Reached:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinondirect");
+                    sprite.LayerSetRotation(PinpointerLayers.Screen, Angle.Zero);
                     break;
                 case Distance.Close:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonclose");
@@ -54,6 +52,7 @@ namespace Content.Client.Pinpointer
                     break;
                 case Distance.Unknown:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonnull");
+                    sprite.LayerSetRotation(PinpointerLayers.Screen, Angle.Zero);
                     break;
             }
         }

--- a/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
+++ b/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Client.Pinpointer
             sprite.LayerSetVisible(PinpointerLayers.Screen, true);
             sprite.LayerSetRotation(PinpointerLayers.Screen, Angle.Zero);
 
-            if (!args.Component.TryGetData(PinpointerVisuals.TargetDirection, out Direction dir) || dir == Direction.Invalid)
+            if (!args.Component.TryGetData(PinpointerVisuals.TargetDirection, out Angle angle))
             {
                 sprite.LayerSetState(PinpointerLayers.Screen, "pinonnull");
                 return;
@@ -42,16 +42,16 @@ namespace Content.Client.Pinpointer
                     break;
                 case Distance.Close:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonclose");
-                    sprite.LayerSetRotation(PinpointerLayers.Screen, dir.ToAngle());
+                    sprite.LayerSetRotation(PinpointerLayers.Screen, angle);
                     break;
                 case Distance.Medium:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonmedium");
-                    sprite.LayerSetRotation(PinpointerLayers.Screen, dir.ToAngle());
+                    sprite.LayerSetRotation(PinpointerLayers.Screen, angle);
                     break;
                 case Distance.Far:
                 case Distance.Unknown:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonfar");
-                    sprite.LayerSetRotation(PinpointerLayers.Screen, dir.ToAngle());
+                    sprite.LayerSetRotation(PinpointerLayers.Screen, angle);
                     break;
             }
         }

--- a/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
+++ b/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
@@ -33,23 +33,23 @@ namespace Content.Client.Pinpointer
 
             // check distance to target
             if (!args.Component.TryGetData(PinpointerVisuals.TargetDistance, out Distance dis))
-                dis = Distance.UNKNOWN;
+                dis = Distance.Unknown;
 
             switch (dis)
             {
-                case Distance.REACHED:
+                case Distance.Reached:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinondirect");
                     break;
-                case Distance.CLOSE:
+                case Distance.Close:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonclose");
                     sprite.LayerSetRotation(PinpointerLayers.Screen, dir.ToAngle());
                     break;
-                case Distance.MEDIUM:
+                case Distance.Medium:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonmedium");
                     sprite.LayerSetRotation(PinpointerLayers.Screen, dir.ToAngle());
                     break;
-                case Distance.FAR:
-                case Distance.UNKNOWN:
+                case Distance.Far:
+                case Distance.Unknown:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonfar");
                     sprite.LayerSetRotation(PinpointerLayers.Screen, dir.ToAngle());
                     break;

--- a/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
+++ b/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
@@ -49,9 +49,11 @@ namespace Content.Client.Pinpointer
                     sprite.LayerSetRotation(PinpointerLayers.Screen, angle);
                     break;
                 case Distance.Far:
-                case Distance.Unknown:
                     sprite.LayerSetState(PinpointerLayers.Screen, "pinonfar");
                     sprite.LayerSetRotation(PinpointerLayers.Screen, angle);
+                    break;
+                case Distance.Unknown:
+                    sprite.LayerSetState(PinpointerLayers.Screen, "pinonnull");
                     break;
             }
         }

--- a/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
+++ b/Content.Client/Pinpointer/PinpointerVisualizerSystem.cs
@@ -1,26 +1,21 @@
 using Content.Shared.Pinpointer;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Maths;
 
 namespace Content.Client.Pinpointer
 {
     [UsedImplicitly]
-    public sealed class PinpointerVisualizer : AppearanceVisualizer
+    public sealed class PinpointerVisualizerSystem : VisualizerSystem<PinpointerComponent>
     {
-        [Obsolete("Subscribe to AppearanceChangeEvent instead.")]
-        public override void OnChangeData(AppearanceComponent component)
+        protected override void OnAppearanceChange(EntityUid uid, PinpointerComponent component, ref AppearanceChangeEvent args)
         {
-            base.OnChangeData(component);
+            base.OnAppearanceChange(uid, component, ref args);
 
-            var entities = IoCManager.Resolve<IEntityManager>();
-            if (!entities.TryGetComponent(component.Owner, out SpriteComponent? sprite))
+            if (!TryComp(component.Owner, out SpriteComponent? sprite))
                 return;
 
             // check if pinpointer screen is active
-            if (!component.TryGetData(PinpointerVisuals.IsActive, out bool isActive) || !isActive)
+            if (!args.Component.TryGetData(PinpointerVisuals.IsActive, out bool isActive) || !isActive)
             {
                 sprite.LayerSetVisible(PinpointerLayers.Screen, false);
                 return;
@@ -30,14 +25,14 @@ namespace Content.Client.Pinpointer
             sprite.LayerSetVisible(PinpointerLayers.Screen, true);
             sprite.LayerSetRotation(PinpointerLayers.Screen, Angle.Zero);
 
-            if (!component.TryGetData(PinpointerVisuals.TargetDirection, out Direction dir) || dir == Direction.Invalid)
+            if (!args.Component.TryGetData(PinpointerVisuals.TargetDirection, out Direction dir) || dir == Direction.Invalid)
             {
                 sprite.LayerSetState(PinpointerLayers.Screen, "pinonnull");
                 return;
             }
 
             // check distance to target
-            if (!component.TryGetData(PinpointerVisuals.TargetDistance, out Distance dis))
+            if (!args.Component.TryGetData(PinpointerVisuals.TargetDistance, out Distance dis))
                 dis = Distance.UNKNOWN;
 
             switch (dis)

--- a/Content.Server/Pinpointer/ServerPinpointerSystem.cs
+++ b/Content.Server/Pinpointer/ServerPinpointerSystem.cs
@@ -123,7 +123,6 @@ namespace Content.Server.Pinpointer
             var target = pinpointer.Target;
             if (target == null || !EntityManager.EntityExists(target.Value))
             {
-                SetDirection(uid, Direction.Invalid, pinpointer);
                 SetDistance(uid, Distance.Unknown, pinpointer);
                 return;
             }
@@ -131,14 +130,13 @@ namespace Content.Server.Pinpointer
             var dirVec = CalculateDirection(uid, target.Value);
             if (dirVec != null)
             {
-                var dir = dirVec.Value.GetDir();
-                SetDirection(uid, dir, pinpointer);
+                var angle = dirVec.Value.ToWorldAngle();
+                TrySetArrowAngle(uid, angle, pinpointer);
                 var dist = CalculateDistance(uid, dirVec.Value, pinpointer);
                 SetDistance(uid, dist, pinpointer);
             }
             else
             {
-                SetDirection(uid, Direction.Invalid, pinpointer);
                 SetDistance(uid, Distance.Unknown, pinpointer);
             }
         }

--- a/Content.Server/Pinpointer/ServerPinpointerSystem.cs
+++ b/Content.Server/Pinpointer/ServerPinpointerSystem.cs
@@ -85,14 +85,14 @@ namespace Content.Server.Pinpointer
 
             foreach (var comp in EntityManager.GetAllComponents(whitelist))
             {
-                if (!xformQuery.TryGetComponent(comp.Owner, out var compXform) ||
-                    compXform.MapID != mapId) continue;
+                if (!xformQuery.TryGetComponent(comp.Owner, out var compXform) || compXform.MapID != mapId)
+                    continue;
 
                 var dist = (_transform.GetWorldPosition(compXform, xformQuery) - worldPos).LengthSquared;
                 l.TryAdd(dist, comp.Owner);
             }
 
-            // return uid with a smallest distacne
+            // return uid with a smallest distance
             return l.Count > 0 ? l.First().Value : null;
         }
 
@@ -124,7 +124,7 @@ namespace Content.Server.Pinpointer
             if (target == null || !EntityManager.EntityExists(target.Value))
             {
                 SetDirection(uid, Direction.Invalid, pinpointer);
-                SetDistance(uid, Distance.UNKNOWN, pinpointer);
+                SetDistance(uid, Distance.Unknown, pinpointer);
                 return;
             }
 
@@ -139,14 +139,14 @@ namespace Content.Server.Pinpointer
             else
             {
                 SetDirection(uid, Direction.Invalid, pinpointer);
-                SetDistance(uid, Distance.UNKNOWN, pinpointer);
+                SetDistance(uid, Distance.Unknown, pinpointer);
             }
         }
 
         /// <summary>
         ///     Calculate direction from pinUid to trgUid
         /// </summary>
-        /// <returns>Null if failed to caluclate distance between two entities</returns>
+        /// <returns>Null if failed to calculate distance between two entities</returns>
         private Vector2? CalculateDirection(EntityUid pinUid, EntityUid trgUid)
         {
             var xformQuery = GetEntityQuery<TransformComponent>();
@@ -169,17 +169,17 @@ namespace Content.Server.Pinpointer
         private Distance CalculateDistance(EntityUid uid, Vector2 vec, PinpointerComponent? pinpointer = null)
         {
             if (!Resolve(uid, ref pinpointer))
-                return Distance.UNKNOWN;
+                return Distance.Unknown;
 
             var dist = vec.Length;
             if (dist <= pinpointer.ReachedDistance)
-                return Distance.REACHED;
+                return Distance.Reached;
             else if (dist <= pinpointer.CloseDistance)
-                return Distance.CLOSE;
+                return Distance.Close;
             else if (dist <= pinpointer.MediumDistance)
-                return Distance.MEDIUM;
+                return Distance.Medium;
             else
-                return Distance.FAR;
+                return Distance.Far;
         }
     }
 }

--- a/Content.Server/Pinpointer/ServerPinpointerSystem.cs
+++ b/Content.Server/Pinpointer/ServerPinpointerSystem.cs
@@ -26,6 +26,9 @@ namespace Content.Server.Pinpointer
         private void OnLocateTarget(HyperspaceJumpCompletedEvent ev)
         {
             // This feels kind of expensive, but it only happens once per hyperspace jump
+
+            // todo: ideally, you would need to raise this event only on jumped entities
+            // this code update ALL pinpointers in game
             foreach (var pinpointer in EntityQuery<PinpointerComponent>())
             {
                 LocateTarget(pinpointer.Owner, pinpointer);
@@ -115,6 +118,9 @@ namespace Content.Server.Pinpointer
         private void UpdateDirectionToTarget(EntityUid uid, PinpointerComponent? pinpointer = null)
         {
             if (!Resolve(uid, ref pinpointer))
+                return;
+
+            if (!pinpointer.IsActive)
                 return;
 
             var target = pinpointer.Target;

--- a/Content.Server/Pinpointer/ServerPinpointerSystem.cs
+++ b/Content.Server/Pinpointer/ServerPinpointerSystem.cs
@@ -26,12 +26,9 @@ namespace Content.Server.Pinpointer
         private void OnLocateTarget(HyperspaceJumpCompletedEvent ev)
         {
             // This feels kind of expensive, but it only happens once per hyperspace jump
-            foreach (var uid in ActivePinpointers)
+            foreach (var pinpointer in EntityQuery<PinpointerComponent>())
             {
-                if (TryComp<PinpointerComponent>(uid, out var component))
-                {
-                    LocateTarget(uid, component);
-                }
+                LocateTarget(pinpointer.Owner, pinpointer);
             }
         }
 
@@ -58,9 +55,9 @@ namespace Content.Server.Pinpointer
 
             // because target or pinpointer can move
             // we need to update pinpointers arrow each frame
-            foreach (var uid in ActivePinpointers)
+            foreach (var pinpointer in EntityQuery<PinpointerComponent>())
             {
-                UpdateDirectionToTarget(uid);
+                UpdateDirectionToTarget(pinpointer.Owner, pinpointer);
             }
         }
 

--- a/Content.Shared/Pinpointer/PinpointerComponent.cs
+++ b/Content.Shared/Pinpointer/PinpointerComponent.cs
@@ -24,17 +24,24 @@ namespace Content.Shared.Pinpointer
         [DataField("reachedDistance")]
         public float ReachedDistance = 1f;
 
+        /// <summary>
+        ///     Pinpointer arrow precision in radians.
+        /// </summary>
+        [DataField("precision")]
+        public double Precision = 0.09;
+
         public EntityUid? Target = null;
         public bool IsActive = false;
-        public Direction DirectionToTarget = Direction.Invalid;
+        public Angle ArrowAngle;
         public Distance DistanceToTarget = Distance.Unknown;
+        public bool HasTarget => DistanceToTarget != Distance.Unknown;
     }
 
     [Serializable, NetSerializable]
     public sealed class PinpointerComponentState : ComponentState
     {
         public bool IsActive;
-        public Direction DirectionToTarget;
+        public Angle ArrowAngle;
         public Distance DistanceToTarget;
     }
 

--- a/Content.Shared/Pinpointer/PinpointerComponent.cs
+++ b/Content.Shared/Pinpointer/PinpointerComponent.cs
@@ -27,7 +27,7 @@ namespace Content.Shared.Pinpointer
         public EntityUid? Target = null;
         public bool IsActive = false;
         public Direction DirectionToTarget = Direction.Invalid;
-        public Distance DistanceToTarget = Distance.UNKNOWN;
+        public Distance DistanceToTarget = Distance.Unknown;
     }
 
     [Serializable, NetSerializable]
@@ -41,10 +41,10 @@ namespace Content.Shared.Pinpointer
     [Serializable, NetSerializable]
     public enum Distance : byte
     {
-        UNKNOWN,
-        REACHED,
-        CLOSE,
-        MEDIUM,
-        FAR
+        Unknown,
+        Reached,
+        Close,
+        Medium,
+        Far
     }
 }

--- a/Content.Shared/Pinpointer/PinpointerVisuals.cs
+++ b/Content.Shared/Pinpointer/PinpointerVisuals.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Pinpointer
     public enum PinpointerVisuals : byte
     {
         IsActive,
-        TargetDirection,
+        ArrowAngle,
         TargetDistance
     }
 

--- a/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
+++ b/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
@@ -4,13 +4,10 @@ namespace Content.Shared.Pinpointer
 {
     public abstract class SharedPinpointerSystem : EntitySystem
     {
-        protected readonly HashSet<EntityUid> ActivePinpointers = new();
-
         public override void Initialize()
         {
             base.Initialize();
             SubscribeLocalEvent<PinpointerComponent, ComponentGetState>(GetCompState);
-            SubscribeLocalEvent<PinpointerComponent, ComponentShutdown>(OnPinpointerShutdown);
         }
 
         private void GetCompState(EntityUid uid, PinpointerComponent pinpointer, ref ComponentGetState args)
@@ -21,12 +18,6 @@ namespace Content.Shared.Pinpointer
                 ArrowAngle = pinpointer.ArrowAngle,
                 DistanceToTarget = pinpointer.DistanceToTarget
             };
-        }
-
-        private void OnPinpointerShutdown(EntityUid uid, PinpointerComponent component, ComponentShutdown _)
-        {
-            // no need to dirty it/etc: it's shutting down anyway!
-            ActivePinpointers.Remove(uid);
         }
 
         /// <summary>
@@ -72,13 +63,7 @@ namespace Content.Shared.Pinpointer
                 return;
             if (isActive == pinpointer.IsActive)
                 return;
-
-            // add-remove pinpointer from update list
-            if (isActive)
-                ActivePinpointers.Add(uid);
-            else
-                ActivePinpointers.Remove(uid);
-
+            
             pinpointer.IsActive = isActive;
             Dirty(pinpointer);
         }

--- a/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
+++ b/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
@@ -18,7 +18,7 @@ namespace Content.Shared.Pinpointer
             args.State = new PinpointerComponentState
             {
                 IsActive = pinpointer.IsActive,
-                DirectionToTarget = pinpointer.DirectionToTarget,
+                ArrowAngle = pinpointer.ArrowAngle,
                 DistanceToTarget = pinpointer.DistanceToTarget
             };
         }
@@ -45,18 +45,22 @@ namespace Content.Shared.Pinpointer
         }
 
         /// <summary>
-        ///     Manually set pinpointer arrow direction
+        ///     Try to manually set pinpointer arrow direction.
+        ///     If difference between current angle and new angle is smaller than
+        ///     pinpointer precision, new value will be ignored and it will return false.
         /// </summary>
-        public void SetDirection(EntityUid uid, Direction directionToTarget, PinpointerComponent? pinpointer = null)
+        public bool TrySetArrowAngle(EntityUid uid, Angle arrowAngle, PinpointerComponent? pinpointer = null)
         {
             if (!Resolve(uid, ref pinpointer))
-                return;
+                return false;
 
-            if (directionToTarget == pinpointer.DirectionToTarget)
-                return;
+            if (pinpointer.ArrowAngle.EqualsApprox(arrowAngle, pinpointer.Precision))
+                return false;
 
-            pinpointer.DirectionToTarget = directionToTarget;
+            pinpointer.ArrowAngle = arrowAngle;
             Dirty(pinpointer);
+
+            return true;
         }
 
         /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -9,6 +9,7 @@
     noRot: True
   - type: Sprite
     netsync: false
+    noRot: True
     sprite: Objects/Devices/pinpointer.rsi
     layers:
     - state: pinpointer

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -20,8 +20,6 @@
     sprite: Objects/Devices/pinpointer.rsi
   - type: Pinpointer
   - type: Appearance
-    visuals:
-    - type: PinpointerVisualizer
 
 - type: entity
   name: pinpointer

--- a/SpaceStation14.sln.DotSettings
+++ b/SpaceStation14.sln.DotSettings
@@ -560,6 +560,8 @@ public sealed class $CLASS$ : Shared$CLASS$ {
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Patreon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pdas/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Phoron/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pinpointer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pinpointers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pipenet/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pipenode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=placeable/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Originally reported in Discord. Pinpointer was really inaccurate for long ranges due to rounding into cardinal coordinates. I changed it to send not direction, but rotation angle. 

I also did minor cleanup in pinpointers code:
- Moved old visualizer to systemt
- Replaced `ActivePinpointers` collection to `EntityQyery`
- Fixed pinpointer sprite rotation

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

https://user-images.githubusercontent.com/6161335/199831842-a5415dbc-3b5e-4bae-8120-477217d88487.mov

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Pinpointer arrow should be more accurate.

