### PR TITLE
Belt Slot PKAs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -32,3 +32,9 @@
     proto: BulletKinetic
     capacity: 1
     count: 1
+  - type: Clothing
+    #sprite: WRITEMEWRITEMEWRITEME
+    quickEquip: false
+    slots:
+    - suitStorage
+    - Belt


### PR DESCRIPTION
## About the PR:
Allows Proto-Kinetic Accelerators (PKAs) to be placed in your belt slot, making the toolbelt not always the best-in-slot option for a salvager.
No fancy belt sprite, though.

This PR is mainly for salvagers that use the Jetpack, and as such cannot store their PKA in their backpack. The lack of easy tool storage will make the small amount of pocket space offered to salvagers even more valuable.
(shh. yes i know about the backpack with jetpack strategy.)

**Screenshots**
![image](https://user-images.githubusercontent.com/48499004/200140785-5a7aaabb-0257-4385-ad23-3b87bb0d2292.png)

No special belt sprite for the PKA, sadly. I am no artist.
**Changelog**

:cl: civilCornball
- tweak: Allowed Proto-Kinetic Accelerators to be stored in the belt slot.

