### PR TITLE
Prevent inserting into unpowered lathes

### DIFF
--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Materials;
 using Content.Shared.Popups;
+using Content.Server.Power.Components;
 using Robust.Shared.Player;
 
 namespace Content.Server.Materials;
@@ -15,6 +16,8 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
     public override bool TryInsertMaterialEntity(EntityUid user, EntityUid toInsert, EntityUid receiver, MaterialStorageComponent? component = null)
     {
         if (!Resolve(receiver, ref component))
+            return false;
+        if (TryComp<ApcPowerReceiverComponent>(receiver, out var power) && !power.Powered)
             return false;
         if (!base.TryInsertMaterialEntity(user, toInsert, receiver, component))
             return false;


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Entities with MaterialStorageComponent should not accept materials if they are supposed to be powered, and are not actually powered.

This fixes being able to insert ores into unpowered or unanchored ore processors, among other issues.

**Screenshots**
N/A

**Changelog**
:cl: notafet
- fix: Ore processors and lathes require power to process materials.