### PR TITLE
Makes ActivateItemInWorld on Players open the stripping menu

### DIFF
--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Player;
 using System.Threading;
 using Content.Server.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.Interaction;
 
 namespace Content.Server.Strip
 {
@@ -37,6 +38,7 @@ namespace Content.Server.Strip
             base.Initialize();
 
             SubscribeLocalEvent<StrippableComponent, GetVerbsEvent<Verb>>(AddStripVerb);
+            SubscribeLocalEvent<StrippableComponent, ActivateInWorldEvent>(OnActivateInWorld);
 
             // BUI
             SubscribeLocalEvent<StrippableComponent, StrippingSlotButtonPressed>(OnStripButtonPressed);
@@ -130,6 +132,17 @@ namespace Content.Server.Strip
                 Act = () => StartOpeningStripper(args.User, component, true),
             };
             args.Verbs.Add(verb);
+        }
+
+        private void OnActivateInWorld(EntityUid uid, StrippableComponent component, ActivateInWorldEvent args)
+        {
+            if (args.Target == args.User)
+                return;
+
+            if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
+                return;
+
+            StartOpeningStripper(args.User, component, true);
         }
 
         /// <summary>


### PR DESCRIPTION

**Screenshots**
https://user-images.githubusercontent.com/70486856/200150440-5c8abb50-4cc2-40a7-bbaf-16ccb1137056.mp4

**Changelog**

Added the feature request mentioned  #11084
Not too sure about the code, so please correct me if I'm wrong

:cl:
- add: ActivateItemInWorld opens the stripping menu

