### PR TITLE
Ignore falling body sound on component startup

### DIFF
--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -101,7 +101,9 @@ namespace Content.Shared.Standing
                 }
             }
 
-            if (!_gameTiming.IsFirstTimePredicted)
+            // check if component was just added or streamed to client
+            // if true, no need to play sound - mob was down before player could seen that
+            if (!_gameTiming.IsFirstTimePredicted || standingState.LifeStage <= ComponentLifeStage.Starting)
                 return true;
 
             if (playSound)

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -103,7 +103,7 @@ namespace Content.Shared.Standing
 
             // check if component was just added or streamed to client
             // if true, no need to play sound - mob was down before player could seen that
-            if (!_gameTiming.IsFirstTimePredicted || standingState.LifeStage <= ComponentLifeStage.Starting)
+            if (standingState.LifeStage <= ComponentLifeStage.Starting)
                 return true;
 
             if (playSound)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When you late join as ghost or go to new areas, you could hear dead bodies falling sound, even if bodies were laying for a long time. 

This PR fix that, so dead body sound doesn't play on component startup.

