### PR TITLE
Fix action bar duplication

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -87,6 +87,9 @@ namespace Content.Client.Actions
                 added.Add(action);
             }
 
+            if (_playerManager.LocalPlayer?.ControlledEntity != uid)
+                return;
+
             foreach (var action in removed)
             {
                 ActionRemoved?.Invoke(action);


### PR DESCRIPTION
AFAICT this was causing duplicate actions to appear in the actions UI for things like the ghost toggle light ability.

:cl:
- fix: Fixed a bug causing duplicate actions to appear in the actions bar/menu.