### PR TITLE
Map renderer file name option

### DIFF
--- a/Content.MapRenderer/CommandLineArguments.cs
+++ b/Content.MapRenderer/CommandLineArguments.cs
@@ -10,8 +10,8 @@ public sealed class CommandLineArguments
     public List<string> Maps { get; set; } = new();
     public OutputFormat Format { get; set; } = OutputFormat.png;
     public bool ExportViewerJson { get; set; } = false;
-
     public string OutputPath { get; set; } = DirectoryExtensions.MapImages().FullName;
+    public bool ArgumentsAreFileNames { get; set; } = false;
 
     public static bool TryParse(IReadOnlyList<string> args, [NotNullWhen(true)] out CommandLineArguments? parsed)
     {
@@ -53,6 +53,11 @@ public sealed class CommandLineArguments
                     parsed.OutputPath = enumerator.Current;
                     break;
 
+                case "-f":
+                case "--files":
+                    parsed.ArgumentsAreFileNames = true;
+                    break;
+
                 case "-h":
                 case "--help":
                     PrintHelp();
@@ -80,6 +85,9 @@ Options:
     -o / --output <output path>
         Changes the path the rendered maps will get saved to.
         Defaults to Resources/MapImages
+    -f / --files
+        This option tells the map renderer that you supplied a list of map file names instead of their ids.
+        Example: Content.MapRenderer -f box.yml bagel.yml
     -h / --help
         Displays this help text");
     }

--- a/Content.MapRenderer/CommandLineArguments.cs
+++ b/Content.MapRenderer/CommandLineArguments.cs
@@ -20,7 +20,8 @@ public sealed class CommandLineArguments
         if (args.Count == 0)
         {
             PrintHelp();
-            return false;
+            //Returns true here so the user can select what maps they want to render
+            return true;
         }
 
         using var enumerator = args.GetEnumerator();
@@ -67,6 +68,13 @@ public sealed class CommandLineArguments
                     parsed.Maps.Add(argument);
                     break;
             }
+        }
+
+        if (parsed.ArgumentsAreFileNames && parsed.Maps.Count == 0)
+        {
+            Console.WriteLine("No file names specified!");
+            PrintHelp();
+            return false;
         }
 
         return true;

--- a/Content.MapRenderer/Program.cs
+++ b/Content.MapRenderer/Program.cs
@@ -25,10 +25,11 @@ namespace Content.MapRenderer
 
         internal static async Task Main(string[] args)
         {
+
             if (args.Length == 0)
             {
                 Console.WriteLine("Didn't specify any maps to paint! Loading the map list...");
-                
+
                 await using var server = await PoolManager.GetServerClient();
                 var mapIds = server.Pair.Server
                     .ResolveDependency<IPrototypeManager>()
@@ -103,6 +104,38 @@ namespace Content.MapRenderer
             if (!CommandLineArguments.TryParse(args, out var arguments))
                 return;
 
+            if (arguments.ArgumentsAreFileNames)
+            {
+                Console.WriteLine("Retrieving map ids by map file names...");
+
+                Console.Write("Fetching map prototypes... ");
+                await using var server = await PoolManager.GetServerClient();
+                var mapPrototypes = server.Pair.Server
+                    .ResolveDependency<IPrototypeManager>()
+                    .EnumeratePrototypes<GameMapPrototype>()
+                    .ToArray();
+                Console.WriteLine("[Done]");
+
+                var ids = new List<string>();
+
+                foreach (var mapPrototype in mapPrototypes)
+                {
+                    if (arguments.Maps.Contains(mapPrototype.MapPath.Filename))
+                    {
+                        ids.Add(mapPrototype.ID);
+                        Console.WriteLine($"Found map: {mapPrototype.MapName}");
+                    }
+                }
+
+                if (ids.Count == 0)
+                {
+                    await Console.Error.WriteLineAsync("Found no maps for the given file names!");
+                    return;
+                }
+
+                arguments.Maps = ids;
+            }
+
             await Run(arguments);
         }
 
@@ -123,7 +156,7 @@ namespace Content.MapRenderer
 
                 mapViewerData.ParallaxLayers.Add(LayerGroup.DefaultParallax());
                 var directory = Path.Combine(arguments.OutputPath, map);
-                
+
                 var i = 0;
                 try
                 {

--- a/Content.MapRenderer/Program.cs
+++ b/Content.MapRenderer/Program.cs
@@ -26,7 +26,10 @@ namespace Content.MapRenderer
         internal static async Task Main(string[] args)
         {
 
-            if (args.Length == 0)
+            if (!CommandLineArguments.TryParse(args, out var arguments))
+                return;
+
+            if (arguments.Maps.Count == 0)
             {
                 Console.WriteLine("Didn't specify any maps to paint! Loading the map list...");
 
@@ -88,9 +91,7 @@ namespace Content.MapRenderer
                     selectedMapPrototypes.Add(mapIds[id]);
                 }
 
-                var argsLength = args.Length;
-                Array.Resize(ref args, argsLength + selectedMapPrototypes.Count);
-                selectedMapPrototypes.CopyTo(args, argsLength);
+                arguments.Maps.AddRange(selectedMapPrototypes);
 
                 if (selectedMapPrototypes.Count == 0)
                 {
@@ -100,9 +101,6 @@ namespace Content.MapRenderer
 
                 Console.WriteLine($"Selected maps: {string.Join(", ", selectedMapPrototypes)}");
             }
-
-            if (!CommandLineArguments.TryParse(args, out var arguments))
-                return;
 
             if (arguments.ArgumentsAreFileNames)
             {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a new option to the map renderer that allows you to specify map yml file names (like box.yml) instead of Ids for rendering.

This is required for using the map renderer in github actions.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

![image](https://user-images.githubusercontent.com/8915246/200446122-bf524d50-68d1-4717-bf35-25b30543490f.png)

![image](https://user-images.githubusercontent.com/8915246/200446290-f8e75153-bb6b-47f6-99eb-952328c2d4f3.png)

