### PR TITLE
Fix damage colour persisting

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -22,6 +22,9 @@ public sealed partial class MeleeWeaponSystem
 
     private void OnEffectAnimation(EntityUid uid, DamageEffectComponent component, AnimationCompletedEvent args)
     {
+        if (args.Key != DamageAnimationKey)
+            return;
+
         if (TryComp<SpriteComponent>(uid, out var sprite))
         {
             sprite.Color = component.Color;


### PR DESCRIPTION
Probably. Easiest way to repro is make spaceman go horizontal and most of the time the red colour persists when the rotation animation starts.

:cl:
- fix: Fix damage effect persisting indefinitely.
