### PR TITLE
Add automatic emergency shuttle call

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1029,6 +1029,19 @@ namespace Content.Shared.CCVar
             CVarDef.Create("shuttle.recall_turning_point", 0.5f, CVar.SERVERONLY);
 
         /// <summary>
+        ///     Time in minutes after round start to auto-call the shuttle. Set to zero to disable.
+        /// </summary>
+        public static readonly CVarDef<int> EmergencyShuttleAutoCallTime =
+            CVarDef.Create("shuttle.auto_call_time", 90, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Time in minutes after the round was extended (by recalling the shuttle) to call
+        ///     the shuttle again.
+        /// </summary>
+        public static readonly CVarDef<int> EmergencyShuttleAutoCallExtensionTime =
+            CVarDef.Create("shuttle.auto_call_extension_time", 45, CVar.SERVERONLY);
+
+        /// <summary>
         /// The map to load for CentCom for the emergency shuttle to dock to.
         /// </summary>
         public static readonly CVarDef<string> CentcommMap =

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -1,7 +1,7 @@
 ## RoundEndSystem
 
 round-end-system-shuttle-called-announcement = An emergency shuttle has been sent. ETA: {$time} {$units}.
-round-end-system-shuttle-auto-called-announcement = A departure shuttle has been sent. ETA: {$time} {$units}. Recall the shuttle to extend the shift.
+round-end-system-shuttle-auto-called-announcement = An automatic crew shift change shuttle has been sent. ETA: {$time} {$units}. Recall the shuttle to extend the shift.
 round-end-system-shuttle-recalled-announcement = The emergency shuttle has been recalled.
 round-end-system-round-restart-eta-announcement = Restarting the round in {$minutes} minutes...
 

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -1,6 +1,7 @@
 ## RoundEndSystem
 
 round-end-system-shuttle-called-announcement = An emergency shuttle has been sent. ETA: {$time} {$units}.
+round-end-system-shuttle-auto-called-announcement = A departure shuttle has been sent. ETA: {$time} {$units}. Recall the shuttle to extend the shift.
 round-end-system-shuttle-recalled-announcement = The emergency shuttle has been recalled.
 round-end-system-round-restart-eta-announcement = Restarting the round in {$minutes} minutes...
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds a `cvar shuttle.auto_call_time` which is an integer *N*, that calls the emergency shuttle automatically without intervention every *N* minutes. This can be disabled by setting *N* to 0, but defaults to 90 (minutes).

Note that auto-call will happen regardless of the state of the shuttle console. You can think of this as CentCom SoP "default" to relieve tired crews after a long round. See additional arguments below.

Rounds can be extended by recalling if there is a functional communication console, at which point the next auto-call will happen again after *N* minutes.

### Why
While there are a handful of players who enjoy longer rounds, most players (informal survey conducted by @Emisse) prefer shorter rounds. Adding an automatic shuttle call would strongly signal this preference.

Arguments for shorter rounds:

- Players with limited time are more likely to be able to play shorter rounds than longer ones
  - Many MRP players I've talked to sit out of rounds, or don't ready up, because they want to see who's playing before they commit to a long round. Reducing average round length would encourage more folks with limited time to actually play.
- Players with limited time are more likely to play command roles
  - Many MRP players elect not to chose command roles because heads are expected to be available for the duration of the round. As a result, MRP is frequently missing command, and so inevitably someone has to break into HoP's locker *on MRP*. Shorter rounds would encourage more time-limited command players to actually play.
  - I have found that *command* players typically prefer shorter rounds, but *non-command* players typically want to stay longer. Command typically defers to those who want to stay, burning out command players.
- Dying doesn't keep you out of the game for 3 hours on MRP
- Traitors and other antags get re-rolled more often on MRP
- Traitors don't have to hang onto an objective for 3 hours waiting for a shuttle on MRP

Arguments for auto-call:

- Ends the round if there are no heads (or if the heads are all incapacitated) after 90 minutes
- Reduces round-stalling, e.g. a syndicate operative destroying all communications consoles and murder-boning the whole station
- This mechanic is well-tested on TG

This change will likely have little impact on LRP, where rounds are already short.

**Screenshots**
N/A

**Changelog**
:cl: notafet
- add: CentCom now calls the shuttle automatically after a long round.
