### PR TITLE
World target action uses entity coordinates

### DIFF
--- a/Content.Client/Decals/DecalPlacementSystem.cs
+++ b/Content.Client/Decals/DecalPlacementSystem.cs
@@ -100,26 +100,24 @@ public sealed class DecalPlacementSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (!_mapMan.TryFindGridAt(args.Target, out var grid))
+        if (args.Target.GetGridUid(EntityManager) == null)
             return;
 
         args.Handled = true;
 
-        var coords =  EntityCoordinates.FromMap(grid.GridEntityId, args.Target, EntityManager);
-
         if (args.Snap)
         {
             var newPos = new Vector2(
-                (float) (MathF.Round(coords.X - 0.5f, MidpointRounding.AwayFromZero) + 0.5),
-                (float) (MathF.Round(coords.Y - 0.5f, MidpointRounding.AwayFromZero) + 0.5)
+                (float) (MathF.Round(args.Target.X - 0.5f, MidpointRounding.AwayFromZero) + 0.5),
+                (float) (MathF.Round(args.Target.Y - 0.5f, MidpointRounding.AwayFromZero) + 0.5)
             );
-            coords = coords.WithPosition(newPos);
+            args.Target = args.Target.WithPosition(newPos);
         }
 
-        coords = coords.Offset(new Vector2(-0.5f, -0.5f));
+        args.Target = args.Target.Offset(new Vector2(-0.5f, -0.5f));
 
-        var decal = new Decal(coords.Position, args.DecalId, args.Color, Angle.FromDegrees(args.Rotation), args.ZIndex, args.Cleanable);
-        RaiseNetworkEvent(new RequestDecalPlacementEvent(decal, coords));
+        var decal = new Decal(args.Target.Position, args.DecalId, args.Color, Angle.FromDegrees(args.Rotation), args.ZIndex, args.Cleanable);
+        RaiseNetworkEvent(new RequestDecalPlacementEvent(decal, args.Target));
     }
 
     private void OnFillSlot(FillActionSlotEvent ev)

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -205,7 +205,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (_actionsSystem == null)
             return false;
 
-        var coords = args.Coordinates.ToMap(_entities);
+        var coords = args.Coordinates;
 
         if (!_actionsSystem.ValidateWorldTarget(user, coords, action))
         {

--- a/Content.Server/Magic/MagicSystem.cs
+++ b/Content.Server/Magic/MagicSystem.cs
@@ -232,7 +232,7 @@ public sealed class MagicSystem : EntitySystem
 
         var transform = Transform(args.Performer);
 
-        if (transform.MapID != args.Target.MapId) return;
+        if (transform.MapID != args.Target.GetMapId(EntityManager)) return;
 
         transform.WorldPosition = args.Target.Position;
         transform.AttachToGridOrMap();
@@ -323,14 +323,14 @@ public sealed class MagicSystem : EntitySystem
     /// offset
     /// </remarks>
     /// <param name="entityEntries"> The list of Entities to spawn in</param>
-    /// <param name="mapCoords"> Map Coordinates where the entities will spawn</param>
+    /// <param name="entityCoords"> Map Coordinates where the entities will spawn</param>
     /// <param name="lifetime"> Check to see if the entities should self delete</param>
     /// <param name="offsetVector2"> A Vector2 offset that the entities will spawn in</param>
-    private void SpawnSpellHelper(List<EntitySpawnEntry> entityEntries, MapCoordinates mapCoords, float? lifetime, Vector2 offsetVector2)
+    private void SpawnSpellHelper(List<EntitySpawnEntry> entityEntries, EntityCoordinates entityCoords, float? lifetime, Vector2 offsetVector2)
     {
         var getProtos = EntitySpawnCollection.GetSpawns(entityEntries, _random);
 
-        var offsetCoords = mapCoords;
+        var offsetCoords = entityCoords;
         foreach (var proto in getProtos)
         {
             // TODO: Share this code with instant because they're both doing similar things for positioning.

--- a/Content.Server/Magic/MagicSystem.cs
+++ b/Content.Server/Magic/MagicSystem.cs
@@ -39,7 +39,7 @@ public sealed class MagicSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly GunSystem _gunSystem = default!;
-
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -159,7 +159,7 @@ public sealed class MagicSystem : EntitySystem
         foreach (var pos in GetSpawnPositions(xform, ev.Pos))
         {
             var ent = Spawn(ev.Prototype, pos.SnapToGrid(EntityManager, _mapManager));
-            _gunSystem.ShootProjectile(ent,ev.Target.Position - Transform(ent).MapPosition.Position, ev.Performer);
+            _gunSystem.ShootProjectile(ent, ev.Target.Position - Transform(ent).Coordinates.Position, ev.Performer);
         }
     }
 
@@ -234,7 +234,7 @@ public sealed class MagicSystem : EntitySystem
 
         if (transform.MapID != args.Target.GetMapId(EntityManager)) return;
 
-        transform.WorldPosition = args.Target.Position;
+        _transformSystem.SetCoordinates(args.Performer, args.Target);
         transform.AttachToGridOrMap();
         SoundSystem.Play(args.BlinkSound.GetSound(), Filter.Pvs(args.Target), args.Performer, AudioParams.Default.WithVolume(args.BlinkVolume));
         args.Handled = true;

--- a/Content.Shared/Actions/ActionEvents.cs
+++ b/Content.Shared/Actions/ActionEvents.cs
@@ -44,7 +44,7 @@ public sealed class RequestPerformActionEvent : EntityEventArgs
 {
     public readonly ActionType Action;
     public readonly EntityUid? EntityTarget;
-    public readonly MapCoordinates? MapTarget;
+    public readonly EntityCoordinates? EntityCoordinatesTarget;
 
     public RequestPerformActionEvent(InstantAction action)
     {
@@ -57,10 +57,10 @@ public sealed class RequestPerformActionEvent : EntityEventArgs
         EntityTarget = entityTarget;
     }
 
-    public RequestPerformActionEvent(WorldTargetAction action, MapCoordinates mapTarget)
+    public RequestPerformActionEvent(WorldTargetAction action, EntityCoordinates entityCoordinatesTarget)
     {
         Action = action;
-        MapTarget = mapTarget;
+        EntityCoordinatesTarget = entityCoordinatesTarget;
     }
 }
 
@@ -102,7 +102,7 @@ public abstract class WorldTargetActionEvent : BaseActionEvent
     /// <summary>
     ///     The coordinates of the location that the user targeted.
     /// </summary>
-    public MapCoordinates Target;
+    public EntityCoordinates Target;
 }
 
 /// <summary>

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -158,7 +158,7 @@ public abstract class SharedActionsSystem : EntitySystem
 
                 if (ev.EntityCoordinatesTarget is not EntityCoordinates entityCoordinatesTarget)
                 {
-                    Logger.Error($"Attempted to perform a map-targeted action without a target! Action: {worldAction.DisplayName}");
+                    Logger.Error($"Attempted to perform a world-targeted action without a target! Action: {worldAction.DisplayName}");
                     return;
                 }
 
@@ -245,9 +245,6 @@ public abstract class SharedActionsSystem : EntitySystem
 
     public bool ValidateWorldTarget(EntityUid user, EntityCoordinates coords, WorldTargetAction action)
     {
-        if (coords == EntityCoordinates.Invalid)
-            return false;
-
         if (action.CheckCanInteract && !_actionBlockerSystem.CanInteract(user, null))
             return false;
 
@@ -262,7 +259,7 @@ public abstract class SharedActionsSystem : EntitySystem
             if (action.Range <= 0)
                 return true;
 
-            return (xform.WorldPosition - coords.Position).Length <= action.Range;
+            return coords.InRange(EntityManager, Transform(user).Coordinates, action.Range);
         }
 
         return _interactionSystem.InRangeUnobstructed(user, coords, range: action.Range);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As discussed privately with @ElectroJr , this makes them much easier to use because there's so many more helpers, etc for entity coordinates. This is because the interaction system uses entity coordinates. Actions, if they want to be easy to use, should emulate interactions a lot more. 

Tested locally, decals, map actions, all the spells, etc work on my machine
