### PR TITLE
Fixes vehicle movement blocking

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Movement;
 using Content.Shared.Movement.Events;
 using Content.Shared.Standing;
 using Content.Shared.Throwing;
+using Content.Shared.Vehicle.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Timing;
@@ -81,7 +82,8 @@ namespace Content.Shared.Buckle
             if (component.LifeStage > ComponentLifeStage.Running)
                 return;
 
-            if (component.Buckled)
+            if (component.Buckled &&
+                !HasComp<VehicleComponent>(Transform(uid).ParentUid)) // buckle+vehicle shitcode
                 args.Cancel();
         }
 


### PR DESCRIPTION
Movement action blockers now block movement relaying, but vehicles buckle the player which blocks movement.
This just adds a basic check to the buckle action blocking. Really buckling should just have the option to not block movement or automatically disable if movement is getting relayed, but I'll leave that as an exercise for whoever finishes ECSing buckles.

Fixes #12470.

:cl:
- fix: Fixed vehicles not working.

