### PR TITLE
Fix item cabinet locking while open and locker favoritism

### DIFF
--- a/Content.Server/Cabinet/ItemCabinetSystem.cs
+++ b/Content.Server/Cabinet/ItemCabinetSystem.cs
@@ -27,6 +27,8 @@ namespace Content.Server.Cabinet
 
             SubscribeLocalEvent<ItemCabinetComponent, EntInsertedIntoContainerMessage>(OnContainerModified);
             SubscribeLocalEvent<ItemCabinetComponent, EntRemovedFromContainerMessage>(OnContainerModified);
+
+            SubscribeLocalEvent<ItemCabinetComponent, LockToggleAttemptEvent>(OnLockToggleAttempt);
         }
 
         private void OnComponentInit(EntityUid uid, ItemCabinetComponent cabinet, ComponentInit args)
@@ -61,6 +63,13 @@ namespace Content.Server.Cabinet
 
             if (args.Container.ID == cabinet.CabinetSlot.ID)
                 UpdateAppearance(uid, cabinet);
+        }
+
+        private void OnLockToggleAttempt(EntityUid uid, ItemCabinetComponent cabinet, LockToggleAttemptEvent args)
+        {
+            // Cannot lock or unlock while open.
+            if (cabinet.Opened)
+                args.Cancel();
         }
 
         private void AddToggleOpenVerb(EntityUid uid, ItemCabinetComponent cabinet, GetVerbsEvent<ActivationVerb> args)

--- a/Content.Server/Lock/LockComponent.cs
+++ b/Content.Server/Lock/LockComponent.cs
@@ -14,3 +14,15 @@ namespace Content.Server.Storage.Components
         [ViewVariables(VVAccess.ReadWrite)] [DataField("lockingSound")] public SoundSpecifier LockSound { get; set; } = new SoundPathSpecifier("/Audio/Machines/door_lock_on.ogg");
     }
 }
+public sealed class LockToggleAttemptEvent : CancellableEntityEventArgs
+{
+    public bool Silent = false;
+    public EntityUid User;
+
+    public LockToggleAttemptEvent(EntityUid user, bool silent = false)
+    {
+        User = user;
+        Silent = silent;
+    }
+}
+public sealed class LockToggleAttemptArgs : EventArgs { }

--- a/Content.Server/Lock/LockSystem.cs
+++ b/Content.Server/Lock/LockSystem.cs
@@ -148,23 +148,14 @@ namespace Content.Server.Lock
         /// <summary>
         ///     Before locking the entity, check whether it's a locker. If is, prevent it from being locked from the inside or while it is open.
         /// </summary>
-        public bool CanToggleLock(EntityUid uid, EntityUid user, EntityStorageComponent? storage = null, bool quiet = true)
+        public bool CanToggleLock(EntityUid uid, EntityUid user, bool quiet = true)
         {
-            if (!Resolve(uid, ref storage, logMissing: false))
-                return true;
-
             if (!HasComp<SharedHandsComponent>(user))
                 return false;
 
-            // Cannot lock if the entity is currently opened.
-            if (storage.Open)
-                return false;
-
-            // Cannot (un)lock from the inside. Maybe a bad idea? Security jocks could trap nerds in lockers?
-            if (storage.Contents.Contains(user))
-                return false;
-
-            return true;
+            var ev = new LockToggleAttemptEvent(user, quiet);
+            RaiseLocalEvent(uid, ev, true);
+            return !ev.Cancelled;
         }
 
         private bool HasUserAccess(EntityUid uid, EntityUid user, AccessReaderComponent? reader = null, bool quiet = true)

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -45,6 +45,7 @@ public sealed class EntityStorageSystem : EntitySystem
         SubscribeLocalEvent<EntityStorageComponent, ActivateInWorldEvent>(OnInteract);
         SubscribeLocalEvent<EntityStorageComponent, WeldableAttemptEvent>(OnWeldableAttempt);
         SubscribeLocalEvent<EntityStorageComponent, WeldableChangedEvent>(OnWelded);
+        SubscribeLocalEvent<EntityStorageComponent, LockToggleAttemptEvent>(OnLockToggleAttempt);
         SubscribeLocalEvent<EntityStorageComponent, DestructionEventArgs>(OnDestroy);
 
         SubscribeLocalEvent<InsideEntityStorageComponent, InhaleLocationEvent>(OnInsideInhale);
@@ -100,6 +101,17 @@ public sealed class EntityStorageSystem : EntitySystem
     private void OnWelded(EntityUid uid, EntityStorageComponent component, WeldableChangedEvent args)
     {
         component.IsWeldedShut = args.IsWelded;
+    }
+
+    private void OnLockToggleAttempt(EntityUid uid, EntityStorageComponent target, LockToggleAttemptEvent args)
+    {
+        // Cannot (un)lock open lockers.
+        if (target.Open)
+            args.Cancel();
+
+        // Cannot (un)lock from the inside. Maybe a bad idea? Security jocks could trap nerds in lockers?
+        if (target.Contents.Contains(args.User))
+            args.Cancel();
     }
 
     private void OnDestroy(EntityUid uid, EntityStorageComponent component, DestructionEventArgs args)


### PR DESCRIPTION
## About the PR
Fixes: #12426
LockSystem now raises a local event on an entity with a lock when attempting to ascertain if the lock can be toggled. Other systems who subscribe to that event can cancel it to indicate that the lock should not be toggled in whatever state it's in. This is cleaner and more reusable than the previous method, which specifically checked if the target being toggled was a locker. Locker logic has also been moved to EntityStorageSystem.

**Screenshots**
https://user-images.githubusercontent.com/55061890/200760259-c7940506-79ec-4376-93dc-579c14748eac.mp4
A bit hard to show it, but this is me attempting to lock a locker from the inside and then once again trying when it's open, then trying to lock an open fire axe cabinet.

**Changelog**
:cl:
- fix: item cabinets no longer can be (un)locked while open