### PR TITLE
Destructible cell charger

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -22,6 +22,21 @@
   - type: Pullable
   - type: Clickable
   - type: InteractionOutline
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 40
+        behaviors:
+          - !type:EmptyAllContainersBehaviour
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              path: /Audio/Effects/metalbreak.ogg
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -31,9 +46,7 @@
         bounds: "-0.10,-0.10,0.10,0.10"
       density: 500
       mask:
-        - MachineMask
-      layer:
-        - HighImpassable
+        - TabletopMachineMask
   - type: ItemSlots
     slots:
       charger_slot:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cell charger wasn't destructible and was blocking mobs movement. Some mobs could stuck in it.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Cell charger is destructible and doesn't block mobs movement.
