### PR TITLE
Internals alert fix and adjustment

### DIFF
--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -8,9 +8,11 @@ namespace Content.Server.Atmos.Components
     public sealed class GasTankComponent : Component, IGasMixtureHolder
     {
         public const float MaxExplosionRange = 14f;
+        private const float DefaultLowPressure = 0f;
         private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 
         public int Integrity = 3;
+        public bool IsLowPressure => (Air?.Pressure ?? 0F) <= TankLowPressure;
 
         [ViewVariables(VVAccess.ReadWrite), DataField("ruptureSound")]
         public SoundSpecifier RuptureSound = new SoundPathSpecifier("/Audio/Effects/spray.ogg");
@@ -31,6 +33,13 @@ namespace Content.Server.Atmos.Components
         public IPlayingAudioStream? DisconnectStream;
 
         [DataField("air")] [ViewVariables] public GasMixture Air { get; set; } = new();
+
+        /// <summary>
+        ///     Pressure at which tank should be considered 'low' such as for internals.
+        /// </summary>
+        [DataField("tankLowPressure")]
+        [ViewVariables]
+        public float TankLowPressure { get; set; } = DefaultLowPressure;
 
         /// <summary>
         ///     Distributed pressure.
@@ -77,12 +86,6 @@ namespace Content.Server.Atmos.Components
         /// </summary>
         [DataField("tankFragmentScale")]
         public float TankFragmentScale { get; set; }    = 10 * Atmospherics.OneAtmosphere;
-
-        /// <summary>
-        ///     Pressure at which tank should be considered 'low' such as for internals.
-        /// </summary>
-        [DataField("tankLowPressure")]
-        public float TankLowPressure { get; set; } = 0;
 
         [DataField("toggleAction", required: true)]
         public InstantAction ToggleAction = new();

--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -78,6 +78,12 @@ namespace Content.Server.Atmos.Components
         [DataField("tankFragmentScale")]
         public float TankFragmentScale { get; set; }    = 10 * Atmospherics.OneAtmosphere;
 
+        /// <summary>
+        ///     Pressure at which tank should be considered 'low' such as for internals.
+        /// </summary>
+        [DataField("tankLowPressure")]
+        public float TankLowPressure { get; set; } = 0;
+
         [DataField("toggleAction", required: true)]
         public InstantAction ToggleAction = new();
     }

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -208,12 +208,12 @@ public sealed class InternalsSystem : EntitySystem
     {
         if (component.BreathToolEntity == null || !AreInternalsWorking(component)) return 2;
 
-        // Check if pressure in the tank is above low pressure threshhold
+        // If pressure in the tank is below low pressure threshhold, flash warning on internals UI
         if (TryComp<GasTankComponent>(component.GasTankEntity, out var gasTank)
-            && (gasTank.Air.Pressure > gasTank.TankLowPressure))
-            return 1;
+            && gasTank.IsLowPressure)
+                return 0;
 
-        return 0;
+        return 1;
     }
 
     public GasTankComponent? FindBestGasTank(InternalsComponent component)

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -208,12 +208,12 @@ public sealed class InternalsSystem : EntitySystem
     {
         if (component.BreathToolEntity == null || !AreInternalsWorking(component)) return 2;
 
-        // What we are checking here is if there is more moles in tank than we need.
+        // Check if pressure in the tank is above low pressure threshhold
         if (TryComp<GasTankComponent>(component.GasTankEntity, out var gasTank)
-            && (gasTank.OutputPressure * Atmospherics.BreathVolume / Atmospherics.R * gasTank.Air.Temperature) >= gasTank.Air.TotalMoles)
-            return 0;
+            && (gasTank.Air.Pressure > gasTank.TankLowPressure))
+            return 1;
 
-        return 1;
+        return 0;
     }
 
     public GasTankComponent? FindBestGasTank(InternalsComponent component)

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: BaseItem
   id: GasTankBase
@@ -44,6 +44,7 @@
     air:
       volume: 70
       temperature: 293.15
+    lowPressure: 75
   - type: Clothing
     sprite: Objects/Tanks/oxygen.rsi
     slots:

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -44,7 +44,7 @@
     air:
       volume: 70
       temperature: 293.15
-    lowPressure: 75
+    tankLowPressure: 30.0
   - type: Clothing
     sprite: Objects/Tanks/oxygen.rsi
     slots:


### PR DESCRIPTION
## About the PR
Fixes: #12490
Previously, CheckSeverity would check if there was more gas in the tank than was needed to breathe with some maths. This was returning 0 to flash a warning that there was low O2 in the tank when the check passed. This changes it so gas tanks have a configurable "low pressure" threshhold (0 by default) which can be re-used or adjusted as needed. Oxygen tanks now flash an internals warning when below 30 kpa, enough time to be a proper warning but short enough to be worrying (especially with emergency tanks where it's a few seconds).

**Screenshots**
![Content Client_3yOG2zVaPB](https://user-images.githubusercontent.com/55061890/200945931-b628d6a4-55f3-48cd-9ada-a550a1cf2b88.png)
![Content Client_GPakNdnTND](https://user-images.githubusercontent.com/55061890/200945966-ca62ec2e-6cc0-4288-9737-033989cb5d83.png)

**Changelog**
:cl:
- fix: internals tanks with air no longer flash warning

