### PR TITLE
droppers behave more like syringes

### DIFF
--- a/Content.Server/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Server/Chemistry/Components/InjectorComponent.cs
@@ -26,6 +26,16 @@ namespace Content.Server.Chemistry.Components
         public bool InjectOnly;
 
         /// <summary>
+        /// Whether or not the injector is able to draw from or inject from mobs
+        /// </summary>
+        /// <remarks>
+        ///     for example: droppers would ignore mobs
+        /// </remarks>
+        [ViewVariables]
+        [DataField("ignoreMobs")]
+        public bool IgnoreMobs = false;
+
+        /// <summary>
         ///     The minimum amount of solution that can be transferred at once from this solution.
         /// </summary>
         [DataField("minTransferAmount")]
@@ -72,6 +82,7 @@ namespace Content.Server.Chemistry.Components
         /// only ever be set to Inject
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("toggleState")]
         public InjectorToggleMode ToggleState
         {
             get => _toggleState;

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
@@ -27,7 +27,7 @@ public sealed partial class ChemistrySystem
     /// <summary>
     ///     Default transfer amounts for the set-transfer verb.
     /// </summary>
-    public static readonly List<int> TransferAmounts = new() { 5, 10, 15};
+    public static readonly List<int> TransferAmounts = new() {1, 5, 10, 15};
     private void InitializeInjector()
     {
         SubscribeLocalEvent<InjectorComponent, GetVerbsEvent<AlternativeVerb>>(AddSetTransferVerbs);
@@ -173,6 +173,10 @@ public sealed partial class ChemistrySystem
         if (HasComp<MobStateComponent>(target) ||
             HasComp<BloodstreamComponent>(target))
         {
+            // Are use using an injector capible of targeting a mob?
+            if (component.IgnoreMobs)
+                return;
+
             InjectDoAfter(component, args.User, target);
             args.Handled = true;
             return;

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -186,25 +186,23 @@
         visible: false
   - type: SolutionContainerManager
     solutions:
-      dropper:
+      injector:
         maxVol: 5
-  - type: RefillableSolution
-    solution: dropper
-  - type: DrainableSolution
-    solution: dropper
+  - type: Injector
+    injectOnly: false
+    ignoreMobs: true
+    minTransferAmount: 1
+    maxTransferAmount: 5
+    transferAmount: 1
+    toggleState: 1 # draw
   - type: ExaminableSolution
     solution: dropper
-  - type: SolutionTransfer
-    minTransferAmount: 1
-    transferAmount: 1
-    maxTransferAmount: 5
-    canChangeTransferAmount: true
   - type: UserInterface
     interfaces:
     - key: enum.TransferAmountUiKey.Key
       type: TransferAmountBoundUserInterface
   - type: Spillable
-    solution: dropper
+    solution: injector
   - type: Item
     sprite: Objects/Specific/Chemistry/dropper.rsi
   - type: Appearance


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes: #12231
I've moved droppers into syringe the component. Also added the ignoreMob flag so that you can't inject people with a dropper.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Droppers behave more like injectors. 

