### PR TITLE
Fix missing name for notekeeper cartridge and fix preinstalled programs being deinstallable

### DIFF
--- a/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
+++ b/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
@@ -109,7 +109,7 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
         //This will eventually be replaced by serializing and deserializing the cartridge to copy it when something needs
         //the data on the cartridge to carry over when installing
         var prototypeId = Prototype(cartridgeUid)?.ID;
-        return prototypeId != null && InstallProgram(loaderUid, prototypeId, loader);
+        return prototypeId != null && InstallProgram(loaderUid, prototypeId, loader: loader);
     }
 
     /// <summary>
@@ -117,9 +117,10 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
     /// </summary>
     /// <param name="loaderUid">The cartridge loader uid</param>
     /// <param name="prototype">The prototype name</param>
+    /// <param name="deinstallable">Whether the program can be deinstalled or not</param>
     /// <param name="loader">The cartridge loader component</param>
     /// <returns>Whether installing the cartridge was successful</returns>
-    public bool InstallProgram(EntityUid loaderUid, string prototype, CartridgeLoaderComponent? loader  = default!)
+    public bool InstallProgram(EntityUid loaderUid, string prototype, bool deinstallable = true, CartridgeLoaderComponent? loader  = default!)
     {
         if (!Resolve(loaderUid, ref loader) || loader.InstalledPrograms.Count >= loader.DiskSpace)
             return false;
@@ -134,7 +135,7 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
         var installedProgram = Spawn(prototype, new EntityCoordinates(loaderUid, 0, 0));
         container?.Insert(installedProgram);
 
-        UpdateCartridgeInstallationStatus(installedProgram, InstallationStatus.Installed);
+        UpdateCartridgeInstallationStatus(installedProgram, deinstallable ? InstallationStatus.Installed : InstallationStatus.Readonly);
         loader.InstalledPrograms.Add(installedProgram);
 
         RaiseLocalEvent(installedProgram, new CartridgeAddedEvent(loaderUid));
@@ -270,7 +271,7 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
     {
         foreach (var prototype in component.PreinstalledPrograms)
         {
-            InstallProgram(uid, prototype);
+            InstallProgram(uid, prototype, deinstallable: false);
         }
     }
 

--- a/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
+++ b/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
@@ -1,6 +1,2 @@
 ﻿default-program-name = Program
-
-ent-notekeeper-cartridge = notekeeper cartridge
-    .desc = A program for keeping notes
-
 notekeeper-program-name = Notekeeper

--- a/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
@@ -1,6 +1,8 @@
 ﻿- type: entity
   parent: BaseItem
   id: NotekeeperCartridge
+  name: notekeeper cartridge
+  description: A program for keeping notes
   components:
   - type: Sprite
     sprite: Objects/Devices/cartridge.rsi


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does what it says on the tin

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->
![image](https://user-images.githubusercontent.com/8915246/200960611-fe054394-a060-4d65-9328-3f893c3a46e1.png)


:cl:
- tweak: An update to Robust#OS™ now prevents deinstalling preinstalled programs.