### PR TITLE
Update zombie regen

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -120,7 +120,7 @@ namespace Content.Server.Zombies
                 else if (mobState.CurrentState == DamageState.Alive) //heals when zombies bite live entities
                 {
                     var healingSolution = new Solution();
-                    healingSolution.AddReagent("Bicaridine", 1.00); //if OP, reduce/change chem
+                    healingSolution.AddReagent("Omnizine", 5.00); //if OP, reduce/change chem
                     _bloodstream.TryAddToChemicals(args.User, healingSolution);
                 }
             }


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Changelog**
<!-- 
For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->
Change Bicaridine to omnizine, because zombie do not normal regen hp and lay in crit all round

:cl:
- fix: zombie now have normal regen!

