### PR TITLE
Strong revolvers no way

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -13,7 +13,7 @@
 - type: listing
   id: UplinkRevolverPython
   name: Python
-  description: A loud and deadly revolver. Uses .40 Magnum.
+  description: A loud and deadly revolver. Uses .45 Magnum.
   productEntity: WeaponRevolverPython
   cost:
     Telecrystal: 8

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -38,6 +38,22 @@
     proto: BulletMagnumHighVelocity
 
 - type: entity
+  id: CartridgeMagnumHC
+  name: cartridge (.45 magnum)
+  parent: BaseCartridgeMagnum
+  components:
+  - type: CartridgeAmmo
+    proto: BulletMagnumHC
+
+- type: entity
+  id: CartridgeMagnumHCHighVelocity
+  name: cartridge (.45 magnum high-velocity)
+  parent: BaseCartridgeMagnum
+  components:
+  - type: CartridgeAmmo
+    proto: BulletMagnumHCHighVelocity
+
+- type: entity
   id: CartridgeMagnumPractice
   name: cartridge (.40 magnum practice)
   parent: BaseCartridgeMagnum

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -21,6 +21,28 @@
         Piercing: 24
 
 - type: entity
+  id: BulletMagnumHC
+  name: bullet (.45 magnum)
+  parent: BaseBullet
+  noSpawn: true
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 22
+
+- type: entity
+  id: BulletMagnumHCHighVelocity
+  name: bullet (.45 magnum high-velocity)
+  parent: BaseBulletHighVelocity
+  noSpawn: true
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 24
+
+- type: entity
   id: BulletMagnumPractice
   name: bullet (.40 magnum practice)
   parent: BaseBulletPractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
@@ -60,6 +60,46 @@
   - type: Appearance
 
 - type: entity
+  id: SpeedLoaderMagnum
+  name: "speed loader (.45 magnum)"
+  parent: BaseSpeedLoaderMagnum
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeMagnumHC
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
+    layers:
+      - state: base
+        map: [ "enum.GunVisualLayers.Base" ]
+      - state: base-6
+        map: [ "enum.GunVisualLayers.Mag" ]
+  - type: MagazineVisuals
+    magState: base
+    steps: 7
+    zeroVisible: false
+  - type: Appearance
+
+- type: entity
+  id: SpeedLoaderMagnumHighVelocity
+  name: "speed loader (.45 magnum high-velocity)"
+  parent: BaseSpeedLoaderMagnum
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeMagnumHCHighVelocity
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
+    layers:
+      - state: base
+        map: [ "enum.GunVisualLayers.Base" ]
+      - state: high-velocity-6
+        map: [ "enum.GunVisualLayers.Mag" ]
+  - type: MagazineVisuals
+    magState: high-velocity
+    steps: 7
+    zeroVisible: false
+  - type: Appearance
+
+- type: entity
   id: SpeedLoaderMagnumPractice
   name: "speed loader (.40 magnum practice)"
   parent: BaseSpeedLoaderMagnum

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -29,9 +29,9 @@
   - type: RevolverAmmoProvider
     whitelist:
       tags:
-        - CartridgeMagnum
-        - SpeedLoaderMagnum
-    proto: CartridgeMagnum
+        - CartridgeMagnumHC
+        - SpeedLoaderMagnumHC
+    proto: CartridgeMagnumHC
     capacity: 7
     chambers: [ True, True, True, True, True, True, True ]
     ammoSlots: [ null, null, null, null, null, null, null ]
@@ -46,7 +46,7 @@
   name: Deckard
   parent: BaseWeaponRevolver
   id: WeaponRevolverDeckard
-  description: A rare, custom-built revolver. Use when there is no time for Voight-Kampff test. Uses .40 magnum ammo.
+  description: A rare, custom-built revolver. Use when there is no time for Voight-Kampff test. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
@@ -70,7 +70,7 @@
   name: Inspector
   parent: BaseWeaponRevolver
   id: WeaponRevolverInspector
-  description: A detective's best friend. Uses .40 magnum ammo.
+  description: A detective's best friend. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
@@ -85,7 +85,7 @@
   name: Mateba
   parent: BaseWeaponRevolver
   id: WeaponRevolverMateba
-  description: The iconic sidearm of the dreaded death squads. Uses .40 magnum ammo.
+  description: The iconic sidearm of the dreaded death squads. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
@@ -99,7 +99,7 @@
   name: Predator
   parent: BaseWeaponRevolver
   id: WeaponRevolverPython
-  description: A robust revolver favoured by Syndicate agents. Uses .40 magnum ammo.
+  description: A robust revolver favoured by Syndicate agents. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/python.rsi
@@ -110,7 +110,7 @@
   name: pirate revolver
   parent: BaseWeaponRevolver
   id: WeaponRevolverPirate
-  description: An odd, muzzle-loading revolver, favoured by pirate crews. Uses .40 magnum ammo.
+  description: An odd, muzzle-loading revolver, favoured by pirate crews. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes revolvers actually powerful and not some shooty that costs more than a normal pistol, yet is 10x worse.
I forgor the exact damage numbers, but it's 22-24 to 34-36 now if I remember correctly.

<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: BurninDreamear
- add: All sorts of corporations now supply higher caliber bullets, revolver only, for now...
- tweak: Nanotrasen and Syndicate revolvers have been retrofitted to use .45 magnum rounds instead of .40. Happy shooting!

