### PR TITLE
Makes damaging items stop on hit and play a sound

### DIFF
--- a/Content.Server/Damage/Components/DamageOtherOnHitComponent.cs
+++ b/Content.Server/Damage/Components/DamageOtherOnHitComponent.cs
@@ -12,6 +12,10 @@ namespace Content.Server.Damage.Components
         [ViewVariables(VVAccess.ReadWrite)]
         public bool IgnoreResistances = false;
 
+        [DataField("stopOnHit")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool StopOnHit = true;
+
         [DataField("damage", required: true)]
         [ViewVariables(VVAccess.ReadWrite)]
         public DamageSpecifier Damage = default!;

--- a/Content.Server/Damage/Components/DamageOtherOnHitComponent.cs
+++ b/Content.Server/Damage/Components/DamageOtherOnHitComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Damage.Systems;
 using Content.Shared.Damage;
+using Robust.Shared.Audio;
 
 namespace Content.Server.Damage.Components
 {
@@ -15,5 +16,8 @@ namespace Content.Server.Damage.Components
         [ViewVariables(VVAccess.ReadWrite)]
         public DamageSpecifier Damage = default!;
 
+        [DataField("soundHit")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public SoundSpecifier? HitSound { get; set; } = new SoundPathSpecifier("/Audio/Weapons/genhit1.ogg");
     }
 }

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -23,14 +23,14 @@ namespace Content.Server.Damage.Systems
         {
             var dmg = _damageableSystem.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances, origin: args.User);
 
-            // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
-            if (dmg != null && HasComp<MobStateComponent>(args.Target))
-                _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total:damage} damage from collision");
-
-            // Only play hitsound of thrown item and signal to stop when hitting mobs
+            // Only play hitsound and stop if hitting mobs.
             if (HasComp<MobStateComponent>(args.Target))
             {
                 _audio.Play(component.HitSound, Filter.Pvs(args.Target), args.Target);
+
+                // Log nonzero damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
+                if (dmg != null)
+                    _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total:damage} damage from collision");
 
                 if (component.StopOnHit)
                 {

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -27,8 +27,9 @@ namespace Content.Server.Damage.Systems
             if (dmg != null && HasComp<MobStateComponent>(args.Target))
                 _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total:damage} damage from collision");
 
-            // Play hit sound on target
-            _audio.Play(component.HitSound, Filter.Pvs(args.Target), args.Target);
+            // Play hit sound on target if it's damageable
+            if (HasComp<DamageableComponent>(args.Target))
+                _audio.Play(component.HitSound, Filter.Pvs(args.Target), args.Target);
         }
     }
 }

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.MobState.Components;
 using Content.Shared.Throwing;
+using Robust.Shared.Player;
 
 namespace Content.Server.Damage.Systems
 {
@@ -11,6 +12,7 @@ namespace Content.Server.Damage.Systems
     {
         [Dependency] private readonly DamageableSystem _damageableSystem = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger= default!;
+        [Dependency] private readonly SharedAudioSystem _audio = default!;
 
         public override void Initialize()
         {
@@ -24,6 +26,9 @@ namespace Content.Server.Damage.Systems
             // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
             if (dmg != null && HasComp<MobStateComponent>(args.Target))
                 _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.Total:damage} damage from collision");
+
+            // Play hit sound on target
+            _audio.Play(component.HitSound, Filter.Pvs(args.Target), args.Target);
         }
     }
 }

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -280,7 +280,7 @@ namespace Content.Server.Disposal.Unit.EntitySystems
         /// <summary>
         /// Thrown items have a chance of bouncing off the unit and not going in.
         /// </summary>
-        private void HandleThrowCollide(EntityUid uid, DisposalUnitComponent component, ThrowHitByEvent args)
+        private void HandleThrowCollide(EntityUid uid, DisposalUnitComponent component, ref ThrowHitByEvent args)
         {
             if (!CanInsert(component, args.Thrown) ||
                 _robustRandom.NextDouble() > 0.75 ||

--- a/Content.Server/Ensnaring/EnsnareableSystem.Ensnaring.cs
+++ b/Content.Server/Ensnaring/EnsnareableSystem.Ensnaring.cs
@@ -42,7 +42,7 @@ public sealed partial class EnsnareableSystem
         TryEnsnare(args.Tripper, component);
     }
 
-    private void OnThrowHit(EntityUid uid, EnsnaringComponent component, ThrowDoHitEvent args)
+    private void OnThrowHit(EntityUid uid, EnsnaringComponent component, ref ThrowDoHitEvent args)
     {
         if (!component.CanThrowTrigger)
             return;

--- a/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
@@ -39,7 +39,7 @@ namespace Content.Server.Nutrition.EntitySystems
             EntityManager.QueueDeleteEntity(uid);
         }
 
-        protected override void CreamedEntity(EntityUid uid, CreamPiedComponent creamPied, ThrowHitByEvent args)
+        protected override void CreamedEntity(EntityUid uid, CreamPiedComponent creamPied, ref ThrowHitByEvent args)
         {
             creamPied.Owner.PopupMessage(Loc.GetString("cream-pied-component-on-hit-by-message",("thrower", args.Thrown)));
             creamPied.Owner.PopupMessageOtherClients(Loc.GetString("cream-pied-component-on-hit-by-message-others", ("owner", creamPied.Owner),("thrower", args.Thrown)));

--- a/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
@@ -47,7 +47,7 @@ namespace Content.Server.Stunnable
             TryDoCollideStun(uid, component, args.OtherFixture.Body.Owner);
         }
 
-        private void HandleThrow(EntityUid uid, StunOnCollideComponent component, ThrowDoHitEvent args)
+        private void HandleThrow(EntityUid uid, StunOnCollideComponent component, ref ThrowDoHitEvent args)
         {
             TryDoCollideStun(uid, component, args.Target);
         }

--- a/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
@@ -50,22 +50,22 @@ namespace Content.Shared.Nutrition.EntitySystems
             SplatCreamPie(uid, component);
         }
 
-        private void OnCreamPieHit(EntityUid uid, CreamPieComponent component, ThrowDoHitEvent args)
+        private void OnCreamPieHit(EntityUid uid, CreamPieComponent component, ref ThrowDoHitEvent args)
         {
             SplatCreamPie(uid, component);
         }
 
-        private void OnCreamPiedHitBy(EntityUid uid, CreamPiedComponent creamPied, ThrowHitByEvent args)
+        private void OnCreamPiedHitBy(EntityUid uid, CreamPiedComponent creamPied, ref ThrowHitByEvent args)
         {
             if (!EntityManager.EntityExists(args.Thrown) || !EntityManager.TryGetComponent(args.Thrown, out CreamPieComponent? creamPie)) return;
 
             SetCreamPied(uid, creamPied, true);
 
-            CreamedEntity(uid, creamPied, args);
+            CreamedEntity(uid, creamPied, ref args);
 
             _stunSystem.TryParalyze(uid, TimeSpan.FromSeconds(creamPie.ParalyzeTime), true);
         }
 
-        protected virtual void CreamedEntity(EntityUid uid, CreamPiedComponent creamPied, ThrowHitByEvent args) {}
+        protected virtual void CreamedEntity(EntityUid uid, CreamPiedComponent creamPied, ref ThrowHitByEvent args) {}
     }
 }

--- a/Content.Shared/Throwing/LandEvent.cs
+++ b/Content.Shared/Throwing/LandEvent.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.Throwing
     /// Raised when a thrown entity is no longer moving.
     /// </summary>
     [ByRefEvent]
-    public struct StopThrowEvent
+    public record struct StopThrowEvent
     {
         public EntityUid? User;
 

--- a/Content.Shared/Throwing/LandEvent.cs
+++ b/Content.Shared/Throwing/LandEvent.cs
@@ -14,8 +14,14 @@ namespace Content.Shared.Throwing
     /// <summary>
     /// Raised when a thrown entity is no longer moving.
     /// </summary>
-    public sealed class StopThrowEvent : EntityEventArgs
+    [ByRefEvent]
+    public struct StopThrowEvent
     {
         public EntityUid? User;
+
+        public StopThrowEvent(EntityUid? user)
+        {
+            User = user;
+        }
     }
 }

--- a/Content.Shared/Throwing/LandEvent.cs
+++ b/Content.Shared/Throwing/LandEvent.cs
@@ -15,13 +15,5 @@ namespace Content.Shared.Throwing
     /// Raised when a thrown entity is no longer moving.
     /// </summary>
     [ByRefEvent]
-    public record struct StopThrowEvent
-    {
-        public EntityUid? User;
-
-        public StopThrowEvent(EntityUid? user)
-        {
-            User = user;
-        }
-    }
+    public readonly record struct StopThrowEvent(EntityUid? User);
 }

--- a/Content.Shared/Throwing/ThrowEvents.cs
+++ b/Content.Shared/Throwing/ThrowEvents.cs
@@ -34,7 +34,7 @@ namespace Content.Shared.Throwing
     ///     Raised directed on the target entity being hit by the thrown entity.
     /// </summary>
     [ByRefEvent]
-    public struct ThrowHitByEvent
+    public record struct ThrowHitByEvent
     {
         public EntityUid? User;
         public EntityUid Thrown;
@@ -59,7 +59,7 @@ namespace Content.Shared.Throwing
     ///     Raised directed on the thrown entity that hits another. 'User' is whoever threw it, if anyone.
     /// </summary>
     [ByRefEvent]
-    public struct ThrowDoHitEvent
+    public record struct ThrowDoHitEvent
     {
         public EntityUid? User;
         public EntityUid Thrown;

--- a/Content.Shared/Throwing/ThrowEvents.cs
+++ b/Content.Shared/Throwing/ThrowEvents.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Physics;
+
 namespace Content.Shared.Throwing
 {
     /// <summary>
@@ -31,20 +33,52 @@ namespace Content.Shared.Throwing
     /// <summary>
     ///     Raised directed on the target entity being hit by the thrown entity.
     /// </summary>
-    public sealed class ThrowHitByEvent : ThrowEvent
+    [ByRefEvent]
+    public struct ThrowHitByEvent
     {
-        public ThrowHitByEvent(EntityUid? user, EntityUid thrown, EntityUid target) : base(user, thrown, target)
+        public EntityUid? User;
+        public EntityUid Thrown;
+        public EntityUid Target;
+
+        public ThrowHitByEvent(EntityUid? user, EntityUid thrown, EntityUid target)
         {
+            User = user;
+            Thrown = thrown;
+            Target = target;
+        }
+
+        public ThrowHitByEvent(EntityUid? user, IPhysBody thrown, IPhysBody target)
+        {
+            User = user;
+            Thrown = thrown.Owner;
+            Target = target.Owner;
         }
     }
 
     /// <summary>
-    ///     Raised directed on the thrown entity that hits another. 'User' is whoever threw it.
+    ///     Raised directed on the thrown entity that hits another. 'User' is whoever threw it, if anyone.
     /// </summary>
-    public sealed class ThrowDoHitEvent : ThrowEvent
+    [ByRefEvent]
+    public struct ThrowDoHitEvent
     {
-        public ThrowDoHitEvent(EntityUid? user, EntityUid thrown, EntityUid target) : base(user, thrown, target)
+        public EntityUid? User;
+        public EntityUid Thrown;
+        public EntityUid Target;
+        public bool StopCollisions = false;
+        public bool StopMoving = false;
+
+        public ThrowDoHitEvent(EntityUid? user, EntityUid thrown, EntityUid target)
         {
+            User = user;
+            Thrown = thrown;
+            Target = target;
+        }
+
+        public ThrowDoHitEvent(EntityUid? user, IPhysBody thrown, IPhysBody target)
+        {
+            User = user;
+            Thrown = thrown.Owner;
+            Target = target.Owner;
         }
     }
 }

--- a/Content.Shared/Throwing/ThrowEvents.cs
+++ b/Content.Shared/Throwing/ThrowEvents.cs
@@ -39,7 +39,7 @@ namespace Content.Shared.Throwing
     }
 
     /// <summary>
-    ///     Raised directed on the thrown entity that hits another.
+    ///     Raised directed on the thrown entity that hits another. 'User' is whoever threw it.
     /// </summary>
     public sealed class ThrowDoHitEvent : ThrowEvent
     {

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -119,7 +119,8 @@ namespace Content.Shared.Throwing
                 }
             }
 
-            EntityManager.EventBus.RaiseLocalEvent(uid, new StopThrowEvent {User = thrownItemComponent.Thrower}, true);
+            var stopThrow = new StopThrowEvent(thrownItemComponent.Thrower);
+            EntityManager.EventBus.RaiseLocalEvent(uid, ref stopThrow, true);
             EntityManager.RemoveComponent<ThrownItemComponent>(uid);
         }
 

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -74,7 +74,7 @@ namespace Content.Shared.Throwing
 
         private void HandleCollision(EntityUid uid, ThrownItemComponent component, ref StartCollideEvent args)
         {
-            if (args.OtherFixture.Hard == false || component.StopColliding)
+            if (args.OtherFixture.Hard == false)
                 return;
 
             var thrower = component.Thrower;

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -119,7 +119,7 @@ namespace Content.Shared.Throwing
             }
 
             var stopThrow = new StopThrowEvent(thrownItemComponent.Thrower);
-            EntityManager.EventBus.RaiseLocalEvent(uid, ref stopThrow, true);
+            RaiseLocalEvent(uid, ref stopThrow, true);
             EntityManager.RemoveComponent<ThrownItemComponent>(uid);
         }
 
@@ -132,7 +132,7 @@ namespace Content.Shared.Throwing
 
             var landing = thrownItem.Owner;
 
-            if (stopMoving && _entityManager.TryGetComponent(landing, out IPhysBody? physics))
+            if (stopMoving && EntityManager.TryGetComponent(landing, out IPhysBody? physics))
                 physics.LinearVelocity = (0, 0);
 
             // Unfortunately we can't check for hands containers as they have specific names.

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -23,7 +23,6 @@ namespace Content.Shared.Throwing
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
         [Dependency] private readonly FixtureSystem _fixtures = default!;
-        [Dependency] private readonly EntityManager _entityManager = default!;
 
         private const string ThrowingFixture = "throw-fixture";
 

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -151,8 +151,12 @@ namespace Content.Shared.Throwing
             // TODO: Just pass in the bodies directly
             RaiseLocalEvent(target.Owner, new ThrowHitByEvent(user, thrown.Owner, target.Owner), true);
             RaiseLocalEvent(thrown.Owner, new ThrowDoHitEvent(user, thrown.Owner, target.Owner), true);
-            // if (thrown item has tag "StopOnCollide") stop thrown item
-            //thrown.LinearVelocity = (0,0);
+
+            // If still being "thrown", remove ThrownItemComponent. after, remove velocity to prevent more collisions
+            // TODO: if an item shouldn't care, add tag to check for
+            if (TryComp<ThrownItemComponent>(thrown.Owner, out var comp))
+                StopThrow(thrown.Owner, comp);
+            thrown.LinearVelocity = (0,0);
         }
     }
 }

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -151,6 +151,7 @@ namespace Content.Shared.Throwing
             // TODO: Just pass in the bodies directly
             RaiseLocalEvent(target.Owner, new ThrowHitByEvent(user, thrown.Owner, target.Owner), true);
             RaiseLocalEvent(thrown.Owner, new ThrowDoHitEvent(user, thrown.Owner, target.Owner), true);
+            // if (thrown item has tag "StopOnCollide") stop thrown item
         }
     }
 }

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -152,6 +152,7 @@ namespace Content.Shared.Throwing
             RaiseLocalEvent(target.Owner, new ThrowHitByEvent(user, thrown.Owner, target.Owner), true);
             RaiseLocalEvent(thrown.Owner, new ThrowDoHitEvent(user, thrown.Owner, target.Owner), true);
             // if (thrown item has tag "StopOnCollide") stop thrown item
+            //thrown.LinearVelocity = (0,0);
         }
     }
 }

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -56,9 +56,9 @@ namespace Content.Shared.Throwing
 
         private void ThrowItem(EntityUid uid, ThrownItemComponent component, ThrownEvent args)
         {
-            if (!EntityManager.TryGetComponent(component.Owner, out FixturesComponent? fixturesComponent) ||
+            if (!TryComp(component.Owner, out FixturesComponent? fixturesComponent) ||
                 fixturesComponent.Fixtures.Count != 1) return;
-            if (!EntityManager.TryGetComponent(component.Owner, out PhysicsComponent? physicsComponent)) return;
+            if (!TryComp(component.Owner, out PhysicsComponent? physicsComponent)) return;
 
             if (fixturesComponent.Fixtures.ContainsKey(ThrowingFixture))
             {
@@ -99,7 +99,7 @@ namespace Content.Shared.Throwing
         private void HandlePullStarted(PullStartedMessage message)
         {
             // TODO: this isn't directed so things have to be done the bad way
-            if (EntityManager.TryGetComponent(message.Pulled.Owner, out ThrownItemComponent? thrownItemComponent))
+            if (TryComp(message.Pulled.Owner, out ThrownItemComponent? thrownItemComponent))
                 StopThrow(message.Pulled.Owner, thrownItemComponent);
         }
 
@@ -108,7 +108,7 @@ namespace Content.Shared.Throwing
         /// </summary>
         private void StopThrow(EntityUid uid, ThrownItemComponent thrownItemComponent)
         {
-            if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
+            if (TryComp(uid, out PhysicsComponent? physicsComponent))
             {
                 var fixture = _fixtures.GetFixtureOrNull(physicsComponent, ThrowingFixture);
 
@@ -120,7 +120,7 @@ namespace Content.Shared.Throwing
 
             var stopThrow = new StopThrowEvent(thrownItemComponent.Thrower);
             RaiseLocalEvent(uid, ref stopThrow, true);
-            EntityManager.RemoveComponent<ThrownItemComponent>(uid);
+            RemComp<ThrownItemComponent>(uid);
         }
 
         /// <summary>
@@ -132,14 +132,15 @@ namespace Content.Shared.Throwing
 
             var landing = thrownItem.Owner;
 
-            if (stopMoving && EntityManager.TryGetComponent(landing, out IPhysBody? physics))
+            if (stopMoving && TryComp<IPhysBody?>(landing, out IPhysBody? physics))
                 physics.LinearVelocity = (0, 0);
+
 
             // Unfortunately we can't check for hands containers as they have specific names.
             if (landing.TryGetContainerMan(out var containerManager) &&
-                EntityManager.HasComponent<SharedHandsComponent>(containerManager.Owner))
+                HasComp<SharedHandsComponent>(containerManager.Owner))
             {
-                EntityManager.RemoveComponent(landing, thrownItem);
+                RemComp(landing, thrownItem);
                 return;
             }
 

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -49,6 +49,7 @@
     damage:
       types:
         Slash: 2
+    soundHit: /Audio/Weapons/bladeslice.ogg
   - type: Tag
     tags:
     - Trash

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: BaseItem
   id: ShardBase
@@ -24,6 +24,8 @@
     damage:
       types:
         Slash: 3.5
+    soundHit:
+      path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     sprite: Objects/Materials/Shards/shard.rsi
   - type: CollisionWake

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -16,10 +16,6 @@
         Blunt: 5
     soundHit:
       path: /Audio/Effects/hit_kick.ogg
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Blunt: 0 # no owies, just for the sound
   - type: CollisionWake
   - type: TileFrictionModifier
     modifier: 0.5

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -16,6 +16,10 @@
         Blunt: 5
     soundHit:
       path: /Audio/Effects/hit_kick.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 0 # no owies, just for the sound
   - type: CollisionWake
   - type: TileFrictionModifier
     modifier: 0.5


### PR DESCRIPTION
## About the PR
Fixes: #3920
Previously, thrown items just kinda passed through everything silently, even ones that damage things. This PR mimics behavior in SS13, where thrown items will stop in their tracks on collision and play a hit sound depending on what the item is. This also makes it so that thrown items should only collide and deal damage one time and then stop, but there's room for extra checks to be made if an item shouldn't care. This will also help illuminate bugs with the throwing system now that there's an audio cue when something's hit.

**Screenshots**
https://user-images.githubusercontent.com/55061890/201219384-85e0f960-c9dc-4e7e-ae6a-4aeca21f1223.mp4

**Changelog**
:cl:
- fix: thrown items that deal damage don't phase through people
- add: thrown items that deal damage make a sound on hit