### PR TITLE
Rebuild excited groups if blocked airflow direction of tile has changed.

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
@@ -31,7 +31,7 @@ namespace Content.Server.Atmos.EntitySystems
                 var moveEvent = new MoveEvent(airtight.Owner, default, default, Angle.Zero, xform.LocalRotation, xform, false);
                 OnAirtightRotated(uid, airtight, ref moveEvent);
             }
-            
+
             UpdatePosition(airtight);
         }
 
@@ -118,11 +118,7 @@ namespace Content.Server.Atmos.EntitySystems
             var query = EntityManager.GetEntityQuery<AirtightComponent>();
             _explosionSystem.UpdateAirtightMap(gridId, pos, query);
             // TODO make atmos system use query
-            _atmosphereSystem.UpdateAdjacent(gridUid, pos);
             _atmosphereSystem.InvalidateTile(gridUid, pos);
-
-            if(fixVacuum)
-                _atmosphereSystem.FixTileVacuum(gridUid, pos);
         }
 
         private AtmosDirection Rotate(AtmosDirection myDirection, Angle myAngle)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -67,8 +67,15 @@ namespace Content.Server.Atmos.EntitySystems
                 GridIsTileAirBlocked(uid, atmosphere, ref airBlockedEv);
                 var isAirBlocked = airBlockedEv.Result;
 
+                var oldBlocked = tile.BlockedAirflow;
                 var updateAdjacentEv = new UpdateAdjacentMethodEvent(uid, indices, mapGridComp);
                 GridUpdateAdjacent(uid, atmosphere, ref updateAdjacentEv);
+
+                // Blocked airflow changed, rebuild excited groups!
+                if (tile.Excited && tile.BlockedAirflow != oldBlocked)
+                {
+                    RemoveActiveTile(atmosphere, tile);
+                }
 
                 // Call this instead of the grid method as the map has a say on whether the tile is space or not.
                 if ((!mapGrid.TryGetTileRef(indices, out var t) || t.IsSpace(_tileDefinitionManager)) && !isAirBlocked)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes bug where non-air-nulling airtight would block airflow between two sets of tiles but not rebuild the excited group, therefore allowing air sharing between them.
Also stops airtight from immediately updating blocked airflow directions and fixing vacuums, we let the revalidation step do that instead. 

CC @ElectroJr 