### PR TITLE
Species specific jumpsuit sprite fixes

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -298,6 +298,11 @@ public sealed class ClientClothingSystem : ClothingSystem
                 layer.SetRsi(clothingSprite.BaseRSI);
             }
 
+            // Another "temporary" fix for clothing stencil masks.
+            // Sprite layer redactor when
+            if (slot == "jumpsuit")
+                layerData.Shader ??= "StencilDraw";
+
             sprite.LayerSetData(index, layerData);
             layer.Offset += slotDef.Offset;
         }

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -9,10 +9,6 @@
     slots: [innerclothing]
     equipSound:
       path: /Audio/Items/jumpsuit_equip.ogg
-    clothingVisuals:
-      jumpsuit:
-      - state: equipped-INNERCLOTHING
-        shader: StencilDraw
   - type: Butcherable
     butcheringType: Knife
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -106,6 +106,8 @@
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
       - shader: StencilClear
         sprite: Mobs/Species/Human/parts.rsi #PJB on stencil clear being on the left leg: "...this is 'fine'" -https://github.com/space-wizards/space-station-14/pull/12217#issuecomment-1291677115
+        # its fine, but its still very stupid that it has to be done like this instead of allowing sprites to just directly insert a stencil clear.
+        # sprite refactor when
         state: l_leg
       - shader: StencilMask
         map: [ "enum.HumanoidVisualLayers.StencilMask" ]


### PR DESCRIPTION
Reworks some changes made in #12217 so that species-specific jumpsuits are less painful to add.