### PR TITLE
Bump NPC melee range for steering

### DIFF
--- a/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
@@ -93,8 +93,11 @@ public sealed partial class NPCCombatSystem
             return;
         }
 
+        var steering = EnsureComp<NPCSteeringComponent>(component.Owner);
+        steering.Range = MathF.Max(0.2f, weapon.Range - 0.4f);
+
         // Gets unregistered on component shutdown.
-        _steering.TryRegister(component.Owner, new EntityCoordinates(component.Target, Vector2.Zero));
+        _steering.TryRegister(component.Owner, new EntityCoordinates(component.Target, Vector2.Zero), steering);
         _melee.AttemptLightAttack(component.Owner, weapon, component.Target);
     }
 }


### PR DESCRIPTION
No longer will the rat robust you.

:cl:
- tweak: NPCs will now try to stay ~1m away from you for melee rather than 0.2m, meaning rat servants will no longer sit under you in combat.
