### PR TITLE
Fix NPCs stopping steering on 1 bad path

### DIFF
--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -190,13 +190,6 @@ namespace Content.Server.NPC.Systems
                 return;
             }
 
-            // No path set from pathfinding or the likes.
-            if (steering.Status == SteeringStatus.NoPath)
-            {
-                SetDirection(mover, steering, Vector2.Zero);
-                return;
-            }
-
             // Can't move at all, just noop input.
             if (!mover.CanMove)
             {


### PR DESCRIPTION
Needs a more robust approach for this.

:cl:
- fix: NPCs will no longer stall on 1 bad path.
