### PR TITLE
Remove pacifist components on zombify

### DIFF
--- a/Content.Server/Zombies/ZombifyOnDeathSystem.cs
+++ b/Content.Server/Zombies/ZombifyOnDeathSystem.cs
@@ -26,6 +26,8 @@ using Content.Shared.Popups;
 using Content.Server.Atmos.Miasma;
 using Content.Server.Humanoid;
 using Content.Server.IdentityManagement;
+using Content.Server.Traits.Assorted;
+using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Humanoid;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Weapons.Melee;
@@ -99,6 +101,8 @@ namespace Content.Server.Zombies
             RemComp<BarotraumaComponent>(target);
             RemComp<HungerComponent>(target);
             RemComp<ThirstComponent>(target);
+            RemComp<PacifistComponent>(target);
+            RemComp<PacifiedComponent>(target);
 
             //funny voice
             EnsureComp<ReplacementAccentComponent>(target).Accent = "zombie";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes pacifism from players when they get zombified. Currently a pacifist stays that way as a zombie, except they can toggle combat mode and make punch animations. This is not cool.

To remove pacifism we also have to remove Pacified status effect, which may not be cool either. I tested these changes on handcuffed players and they work as expected (they can't attack), so it doesn't look like this will cause any unintended side-effects.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add screenshots or it's liable to be closed by maintainers. -->
https://user-images.githubusercontent.com/8189043/201518513-12a0291e-3f2d-4dd6-97f1-aada76c6a937.mp4

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: spaceghost34
- fix: Zombified pacifist players can attack now

