### PR TITLE
Donksoft guns & foam dart "refactor"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/toy.yml
@@ -28,6 +28,15 @@
   - type: Sprite
     sprite: Objects/Fun/toys.rsi
     state: foambox
+    
+- type: entity
+  parent: BoxDonkSoftBox
+  id: BoxDonkSoftRiot
+  name: riot dart box
+  components:
+  - type: BallisticAmmoProvider
+    capacity: 100
+    proto: BulletRiotFoam
 
 - type: entity
   parent: BoxDonkSoftBase

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/toy.yml
@@ -1,0 +1,57 @@
+# yeah I know there isnt a proper layer for foam darts Ill make a PR for it later*tm*
+
+- type: entity
+  id: MagazineLightRifleFoam
+  name: Donksoft LMG magazine
+  parent: BaseMagazineLightRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: BulletFoam
+  - type: Sprite
+    layers:
+    - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+      
+- type: entity
+  id: MagazineLightRifleRiotFoam
+  name: Donksoft LMG magazine (riot edition)
+  parent: BaseMagazineLightRifle
+  components:
+  - type: BallisticAmmoProvider
+    proto: BulletRiotFoam
+  - type: Sprite
+    layers:
+    - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+      
+- type: entity
+  id: MagazinePistolSubMachineGunFoam
+  name: Donksoft SMG magazine
+  parent: BaseMagazinePistolSubMachineGun
+  components:
+  - type: BallisticAmmoProvider
+    proto: BulletFoam
+  - type: Sprite
+    layers:
+    - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+      
+- type: entity
+  id: MagazinePistolSubMachineGunRiotFoam
+  name: Donksoft SMG magazine (riot edition)
+  parent: BaseMagazinePistolSubMachineGun
+  components:
+  - type: BallisticAmmoProvider
+    proto: BulletRiotFoam
+  - type: Sprite
+    layers:
+    - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/toy.yml
@@ -5,6 +5,13 @@
   name: Donksoft LMG magazine
   parent: BaseMagazineLightRifle
   components:
+    - type: Tag
+    tags:
+      - MagazineDonksoftLMG
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+        - BulletFoam
   - type: BallisticAmmoProvider
     proto: BulletFoam
   - type: Sprite
@@ -17,7 +24,7 @@
 - type: entity
   id: MagazineLightRifleRiotFoam
   name: Donksoft LMG magazine (riot edition)
-  parent: BaseMagazineLightRifle
+  parent: MagazineLightRifleFoam
   components:
   - type: BallisticAmmoProvider
     proto: BulletRiotFoam
@@ -33,6 +40,13 @@
   name: Donksoft SMG magazine
   parent: BaseMagazinePistolSubMachineGun
   components:
+  - type: Tag
+    tags:
+      - MagazineDonksoftSMG
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+        - BulletFoam
   - type: BallisticAmmoProvider
     proto: BulletFoam
   - type: Sprite
@@ -45,7 +59,7 @@
 - type: entity
   id: MagazinePistolSubMachineGunRiotFoam
   name: Donksoft SMG magazine (riot edition)
-  parent: BaseMagazinePistolSubMachineGun
+  parent: MagazinePistolSubMachineGunFoam
   components:
   - type: BallisticAmmoProvider
     proto: BulletRiotFoam
@@ -61,6 +75,13 @@
   name: Donksoft pistol magazine
   parent: BaseMagazinePistol
   components:
+  - type: Tag
+    tags:
+      - MagazineDonksoftPistol
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+        - BulletFoam
   - type: BallisticAmmoProvider
     proto: BulletFoam
   - type: Sprite
@@ -73,7 +94,7 @@
 - type: entity
   id: MagazinePistolRiotFoam
   name: Donksoft pistol magazine (riot edition)
-  parent: BaseMagazinePistol
+  parent: MagazinePistolFoam
   components:
   - type: BallisticAmmoProvider
     proto: BulletRiotFoam
@@ -89,6 +110,13 @@
   name: Donksoft machine pistol magazine
   parent: BaseMagazinePistolHighCapacity
   components:
+  - type: Tag
+    tags:
+      - MagazineDonksoftPistol
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+        - BulletFoam
   - type: BallisticAmmoProvider
     proto: BulletFoam
   - type: Sprite
@@ -101,7 +129,7 @@
 - type: entity
   id: MagazinePistolHighCapacityRiotFoam
   name: Donksoft machine pistol magazine (riot edition)
-  parent: BaseMagazinePistolHighCapacity
+  parent: MagazinePistolHighCapacityFoam
   components:
   - type: BallisticAmmoProvider
     proto: BulletRiotFoam

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/toy.yml
@@ -55,3 +55,59 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazinePistolFoam
+  name: Donksoft pistol magazine
+  parent: BaseMagazinePistol
+  components:
+  - type: BallisticAmmoProvider
+    proto: BulletFoam
+  - type: Sprite
+    layers:
+    - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+      
+- type: entity
+  id: MagazinePistolRiotFoam
+  name: Donksoft pistol magazine (riot edition)
+  parent: BaseMagazinePistol
+  components:
+  - type: BallisticAmmoProvider
+    proto: BulletRiotFoam
+  - type: Sprite
+    layers:
+    - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazinePistolHighCapacityFoam
+  name: Donksoft machine pistol magazine
+  parent: BaseMagazinePistolHighCapacity
+  components:
+  - type: BallisticAmmoProvider
+    proto: BulletFoam
+  - type: Sprite
+    layers:
+    - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: MagazinePistolHighCapacityRiotFoam
+  name: Donksoft machine pistol magazine (riot edition)
+  parent: BaseMagazinePistolHighCapacity
+  components:
+  - type: BallisticAmmoProvider
+    proto: BulletRiotFoam
+  - type: Sprite
+    layers:
+    - state: rubber
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
@@ -2,7 +2,8 @@
   id: BulletFoam
   description: I hope you're wearing eye protection.
   name: foam dart
-  parent: BaseItem
+  parent: BaseBullet
+  noSpawn: true
   components:
     - type: Tag
       tags:
@@ -12,13 +13,20 @@
       sprite: Objects/Fun/toys.rsi
       layers:
         - state: foamdart
+    - type: StaminaDamageOnCollide
+      damage: 5 #You ever been shot with a Nerf gun? Those bullets hit way harder than they look.
+    - type: Projectile
+      damage:
+        types:
+          Blunt: 0
+      soundHit:
+        path: "/Audio/Weapons/tap.ogg"
         
   - type: entity
     id: BulletRiotFoam
     description: Eye protection won't save you this time.
     name: riot dart
-    parent: BaseBullet
-    noSpawn: true
+    parent: BulletFoam
     components:
     - type: Tag
       tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
@@ -12,3 +12,27 @@
       sprite: Objects/Fun/toys.rsi
       layers:
         - state: foamdart
+        
+  - type: entity
+    id: BulletRiotFoam
+    description: Eye protection won't save you this time.
+    name: riot dart
+    parent: BaseBullet
+    noSpawn: true
+    components:
+    - type: Tag
+      tags:
+        - BulletFoam
+    - type: Ammo
+    - type: Sprite
+      sprite: Objects/Fun/toys.rsi
+      layers:
+        - state: foamdart
+    - type: StaminaDamageOnCollide
+      damage: 20 #if stamcrit in 5 shots is too strong I'll tweak this
+    - type: Projectile
+      damage:
+        types:
+          Blunt: 1
+      soundHit:
+        path: /Audio/Weapons/Guns/Hits/snap.ogg #TODO: make a better sound for this

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
@@ -14,7 +14,7 @@
       layers:
         - state: foamdart
     - type: StaminaDamageOnCollide
-      damage: 5 #You ever been shot with a Nerf gun? Those bullets hit way harder than they look.
+      damage: 2 #You ever been shot with a Nerf gun? Those bullets hit way harder than they look.
     - type: Projectile
       damage:
         types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -78,21 +78,22 @@
     id: WeaponLightMachineGunL6Donksoft
     parent: WeaponLightMachineGunL6
     description: A Donksoft-produced replica of the L6 SAW that uses foam darts as ammo. Looks and sounds just like the real thing!
-  - type: ItemSlots
-    slots:
-      gun_magazine:
-        name: Magazine
-        startingItem: MagazineLightRifleFoam #split on whether to make this preloaded with riot darts or regular darts, since I'm eventually adding these to uplinks
-        insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
-        ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
-        priority: 2
-        whitelist:
-          tags:
-            - MagazineDonksoftLMG
-      gun_chamber:
-        name: Chamber
-        startingItem: BulletFoam
-        priority: 1
-        whitelist:
-          tags:
-            - BulletFoam
+    components:
+    - type: ItemSlots
+      slots:
+        gun_magazine:
+          name: Magazine
+          startingItem: MagazineLightRifleFoam #split on whether to make this preloaded with riot darts or regular darts, since I'm eventually adding these to uplinks
+          insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
+          ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
+          priority: 2
+          whitelist:
+            tags:
+              - MagazineDonksoftLMG
+        gun_chamber:
+          name: Chamber
+          startingItem: BulletFoam
+          priority: 1
+          whitelist:
+            tags:
+              - BulletFoam

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -72,3 +72,27 @@
     steps: 4
     zeroVisible: true
   - type: Appearance
+  
+  - type: entity
+    name: L6 SAW (Donksoft edition)
+    id: WeaponLightMachineGunL6Donksoft
+    parent: WeaponLightMachineGunL6
+    description: A Donksoft-produced replica of the L6 SAW that uses foam darts as ammo. Looks and sounds just like the real thing!
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: MagazineLightRifleFoam #split on whether to make this preloaded with riot darts or regular darts, since I'm eventually adding these to uplinks
+        insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+            - MagazineDonksoftLMG
+      gun_chamber:
+        name: Chamber
+        startingItem: BulletFoam
+        priority: 1
+        whitelist:
+          tags:
+            - BulletFoam

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -114,7 +114,6 @@
           tags:
             - BulletFoam
   
-
 - type: entity
   name: handmade pistol
   parent: BaseWeaponPistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -95,6 +95,7 @@
   id: WeaponPistolViperDonksoft
   parent: WeaponPistolViper
   description: A Donksoft-produced replica of the Viper handgun, using foam darts as ammo. Looks and sounds just like the real thing!
+  components:
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -113,6 +114,10 @@
         whitelist:
           tags:
             - BulletFoam
+  - type: ContainerContainer
+    containers:
+      gun_magazine: !type:ContainerSlot
+      gun_chamber: !type:ContainerSlot
   
 - type: entity
   name: handmade pistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -91,6 +91,31 @@
       gun_chamber: !type:ContainerSlot
 
 - type: entity
+  name: Viper (Donksoft edition)
+  id: WeaponPistolViperDonksoft
+  parent: WeaponPistolViper
+  description: A Donksoft-produced replica of the Viper handgun, using foam darts as ammo. Looks and sounds just like the real thing!
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: MagazinePistolFoam # ditto on the L6 comment, adding this to uplinks eventually once I've polished it
+        insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+            - MagazineDonksoftPistol
+      gun_chamber:
+        name: Chamber
+        startingItem: BulletFoam
+        priority: 1
+        whitelist:
+          tags:
+            - BulletFoam
+  
+
+- type: entity
   name: handmade pistol
   parent: BaseWeaponPistol
   id: WeaponPistolHandmade

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -106,24 +106,29 @@
   id: WeaponSubMachineGunC20rDonksoft
   parent: WeaponSubMachineGunC20r
   description: A Donksoft-produced replica of the infamous SMG, uses foam darts as ammo. Looks and sounds just like the real thing!
-- type: ItemSlots
-    slots:
-      gun_magazine:
-        name: Magazine
-        startingItem: MagazinePistolSubMachineGunFoam # ditto on the L6 comment, adding this to uplinks eventually once I've polished it
-        insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
-        ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
-        priority: 2
-        whitelist:
-          tags:
-            - MagazineDonksoftSMG
-      gun_chamber:
-        name: Chamber
-        startingItem: BulletFoam
-        priority: 1
-        whitelist:
-          tags:
-            - BulletFoam
+  components:
+  - type: ItemSlots
+      slots:
+        gun_magazine:
+          name: Magazine
+          startingItem: MagazinePistolSubMachineGunFoam # ditto on the L6 comment, adding this to uplinks eventually once I've polished it
+          insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
+          ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+          priority: 2
+          whitelist:
+            tags:
+              - MagazineDonksoftSMG
+        gun_chamber:
+          name: Chamber
+          startingItem: BulletFoam
+          priority: 1
+          whitelist:
+            tags:
+              - BulletFoam
+  - type: ContainerContainer
+    containers:
+      gun_magazine: !type:ContainerSlot
+      gun_chamber: !type:ContainerSlot
 
 - type: entity
   name: Vector

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -125,6 +125,7 @@
           whitelist:
             tags:
               - BulletFoam
+  - type: ChamberMagazineAmmoProvider
   - type: ContainerContainer
     containers:
       gun_magazine: !type:ContainerSlot

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -102,6 +102,30 @@
   - type: Appearance
 
 - type: entity
+  name: C-20r sub machine gun (Donksoft edition)
+  id: WeaponSubMachineGunC20rDonksoft
+  parent: WeaponSubMachineGunC20r
+  description: A Donksoft-produced replica of the infamous SMG, uses foam darts as ammo. Looks and sounds just like the real thing!
+- type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: MagazinePistolSubMachineGunFoam # ditto on the L6 comment, adding this to uplinks eventually once I've polished it
+        insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+            - MagazineDonksoftSMG
+      gun_chamber:
+        name: Chamber
+        startingItem: BulletFoam
+        priority: 1
+        whitelist:
+          tags:
+            - BulletFoam
+
+- type: entity
   name: Vector
   parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunVector


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Yet another Wheatley webedit pr smh

This PR not only adds Donksoft replicas of the L6, c20r, and Viper, but also makes foam darts proper bullets. I changed the parenting from BaseItem to BaseBullet, so darts will actually fly properly instead of going 1 tile ahead and skidding to a halt. Also added riot darts, modified foam darts which can stamcrit someone in 5 hits. I'm planning in the future once I've added some more Donksoft guns to add the replicas and riot darts to uplinks, so they'll be able to be obtained outside of admin shenanigans.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: foam darts are now proper bullets
- add: Riot darts, rubber-cored foam darts which do moderate stamina damage on hit (unobtainable for now)
- add: Donksoft LMGs, SMGs, and pistols are now in the game (unobtainable for now)

