### PR TITLE
Remove NetSerializable from DamageTypePrototype

### DIFF
--- a/Content.Shared/Damage/Prototypes/DamageTypePrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageTypePrototype.cs
@@ -1,5 +1,4 @@
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared.Damage.Prototypes
 {
@@ -7,7 +6,6 @@ namespace Content.Shared.Damage.Prototypes
     ///     A single damage type. These types are grouped together in <see cref="DamageGroupPrototype"/>s.
     /// </summary>
     [Prototype("damageType")]
-    [Serializable, NetSerializable]
     public sealed class DamageTypePrototype : IPrototype
     {
         [IdDataFieldAttribute]


### PR DESCRIPTION
## About the PR
It's not actually sent over the network.