### PR TITLE
Revert "Cap passive research points so people spend points more"

### DIFF
--- a/Content.Server/Research/Components/ResearchServerComponent.cs
+++ b/Content.Server/Research/Components/ResearchServerComponent.cs
@@ -11,12 +11,6 @@ namespace Content.Server.Research.Components
         [ViewVariables(VVAccess.ReadWrite)] [DataField("points")]
         public int Points = 0;
 
-        /// <summary>
-        /// To encourage people to spend points,
-        /// will not accept passive points gain above this number for each source.
-        /// </summary>
-        [DataField("passiveLimitPerSource")]
-        public int PassiveLimitPerSource = 30000;
         [ViewVariables(VVAccess.ReadOnly)] public int Id { get; set; }
 
         [ViewVariables(VVAccess.ReadOnly)]

--- a/Content.Server/Research/Systems/ResearchSystem.Server.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Server.cs
@@ -7,7 +7,6 @@ namespace Content.Server.Research;
 
 public sealed partial class ResearchSystem
 {
-    [Dependency] private readonly StationSystem _stationSystem = default!;
     private void InitializeServer()
     {
         SubscribeLocalEvent<ResearchServerComponent, ComponentStartup>(OnServerStartup);
@@ -37,10 +36,6 @@ public sealed partial class ResearchSystem
 
     public bool RegisterServerClient(ResearchServerComponent component, ResearchClientComponent clientComponent)
     {
-        // Has to be on the same station
-        if (_stationSystem.GetOwningStation(component.Owner) != _stationSystem.GetOwningStation(clientComponent.Owner))
-            return false;
-
         // TODO: This is shit but I'm just trying to fix RND for now until it gets bulldozed
         if (TryComp<ResearchPointSourceComponent>(clientComponent.Owner, out var source))
         {
@@ -102,8 +97,7 @@ public sealed partial class ResearchSystem
     {
         var points = 0;
 
-        // Is our machine powered, and are we below our limit of passive point gain?
-        if (CanRun(component) && component.Points < (component.PassiveLimitPerSource * component.PointSources.Count))
+        if (CanRun(component))
         {
             foreach (var source in component.PointSources)
             {


### PR DESCRIPTION
Reverts space-wizards/space-station-14#11606
Firstly, I'm not sure capping the gen in the first place was ever really needed. It just kind of served as an annoying thing to keep track of so you don't lose out. Now with xenoarch, it's more of an active punishment if people don't immediately spend points after researching artifacts, which is really weird.

I think it's better overall to just let sci accumulate points so that they can use them as needed.

:cl:
- remove: Science passive research point generation is no longer capped at 30000