### PR TITLE
Fix looc prefix

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -50,17 +50,19 @@ public sealed class ChatUIController : UIController
     public const char AliasLocal = '.';
     public const char AliasConsole = '/';
     public const char AliasDead = '\\';
+    public const char AliasLOOC = '(';
     public const char AliasOOC = '[';
     public const char AliasEmotes = '@';
     public const char AliasAdmin = ']';
     public const char AliasRadio = ';';
     public const char AliasWhisper = ',';
 
-    private static readonly Dictionary<char, ChatSelectChannel> PrefixToChannel = new()
+    public static readonly Dictionary<char, ChatSelectChannel> PrefixToChannel = new()
     {
         {AliasLocal, ChatSelectChannel.Local},
         {AliasWhisper, ChatSelectChannel.Whisper},
         {AliasConsole, ChatSelectChannel.Console},
+        {AliasLOOC, ChatSelectChannel.LOOC},
         {AliasOOC, ChatSelectChannel.OOC},
         {AliasEmotes, ChatSelectChannel.Emotes},
         {AliasAdmin, ChatSelectChannel.Admin},
@@ -68,7 +70,7 @@ public sealed class ChatUIController : UIController
         {AliasDead, ChatSelectChannel.Dead}
     };
 
-    private static readonly Dictionary<ChatSelectChannel, char> ChannelPrefixes =
+    public static readonly Dictionary<ChatSelectChannel, char> ChannelPrefixes =
         PrefixToChannel.ToDictionary(kv => kv.Value, kv => kv.Key);
 
     /// <summary>
@@ -368,23 +370,6 @@ public sealed class ChatUIController : UIController
     public static string GetChannelSelectorName(ChatSelectChannel channelSelector)
     {
         return channelSelector.ToString();
-    }
-
-    public static char GetChannelSelectorPrefix(ChatSelectChannel channelSelector)
-    {
-        return channelSelector switch
-        {
-            ChatSelectChannel.Local => '.',
-            ChatSelectChannel.Whisper => ',',
-            ChatSelectChannel.Radio => ';',
-            ChatSelectChannel.LOOC => '(',
-            ChatSelectChannel.OOC => '[',
-            ChatSelectChannel.Emotes => '@',
-            ChatSelectChannel.Dead => '\\',
-            ChatSelectChannel.Admin => ']',
-            ChatSelectChannel.Console => '/',
-            _ => ' '
-        };
     }
 
     private void UpdateChannelPermissions()

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorItemButton.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorItemButton.cs
@@ -15,7 +15,7 @@ public sealed class ChannelSelectorItemButton : Button
         Channel = selector;
         AddStyleClass(StyleNano.StyleClassChatChannelSelectorButton);
         Text = ChatUIController.GetChannelSelectorName(selector);
-        var prefix = ChatUIController.GetChannelSelectorPrefix(selector);
+        var prefix = ChatUIController.ChannelPrefixes[selector];
         if (prefix != default) Text = Loc.GetString("hud-chatbox-select-name-prefixed", ("name", Text), ("prefix", prefix));
     }
 }


### PR DESCRIPTION

:cl:
- fix: Fixed LOOC chat prefix not working. Now messages starting starting with "(" just be interpreted as LOOC chat

