### PR TITLE
Radio bugfix

### DIFF
--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -50,8 +50,8 @@ public sealed class HeadsetSystem : EntitySystem
     private void OnGotUnequipped(EntityUid uid, HeadsetComponent component, GotUnequippedEvent args)
     {
         component.IsEquipped = false;
-        RemCompDeferred<ActiveRadioComponent>(uid);
-        RemCompDeferred<WearingHeadsetComponent>(args.Equipee);
+        RemComp<ActiveRadioComponent>(uid);
+        RemComp<WearingHeadsetComponent>(args.Equipee);
     }
 
     public void SetEnabled(EntityUid uid, bool value, HeadsetComponent? component = null)


### PR DESCRIPTION
Fix a small radio bug that causes issues if a headset is equipped and unequipped in the same tick (e.g., set outfit command).