### PR TITLE
Fix debug crash due to probability being outside 0-1

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -112,8 +112,10 @@ public class MutationSystem : EntitySystem
             return;
         }
 
-        // Starting number of bits that are high, between 0 and n.
+        // Starting number of bits that are high, between 0 and bits.
         int n = (int)Math.Round((val - min) / (max - min) * bits);
+        // val may be outside the range of min/max due to starting prototype values, so clamp
+        n = Math.Clamp(n, 0, bits);
 
         // Probability that the bit flip increases n.
         float p_increase = 1-(float)n/bits;


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Seed prototypes can have initial values outside of the thermometer code mutation range, which could result in a probability value _p_ greater than 1, causing an assertion failure and crash in the debug build.

Reported by: @JustinTrotter and others on Discord

**Screenshots**
N/A

**Changelog**
N/A