### PR TITLE
TC price changes

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -423,7 +423,7 @@
   description: And who says guns don't grow on trees?
   productEntity: GatfruitSeeds
   cost:
-    Telecrystal: 4
+    Telecrystal: 6
   categories:
   - UplinkJob
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -570,13 +570,22 @@
   categories:
   - UplinkMisc
 
-#- type: listing
-#  id: UplinkCostumeCentcom
-#  productEntity: ClothingBackpackDuffelSyndicateCostumeCentcom
-#  cost:
-#    Telecrystal: 4
-#  categories:
-#  - UplinkMisc
+- type: listing
+  id: UplinkCostumeCentcom
+  productEntity: ClothingBackpackDuffelSyndicateCostumeCentcom
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkMisc
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 
 # - type: listing
 #   id: UplinkGigacancerScanner

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -94,7 +94,7 @@
   id: UplinkSyndieMiniBomb
   productEntity: SyndieMiniBomb
   cost:
-    Telecrystal: 7
+    Telecrystal: 6
   categories:
     - UplinkExplosives
 
@@ -194,7 +194,7 @@
   description: A deep shoulder holster capable of holding many types of ballistics.
   productEntity: ClothingBeltSyndieHolster
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkUtility
 
@@ -224,7 +224,7 @@
   description: A black jetpack. It allows you to fly around in space. Additional fuel not included.
   productEntity: JetpackBlack
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkUtility
 
@@ -235,7 +235,7 @@
   productEntity: ReinforcementTeleporterSyndicate
   icon: Objects/Devices/communication.rsi/old-radio.png
   cost:
-    Telecrystal: 25
+    Telecrystal: 20
   categories:
   - UplinkUtility
 
@@ -266,7 +266,7 @@
   description: A chemical hypospray disguised as a pen, capable of instantly injecting up to 15u of reagents. Starts empty.
   productEntity: Hypopen
   cost:
-    Telecrystal: 4
+    Telecrystal: 6
   categories:
   - UplinkUtility
 
@@ -404,7 +404,7 @@
   id: UplinkPowerSink
   productEntity: PowerSink
   cost:
-    Telecrystal: 5
+    Telecrystal: 10
   categories:
   - UplinkTools
 
@@ -412,7 +412,7 @@
   id: UplinkCarpDehydrated
   productEntity: DehydratedSpaceCarp
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkTools
 
@@ -485,7 +485,7 @@
   id: UplinkClothingOuterVestWeb
   productEntity: ClothingOuterVestWeb
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkArmor
 
@@ -512,7 +512,7 @@
   description: A simple EVA suit that offers no protection other than what's needed to survive in space.
   productEntity: ClothingBackpackDuffelSyndicateEVABundle
   cost:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
   - UplinkArmor
 
@@ -532,7 +532,7 @@
   description: Cybersun's legal department pen. Smells vaguely of hard-light and war profiteering.
   productEntity: CyberPen
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkMisc
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -404,7 +404,7 @@
   id: UplinkPowerSink
   productEntity: PowerSink
   cost:
-    Telecrystal: 10
+    Telecrystal: 8
   categories:
   - UplinkTools
 
@@ -532,7 +532,7 @@
   description: Cybersun's legal department pen. Smells vaguely of hard-light and war profiteering.
   productEntity: CyberPen
   cost:
-    Telecrystal: 2
+    Telecrystal: 3
   categories:
   - UplinkMisc
 
@@ -569,23 +569,6 @@
     Telecrystal: 2
   categories:
   - UplinkMisc
-
-- type: listing
-  id: UplinkCostumeCentcom
-  productEntity: ClothingBackpackDuffelSyndicateCostumeCentcom
-  cost:
-    Telecrystal: 4
-  categories:
-  - UplinkMisc
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
-  - !type:BuyerWhitelistCondition
-    blacklist:
-      components:
-      - SurplusBundle
 
 # - type: listing
 #   id: UplinkGigacancerScanner

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -38,7 +38,7 @@
   description: A bolt action service rifle that has seen many wars. Not modern by any standard, hand loaded, and terrible recoil, but it is cheap.
   productEntity: WeaponSniperMosin
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkWeapons
 
@@ -276,7 +276,7 @@
   description: A gas mask that lets you adjust your voice to whoever you can think of.
   productEntity: ClothingMaskGasVoiceMasker
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkUtility
 
@@ -436,7 +436,7 @@
   description: An unholy book capable of summoning a demonic familiar.
   productEntity: BibleNecronomicon
   cost:
-    Telecrystal: 6
+    Telecrystal: 4
   categories:
   - UplinkJob
   conditions:
@@ -457,7 +457,7 @@
   productEntity: ClothingBackpackChameleonFill
   icon: /Textures/Clothing/Uniforms/Jumpsuit/rainbow.rsi/icon.png
   cost:
-    Telecrystal: 4
+    Telecrystal: 6
   categories:
     - UplinkArmor
 
@@ -512,7 +512,7 @@
   description: A simple EVA suit that offers no protection other than what's needed to survive in space.
   productEntity: ClothingBackpackDuffelSyndicateEVABundle
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkArmor
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Rebalanced a bunch of TC prices in the uplink. My justification for each change:
- Minibomb: Underused, felt a small price buff could make it see more use
- Syndie Holster: Available in sus toolbox, changed the price so its cheaper than the toolbox
- Reinforcement Teleporter: I've never seen this actually used in Traitor rounds outside of getting it in a surplus. Making it available to the standard Traitor without having to butcher Renault would make it see more use.
- Hypopen: Stupidly good for its price currently, until hypos cant inject through hardsuits I'm raising the price so it isn't a must-buy
- Powersink: Considering that a standard sink takes out the power for a good 3-5 minutes, 5 TC is way too cheap.
- Dehydrated Carp: Really cool item that nobody uses, lowering the price could make it see more use
- Web Vest: Same reason as minibomb
- Syndie EVA suit: Don't really have a good reason for this, having a low price means it could be bought in a emergency?
- Cybersun pen: Price parity with edagger, which it has similar stats to. 

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: The Syndicate has adjusted the price of several uplink items to encourage traitors to use more diverse strategies.

