### PR TITLE
Chameleon clothing hides identity

### DIFF
--- a/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
+++ b/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
@@ -1,5 +1,7 @@
 ﻿using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
+using Content.Shared.IdentityManagement.Components;
+using Content.Shared.Prototypes;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameStates;
@@ -11,6 +13,7 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    [Dependency] private readonly IComponentFactory _factory = default!;
 
     public override void Initialize()
     {
@@ -90,6 +93,12 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
         if (!IsValidTarget(proto, component.Slot))
             return;
         component.SelectedId = protoId;
+
+        // update identity blocker
+        if (proto.HasComponent<IdentityBlockerComponent>(_factory))
+            EnsureComp<IdentityBlockerComponent>(uid);
+        else
+            RemComp<IdentityBlockerComponent>(uid);
 
         UpdateVisuals(uid, component);
         UpdateUi(uid, component);

--- a/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
+++ b/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Clothing.Components;
+﻿using Content.Server.IdentityManagement;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Prototypes;
@@ -14,6 +15,7 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly IComponentFactory _factory = default!;
+    [Dependency] private readonly IdentitySystem _identity = default!;
 
     public override void Initialize()
     {
@@ -94,14 +96,20 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
             return;
         component.SelectedId = protoId;
 
-        // update identity blocker
+        UpdateIdentityBlocker(uid, component, proto);
+        UpdateVisuals(uid, component);
+        UpdateUi(uid, component);
+        Dirty(component);
+    }
+
+    private void UpdateIdentityBlocker(EntityUid uid, ChameleonClothingComponent component, EntityPrototype proto)
+    {
         if (proto.HasComponent<IdentityBlockerComponent>(_factory))
             EnsureComp<IdentityBlockerComponent>(uid);
         else
             RemComp<IdentityBlockerComponent>(uid);
 
-        UpdateVisuals(uid, component);
-        UpdateUi(uid, component);
-        Dirty(component);
+        if (component.User != null)
+            _identity.QueueIdentityUpdate(component.User.Value);
     }
 }

--- a/Content.Shared/Clothing/Components/ChameleonClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ChameleonClothingComponent.cs
@@ -27,6 +27,12 @@ public sealed class ChameleonClothingComponent : Component
     [ViewVariables(VVAccess.ReadOnly)]
     [DataField("default", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string? SelectedId;
+
+    /// <summary>
+    ///     Current user that wears chameleon clothing.
+    /// </summary>
+    [ViewVariables]
+    public EntityUid? User;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Clothing.Components;
 using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
@@ -12,6 +13,23 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly SharedItemSystem _itemSystem = default!;
     [Dependency] private readonly ClothingSystem _clothingSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ChameleonClothingComponent, GotEquippedEvent>(OnGotEquipped);
+        SubscribeLocalEvent<ChameleonClothingComponent, GotUnequippedEvent>(OnGotUnequipped);
+    }
+
+    private void OnGotEquipped(EntityUid uid, ChameleonClothingComponent component, GotEquippedEvent args)
+    {
+        component.User = args.Equipee;
+    }
+
+    private void OnGotUnequipped(EntityUid uid, ChameleonClothingComponent component, GotUnequippedEvent args)
+    {
+        component.User = null;
+    }
 
     // Updates chameleon visuals and meta information.
     // This function is called on a server after user selected new outfit.

--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -15,6 +15,7 @@
     - type: ChameleonClothing
       slot: [mask]
       default: ClothingMaskGas
+    - type: IdentityBlocker # need that for default ClothingMaskGas
     - type: UserInterface
       interfaces:
         - key: enum.ChameleonUiKey.Key


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Now chameleon clothing copies `IdentityBlockerComponent` and manually updates identity system.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Chameleon masks and helmets can hide your identity.

