### PR TITLE
Fix price calculation of stacks

### DIFF
--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -130,6 +130,9 @@ public sealed class PricingSystem : EntitySystem
 
     private void CalculateStaticPrice(EntityUid uid, StaticPriceComponent component, ref PriceCalculationEvent args)
     {
+        if (HasComp<StackPriceComponent>(uid))
+            return;
+
         args.Price += component.Price;
     }
 

--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -130,9 +130,6 @@ public sealed class PricingSystem : EntitySystem
 
     private void CalculateStaticPrice(EntityUid uid, StaticPriceComponent component, ref PriceCalculationEvent args)
     {
-        if (HasComp<StackPriceComponent>(uid))
-            return;
-
         args.Price += component.Price;
     }
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coillv-30
   product: CrateEngineeringCableLV
-  cost: 300
+  cost: 500
   category: Engineering
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilmv-30
   product: CrateEngineeringCableMV
-  cost: 300
+  cost: 500
   category: Engineering
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilhv-30
   product: CrateEngineeringCableHV
-  cost: 300
+  cost: 500
   category: Engineering
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilall-30
   product: CrateEngineeringCableBulk
-  cost: 500
+  cost: 1000
   category: Engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coillv-30
   product: CrateEngineeringCableLV
-  cost: 500
+  cost: 600
   category: Engineering
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilmv-30
   product: CrateEngineeringCableMV
-  cost: 500
+  cost: 600
   category: Engineering
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilhv-30
   product: CrateEngineeringCableHV
-  cost: 500
+  cost: 600
   category: Engineering
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilall-30
   product: CrateEngineeringCableBulk
-  cost: 1000
+  cost: 1200
   category: Engineering
   group: market
 

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -14,6 +14,8 @@
   - type: Stack
     count: 20
     stackType: Telecrystal
+  - type: StaticPrice
+    price: 0
   - type: StackPrice
     price: 200
   - type: Currency

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -22,6 +22,8 @@
     sprite: Objects/Tools/cable-coils.rsi
   - type: CablePlacer
   - type: Clickable
+  - type: StaticPrice
+    price: 0
   - type: StackPrice
     price: 5
 

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -23,7 +23,7 @@
   - type: CablePlacer
   - type: Clickable
   - type: StackPrice
-    price: 0.5
+    price: 2
 
 - type: entity
   id: CableHVStack

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -23,7 +23,7 @@
   - type: CablePlacer
   - type: Clickable
   - type: StackPrice
-    price: 2
+    price: 5
 
 - type: entity
   id: CableHVStack


### PR DESCRIPTION
## About the PR 
closes #12635
StackPriceComponent is not compatible with StaticPriceComp because if you split the stack in 2 you now have 2 times the staticPrice which makes it not static anymore...

also adjust the price of cargo cable crates