### PR TITLE
Universal Door Remote

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -50,7 +50,7 @@
       - id: CigarGoldCase
         prob: 0.25
       - id: ClothingBeltSheathFilled
-      - id: DoorRemoteCommand
+      - id: DoorRemoteUniversal
       - id: ClothingNeckCloakCapFormal
       - id: ClothingUniformJumpsuitCapFormal
       - id: ClothingUniformJumpskirtCapFormalDress

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -13,8 +13,8 @@
 
 - type: entity
   parent: DoorRemoteDefault
-  id: DoorRemoteCommand
-  name: command door remote
+  id: DoorRemoteUniversal
+  name: universal door remote
   components:
   - type: Sprite
     layers:
@@ -26,6 +26,12 @@
   - type: Access
     groups:
     - Command
+    - Security
+    - Service
+    - Research
+    - Cargo
+    - Medical
+    - Engineering
 
 - type: entity
   parent: DoorRemoteDefault


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the captain's door remote to be able to work on any door on the station. Perfect for when the armory is bolted and the HoS has disappeared, or you just can't be bothered to call for an engi to fix a bolted door.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: The captain's door remote now works on all station doors.

