### PR TITLE
Weapons and Tools damage rebalance.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -42,7 +42,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Piercing: 10
+        Piercing: 15
     soundHit:
       path: /Audio/Items/drill_hit.ogg
 
@@ -216,7 +216,7 @@
     attackRate: 1.5
     damage:
       groups:
-        Brute: 10
+        Brute: 15
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -27,6 +27,10 @@
         state: internal1
       event: !type:ToggleActionEvent
       useDelay: 1.0
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 10
   - type: Explosive
     explosionType: Default
     maxIntensity: 20

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -16,7 +16,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 12
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
   - type: Tag
@@ -87,7 +87,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 20
+        Blunt: 18
 
 - type: entity
   name: golden toolbox

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -22,7 +22,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 5
   - type: Tool
     qualities:
       - Cutting
@@ -64,7 +64,7 @@
     attackRate: 1.5
     damage:
       types:
-        Piercing: 7
+        Piercing: 3.5
   - type: Tool
     qualities:
       - Screwing
@@ -100,7 +100,7 @@
     attackRate: 1.5
     damage:
       types:
-        Blunt: 6.5
+        Blunt: 4
   - type: Tool
     qualities:
       - Anchoring
@@ -132,7 +132,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 5
   - type: Tool
     qualities:
       - Prying

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -33,7 +33,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 3
   - type: ItemStatus
   - type: RefillableSolution
     solution: Welder
@@ -51,8 +51,8 @@
   - type: Welder
     litMeleeDamageBonus:
       types: # When lit, negate standard melee damage and replace with heat
-        Heat: 10
-        Blunt: -10
+        Heat: 15
+        Blunt: -3
   - type: PointLight
     netsync: false
     enabled: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -10,7 +10,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 14
+        Blunt: 12
   - type: Item
     size: 15
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -60,7 +60,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 10
+        Slash: 15
   - type: Item
     size: 10
     sprite: Objects/Weapons/Melee/cleaver.rsi


### PR DESCRIPTION
**About PR**
I played this game after SS13, and me and my friends though that damage sometimes is strange.
So I have made this PR.

**Screenshots**
![image](https://user-images.githubusercontent.com/55444968/202527901-06dce578-cdd3-4d43-bab6-ff2195a84ee8.png)
Crowbars have less damage.


![image](https://user-images.githubusercontent.com/55444968/202527996-caf4de0f-3d2c-4228-9681-309e00c918da.png)
Toolboxes slightly buffed! (except for syndicate toolbox)


![image](https://user-images.githubusercontent.com/55444968/202528005-1e6e1eab-3b7b-4887-b21d-a58663faba03.png)
Now you can ~~troll~~ kill people with oxygen tanks!


![image](https://user-images.githubusercontent.com/55444968/202531766-64f3fbbc-cc38-4f4a-8dec-fe7c2b7fb8b2.png)
Every item with changed damage.

**Changelog**
:cl:
- add: Added damage to gas tanks.
- tweak: Changed damage for engineering tools, toolboxes, weapons and some surgical tools.