### PR TITLE
Do not interrupt mapping with auto-shuttle

### DIFF
--- a/Content.Server/Mapping/MappingCommand.cs
+++ b/Content.Server/Mapping/MappingCommand.cs
@@ -118,7 +118,10 @@ namespace Content.Server.Mapping
 
             var cfg = IoCManager.Resolve<IConfigurationManager>();
 
+            // don't interrupt mapping with events or auto-shuttle
             shell.ExecuteCommand("sudo cvar events.enabled false");
+            shell.ExecuteCommand("sudo cvar shuttle.auto_call_time 0");
+
             if (cfg.GetCVar(CCVars.AutosaveEnabled))
                 shell.ExecuteCommand($"toggleautosave {mapId} {toLoad ?? "NEWMAP"}");
             shell.ExecuteCommand($"tp 0 0 {mapId}");


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The default auto-shuttle call time of 90 minutes could interrupt a mapping session, resulting in inconvenience and possibly lost work if the mapper is away.

This disables auto-shuttle when entering mapping mode.

Requested by: @juliangiebel 

**Screenshots**
N/A

**Changelog**
N/A