### PR TITLE
Add verbs to Two Way Levers, make some odds and ends recyclable. 

### DIFF
--- a/Content.Server/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Server/Cuffs/Components/CuffableComponent.cs
@@ -17,6 +17,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
+using Content.Server.Recycling.Components;
 
 namespace Content.Server.Cuffs.Components
 {
@@ -270,6 +271,8 @@ namespace Content.Server.Cuffs.Components
                     {
                         sprite.LayerSetState(0, cuff.BrokenState); // TODO: safety check to see if RSI contains the state?
                     }
+
+                    _entMan.AddComponent<RecyclableComponent>(cuffsToRemove.Value);
                 }
 
                 CanStillInteract = _entMan.TryGetComponent(Owner, out HandsComponent? handsComponent) && handsComponent.SortedHands.Count() > CuffedHandCount;

--- a/Content.Server/MachineLinking/System/TwoWayLeverSystem.cs
+++ b/Content.Server/MachineLinking/System/TwoWayLeverSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.MachineLinking.Components;
 using Content.Shared.Interaction;
 using Content.Shared.MachineLinking;
+using Content.Shared.Verbs;
 
 namespace Content.Server.MachineLinking.System
 {
@@ -8,11 +9,15 @@ namespace Content.Server.MachineLinking.System
     {
         [Dependency] private readonly SignalLinkerSystem _signalSystem = default!;
 
+        const string _leftToggleImage = "rotate_ccw.svg.192dpi.png";
+        const string _rightToggleImage = "rotate_cw.svg.192dpi.png";
+
         public override void Initialize()
         {
             base.Initialize();
             SubscribeLocalEvent<TwoWayLeverComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<TwoWayLeverComponent, ActivateInWorldEvent>(OnActivated);
+            SubscribeLocalEvent<TwoWayLeverComponent, GetVerbsEvent<InteractionVerb>>(OnGetInteractionVerbs);
         }
 
         private void OnInit(EntityUid uid, TwoWayLeverComponent component, ComponentInit args)
@@ -33,6 +38,56 @@ namespace Content.Server.MachineLinking.System
                 _ => throw new ArgumentOutOfRangeException()
             };
 
+            StateChanged(uid, component);
+
+            args.Handled = true;
+        }
+
+        private void OnGetInteractionVerbs(EntityUid uid, TwoWayLeverComponent component, GetVerbsEvent<InteractionVerb> args)
+        {
+            InteractionVerb verbLeft = new()
+            {
+                Act = () =>
+                {
+                    component.State = component.State switch
+                    {
+                        TwoWayLeverState.Middle => TwoWayLeverState.Left,
+                        TwoWayLeverState.Right => TwoWayLeverState.Middle,
+                        _ => throw new ArgumentOutOfRangeException()
+                    };
+                    StateChanged(uid, component);
+                },
+                Message = Loc.GetString("two-way-lever-cant"),
+                Disabled = component.State == TwoWayLeverState.Left,
+                IconTexture = $"/Textures/Interface/VerbIcons/{_leftToggleImage}",
+                Text = Loc.GetString("two-way-lever-left"),
+            };
+
+            args.Verbs.Add(verbLeft);
+
+            InteractionVerb verbRight = new()
+            {
+                Act = () =>
+                {
+                    component.State = component.State switch
+                    {
+                        TwoWayLeverState.Left => TwoWayLeverState.Middle,
+                        TwoWayLeverState.Middle => TwoWayLeverState.Right,
+                        _ => throw new ArgumentOutOfRangeException()
+                    };
+                    StateChanged(uid, component);
+                },
+                Message = Loc.GetString("two-way-lever-cant"),
+                Disabled = component.State == TwoWayLeverState.Right,
+                IconTexture = $"/Textures/Interface/VerbIcons/{_rightToggleImage}",
+                Text = Loc.GetString("two-way-lever-right"),
+            };
+
+            args.Verbs.Add(verbRight);
+        }
+
+        private void StateChanged(EntityUid uid, TwoWayLeverComponent component)
+        {
             if (component.State == TwoWayLeverState.Middle)
                 component.NextSignalLeft = !component.NextSignalLeft;
 
@@ -48,7 +103,6 @@ namespace Content.Server.MachineLinking.System
             };
 
             _signalSystem.InvokePort(uid, port);
-            args.Handled = true;
         }
     }
 }

--- a/Content.Server/Recycling/Components/RecyclerComponent.cs
+++ b/Content.Server/Recycling/Components/RecyclerComponent.cs
@@ -43,5 +43,7 @@ namespace Content.Server.Recycling.Components
 
         // Ratelimit sounds to avoid spam
         public TimeSpan LastSound;
+
+        public int ItemsProcessed;
     }
 }

--- a/Content.Server/Recycling/RecyclerSystem.cs
+++ b/Content.Server/Recycling/RecyclerSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Recycling.Components;
 using Content.Shared.Audio;
 using Content.Shared.Body.Components;
 using Content.Shared.Emag.Systems;
+using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Recycling;
@@ -33,9 +34,15 @@ namespace Content.Server.Recycling
 
         public override void Initialize()
         {
+            SubscribeLocalEvent<RecyclerComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<RecyclerComponent, StartCollideEvent>(OnCollide);
             SubscribeLocalEvent<RecyclerComponent, GotEmaggedEvent>(OnEmagged);
             SubscribeLocalEvent<RecyclerComponent, SuicideEvent>(OnSuicide);
+        }
+
+        private void OnExamined(EntityUid uid, RecyclerComponent component, ExaminedEvent args)
+        {
+            args.PushMarkup(Loc.GetString("recycler-count-items", ("items", component.ItemsProcessed)));
         }
 
         private void OnSuicide(EntityUid uid, RecyclerComponent component, SuicideEvent args)
@@ -119,6 +126,8 @@ namespace Content.Server.Recycling
                 SoundSystem.Play(component.Sound.GetSound(), Filter.Pvs(component.Owner, entityManager: EntityManager), component.Owner, AudioHelpers.WithVariation(0.01f).WithVolume(-3));
                 component.LastSound = _timing.CurTime;
             }
+
+            component.ItemsProcessed++;
         }
 
         private bool CanGib(RecyclerComponent component, EntityUid entity)

--- a/Resources/Locale/en-US/machine/machine.ftl
+++ b/Resources/Locale/en-US/machine/machine.ftl
@@ -11,3 +11,5 @@ machine-upgrade-not-upgraded = [color=yellow]{CAPITALIZE($upgraded)}[/color] not
 upgrade-power-draw = power draw
 upgrade-max-charge = max charge
 upgrade-power-supply = power supply
+
+recycler-count-items = Recycled {$items} objects.

--- a/Resources/Locale/en-US/machine/machine.ftl
+++ b/Resources/Locale/en-US/machine/machine.ftl
@@ -12,4 +12,8 @@ upgrade-power-draw = power draw
 upgrade-max-charge = max charge
 upgrade-power-supply = power supply
 
+two-way-lever-left = push left
+two-way-lever-right = push right
+two-way-lever-cant = can't push the lever that way!
+
 recycler-count-items = Recycled {$items} objects.

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -146,6 +146,7 @@
   - type: Tag
     tags:
     - PetWearable
+  - type: Recyclable
 
 - type: entity
   parent: ClothingMaskBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
@@ -23,6 +23,8 @@
         reagents:
         - ReagentId: Water
           Quantity: 50
+  - type: TrashOnEmpty
+    solution: drink
 
 - type: entity
   parent: DrinkBase

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -30,6 +30,7 @@
     - Document
   - type: Appearance
   - type: PaperVisuals
+  - type: Recyclable
 
 - type: entity
   parent: Paper
@@ -76,6 +77,7 @@
     sprite: Objects/Misc/bureaucracy.rsi
     heldPrefix: pen
     size: 2
+  - type: Recyclable
 
 - type: entity
   name: Cybersun pen

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
@@ -12,3 +12,4 @@
       sprite: Objects/Fun/toys.rsi
       layers:
         - state: foamdart
+    - type: Recyclable


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I played a few games where I just watched what people threw into the trash and came out with this pr.

**Recyclables**

The following objects are now `Recyclable`, meaning they are deleted by the recycler:
- Paper - When the recycler is being run, your paper secrets get properly destroyed.
- Breath Mask - The basic one, from the survival kit. They are constantly being thrown away - let them maybe learn from this mistake.
- Pen - Just the normal one that comes with the pda
- Foam Dart
- Empty MRE Flask (via `TrashOnEmpty`)
- Broken cuffs - i.e. broken zipties, since they are unrepairable they are trash.

**Recycler Count**

![2022-11-17 23_10_26-Space Station 14](https://user-images.githubusercontent.com/6798456/202644888-91b4bc07-4041-4333-9e92-24b55d490e91.png)

- The recycler keeps track of how many items it's processed. This is just a for-fun thing. Maybe janitors will try and go for a record? Who knows.

**Lever Verbs**

![2022-11-17 23_07_44-Space Station 14](https://user-images.githubusercontent.com/6798456/202645227-83a35210-82c1-41f3-8127-92eb61fb1115.png)

The two way level can now be pushed in specific directions via the right-click menu. Now you don't have to awkwardly double click when using this.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Paper and some misc other objects are now recyclable
- add: Recycler counts the number of recycled items
- add: Two way levels can be switched in a specific direction with the right-click menu