### PR TITLE
Adds separate entities with GhostTakeoverAvailable component and removes that component from base entities

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Conditional/timed.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Conditional/timed.yml
@@ -50,9 +50,9 @@
     - type: Timer
     - type: TimedSpawner
       prototypes:
-        - MobMouse
-        - MobMouse1
-        - MobMouse2
+        - MobMouseGhostRole
+        - MobMouseGhostRole1
+        - MobMouseGhostRole2
       # round ~90m
       # one spawner should only spawn ~5 mice for sanity reasons
       # therefore 18m

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -5,7 +5,7 @@
   parent: MarkerBase
   components:
   - type: GhostRoleMobSpawner
-    prototype: MobRatKing
+    prototype: MobRatKingGhostRole
     name: Rat King
     description: You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
     rules: You are an antagonist, scavenge, attack, and grow your hoard!
@@ -22,7 +22,7 @@
   parent: MarkerBase
   components:
   - type: GhostRoleMobSpawner
-    prototype: MobBatRemilia
+    prototype: MobBatRemiliaGhostRole
     name: Remilia, the chaplain's familiar
     description: Obey your master. Eat fruit.
     rules: You are an intelligent fruit bat. Follow the chaplain around. Don't cause any trouble unless the chaplain tells you to.
@@ -39,7 +39,7 @@
   parent: MarkerBase
   components:
   - type: GhostRoleMobSpawner
-    prototype: MobCorgiCerberus
+    prototype: MobCorgiCerberusGhostRole
     name: Cerberus, Evil Familiar
     description: Obey your master. Spread chaos.
     rules: You are an intelligent, demonic dog. Try to help the chaplain and any of his flock. As an antagonist, you're otherwise unrestrained.

--- a/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
@@ -12,9 +12,9 @@
       - state: ai
   - type: ConditionalSpawner
     prototypes:
-      - MobMouse
-      - MobMouse1
-      - MobMouse2
+      - MobMouseGhostRole
+      - MobMouseGhostRole1
+      - MobMouseGhostRole2
 
 - type: entity
   name: Ian Spawner
@@ -214,4 +214,4 @@
       sprite: Mobs/Animals/bear.rsi
   - type: ConditionalSpawner
     prototypes:
-    - MobBearSpace
+    - MobBearSpaceGhostRole

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -738,12 +738,6 @@
   id: MobMouse
   description: Squeak!
   components:
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-mouse-name
-    description: ghost-role-information-mouse-description
   - type: Speech
     speechSounds: Squeak
   - type: Sprite
@@ -849,6 +843,21 @@
     price: 50
 
 - type: entity
+  suffix: "Ghost Role"
+  parent: MobMouse
+  id: MobMouseGhostRole
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: ghost-role-information-mouse-name
+    description: ghost-role-information-mouse-description
+  - type: Bloodstream
+    bloodMaxVolume: 50
+  - type: DiseaseCarrier
+
+- type: entity
   parent: MobMouse
   id: MobMouse1
   components:
@@ -873,6 +882,20 @@
     bloodMaxVolume: 50
   - type: DiseaseCarrier #Why doesn't this save if it's only on the parent wtf
 
+- type: entity
+  suffix: "Ghost Role"
+  parent: MobMouse1
+  id: MobMouse1GhostRole
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: ghost-role-information-mouse-name
+    description: ghost-role-information-mouse-description
+  - type: Bloodstream
+    bloodMaxVolume: 50
+  - type: DiseaseCarrier
 
 - type: entity
   parent: MobMouse
@@ -899,6 +922,20 @@
     bloodMaxVolume: 50
   - type: DiseaseCarrier
 
+- type: entity
+  suffix: "Ghost Role"
+  parent: MobMouse2
+  id: MobMouse2GhostRole
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: ghost-role-information-mouse-name
+    description: ghost-role-information-mouse-description
+  - type: Bloodstream
+    bloodMaxVolume: 50
+  - type: DiseaseCarrier
 
 - type: entity
   name: lizard #Weh
@@ -1315,6 +1352,12 @@
     - type: MobMover
     - type: HTN
       rootTask: SimpleHostileCompound
+
+- type: entity
+  parent: MobGiantSpiderAngry
+  id: MobGiantSpiderGhostRole
+  suffix: "Angry, Ghost Role"
+  components:
     - type: GhostTakeoverAvailable
       makeSentient: true
       name: ghost-role-information-giant-spider-name

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -885,7 +885,7 @@
 - type: entity
   suffix: "Ghost Role"
   parent: MobMouse1
-  id: MobMouse1GhostRole
+  id: MobMouseGhostRole1
   components:
   - type: GhostTakeoverAvailable
     makeSentient: true
@@ -925,7 +925,7 @@
 - type: entity
   suffix: "Ghost Role"
   parent: MobMouse2
-  id: MobMouse2GhostRole
+  id: MobMouseGhostRole2
   components:
   - type: GhostTakeoverAvailable
     makeSentient: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -69,6 +69,12 @@
         Brute: 15
   - type: ReplacementAccent
     accent: genericAggressive
+
+- type: entity
+  id: MobBearSpaceGhostRole
+  parent: MobBearSpace
+  suffix: "Ghost Role"
+  components:
   - type: GhostTakeoverAvailable
     prob: 0.05
     name: space bear
@@ -78,7 +84,7 @@
 - type: entity
   id: MobBearSpaceSalvage
   parent: MobBearSpace
-  suffix: "Salvage Ruleset"
+  suffix: "Ghost Role, Salvage Ruleset"
   components:
   - type: GhostTakeoverAvailable
     prob: 0.05

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -130,7 +130,7 @@
 - type: entity
   id: MobCarpSalvage
   parent: MobCarp
-  suffix: "Salvage Ruleset"
+  suffix: "Ghost Role, Salvage Ruleset"
   components:
     - type: GhostTakeoverAvailable
       prob: 0.33
@@ -147,11 +147,18 @@
   suffix: DragonBrood
   parent: BaseMobCarp
   components:
+    - type: HTN
+      rootTask: DragonCarpCompound
+
+- type: entity
+  name: space carp
+  id: MobCarpDragonGhostRole
+  suffix: "DragonBrood, Ghost Role"
+  parent: MobCarpDragon
+  components:
     - type: GhostTakeoverAvailable
       allowMovement: true
       allowSpeech: true
       makeSentient: true
       name: Sentient Carp
       description: Help the dragon flood the station with carps!
-    - type: HTN
-      rootTask: DragonCarpCompound

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -62,11 +62,6 @@
         Base: dead
   - type: Puller
     needsHands: false
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    name: Rat King
-    description: You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
-    rules: You are an antagonist, scavenge, attack, and grow your hoard!
   - type: Tag
     tags:
       - CannotSuicide
@@ -112,6 +107,17 @@
     nameSegments:
     - RegalRatNameKingdom
     - RegalRatNameTitle
+
+- type: entity
+  id: MobRatKingGhostRole
+  parent: MobRatKing
+  suffix: "Ghost Role"
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: Rat King
+    description: You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
+    rules: You are an antagonist, scavenge, attack, and grow your hoard!
 
 - type: entity
   id: MobRatKingBuff

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -48,11 +48,6 @@
   - type: Alerts
   - type: NameIdentifier
     group: GenericNumber
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    name: Revenant
-    description: You are a Revenant. Use your powers to harvest souls and unleash chaos upon the crew. Unlock new abilities with the essence you harvest.
-    rules: You are an antagonist, harvest, defile, and drive the crew insane.
   - type: Revenant
   - type: PointLight
     color: MediumPurple
@@ -77,3 +72,14 @@
     - of
     - RevenantAdjective
     - RevenantTheme
+
+- type: entity
+  id: MobRevenantGhostRole
+  parent: MobRevenant
+  suffix: "Ghost Role"
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: Revenant
+    description: You are a Revenant. Use your powers to harvest souls and unleash chaos upon the crew. Unlock new abilities with the essence you harvest.
+    rules: You are an antagonist, harvest, defile, and drive the crew insane.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -124,10 +124,6 @@
   - type: Construction
     graph: HonkBot
     node: bot
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    name: honkbot
-    description: An artificial being of pure evil.
   - type: InteractionPopup
     interactSuccessString: petting-success-honkbot
     interactFailureString: petting-failure-honkbot
@@ -192,3 +188,13 @@
     interactFailureString: petting-failure-medibot
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg
+
+- type: entity
+  parent: MobHonkBot
+  id: MobHonkBotGhostRole
+  suffix: "Ghost Role"
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: honkbot
+    description: An artificial being of pure evil.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -70,19 +70,25 @@
           Quantity: 5
   - type: MeleeChemicalInjector
     solution: melee
+  - type: ReplacementAccent
+    accent: genericAggressive
+
+- type: entity
+  id: MobTickGhostRole
+  parent: MobTick
+  suffix: "Ghost Role"
+  components:
   - type: GhostTakeoverAvailable
     prob: 0.33
     makeSentient: true
     name: space tick
     description: |
       Wreak havoc on the station!
-  - type: ReplacementAccent
-    accent: genericAggressive
 
 - type: entity
   id: MobTickSalvage
   parent: MobTick
-  suffix: "Salvage Ruleset"
+  suffix: "Ghost Role, Salvage Ruleset"
   components:
   - type: GhostTakeoverAvailable
     name: space tick on salvage wreck

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -5,12 +5,6 @@
   suffix:
   description: A flying leviathan, loosely related to space carps.
   components:
-    - type: GhostTakeoverAvailable
-      allowMovement: true
-      allowSpeech: true
-      makeSentient: true
-      name: Space dragon
-      description: Call in 3 carp rifts and take over this quadrant! You have only 5 minutes in between each rift before you will disappear.
     - type: HTN
       rootTask: XenoCompound
     - type: Faction
@@ -100,7 +94,7 @@
           Slash: 15
     - type: Dragon
       spawnsLeft: 2
-      spawnsProto: MobCarpDragon
+      spawnsProto: MobCarpDragonGhostRole
       devourAction:
         event: !type:DragonDevourActionEvent
         icon: Interface/Actions/devour.png
@@ -122,3 +116,15 @@
         name: action-name-carp-rift
         description: action-description-carp-rift
         useDelay: 1
+
+- type: entity
+  parent: MobDragon
+  id: MobDragonGhostRole
+  suffix: "Ghost Role"
+  components:
+    - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
+      makeSentient: true
+      name: Space dragon
+      description: Call in 3 carp rifts and take over this quadrant! You have only 5 minutes in between each rift before you will disappear.

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -4,13 +4,6 @@
   id: MobBatRemilia
   description: The chaplain's familiar. Likes fruit.
   components:
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    allowMovement: true
-    allowSpeech: true
-    name: Remilia, the chaplain's familiar
-    description: Obey your master. Eat fruit.
-    rules: You are an intelligent fruit bat. Follow the chaplain around. Don't cause any trouble unless the chaplain tells you to.
   - type: Grammar
     attributes:
       gender: female
@@ -27,18 +20,23 @@
   - type: Familiar
 
 - type: entity
+  parent: MobBatRemilia
+  id: MobBatRemiliaGhostRole
+  suffix: "Ghost Role"
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    allowMovement: true
+    allowSpeech: true
+    name: Remilia, the chaplain's familiar
+    description: Obey your master. Eat fruit.
+    rules: You are an intelligent fruit bat. Follow the chaplain around. Don't cause any trouble unless the chaplain tells you to.
+
+- type: entity
   name: Cerberus
   parent: MobCorgiNarsi
   id: MobCorgiCerberus
   description: This pupper is not wholesome.
   components:
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    allowMovement: true
-    allowSpeech: true
-    name: Cerberus, Evil Familiar
-    description: Obey your master. Spread chaos.
-    rules: You are an intelligent, demonic dog. Try to help the chaplain and any of his flock. As an antagonist, you're otherwise unrestrained.
   - type: MeleeWeapon
     hidden: true
     angle: 0
@@ -74,3 +72,16 @@
   - type: Mind
     showExamineInfo: true
   - type: Familiar
+
+- type: entity
+  parent: MobCorgiCerberus
+  id: MobCorgiCerberusGhostRole
+  suffix: "Ghost Role"
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    allowMovement: true
+    allowSpeech: true
+    name: Cerberus, Evil Familiar
+    description: Obey your master. Spread chaos.
+    rules: You are an intelligent, demonic dog. Try to help the chaplain and any of his flock. As an antagonist, you're otherwise unrestrained.

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -23,6 +23,7 @@
   parent: MobBatRemilia
   id: MobBatRemiliaGhostRole
   suffix: "Ghost Role"
+  components:
   - type: GhostTakeoverAvailable
     makeSentient: true
     allowMovement: true

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -7,12 +7,6 @@
   save: false
   components:
     - type: LagCompensation
-    - type: GhostTakeoverAvailable
-      allowMovement: true
-      allowSpeech: true
-      makeSentient: true
-      name: Guardian
-      description: Listen to your owner. Don't tank damage. Punch people hard.
     - type: Input
       context: "human"
     - type: MobMover
@@ -97,6 +91,18 @@
       tags:
         - CannotSuicide
 
+- type: entity
+  id: MobGuardianGhostRole
+  parent: MobGuardianBase
+  suffix: "Ghost Role"
+  components:
+    - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
+      makeSentient: true
+      name: Guardian
+      description: Listen to your owner. Don't tank damage. Punch people hard.
+
 # From the uplink injector
 - type: entity
   name: Holoparasite
@@ -104,12 +110,6 @@
   parent: MobGuardianBase
   description: A mesmerising whirl of hard-light patterns weaves a marvelous, yet oddly familiar visage. It stands proud, tuning into its owner's life to sustain itself.
   components:
-    - type: GhostTakeoverAvailable
-      allowMovement: true
-      allowSpeech: true
-      makeSentient: true
-      name: Holoparasite
-      description: Listen to your owner. Don't tank damage. Punch people hard.
     - type: NameIdentifier
       group: Holoparasite
     - type: TypingIndicator
@@ -123,6 +123,18 @@
           color: "#40a7d7"
           shader: unshaded
 
+- type: entity
+  id: MobHoloparasiteGuardianGhostRole
+  parent: MobHoloparasiteGuardian
+  suffix: "Ghost Role"
+  components:
+    - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
+      makeSentient: true
+      name: Holoparasite
+      description: Listen to your owner. Don't tank damage. Punch people hard.
+
 # From Wizard deck of cards
 - type: entity
   name: Ifrit
@@ -130,12 +142,6 @@
   id: MobIfritGuardian
   description: A corrupted jinn, ripped from fitra to serve the wizard's petty needs. It stands wicked, tuning into it's owner's life to sustain itself.
   components:
-    - type: GhostTakeoverAvailable
-      allowMovement: true
-      allowSpeech: true
-      makeSentient: true
-      name: Ifrit
-      description: Listen to your owner. Don't tank damage. Punch people hard.
     - type: RandomSprite
       available:
         - enum.DamageStateVisualLayers.BaseUnshaded:
@@ -148,3 +154,15 @@
           map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
           color: "#40a7d7"
           shader: unshaded
+
+- type: entity
+  parent: MobIfritGuardian
+  id: MobIfritGuardianGhostRole
+  suffix: "Ghost Role"
+  components:
+    - type: GhostTakeoverAvailable
+      allowMovement: true
+      allowSpeech: true
+      makeSentient: true
+      name: Ifrit
+      description: Listen to your owner. Don't tank damage. Punch people hard.

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -183,11 +183,6 @@
     interfaces:
     - key: enum.StrippingUiKey.Key
       type: StrippableBoundUserInterface
-  - type: GhostTakeoverAvailable
-    makeSentient: true
-    name: Onestar Mecha
-    description: You are an experimental mecha created by who-knows-what, all you know is that you have weapons and you detect fleshy moving targets nearby...
-    rules: Use your weapons to cause havoc. You are an antagonist.
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
     baseSprintSpeed : 2
@@ -223,3 +218,14 @@
       Dead:
         Base: onestar_boss_wrecked
   - type: CombatMode
+
+- type: entity
+  id: OnestarGhostRole
+  parent: Onestar
+  suffix: "Ghost Role"
+  components:
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    name: Onestar Mecha
+    description: You are an experimental mecha created by who-knows-what, all you know is that you have weapons and you detect fleshy moving targets nearby...
+    rules: Use your weapons to cause havoc. You are an antagonist.

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -32,22 +32,33 @@
   parent: MobSkeletonPerson
   id: MobSkeletonPirate
   components:
-  - type: GhostTakeoverAvailable
-    name: Skeleton Pirate
-    description: Cause chaos and loot the station for treasure.
   - type: Loadout
     prototypes: [PirateGear]
   - type: RandomHumanoidAppearance
 
+- type: entity
+  parent: MobSkeletonPirate
+  id: MobSkeletonPirateGhostRole
+  suffix: "Ghost Role"
+  components:
+  - type: GhostTakeoverAvailable
+    name: Skeleton Pirate
+    description: Cause chaos and loot the station for treasure.
 
 - type: entity
   name: Skeleton Biker
   parent: MobSkeletonPerson
   id: MobSkeletonBiker
   components:
-  - type: GhostTakeoverAvailable
-    name: Skeleton Biker
-    description: Ride around on your sweet ride.
   - type: Loadout
     prototypes: [SkeletonBiker]
   - type: RandomHumanoidAppearance
+
+- type: entity
+  parent: MobSkeletonBiker
+  id: MobSkeletonBikerGhostRole
+  suffix: "Ghost Role"
+  components:
+  - type: GhostTakeoverAvailable
+    name: Skeleton Biker
+    description: Ride around on your sweet ride.

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/bots/honkbot.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/bots/honkbot.yml
@@ -35,4 +35,4 @@
         name: borg arm
         doAfter: 2
   - node: bot
-    entity: MobHonkBot
+    entity: MobHonkBotGhostRole


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements and closes #10442, basically adds mob variants that could be spawned without a ghost role immediately available, which should be useful (and less frustrating in some cases) for admins and game masters, Also adds a "Ghost Role" suffix to differentiate mobs in entity spawn panel.

**Screenshots**

![entity panel](https://user-images.githubusercontent.com/43905364/202864236-7123016e-8a7b-4278-aa6c-03a0eb230fb3.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Injazz
- tweak: separate mob variants without ghost roles for admin's preference
- tweak: mobs with ghost roles now have "Ghost Role" suffix in Entity Spawn Panel 