### PR TITLE
Fix loading custom map entities.

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -80,6 +80,7 @@ namespace Content.Server.GameTicking
 
             DefaultMap = _mapManager.CreateMap();
             _mapManager.AddUninitializedMap(DefaultMap);
+            _mapManager.DeleteMap(DefaultMap);
             var startTime = _gameTiming.RealTime;
 
             var maps = new List<GameMapPrototype>();
@@ -116,6 +117,7 @@ namespace Content.Server.GameTicking
                     // Create other maps for the others since we need to.
                     toLoad = _mapManager.CreateMap();
                     _mapManager.AddUninitializedMap(toLoad);
+                    _mapManager.DeleteMap(toLoad);
                 }
 
                 LoadGameMap(map, toLoad, null);

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -618,6 +618,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         }
 
         var mapId = _mapManager.CreateMap();
+        _mapManager.AddUninitializedMap(mapId);
+        _mapManager.DeleteMap(mapId);
 
         var outpostGrids = _map.LoadMap(mapId, path.ToString());
         if (outpostGrids.Count == 0)
@@ -650,6 +652,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
         _nukiePlanet = mapId;
         _nukieShuttle = shuttleId;
+        _mapManager.DoMapInitialize(mapId);
 
         return true;
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Despite #12650, maps with custom Map entities are not loading properly during the proper gameloop. This is because `MapManager.CreateMap()` creates a default Entity with a MapComponent and the new MapLoader system sees this entity with a MapComponent as superior to any YML-loaded MapComponent, deferring to it instead and discarding the saved Map entity.

A quick workaround for this is to run DeleteMap after adding the created map, so we have a valid MapId to work with. This will fool the MapLoader system into using the saved map entity, allowing nukieplanet and downstream maps with atmospheres and parallax to work again.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Allowed maps with custom Map entities to be loaded during play again.