### PR TITLE
Revolver fixe

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -154,7 +154,7 @@
 - type: listing
   id: UplinkSpeedLoaderMagnum
   icon: /Textures/Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi/base.png
-  productEntity: SpeedLoaderMagnum
+  productEntity: SpeedLoaderMagnumHC
   cost:
     Telecrystal: 2
   categories:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -29,7 +29,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 34
+        Piercing: 40
 
 - type: entity
   id: BulletMagnumHCHighVelocity
@@ -40,7 +40,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 36
+        Piercing: 42
 
 - type: entity
   id: BulletMagnumPractice

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -107,6 +107,17 @@
     Steel: 5
 
 - type: latheRecipe
+  id: SpeedloaderMagnumHC
+  icon:
+    sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
+    state: base
+  result: SpeedloaderMagnumHC
+  completetime: 8
+  materials:
+    Plastic: 60
+    Steel: 70
+
+- type: latheRecipe
   id: CartridgeCaselessRifleRubber
   icon:
     sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -107,11 +107,11 @@
     Steel: 5
 
 - type: latheRecipe
-  id: SpeedloaderMagnumHC
+  id: SpeedLoaderMagnumHC
   icon:
     sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
     state: base
-  result: SpeedloaderMagnumHC
+  result: SpeedLoaderMagnumHC
   completetime: 8
   materials:
     Plastic: 60


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Revvies deal more damage (34-36 to 40-42 i thimk)
Speedloaders (with bullets) are now printable in seclathes
Uplinks sell the proper speedloaders now
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: BurninDreamer
- tweak: Revolvers should be a little more punchy now, yes, even more than before.
- fix: The Syndicate now distributes proper ammo in their uplinks for said revvies, uh oh.
- add: NT has tweaked seclathes to be able to produce speedloaders with revolver ammo!