### PR TITLE
welding modular mines/grenades to salvage them

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_grenade.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_grenade.yml
@@ -21,6 +21,15 @@
       steps:
       - material: Cable
         doAfter: 0.5
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 5
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 2
 
   - node: wiredCase
     entity: ModularGrenade      

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_mine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/modular_mine.yml
@@ -23,6 +23,15 @@
           sprite: Objects/Misc/proximity_sensor.rsi
           state: icon
         name: proximity sensor
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 5
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 2
 
   - node: wiredCase
     entity: LandMineModular


### PR DESCRIPTION
## About the PR
If you disarm a modular mine or grenade, you are left with an empty waste of space. With crates, machines, computers you can salvage them for steel. This PR lets you weld these 2 items to get the steel back.

TODO: video

**Changelog**
:cl:
- tweak: Weld modular mines and grenades to salvage them

