### PR TITLE
Allow stations to specify their own custom emergency shuttles.

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -221,9 +221,10 @@ namespace Content.IntegrationTests.Tests
                 // Test shuttle can dock.
                 // This is done inside gamemap test because loading the map takes ages and we already have it.
                 var station = entManager.GetComponent<StationMemberComponent>(targetGrid!.Value).Station;
-                var shuttlePath = entManager.GetComponent<StationDataComponent>(station).EmergencyShuttlePath
-                    .ToString();
-                var shuttle = mapLoader.LoadGrid(shuttleMap, entManager.GetComponent<StationDataComponent>(station).EmergencyShuttlePath.ToString());
+                var stationConfig = entManager.GetComponent<StationDataComponent>(station).StationConfig;
+                Assert.IsNotNull(stationConfig, $"{targetGrid} had null StationConfig.");
+                var shuttlePath = stationConfig.EmergencyShuttlePath.ToString();
+                var shuttle = mapLoader.LoadGrid(shuttleMap, shuttlePath);
                 Assert.That(shuttle != null && shuttleSystem.TryFTLDock(entManager.GetComponent<ShuttleComponent>(shuttle.Value), targetGrid.Value), $"Unable to dock {shuttlePath} to {mapProto}");
 
                 mapManager.DeleteMap(shuttleMap);

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -222,7 +222,7 @@ namespace Content.IntegrationTests.Tests
                 // This is done inside gamemap test because loading the map takes ages and we already have it.
                 var station = entManager.GetComponent<StationMemberComponent>(targetGrid!.Value).Station;
                 var stationConfig = entManager.GetComponent<StationDataComponent>(station).StationConfig;
-                Assert.IsNotNull(stationConfig, $"{targetGrid} had null StationConfig.");
+                Assert.IsNotNull(stationConfig, $"{entManager.ToPrettyString(station)} had null StationConfig.");
                 var shuttlePath = stationConfig.EmergencyShuttlePath.ToString();
                 var shuttle = mapLoader.LoadGrid(shuttleMap, shuttlePath);
                 Assert.That(shuttle != null && shuttleSystem.TryFTLDock(entManager.GetComponent<ShuttleComponent>(shuttle.Value), targetGrid.Value), $"Unable to dock {shuttlePath} to {mapProto}");

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.EmergencyShuttle.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.EmergencyShuttle.cs
@@ -426,10 +426,17 @@ public sealed partial class ShuttleSystem
 
    private void AddEmergencyShuttle(StationDataComponent component)
    {
-       if (!_emergencyShuttleEnabled || CentComMap == null || component.EmergencyShuttle != null) return;
+       if (!_emergencyShuttleEnabled
+           || CentComMap == null
+           || component.EmergencyShuttle != null
+           || component.StationConfig == null)
+       {
+           return;
+       }
 
        // Load escape shuttle
-       var shuttle = _map.LoadGrid(CentComMap.Value, component.EmergencyShuttlePath.ToString(), new MapLoadOptions()
+       var shuttlePath = component.StationConfig.EmergencyShuttlePath;
+       var shuttle = _map.LoadGrid(CentComMap.Value, shuttlePath.ToString(), new MapLoadOptions()
        {
            // Should be far enough... right? I'm too lazy to bounds check CentCom rn.
            Offset = new Vector2(500f + _shuttleIndex, 0f)
@@ -437,7 +444,7 @@ public sealed partial class ShuttleSystem
 
        if (shuttle == null)
        {
-           _sawmill.Error($"Unable to spawn emergency shuttle {component.EmergencyShuttlePath} for {ToPrettyString(component.Owner)}");
+           _sawmill.Error($"Unable to spawn emergency shuttle {shuttlePath} for {ToPrettyString(component.Owner)}");
            return;
        }
 

--- a/Content.Server/Station/Components/StationDataComponent.cs
+++ b/Content.Server/Station/Components/StationDataComponent.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Systems;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Station.Components;
 
@@ -31,10 +30,4 @@ public sealed class StationDataComponent : Component
     /// </summary>
     [ViewVariables, Access(typeof(ShuttleSystem), Friend = AccessPermissions.ReadWrite)]
     public EntityUid? EmergencyShuttle;
-
-    /// <summary>
-    /// Emergency shuttle map path for this station.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), Access(typeof(ShuttleSystem), Other = AccessPermissions.ReadWriteExecute)]
-    public ResourcePath EmergencyShuttlePath = new("/Maps/Shuttles/emergency.yml");
 }

--- a/Content.Server/Station/StationConfig.Shuttles.cs
+++ b/Content.Server/Station/StationConfig.Shuttles.cs
@@ -1,0 +1,13 @@
+﻿using Robust.Shared.Utility;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
+
+namespace Content.Server.Station;
+
+public sealed partial class StationConfig
+{
+    /// <summary>
+    /// Emergency shuttle map path for this station.
+    /// </summary>
+    [DataField("emergencyShuttlePath", customTypeSerializer: typeof(ResourcePathSerializer))]
+    public ResourcePath EmergencyShuttlePath { get; set; } = new("/Maps/Shuttles/emergency.yml");
+}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR moves the specification of the EmergencyShuttlePath into StationConfig, so it can be set on a per-station basis if desired.

```
  stations:
    Example:
      mapNameTemplate: '{0} Example {1}'
      emergencyShuttlePath: /Maps/Shuttles/your_custom_shuttle.yml
```

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Individual stations can now have specific emergency shuttles.
