### PR TITLE
Origin Update 3.0.1

### DIFF
--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -6,6 +6,7 @@
   stations:
     Origin:
       mapNameTemplate: '{0} Origin Station {1}'
+      emergencyShuttlePath: /Maps/Shuttles/emergency_courser.yml
       nameGenerator:
         !type:NanotrasenNameGenerator
         prefixCreator: '14'


### PR DESCRIPTION
![Origin-0](https://user-images.githubusercontent.com/113240905/204089551-07d771c4-d7d0-4ee6-a542-ce75a19c4e74.png)

Origin has been updated. Here is a list of changes.

- Science shuttle was removed from south of science. (moony requested change).
- Science genetics was removed from the south of science. (a genetics can be added when we have gameplay incoming for it). (moony requested change).
- EVA suits removed from maintenance and science. (moony requested change).
- Surgery and tools removed from robotics (they can be added again when there is a need for it). (moony requested change).
- Machette and combat knife spawns were removed. (moony requested change).
- The drug den (gamer room) north of medical was removed and replaced with an arcade. (moony requested change but not specifically replacement).
- Science uranium generators were removed, science can no longer go off grid. (moony requested change).
- An analyzer was removed from artifacts lab (now only one but space to place another).
- RTG was added to engineering
- Tools removed from the CE office (has enough tools). (checkraze requested change).
- The armory loadout was altered as well as the armory layout. (moony requested change).
- Maintenance tunnels added to the north and south sides of science. (moony requested change).
- Many walls have changed between rwalls and solid walls depending on their ingame purpose. (checkraze requested change).
- Many windows have changed between reinforced window and normal window depending on their ingame purpose. (checkraze requested change).
- Many of the head rooms now have switches and shutters to help syndies and heads in different situations. (checkraze requested change).
- The kitchen now has shutters and can close up shop. (checkraze requested change).
- The icecream parlor now has shutters and can close up shop.
- The donk cafe was improved.
- The doors on the syndie shuttle were changed from vault doors to external doors (stealth requested change).
- The protolathe removed from engineering. (checkraze requested change).
- The rd server and points in science moved to a new secure location. (checkraze requested change).
- Telecomms now has rwalls.  (checkraze requested change).
- Vault now has a stack of silver.
- The maint cloner removed.  (moony requested change).
- Chem stuff removed from virology.  (moony requested change).
- Open prison made more secure.
- Fixed hole in wall near detective office.
- Most counters replaced with reinforced tables.  (checkraze requested change).
- Some maint loot spawners were reduced specficially those adding resources.  (moony requested change).
- Drone room replaced with a sec checkpoint. (moony requested change but not specifically a replacement).
- High level tech removed from maintenance.  (checkraze requested change).
- Ore processor now in wall between salv and cargo. (checkraze requested change).
- A few lights added to dark areas of station that should not be dark such as north part of botany. (stealth requested change).
- RTVs removed from robotics. (moony requested change).
- The miasma room removed. (moony requested change).
- baby singulo has been removed. (moony requested change).
- Solar arrays have had an increase in connectivity to the main station to reduce the ease of sabotage. (mervill requested this change).
- Grav is now separate from the rest of the room it resides in making it a little harder to sabotage. (mervil requested this change).
- Courser shuttle by checkraze now selected as the default emergency shuttle for origin.
- altered the catwalk north of xenoarch room, this modification gives more room for the new emergency shuttle.
- Added a spare set of magboots to engineering.
- Moved the golden toolbox to the bridge.
- Added a zebra scarf to theatre.