### PR TITLE
Adjust VentClog Reagents

### DIFF
--- a/Content.Server/StationEvents/Events/VentClog.cs
+++ b/Content.Server/StationEvents/Events/VentClog.cs
@@ -16,8 +16,7 @@ public sealed class VentClog : StationEventSystem
 
     public readonly IReadOnlyList<string> SafeishVentChemicals = new[]
     {
-        "Water", "Iron", "Oxygen", "Tritium", "Plasma", "SulfuricAcid", "Blood", "SpaceDrugs", "SpaceCleaner", "Flour",
-        "Nutriment", "Sugar", "SpaceLube", "Ethanol", "Mercury", "Ephedrine", "WeldingFuel", "VentCrud"
+        "Water", "Blood", "Slime", "Acetone", "SpaceDrugs", "SpaceCleaner", "Nutriment", "Sugar", "SpaceLube", "Ethanol", "Ephedrine", "WeldingFuel", "VentCrud", "Ale", "Beer"
     };
 
     public override void Started()


### PR DESCRIPTION
Adjust VentClog reagents to be less dangerous.

:cl:
- tweak: Chemists have stopped pouring dangerous chemicals into the vents.

