### PR TITLE
Change the hunger and thirst values of animals

### DIFF
--- a/Content.Server/Nutrition/Components/HungerComponent.cs
+++ b/Content.Server/Nutrition/Components/HungerComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Nutrition.Components;
 using Robust.Shared.Random;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 
 namespace Content.Server.Nutrition.Components
 {
@@ -44,11 +45,14 @@ namespace Content.Server.Nutrition.Components
             get => _currentHunger;
             set => _currentHunger = value;
         }
-        private float _currentHunger;
+        [DataField("startingHunger")]
+        private float _currentHunger = -1f;
 
         [ViewVariables(VVAccess.ReadOnly)]
         public Dictionary<HungerThreshold, float> HungerThresholds => _hungerThresholds;
-        private readonly Dictionary<HungerThreshold, float> _hungerThresholds = new()
+
+        [DataField("thresholds", customTypeSerializer: typeof(DictionarySerializer<HungerThreshold, float>))]
+        private Dictionary<HungerThreshold, float> _hungerThresholds = new()
         {
             { HungerThreshold.Overfed, 200.0f },
             { HungerThreshold.Okay, 150.0f },
@@ -123,10 +127,15 @@ namespace Content.Server.Nutrition.Components
         protected override void Startup()
         {
             base.Startup();
-            // Similar functionality to SS13. Should also stagger people going to the chef.
-            _currentHunger = _random.Next(
-                (int)_hungerThresholds[HungerThreshold.Peckish] + 10,
-                (int)_hungerThresholds[HungerThreshold.Okay] - 1);
+            // Do not change behavior unless starting hunger is explicitly defined
+            if (_currentHunger < 0)
+            {
+                // Similar functionality to SS13. Should also stagger people going to the chef.
+                _currentHunger = _random.Next(
+                    (int) _hungerThresholds[HungerThreshold.Peckish] + 10,
+                    (int) _hungerThresholds[HungerThreshold.Okay] - 1);
+            }
+
             _currentHungerThreshold = GetHungerThreshold(_currentHunger);
             _lastHungerThreshold = HungerThreshold.Okay; // TODO: Potentially change this -> Used Okay because no effects.
             HungerThresholdEffect(true);

--- a/Content.Server/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Server/Nutrition/Components/ThirstComponent.cs
@@ -31,8 +31,10 @@ namespace Content.Server.Nutrition.Components
         public ThirstThreshold LastThirstThreshold;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public float CurrentThirst;
+        [DataField("startingThirst")]
+        public float CurrentThirst = -1f;
 
+        [DataField("thresholds")]
         public Dictionary<ThirstThreshold, float> ThirstThresholds { get; } = new()
         {
             {ThirstThreshold.OverHydrated, 600.0f},

--- a/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/ThirstSystem.cs
@@ -30,9 +30,13 @@ namespace Content.Server.Nutrition.EntitySystems
         }
         private void OnComponentStartup(EntityUid uid, ThirstComponent component, ComponentStartup args)
         {
-            component.CurrentThirst = _random.Next(
-                (int) component.ThirstThresholds[ThirstThreshold.Thirsty] + 10,
-                (int) component.ThirstThresholds[ThirstThreshold.Okay] - 1);
+            // Do not change behavior unless starting value is explicitly defined
+            if (component.CurrentThirst < 0)
+            {
+                component.CurrentThirst = _random.Next(
+                    (int) component.ThirstThresholds[ThirstThreshold.Thirsty] + 10,
+                    (int) component.ThirstThresholds[ThirstThreshold.Okay] - 1);
+            }
             component.CurrentThirstThreshold = GetThirstThreshold(component, component.CurrentThirst);
             component.LastThirstThreshold = ThirstThreshold.Okay; // TODO: Potentially change this -> Used Okay because no effects.
             // TODO: Check all thresholds make sense and throw if they don't.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -50,6 +50,22 @@
         Piercing: 8
   - type: Body
     prototype: Rat
+  - type: Hunger # probably should be prototyped
+    thresholds:
+      Overfed: 200
+      Okay: 150
+      Peckish: 100
+      Starving: 50
+      Dead: 0
+    baseDecayRate: 0.01666666666
+  - type: Thirst
+    thresholds:
+      OverHydrated: 600
+      Okay: 450
+      Thirsty: 300
+      Parched: 150
+      Dead: 0
+    baseDecayRate: 0.1
   - type: Appearance
   - type: DamageStateVisuals
     rotate: true
@@ -209,6 +225,22 @@
         Piercing: 3
   - type: Body
     prototype: Rat
+  - type: Hunger # probably should be prototyped
+    thresholds:
+      Overfed: 200
+      Okay: 150
+      Peckish: 100
+      Starving: 50
+      Dead: 0
+    baseDecayRate: 0.01666666666
+  - type: Thirst
+    thresholds:
+      OverHydrated: 600
+      Okay: 450
+      Thirsty: 300
+      Parched: 150
+      Dead: 0
+    baseDecayRate: 0.1
   - type: Appearance
   - type: DamageStateVisuals
     rotate: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -169,7 +169,7 @@
       Peckish: 25
       Starving: 10
       Dead: 0
-    baseDecayRate: 0,00925925925926 # it is okay for animals to eat and drink less than humans, but more frequently
+    baseDecayRate: 0.00925925925926 # it is okay for animals to eat and drink less than humans, but more frequently
   - type: Thirst
     thresholds:
       OverHydrated: 200

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -163,7 +163,21 @@
   - type: InputMover
   - type: MobMover
   - type: Hunger
+    thresholds: # only animals and rats are derived from this prototype so let's override it here and in rats' proto
+      Overfed: 100
+      Okay: 50
+      Peckish: 25
+      Starving: 10
+      Dead: 0
+    baseDecayRate: 0,00925925925926 # it is okay for animals to eat and drink less than humans, but more frequently
   - type: Thirst
+    thresholds:
+      OverHydrated: 200
+      Okay: 150
+      Thirsty: 100
+      Parched: 50
+      Dead: 0
+    baseDecayRate: 0.04
   - type: Barotrauma
     damage:
       types:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I am not highly experienced developer and non-native English speaker so comments and tweaks are welcome.
After playing several rounds as sentient animal I was frustrated by the size of my stomach comparing to the amount of food I have to eat. Added serialization to hunger and thirst thresholds. Put values I think are right for hunger and thirst thresholds and their decay rates of animals. Rats are unchanged since they have thresholds suitable for their role.
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Prentor
- tweak: Animals have to eat less but more frequently

