### PR TITLE
Fix hypospray initial client component state.

### DIFF
--- a/Content.Client/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Client/Chemistry/Components/InjectorComponent.cs
@@ -1,15 +1,5 @@
-using Content.Client.Items.Components;
-using Content.Client.Message;
-using Content.Client.Stylesheets;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
-using Robust.Client.UserInterface;
-using Robust.Client.UserInterface.Controls;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Localization;
-using Robust.Shared.Timing;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Client.Chemistry.Components
 {

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
@@ -1,7 +1,6 @@
 using Content.Server.Body.Components;
 using Content.Server.Chemistry.Components;
 using Content.Server.Chemistry.Components.SolutionManager;
-using Content.Server.CombatMode;
 using Content.Server.DoAfter;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
@@ -455,6 +454,7 @@ public sealed partial class ChemistrySystem
         Dirty(component);
         AfterDraw(component);
     }
+
     private sealed class InjectionCompleteEvent : EntityEventArgs
     {
         public InjectorComponent Component { get; init; } = default!;

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystem.Injector.cs
@@ -187,7 +187,7 @@ public sealed partial class ChemistrySystem
 
     private void OnInjectorStartup(EntityUid uid, InjectorComponent component, ComponentStartup args)
     {
-        /// ???? why ?????
+        // Necessary for the Client-side InjectorStatusControl to get the appropriate Volume values.
         Dirty(component);
     }
 

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
@@ -23,6 +23,13 @@ namespace Content.Server.Chemistry.EntitySystems
             SubscribeLocalEvent<HyposprayComponent, MeleeHitEvent>(OnAttack);
             SubscribeLocalEvent<HyposprayComponent, SolutionChangedEvent>(OnSolutionChange);
             SubscribeLocalEvent<HyposprayComponent, UseInHandEvent>(OnUseInHand);
+            SubscribeLocalEvent<HyposprayComponent, ComponentStartup>(OnStartup);
+        }
+
+        private void OnStartup(EntityUid uid, HyposprayComponent component, ComponentStartup args)
+        {
+            // Necessary for the Client-side HyposprayStatusControl to get the appropriate Volume values.
+            Dirty(component);
         }
 
         private void OnUseInHand(EntityUid uid, HyposprayComponent component, UseInHandEvent args)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Items which had HyposprayComponent, such as the emergency pens and the Hypospray itself, were not showing their appropriate volume at spawn. It would show `0/0` until the solution had changed in some way, either by filling or injecting. InjectorComponent (which are your syringe type objects) already had this handled via ComponentStartup, but it wasn't obvious what the `Dirty()` was for. I have explained the comment left behind and duplicated the necessary functionality from Injector to Hypospray to fix this cosmetic bug.

Resolves #12875

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Hyposprays and emergency pens will show their proper volume again.
