### PR TITLE
Avoid a display bug when showing a network using multitool

### DIFF
--- a/Content.Client/NetworkConfigurator/NetworkConfiguratorLinkOverlay.cs
+++ b/Content.Client/NetworkConfigurator/NetworkConfiguratorLinkOverlay.cs
@@ -2,7 +2,7 @@ using Content.Shared.DeviceNetwork;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.Random;
-using Robust.Shared.Utility;
+using Robust.Shared.Map;
 
 namespace Content.Client.NetworkConfigurator;
 
@@ -48,6 +48,12 @@ public sealed class NetworkConfiguratorLinkOverlay : Overlay
             }
 
             var sourceTransform = _entityManager.GetComponent<TransformComponent>(tracker.Owner);
+            if (sourceTransform.MapID == MapId.Nullspace)
+            {
+                // Can happen if the item is outside the client's view. In that case,
+                // we don't have a sensible transform to draw, so we need to skip it.
+                continue;
+            }
 
             foreach (var device in _deviceListSystem.GetAllDevices(tracker.Owner, deviceList))
             {
@@ -57,6 +63,10 @@ public sealed class NetworkConfiguratorLinkOverlay : Overlay
                 }
 
                 var linkTransform = _entityManager.GetComponent<TransformComponent>(device);
+                if (linkTransform.MapID == MapId.Nullspace)
+                {
+                    continue;
+                }
 
                 args.WorldHandle.DrawLine(sourceTransform.WorldPosition, linkTransform.WorldPosition, _colors[tracker.Owner]);
             }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If using a multitool to display a link to a device which is not in the client's viewport, lines would be drawn to (0,0), which looked unexpected.

Check the MapID is not Nullspace before rendering. This can cause some lines to not be rendered, but better than incorrect lines.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

