### PR TITLE
Add a label to make lathe UI clearer

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml
@@ -65,12 +65,18 @@
                 VerticalExpand="True">
             </BoxContainer>
         </ScrollContainer>
-        <LineEdit
-            Name="AmountLineEdit"
-            PlaceHolder="{Loc 'lathe-menu-search-amount'}"
-            Text="1"
-            HorizontalExpand="True">
-        </LineEdit>
+        <BoxContainer
+            Orientation="Horizontal"
+            HorizontalExpand="True"
+            VerticalExpand="True"
+            SizeFlagsStretchRatio="1">
+            <Label Margin="8 0 8 0" Text="{Loc 'lathe-menu-amount'}"/>
+            <LineEdit
+                Name="AmountLineEdit"
+                PlaceHolder="0"
+                Text="1"
+                HorizontalExpand="True" />
+        </BoxContainer>
         <ItemList
             Name="Materials"
             VerticalExpand="True"

--- a/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
+++ b/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
@@ -4,5 +4,5 @@ lathe-menu-server-list = Server list
 lathe-menu-sync = Sync
 lathe-menu-search-designs = Search designs
 lathe-menu-search-filter = Filter
-lathe-menu-search-amount = Amount
+lathe-menu-amount = Amount:
 lathe-menu-material-display = {$material} {$amount} cm³


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an extra label to the lathe UI to make the "amount" usage clearer. I'd never really noticed the ability to make more than one item at a time because it was missing a label -- the text box for the amount had a placeholder text, but because it also had a default value, it was never visible to the user. 

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

Before:

![2022-11-29_21-52](https://user-images.githubusercontent.com/1676295/204656817-5cf518cf-abbc-41d5-81fa-4cdc4355c8da.png)

After:

![2022-11-29_21-51](https://user-images.githubusercontent.com/1676295/204656838-9580c081-05cc-4e6c-9c52-d61417b50f72.png)


**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
