### PR TITLE
Fix shutter drawdepth

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -10,6 +10,7 @@
   - type: Sprite
     netsync: false
     sprite: Structures/Doors/Shutters/shutters.rsi
+    drawdepth: Overdoors
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

this was unspecified and y-fighting with doors, should always render above airlocks and such

after

![image](https://user-images.githubusercontent.com/19853115/204975291-749ec7d6-c108-4614-8b8a-4f1d30328448.png)

