### PR TITLE
Reduce C4 Amount

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -194,7 +194,7 @@
     - type: StorageFill
       contents:
         - id: C4
-          amount: 8
+          amount: 3
 
 - type: entity
   parent: ClothingBackpackChameleon

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -124,7 +124,7 @@
 
 - type: listing
   id: UplinkC4Bundle
-  description: Because sometimes quantity is quality. Contains 8 C-4 plastic explosives.
+  description: Because sometimes quantity is quality. Contains 3 C-4 plastic explosives.
   productEntity: ClothingBackpackDuffelSyndicateC4tBundle
   cost:
     Telecrystal: 12


### PR DESCRIPTION
Why do you get 8 C4 for 12 TC when a normal grenade is 4 TC?
Reduces C4 bundle to 3 C4.

:cl: Pancake
- tweak: The Syndicate has finally run through their backstock of C4.

