### PR TITLE
Clear chat input when focus is released with Esc

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -168,6 +168,7 @@ public partial class ChatBox : UIWidget
         if (args.Function == EngineKeyFunctions.TextReleaseFocus)
         {
             ChatInput.Input.ReleaseKeyboardFocus();
+            ChatInput.Input.Clear();
             args.Handle();
             return;
         }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In the short time I've played, I've not had any need to keep the message without sending it. Instead there's been a few times I've accidentally sent a message together with some leftover text.

If someone has a need for keeping text in chat, I could make it so the message is added to scrollback before clearing. Then you could recover the message by pressing up arrow.

**Alternative**
Players can already clear input with Ctrl+A and Backspace or Ctrl+X. Maybe that's enough?

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: jick
- tweak: Escape key clears chat input

