### PR TITLE
Allow crew manifest window resizing

### DIFF
--- a/Content.Client/CrewManifest/CrewManifestEui.cs
+++ b/Content.Client/CrewManifest/CrewManifestEui.cs
@@ -1,5 +1,4 @@
 using Content.Client.Eui;
-using Content.Client.GameTicking.Managers;
 using Content.Shared.CrewManifest;
 using Content.Shared.Eui;
 using JetBrains.Annotations;
@@ -9,12 +8,10 @@ namespace Content.Client.CrewManifest;
 [UsedImplicitly]
 public sealed class CrewManifestEui : BaseEui
 {
-    private readonly ClientGameTicker _gameTicker;
     private readonly CrewManifestUi _window;
 
     public CrewManifestEui()
     {
-        _gameTicker = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ClientGameTicker>();
         _window = new();
 
         _window.OnClose += () =>

--- a/Content.Client/CrewManifest/CrewManifestUi.xaml
+++ b/Content.Client/CrewManifest/CrewManifestUi.xaml
@@ -1,7 +1,7 @@
 <DefaultWindow xmlns="https://spacestation14.io"
                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                Title="{Loc 'crew-manifest-window-title'}"
-               MinSize="450 750">
+               SetSize="450 750">
     <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True">
         <controls:StripeBack Name="StationNameContainer">
             <PanelContainer>


### PR DESCRIPTION
Allows crew manifest to be made smaller than its starting size.
