### PR TITLE
Add `PopupCoordinates()` overrides

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -9,6 +9,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
+using Robust.Shared.Players;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -48,13 +49,6 @@ namespace Content.Client.Popups
             _aliveCursorLabels.Add(label);
         }
 
-        public void PopupCoordinates(string message, EntityCoordinates coordinates, PopupType type=PopupType.Small)
-        {
-            if (_eyeManager.CurrentMap != Transform(coordinates.EntityId).MapID)
-                return;
-            PopupMessage(message, type, coordinates, null);
-        }
-
         public void PopupEntity(string message, EntityUid uid, PopupType type=PopupType.Small)
         {
             if (!EntityManager.EntityExists(uid))
@@ -86,6 +80,22 @@ namespace Content.Client.Popups
         #endregion
 
         #region Abstract Method Implementations
+        public override void PopupCoordinates(string message, EntityCoordinates coordinates, PopupType type = PopupType.Small)
+        {
+            PopupMessage(message, type, coordinates, null);
+        }
+
+        public override void PopupCoordinates(string message, EntityCoordinates coordinates, ICommonSession recipient, PopupType type = PopupType.Small)
+        {
+            if (_playerManager.LocalPlayer?.Session == recipient)
+                PopupMessage(message, type, coordinates, null);
+        }
+
+        public override void PopupCoordinates(string message, EntityCoordinates coordinates, EntityUid recipient, PopupType type = PopupType.Small)
+        {
+            if (_playerManager.LocalPlayer?.ControlledEntity == recipient)
+                PopupMessage(message, type, coordinates, null);
+        }
 
         public override void PopupCursor(string message, Filter filter, PopupType type=PopupType.Small)
         {
@@ -95,11 +105,8 @@ namespace Content.Client.Popups
             PopupCursor(message, type);
         }
 
-        public override void PopupCoordinates(string message, EntityCoordinates coordinates, Filter filter, PopupType type=PopupType.Small)
+        public override void PopupCoordinates(string message, EntityCoordinates coordinates, Filter filter, bool replayRecord, PopupType type = PopupType.Small)
         {
-            if (!filter.CheckPrediction)
-                return;
-
             PopupCoordinates(message, coordinates, type);
         }
 

--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Access.Systems
                     if (transformComponent != null)
                     {
                         _popupSystem.PopupCoordinates(Loc.GetString("id-card-component-microwave-burnt", ("id", uid)),
-                         transformComponent.Coordinates, Filter.Pvs(uid), PopupType.Medium);
+                         transformComponent.Coordinates, PopupType.Medium);
                         EntityManager.SpawnEntity("FoodBadRecipe",
                             transformComponent.Coordinates);
                     }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -126,7 +126,7 @@ public sealed partial class AdminVerbSystem
                     Filter.Entities(args.Target), PopupType.LargeCaution);
                 _popupSystem.PopupCoordinates(
                     Loc.GetString("admin-smite-chess-others", ("name", args.Target)), xform.Coordinates,
-                    Filter.PvsExcept(args.Target), PopupType.MediumCaution);
+                    Filter.PvsExcept(args.Target), true, PopupType.MediumCaution);
                 var board = Spawn("ChessBoard", xform.Coordinates);
                 var session = _tabletopSystem.EnsureSession(Comp<TabletopGameComponent>(board));
                 xform.Coordinates = EntityCoordinates.FromMap(_mapManager, session.Position);
@@ -153,7 +153,7 @@ public sealed partial class AdminVerbSystem
                     _popupSystem.PopupEntity(Loc.GetString("admin-smite-set-alight-self"), args.Target,
                         Filter.Entities(args.Target), PopupType.LargeCaution);
                     _popupSystem.PopupCoordinates(Loc.GetString("admin-smite-set-alight-others", ("name", args.Target)), xform.Coordinates,
-                        Filter.PvsExcept(args.Target), PopupType.MediumCaution);
+                        Filter.PvsExcept(args.Target), true, PopupType.MediumCaution);
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-smite-set-alight-description")
@@ -287,7 +287,7 @@ public sealed partial class AdminVerbSystem
                     _popupSystem.PopupEntity(Loc.GetString("admin-smite-remove-blood-self"), args.Target,
                         Filter.Entities(args.Target), PopupType.LargeCaution);
                     _popupSystem.PopupCoordinates(Loc.GetString("admin-smite-remove-blood-others", ("name", args.Target)), xform.Coordinates,
-                        Filter.PvsExcept(args.Target), PopupType.MediumCaution);
+                        Filter.PvsExcept(args.Target), true, PopupType.MediumCaution);
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-smite-remove-blood-description")
@@ -320,7 +320,7 @@ public sealed partial class AdminVerbSystem
                     _popupSystem.PopupEntity(Loc.GetString("admin-smite-vomit-organs-self"), args.Target,
                         Filter.Entities(args.Target), PopupType.LargeCaution);
                     _popupSystem.PopupCoordinates(Loc.GetString("admin-smite-vomit-organs-others", ("name", args.Target)), baseXform.Coordinates,
-                        Filter.PvsExcept(args.Target), PopupType.MediumCaution);
+                        Filter.PvsExcept(args.Target), true, PopupType.MediumCaution);
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-smite-vomit-organs-description")
@@ -342,7 +342,7 @@ public sealed partial class AdminVerbSystem
                     _popupSystem.PopupEntity(Loc.GetString("admin-smite-remove-hands-self"), args.Target,
                         Filter.Entities(args.Target), PopupType.LargeCaution);
                     _popupSystem.PopupCoordinates(Loc.GetString("admin-smite-remove-hands-others", ("name", args.Target)), baseXform.Coordinates,
-                        Filter.PvsExcept(args.Target), PopupType.Medium);
+                        Filter.PvsExcept(args.Target), true, PopupType.Medium);
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-smite-remove-hands-description")
@@ -365,7 +365,7 @@ public sealed partial class AdminVerbSystem
                     _popupSystem.PopupEntity(Loc.GetString("admin-smite-remove-hands-self"), args.Target,
                         Filter.Entities(args.Target), PopupType.LargeCaution);
                     _popupSystem.PopupCoordinates(Loc.GetString("admin-smite-remove-hands-others", ("name", args.Target)), baseXform.Coordinates,
-                        Filter.PvsExcept(args.Target), PopupType.Medium);
+                        Filter.PvsExcept(args.Target), true, PopupType.Medium);
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-smite-remove-hand-description")

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -81,8 +81,7 @@ public sealed class ImmovableRodSystem : EntitySystem
         {
             // oh god.
             var coords = Transform(uid).Coordinates;
-            _popup.PopupCoordinates(Loc.GetString("immovable-rod-collided-rod-not-good"), coords,
-                Filter.Pvs(uid), PopupType.LargeCaution);
+            _popup.PopupCoordinates(Loc.GetString("immovable-rod-collided-rod-not-good"), coords, PopupType.LargeCaution);
 
             Del(uid);
             Del(ent);

--- a/Content.Server/LandMines/LandMineSystem.cs
+++ b/Content.Server/LandMines/LandMineSystem.cs
@@ -35,7 +35,7 @@ public sealed class LandMineSystem : EntitySystem
             _popupSystem.PopupCoordinates(
                 Loc.GetString("land-mine-triggered", ("mine", uid)),
                 Transform(uid).Coordinates,
-                Filter.Entities(args.Tripper),
+                args.Tripper,
                 PopupType.LargeCaution);
         }
     }

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -1,11 +1,16 @@
 using Content.Shared.Popups;
+using Robust.Server.GameObjects;
+using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
+using Robust.Shared.Players;
 
 namespace Content.Server.Popups
 {
     public sealed class PopupSystem : SharedPopupSystem
     {
+        [Dependency] private readonly IPlayerManager _player = default!;
+
         public override void PopupCursor(string message, Filter filter, PopupType type=PopupType.Small)
         {
             // TODO REPLAYS
@@ -16,10 +21,25 @@ namespace Content.Server.Popups
             RaiseNetworkEvent(new PopupCursorEvent(message, type), filter);
         }
 
-        public override void PopupCoordinates(string message, EntityCoordinates coordinates, Filter filter, PopupType type=PopupType.Small)
+        public override void PopupCoordinates(string message, EntityCoordinates coordinates, Filter filter, bool replayRecord, PopupType type = PopupType.Small)
         {
-            // TODO REPLAYS See above
-            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, coordinates), filter);
+            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, coordinates), filter, replayRecord);
+        }
+
+        public override void PopupCoordinates(string message, EntityCoordinates coordinates, PopupType type = PopupType.Small)
+        {
+            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, coordinates), Filter.Pvs(coordinates, entityMan:EntityManager, playerMan: _player));
+        }
+
+        public override void PopupCoordinates(string message, EntityCoordinates coordinates, ICommonSession recipient, PopupType type = PopupType.Small)
+        {
+            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, coordinates), recipient);
+        }
+
+        public override void PopupCoordinates(string message, EntityCoordinates coordinates, EntityUid recipient, PopupType type = PopupType.Small)
+        {
+            if (TryComp(recipient, out ActorComponent? actor))
+                RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, coordinates), actor.PlayerSession);
         }
 
         public override void PopupEntity(string message, EntityUid uid, Filter filter, PopupType type=PopupType.Small)

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Popups;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Players;
@@ -10,6 +11,7 @@ namespace Content.Server.Popups
     public sealed class PopupSystem : SharedPopupSystem
     {
         [Dependency] private readonly IPlayerManager _player = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
 
         public override void PopupCursor(string message, Filter filter, PopupType type=PopupType.Small)
         {
@@ -28,7 +30,9 @@ namespace Content.Server.Popups
 
         public override void PopupCoordinates(string message, EntityCoordinates coordinates, PopupType type = PopupType.Small)
         {
-            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, coordinates), Filter.Pvs(coordinates, entityMan:EntityManager, playerMan: _player));
+            var mapPos = coordinates.ToMap(EntityManager);
+            var filter = Filter.Empty().AddPlayersByPvs(mapPos, entManager: EntityManager, playerMan: _player, cfgMan: _cfg);
+            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, coordinates), filter);
         }
 
         public override void PopupCoordinates(string message, EntityCoordinates coordinates, ICommonSession recipient, PopupType type = PopupType.Small)

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/RandomTeleportArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/RandomTeleportArtifactSystem.cs
@@ -23,7 +23,7 @@ public sealed class RandomTeleportArtifactSystem : EntitySystem
     private void OnActivate(EntityUid uid, RandomTeleportArtifactComponent component, ArtifactActivatedEvent args)
     {
         var xform = Transform(uid);
-        _popup.PopupCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, Filter.Pvs(uid), PopupType.Medium);
+        _popup.PopupCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, PopupType.Medium);
 
         xform.Coordinates = xform.Coordinates.Offset(_random.NextVector2(component.Range));
     }

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.Map;
 using Robust.Shared.Player;
+using Robust.Shared.Players;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Popups
@@ -18,13 +19,29 @@ namespace Content.Shared.Popups
         public abstract void PopupCursor(string message, Filter filter, PopupType type=PopupType.Small);
 
         /// <summary>
-        ///     Shows a popup at a world location.
+        ///     Shows a popup at a world location to every entity in PVS range.
         /// </summary>
         /// <param name="message">The message to display.</param>
         /// <param name="coordinates">The coordinates where to display the message.</param>
-        /// <param name="filter">Filter for the players that will see the popup.</param>
         /// <param name="type">Used to customize how this popup should appear visually.</param>
-        public abstract void PopupCoordinates(string message, EntityCoordinates coordinates, Filter filter, PopupType type=PopupType.Small);
+        public abstract void PopupCoordinates(string message, EntityCoordinates coordinates, PopupType type = PopupType.Small);
+
+        /// <summary>
+        ///     Filtered variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/>.
+        /// </summary>
+        /// <param name="filter">Filter for the players that will see the popup.</param>
+        /// <param name="recordReplay">If true, this pop-up will be considered as a globally visible pop-up that gets shown during replays.</param>
+        public abstract void PopupCoordinates(string message, EntityCoordinates coordinates, Filter filter, bool recordReplay, PopupType type = PopupType.Small);
+
+        /// <summary>
+        ///     Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> that sends a pop-up to the player attached to some entity.
+        /// </summary>
+        public abstract void PopupCoordinates(string message, EntityCoordinates coordinates, EntityUid recipient, PopupType type = PopupType.Small);
+
+        /// <summary>
+        ///     Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> that sends a pop-up to a specific player.
+        /// </summary>
+        public abstract void PopupCoordinates(string message, EntityCoordinates coordinates, ICommonSession recipient, PopupType type = PopupType.Small);
 
         /// <summary>
         ///     Shows a popup above an entity.

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -27,7 +27,8 @@ namespace Content.Shared.Popups
         public abstract void PopupCoordinates(string message, EntityCoordinates coordinates, PopupType type = PopupType.Small);
 
         /// <summary>
-        ///     Filtered variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/>.
+        ///     Filtered variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/>, which should only be used
+        ///     if the filtering has to be more specific than simply PVS range based.
         /// </summary>
         /// <param name="filter">Filter for the players that will see the popup.</param>
         /// <param name="recordReplay">If true, this pop-up will be considered as a globally visible pop-up that gets shown during replays.</param>

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -72,18 +72,18 @@ namespace Content.Shared.Stacks
             switch (transfered)
             {
                 case > 0:
-                    PopupSystem.PopupCoordinates($"+{transfered}", popupPos, Filter.Local());
+                    PopupSystem.PopupCoordinates($"+{transfered}", popupPos);
 
                     if (GetAvailableSpace(recipientStack) == 0)
                     {
                         PopupSystem.PopupCoordinates(Loc.GetString("comp-stack-becomes-full"),
-                            popupPos.Offset(new Vector2(0, -0.5f)), Filter.Local());
+                            popupPos.Offset(new Vector2(0, -0.5f)));
                     }
 
                     break;
 
                 case 0 when GetAvailableSpace(recipientStack) == 0:
-                    PopupSystem.PopupCoordinates(Loc.GetString("comp-stack-already-full"), popupPos, Filter.Local());
+                    PopupSystem.PopupCoordinates(Loc.GetString("comp-stack-already-full"), popupPos);
                     break;
             }
         }


### PR DESCRIPTION
Adds some new `PopupSystem.PopupCoordinates()` overrides for sending pop-ups to specific clients or to every entity in PVS range. also adds a new argument to the filtered override that specifies whether the pop-up should be included in replays,