### PR TITLE
Fix bug where AirAlarmUI would display incorrect scrubber filters

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -115,12 +115,9 @@ public sealed partial class ScrubberControl : BoxContainer
         _data.WideNet = data.WideNet;
         _wideNet.Pressed = _data.WideNet;
 
-        var intersect = _data.FilterGases.Intersect(data.FilterGases);
-
         foreach (var value in Enum.GetValues<Gas>())
         {
-            if (!intersect.Contains(value))
-                _gasControls[value].Pressed = false;
+            _gasControls[value].Pressed = data.FilterGases.Contains(value);
         }
     }
 }

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -114,6 +114,7 @@ public sealed partial class ScrubberControl : BoxContainer
 
         _data.WideNet = data.WideNet;
         _wideNet.Pressed = _data.WideNet;
+        _data.FilterGases = data.FilterGases;
 
         foreach (var value in Enum.GetValues<Gas>())
         {


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sometimes, user interaction could lead to the AirAlarmUI displaying filter settings for a scrubber which did not match the server data, leading atmos to mistakenly filter some undesirable gases.

To repro the bug:

1. Open AirAlarmUI and inspect a scrubber
2. Toggle some settings (i.e turn on o2 scrubbing, turn off miasma)
3. Change the whole alarm filtering mode (i.e., change to "Filtering (Wide)"
4. Observe the state of the filters change (o2 is off, miasma is off)
5. Close the air alarm UI
6. Re-open the air alarm UI and navigate to your scrubber
7. Observe the filters are different from step 5 (o2 is off, miasma is on)

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Cripes
- fix: Fix bug where air alarm would show incorrect filters for a scrubber