### PR TITLE
Increase NPC chase persistence

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -232,7 +232,7 @@ public sealed partial class PathfindingSystem
 
     private bool IsBodyRelevant(PhysicsComponent body)
     {
-        if (!body.Hard || !body.CanCollide || body.BodyType != BodyType.Static)
+        if (!body.Hard || body.BodyType != BodyType.Static)
         {
             return false;
         }
@@ -262,7 +262,8 @@ public sealed partial class PathfindingSystem
 
     private void OnBodyTypeChange(ref PhysicsBodyTypeChangedEvent ev)
     {
-        if (IsBodyRelevant(ev.Component) &&
+        if (ev.Component.CanCollide &&
+            IsBodyRelevant(ev.Component) &&
             TryComp<TransformComponent>(ev.Entity, out var xform) &&
             xform.GridUid != null)
         {

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Melee.cs
@@ -87,13 +87,20 @@ public sealed partial class NPCCombatSystem
             return;
         }
 
+        if (TryComp<NPCSteeringComponent>(component.Owner, out var steering) &&
+            steering.Status == SteeringStatus.NoPath)
+        {
+            component.Status = CombatStatus.TargetUnreachable;
+            return;
+        }
+
         if (distance > weapon.Range)
         {
             component.Status = CombatStatus.TargetOutOfRange;
             return;
         }
 
-        var steering = EnsureComp<NPCSteeringComponent>(component.Owner);
+        steering = EnsureComp<NPCSteeringComponent>(component.Owner);
         steering.Range = MathF.Max(0.2f, weapon.Range - 0.4f);
 
         // Gets unregistered on component shutdown.

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -325,6 +325,12 @@ namespace Content.Server.NPC.Systems
             // TODO: Probably need partial planning support i.e. patch from the last node to where the target moved to.
             CheckPath(steering, xform, needsPath, distance);
 
+            if (steering.Pathfind && steering.CurrentPath.Count == 0)
+            {
+                SetDirection(mover, steering, Vector2.Zero, false);
+                return;
+            }
+
             modifierQuery.TryGetComponent(steering.Owner, out var modifier);
             var moveSpeed = GetSprintSpeed(steering.Owner, modifier);
 

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -250,11 +250,6 @@ namespace Content.Server.NPC.Systems
 
             var direction = targetMap.Position - ourMap.Position;
 
-            if (steering.Owner == new EntityUid(15315))
-            {
-
-            }
-
             // Are we in range
             if (direction.Length <= arrivalDistance)
             {


### PR DESCRIPTION
- Open airlocks will update the graph again so NPCs that can't touch them will still follow you through
- Cancel combat behaviour if no path
- Remove an old debug thing (oop)
- Don't steer until we actually get a path (prevents false paths from stop-starting NPCs).

:cl:
- tweak: NPCs will be more persistent in chases.