### PR TITLE
made SalvageSystem configurable

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1205,6 +1205,30 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string>
             SalvageForced = CVarDef.Create("salvage.forced", "", CVar.SERVERONLY);
 
+        /// <summary>
+        ///     Salvage hold phase time, in seconds. Set to zero to hold indefinetely.
+        /// </summary>
+        public static readonly CVarDef<int>
+            SalvageHoldTime = CVarDef.Create("salvage.hold_time", 240, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Salvage attaching phase time, in seconds. Set to zero to skip to next phase immediately.
+        /// </summary>
+        public static readonly CVarDef<int>
+            SalvageAttachingTime = CVarDef.Create("salvage.attaching_time", 30, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Salvage detaching phase time, in seconds. Set to zero to skip to next phase immediately.
+        /// </summary>
+        public static readonly CVarDef<int>
+            SalvageDetachingTime = CVarDef.Create("salvage.detaching_time", 30, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Salvage cooldown phase time, in seconds. Set to zero to skip to next phase immediately.
+        /// </summary>
+        public static readonly CVarDef<int>
+            SalvageCooldownTime = CVarDef.Create("salvage.cooldown_time", 60, CVar.SERVERONLY);
+
         /*
 
          * Flavor

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1206,7 +1206,7 @@ namespace Content.Shared.CCVar
             SalvageForced = CVarDef.Create("salvage.forced", "", CVar.SERVERONLY);
 
         /// <summary>
-        ///     Salvage hold phase time, in seconds. Set to zero to hold indefinetely.
+        ///     Salvage hold phase time, in seconds. Set to zero to hold indefinitely.
         /// </summary>
         public static readonly CVarDef<int>
             SalvageHoldTime = CVarDef.Create("salvage.hold_time", 240, CVar.SERVERONLY);

--- a/Resources/Locale/en-US/salvage/salvage-system.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-system.ftl
@@ -1,6 +1,8 @@
 salvage-system-announcement-source = Salvage Control System
 salvage-system-announcement-arrived = A piece of salvagable debris has been pulled in. Estimated hold time: {$timeLeft} seconds.
+salvage-system-announcement-arrived-timeless = A piece of salvagable debris has been pulled in.
 salvage-system-announcement-losing = The magnet is no longer able to hold the salvagable debris. Estimated time until loss: {$timeLeft} seconds.
+salvage-system-announcement-losing-timeless = The magnet is no longer able to hold the salvagable debris.
 salvage-system-announcement-lost = The salvagable debris have been lost.
 
 salvage-system-announcement-spawn-magnet-lost = The salvage magnet has been lost.
@@ -17,5 +19,6 @@ salvage-system-magnet-examined-active = The salvage magnet is holding salvage in
     [1] one second.
     *[other] { $timeLeft } seconds.
 }
+salvage-system-magnet-examined-active-timeless = The salvage magnet is holding salvage in place.
 salvage-system-magnet-examined-releasing = The salvage magnet is releasing the salvage.
 salvage-system-magnet-examined-cooling-down = The salvage magnet is cooling down.


### PR DESCRIPTION
## About the PR 
I've made SalvageSystem configurable.
Following CCVars added:

salvage.hold_time - Salvage hold phase time, in seconds. Set to zero to hold indefinitely.
salvage.attaching_time - Salvage attaching phase time, in seconds. Set to zero to skip to next phase immediately.
salvage.detaching_time - Salvage detaching phase time, in seconds. Set to zero to skip to next phase immediately.
salvage.cooldown_time - Salvage cooldown phase time, in seconds. Set to zero to skip to next phase immediately.

**Screenshots**

**Changelog**
:cl:
- add: SalvageSystem now configurable using CVars
- tweak: you can click salvage magnet again to let go of a debris before timer runs out
