### PR TITLE
Replace nutriment in snowcones with ice, water, and sugar

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -133,24 +133,47 @@
 # layer depending on soda/syrup/waterever. Name and description will also have
 # to be modified.
 - type: entity
-  name: flavorless snowcone
-#  name: [Flavor] snowcone
+  name: sweet snowcone
+  #  name: [Flavor] snowcone
   parent: FoodFrozenBase
+  id: FoodFrozenSnowconeBase
+  description: It's just shaved ice and simple syrup, minimum effort.
+  #  description: [Liquid] drizzled over a snowball in a paper cup.
+  components:
+    - type: Sprite
+      layers:
+        - state: cone
+        - state: alpha-filling
+    #      color: foo
+    - type: Food
+      trash: FoodFrozenSnowconeTrash
+    - type: SolutionContainerManager
+      solutions:
+        food:
+          maxVol: 20 # For sprinkles or something? Idk.
+          reagents:
+            - ReagentId: Water
+              Quantity: 10
+            - ReagentId: Sugar
+              Quantity: 2
+
+- type: entity
+  name: flavorless snowcone
+  parent: FoodFrozenSnowconeBase
   id: FoodFrozenSnowcone
   description: It's just shaved ice. Still fun to chew on.
-#  description: [Liquid] drizzled over a snowball in a paper cup.
   components:
-  - type: Sprite
-    layers:
-    - state: cone
-    - state: alpha-filling
-#      color: foo
-  - type: Food
-    trash: FoodFrozenSnowconeTrash
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+          - ReagentId: Water
+            Quantity: 10
 
 - type: entity
   name: berry snowcone
-  parent: FoodFrozenBase
+  parent: FoodFrozenSnowconeBase
   id: FoodFrozenSnowconeBerry
   description: Berry syrup drizzled over a snowball in a paper cup.
   components:
@@ -163,7 +186,7 @@
 
 - type: entity
   name: fruit salad snowcone
-  parent: FoodFrozenBase
+  parent: FoodFrozenSnowconeBase
   id: FoodFrozenSnowconeFruit
   description: A delightful mix of citrus syrups drizzled over a snowball in a paper cup.
   components:
@@ -176,7 +199,7 @@
 
 - type: entity
   name: clowncone
-  parent: FoodFrozenBase
+  parent: FoodFrozenSnowconeBase
   id: FoodFrozenSnowconeClown
   description: Laughter drizzled over a snowball in a paper cup.
   components:
@@ -189,7 +212,7 @@
 
 - type: entity
   name: mime snowcone
-  parent: FoodFrozenBase
+  parent: FoodFrozenSnowconeBase
   id: FoodFrozenSnowconeMime
   description: ...
   components:
@@ -202,7 +225,7 @@
 
 - type: entity
   name: rainbow snowcone
-  parent: FoodFrozenBase
+  parent: FoodFrozenSnowconeBase
   id: FoodFrozenSnowconeRainbow
   description: A very colorful snowball in a paper cup.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/frozen.yml
@@ -152,8 +152,10 @@
         food:
           maxVol: 20 # For sprinkles or something? Idk.
           reagents:
+            - ReagentId: Ice
+              Quantity: 8
             - ReagentId: Water
-              Quantity: 10
+              Quantity: 2
             - ReagentId: Sugar
               Quantity: 2
 
@@ -168,8 +170,8 @@
       food:
         maxVol: 20
         reagents:
-          - ReagentId: Water
-            Quantity: 10
+          - ReagentId: Ice
+            Quantity: 8
 
 - type: entity
   name: berry snowcone


### PR DESCRIPTION
Snowcones are mostly water. The 10u nutriment in snowcones is replaced with 8u ice. Snowcones with syrup are given an additional 2u water and 2u sugar. A new snowcone base was created and snowcones were modified to actually use the snowcone base instead of `FoodFrozenBase`.

I think there's one snowcone on Kettle, one on a salvage, and they're uncraftable so I'm not sure if this requires a changelog.