### PR TITLE
Fix potato battery client-side exception

### DIFF
--- a/Content.Client/PowerCell/PowerCellSystem.cs
+++ b/Content.Client/PowerCell/PowerCellSystem.cs
@@ -15,17 +15,21 @@ public sealed class PowerCellSystem : SharedPowerCellSystem
 
     private void OnPowerCellVisualsChange(EntityUid uid, PowerCellVisualsComponent component, ref AppearanceChangeEvent args)
     {
-        if (args.Sprite == null) return;
+        if (args.Sprite == null)
+            return;
+
+        if (!args.Sprite.TryGetLayer((int) PowerCellVisualLayers.Unshaded, out var unshadedLayer))
+            return;
 
         if (args.Component.TryGetData(PowerCellVisuals.ChargeLevel, out byte level))
         {
             if (level == 0)
             {
-                args.Sprite.LayerSetVisible(PowerCellVisualLayers.Unshaded, false);
+                unshadedLayer.Visible = false;
                 return;
             }
 
-            args.Sprite.LayerSetVisible(PowerCellVisualLayers.Unshaded, true);
+            unshadedLayer.Visible = true;
             args.Sprite.LayerSetState(PowerCellVisualLayers.Unshaded, $"o{level}");
         }
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
visualizer used to throw an exception because the potato didn't have an unshaded enum mapped in the sprite.
makes it do a tryget for the layer, avoid the exception.
just your average potato quality of life pr
**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

no cl but potato is fun

