### PR TITLE
Remove active doors on bagel

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -52230,9 +52230,6 @@ entities:
   - pos: 48.5,-39.5
     parent: 60
     type: Transform
-  - SecondsUntilStateChange: -37666.23
-    state: Opening
-    type: Door
 - uid: 3729
   type: PoweredSmallLight
   components:
@@ -123908,9 +123905,6 @@ entities:
   - pos: 31.5,-19.5
     parent: 60
     type: Transform
-  - SecondsUntilStateChange: -31179.133
-    state: Closing
-    type: Door
 - uid: 14524
   type: ReinforcedWindow
   components:


### PR DESCRIPTION
Some doors on bagel are mid opening/closing. This just fixes that in order to fix some tests. Long term fix needs something like #12679