### PR TITLE
Add label to lathe UI (and friends) to show when no materials are loaded

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -67,14 +67,26 @@ public sealed partial class LatheMenu : DefaultWindow
             return;
 
         Materials.Clear();
+
         foreach (var (id, amount) in materials.Storage)
         {
             if (!_prototypeManager.TryIndex(id, out MaterialPrototype? material))
                 continue;
-            var mat = Loc.GetString("lathe-menu-material-display",
-                ("material", material.Name), ("amount", amount));
-            Materials.AddItem(mat, _spriteSystem.Frame0(material.Icon), false);
+
+            if (amount > 0)
+            {
+                var mat = Loc.GetString("lathe-menu-material-display",
+                    ("material", material.Name), ("amount", amount));
+                Materials.AddItem(mat, _spriteSystem.Frame0(material.Icon), false);
+            }
         }
+
+        if (Materials.Count == 0)
+        {
+            var noMaterialsMsg = Loc.GetString("lathe-menu-no-materials-message");
+            Materials.AddItem(noMaterialsMsg, null, false);
+        }
+
         PopulateRecipes(lathe);
     }
 

--- a/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
+++ b/Resources/Locale/en-US/lathe/ui/lathe-menu.ftl
@@ -6,3 +6,4 @@ lathe-menu-search-designs = Search designs
 lathe-menu-search-filter = Filter
 lathe-menu-amount = Amount:
 lathe-menu-material-display = {$material} {$amount} cm³
+lathe-menu-no-materials-message = No materials loaded


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Saw someone on Discord question what the "Materials" list was for in the lathe UI, as it's just an empty box if no materials have ever been loaded. This adds an extra bit of info to give the user some idea what that box is for. 

Also, don't list materials which have previously been loaded and completely consumed.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![2022-12-05_16-55](https://user-images.githubusercontent.com/1676295/205696620-d9f7d7c6-2599-4dd3-a53e-cc45969e0e8f.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame
- [ ] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
