### PR TITLE
Don't clip ban reason text

### DIFF
--- a/Content.Client/Launcher/LauncherConnectingGui.xaml
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml
@@ -22,7 +22,7 @@
                         <Label Name="ConnectStatus" StyleClasses="LabelSubText" Align="Center" />
                     </BoxContainer>
                     <BoxContainer Orientation="Vertical" Name="ConnectFail" Visible="False">
-                        <Label Name="ConnectFailReason" Align="Center" />
+                        <RichTextLabel Name="ConnectFailReason" VerticalAlignment="Stretch"/>
                         <Button Name="RetryButton" Text="{Loc 'connecting-retry'}"
                                 HorizontalAlignment="Center"
                                 VerticalExpand="True" VerticalAlignment="Bottom" />

--- a/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
@@ -55,9 +55,9 @@ namespace Content.Client.Launcher
 
         private void ConnectFailReasonChanged(string? reason)
         {
-            ConnectFailReason.Text = reason == null
-                ? null
-                : Loc.GetString("connecting-fail-reason", ("reason", reason));
+            ConnectFailReason.SetMessage(reason == null
+                ? ""
+                : Loc.GetString("connecting-fail-reason", ("reason", reason)));
         }
 
         private void LastNetDisconnectedArgsChanged(NetDisconnectedArgs? args)


### PR DESCRIPTION
Not the prettiest but the ban message code is slightly weird.
![image](https://user-images.githubusercontent.com/31366439/206330681-0dec23c5-fe2b-4eb1-ba7f-2b2d77b8a77b.png)

:cl:
- fix: Ban reason text no longer clips off screen.