### PR TITLE
make legs affect movement speed with body

### DIFF
--- a/Content.Shared/Body/Components/BodyComponent.cs
+++ b/Content.Shared/Body/Components/BodyComponent.cs
@@ -21,6 +21,13 @@ public sealed class BodyComponent : Component, IDraggable
     [DataField("gibSound")]
     public SoundSpecifier GibSound = new SoundCollectionSpecifier("gib");
 
+    /// <summary>
+    /// The amount of legs required to move at full speed.
+    /// If null, then legs do not impact speed.
+    /// </summary>
+    [DataField("requiredLegs")]
+    public int RequiredLegs;
+
     bool IDraggable.CanStartDrag(StartDragDropEvent args)
     {
         return true;

--- a/Content.Shared/Body/Components/BodyComponent.cs
+++ b/Content.Shared/Body/Components/BodyComponent.cs
@@ -23,7 +23,7 @@ public sealed class BodyComponent : Component, IDraggable
 
     /// <summary>
     /// The amount of legs required to move at full speed.
-    /// If null, then legs do not impact speed.
+    /// If 0, then legs do not impact speed.
     /// </summary>
     [DataField("requiredLegs")]
     public int RequiredLegs;

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -161,6 +161,28 @@ public partial class SharedBodySystem
         }
     }
 
+    /// <summary>
+    /// Returns all body part slots in the graph, including ones connected by
+    /// body parts which are null.
+    /// </summary>
+    /// <param name="part"></param>
+    /// <returns></returns>
+    public IEnumerable<BodyPartSlot> GetAllBodyPartSlots(BodyPartComponent part)
+    {
+        foreach (var slot in part.Children.Values)
+        {
+            if (!TryComp<BodyPartComponent>(slot.Child, out var childPart))
+                continue;
+
+            yield return slot;
+
+            foreach (var child in GetAllBodyPartSlots(childPart))
+            {
+                yield return child;
+            }
+        }
+    }
+
     public virtual HashSet<EntityUid> GibBody(EntityUid? partId, bool gibOrgans = false,
         BodyComponent? body = null, bool deleteItems = false)
     {

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -179,7 +179,7 @@ public partial class SharedBodySystem
 
             yield return slot;
 
-            foreach (var child in GetAllBodyPartSlots(childPart))
+            foreach (var child in GetAllBodyPartSlots(slot.Child, childPart))
             {
                 yield return child;
             }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -167,8 +167,11 @@ public partial class SharedBodySystem
     /// </summary>
     /// <param name="part"></param>
     /// <returns></returns>
-    public IEnumerable<BodyPartSlot> GetAllBodyPartSlots(BodyPartComponent part)
+    public IEnumerable<BodyPartSlot> GetAllBodyPartSlots(EntityUid partId, BodyPartComponent? part = null)
     {
+        if (!Resolve(partId, ref part, false))
+            yield break;
+
         foreach (var slot in part.Children.Values)
         {
             if (!TryComp<BodyPartComponent>(slot.Child, out var childPart))

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -165,6 +165,7 @@ public partial class SharedBodySystem
     /// Returns all body part slots in the graph, including ones connected by
     /// body parts which are null.
     /// </summary>
+    /// <param name="partId"></param>
     /// <param name="part"></param>
     /// <returns></returns>
     public IEnumerable<BodyPartSlot> GetAllBodyPartSlots(EntityUid partId, BodyPartComponent? part = null)
@@ -179,7 +180,7 @@ public partial class SharedBodySystem
 
             yield return slot;
 
-            foreach (var child in GetAllBodyPartSlots(slot.Child, childPart))
+            foreach (var child in GetAllBodyPartSlots(slot.Child.Value, childPart))
             {
                 yield return child;
             }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -306,8 +306,6 @@ public partial class SharedBodySystem
                 allLegs.Add(child);
         }
 
-        Logger.Debug($"LEGAMOUNT: {allLegs.Count}");
-
         var walkSpeed = 0f;
         var sprintSpeed = 0f;
         var acceleration = 0f;

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -298,10 +298,7 @@ public partial class SharedBodySystem
         if (component.Root?.Child is not { } root)
             return;
 
-        if (!TryComp<BodyPartComponent>(root, out var rootPart))
-            return;
-
-        var allSlots = GetAllBodyPartSlots(rootPart).ToHashSet();
+        var allSlots = GetAllBodyPartSlots(root).ToHashSet();
         var allLegs = new HashSet<EntityUid>();
         foreach (var slot in allSlots)
         {

--- a/Content.Shared/Body/Systems/SharedBodySystem.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Damage;
+using Content.Shared.Movement.Systems;
 using Content.Shared.Standing;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
@@ -14,6 +15,7 @@ public abstract partial class SharedBodySystem : EntitySystem
     [Dependency] protected readonly SharedContainerSystem Containers = default!;
     [Dependency] protected readonly DamageableSystem Damageable = default!;
     [Dependency] protected readonly StandingStateSystem Standing = default!;
+    [Dependency] protected readonly MovementSpeedModifierSystem Movement = default!;
 
     public override void Initialize()
     {

--- a/Resources/Prototypes/Body/Parts/animal.yml
+++ b/Resources/Prototypes/Body/Parts/animal.yml
@@ -37,6 +37,7 @@
   components:
   - type: BodyPart
     partType: Leg
+  - type: MovementSpeedModifier
 
 - type: entity
   id: FeetAnimal

--- a/Resources/Prototypes/Body/Parts/diona.yml
+++ b/Resources/Prototypes/Body/Parts/diona.yml
@@ -118,6 +118,9 @@
   - type: BodyPart
     partType: Leg
     symmetry: Left
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 1.5
+    baseSprintSpeed : 3.5
 
 - type: entity
   id: RightLegDiona
@@ -131,6 +134,9 @@
   - type: BodyPart
     partType: Leg
     symmetry: Right
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 1.5
+    baseSprintSpeed : 3.5
 
 - type: entity
   id: LeftFootDiona

--- a/Resources/Prototypes/Body/Parts/human.yml
+++ b/Resources/Prototypes/Body/Parts/human.yml
@@ -136,6 +136,7 @@
   - type: BodyPart
     partType: Leg
     symmetry: Left
+  - type: MovementSpeedModifier
 
 - type: entity
   id: RightLegHuman
@@ -152,6 +153,7 @@
   - type: BodyPart
     partType: Leg
     symmetry: Right
+  - type: MovementSpeedModifier
 
 - type: entity
   id: LeftFootHuman

--- a/Resources/Prototypes/Body/Parts/reptilian.yml
+++ b/Resources/Prototypes/Body/Parts/reptilian.yml
@@ -134,6 +134,9 @@
   - type: BodyPart
     partType: Leg
     symmetry: Left
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 2.7
+    baseSprintSpeed : 4.5
 
 - type: entity
   id: RightLegReptilian
@@ -150,6 +153,9 @@
   - type: BodyPart
     partType: Leg
     symmetry: Right
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 2.7
+    baseSprintSpeed : 4.5
 
 - type: entity
   id: LeftFootReptilian

--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -149,6 +149,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Left
+    - type: MovementSpeedModifier
 
 - type: entity
   id: RightLegSkeleton
@@ -165,6 +166,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Right
+    - type: MovementSpeedModifier
 
 - type: entity
   id: LeftFootSkeleton

--- a/Resources/Prototypes/Body/Parts/slime.yml
+++ b/Resources/Prototypes/Body/Parts/slime.yml
@@ -135,6 +135,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Left
+    - type: MovementSpeedModifier
 
 - type: entity
   id: RightLegSlime
@@ -151,6 +152,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Right
+    - type: MovementSpeedModifier
 
 - type: entity
   id: LeftFootSlime

--- a/Resources/Prototypes/Body/Parts/vox.yml
+++ b/Resources/Prototypes/Body/Parts/vox.yml
@@ -136,6 +136,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Left
+    - type: MovementSpeedModifier
 
 - type: entity
   id: RightLegVox
@@ -152,6 +153,7 @@
     - type: BodyPart
       partType: Leg
       symmetry: Right
+    - type: MovementSpeedModifier
 
 - type: entity
   id: LeftFootVox

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -711,7 +711,7 @@
     speechSounds: Monkey
   - type: Body
     prototype: Primate
-    requiredLegs: 1
+    requiredLegs: 1 # TODO: More than 1 leg
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -711,6 +711,7 @@
     speechSounds: Monkey
   - type: Body
     prototype: Primate
+    requiredLegs: 1
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -226,7 +226,7 @@
         Piercing: 3
   - type: Body
     prototype: Rat
-    requiredLegs: 1
+    requiredLegs: 1 # TODO: More than 1 leg
   - type: Hunger # probably should be prototyped
     thresholds:
       Overfed: 200

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -50,7 +50,7 @@
         Piercing: 8
   - type: Body
     prototype: Rat
-    requiredLegs: 1
+    requiredLegs: 1 # TODO: More than 1 leg
   - type: Hunger # probably should be prototyped
     thresholds:
       Overfed: 200

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -50,6 +50,7 @@
         Piercing: 8
   - type: Body
     prototype: Rat
+    requiredLegs: 1
   - type: Hunger # probably should be prototyped
     thresholds:
       Overfed: 200
@@ -225,6 +226,7 @@
         Piercing: 3
   - type: Body
     prototype: Rat
+    requiredLegs: 1
   - type: Hunger # probably should be prototyped
     thresholds:
       Overfed: 200

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -177,6 +177,7 @@
     species: Human
   - type: Body
     prototype: Human
+    requiredLegs: 2
   - type: Damageable
     damageContainer: Biological
   - type: RadiationReceiver
@@ -366,6 +367,7 @@
       species: Human
     - type: Body
       prototype: Human
+      requiredLegs: 2
     - type: Damageable
       damageContainer: Biological
     - type: MobState

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -15,6 +15,7 @@
     state: full
   - type: Body
     prototype: Diona
+    requiredLegs: 2
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Diona

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -24,6 +24,7 @@
     scale: 1, 0.8
   - type: Body
     prototype: Human
+    requiredLegs: 2
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -14,6 +14,7 @@
     state: full
   - type: Body
     prototype: Reptilian
+    requiredLegs: 2
   - type: LizardAccent
   - type: Speech
     speechSounds: Lizard

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -12,6 +12,7 @@
     state: full
   - type: Body
     prototype: Skeleton
+    requiredLegs: 2
     gibSound: /Audio/Effects/bone_rattle.ogg
   - type: Damageable
     damageContainer: Biological

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -11,6 +11,7 @@
     state: full
   - type: Body
     prototype: Slime
+    requiredLegs: 2
   - type: Humanoid
     species: SlimePerson
   - type: Speech

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -81,6 +81,7 @@
       - map: [ "pocket2" ]
   - type: Body
     prototype: Vox
+    requiredLegs: 2
   # Vox nitrogen stuff is handled in their metabolism
   - type: Respirator
     damage:
@@ -110,4 +111,5 @@
     species: Vox
   - type: Body
     prototype: Vox
+    requiredLegs: 2
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Retools bodysystem so that an entity's movement speed is an average of all of the movement speeds of their legs.

### Why?
1. losing legs now affects how fast you can move
2. I need this for silicons

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame
- [x] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

no cl but remind me to do codebase changes for this.

