### PR TITLE
Fix in-game voting

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -71,7 +71,6 @@ namespace Content.Client.Lobby
             };
 
             LayoutContainer.SetAnchorPreset(_lobby, LayoutContainer.LayoutPreset.Wide);
-            _voteManager.SetPopupContainer(_lobby.VoteContainer);
             _lobby.ServerName.Text = _baseClient.GameInfo?.ServerName; //The eye of refactor gazes upon you...
             UpdateLobbyUi();
 

--- a/Content.Client/Voting/VoteManager.cs
+++ b/Content.Client/Voting/VoteManager.cs
@@ -34,6 +34,7 @@ namespace Content.Client.Voting
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IClientConsoleHost _console = default!;
         [Dependency] private readonly IBaseClient _client = default!;
+        [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
 
         private readonly Dictionary<StandardVoteType, TimeSpan> _standardVoteTimeouts = new();
         private readonly Dictionary<int, ActiveVote> _votes = new();
@@ -120,6 +121,7 @@ namespace Content.Client.Voting
                 @new = true;
                 IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<AudioSystem>()
                     .PlayGlobal("/Audio/Effects/voteding.ogg", Filter.Local(), false);
+                SetPopupContainer(_userInterfaceManager.WindowRoot);
 
                 // New vote from the server.
                 var vote = new ActiveVote(voteId)

--- a/Content.Client/Voting/VoteManager.cs
+++ b/Content.Client/Voting/VoteManager.cs
@@ -121,6 +121,8 @@ namespace Content.Client.Voting
                 @new = true;
                 IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<AudioSystem>()
                     .PlayGlobal("/Audio/Effects/voteding.ogg", Filter.Local(), false);
+                // TODO: It would be better if this used a per-state container, i.e. a container
+                // for the lobby and each HUD layout.
                 SetPopupContainer(_userInterfaceManager.WindowRoot);
 
                 // New vote from the server.

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -908,12 +908,11 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> VoteEnabled =
             CVarDef.Create("vote.enabled", true, CVar.SERVERONLY);
 
-        // TODO HUD REFACTOR REENABLE
         /// <summary>
         ///     See vote.enabled, but specific to restart votes
         /// </summary>
         public static readonly CVarDef<bool> VoteRestartEnabled =
-            CVarDef.Create("vote.restart_enabled", false, CVar.SERVERONLY);
+            CVarDef.Create("vote.restart_enabled", true, CVar.SERVERONLY);
 
         /// <summary>
         ///     See vote.enabled, but specific to preset votes


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A regression introduced after the UI refactor caused the vote-casting window to not appear when the client was in-game.

*This fix was sponsored by Mining Station 14.*

**Steps To Reproduce**
Enter the game as a ghost or player, call a vote. You hear the "ding" but no vote window shows up.

**Media**
![2022-12-08_11-05](https://user-images.githubusercontent.com/3229565/206546771-a074dacb-38c8-46a9-a71d-2926d5d0d956.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame
- [ ] This PR does not require an ingame showcase

**Changelog**
:cl: notafet
- fix: Votes can once again be cast in-game