### PR TITLE
nullable parts in body prototypes

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -5,13 +5,13 @@ using Content.Server.GameTicking;
 using Content.Server.Humanoid;
 using Content.Server.Kitchen.Components;
 using Content.Server.Mind.Components;
+using Content.Server.MobState;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Prototypes;
 using Content.Shared.Body.Systems;
 using Content.Shared.Coordinates;
 using Content.Shared.Humanoid;
-using Content.Shared.MobState.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Audio;
@@ -25,8 +25,8 @@ public sealed class BodySystem : SharedBodySystem
 {
     [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
-
     [Dependency] private readonly HumanoidSystem _humanoidSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
 
     public override void Initialize()
@@ -40,8 +40,7 @@ public sealed class BodySystem : SharedBodySystem
 
     private void OnRelayMoveInput(EntityUid uid, BodyComponent component, ref MoveInputEvent args)
     {
-        if (EntityManager.TryGetComponent<MobStateComponent>(uid, out var mobState) &&
-            mobState.IsDead() &&
+        if (_mobState.IsDead(uid) &&
             EntityManager.TryGetComponent<MindComponent>(uid, out var mind) &&
             mind.HasMind)
         {
@@ -119,13 +118,14 @@ public sealed class BodySystem : SharedBodySystem
     protected override void InitBody(BodyComponent body, BodyPrototype prototype)
     {
         var root = prototype.Slots[prototype.Root];
+        Containers.EnsureContainer<Container>(body.Owner, BodyContainerId);
+        if (root.Part == null)
+            return;
         var bodyId = Spawn(root.Part, body.Owner.ToCoordinates());
         var partComponent = Comp<BodyPartComponent>(bodyId);
-        var slot = new BodyPartSlot(root.Part, body.Owner, partComponent.PartType);
+        var slot = new BodyPartSlot("root", body.Owner, partComponent.PartType);
         body.Root = slot;
         partComponent.Body = bodyId;
-
-        Containers.EnsureContainer<Container>(body.Owner, BodyContainerId);
 
         AttachPart(bodyId, slot, partComponent);
         InitPart(partComponent, prototype, prototype.Root);
@@ -136,7 +136,7 @@ public sealed class BodySystem : SharedBodySystem
         if (bodyId == null || !Resolve(bodyId.Value, ref body, false))
             return new HashSet<EntityUid>();
 
-        var gibs = base.GibBody(bodyId, gibOrgans, body);
+        var gibs = base.GibBody(bodyId, gibOrgans, body, deleteItems);
 
         var xform = Transform(bodyId.Value);
         var coordinates = xform.Coordinates;
@@ -157,7 +157,7 @@ public sealed class BodySystem : SharedBodySystem
                     }
                     else
                     {
-                        cont.ForceRemove(ent);
+                        cont.Remove(ent, EntityManager, force: true);
                         Transform(ent).Coordinates = coordinates;
                         ent.RandomOffset(0.25f);
                     }

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -123,7 +123,7 @@ public sealed class BodySystem : SharedBodySystem
             return;
         var bodyId = Spawn(root.Part, body.Owner.ToCoordinates());
         var partComponent = Comp<BodyPartComponent>(bodyId);
-        var slot = new BodyPartSlot("root", body.Owner, partComponent.PartType);
+        var slot = new BodyPartSlot(root.Part, body.Owner, partComponent.PartType);
         body.Root = slot;
         partComponent.Body = bodyId;
 

--- a/Content.Shared/Body/Prototypes/BodyPrototype.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototype.cs
@@ -1,4 +1,5 @@
 ﻿using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Body.Prototypes;
 
@@ -34,7 +35,8 @@ public sealed class BodyPrototype : IPrototype
 [DataRecord]
 public sealed record BodyPrototypeSlot
 {
-    [DataField("part")] public readonly string? Part;
+    [DataField("part", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public readonly string? Part;
     public readonly HashSet<string> Connections = new();
     public readonly Dictionary<string, string> Organs = new();
 

--- a/Content.Shared/Body/Prototypes/BodyPrototype.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototype.cs
@@ -34,18 +34,18 @@ public sealed class BodyPrototype : IPrototype
 [DataRecord]
 public sealed record BodyPrototypeSlot
 {
-    [DataField("part", required: true)] public readonly string Part = default!;
+    [DataField("part")] public readonly string? Part;
     public readonly HashSet<string> Connections = new();
     public readonly Dictionary<string, string> Organs = new();
 
-    public BodyPrototypeSlot(string part, HashSet<string>? connections, Dictionary<string, string>? organs)
+    public BodyPrototypeSlot(string? part, HashSet<string>? connections, Dictionary<string, string>? organs)
     {
         Part = part;
         Connections = connections ?? new HashSet<string>();
         Organs = organs ?? new Dictionary<string, string>();
     }
 
-    public void Deconstruct(out string part, out HashSet<string> connections, out Dictionary<string, string> organs)
+    public void Deconstruct(out string? part, out HashSet<string> connections, out Dictionary<string, string> organs)
     {
         part = Part;
         connections = Connections;

--- a/Content.Shared/Body/Prototypes/BodyPrototypeSerializer.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototypeSerializer.cs
@@ -14,18 +14,10 @@ namespace Content.Shared.Body.Prototypes;
 [TypeSerializer]
 public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, MappingDataNode>
 {
-    private (ValidationNode Node, List<string> Connections) ValidateSlot(ISerializationManager serializationManager, MappingDataNode slot, string slotId, IDependencyCollection dependencies)
+    private (ValidationNode Node, List<string> Connections) ValidateSlot( MappingDataNode slot, IDependencyCollection dependencies)
     {
         var nodes = new List<ValidationNode>();
         var prototypes = dependencies.Resolve<IPrototypeManager>();
-        if (!slot.TryGet("part", out ValueDataNode? part))
-        {
-            nodes.Add(new ErrorNode(slot, $"No part value data node found in root slot {slotId}"));
-        }
-        else if (!prototypes.HasIndex<EntityPrototype>(part.Value))
-        {
-            nodes.Add(new ErrorNode(slot, $"No entity prototype found with id {part.Value} for root slot {slotId}"));
-        }
 
         var connections = new List<string>();
         if (slot.TryGet("connections", out SequenceDataNode? connectionsNode))
@@ -79,8 +71,6 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
         IDependencyCollection dependencies, ISerializationContext? context = null)
     {
         var nodes = new List<ValidationNode>();
-        if (!node.TryGet("id", out ValueDataNode? id))
-            nodes.Add(new ErrorNode(node, "No id value data node found"));
 
         if (!node.TryGet("root", out ValueDataNode? root))
             nodes.Add(new ErrorNode(node, $"No root value data node found"));
@@ -111,7 +101,7 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
                     continue;
                 }
 
-                var result = ValidateSlot(serializationManager, slot, root.Value, dependencies);
+                var result = ValidateSlot(slot, dependencies);
                 nodes.Add(result.Node);
 
                 foreach (var connection in result.Connections)
@@ -134,13 +124,18 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
         var name = node.Get<ValueDataNode>("name").Value;
         var root = node.Get<ValueDataNode>("root").Value;
         var slotNodes = node.Get<MappingDataNode>("slots");
-        var allConnections = new Dictionary<string, (string Part, HashSet<string>? Connections, Dictionary<string, string>? Organs)>();
+        var allConnections = new Dictionary<string, (string? Part, HashSet<string>? Connections, Dictionary<string, string>? Organs)>();
 
         foreach (var (keyNode, valueNode) in slotNodes)
         {
             var slotId = ((ValueDataNode) keyNode).Value;
             var slot = ((MappingDataNode) valueNode);
-            var part = slot.Get<ValueDataNode>("part").Value;
+
+            string? part = null;
+            if (slot.TryGet<ValueDataNode>("part", out var value))
+            {
+                part = value.Value;
+            }
 
             HashSet<string>? connections = null;
             if (slot.TryGet("connections", out SequenceDataNode? slotConnectionsNode))

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -88,6 +88,9 @@ public partial class SharedBodySystem
         foreach (var connection in connections)
         {
             var childSlot = prototype.Slots[connection];
+            if (childSlot.Part == null)
+                continue;
+
             var childPart = Spawn(childSlot.Part, coordinates);
             var childPartComponent = Comp<BodyPartComponent>(childPart);
             var slot = CreatePartSlot(connection, parent.Owner, childPartComponent.PartType, parent);

--- a/Resources/Prototypes/Body/Prototypes/human.yml
+++ b/Resources/Prototypes/Body/Prototypes/human.yml
@@ -36,11 +36,11 @@
     left hand:
       part: LeftHandHuman
     right leg:
-      #part: RightLegHuman
+      part: RightLegHuman
       connections:
       - right foot
     left leg:
-      #part: LeftLegHuman
+      part: LeftLegHuman
       connections:
       - left foot
     right foot:

--- a/Resources/Prototypes/Body/Prototypes/human.yml
+++ b/Resources/Prototypes/Body/Prototypes/human.yml
@@ -36,11 +36,11 @@
     left hand:
       part: LeftHandHuman
     right leg:
-      part: RightLegHuman
+      #part: RightLegHuman
       connections:
       - right foot
     left leg:
-      part: LeftLegHuman
+      #part: LeftLegHuman
       connections:
       - left foot
     right foot:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
silicons!!!!

putting myself in the smugleaf meat grinder
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame
- [x] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->
no cl no fun

