### PR TITLE
Make ghost boo action start with a cooldown.

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -119,6 +119,7 @@ namespace Content.Server.Ghost
             var time = _gameTiming.CurTime;
             component.TimeOfDeath = time;
 
+            // TODO ghost: remove once ghosts are persistent and aren't deleted when returning to body
             if (component.Action.UseDelay != null)
                 component.Action.Cooldown = (time, time + component.Action.UseDelay.Value);
             _actions.AddAction(uid, component.Action, null);

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -116,8 +116,11 @@ namespace Content.Server.Ghost
                 eye.VisibilityMask |= (uint) VisibilityFlags.Ghost;
             }
 
-            component.TimeOfDeath = _gameTiming.RealTime;
+            var time = _gameTiming.CurTime;
+            component.TimeOfDeath = time;
 
+            if (component.Action.UseDelay != null)
+                component.Action.Cooldown = (time, time + component.Action.UseDelay.Value);
             _actions.AddAction(uid, component.Action, null);
         }
 


### PR DESCRIPTION
This just makes the ghost boo start with a cooldown, which is a roundabout way of fixing #12779. A better fix would be to somehow have a players ghost be persistent & stored in null-space so that options like light/fov & ghost visibility toggling is also persistent.