### PR TITLE
Misc flare fixes

### DIFF
--- a/Content.Client/Light/Components/ExpendableLightComponent.cs
+++ b/Content.Client/Light/Components/ExpendableLightComponent.cs
@@ -1,6 +1,5 @@
-﻿using Content.Shared.Light.Component;
+using Content.Shared.Light.Component;
 using Robust.Shared.Audio;
-using Robust.Shared.GameObjects;
 
 namespace Content.Client.Light.Components
 {

--- a/Content.Client/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Client/Light/EntitySystems/ExpendableLightSystem.cs
@@ -1,0 +1,18 @@
+using Content.Client.Light.Components;
+
+namespace Content.Client.Light.EntitySystems;
+
+public sealed class ExpendableLightSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ExpendableLightComponent, ComponentShutdown>(OnLightShutdown);
+    }
+
+    private void OnLightShutdown(EntityUid uid, ExpendableLightComponent component, ComponentShutdown args)
+    {
+        component.PlayingStream?.Stop();
+    }
+}

--- a/Content.Client/Light/Visualizers/ExpendableLightVisualizer.cs
+++ b/Content.Client/Light/Visualizers/ExpendableLightVisualizer.cs
@@ -2,10 +2,6 @@ using Content.Client.Light.Components;
 using Content.Shared.Light.Component;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
-using Robust.Shared.Audio;
-using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
-using Robust.Shared.Player;
 
 namespace Content.Client.Light.Visualizers
 {
@@ -35,31 +31,21 @@ namespace Content.Client.Light.Visualizers
                 }
             }
 
-            void TryStopStream(IPlayingAudioStream? stream)
-            {
-                stream?.Stop();
-            }
-
             if (component.TryGetData(ExpendableLightVisuals.State, out ExpendableLightState state)
-            && entities.TryGetComponent(component.Owner, out ExpendableLightComponent? expendableLight))
+                && entities.TryGetComponent(component.Owner, out ExpendableLightComponent? expendableLight))
             {
                 switch (state)
                 {
                     case ExpendableLightState.Lit:
-                    {
-                        TryStopStream(expendableLight.PlayingStream);
-                        if (expendableLight.LoopedSound != null)
-                        {
-                            expendableLight.PlayingStream = SoundSystem.Play(expendableLight.LoopedSound, Filter.Local(),
-                                expendableLight.Owner, SharedExpendableLightComponent.LoopedSoundParams.WithLoop(true));
-                        }
+                        expendableLight.PlayingStream?.Stop();
+                        expendableLight.PlayingStream = entities.EntitySysManager.GetEntitySystem<SharedAudioSystem>().PlayPvs(
+                            expendableLight.LoopedSound,
+                            expendableLight.Owner,
+                            SharedExpendableLightComponent.LoopedSoundParams);
                         break;
-                    }
                     case ExpendableLightState.Dead:
-                    {
-                        TryStopStream(expendableLight.PlayingStream);
+                        expendableLight.PlayingStream?.Stop();
                         break;
-                    }
                 }
             }
         }

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -19,6 +19,7 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly SharedItemSystem _item = default!;
         [Dependency] private readonly ClothingSystem _clothing = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
+        [Dependency] private readonly SharedAudioSystem _audio = default!;
 
         public override void Initialize()
         {
@@ -130,9 +131,7 @@ namespace Content.Server.Light.EntitySystems
                 switch (component.CurrentState)
                 {
                     case ExpendableLightState.Lit:
-                    {
-                        SoundSystem.Play(component.LitSound.GetSound(), Filter.Pvs(component.Owner), component.Owner);
-
+                        _audio.PlayPvs(component.LitSound, component.Owner);
                         if (component.IconStateLit != string.Empty)
                         {
                             sprite.LayerSetState(2, component.IconStateLit);
@@ -141,22 +140,21 @@ namespace Content.Server.Light.EntitySystems
 
                         sprite.LayerSetVisible(1, true);
                         break;
-                    }
                     case ExpendableLightState.Fading:
                     {
                         break;
                     }
                     default:
                     case ExpendableLightState.Dead:
-                    {
-                        if (component.DieSound != null)
-                            SoundSystem.Play(component.DieSound.GetSound(), Filter.Pvs(component.Owner), component.Owner);
+                        _audio.PlayPvs(component.DieSound, component.Owner);
+                        if (!string.IsNullOrEmpty(component.IconStateSpent))
+                        {
+                            sprite.LayerSetState(0, component.IconStateSpent);
+                            sprite.LayerSetShader(0, "shaded");
+                        }
 
-                        sprite.LayerSetState(0, component.IconStateSpent);
-                        sprite.LayerSetShader(0, "shaded");
                         sprite.LayerSetVisible(1, false);
                         break;
-                    }
                 }
             }
 

--- a/Content.Shared/Light/Component/SharedExpendableLightComponent.cs
+++ b/Content.Shared/Light/Component/SharedExpendableLightComponent.cs
@@ -52,11 +52,11 @@ namespace Content.Shared.Light.Component
         [DataField("iconStateOn")]
         public string IconStateLit { get; set; } = string.Empty;
 
-        [DataField("litSound", required: true)]
-        public SoundSpecifier LitSound { get; set; } = default!;
+        [DataField("litSound")]
+        public SoundSpecifier? LitSound { get; set; }
 
         [DataField("loopedSound")]
-        public string? LoopedSound { get; set; } = null;
+        public SoundSpecifier? LoopedSound { get; set; }
 
         [DataField("dieSound")]
         public SoundSpecifier? DieSound { get; set; } = null;


### PR DESCRIPTION
Stops audio from playing when deleted, replaces obsolete methods, and makes the component use sound specifiers.

Should hopefully fix #12905 when combined with space-wizards/RobustToolbox/pull/3562