### PR TITLE
make nukie round-end screen good

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -792,11 +792,10 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     private void OnStartAttempt(RoundStartAttemptEvent ev)
     {
-        if (/*!RuleAdded ||*/ Configuration is not NukeopsRuleConfiguration nukeOpsConfig)
+        if (!RuleAdded || Configuration is not NukeopsRuleConfiguration nukeOpsConfig)
             return;
 
         _nukeopsRuleConfig = nukeOpsConfig;
-        return;
         var minPlayers = nukeOpsConfig.MinPlayers;
         if (!ev.Forced && ev.Players.Length < minPlayers)
         {

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -27,7 +27,6 @@ using Content.Shared.Roles;
 using Robust.Server.GameObjects;
 using Robust.Server.Maps;
 using Robust.Server.Player;
-using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -40,7 +39,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IServerPreferencesManager _prefs = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
@@ -144,8 +142,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     /// <summary>
     ///     Players who played as an operative at some point in the round.
+    ///     Stores the session as well as the entity name
     /// </summary>
-    private readonly HashSet<IPlayerSession> _operativePlayers = new();
+    private readonly Dictionary<string, IPlayerSession> _operativePlayers = new();
 
 
     public override void Initialize()
@@ -172,8 +171,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
             return;
 
         var session = mindComponent.Mind?.Session;
+        var name = MetaData(uid).EntityName;
         if (session != null)
-            _operativePlayers.Add(session);
+            _operativePlayers.Add(name, session);
     }
 
     private void OnComponentRemove(EntityUid uid, NukeOperativeComponent component, ComponentRemove args)
@@ -331,7 +331,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         _winConditions.Add(WinCondition.SomeNukiesAlive);
 
         var diskAtCentCom = false;
-        foreach (var (comp, transform) in EntityManager.EntityQuery<NukeDiskComponent, TransformComponent>())
+        foreach (var (_, transform) in EntityManager.EntityQuery<NukeDiskComponent, TransformComponent>())
         {
             var diskMapId = transform.MapID;
             diskAtCentCom = _shuttleSystem.CentComMap == diskMapId;
@@ -373,9 +373,10 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         }
 
         ev.AddLine(Loc.GetString("nukeops-list-start"));
-        foreach (var nukeop in _operativePlayers)
+        foreach (var (name, session) in _operativePlayers)
         {
-            ev.AddLine($"- {nukeop.Name}");
+            var listing = Loc.GetString("nukeops-list-name", ("name", name), ("user", session.Name));
+            ev.AddLine(listing);
         }
     }
 
@@ -545,7 +546,10 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         {
             ev.PlayerPool.Remove(session);
             GameTicker.PlayerJoinGame(session);
-            _operativePlayers.Add(session);
+            var name = session.AttachedEntity == null
+                ? string.Empty
+                : MetaData(session.AttachedEntity.Value).EntityName;
+            _operativePlayers.Add(name, session);
         }
     }
 
@@ -580,8 +584,12 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
         if (!mind.TryGetSession(out var playerSession))
             return;
+        if (_operativePlayers.ContainsValue(playerSession))
+            return;
 
-        _operativePlayers.Add(playerSession);
+        var name = MetaData(uid).EntityName;
+
+        _operativePlayers.Add(name, playerSession);
 
         if (_ticker.RunLevel != GameRunLevel.InRound)
             return;
@@ -614,8 +622,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
         var mapId = _mapManager.CreateMap();
 
-        var outpostGrids = _map.LoadMap(mapId, path.ToString());
-        if (outpostGrids.Count == 0)
+        if (!_map.TryLoad(mapId, path.ToString(), out var outpostGrids) || outpostGrids.Count == 0)
         {
             Logger.ErrorS("nukies", $"Error loading map {path} for nukies!");
             return false;
@@ -625,10 +632,13 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         _nukieOutpost = outpostGrids[0];
 
         // Listen I just don't want it to overlap.
-        var shuttleId = _map.LoadGrid(mapId, shuttlePath.ToString(), new MapLoadOptions()
+        if (!_map.TryLoad(mapId, shuttlePath.ToString(), out var grids, new MapLoadOptions {Offset = Vector2.One*1000f}) || !grids.Any())
         {
-            Offset = Vector2.One * 1000f,
-        });
+            Logger.ErrorS("nukies", $"Error loading grid {shuttlePath} for nukies!");
+            return false;
+        }
+
+        var shuttleId = grids.First();
 
         // Naughty, someone saved the shuttle as a map.
         if (Deleted(shuttleId))
@@ -691,7 +701,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
             _stationSpawningSystem.EquipStartingGear(mob, gearPrototype, profile);
 
         _faction.RemoveFaction(mob, "NanoTrasen", false);
-        _faction.AddFaction(mob, "Syndicate", true);
+        _faction.AddFaction(mob, "Syndicate");
     }
 
     private void SpawnOperatives(int spawnCount, List<IPlayerSession> sessions, bool addSpawnPoints)
@@ -782,11 +792,11 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
 
     private void OnStartAttempt(RoundStartAttemptEvent ev)
     {
-        if (!RuleAdded || Configuration is not NukeopsRuleConfiguration nukeOpsConfig)
+        if (/*!RuleAdded ||*/ Configuration is not NukeopsRuleConfiguration nukeOpsConfig)
             return;
 
         _nukeopsRuleConfig = nukeOpsConfig;
-
+        return;
         var minPlayers = nukeOpsConfig.MinPlayers;
         if (!ev.Forced && ev.Players.Length < minPlayers)
         {
@@ -841,8 +851,10 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         var query = EntityQuery<NukeOperativeComponent, MindComponent>(true);
         foreach (var (_, mindComp) in query)
         {
-            if (mindComp.Mind != null && mindComp.Mind.TryGetSession(out var session) == true)
-                _operativePlayers.Add(session);
+            if (mindComp.Mind == null || !mindComp.Mind.TryGetSession(out var session))
+                continue;
+            var name = MetaData(mindComp.Owner).EntityName;
+            _operativePlayers.Add(name, session);
         }
 
         if (GameTicker.RunLevel == GameRunLevel.InRound)

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
@@ -5,11 +5,11 @@ nukeops-welcome =
     You are a nuclear operative. Your goal is to blow up {$station}, and ensure that it is nothing but a pile of rubble. Your bosses, the Syndicate, have provided you with the tools you'll need for the task.
     Death to Nanotrasen!
 
-nukeops-opsmajor = Syndicate major victory!
-nukeops-opsminor = Syndicate minor victory!
-nukeops-neutral = Neutral outcome!
-nukeops-crewminor = Crew minor victory!
-nukeops-crewmajor = Crew major victory!
+nukeops-opsmajor = [color=crimson]Syndicate major victory![/color]
+nukeops-opsminor = [color=crimson]Syndicate minor victory![/color]
+nukeops-neutral = [color=yellow]Neutral outcome![/color]
+nukeops-crewminor = [color=green]Crew minor victory![/color]
+nukeops-crewmajor = [color=green]Crew major victory![/color]
 
 nukeops-cond-nukeexplodedoncorrectstation = The nuclear operatives managed to blow up the station.
 nukeops-cond-nukeexplodedonnukieoutpost = The nuclear operative outpost was destroyed by a nuclear blast.
@@ -23,7 +23,8 @@ nukeops-cond-allnukiesdead = All nuclear operatives have died.
 nukeops-cond-somenukiesalive = Some nuclear operatives died.
 nukeops-cond-allnukiesalive = No nuclear operatives died.
 
-nukeops-list-start = The nuke ops were:
+nukeops-list-start = The operatives were:
+nukeops-list-name = - [color=White]{$name}[/color] ([color=gray]{$user}[/color])
 nukeops-not-enough-ready-players = Not enough players readied up for the game! There were {$readyPlayersCount} players readied up out of {$minimumPlayers} needed. Can't start Nukeops.
 nukeops-no-one-ready = No players readied up! Can't start Nukeops.
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
ooo ooo ahh oh to have a good looking round-end screen
Closes #8941
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame
- [ ] This PR does not require an ingame showcase

![image](https://user-images.githubusercontent.com/98561806/206821858-95d056b2-0ec6-46e6-b78e-2489fd1b9784.png)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Revamped the Nuke Ops round end screen.

