### PR TITLE
Fix rat pathfinding

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -458,10 +458,11 @@ public sealed partial class PathfindingSystem
                                 continue;
 
                             // TODO: Inefficient af
-                            foreach (var (_, fixture) in fixtures.Fixtures)
+                            foreach (var fixture in fixtures.Fixtures.Values)
                             {
                                 // Don't need to re-do it.
-                                if ((collisionMask & fixture.CollisionMask) == fixture.CollisionMask &&
+                                if (!fixture.Hard ||
+                                    (collisionMask & fixture.CollisionMask) == fixture.CollisionMask &&
                                     (collisionLayer & fixture.CollisionLayer) == fixture.CollisionLayer)
                                     continue;
 

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.NPC;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
+using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Players;
@@ -43,6 +44,7 @@ namespace Content.Server.NPC.Pathfinding
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly DestructibleSystem _destructible = default!;
         [Dependency] private readonly FixtureSystem _fixtures = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
         private ISawmill _sawmill = default!;
 
@@ -239,10 +241,9 @@ namespace Content.Server.NPC.Pathfinding
             var layer = 0;
             var mask = 0;
 
-            if (TryComp<PhysicsComponent>(entity, out var body))
+            if (TryComp<FixturesComponent>(entity, out var fixtures))
             {
-                layer = body.CollisionLayer;
-                mask = body.CollisionMask;
+                (layer, mask) = _physics.GetHardCollision(entity, fixtures);
             }
 
             var request = new BFSPathRequest(maxRange, limit, start.Coordinates, flags, layer, mask, cancelToken);
@@ -386,10 +387,9 @@ namespace Content.Server.NPC.Pathfinding
             var layer = 0;
             var mask = 0;
 
-            if (TryComp<PhysicsComponent>(entity, out var body))
+            if (TryComp<FixturesComponent>(entity, out var fixtures))
             {
-                layer = body.CollisionLayer;
-                mask = body.CollisionMask;
+                (layer, mask) = _physics.GetHardCollision(entity, fixtures);
             }
 
             return new AStarPathRequest(start, end, flags, range, layer, mask, cancelToken);

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -30,6 +30,7 @@ namespace Content.Server.NPC.Systems
         [Dependency] private readonly SharedInteractionSystem _interaction = default!;
         [Dependency] private readonly SharedMeleeWeaponSystem _melee = default!;
         [Dependency] private readonly SharedMoverController _mover = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
         // This will likely get moved onto an abstract pathfinding node that specifies the max distance allowed from the coordinate.
         private const float TileTolerance = 0.40f;


### PR DESCRIPTION
Their non-hard fixtures (flammable?) were being considered for pathfinding.

Fixes https://github.com/space-wizards/space-station-14/issues/12950
Requires https://github.com/space-wizards/RobustToolbox/pull/3565

:cl:
- fix: Rat servants will pathfind under doors again.
