### PR TITLE
Add bluespace lockers

### DIFF
--- a/Content.Server/Administration/Commands/ClearBluespaceLockerLinks.cs
+++ b/Content.Server/Administration/Commands/ClearBluespaceLockerLinks.cs
@@ -1,0 +1,39 @@
+﻿using Content.Server.Storage.Components;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class ClearBluespaceLockerLinks : IConsoleCommand
+{
+    public string Command => "clearbluespacelockerlinks";
+    public string Description => "Removes the bluespace links of the given uid. Does not remove links this uid is the target of.";
+    public string Help => "Usage: clearbluespacelockerlinks <storage uid>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        if (!EntityUid.TryParse(args[0], out var entityUid))
+        {
+            shell.WriteError(Loc.GetString("shell-entity-uid-must-be-number"));
+            return;
+        }
+
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+
+        if (!entityManager.TryGetComponent<EntityStorageComponent>(entityUid, out var originComponent))
+        {
+            shell.WriteError(Loc.GetString("shell-entity-with-uid-lacks-component", ("uid", entityUid), ("componentName", nameof(EntityStorageComponent))));
+            return;
+        }
+
+        originComponent.BluespaceLinks.Clear();
+    }
+}

--- a/Content.Server/Administration/Commands/ClearBluespaceLockerLinks.cs
+++ b/Content.Server/Administration/Commands/ClearBluespaceLockerLinks.cs
@@ -28,12 +28,7 @@ public sealed class ClearBluespaceLockerLinks : IConsoleCommand
 
         var entityManager = IoCManager.Resolve<IEntityManager>();
 
-        if (!entityManager.TryGetComponent<EntityStorageComponent>(entityUid, out var originComponent))
-        {
-            shell.WriteError(Loc.GetString("shell-entity-with-uid-lacks-component", ("uid", entityUid), ("componentName", nameof(EntityStorageComponent))));
-            return;
-        }
-
-        originComponent.BluespaceLinks.Clear();
+        if (entityManager.TryGetComponent<EntityStorageComponent>(entityUid, out var originComponent))
+            entityManager.RemoveComponent(entityUid, originComponent);
     }
 }

--- a/Content.Server/Administration/Commands/ClearBluespaceLockerLinks.cs
+++ b/Content.Server/Administration/Commands/ClearBluespaceLockerLinks.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Server.Storage.Components;
-using Content.Server.Storage.EntitySystems;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 

--- a/Content.Server/Administration/Commands/LinkBluespaceLocker.cs
+++ b/Content.Server/Administration/Commands/LinkBluespaceLocker.cs
@@ -52,8 +52,12 @@ public sealed class LinkBluespaceLocker : IConsoleCommand
             return;
         }
 
-        originComponent.BluespaceLinks.Add(targetComponent);
+        entityManager.EnsureComponent<BluespaceLockerComponent>(originUid, out var originBluespaceComponent);
+        originBluespaceComponent.BluespaceLinks.Add(targetComponent);
         if (bidirectional)
-            targetComponent.BluespaceLinks.Add(originComponent);
+        {
+            entityManager.EnsureComponent<BluespaceLockerComponent>(targetUid, out var targetBluespaceComponent);
+            targetBluespaceComponent.BluespaceLinks.Add(originComponent);
+        }
     }
 }

--- a/Content.Server/Administration/Commands/LinkBluespaceLocker.cs
+++ b/Content.Server/Administration/Commands/LinkBluespaceLocker.cs
@@ -1,0 +1,59 @@
+﻿using Content.Server.Storage.Components;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class LinkBluespaceLocker : IConsoleCommand
+{
+    public string Command => "linkbluespacelocker";
+    public string Description => "Links an entity, the target, to another as a bluespace locker target.";
+    public string Help => "Usage: linkbluespacelocker <two-way link> <origin storage uid> <target storage uid>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 3)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        if (!Boolean.TryParse(args[0], out var bidirectional))
+        {
+            shell.WriteError(Loc.GetString("shell-invalid-bool"));
+            return;
+        }
+
+        if (!EntityUid.TryParse(args[1], out var originUid))
+        {
+            shell.WriteError(Loc.GetString("shell-entity-uid-must-be-number"));
+            return;
+        }
+
+        if (!EntityUid.TryParse(args[2], out var targetUid))
+        {
+            shell.WriteError(Loc.GetString("shell-entity-uid-must-be-number"));
+            return;
+        }
+
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+
+        if (!entityManager.TryGetComponent<EntityStorageComponent>(originUid, out var originComponent))
+        {
+            shell.WriteError(Loc.GetString("shell-entity-with-uid-lacks-component", ("uid", originUid), ("componentName", nameof(EntityStorageComponent))));
+            return;
+        }
+
+        if (!entityManager.TryGetComponent<EntityStorageComponent>(targetUid, out var targetComponent))
+        {
+            shell.WriteError(Loc.GetString("shell-entity-with-uid-lacks-component", ("uid", targetUid), ("componentName", nameof(EntityStorageComponent))));
+            return;
+        }
+
+        originComponent.BluespaceLinks.Add(targetComponent);
+        if (bidirectional)
+            targetComponent.BluespaceLinks.Add(originComponent);
+    }
+}

--- a/Content.Server/Administration/Commands/LinkBluespaceLocker.cs
+++ b/Content.Server/Administration/Commands/LinkBluespaceLocker.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Server.Storage.Components;
-using Content.Server.Storage.EntitySystems;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
 

--- a/Content.Server/Lock/LockSystem.cs
+++ b/Content.Server/Lock/LockSystem.cs
@@ -109,12 +109,13 @@ namespace Content.Server.Lock
             return true;
         }
 
-        public void Unlock(EntityUid uid, EntityUid user, LockComponent? lockComp = null)
+        public void Unlock(EntityUid uid, EntityUid? user, LockComponent? lockComp = null)
         {
             if (!Resolve(uid, ref lockComp))
                 return;
 
-            lockComp.Owner.PopupMessage(user, Loc.GetString("lock-comp-do-unlock-success", ("entityName", EntityManager.GetComponent<MetaDataComponent>(lockComp.Owner).EntityName)));
+            if (user is {Valid: true})
+                lockComp.Owner.PopupMessage(user.Value, Loc.GetString("lock-comp-do-unlock-success", ("entityName", EntityManager.GetComponent<MetaDataComponent>(lockComp.Owner).EntityName)));
             lockComp.Locked = false;
 
             if (lockComp.UnlockSound != null)

--- a/Content.Server/Storage/Components/BluespaceLockerComponent.cs
+++ b/Content.Server/Storage/Components/BluespaceLockerComponent.cs
@@ -4,6 +4,24 @@
 public sealed class BluespaceLockerComponent : Component
 {
     /// <summary>
+    /// Determines if gas will be transported.
+    /// </summary>
+    [DataField("transportGas"), ViewVariables(VVAccess.ReadWrite)]
+    public bool TransportGas = true;
+
+    /// <summary>
+    /// Determines if entities will be transported.
+    /// </summary>
+    [DataField("transportEntities"), ViewVariables(VVAccess.ReadWrite)]
+    public bool TransportEntities = true;
+
+    /// <summary>
+    /// Determines if entities with a Mind component will be transported.
+    /// </summary>
+    [DataField("allowSentient"), ViewVariables(VVAccess.ReadWrite)]
+    public bool AllowSentient = true;
+
+    /// <summary>
     /// If length > 0, when something is added to the storage, it will instead be teleported to a random storage
     /// from the list and the other storage will be opened.
     /// </summary>

--- a/Content.Server/Storage/Components/BluespaceLockerComponent.cs
+++ b/Content.Server/Storage/Components/BluespaceLockerComponent.cs
@@ -1,0 +1,12 @@
+﻿namespace Content.Server.Storage.Components;
+
+[RegisterComponent]
+public sealed class BluespaceLockerComponent : Component
+{
+    /// <summary>
+    /// If length > 0, when something is added to the storage, it will instead be teleported to a random storage
+    /// from the list and the other storage will be opened.
+    /// </summary>
+    [DataField("bluespaceLinks"), ViewVariables(VVAccess.ReadOnly)]
+    public HashSet<EntityStorageComponent> BluespaceLinks = new();
+}

--- a/Content.Server/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Server/Storage/Components/EntityStorageComponent.cs
@@ -98,13 +98,6 @@ public sealed class EntityStorageComponent : Component, IGasMixtureHolder
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public GasMixture Air { get; set; } = new (GasMixVolume);
-
-    /// <summary>
-    /// If length > 0, when something is added to the storage, it will instead be teleported to a random storage
-    /// from the list and the other storage will be opened.
-    /// </summary>
-    [DataField("bluespaceLinks"), ViewVariables(VVAccess.ReadOnly)]
-    public HashSet<EntityStorageComponent> BluespaceLinks = new();
 }
 
 public sealed class InsertIntoEntityStorageAttemptEvent : CancellableEntityEventArgs { }
@@ -121,6 +114,7 @@ public sealed class StorageOpenAttemptEvent : CancellableEntityEventArgs
         Silent = silent;
     }
 }
+public sealed class StorageBeforeOpenEvent : EventArgs { }
 public sealed class StorageAfterOpenEvent : EventArgs { }
 public sealed class StorageCloseAttemptEvent : CancellableEntityEventArgs { }
 public sealed class StorageBeforeCloseEvent : EventArgs

--- a/Content.Server/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Server/Storage/Components/EntityStorageComponent.cs
@@ -98,6 +98,13 @@ public sealed class EntityStorageComponent : Component, IGasMixtureHolder
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public GasMixture Air { get; set; } = new (GasMixVolume);
+
+    /// <summary>
+    /// If length > 0, when something is added to the storage, it will instead be teleported to a random storage
+    /// from the list and the other storage will be opened.
+    /// </summary>
+    [DataField("bluespaceLinks"), ViewVariables(VVAccess.ReadOnly)]
+    public HashSet<EntityStorageComponent> BluespaceLinks = new();
 }
 
 public sealed class InsertIntoEntityStorageAttemptEvent : CancellableEntityEventArgs { }

--- a/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
+++ b/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
@@ -1,0 +1,96 @@
+﻿using System.Linq;
+using Content.Server.Storage.Components;
+using Content.Server.Tools.Systems;
+
+namespace Content.Server.Storage.EntitySystems;
+
+public sealed class BluespaceLockerSystem : EntitySystem
+{
+    [Dependency] private readonly EntityStorageSystem _entityStorage = default!;
+    [Dependency] private readonly WeldableSystem _weldableSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BluespaceLockerComponent, StorageBeforeOpenEvent>(PreOpen);
+        SubscribeLocalEvent<BluespaceLockerComponent, StorageAfterCloseEvent>(PostClose);
+    }
+
+
+    private void PreOpen(EntityUid uid, BluespaceLockerComponent component, StorageBeforeOpenEvent args)
+    {
+        EntityStorageComponent? entityStorageComponent = null;
+
+        if (component.BluespaceLinks is not { Count: > 0 })
+            return;
+
+        if (!Resolve(uid, ref entityStorageComponent))
+            return;
+
+        // Select target
+        var targetContainerStorageComponent = component.BluespaceLinks.ToArray()[new Random().Next(0, component.BluespaceLinks.Count)];
+        BluespaceLockerComponent? targetContainerBluespaceComponent = null;
+
+        // Close target if it is open
+        if (targetContainerStorageComponent.Open)
+            _entityStorage.CloseStorage(targetContainerStorageComponent.Owner, targetContainerStorageComponent);
+
+        // Apply bluespace effects if target is not a bluespace locker, otherwise let it handle it
+        if (!Resolve(targetContainerStorageComponent.Owner, ref targetContainerBluespaceComponent, false) ||
+            targetContainerBluespaceComponent.BluespaceLinks is not { Count: > 0 })
+        {
+            // Move contained items
+            foreach (var entity in targetContainerStorageComponent.Contents.ContainedEntities.ToArray())
+            {
+                entityStorageComponent.Contents.Insert(entity, EntityManager);
+            }
+
+            // Move contained air
+            entityStorageComponent.Air.CopyFromMutable(targetContainerStorageComponent.Air);
+            targetContainerStorageComponent.Air.Clear();
+        }
+    }
+
+    private void PostClose(EntityUid uid, BluespaceLockerComponent component, StorageAfterCloseEvent args)
+    {
+        EntityStorageComponent? entityStorageComponent = null;
+
+        if (component.BluespaceLinks is not { Count: > 0 })
+            return;
+
+        if (!Resolve(uid, ref entityStorageComponent))
+            return;
+
+        // Select target
+        var targetContainerStorageComponent = component.BluespaceLinks.ToArray()[new Random().Next(0, component.BluespaceLinks.Count)];
+
+        // Move contained items
+        foreach (var entity in entityStorageComponent.Contents.ContainedEntities.ToArray())
+        {
+            targetContainerStorageComponent.Contents.Insert(entity, EntityManager);
+        }
+
+        // Move contained air
+        targetContainerStorageComponent.Air.CopyFromMutable(entityStorageComponent.Air);
+        entityStorageComponent.Air.Clear();
+
+        // Open and empty target
+        if (targetContainerStorageComponent.IsWeldedShut)
+        {
+            // It gets bluespaced open...
+            _weldableSystem.ForceWeldedState(targetContainerStorageComponent.Owner, false);
+            if (targetContainerStorageComponent.IsWeldedShut)
+                targetContainerStorageComponent.IsWeldedShut = false;
+        }
+        if (targetContainerStorageComponent.Open)
+        {
+            _entityStorage.EmptyContents(targetContainerStorageComponent.Owner, targetContainerStorageComponent);
+            _entityStorage.ReleaseGas(targetContainerStorageComponent.Owner, targetContainerStorageComponent);
+        }
+        else
+        {
+            _entityStorage.OpenStorage(targetContainerStorageComponent.Owner, targetContainerStorageComponent);
+        }
+    }
+}

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -235,7 +235,14 @@ public sealed class EntityStorageSystem : EntitySystem
             component.Air.Clear();
 
             // Open and empty target
-            targetContainerComponent.IsWeldedShut = false;
+            if (targetContainerComponent.IsWeldedShut)
+            {
+                // It gets bluespaced open...
+                if (EntityManager.TrySystem<WeldableSystem>(out var weldableSystem))
+                    weldableSystem.ForceWeldedState(targetContainerComponent.Owner, false);
+                else
+                    targetContainerComponent.IsWeldedShut = false;
+            }
             if (targetContainerComponent.Open)
             {
                 EmptyContents(targetContainerComponent.Owner, targetContainerComponent);

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -147,6 +147,31 @@ public sealed class EntityStorageSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
+        // Handle bluespace "lockers"
+        if (component.BluespaceLinks is { Count: > 0 })
+        {
+            // Select target
+            var targetContainerComponent = component.BluespaceLinks.ToArray()[new Random().Next(0, component.BluespaceLinks.Count)];
+
+            // Close target if it is open
+            if (targetContainerComponent.Open)
+                CloseStorage(targetContainerComponent.Owner, targetContainerComponent);
+
+            // Apply bluespace effects if target is not a bluespace locker, otherwise let it handle it
+            if (targetContainerComponent.BluespaceLinks is not { Count: > 0 })
+            {
+                // Move contained items
+                foreach (var entity in targetContainerComponent.Contents.ContainedEntities.ToArray())
+                {
+                    component.Contents.Insert(entity, EntityManager);
+                }
+
+                // Move contained air
+                component.Air.CopyFromMutable(targetContainerComponent.Air);
+                targetContainerComponent.Air.Clear();
+            }
+        }
+
         component.Open = true;
         EmptyContents(uid, component);
         ModifyComponents(uid, component);
@@ -192,6 +217,35 @@ public sealed class EntityStorageSystem : EntitySystem
         _audio.PlayPvs(component.CloseSound, component.Owner);
         component.LastInternalOpenAttempt = default;
         RaiseLocalEvent(uid, new StorageAfterCloseEvent());
+
+        // Handle bluespace "lockers"
+        if (component.BluespaceLinks is { Count: > 0 })
+        {
+            // Select target
+            var targetContainerComponent = component.BluespaceLinks.ToArray()[new Random().Next(0, component.BluespaceLinks.Count)];
+
+            // Move contained items
+            foreach (var entity in component.Contents.ContainedEntities.ToArray())
+            {
+                targetContainerComponent.Contents.Insert(entity, EntityManager);
+            }
+
+            // Move contained air
+            targetContainerComponent.Air.CopyFromMutable(component.Air);
+            component.Air.Clear();
+
+            // Open and empty target
+            targetContainerComponent.IsWeldedShut = false;
+            if (targetContainerComponent.Open)
+            {
+                EmptyContents(targetContainerComponent.Owner, targetContainerComponent);
+                ReleaseGas(targetContainerComponent.Owner, targetContainerComponent);
+            }
+            else
+            {
+                OpenStorage(targetContainerComponent.Owner, targetContainerComponent);
+            }
+        }
     }
 
     public bool Insert(EntityUid toInsert, EntityUid container, EntityStorageComponent? component = null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds support for bluespace locker functionality. While this doesn't introduce them without administrator intervention, it does allow them to be used by administrators for both traditional ss13 uses and for use as a one way teleport. Using them as a one way teleporter can be especially useful for administrators to allow players who are preparing at centcom or an admin test area to teleport themselves to the station whenever they're ready.

Function:
- Any EntityStorageComponent can be linked to one or more others, making it a "bluespace container"
- A can link to B without requiring that B link back to A or have any links at all
- When a bluespace container is closed...
  - It's contents, including gas, are transported to a randomly selected link
  - If the target is welded, it is unwelded
  - If the target is locked, it is unlocked
  - If the target is not open, it is opened
- When a bluespace container is opened...
  - The contents, including gas, of a randomly selected link are transported to it
  - If the selected link is open, it is closed

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] [Convince someone to take a video of this for me or convince someone to merge this without a video.](https://github.com/space-wizards/space-station-14/pull/12954#issuecomment-1345552457)
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame
- [ ] This PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Nanotrasen has begun experiments with advanced locker technology.

