### PR TITLE
Fix error when spawning nuke ops

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -549,7 +549,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
             var name = session.AttachedEntity == null
                 ? string.Empty
                 : MetaData(session.AttachedEntity.Value).EntityName;
-            _operativePlayers.Add(name, session);
+            // TODO: Fix this being able to have duplicates
+            _operativePlayers[name] = session;
         }
     }
 


### PR DESCRIPTION
## About the PR
Fixes #12960 

From Grafana:
```
Caught exception in GameTicker
System.ArgumentException: An item with the same key has already been added. Key: Commander Pi
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at Content.Server.GameTicking.Rules.NukeopsRuleSystem.OnPlayersSpawning(RulePlayerSpawningEvent ev) in /home/runner/work/space-station-14/space-station-14/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs:line 552
   at Robust.Shared.GameObjects.EntityEventBus.ProcessSingleEventCore(EventSource source, Unit& unitRef, EventData subs, Boolean byRef) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 321
   at Robust.Shared.GameObjects.EntityEventBus.RaiseEvent[T](EventSource source, T toRaise) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 260
   at Content.Server.GameTicking.GameTicker.SpawnPlayers(List`1 readyPlayers, Dictionary`2 profiles, Boolean force) in /home/runner/work/space-station-14/space-station-14/Content.Server/GameTicking/GameTicker.Spawning.cs:line 40
   at Content.Server.GameTicking.GameTicker.StartRound(Boolean force) in /home/runner/work/space-station-14/space-station-14/Content.Server/GameTicking/GameTicker.RoundFlow.cs:line 236
 Catcher=GameTicker Sawmill=runtime
```

**Media**
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame
- [x] This PR does not require an ingame showcase


**Changelog**
:cl:
- fix: Fixed a server error when spawning nuke ops.

