### PR TITLE
Reset eye lerp on parent map change

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -158,6 +158,20 @@ namespace Content.Shared.Movement.Systems
                 return;
             }
 
+            var oldMapId = args.OldMapId;
+            var mapId = args.Transform.MapID;
+
+            // If we change maps then reset eye rotation entirely.
+            if (oldMapId != mapId)
+            {
+                component.RelativeEntity = relative;
+                component.TargetRelativeRotation = Angle.Zero;
+                component.RelativeRotation = Angle.Zero;
+                component.LerpAccumulator = 0f;
+                Dirty(component);
+                return;
+            }
+
             // If we go on a grid and back off then just reset the accumulator.
             if (relative == component.RelativeEntity)
             {


### PR DESCRIPTION
Shouldn't affect escape shuttles but if we're mapping it will just reset it to our new relative entity.

:cl:
- tweak: Eye lerping will reset on map changes.
