### PR TITLE
Fix salvage magnet parent

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: SalvageMagnet
-  parent: BaseMachine
+  parent: BaseMachinePowered
   name: salvage magnet
   description: "Pulls in salvage."
   components:


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Because this needs power, it should parent BaseMachinePowered so that it gets an ExtensionCableReceiver component.

Steps to reproduce:

- Notice that the salvage magnet always appears unpowered, even when it is wrenched down on powered LV

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: notafet
- fix: Salvage magnets now correctly appear powered