### PR TITLE
Add osay command

### DIFF
--- a/Content.Server/Administration/Commands/OSay.cs
+++ b/Content.Server/Administration/Commands/OSay.cs
@@ -5,59 +5,58 @@ using Content.Shared.Administration;
 using Content.Shared.Database;
 using Robust.Shared.Console;
 
-namespace Content.Server.Administration.Commands
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class OSay : LocalizedCommands
 {
-    [AdminCommand(AdminFlags.Admin)]
-    public sealed class OSay : LocalizedCommands
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    public override string Command => "osay";
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
-        [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-        [Dependency] private readonly IEntityManager _entityManager = default!;
-
-        public override string Command => "osay";
-
-        public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        if (args.Length == 1)
         {
-            if (args.Length == 1)
-            {
-                return CompletionResult.FromHint(Loc.GetString("osay-command-arg-uid"));
-            }
-
-            if (args.Length == 2)
-            {
-                return CompletionResult.FromHintOptions( Enum.GetNames(typeof(InGameICChatType)),
-                    Loc.GetString("osay-command-arg-type"));
-            }
-
-            if (args.Length > 2)
-            {
-                return CompletionResult.FromHint(Loc.GetString("osay-command-arg-message"));
-            }
-
-            return CompletionResult.Empty;
+            return CompletionResult.FromHint(Loc.GetString("osay-command-arg-uid"));
         }
 
-        public override void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (args.Length == 2)
         {
-            if (args.Length < 3)
-            {
-                shell.WriteLine(Loc.GetString("osay-command-error-args"));
-                return;
-            }
-
-            var chatType = (InGameICChatType) Enum.Parse(typeof(InGameICChatType), args[1]);
-
-            if (!EntityUid.TryParse(args[0], out var source) || !_entityManager.EntityExists(source))
-            {
-                shell.WriteLine(Loc.GetString("osay-command-error-euid", ("arg", args[0])));
-                return;
-            }
-
-            var message = string.Join(" ", args.Skip(2)).Trim();
-            if (string.IsNullOrEmpty(message))
-                return;
-
-            _entityManager.System<ChatSystem>().TrySendInGameICMessage(source, message, chatType, false);
-            _adminLogger.Add(LogType.Action, LogImpact.Low, $"{(shell.Player != null ? shell.Player.Name : "An administrator")} forced {_entityManager.ToPrettyString(source)} to {args[1]}: {message}");
+            return CompletionResult.FromHintOptions( Enum.GetNames(typeof(InGameICChatType)),
+                Loc.GetString("osay-command-arg-type"));
         }
+
+        if (args.Length > 2)
+        {
+            return CompletionResult.FromHint(Loc.GetString("osay-command-arg-message"));
+        }
+
+        return CompletionResult.Empty;
+    }
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length < 3)
+        {
+            shell.WriteLine(Loc.GetString("osay-command-error-args"));
+            return;
+        }
+
+        var chatType = (InGameICChatType) Enum.Parse(typeof(InGameICChatType), args[1]);
+
+        if (!EntityUid.TryParse(args[0], out var source) || !_entityManager.EntityExists(source))
+        {
+            shell.WriteLine(Loc.GetString("osay-command-error-euid", ("arg", args[0])));
+            return;
+        }
+
+        var message = string.Join(" ", args.Skip(2)).Trim();
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        _entityManager.System<ChatSystem>().TrySendInGameICMessage(source, message, chatType, false);
+        _adminLogger.Add(LogType.Action, LogImpact.Low, $"{(shell.Player != null ? shell.Player.Name : "An administrator")} forced {_entityManager.ToPrettyString(source)} to {args[1]}: {message}");
     }
 }

--- a/Content.Server/Administration/Commands/OSay.cs
+++ b/Content.Server/Administration/Commands/OSay.cs
@@ -8,18 +8,14 @@ using Robust.Shared.Console;
 namespace Content.Server.Administration.Commands
 {
     [AdminCommand(AdminFlags.Admin)]
-    sealed class OSay : IConsoleCommand
+    sealed class OSay : LocalizedCommands
     {
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
 
-        public string Command => "osay";
+        public override string Command => "osay";
 
-        public string Description => Loc.GetString("osay-command-description");
-
-        public string Help => Loc.GetString("osay-command-help-text", ("command", Command));
-
-        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
         {
             if (args.Length == 1)
             {
@@ -40,7 +36,7 @@ namespace Content.Server.Administration.Commands
             return CompletionResult.Empty;
         }
 
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (args.Length < 3)
             {

--- a/Content.Server/Administration/Commands/OSay.cs
+++ b/Content.Server/Administration/Commands/OSay.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using Content.Server.Administration.Logs;
+using Content.Server.Chat.Systems;
+using Content.Shared.Administration;
+using Content.Shared.Database;
+using Robust.Shared.Console;
+
+namespace Content.Server.Administration.Commands
+{
+    [AdminCommand(AdminFlags.Admin)]
+    sealed class OSay : IConsoleCommand
+    {
+        [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+
+        public string Command => "osay";
+
+        public string Description => Loc.GetString("osay-command-description");
+
+        public string Help => Loc.GetString("osay-command-help-text", ("command", Command));
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 1)
+            {
+                return CompletionResult.FromHint(Loc.GetString("osay-command-arg-uid"));
+            }
+
+            if (args.Length == 2)
+            {
+                return CompletionResult.FromHintOptions( Enum.GetNames(typeof(InGameICChatType)),
+                    Loc.GetString("osay-command-arg-type"));
+            }
+
+            if (args.Length > 2)
+            {
+                return CompletionResult.FromHint(Loc.GetString("osay-command-arg-message"));
+            }
+
+            return CompletionResult.Empty;
+        }
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length < 3)
+            {
+                shell.WriteLine(Loc.GetString("osay-command-error-args"));
+                return;
+            }
+
+            var chatType = (InGameICChatType) Enum.Parse(typeof(InGameICChatType), args[1]);
+
+            EntityUid source;
+            if (!EntityUid.TryParse(args[0], out source) || !_entityManager.EntityExists(source))
+            {
+                shell.WriteLine(Loc.GetString("osay-command-error-euid", ("arg", args[0])));
+                return;
+            }
+
+            var message = string.Join(" ", args.Skip(2)).Trim();
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            var chatSystem = EntitySystem.Get<ChatSystem>();
+            chatSystem.TrySendInGameICMessage(source, message, chatType, false);
+            _adminLogger.Add(LogType.Action, LogImpact.Low, $"{(shell.Player != null ? shell.Player.Name : "An administrator")} forced {_entityManager.ToPrettyString(source)} to {args[1]}: {message}");
+        }
+    }
+}

--- a/Content.Server/Administration/Commands/OSay.cs
+++ b/Content.Server/Administration/Commands/OSay.cs
@@ -61,7 +61,7 @@ namespace Content.Server.Administration.Commands
             if (string.IsNullOrEmpty(message))
                 return;
 
-            var chatSystem = EntitySystem.Get<ChatSystem>();
+            var chatSystem = _entityManager.System<ChatSystem>();
             chatSystem.TrySendInGameICMessage(source, message, chatType, false);
             _adminLogger.Add(LogType.Action, LogImpact.Low, $"{(shell.Player != null ? shell.Player.Name : "An administrator")} forced {_entityManager.ToPrettyString(source)} to {args[1]}: {message}");
         }

--- a/Content.Server/Administration/Commands/OSay.cs
+++ b/Content.Server/Administration/Commands/OSay.cs
@@ -46,8 +46,7 @@ namespace Content.Server.Administration.Commands
 
             var chatType = (InGameICChatType) Enum.Parse(typeof(InGameICChatType), args[1]);
 
-            EntityUid source;
-            if (!EntityUid.TryParse(args[0], out source) || !_entityManager.EntityExists(source))
+            if (!EntityUid.TryParse(args[0], out var source) || !_entityManager.EntityExists(source))
             {
                 shell.WriteLine(Loc.GetString("osay-command-error-euid", ("arg", args[0])));
                 return;
@@ -57,8 +56,7 @@ namespace Content.Server.Administration.Commands
             if (string.IsNullOrEmpty(message))
                 return;
 
-            var chatSystem = _entityManager.System<ChatSystem>();
-            chatSystem.TrySendInGameICMessage(source, message, chatType, false);
+            _entityManager.System<ChatSystem>().TrySendInGameICMessage(source, message, chatType, false);
             _adminLogger.Add(LogType.Action, LogImpact.Low, $"{(shell.Player != null ? shell.Player.Name : "An administrator")} forced {_entityManager.ToPrettyString(source)} to {args[1]}: {message}");
         }
     }

--- a/Content.Server/Administration/Commands/OSay.cs
+++ b/Content.Server/Administration/Commands/OSay.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Console;
 namespace Content.Server.Administration.Commands
 {
     [AdminCommand(AdminFlags.Admin)]
-    sealed class OSay : LocalizedCommands
+    public sealed class OSay : LocalizedCommands
     {
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;

--- a/Resources/Locale/en-US/administration/commands/osay-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/osay-command.ftl
@@ -1,0 +1,9 @@
+osay-command-description = Forces another entity to try to send a message
+osay-command-help-text = Usage: {$command} <uid> <type> <message>
+
+osay-command-arg-uid = source uid
+osay-command-arg-type = type
+osay-command-arg-message = message
+
+osay-command-error-args = Invalid number of arguments
+osay-command-error-euid = {$arg} is not a valid entity uid.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `osay` command that allows admins to force other entities to try to speak without first controlling them. Doesn't bypass speech requirements, so if the entity can't speak it wont say anything. This means an inanimate object cannot be made to speak without first being made sentient or something.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/119664036/208240842-9e7b1733-ea02-47e7-aac3-57f491167332.png)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase