### PR TITLE
Fix signal linker removing exception

### DIFF
--- a/Content.Server/MachineLinking/System/SignalLinkerSystem.cs
+++ b/Content.Server/MachineLinking/System/SignalLinkerSystem.cs
@@ -163,15 +163,19 @@ namespace Content.Server.MachineLinking.System
             // validate links
             Dictionary<EntityUid, SignalTransmitterComponent?> uidCache = new();
             foreach (var rport in receiver.Inputs)
+            {
+                var toRemove = new List<PortIdentifier>();
                 foreach (var tport in rport.Value)
                 {
                     if (!uidCache.TryGetValue(tport.Uid, out var transmitter))
                         uidCache.Add(tport.Uid, transmitter = CompOrNull<SignalTransmitterComponent>(tport.Uid));
                     if (transmitter == null || !transmitter.Outputs.TryGetValue(tport.Port, out var tpv))
-                        rport.Value.Remove(tport);
+                        toRemove.Add(tport);
                     else if (!tpv.Contains(new(uid, rport.Key)))
                         tpv.Add(new(uid, rport.Key));
                 }
+                toRemove.ForEach(tport => rport.Value.Remove(tport));
+            }
         }
 
         private void OnTransmitterRemoved(EntityUid uid, SignalTransmitterComponent transmitter, ComponentRemove args)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix exception on map loading

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Screenshot_430](https://user-images.githubusercontent.com/14136326/208247840-7017aaff-6ced-4559-9d80-bca98da10243.png)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->


