### PR TITLE
RCD + research unlock test

### DIFF
--- a/Content.IntegrationTests/Tests/ResearchTest.cs
+++ b/Content.IntegrationTests/Tests/ResearchTest.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Content.Shared.Lathe;
+using Content.Shared.Research.Prototypes;
+using NUnit.Framework;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests;
+
+[TestFixture]
+public sealed class ResearchTest
+{
+    [Test]
+    public async Task AllTechPrintableTest()
+    {
+        await using var pairTracker = await PoolManager.GetServerClient(new PoolSettings {NoClient = true});
+        var server = pairTracker.Pair.Server;
+
+        var protoManager = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var allEnts = protoManager.EnumeratePrototypes<EntityPrototype>();
+            var allLathes = new HashSet<LatheComponent>();
+            foreach (var proto in allEnts)
+            {
+                if (proto.Abstract)
+                    continue;
+
+                if (!proto.TryGetComponent<LatheComponent>(out var lathe))
+                    continue;
+                allLathes.Add(lathe);
+            }
+
+            var latheTechs = new HashSet<string>();
+            foreach (var lathe in allLathes)
+            {
+                if (lathe.DynamicRecipes == null)
+                    continue;
+
+                foreach (var recipe in lathe.DynamicRecipes)
+                {
+                    if (!latheTechs.Contains(recipe))
+                        latheTechs.Add(recipe);
+                }
+            }
+
+            foreach (var tech in protoManager.EnumeratePrototypes<TechnologyPrototype>())
+            {
+                foreach (var recipe in tech.UnlockedRecipes)
+                {
+                    Assert.That(latheTechs, Does.Contain(recipe), $"Recipe \"{recipe}\" cannot be unlocked on any lathes.");
+                }
+            }
+        });
+
+        await pairTracker.CleanReturnAsync();
+    }
+}

--- a/Resources/Locale/en-US/prototypes/catalog/research/technologies.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/research/technologies.ftl
@@ -38,7 +38,7 @@ technologies-industrial-engineering = Industrial engineering
 technologies-industrial-engineering-description = A refresher course on modern engineering technology.
 
 technologies-rapid-upgrade = Rapid upgrade
-technologies-rapid-upgrade-description = The ability to quickly upgrade the station like never before.
+technologies-rapid-upgrade-description = The ability to quickly improve the station like never before.
 
 technologies-material-sheet-printing = Material sheet printing
 technologies-material-sheet-printing-description = Print those sheets!

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -357,8 +357,6 @@
   - ElectromagneticTheory
   - IndustrialEngineering
   unlockedRecipes:
-  - RCD
-  - RCDAmmo
   - SMESMachineCircuitboard
   - PowerComputerCircuitboard
   - GeneratorPlasmaMachineCircuitboard
@@ -389,10 +387,12 @@
   icon: 
     sprite: Objects/Specific/Research/rped.rsi
     state: icon
-  requiredPoints: 7500
+  requiredPoints: 10000
   requiredTechnologies:
   - ElectricalEngineering
   unlockedRecipes:
+  - RCD
+  - RCDAmmo
   - RPED
 
 - type: technology

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -268,6 +268,14 @@
     price: 100
 
 - type: entity
+  id: RCDEmpty
+  parent: RCD
+  suffix: Empty
+  components:
+  - type: RCD
+    ammo: 0
+  
+- type: entity
   name: RCD Ammo
   parent: BaseItem
   id: RCDAmmo

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -169,6 +169,7 @@
       - CableHVStack
       - ConveyorBeltAssembly
       - AppraisalTool
+      - RCD
       - RCDAmmo
       - HydroponicsToolScythe
       - HydroponicsToolHatchet

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -115,7 +115,7 @@
   icon:
     sprite: Objects/Tools/rcd.rsi
     state: icon
-  result: RCD
+  result: RCDEmpty
   completetime: 4
   materials:
     Steel: 1000


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds back the RCD in the rapid upgrade tech.
RCD now starts with 0 charges when printed.
Also adds in a test for making sure that all the tech is printable in lathes

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: RCD is once again printable at protolathes. Unlock it in the Rapid Upgrades tech.
- tweak: Freshly-printed RCDs now start with 0 charges.

