### PR TITLE
research disk debug stuff

### DIFF
--- a/Content.Server/Research/Disk/ResearchDiskComponent.cs
+++ b/Content.Server/Research/Disk/ResearchDiskComponent.cs
@@ -3,7 +3,17 @@ namespace Content.Server.Research.Disk
     [RegisterComponent]
     public sealed class ResearchDiskComponent : Component
     {
-        [DataField("points")]
+        [DataField("points"), ViewVariables(VVAccess.ReadWrite)]
         public int Points = 1000;
+
+        /// <summary>
+        /// If true, the value of this disk will be set to the sum
+        /// of all the technologies in the game.
+        /// </summary>
+        /// <remarks>
+        /// This is for debug purposes only.
+        /// </remarks>
+        [DataField("unlockAllTech")]
+        public bool UnlockAllTech = false;
     }
 }

--- a/Content.Server/Research/Disk/ResearchDiskSystem.cs
+++ b/Content.Server/Research/Disk/ResearchDiskSystem.cs
@@ -1,17 +1,22 @@
+using System.Linq;
 using Content.Shared.Interaction;
 using Content.Server.Research.Components;
 using Content.Server.Popups;
+using Content.Shared.Research.Prototypes;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Research.Disk
 {
     public sealed class ResearchDiskSystem : EntitySystem
     {
+        [Dependency] private readonly IPrototypeManager _prototype = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         public override void Initialize()
         {
             base.Initialize();
             SubscribeLocalEvent<ResearchDiskComponent, AfterInteractEvent>(OnAfterInteract);
+            SubscribeLocalEvent<ResearchDiskComponent, MapInitEvent>(OnMapInit);
         }
 
         private void OnAfterInteract(EntityUid uid, ResearchDiskComponent component, AfterInteractEvent args)
@@ -25,6 +30,15 @@ namespace Content.Server.Research.Disk
             server.Points += component.Points;
             _popupSystem.PopupEntity(Loc.GetString("research-disk-inserted", ("points", component.Points)), args.Target.Value, Filter.Entities(args.User));
             EntityManager.QueueDeleteEntity(uid);
+        }
+
+        private void OnMapInit(EntityUid uid, ResearchDiskComponent component, MapInitEvent args)
+        {
+            if (!component.UnlockAllTech)
+                return;
+
+            component.Points = _prototype.EnumeratePrototypes<TechnologyPrototype>()
+                .Sum(tech => tech.RequiredPoints);
         }
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/disk.yml
@@ -26,3 +26,14 @@
   components:
   - type: ResearchDisk
     points: 10000
+
+- type: entity
+  parent: ResearchDisk
+  id: ResearchDiskDebug
+  name: research point disk
+  suffix: DEBUG, DO NOT MAP
+  description: A disk for the R&D server containing all the points you could ever need.
+  components:
+  - type: ResearchDisk
+    points: 10000
+    unlockAllTech: true


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- You can now VV the point cost of research disks
- Added a research disk that has points equal to the sum of all tech unlocks. (for debugging purposes)

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

fake admin cl
- you can now vv research disks
- added a research disk which always has points equal to the sum of all technology unlock costs.