### PR TITLE
Fix stack overflow in FlashOverlay dispose.

### DIFF
--- a/Content.Client/Flash/FlashOverlay.cs
+++ b/Content.Client/Flash/FlashOverlay.cs
@@ -76,7 +76,7 @@ namespace Content.Client.Flash
 
         protected override void DisposeBehavior()
         {
-            base.Dispose();
+            base.DisposeBehavior();
             _screenshotTexture = null;
         }
     }


### PR DESCRIPTION
Test memory leak improvements I'm doing are running into this unironically.