### PR TITLE
Cardboard box bug fixe

### DIFF
--- a/Content.Server/CardboardBox/CardboardBoxSystem.cs
+++ b/Content.Server/CardboardBox/CardboardBoxSystem.cs
@@ -1,18 +1,17 @@
-using System.Linq;
-using Content.Shared.CardboardBox.Components;
 using Content.Server.Storage.Components;
 using Content.Server.Storage.EntitySystems;
 using Content.Shared.CardboardBox;
+using Content.Shared.CardboardBox.Components;
 using Content.Shared.Damage;
-using Content.Shared.Damage.Prototypes;
 using Content.Shared.Interaction;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Stealth;
+using Content.Shared.Stealth.Components;
+using Robust.Server.GameObjects;
+using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
-using Content.Shared.Stealth.Components;
-using Content.Shared.Stealth;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.CardboardBox;
 
@@ -23,16 +22,15 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedStealthSystem _stealth = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly EntityStorageSystem _storage = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<CardboardBoxComponent, StorageBeforeCloseEvent>(OnBeforeStorageClosed);
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterOpenEvent>(AfterStorageOpen);
         SubscribeLocalEvent<CardboardBoxComponent, StorageAfterCloseEvent>(AfterStorageClosed);
         SubscribeLocalEvent<CardboardBoxComponent, InteractedNoHandEvent>(OnNoHandInteracted);
+        SubscribeLocalEvent<CardboardBoxComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
 
         SubscribeLocalEvent<CardboardBoxComponent, DamageChangedEvent>(OnDamage);
     }
@@ -44,26 +42,6 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
             return;
 
         _storage.OpenStorage(uid);
-    }
-
-    private void OnBeforeStorageClosed(EntityUid uid, CardboardBoxComponent component, StorageBeforeCloseEvent args)
-    {
-        var mobMover = args.Contents.Where(HasComp<MobMoverComponent>).ToList();
-
-        //Grab the first mob to set as the mover and to prevent other mobs from entering.
-        foreach (var mover in mobMover)
-        {
-            //Set the movement relay for the box as the first mob
-            if (component.Mover == null)
-            {
-                var relay = EnsureComp<RelayInputMoverComponent>(mover);
-                _mover.SetRelay(mover, uid, relay);
-                component.Mover = mover;
-            }
-
-            if (mover != component.Mover)
-                args.Contents.Remove(mover);
-        }
     }
 
     private void AfterStorageOpen(EntityUid uid, CardboardBoxComponent component, StorageAfterOpenEvent args)
@@ -103,5 +81,24 @@ public sealed class CardboardBoxSystem : SharedCardboardBoxSystem
         {
             _damageable.TryChangeDamage(component.Mover, args.DamageDelta, origin: args.Origin);
         }
+    }
+
+    private void OnEntInserted(EntityUid uid, CardboardBoxComponent component, EntInsertedIntoContainerMessage args)
+    {
+        if (!TryComp(args.Entity, out MobMoverComponent? mover))
+            return;
+
+        if (component.Mover != null)
+        {
+            // player movers take priority
+            if (HasComp<ActorComponent>(component.Mover) || !HasComp<ActorComponent>(args.Entity))
+                return;
+
+            RemComp<RelayInputMoverComponent>(component.Mover.Value);
+        }
+
+        var relay = EnsureComp<RelayInputMoverComponent>(args.Entity);
+        _mover.SetRelay(args.Entity, uid, relay);
+        component.Mover = args.Entity;
     }
 }

--- a/Content.Server/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Server/Storage/Components/EntityStorageComponent.cs
@@ -118,8 +118,6 @@ public sealed class StorageAfterOpenEvent : EventArgs { }
 public sealed class StorageCloseAttemptEvent : CancellableEntityEventArgs { }
 public sealed class StorageBeforeCloseEvent : EventArgs
 {
-    public EntityUid Container;
-
     public HashSet<EntityUid> Contents;
 
     /// <summary>
@@ -127,9 +125,8 @@ public sealed class StorageBeforeCloseEvent : EventArgs
     /// </summary>
     public HashSet<EntityUid> BypassChecks = new();
 
-    public StorageBeforeCloseEvent(EntityUid container, HashSet<EntityUid> contents)
+    public StorageBeforeCloseEvent(HashSet<EntityUid> contents)
     {
-        Container = container;
         Contents = contents;
     }
 }

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -178,8 +178,8 @@ public sealed class EntityStorageSystem : EntitySystem
 
         var entities = _lookup.GetEntitiesInRange(targetCoordinates, component.EnteringRange, LookupFlags.Approximate | LookupFlags.Dynamic | LookupFlags.Sundries);
 
-        var ev = new StorageBeforeCloseEvent(uid, entities);
-        RaiseLocalEvent(uid, ev, true);
+        var ev = new StorageBeforeCloseEvent(entities);
+        RaiseLocalEvent(uid, ev);
         var count = 0;
         foreach (var entity in ev.Contents)
         {


### PR DESCRIPTION
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Changes the relay mover setting code to happen on entity insert, rather than during the before insert entity filtering step.

:cl:
- fix: Fixed a bug allowing players to control a moving cardboard box without being inside of that box.

