### PR TITLE
Cleaning up obsolete properties in mobstate component

### DIFF
--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -1,7 +1,7 @@
-using System.Linq;
 using Content.Server.Body.Components;
 using Content.Server.Chemistry.Components.SolutionManager;
 using Content.Server.Chemistry.EntitySystems;
+using Content.Server.MobState;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Body.Organ;
 using Content.Shared.Chemistry.Components;
@@ -22,6 +22,7 @@ namespace Content.Server.Body.Systems
         [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
         public override void Initialize()
@@ -159,7 +160,7 @@ namespace Content.Server.Body.Systems
                     // still remove reagents
                     if (EntityManager.TryGetComponent<MobStateComponent>(solutionEntityUid.Value, out var state))
                     {
-                        if (state.IsDead())
+                        if (_mobStateSystem.IsDead(solutionEntityUid.Value, state))
                             continue;
                     }
 

--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -91,7 +91,7 @@ namespace Content.Server.GameTicking
         public void SetGamePreset(string preset, bool force = false)
         {
             var proto = FindGamePreset(preset);
-            if(proto != null)
+            if (proto != null)
                 SetGamePreset(proto, force);
         }
 
@@ -180,7 +180,7 @@ namespace Content.Server.GameTicking
 
             if (canReturnGlobal && TryComp(playerEntity, out MobStateComponent? mobState))
             {
-                if (mobState.IsCritical())
+                if (_mobStateSystem.IsCritical(playerEntity.Value, mobState))
                 {
                     canReturn = true;
 
@@ -197,7 +197,7 @@ namespace Content.Server.GameTicking
             // If all else fails, it'll default to the default entity prototype name, "observer".
             // However, that should rarely happen.
             var meta = MetaData(ghost);
-            if(!string.IsNullOrWhiteSpace(mind.CharacterName))
+            if (!string.IsNullOrWhiteSpace(mind.CharacterName))
                 meta.EntityName = mind.CharacterName;
             else if (!string.IsNullOrWhiteSpace(mind.Session?.Name))
                 meta.EntityName = mind.Session.Name;

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -1,11 +1,11 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
-using Content.Server.Chat;
 using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Server.Database;
 using Content.Server.Ghost;
 using Content.Server.Maps;
+using Content.Server.MobState;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Preferences.Managers;
 using Content.Server.ServerUpdates;
@@ -16,24 +16,23 @@ using Content.Shared.GameTicking;
 using Content.Shared.Roles;
 using Robust.Server;
 using Robust.Server.GameObjects;
-using Robust.Server.Maps;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
-#if EXCEPTION_TOLERANCE
-using Robust.Shared.Exceptions;
-#endif
 using Robust.Shared.Map;
-using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+#if EXCEPTION_TOLERANCE
+using Robust.Shared.Exceptions;
+#endif
 
 namespace Content.Server.GameTicking
 {
     public sealed partial class GameTicker : SharedGameTicker
     {
         [Dependency] private readonly MapLoaderSystem _map = default!;
+        [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
 
         [ViewVariables] private bool _initialized;
         [ViewVariables] private bool _postInitialized;
@@ -58,7 +57,8 @@ namespace Content.Server.GameTicking
             InitializeLobbyMusic();
             InitializeLobbyBackground();
             InitializeGamePreset();
-            DebugTools.Assert(_prototypeManager.Index<JobPrototype>(FallbackOverflowJob).Name == FallbackOverflowJobName,
+            DebugTools.Assert(
+                _prototypeManager.Index<JobPrototype>(FallbackOverflowJob).Name == FallbackOverflowJobName,
                 "Overflow role does not have the correct name!");
             InitializeGameRules();
 

--- a/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
@@ -1,5 +1,5 @@
 using Content.Server.Chat.Managers;
-using Content.Server.GameTicking.Rules.Configurations;
+using Content.Server.MobState;
 using Content.Shared.CCVar;
 using Content.Shared.Damage;
 using Content.Shared.MobState.Components;
@@ -19,6 +19,7 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem
 
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private const float RestartDelay = 10f;
@@ -106,7 +107,7 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem
                 || !TryComp(playerEntity, out MobStateComponent? state))
                 continue;
 
-            if (!state.IsAlive())
+            if (!_mobStateSystem.IsAlive(playerEntity, state))
                 continue;
 
             // Found a second person alive, nothing decided yet!
@@ -118,7 +119,7 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem
 
         _chatManager.DispatchServerAnnouncement(winner == null
             ? Loc.GetString("rule-death-match-check-winner-stalemate")
-            : Loc.GetString("rule-death-match-check-winner",("winner", winner)));
+            : Loc.GetString("rule-death-match-check-winner", ("winner", winner)));
 
         _chatManager.DispatchServerAnnouncement(Loc.GetString("rule-restarting-in-seconds", ("seconds", RestartDelay)));
         _restartTimer = RestartDelay;

--- a/Content.Server/Objectives/Conditions/KillRandomPersonCondition.cs
+++ b/Content.Server/Objectives/Conditions/KillRandomPersonCondition.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Mind.Components;
+using Content.Server.MobState;
 using Content.Server.Objectives.Interfaces;
 using Content.Shared.MobState.Components;
 using JetBrains.Annotations;
@@ -14,6 +15,7 @@ namespace Content.Server.Objectives.Conditions
         public override IObjectiveCondition GetAssigned(Mind.Mind mind)
         {
             var entityMgr = IoCManager.Resolve<IEntityManager>();
+            var mobStateMgr = IoCManager.Resolve<MobStateSystem>();
             var allHumans = entityMgr.EntityQuery<MindComponent>(true).Where(mc =>
             {
                 var entity = mc.Mind?.OwnedEntity;
@@ -22,7 +24,7 @@ namespace Content.Server.Objectives.Conditions
                     return false;
 
                 return entityMgr.TryGetComponent(entity, out MobStateComponent? mobState) &&
-                       mobState.IsAlive() &&
+                       mobStateMgr.IsAlive(entity.Value, mobState) &&
                        mc.Mind != mind;
             }).Select(mc => mc.Mind).ToList();
 

--- a/Content.Server/Suspicion/SuspicionRoleComponent.cs
+++ b/Content.Server/Suspicion/SuspicionRoleComponent.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.GameTicking.Rules;
 using Content.Server.Mind.Components;
+using Content.Server.MobState;
 using Content.Server.Roles;
 using Content.Server.Suspicion.Roles;
 using Content.Shared.MobState.Components;
@@ -12,10 +13,10 @@ namespace Content.Server.Suspicion
     public sealed class SuspicionRoleComponent : SharedSuspicionRoleComponent
     {
         [Dependency] private readonly IEntityManager _entMan = default!;
+        [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
 
         private Role? _role;
-        [ViewVariables]
-        private readonly HashSet<SuspicionRoleComponent> _allies = new();
+        [ViewVariables] private readonly HashSet<SuspicionRoleComponent> _allies = new();
 
         [ViewVariables]
         public Role? Role
@@ -52,7 +53,7 @@ namespace Content.Server.Suspicion
         public bool IsDead()
         {
             return _entMan.TryGetComponent(Owner, out MobStateComponent? state) &&
-                   state.IsDead();
+                   _mobStateSystem.IsDead(Owner, state);
         }
 
         public bool IsInnocent()
@@ -113,6 +114,7 @@ namespace Content.Server.Suspicion
 
             Dirty();
         }
+
         public override ComponentState GetComponentState()
         {
             if (Role == null)

--- a/Content.Shared/MobState/Components/MobStateComponent.cs
+++ b/Content.Shared/MobState/Components/MobStateComponent.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
-using Content.Shared.MobState.EntitySystems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.MobState.Components
@@ -23,44 +22,13 @@ namespace Content.Shared.MobState.Components
         ///     to or higher than the int key, but lower than the next threshold.
         ///     Ordered from lowest to highest.
         /// </summary>
-        [DataField("thresholds")]
-        public readonly SortedDictionary<int, DamageState> _lowestToHighestStates = new();
+        [DataField("thresholds")] public readonly SortedDictionary<int, DamageState> _lowestToHighestStates = new();
 
         // TODO Remove Nullability?
-        [ViewVariables]
-        public DamageState? CurrentState { get; set; }
+        [ViewVariables] public DamageState? CurrentState { get; set; }
 
-        [ViewVariables]
-        public FixedPoint2? CurrentThreshold { get; set; }
+        [ViewVariables] public FixedPoint2? CurrentThreshold { get; set; }
 
         public IEnumerable<KeyValuePair<int, DamageState>> _highestToLowestStates => _lowestToHighestStates.Reverse();
-
-        [Obsolete("Use MobStateSystem")]
-        public bool IsAlive()
-        {
-            return IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedMobStateSystem>()
-                .IsAlive(Owner, this);
-        }
-
-        [Obsolete("Use MobStateSystem")]
-        public bool IsCritical()
-        {
-            return IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedMobStateSystem>()
-                .IsCritical(Owner, this);
-        }
-
-        [Obsolete("Use MobStateSystem")]
-        public bool IsDead()
-        {
-            return IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedMobStateSystem>()
-                .IsDead(Owner, this);
-        }
-
-        [Obsolete("Use MobStateSystem")]
-        public bool IsIncapacitated()
-        {
-            return IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedMobStateSystem>()
-                .IsIncapacitated(Owner, this);
-        }
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removing Obsolete properties from mobstate component in preparation for a mob state refactor

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

