### PR TITLE
Spawn PointingArrow with EntityCoordinates instead of MapCoordinates.

### DIFF
--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -144,7 +144,7 @@ namespace Content.Server.Pointing.EntitySystems
             var mapCoords = coords.ToMap(EntityManager);
             _rotateToFaceSystem.TryFaceCoordinates(player, mapCoords.Position);
 
-            var arrow = EntityManager.SpawnEntity("PointingArrow", mapCoords);
+            var arrow = EntityManager.SpawnEntity("PointingArrow", coords);
 
             if (TryComp<PointingArrowComponent>(arrow, out var pointing))
             {


### PR DESCRIPTION
This will cause the arrow to attach to a grid if possible, preventing the arrow from visually floating away (really it's the grid that's moving, but it's a matter of perspective).