### PR TITLE
Fix and improve bluespace lockers

### DIFF
--- a/Content.Server/Administration/Commands/ClearBluespaceLockerLinks.cs
+++ b/Content.Server/Administration/Commands/ClearBluespaceLockerLinks.cs
@@ -27,7 +27,7 @@ public sealed class ClearBluespaceLockerLinks : IConsoleCommand
 
         var entityManager = IoCManager.Resolve<IEntityManager>();
 
-        if (entityManager.TryGetComponent<EntityStorageComponent>(entityUid, out var originComponent))
+        if (entityManager.TryGetComponent<BluespaceLockerComponent>(entityUid, out var originComponent))
             entityManager.RemoveComponent(entityUid, originComponent);
     }
 }

--- a/Content.Server/Administration/Commands/LinkBluespaceLocker.cs
+++ b/Content.Server/Administration/Commands/LinkBluespaceLocker.cs
@@ -53,10 +53,16 @@ public sealed class LinkBluespaceLocker : IConsoleCommand
 
         entityManager.EnsureComponent<BluespaceLockerComponent>(originUid, out var originBluespaceComponent);
         originBluespaceComponent.BluespaceLinks.Add(targetComponent);
+        entityManager.EnsureComponent<BluespaceLockerComponent>(targetUid, out var targetBluespaceComponent);
         if (bidirectional)
         {
-            entityManager.EnsureComponent<BluespaceLockerComponent>(targetUid, out var targetBluespaceComponent);
             targetBluespaceComponent.BluespaceLinks.Add(originComponent);
+        }
+        else if (targetBluespaceComponent.BluespaceLinks.Count == 0)
+        {
+            targetBluespaceComponent.AllowSentient = false;
+            targetBluespaceComponent.TransportEntities = false;
+            targetBluespaceComponent.TransportGas = false;
         }
     }
 }

--- a/Content.Server/Storage/Components/BluespaceLockerComponent.cs
+++ b/Content.Server/Storage/Components/BluespaceLockerComponent.cs
@@ -27,4 +27,35 @@ public sealed class BluespaceLockerComponent : Component
     /// </summary>
     [DataField("bluespaceLinks"), ViewVariables(VVAccess.ReadOnly)]
     public HashSet<EntityStorageComponent> BluespaceLinks = new();
+
+    /// <summary>
+    /// Each time the system attempts to get a link, it will link additional lockers to ensure the minimum amount
+    /// are linked.
+    /// </summary>
+    [DataField("minBluespaceLinks"), ViewVariables(VVAccess.ReadWrite)]
+    public uint MinBluespaceLinks;
+
+    /// <summary>
+    /// Determines if links automatically added are restricted to the same map
+    /// </summary>
+    [DataField("pickLinksFromSameMap"), ViewVariables(VVAccess.ReadWrite)]
+    public bool PickLinksFromSameMap;
+
+    /// <summary>
+    /// Determines if links automatically added must have ResistLockerComponent
+    /// </summary>
+    [DataField("pickLinksFromResistLockers"), ViewVariables(VVAccess.ReadWrite)]
+    public bool PickLinksFromResistLockers = true;
+
+    /// <summary>
+    /// Determines if links automatically added are restricted to being on a station
+    /// </summary>
+    [DataField("PickLinksFromStationGrids"), ViewVariables(VVAccess.ReadWrite)]
+    public bool PickLinksFromStationGrids = true;
+
+    /// <summary>
+    /// Determines if links automatically added are bidirectional
+    /// </summary>
+    [DataField("autoLinksBidirectional"), ViewVariables(VVAccess.ReadWrite)]
+    public bool AutoLinksBidirectional;
 }

--- a/Content.Server/Storage/Components/BluespaceLockerComponent.cs
+++ b/Content.Server/Storage/Components/BluespaceLockerComponent.cs
@@ -50,7 +50,7 @@ public sealed class BluespaceLockerComponent : Component
     /// <summary>
     /// Determines if links automatically added are restricted to being on a station
     /// </summary>
-    [DataField("PickLinksFromStationGrids"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("pickLinksFromStationGrids"), ViewVariables(VVAccess.ReadWrite)]
     public bool PickLinksFromStationGrids = true;
 
     /// <summary>

--- a/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
+++ b/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
@@ -50,8 +50,7 @@ public sealed class BluespaceLockerSystem : EntitySystem
             _entityStorage.CloseStorage(targetContainerStorageComponent.Owner, targetContainerStorageComponent);
 
         // Apply bluespace effects if target is not a bluespace locker, otherwise let it handle it
-        if (!Resolve(targetContainerStorageComponent.Owner, ref targetContainerBluespaceComponent, false) ||
-            targetContainerBluespaceComponent.BluespaceLinks is not { Count: > 0 })
+        if (!Resolve(targetContainerStorageComponent.Owner, ref targetContainerBluespaceComponent, false))
         {
             // Move contained items
             if (component.TransportEntities)

--- a/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
+++ b/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
@@ -1,14 +1,19 @@
 ﻿using System.Linq;
 using Content.Server.Lock;
 using Content.Server.Mind.Components;
+using Content.Server.Resist;
+using Content.Server.Station.Components;
 using Content.Server.Storage.Components;
 using Content.Server.Tools.Systems;
-using Microsoft.Extensions.DependencyModel;
+using Content.Shared.Coordinates;
+using Robust.Shared.Random;
 
 namespace Content.Server.Storage.EntitySystems;
 
 public sealed class BluespaceLockerSystem : EntitySystem
 {
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly EntityStorageSystem _entityStorage = default!;
     [Dependency] private readonly WeldableSystem _weldableSystem = default!;
     [Dependency] private readonly LockSystem _lockSystem = default!;
@@ -17,23 +22,27 @@ public sealed class BluespaceLockerSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<BluespaceLockerComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<BluespaceLockerComponent, StorageBeforeOpenEvent>(PreOpen);
         SubscribeLocalEvent<BluespaceLockerComponent, StorageAfterCloseEvent>(PostClose);
     }
 
+    private void OnStartup(EntityUid uid, BluespaceLockerComponent component, ComponentStartup args)
+    {
+        GetTargetStorage(component);
+    }
 
     private void PreOpen(EntityUid uid, BluespaceLockerComponent component, StorageBeforeOpenEvent args)
     {
         EntityStorageComponent? entityStorageComponent = null;
 
-        if (component.BluespaceLinks is not { Count: > 0 })
-            return;
-
         if (!Resolve(uid, ref entityStorageComponent))
             return;
 
         // Select target
-        var targetContainerStorageComponent = component.BluespaceLinks.ToArray()[new Random().Next(0, component.BluespaceLinks.Count)];
+        var targetContainerStorageComponent = GetTargetStorage(component);
+        if (targetContainerStorageComponent == null)
+            return;
         BluespaceLockerComponent? targetContainerBluespaceComponent = null;
 
         // Close target if it is open
@@ -62,18 +71,84 @@ public sealed class BluespaceLockerSystem : EntitySystem
         }
     }
 
+    private bool ValidLink(BluespaceLockerComponent component, EntityStorageComponent link)
+    {
+        return link.Owner.Valid && link.LifeStage != ComponentLifeStage.Deleted;
+    }
+
+    private bool ValidAutolink(BluespaceLockerComponent component, EntityStorageComponent link)
+    {
+        if (!ValidLink(component, link))
+            return false;
+
+        if (component.PickLinksFromSameMap &&
+            link.Owner.ToCoordinates().GetMapId(_entityManager) == component.Owner.ToCoordinates().GetMapId(_entityManager))
+            return false;
+
+        if (component.PickLinksFromStationGrids &&
+            !_entityManager.HasComponent<StationMemberComponent>(link.Owner.ToCoordinates().GetGridUid(_entityManager)))
+            return false;
+
+        if (component.PickLinksFromResistLockers &&
+            !_entityManager.HasComponent<ResistLockerComponent>(link.Owner))
+            return false;
+
+        return true;
+    }
+
+    private EntityStorageComponent? GetTargetStorage(BluespaceLockerComponent component)
+    {
+        while (true)
+        {
+            // Ensure MinBluespaceLinks
+            if (component.BluespaceLinks.Count < component.MinBluespaceLinks)
+            {
+                // Get an shuffle the list of all EntityStorages
+                var storages = _entityManager.EntityQuery<EntityStorageComponent>().ToArray();
+                _robustRandom.Shuffle(storages);
+
+                // Add valid candidates till MinBluespaceLinks is met
+                foreach (var storage in storages)
+                {
+                    if (!ValidAutolink(component, storage))
+                        continue;
+
+                    component.BluespaceLinks.Add(storage);
+                    if (component.AutoLinksBidirectional)
+                    {
+                        _entityManager.EnsureComponent<BluespaceLockerComponent>(storage.Owner, out var targetBluespaceComponent);
+                        targetBluespaceComponent.BluespaceLinks.Add(_entityManager.GetComponent<EntityStorageComponent>(component.Owner));
+                    }
+                    if (component.BluespaceLinks.Count >= component.MinBluespaceLinks)
+                        break;
+                }
+            }
+
+            // If there are no possible link targets and no links, return null
+            if (component.BluespaceLinks.Count == 0)
+                return null;
+
+            // Attempt to select, validate, and return a link
+            var links = component.BluespaceLinks.ToArray();
+            var link = links[_robustRandom.Next(0, component.BluespaceLinks.Count)];
+            if (ValidLink(component, link))
+                return link;
+            component.BluespaceLinks.Remove(link);
+        }
+    }
+
+
     private void PostClose(EntityUid uid, BluespaceLockerComponent component, StorageAfterCloseEvent args)
     {
         EntityStorageComponent? entityStorageComponent = null;
-
-        if (component.BluespaceLinks is not { Count: > 0 })
-            return;
 
         if (!Resolve(uid, ref entityStorageComponent))
             return;
 
         // Select target
-        var targetContainerStorageComponent = component.BluespaceLinks.ToArray()[new Random().Next(0, component.BluespaceLinks.Count)];
+        var targetContainerStorageComponent = GetTargetStorage(component);
+        if (targetContainerStorageComponent == null)
+            return;
 
         // Move contained items
         if (component.TransportEntities)

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -407,6 +407,7 @@
   parent: WallPlastitaniumIndestructible
   id: WallPlastitanium
   name: plastitanium wall
+  suffix: ""
   components:
     - type: Tag
       tags:

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -388,6 +388,23 @@
 
 - type: entity
   parent: BaseWall
+  id: WallPlastitaniumIndestructible
+  name: plastitanium wall
+  suffix: indestructible
+  components:
+    - type: Tag
+      tags:
+        - Wall
+    - type: Sprite
+      sprite: Structures/Walls/plastitanium.rsi
+    - type: Icon
+      sprite: Structures/Walls/plastitanium.rsi
+    - type: IconSmooth
+      key: walls
+      base: plastitanium
+
+- type: entity
+  parent: WallPlastitaniumIndestructible
   id: WallPlastitanium
   name: plastitanium wall
   components:
@@ -395,10 +412,6 @@
       tags:
         - Wall
         - RCDDeconstructWhitelist
-    - type: Sprite
-      sprite: Structures/Walls/plastitanium.rsi
-    - type: Icon
-      sprite: Structures/Walls/plastitanium.rsi
     - type: Destructible
       thresholds:
         - trigger:
@@ -412,9 +425,6 @@
                   max: 1
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
-    - type: IconSmooth
-      key: walls
-      base: plastitanium
 
 - type: entity
   parent: BaseWall


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Adds invulnerable variant of plastitanium wall for easily making pocket dimensions in-game
* Fixes clearbluespacelinks command which was broken when breaking bluespace lockers out into their own component
* Fix issues that would probably result in Something Very Bad™ if a bluespace locker target was ever destroyed
* Bluespace lockers can be configured to automatically maintain a certain number of linked targets

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase