### PR TITLE
Moved salvage magnet values from system to component

### DIFF
--- a/Content.Server/Salvage/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/SalvageMagnetComponent.cs
@@ -48,28 +48,28 @@ namespace Content.Server.Salvage
         public MagnetState MagnetState = MagnetState.Inactive;
 
         /// <summary>
-        ///     How long it takes for the magnet to pull in the debris (in seconds)
+        ///     How long it takes for the magnet to pull in the debris
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("attachingTime")]
         public TimeSpan AttachingTime = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        ///     How long can the magnet hold the debris until it starts losing the lock (in seconds)
+        ///     How long the magnet can hold the debris until it starts losing the lock
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("holdTime")]
         public TimeSpan HoldTime = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        ///     How long can the magnet hold the debris while losing the lock (in seconds)
+        ///     How long the magnet can hold the debris while losing the lock
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("detachingTime")]
         public TimeSpan DetachingTime = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        ///     How long the magnet has to cool down after use (in seconds)
+        ///     How long the magnet has to cool down after use
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("cooldownTime")]

--- a/Content.Server/Salvage/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/SalvageMagnetComponent.cs
@@ -52,28 +52,28 @@ namespace Content.Server.Salvage
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("attachingTime")]
-        public int AttachingTime;
+        public TimeSpan AttachingTime = TimeSpan.FromSeconds(10);
 
         /// <summary>
         ///     How long can the magnet hold the debris until it starts losing the lock (in seconds)
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("holdTime")]
-        public int HoldTime;
+        public TimeSpan HoldTime = TimeSpan.FromSeconds(10);
 
         /// <summary>
         ///     How long can the magnet hold the debris while losing the lock (in seconds)
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("detachingTime")]
-        public int DetachingTime;
+        public TimeSpan DetachingTime = TimeSpan.FromSeconds(10);
 
         /// <summary>
         ///     How long the magnet has to cool down after use (in seconds)
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("cooldownTime")]
-        public int CooldownTime;
+        public TimeSpan CooldownTime = TimeSpan.FromSeconds(10);
 
         [DataField("salvageChannel", customTypeSerializer: typeof(PrototypeIdSerializer<RadioChannelPrototype>))]
         public string SalvageChannel = "Supply";

--- a/Content.Server/Salvage/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/SalvageMagnetComponent.cs
@@ -53,18 +53,21 @@ namespace Content.Server.Salvage
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("attachingTime")]
         public int AttachingTime;
+
         /// <summary>
         ///     How long can the magnet hold the debris until it starts losing the lock (in seconds)
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("holdTime")]
         public int HoldTime;
+
         /// <summary>
         ///     How long can the magnet hold the debris while losing the lock (in seconds)
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("detachingTime")]
         public int DetachingTime;
+
         /// <summary>
         ///     How long the magnet has to cool down after use (in seconds)
         /// </summary>

--- a/Content.Server/Salvage/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/SalvageMagnetComponent.cs
@@ -47,6 +47,31 @@ namespace Content.Server.Salvage
         [DataField("magnetState")]
         public MagnetState MagnetState = MagnetState.Inactive;
 
+        /// <summary>
+        ///     How long it takes for the magnet to pull in the debris (in seconds)
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("attachingTime")]
+        public int AttachingTime;
+        /// <summary>
+        ///     How long can the magnet hold the debris until it starts losing the lock (in seconds)
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("holdTime")]
+        public int HoldTime;
+        /// <summary>
+        ///     How long can the magnet hold the debris while losing the lock (in seconds)
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("detachingTime")]
+        public int DetachingTime;
+        /// <summary>
+        ///     How long the magnet has to cool down after use (in seconds)
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("cooldownTime")]
+        public int CooldownTime;
+
         [DataField("salvageChannel", customTypeSerializer: typeof(PrototypeIdSerializer<RadioChannelPrototype>))]
         public string SalvageChannel = "Supply";
 

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -30,10 +30,6 @@ namespace Content.Server.Salvage
         [Dependency] private readonly RadioSystem _radioSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
 
-        private static readonly TimeSpan AttachingTime = TimeSpan.FromSeconds(30);
-        private static readonly TimeSpan HoldTime = TimeSpan.FromMinutes(4);
-        private static readonly TimeSpan DetachingTime = TimeSpan.FromSeconds(30);
-        private static readonly TimeSpan CooldownTime = TimeSpan.FromMinutes(1);
         private static readonly int SalvageLocationPlaceAttempts = 16;
 
         // TODO: This is probably not compatible with multi-station
@@ -81,13 +77,13 @@ namespace Content.Server.Salvage
                 component.ChargeRemaining = 5;
             else if (component.MagnetState.StateType == MagnetStateType.Holding)
             {
-                component.ChargeRemaining = (timeLeft / ((HoldTime.Minutes * 60 + HoldTime.Seconds) / component.ChargeCapacity)) + 1;
+                component.ChargeRemaining = (timeLeft / (component.HoldTime / component.ChargeCapacity)) + 1;
             }
             else if (component.MagnetState.StateType == MagnetStateType.Detaching)
                 component.ChargeRemaining = 0;
             else if (component.MagnetState.StateType == MagnetStateType.CoolingDown)
             {
-                component.ChargeRemaining = component.ChargeCapacity - (timeLeft / ((CooldownTime.Minutes * 60 + CooldownTime.Seconds) / component.ChargeCapacity)) - 1;
+                component.ChargeRemaining = component.ChargeCapacity - (timeLeft / ((component.CooldownTime) / component.ChargeCapacity)) - 1;
             }
             if (component.PreviousCharge != component.ChargeRemaining)
             {
@@ -202,7 +198,7 @@ namespace Content.Server.Salvage
                         _salvageGridStates[gridId] = gridState;
                     }
                     gridState.ActiveMagnets.Add(component);
-                    component.MagnetState = new MagnetState(MagnetStateType.Attaching, gridState.CurrentTime + AttachingTime);
+                    component.MagnetState = new MagnetState(MagnetStateType.Attaching, gridState.CurrentTime + TimeSpan.FromSeconds(component.AttachingTime));
                     RaiseLocalEvent(new SalvageMagnetActivatedEvent(component.Owner));
                     Report(component.Owner, component.SalvageChannel, "salvage-system-report-activate-success");
                     break;
@@ -348,7 +344,7 @@ namespace Content.Server.Salvage
             var pulledTransform = EntityManager.GetComponent<TransformComponent>(salvageEntityId.Value);
             pulledTransform.WorldRotation = spAngle;
 
-            Report(component.Owner, component.SalvageChannel, "salvage-system-announcement-arrived", ("timeLeft", HoldTime.TotalSeconds));
+            Report(component.Owner, component.SalvageChannel, "salvage-system-announcement-arrived", ("timeLeft", component.HoldTime));
             return true;
         }
 
@@ -368,16 +364,16 @@ namespace Content.Server.Salvage
                 case MagnetStateType.Attaching:
                     if (SpawnSalvage(magnet))
                     {
-                        magnet.MagnetState = new MagnetState(MagnetStateType.Holding, currentTime + HoldTime);
+                        magnet.MagnetState = new MagnetState(MagnetStateType.Holding, currentTime + TimeSpan.FromSeconds(magnet.HoldTime));
                     }
                     else
                     {
-                        magnet.MagnetState = new MagnetState(MagnetStateType.CoolingDown, currentTime + CooldownTime);
+                        magnet.MagnetState = new MagnetState(MagnetStateType.CoolingDown, currentTime + TimeSpan.FromSeconds(magnet.CooldownTime));
                     }
                     break;
                 case MagnetStateType.Holding:
-                    Report(magnet.Owner, magnet.SalvageChannel, "salvage-system-announcement-losing", ("timeLeft", DetachingTime.TotalSeconds));
-                    magnet.MagnetState = new MagnetState(MagnetStateType.Detaching, currentTime + DetachingTime);
+                    Report(magnet.Owner, magnet.SalvageChannel, "salvage-system-announcement-losing", ("timeLeft", magnet.DetachingTime));
+                    magnet.MagnetState = new MagnetState(MagnetStateType.Detaching, currentTime + TimeSpan.FromSeconds(magnet.DetachingTime));
                     break;
                 case MagnetStateType.Detaching:
                     if (magnet.AttachedEntity.HasValue)
@@ -389,7 +385,7 @@ namespace Content.Server.Salvage
                         Logger.ErrorS("salvage", "Salvage detaching was expecting attached entity but it was null");
                     }
                     Report(magnet.Owner, magnet.SalvageChannel, "salvage-system-announcement-lost");
-                    magnet.MagnetState = new MagnetState(MagnetStateType.CoolingDown, currentTime + CooldownTime);
+                    magnet.MagnetState = new MagnetState(MagnetStateType.CoolingDown, currentTime + TimeSpan.FromSeconds(magnet.CooldownTime));
                     break;
                 case MagnetStateType.CoolingDown:
                     magnet.MagnetState = MagnetState.Inactive;

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -72,18 +72,18 @@ namespace Content.Server.Salvage
             if (!Resolve(uid, ref component, false))
                 return;
 
-            int timeLeft = (component.MagnetState.Until.Minutes * 60 + component.MagnetState.Until.Seconds) - (currentTime.Minutes * 60 + currentTime.Seconds);
+            int timeLeft = Convert.ToInt32(component.MagnetState.Until.TotalSeconds - currentTime.TotalSeconds);
             if (component.MagnetState.StateType == MagnetStateType.Inactive)
                 component.ChargeRemaining = 5;
             else if (component.MagnetState.StateType == MagnetStateType.Holding)
             {
-                component.ChargeRemaining = (timeLeft / (component.HoldTime / component.ChargeCapacity)) + 1;
+                component.ChargeRemaining = (timeLeft / (Convert.ToInt32(component.HoldTime.TotalSeconds) / component.ChargeCapacity)) + 1;
             }
             else if (component.MagnetState.StateType == MagnetStateType.Detaching)
                 component.ChargeRemaining = 0;
             else if (component.MagnetState.StateType == MagnetStateType.CoolingDown)
             {
-                component.ChargeRemaining = component.ChargeCapacity - (timeLeft / ((component.CooldownTime) / component.ChargeCapacity)) - 1;
+                component.ChargeRemaining = component.ChargeCapacity - (timeLeft / (Convert.ToInt32(component.CooldownTime.TotalSeconds) / component.ChargeCapacity)) - 1;
             }
             if (component.PreviousCharge != component.ChargeRemaining)
             {
@@ -198,7 +198,7 @@ namespace Content.Server.Salvage
                         _salvageGridStates[gridId] = gridState;
                     }
                     gridState.ActiveMagnets.Add(component);
-                    component.MagnetState = new MagnetState(MagnetStateType.Attaching, gridState.CurrentTime + TimeSpan.FromSeconds(component.AttachingTime));
+                    component.MagnetState = new MagnetState(MagnetStateType.Attaching, gridState.CurrentTime + component.AttachingTime);
                     RaiseLocalEvent(new SalvageMagnetActivatedEvent(component.Owner));
                     Report(component.Owner, component.SalvageChannel, "salvage-system-report-activate-success");
                     break;
@@ -344,7 +344,7 @@ namespace Content.Server.Salvage
             var pulledTransform = EntityManager.GetComponent<TransformComponent>(salvageEntityId.Value);
             pulledTransform.WorldRotation = spAngle;
 
-            Report(component.Owner, component.SalvageChannel, "salvage-system-announcement-arrived", ("timeLeft", component.HoldTime));
+            Report(component.Owner, component.SalvageChannel, "salvage-system-announcement-arrived", ("timeLeft", component.HoldTime.TotalSeconds));
             return true;
         }
 
@@ -364,16 +364,16 @@ namespace Content.Server.Salvage
                 case MagnetStateType.Attaching:
                     if (SpawnSalvage(magnet))
                     {
-                        magnet.MagnetState = new MagnetState(MagnetStateType.Holding, currentTime + TimeSpan.FromSeconds(magnet.HoldTime));
+                        magnet.MagnetState = new MagnetState(MagnetStateType.Holding, currentTime + magnet.HoldTime);
                     }
                     else
                     {
-                        magnet.MagnetState = new MagnetState(MagnetStateType.CoolingDown, currentTime + TimeSpan.FromSeconds(magnet.CooldownTime));
+                        magnet.MagnetState = new MagnetState(MagnetStateType.CoolingDown, currentTime + magnet.CooldownTime);
                     }
                     break;
                 case MagnetStateType.Holding:
-                    Report(magnet.Owner, magnet.SalvageChannel, "salvage-system-announcement-losing", ("timeLeft", magnet.DetachingTime));
-                    magnet.MagnetState = new MagnetState(MagnetStateType.Detaching, currentTime + TimeSpan.FromSeconds(magnet.DetachingTime));
+                    Report(magnet.Owner, magnet.SalvageChannel, "salvage-system-announcement-losing", ("timeLeft", magnet.DetachingTime.TotalSeconds));
+                    magnet.MagnetState = new MagnetState(MagnetStateType.Detaching, currentTime + magnet.DetachingTime);
                     break;
                 case MagnetStateType.Detaching:
                     if (magnet.AttachedEntity.HasValue)
@@ -385,7 +385,7 @@ namespace Content.Server.Salvage
                         Logger.ErrorS("salvage", "Salvage detaching was expecting attached entity but it was null");
                     }
                     Report(magnet.Owner, magnet.SalvageChannel, "salvage-system-announcement-lost");
-                    magnet.MagnetState = new MagnetState(MagnetStateType.CoolingDown, currentTime + TimeSpan.FromSeconds(magnet.CooldownTime));
+                    magnet.MagnetState = new MagnetState(MagnetStateType.CoolingDown, currentTime + magnet.CooldownTime);
                     break;
                 case MagnetStateType.CoolingDown:
                     magnet.MagnetState = MagnetState.Inactive;

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -62,6 +62,10 @@
     offset: 0, 0
     offsetRadiusMin: 24
     offsetRadiusMax: 48
+    attachingTime: 30
+    holdTime: 240
+    detachingTime: 30
+    cooldownTime: 60
   - type: ApcPowerReceiver
     powerLoad: 2500 # TODO change this to a HV power draw that really hits the grid hard WHEN active
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
80% less heretical, and salvage magnets are now more easily tunable

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

