### PR TITLE
Call reload protoypes on admin changes

### DIFF
--- a/Content.Client/Administration/Managers/GamePrototypeLoadManager.cs
+++ b/Content.Client/Administration/Managers/GamePrototypeLoadManager.cs
@@ -21,8 +21,10 @@ public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
 
     private void LoadGamePrototype(GamePrototypeLoadMessage message)
     {
-        _prototypeManager.LoadString(message.PrototypeData, true);
+        var changed = new Dictionary<Type, HashSet<string>>();
+        _prototypeManager.LoadString(message.PrototypeData, true, changed);
         _prototypeManager.ResolveResults();
+        _prototypeManager.ReloadPrototypes(changed);
         _localizationManager.ReloadLocalizations();
         GamePrototypeLoaded?.Invoke();
         Logger.InfoS("adminbus", "Loaded adminbus prototype data.");

--- a/Content.Client/Administration/Managers/GamePrototypeLoadManager.cs
+++ b/Content.Client/Administration/Managers/GamePrototypeLoadManager.cs
@@ -1,8 +1,4 @@
-using System;
 using Content.Shared.Administration;
-using Robust.Shared.IoC;
-using Robust.Shared.Localization;
-using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 
@@ -26,16 +22,15 @@ public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
         _prototypeManager.ResolveResults();
         _prototypeManager.ReloadPrototypes(changed);
         _localizationManager.ReloadLocalizations();
-        GamePrototypeLoaded?.Invoke();
         Logger.InfoS("adminbus", "Loaded adminbus prototype data.");
     }
 
     public void SendGamePrototype(string prototype)
     {
-        var msg = _netManager.CreateNetMessage<GamePrototypeLoadMessage>();
-        msg.PrototypeData = prototype;
+        var msg = new GamePrototypeLoadMessage
+        {
+            PrototypeData = prototype
+        };
         _netManager.ClientSendMessage(msg);
     }
-
-    public event Action? GamePrototypeLoaded;
 }

--- a/Content.Server/Administration/GamePrototypeLoadManager.cs
+++ b/Content.Server/Administration/GamePrototypeLoadManager.cs
@@ -17,7 +17,7 @@ public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly ILocalizationManager _localizationManager = default!;
 
-    private readonly List<string> LoadedPrototypes = new();
+    private readonly List<string> _loadedPrototypes = new();
 
     public void Initialize()
     {
@@ -29,8 +29,6 @@ public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
     {
 
     }
-
-    public event Action? GamePrototypeLoaded;
 
     private void ClientLoadsPrototype(GamePrototypeLoadMessage message)
     {
@@ -48,25 +46,28 @@ public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
 
     private void LoadPrototypeData(string prototypeData)
     {
-        LoadedPrototypes.Add(prototypeData);
-        var msg = new GamePrototypeLoadMessage();
-        msg.PrototypeData = prototypeData;
+        _loadedPrototypes.Add(prototypeData);
+        var msg = new GamePrototypeLoadMessage
+        {
+            PrototypeData = prototypeData
+        };
         _netManager.ServerSendToAll(msg); // everyone load it up!
         var changed = new Dictionary<Type, HashSet<string>>();
         _prototypeManager.LoadString(prototypeData, true, changed); // server needs it too.
         _prototypeManager.ResolveResults();
         _prototypeManager.ReloadPrototypes(changed);
         _localizationManager.ReloadLocalizations();
-        GamePrototypeLoaded?.Invoke();
     }
 
     private void NetManagerOnConnected(object? sender, NetChannelArgs e)
     {
         // Just dump all the prototypes on connect, before them missing could be an issue.
-        foreach (var prototype in LoadedPrototypes)
+        foreach (var prototype in _loadedPrototypes)
         {
-            var msg = new GamePrototypeLoadMessage();
-            msg.PrototypeData = prototype;
+            var msg = new GamePrototypeLoadMessage
+            {
+                PrototypeData = prototype
+            };
             e.Channel.SendMessage(msg);
         }
     }

--- a/Content.Server/Administration/GamePrototypeLoadManager.cs
+++ b/Content.Server/Administration/GamePrototypeLoadManager.cs
@@ -52,8 +52,10 @@ public sealed class GamePrototypeLoadManager : IGamePrototypeLoadManager
         var msg = new GamePrototypeLoadMessage();
         msg.PrototypeData = prototypeData;
         _netManager.ServerSendToAll(msg); // everyone load it up!
-        _prototypeManager.LoadString(prototypeData, true); // server needs it too.
+        var changed = new Dictionary<Type, HashSet<string>>();
+        _prototypeManager.LoadString(prototypeData, true, changed); // server needs it too.
         _prototypeManager.ResolveResults();
+        _prototypeManager.ReloadPrototypes(changed);
         _localizationManager.ReloadLocalizations();
         GamePrototypeLoaded?.Invoke();
     }

--- a/Content.Server/Chemistry/EntitySystems/ChemicalReactionSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemicalReactionSystem.cs
@@ -16,7 +16,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             var coordinates = Transform(owner).Coordinates;
 
-            _adminLogger.Add(LogType.ChemicalReaction, reaction.Impact,
+            AdminLogger.Add(LogType.ChemicalReaction, reaction.Impact,
                 $"Chemical reaction {reaction.ID:reaction} occurred with strength {unitReactions:strength} on entity {ToPrettyString(owner):metabolizer} at {coordinates}");
 
             SoundSystem.Play(reaction.Sound.GetSound(), Filter.Pvs(owner, entityManager:EntityManager), owner);

--- a/Content.Shared/Administration/IGamePrototypeLoadManager.cs
+++ b/Content.Shared/Administration/IGamePrototypeLoadManager.cs
@@ -4,6 +4,4 @@ public interface IGamePrototypeLoadManager
 {
     public void Initialize();
     public void SendGamePrototype(string prototype);
-
-    event Action GamePrototypeLoaded;
 }

--- a/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/SharedChemicalReactionSystem.cs
@@ -21,8 +21,7 @@ namespace Content.Shared.Chemistry.Reaction
 
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] protected readonly ISharedAdminLogManager _adminLogger = default!;
-        [Dependency] private readonly IGamePrototypeLoadManager _gamePrototypeLoadManager = default!;
+        [Dependency] protected readonly ISharedAdminLogManager AdminLogger = default!;
 
         /// <summary>
         ///     A cache of all existant chemical reactions indexed by one of their
@@ -36,7 +35,12 @@ namespace Content.Shared.Chemistry.Reaction
 
             InitializeReactionCache();
             _prototypeManager.PrototypesReloaded += OnPrototypesReloaded;
-            _gamePrototypeLoadManager.GamePrototypeLoaded += InitializeReactionCache;
+        }
+
+        public override void Shutdown()
+        {
+            base.Shutdown();
+            _prototypeManager.PrototypesReloaded -= OnPrototypesReloaded;
         }
 
         /// <summary>
@@ -210,7 +214,7 @@ namespace Content.Shared.Chemistry.Reaction
                 if (effect.ShouldLog)
                 {
                     var entity = args.SolutionEntity;
-                    _adminLogger.Add(LogType.ReagentEffect, effect.LogImpact,
+                    AdminLogger.Add(LogType.ReagentEffect, effect.LogImpact,
                         $"Reaction effect {effect.GetType().Name:effect} of reaction ${reaction.ID:reaction} applied on entity {ToPrettyString(entity):entity} at {Transform(entity).Coordinates:coordinates}");
                 }
 


### PR DESCRIPTION
Fixes NPCs not working, after an engine change.
A lot of content stuff subscribed to prototype reloads but the event is never invoked.

Not sure if this is the best solution, I could maybe invoke it under another method instead, also not sure why chemicals subscribes to both events yet does something different for both.