### PR TITLE
Fix some NPC dancing

### DIFF
--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -37,20 +37,6 @@ public sealed class NPCSteeringComponent : Component
     #endregion
 
     /// <summary>
-    /// How many times per second we're allowed to update our steering frequency.
-    /// </summary>
-    public const byte SteerFrequency = 10;
-
-    /// <summary>
-    /// Last time the NPC steered.
-    /// </summary>
-    [ViewVariables]
-    public TimeSpan LastTimeSteer;
-
-    [ViewVariables]
-    public Vector2 LastSteer;
-
-    /// <summary>
     /// Have we currently requested a path.
     /// </summary>
     [ViewVariables]

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -216,7 +216,6 @@ namespace Content.Server.NPC.Systems
                 var (steering, _, mover, xform) = npcs[i];
 
                 Steer(steering, mover, xform, modifierQuery, bodyQuery, xformQuery, frameTime);
-                steering.LastSteer = mover.CurTickSprintMovement;
             });
 
 
@@ -287,8 +286,7 @@ namespace Content.Server.NPC.Systems
                 return;
             }
 
-            // TODO: Pause time
-            // Need it on the paused event which needs an engine PR.
+            /* If you wish to not steer every tick A) Add pause support B) fix overshoots to prevent dancing
             var nextSteer = steering.LastTimeSteer + TimeSpan.FromSeconds(1f / NPCSteeringComponent.SteerFrequency);
 
             if (nextSteer > _timing.CurTime)
@@ -296,8 +294,8 @@ namespace Content.Server.NPC.Systems
                 SetDirection(mover, steering, steering.LastSteer, false);
                 return;
             }
+            */
 
-            steering.LastTimeSteer = _timing.CurTime;
             var uid = mover.Owner;
             var interest = steering.Interest;
             var danger = steering.Danger;
@@ -309,7 +307,6 @@ namespace Content.Server.NPC.Systems
             var offsetRot = -_mover.GetParentGridAngle(mover);
             modifierQuery.TryGetComponent(uid, out var modifier);
             var moveSpeed = GetSprintSpeed(steering.Owner, modifier);
-            var tickMove = moveSpeed * frameTime;
             var body = bodyQuery.GetComponent(uid);
             var dangerPoints = steering.DangerPoints;
             dangerPoints.Clear();
@@ -331,7 +328,7 @@ namespace Content.Server.NPC.Systems
             DebugTools.Assert(!float.IsNaN(interest[0]));
 
             // Avoid static objects like walls
-            CollisionAvoidance(uid, offsetRot, worldPos, agentRadius, tickMove, layer, mask, xform, danger, dangerPoints, bodyQuery, xformQuery);
+            CollisionAvoidance(uid, offsetRot, worldPos, agentRadius, moveSpeed, layer, mask, xform, danger, dangerPoints, bodyQuery, xformQuery);
             DebugTools.Assert(!float.IsNaN(danger[0]));
 
             Separation(uid, offsetRot, worldPos, agentRadius, layer, mask, body, xform, danger, bodyQuery, xformQuery);


### PR DESCRIPTION
- Bump the collision avoidance range, seemed okay compared to last time I tried. Means they shouldn't get caught by thindows
- Removed the steer frequency because I'm pretty sure that lead to dancing in some instances.

:cl:
- fix: Bump NPC avoidance range and fix some instances of unapproved dancing.
