### PR TITLE
Fixes quick dialog exception

### DIFF
--- a/Content.Server/Administration/QuickDialogSystem.cs
+++ b/Content.Server/Administration/QuickDialogSystem.cs
@@ -1,10 +1,12 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Content.Server.Administration;
 
@@ -139,7 +141,10 @@ public sealed partial class QuickDialogSystem : EntitySystem
                     return false;
                 }
 
-                output = (T?) (object?) input;
+                //It's verrrry likely that this will be longstring
+                var longString = (LongString) input;
+
+                output = (T?) (object?) longString;
                 return output is not null;
             }
             default:
@@ -150,20 +155,16 @@ public sealed partial class QuickDialogSystem : EntitySystem
     private QuickDialogEntryType TypeToEntryType(Type T)
     {
         if (T == typeof(int) || T == typeof(uint) || T == typeof(long) || T == typeof(ulong))
-        {
             return QuickDialogEntryType.Integer;
-        }
-        else if (T == typeof(float) || T == typeof(double))
-        {
+
+        if (T == typeof(float) || T == typeof(double))
             return QuickDialogEntryType.Float;
-        }
-        else if (T == typeof(string)) // People are more likely to notice the input box is too short than they are to notice it's too long.
-        {
+
+        if (T == typeof(string)) // People are more likely to notice the input box is too short than they are to notice it's too long.
             return QuickDialogEntryType.ShortText;
-        } else if (T == typeof(LongString))
-        {
+
+        if (T == typeof(LongString))
             return QuickDialogEntryType.LongText;
-        }
 
         throw new ArgumentException($"Tried to open a dialog with unsupported type {T}.");
     }
@@ -173,4 +174,14 @@ public sealed partial class QuickDialogSystem : EntitySystem
 /// A type used with quick dialogs to indicate you want a large entry window for text and not a short one.
 /// </summary>
 /// <param name="String">The string retrieved.</param>
-public record struct LongString(string String);
+public record struct LongString(string String)
+{
+    public static implicit operator string(LongString longString)
+    {
+        return longString.String;
+    }
+    public static explicit operator LongString(string s)
+    {
+        return new(s);
+    }
+}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

closes #13017 

Adds implicit and explicit casting for Longstring and fixes an issue where it threw an exception on quickdialog

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->