### PR TITLE
Adds delay to internals alert

### DIFF
--- a/Content.Server/Alert/Click/ToggleInternals.cs
+++ b/Content.Server/Alert/Click/ToggleInternals.cs
@@ -1,12 +1,6 @@
-using Content.Server.Atmos.EntitySystems;
-using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
-using Content.Server.Popups;
-using Content.Server.Shuttles.Systems;
 using Content.Shared.Alert;
-using Content.Shared.Shuttles.Components;
 using JetBrains.Annotations;
-using Robust.Shared.Player;
 
 namespace Content.Server.Alert.Click;
 

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -188,9 +188,12 @@ namespace Content.Server.Atmos.EntitySystems
 
         public void ConnectToInternals(GasTankComponent component)
         {
-            if (component.IsConnected || !CanConnectToInternals(component)) return;
+            if (component.IsConnected || !CanConnectToInternals(component))
+                return;
+
             var internals = GetInternalsComponent(component);
-            if (internals == null) return;
+            if (internals == null)
+                return;
 
             if (_internals.TryConnectTank(internals, component.Owner))
                 component.User = internals.Owner;
@@ -198,7 +201,8 @@ namespace Content.Server.Atmos.EntitySystems
             _actions.SetToggled(component.ToggleAction, component.IsConnected);
 
             // Couldn't toggle!
-            if (!component.IsConnected) return;
+            if (!component.IsConnected)
+                return;
 
             component.ConnectStream?.Stop();
 

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -9,7 +9,6 @@ using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Content.Shared.Verbs;
 using Content.Server.Popups;
-using Robust.Shared.Player;
 using Content.Server.DoAfter;
 using System.Threading;
 
@@ -86,12 +85,15 @@ public sealed class InternalsSystem : EntitySystem
             return;
         }
 
-        // Is the target not you? If yes, use a do-after to give them time to respond.
-        if (!force && uid != user)
+        if (!force)
         {
+            // Is the target not you? If yes, use a do-after to give them time to respond.
+            //If no, do a short delay. There's no reason it should be beyond 1 second.
+            var delay = uid != user ? internals.Delay : 1.0f;
+
             internals.CancelToken?.Cancel();
             internals.CancelToken = new CancellationTokenSource();
-            _doAfter.DoAfter(new DoAfterEventArgs(user, internals.Delay, internals.CancelToken.Token, uid)
+            _doAfter.DoAfter(new DoAfterEventArgs(user, delay, internals.CancelToken.Token, uid)
             {
                 BreakOnUserMove = true,
                 BreakOnDamage = true,

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -26,7 +26,7 @@
         sprite: Interface/Alerts/internals.rsi
         state: internal1
       event: !type:ToggleActionEvent
-      useDelay: 1.0
+      useDelay: 1
   - type: Explosive
     explosionType: Default
     maxIntensity: 20


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

closes #12721 

Adds a second delay to the internals alert button so it matches the item action.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added a delay for internals alerts to match the action button delay.