### PR TITLE
Checks if a buckled entity is terminating before reparent

### DIFF
--- a/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
+++ b/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
@@ -322,7 +322,7 @@ public sealed partial class BuckleSystem
         var xform = Transform(buckleId);
         var oldBuckledXform = Transform(oldBuckledTo.Owner);
 
-        if (xform.ParentUid == oldBuckledXform.Owner && !Terminating(xform.ParentUid) || !Terminating(oldBuckledTo.Owner))
+        if (xform.ParentUid == oldBuckledXform.Owner && !Terminating(xform.ParentUid))
         {
             _containers.AttachParentToContainerOrGrid(xform);
             xform.WorldRotation = oldBuckledXform.WorldRotation;

--- a/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
+++ b/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
@@ -322,7 +322,7 @@ public sealed partial class BuckleSystem
         var xform = Transform(buckleId);
         var oldBuckledXform = Transform(oldBuckledTo.Owner);
 
-        if (xform.ParentUid == oldBuckledXform.Owner)
+        if (xform.ParentUid == oldBuckledXform.Owner && !Terminating(xform.ParentUid) || !Terminating(oldBuckledTo.Owner))
         {
             _containers.AttachParentToContainerOrGrid(xform);
             xform.WorldRotation = oldBuckledXform.WorldRotation;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

closes #12941 

Prevents a buckled entity from being reattached if their terminating, should prevent the exception.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:

