### PR TITLE
Salvage magnet shows cooldown time on Examine

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -141,8 +141,8 @@ namespace Content.Server.Salvage
 
         private void OnExamined(EntityUid uid, SalvageMagnetComponent component, ExaminedEvent args)
         {
-            bool _gotGrid = false;
-            var _remainingTime = TimeSpan.Zero;
+            var gotGrid = false;
+            var remainingTime = TimeSpan.Zero;
 
             if (!args.IsInDetailsRange)
                 return;
@@ -150,8 +150,8 @@ namespace Content.Server.Salvage
             if (EntityManager.GetComponent<TransformComponent>(component.Owner).GridUid is EntityUid gridId &&
                 _salvageGridStates.TryGetValue(gridId, out var salvageGridState))
             {
-                _remainingTime = component.MagnetState.Until - salvageGridState.CurrentTime;
-                _gotGrid = true;
+                remainingTime = component.MagnetState.Until - salvageGridState.CurrentTime;
+                gotGrid = true;
             }
             else
             {
@@ -169,12 +169,12 @@ namespace Content.Server.Salvage
                     args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-releasing"));
                     break;
                 case MagnetStateType.CoolingDown:
-                    if (_gotGrid == true)
-                        args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-cooling-down", ("timeLeft", Math.Ceiling(_remainingTime.TotalSeconds))));
+                    if (gotGrid)
+                        args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-cooling-down", ("timeLeft", Math.Ceiling(remainingTime.TotalSeconds))));
                     break;
                 case MagnetStateType.Holding:
-                    if (_gotGrid == true)
-                        args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-active", ("timeLeft", Math.Ceiling(_remainingTime.TotalSeconds))));
+                    if (gotGrid)
+                        args.PushMarkup(Loc.GetString("salvage-system-magnet-examined-active", ("timeLeft", Math.Ceiling(remainingTime.TotalSeconds))));
                     break;
                 default:
                     throw new NotImplementedException("Unexpected magnet state type");

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -148,14 +148,14 @@ namespace Content.Server.Salvage
                 return;
 
             if (EntityManager.GetComponent<TransformComponent>(component.Owner).GridUid is EntityUid gridId &&
-                        _salvageGridStates.TryGetValue(gridId, out var salvageGridState))
+                _salvageGridStates.TryGetValue(gridId, out var salvageGridState))
             {
                 _remainingTime = component.MagnetState.Until - salvageGridState.CurrentTime;
                 _gotGrid = true;
             }
             else
             {
-                        Logger.WarningS("salvage", "Failed to load salvage grid state, can't display remaining time");
+                Logger.WarningS("salvage", "Failed to load salvage grid state, can't display remaining time");
             }
             switch (component.MagnetState.StateType)
             {

--- a/Resources/Locale/en-US/salvage/salvage-system.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-system.ftl
@@ -18,4 +18,4 @@ salvage-system-magnet-examined-active = The salvage magnet is holding salvage in
     *[other] { $timeLeft } seconds.
 }
 salvage-system-magnet-examined-releasing = The salvage magnet is releasing the salvage.
-salvage-system-magnet-examined-cooling-down = The salvage magnet is cooling down.
+salvage-system-magnet-examined-cooling-down = The salvage magnet is cooling down. It will be ready in: {$timeLeft} seconds.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/35878406/209811570-c651cc89-c8a1-4be0-9204-27379284cb9b.png)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Errant
- tweak: Salvage magnet shows remaining cooldown time when examined.

