### PR TITLE
Adds directional switches

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -149,3 +149,41 @@
         Left: []
         Right: []
         Middle: []
+
+#directional
+
+- type: entity
+  id: SignalSwitchDirectional
+  name: signal switch
+  suffix: directional
+  parent: SignalSwitch
+  description: It's a switch for toggling power to things.
+  components:
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25
+
+- type: entity
+  id: SignalButtonDirectional
+  name: signal button
+  suffix: directional
+  parent: SignalButton
+  description: It's a button for activating something.
+  components:
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25
+
+- type: entity
+  id: ApcNetSwitchDirectional
+  name: apc net switch
+  suffix: directional
+  parent: ApcNetSwitch
+  description: Its a switch for toggling lights that are connected to the same apc.
+  components:
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -163,6 +163,9 @@
     arc: 180
   - type: Sprite
     offset: 0,-0.25
+  - type: Construction
+    graph: SignalSwitchDirectionalGraph
+    node: SignalSwitchDirectionalNode
 
 - type: entity
   id: SignalButtonDirectional
@@ -175,6 +178,9 @@
     arc: 180
   - type: Sprite
     offset: 0,-0.25
+  - type: Construction
+    graph: SignalButtonDirectionalGraph
+    node: SignalButtonDirectionalNode
 
 - type: entity
   id: ApcNetSwitchDirectional
@@ -187,3 +193,6 @@
     arc: 180
   - type: Sprite
     offset: 0,-0.25
+  - type: Construction
+    graph: LightSwitchDirectionalGraph
+    node: LightSwitchDirectionalNode

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -7,26 +7,26 @@
     snap:
     - Wallmount
   components:
-    - type: WallMount
-      arc: 360
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Physics
-    - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: on
-    - type: SignalSwitch
-    - type: UseDelay
-      delay: 0.5 # prevent light-toggling auto-clickers.
-    - type: Rotatable
-    - type: Construction
-      graph: SignalSwitchGraph
-      node: SignalSwitchNode
-    - type: Fixtures
-    - type: SignalTransmitter
-      outputs:
-        On: []
-        Off: []
+  - type: WallMount
+    arc: 360
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Physics
+  - type: Sprite
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  - type: SignalSwitch
+  - type: UseDelay
+    delay: 0.5 # prevent light-toggling auto-clickers.
+  - type: Rotatable
+  - type: Construction
+    graph: SignalSwitchGraph
+    node: SignalSwitchNode
+  - type: Fixtures
+  - type: SignalTransmitter
+    outputs:
+      On: []
+      Off: []
 
 - type: entity
   id: SignalButton
@@ -37,41 +37,41 @@
     snap:
     - Wallmount
   components:
-    - type: WallMount
-      arc: 360
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Physics
-    - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: dead
-    - type: UseDelay
-      delay: 0.5 # prevent light-toggling auto-clickers.
-    - type: SignalSwitch
-      onPort: Pressed
-      offPort: Pressed
-    - type: Rotatable
-    - type: Construction
-      graph: SignalButtonGraph
-      node: SignalButtonNode
-    - type: Fixtures
-    - type: SignalTransmitter
-      outputs:
-        Pressed: []
-    - type: Damageable
-      damageContainer: Inorganic
-      damageModifierSet: Metallic
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 40
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-            - !type:PlaySoundBehavior
-              sound:
-                path: /Audio/Effects/metalbreak.ogg
+  - type: WallMount
+    arc: 360
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Physics
+  - type: Sprite
+    sprite: Structures/Wallmounts/switch.rsi
+    state: dead
+  - type: UseDelay
+    delay: 0.5 # prevent light-toggling auto-clickers.
+  - type: SignalSwitch
+    onPort: Pressed
+    offPort: Pressed
+  - type: Rotatable
+  - type: Construction
+    graph: SignalButtonGraph
+    node: SignalButtonNode
+  - type: Fixtures
+  - type: SignalTransmitter
+    outputs:
+      Pressed: []
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 40
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              path: /Audio/Effects/metalbreak.ogg
 
 - type: entity
   id: ApcNetSwitch
@@ -82,27 +82,27 @@
     snap:
       - Wallmount
   components:
-    - type: WallMount
-      arc: 360
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Physics
-    - type: Transform
-      anchored: true
-    - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: on
-    - type: Rotatable
-    - type: ExtensionCableReceiver
-    - type: DeviceNetwork
-      deviceNetId: Apc
-      transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
-    - type: ApcNetworkConnection
-    - type: ApcNetSwitch
-    - type: Construction
-      graph: LightSwitchGraph
-      node: LightSwitchNode
-    - type: Fixtures
+  - type: WallMount
+    arc: 360
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Physics
+  - type: Transform
+    anchored: true
+  - type: Sprite
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  - type: Rotatable
+  - type: ExtensionCableReceiver
+  - type: DeviceNetwork
+    deviceNetId: Apc
+    transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
+  - type: ApcNetworkConnection
+  - type: ApcNetSwitch
+  - type: Construction
+    graph: LightSwitchGraph
+    node: LightSwitchNode
+  - type: Fixtures
 
 - type: entity
   id: TwoWayLever
@@ -111,44 +111,44 @@
   placement:
     mode: SnapgridCenter
   components:
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Sprite
-      netsync: false
-      sprite: Structures/conveyor.rsi
-      layers:
-        - state: switch-off
-          map: ["enabled", "enum.TwoWayLeverState.Middle"]
-    - type: TwoWayLever
-    - type: UseDelay
-      delay: 0.2 # prevent light-toggling auto-clickers.
-    - type: Appearance
-    - type: GenericVisualizer
-      visuals:
-        enum.TwoWayLeverVisuals.State:
-          enabled:
-            Right: { state: switch-fwd }
-            Middle: { state: switch-off }
-            Left: { state: switch-rev }
-    - type: Damageable
-      damageContainer: Inorganic
-      damageModifierSet: Metallic
-    - type: Destructible
-      thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-    - type: Construction
-      graph: LeverGraph
-      node: LeverNode
-    - type: SignalTransmitter
-      outputs:
-        Left: []
-        Right: []
-        Middle: []
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Sprite
+    netsync: false
+    sprite: Structures/conveyor.rsi
+    layers:
+      - state: switch-off
+        map: ["enabled", "enum.TwoWayLeverState.Middle"]
+  - type: TwoWayLever
+  - type: UseDelay
+    delay: 0.2 # prevent light-toggling auto-clickers.
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.TwoWayLeverVisuals.State:
+        enabled:
+          Right: { state: switch-fwd }
+          Middle: { state: switch-off }
+          Left: { state: switch-rev }
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Construction
+    graph: LeverGraph
+    node: LeverNode
+  - type: SignalTransmitter
+    outputs:
+      Left: []
+      Right: []
+      Middle: []
 
 #directional
 
@@ -158,15 +158,15 @@
   suffix: directional
   parent: SignalSwitch
   components:
-    - type: Physics
-      canCollide: false
-    - type: WallMount
-      arc: 180
-    - type: Sprite
-      offset: 0,-0.25
-    - type: Construction
-      graph: SignalSwitchDirectionalGraph
-      node: SignalSwitchDirectionalNode
+  - type: Physics
+    canCollide: false
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25
+  - type: Construction
+    graph: SignalSwitchDirectionalGraph
+    node: SignalSwitchDirectionalNode
 
 - type: entity
   id: SignalButtonDirectional
@@ -174,15 +174,15 @@
   suffix: directional
   parent: SignalButton
   components:
-    - type: Physics
-      canCollide: false
-    - type: WallMount
-      arc: 180
-    - type: Sprite
-      offset: 0,-0.25
-    - type: Construction
-      graph: SignalButtonDirectionalGraph
-      node: SignalButtonDirectionalNode
+  - type: Physics
+    canCollide: false
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25
+  - type: Construction
+    graph: SignalButtonDirectionalGraph
+    node: SignalButtonDirectionalNode
 
 - type: entity
   id: ApcNetSwitchDirectional
@@ -190,12 +190,12 @@
   suffix: directional
   parent: ApcNetSwitch
   components:
-    - type: Physics
-      canCollide: false
-    - type: WallMount
-      arc: 180
-    - type: Sprite
-      offset: 0,-0.25
-    - type: Construction
-      graph: LightSwitchDirectionalGraph
-      node: LightSwitchDirectionalNode
+  - type: Physics
+    canCollide: false
+  - type: WallMount
+    arc: 180
+  - type: Sprite
+    offset: 0,-0.25
+  - type: Construction
+    graph: LightSwitchDirectionalGraph
+    node: LightSwitchDirectionalNode

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -159,6 +159,8 @@
   parent: SignalSwitch
   description: It's a switch for toggling power to things.
   components:
+    - type: Physics
+      canCollide: false
     - type: WallMount
       arc: 180
     - type: Sprite
@@ -174,6 +176,8 @@
   parent: SignalButton
   description: It's a button for activating something.
   components:
+    - type: Physics
+      canCollide: false
     - type: WallMount
       arc: 180
     - type: Sprite
@@ -189,6 +193,8 @@
   parent: ApcNetSwitch
   description: Its a switch for toggling lights that are connected to the same apc.
   components:
+    - type: Physics
+      canCollide: false
     - type: WallMount
       arc: 180
     - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -159,6 +159,7 @@
   parent: SignalSwitch
   description: It's a switch for toggling power to things.
   components:
+  - type: Physics
   - type: WallMount
     arc: 180
   - type: Sprite
@@ -174,6 +175,7 @@
   parent: SignalButton
   description: It's a button for activating something.
   components:
+  - type: Physics
   - type: WallMount
     arc: 180
   - type: Sprite
@@ -189,6 +191,7 @@
   parent: ApcNetSwitch
   description: Its a switch for toggling lights that are connected to the same apc.
   components:
+  - type: Physics
   - type: WallMount
     arc: 180
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -156,110 +156,43 @@
   id: SignalSwitchDirectional
   name: signal switch
   suffix: directional
+  parent: SignalSwitch
   description: It's a switch for toggling power to things.
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wallmount
   components:
     - type: WallMount
       arc: 180
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Physics
     - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: on
       offset: 0,-0.25
-    - type: SignalSwitch
-    - type: UseDelay
-      delay: 0.5 # prevent light-toggling auto-clickers.
-    - type: Rotatable
     - type: Construction
       graph: SignalSwitchDirectionalGraph
       node: SignalSwitchDirectionalNode
-    - type: Fixtures
-    - type: SignalTransmitter
-      outputs:
-        On: []
-        Off: []
 
 - type: entity
   id: SignalButtonDirectional
   name: signal button
   suffix: directional
+  parent: SignalButton
   description: It's a button for activating something.
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wallmount
   components:
     - type: WallMount
       arc: 180
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Physics
     - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: dead
       offset: 0,-0.25
-    - type: UseDelay
-      delay: 0.5 # prevent light-toggling auto-clickers.
-    - type: SignalSwitch
-      onPort: Pressed
-      offPort: Pressed
-    - type: Rotatable
     - type: Construction
       graph: SignalButtonDirectionalGraph
       node: SignalButtonDirectionalNode
-    - type: Fixtures
-    - type: SignalTransmitter
-      outputs:
-        Pressed: []
-    - type: Damageable
-      damageContainer: Inorganic
-      damageModifierSet: Metallic
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 40
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-            - !type:PlaySoundBehavior
-              sound:
-                path: /Audio/Effects/metalbreak.ogg
 
 - type: entity
   id: ApcNetSwitchDirectional
   name: apc net switch
   suffix: directional
+  parent: ApcNetSwitch
   description: Its a switch for toggling lights that are connected to the same apc.
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wallmount
   components:
     - type: WallMount
       arc: 180
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Physics
-    - type: Transform
-      anchored: true
     - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: on
       offset: 0,-0.25
-    - type: Rotatable
-    - type: ExtensionCableReceiver
-    - type: DeviceNetwork
-      deviceNetId: Apc
-      transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
-    - type: ApcNetworkConnection
-    - type: ApcNetSwitch
     - type: Construction
       graph: LightSwitchDirectionalGraph
       node: LightSwitchDirectionalNode
-    - type: Fixtures

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -1,98 +1,90 @@
 - type: entity
-  id: SignalSwitch
-  name: signal switch
-  description: It's a switch for toggling power to things.
+  id: SwitchBase
+  abstract: true
+  name: "switch"
   placement:
     mode: SnapgridCenter
     snap:
     - Wallmount
   components:
-  - type: WallMount
-    arc: 360
-  - type: Clickable
-  - type: InteractionOutline
-  - type: Physics
-  - type: Sprite
-    sprite: Structures/Wallmounts/switch.rsi
-    state: on
-  - type: SignalSwitch
-  - type: UseDelay
-    delay: 0.5 # prevent light-toggling auto-clickers.
-  - type: Rotatable
-  - type: Construction
-    graph: SignalSwitchGraph
-    node: SignalSwitchNode
-  - type: Fixtures
-  - type: SignalTransmitter
-    outputs:
-      On: []
-      Off: []
+    - type: Clickable
+    - type: InteractionOutline
+    - type: Physics
+    - type: Rotatable
+    - type: Fixtures
+
+- type: entity
+  id: SignalSwitch
+  name: signal switch
+  parent: SwitchBase
+  description: It's a switch for toggling power to things.
+  components:
+    - type: WallMount
+      arc: 360
+    - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: on
+    - type: UseDelay
+      delay: 0.5 # prevent light-toggling auto-clickers.
+    - type: SignalSwitch
+    - type: Construction
+      graph: SignalSwitchGraph
+      node: SignalSwitchNode
+    - type: SignalTransmitter
+      outputs:
+        On: []
+        Off: []
 
 - type: entity
   id: SignalButton
   name: signal button
+  parent: SwitchBase
   description: It's a button for activating something.
-  placement:
-    mode: SnapgridCenter
-    snap:
-    - Wallmount
   components:
-  - type: WallMount
-    arc: 360
-  - type: Clickable
-  - type: InteractionOutline
-  - type: Physics
-  - type: Sprite
-    sprite: Structures/Wallmounts/switch.rsi
-    state: dead
-  - type: UseDelay
-    delay: 0.5 # prevent light-toggling auto-clickers.
-  - type: SignalSwitch
-    onPort: Pressed
-    offPort: Pressed
-  - type: Rotatable
-  - type: Construction
-    graph: SignalButtonGraph
-    node: SignalButtonNode
-  - type: Fixtures
-  - type: SignalTransmitter
-    outputs:
-      Pressed: []
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 40
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-          - !type:PlaySoundBehavior
-            sound:
-              path: /Audio/Effects/metalbreak.ogg
+    - type: WallMount
+      arc: 360
+    - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: dead
+    - type: UseDelay
+      delay: 0.5 # prevent light-toggling auto-clickers.
+    - type: SignalSwitch
+      onPort: Pressed
+      offPort: Pressed
+    - type: Construction
+      graph: SignalButtonGraph
+      node: SignalButtonNode
+    - type: SignalTransmitter
+      outputs:
+        Pressed: []
+    - type: Damageable
+      damageContainer: Inorganic
+      damageModifierSet: Metallic
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 40
+          behaviors:
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+            - !type:PlaySoundBehavior
+              sound:
+                path: /Audio/Effects/metalbreak.ogg
 
 - type: entity
   id: ApcNetSwitch
   name: apc net switch
+  parent: SwitchBase
   description: Its a switch for toggling lights that are connected to the same apc.
-  placement:
-    mode: SnapgridCenter
-    snap:
-      - Wallmount
   components:
     - type: WallMount
       arc: 360
-    - type: Clickable
-    - type: InteractionOutline
-    - type: Physics
     - type: Transform
       anchored: true
     - type: Sprite
       sprite: Structures/Wallmounts/switch.rsi
       state: on
-    - type: Rotatable
     - type: ExtensionCableReceiver
     - type: DeviceNetwork
       deviceNetId: Apc
@@ -102,7 +94,6 @@
     - type: Construction
       graph: LightSwitchGraph
       node: LightSwitchNode
-    - type: Fixtures
 
 - type: entity
   id: TwoWayLever
@@ -156,43 +147,86 @@
   id: SignalSwitchDirectional
   name: signal switch
   suffix: directional
-  parent: SignalSwitch
+  parent: SwitchBase
   description: It's a switch for toggling power to things.
   components:
-  - type: WallMount
-    arc: 180
-  - type: Sprite
-    offset: 0,-0.25
-  - type: Construction
-    graph: SignalSwitchDirectionalGraph
-    node: SignalSwitchDirectionalNode
+    - type: WallMount
+      arc: 180
+    - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: on
+      offset: 0,-0.25
+    - type: UseDelay
+      delay: 0.5 # prevent light-toggling auto-clickers.
+    - type: SignalSwitch
+    - type: Construction
+      graph: SignalSwitchDirectionalGraph
+      node: SignalSwitchDirectionalNode
+    - type: SignalTransmitter
+      outputs:
+        On: []
+        Off: []
 
 - type: entity
   id: SignalButtonDirectional
   name: signal button
   suffix: directional
-  parent: SignalButton
+  parent: SwitchBase
   description: It's a button for activating something.
   components:
-  - type: WallMount
-    arc: 180
-  - type: Sprite
-    offset: 0,-0.25
-  - type: Construction
-    graph: SignalButtonDirectionalGraph
-    node: SignalButtonDirectionalNode
+    - type: WallMount
+      arc: 180
+    - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: dead
+      offset: 0,-0.25
+    - type: UseDelay
+      delay: 0.5 # prevent light-toggling auto-clickers.
+    - type: SignalSwitch
+      onPort: Pressed
+      offPort: Pressed
+    - type: Construction
+      graph: SignalButtonDirectionalGraph
+      node: SignalButtonDirectionalNode
+    - type: SignalTransmitter
+      outputs:
+        Pressed: []
+    - type: Damageable
+      damageContainer: Inorganic
+      damageModifierSet: Metallic
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 40
+          behaviors:
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+            - !type:PlaySoundBehavior
+              sound:
+                path: /Audio/Effects/metalbreak.ogg
 
 - type: entity
   id: ApcNetSwitchDirectional
   name: apc net switch
   suffix: directional
-  parent: ApcNetSwitch
+  parent: SwitchBase
   description: Its a switch for toggling lights that are connected to the same apc.
   components:
-  - type: WallMount
-    arc: 180
-  - type: Sprite
-    offset: 0,-0.25
-  - type: Construction
-    graph: LightSwitchDirectionalGraph
-    node: LightSwitchDirectionalNode
+    - type: WallMount
+      arc: 180
+    - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: on
+      offset: 0,-0.25
+    - type: Transform
+      anchored: true
+    - type: ExtensionCableReceiver
+    - type: DeviceNetwork
+      deviceNetId: Apc
+      transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
+    - type: ApcNetworkConnection
+    - type: ApcNetSwitch
+    - type: Construction
+      graph: LightSwitchDirectionalGraph
+      node: LightSwitchDirectionalNode

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -157,7 +157,6 @@
   name: signal switch
   suffix: directional
   parent: SignalSwitch
-  description: It's a switch for toggling power to things.
   components:
     - type: Physics
       canCollide: false
@@ -174,7 +173,6 @@
   name: signal button
   suffix: directional
   parent: SignalButton
-  description: It's a button for activating something.
   components:
     - type: Physics
       canCollide: false
@@ -191,7 +189,6 @@
   name: apc net switch
   suffix: directional
   parent: ApcNetSwitch
-  description: Its a switch for toggling lights that are connected to the same apc.
   components:
     - type: Physics
       canCollide: false

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -156,43 +156,110 @@
   id: SignalSwitchDirectional
   name: signal switch
   suffix: directional
-  parent: SignalSwitch
   description: It's a switch for toggling power to things.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
   components:
     - type: WallMount
       arc: 180
+    - type: Clickable
+    - type: InteractionOutline
+    - type: Physics
     - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: on
       offset: 0,-0.25
+    - type: SignalSwitch
+    - type: UseDelay
+      delay: 0.5 # prevent light-toggling auto-clickers.
+    - type: Rotatable
     - type: Construction
       graph: SignalSwitchDirectionalGraph
       node: SignalSwitchDirectionalNode
+    - type: Fixtures
+    - type: SignalTransmitter
+      outputs:
+        On: []
+        Off: []
 
 - type: entity
   id: SignalButtonDirectional
   name: signal button
   suffix: directional
-  parent: SignalButton
   description: It's a button for activating something.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
   components:
     - type: WallMount
       arc: 180
+    - type: Clickable
+    - type: InteractionOutline
+    - type: Physics
     - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: dead
       offset: 0,-0.25
+    - type: UseDelay
+      delay: 0.5 # prevent light-toggling auto-clickers.
+    - type: SignalSwitch
+      onPort: Pressed
+      offPort: Pressed
+    - type: Rotatable
     - type: Construction
       graph: SignalButtonDirectionalGraph
       node: SignalButtonDirectionalNode
+    - type: Fixtures
+    - type: SignalTransmitter
+      outputs:
+        Pressed: []
+    - type: Damageable
+      damageContainer: Inorganic
+      damageModifierSet: Metallic
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 40
+          behaviors:
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
+            - !type:PlaySoundBehavior
+              sound:
+                path: /Audio/Effects/metalbreak.ogg
 
 - type: entity
   id: ApcNetSwitchDirectional
   name: apc net switch
   suffix: directional
-  parent: ApcNetSwitch
   description: Its a switch for toggling lights that are connected to the same apc.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
   components:
     - type: WallMount
       arc: 180
+    - type: Clickable
+    - type: InteractionOutline
+    - type: Physics
+    - type: Transform
+      anchored: true
     - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: on
       offset: 0,-0.25
+    - type: Rotatable
+    - type: ExtensionCableReceiver
+    - type: DeviceNetwork
+      deviceNetId: Apc
+      transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
+    - type: ApcNetworkConnection
+    - type: ApcNetSwitch
     - type: Construction
       graph: LightSwitchDirectionalGraph
       node: LightSwitchDirectionalNode
+    - type: Fixtures

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -11,7 +11,6 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
-  - type: Physics
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: on
@@ -22,7 +21,6 @@
   - type: Construction
     graph: SignalSwitchGraph
     node: SignalSwitchNode
-  - type: Fixtures
   - type: SignalTransmitter
     outputs:
       On: []
@@ -41,7 +39,6 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
-  - type: Physics
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: dead
@@ -54,7 +51,6 @@
   - type: Construction
     graph: SignalButtonGraph
     node: SignalButtonNode
-  - type: Fixtures
   - type: SignalTransmitter
     outputs:
       Pressed: []
@@ -86,7 +82,6 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
-  - type: Physics
   - type: Transform
     anchored: true
   - type: Sprite
@@ -102,7 +97,6 @@
   - type: Construction
     graph: LightSwitchGraph
     node: LightSwitchNode
-  - type: Fixtures
 
 - type: entity
   id: TwoWayLever
@@ -158,8 +152,6 @@
   suffix: directional
   parent: SignalSwitch
   components:
-  - type: Physics
-    canCollide: false
   - type: WallMount
     arc: 180
   - type: Sprite
@@ -174,8 +166,6 @@
   suffix: directional
   parent: SignalButton
   components:
-  - type: Physics
-    canCollide: false
   - type: WallMount
     arc: 180
   - type: Sprite
@@ -190,8 +180,6 @@
   suffix: directional
   parent: ApcNetSwitch
   components:
-  - type: Physics
-    canCollide: false
   - type: WallMount
     arc: 180
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -159,7 +159,6 @@
   parent: SignalSwitch
   description: It's a switch for toggling power to things.
   components:
-  - type: Physics
   - type: WallMount
     arc: 180
   - type: Sprite
@@ -175,7 +174,6 @@
   parent: SignalButton
   description: It's a button for activating something.
   components:
-  - type: Physics
   - type: WallMount
     arc: 180
   - type: Sprite
@@ -191,7 +189,6 @@
   parent: ApcNetSwitch
   description: Its a switch for toggling lights that are connected to the same apc.
   components:
-  - type: Physics
   - type: WallMount
     arc: 180
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -1,35 +1,28 @@
 - type: entity
-  id: SwitchBase
-  abstract: true
-  name: "switch"
+  id: SignalSwitch
+  name: signal switch
+  description: It's a switch for toggling power to things.
   placement:
     mode: SnapgridCenter
     snap:
     - Wallmount
   components:
+    - type: WallMount
+      arc: 360
     - type: Clickable
     - type: InteractionOutline
     - type: Physics
-    - type: Rotatable
-    - type: Fixtures
-
-- type: entity
-  id: SignalSwitch
-  name: signal switch
-  parent: SwitchBase
-  description: It's a switch for toggling power to things.
-  components:
-    - type: WallMount
-      arc: 360
     - type: Sprite
       sprite: Structures/Wallmounts/switch.rsi
       state: on
+    - type: SignalSwitch
     - type: UseDelay
       delay: 0.5 # prevent light-toggling auto-clickers.
-    - type: SignalSwitch
+    - type: Rotatable
     - type: Construction
       graph: SignalSwitchGraph
       node: SignalSwitchNode
+    - type: Fixtures
     - type: SignalTransmitter
       outputs:
         On: []
@@ -38,11 +31,17 @@
 - type: entity
   id: SignalButton
   name: signal button
-  parent: SwitchBase
   description: It's a button for activating something.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
   components:
     - type: WallMount
       arc: 360
+    - type: Clickable
+    - type: InteractionOutline
+    - type: Physics
     - type: Sprite
       sprite: Structures/Wallmounts/switch.rsi
       state: dead
@@ -51,9 +50,11 @@
     - type: SignalSwitch
       onPort: Pressed
       offPort: Pressed
+    - type: Rotatable
     - type: Construction
       graph: SignalButtonGraph
       node: SignalButtonNode
+    - type: Fixtures
     - type: SignalTransmitter
       outputs:
         Pressed: []
@@ -75,16 +76,23 @@
 - type: entity
   id: ApcNetSwitch
   name: apc net switch
-  parent: SwitchBase
   description: Its a switch for toggling lights that are connected to the same apc.
+  placement:
+    mode: SnapgridCenter
+    snap:
+      - Wallmount
   components:
     - type: WallMount
       arc: 360
+    - type: Clickable
+    - type: InteractionOutline
+    - type: Physics
     - type: Transform
       anchored: true
     - type: Sprite
       sprite: Structures/Wallmounts/switch.rsi
       state: on
+    - type: Rotatable
     - type: ExtensionCableReceiver
     - type: DeviceNetwork
       deviceNetId: Apc
@@ -94,6 +102,7 @@
     - type: Construction
       graph: LightSwitchGraph
       node: LightSwitchNode
+    - type: Fixtures
 
 - type: entity
   id: TwoWayLever
@@ -147,86 +156,43 @@
   id: SignalSwitchDirectional
   name: signal switch
   suffix: directional
-  parent: SwitchBase
+  parent: SignalSwitch
   description: It's a switch for toggling power to things.
   components:
     - type: WallMount
       arc: 180
     - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: on
       offset: 0,-0.25
-    - type: UseDelay
-      delay: 0.5 # prevent light-toggling auto-clickers.
-    - type: SignalSwitch
     - type: Construction
       graph: SignalSwitchDirectionalGraph
       node: SignalSwitchDirectionalNode
-    - type: SignalTransmitter
-      outputs:
-        On: []
-        Off: []
 
 - type: entity
   id: SignalButtonDirectional
   name: signal button
   suffix: directional
-  parent: SwitchBase
+  parent: SignalButton
   description: It's a button for activating something.
   components:
     - type: WallMount
       arc: 180
     - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: dead
       offset: 0,-0.25
-    - type: UseDelay
-      delay: 0.5 # prevent light-toggling auto-clickers.
-    - type: SignalSwitch
-      onPort: Pressed
-      offPort: Pressed
     - type: Construction
       graph: SignalButtonDirectionalGraph
       node: SignalButtonDirectionalNode
-    - type: SignalTransmitter
-      outputs:
-        Pressed: []
-    - type: Damageable
-      damageContainer: Inorganic
-      damageModifierSet: Metallic
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 40
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-            - !type:PlaySoundBehavior
-              sound:
-                path: /Audio/Effects/metalbreak.ogg
 
 - type: entity
   id: ApcNetSwitchDirectional
   name: apc net switch
   suffix: directional
-  parent: SwitchBase
+  parent: ApcNetSwitch
   description: Its a switch for toggling lights that are connected to the same apc.
   components:
     - type: WallMount
       arc: 180
     - type: Sprite
-      sprite: Structures/Wallmounts/switch.rsi
-      state: on
       offset: 0,-0.25
-    - type: Transform
-      anchored: true
-    - type: ExtensionCableReceiver
-    - type: DeviceNetwork
-      deviceNetId: Apc
-      transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
-    - type: ApcNetworkConnection
-    - type: ApcNetSwitch
     - type: Construction
       graph: LightSwitchDirectionalGraph
       node: LightSwitchDirectionalNode

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -11,6 +11,8 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
+  - type: Physics
+    canCollide: false
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: on
@@ -39,6 +41,8 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
+  - type: Physics
+    canCollide: false
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: dead
@@ -78,25 +82,25 @@
     snap:
       - Wallmount
   components:
-  - type: WallMount
-    arc: 360
-  - type: Clickable
-  - type: InteractionOutline
-  - type: Transform
-    anchored: true
-  - type: Sprite
-    sprite: Structures/Wallmounts/switch.rsi
-    state: on
-  - type: Rotatable
-  - type: ExtensionCableReceiver
-  - type: DeviceNetwork
-    deviceNetId: Apc
-    transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
-  - type: ApcNetworkConnection
-  - type: ApcNetSwitch
-  - type: Construction
-    graph: LightSwitchGraph
-    node: LightSwitchNode
+    - type: WallMount
+      arc: 360
+    - type: Clickable
+    - type: InteractionOutline
+    - type: Transform
+      anchored: true
+    - type: Sprite
+      sprite: Structures/Wallmounts/switch.rsi
+      state: on
+    - type: Rotatable
+    - type: ExtensionCableReceiver
+    - type: DeviceNetwork
+      deviceNetId: Apc
+      transmitFrequencyId: SmartLight # assuming people want to use it for light switches.
+    - type: ApcNetworkConnection
+    - type: ApcNetSwitch
+    - type: Construction
+      graph: LightSwitchGraph
+      node: LightSwitchNode
 
 - type: entity
   id: TwoWayLever

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -11,8 +11,6 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
-  - type: Physics
-    canCollide: false
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: on
@@ -41,8 +39,6 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
-  - type: Physics
-    canCollide: false
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: dead
@@ -86,8 +82,6 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
-  - type: Physics
-    canCollide: false
   - type: Transform
     anchored: true
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -11,6 +11,8 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
+  - type: Physics
+    canCollide: false
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: on
@@ -39,6 +41,8 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
+  - type: Physics
+    canCollide: false
   - type: Sprite
     sprite: Structures/Wallmounts/switch.rsi
     state: dead
@@ -82,6 +86,8 @@
     arc: 360
   - type: Clickable
   - type: InteractionOutline
+  - type: Physics
+    canCollide: false
   - type: Transform
     anchored: true
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -187,3 +187,4 @@
   - type: Construction
     graph: LightSwitchDirectionalGraph
     node: LightSwitchDirectionalNode
+    

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
@@ -97,3 +97,75 @@
               prototype: SheetSteel1
               amount: 1
             - !type:DeleteEntity {}
+            
+- type: constructionGraph
+  id: LightSwitchDirectionalGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: LightSwitchDirectionalNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+    - node: LightSwitchDirectionalNode
+      entity: ApcNetSwitchDirectional
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+
+- type: constructionGraph
+  id: SignalSwitchDirectionalGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: SignalSwitchDirectionalNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+    - node: SignalSwitchDirectionalNode
+      entity: SignalSwitchDirectional
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+            
+- type: constructionGraph
+  id: SignalButtonDirectionalGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: SignalButtonDirectionalNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+    - node: SignalButtonDirectionalNode
+      entity: SignalButtonDirectional
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Recipes/Construction/machines.yml
@@ -96,3 +96,58 @@
   canBuildInImpassable: true
   conditions:
     - !type:WallmountCondition
+    
+
+- type: construction
+  name: directional light switch
+  id: LightSwitchDirectionalRecipe
+  graph: LightSwitchDirectionalGraph
+  startNode: start
+  targetNode: LightSwitchDirectionalNode
+  category: construction-category-machines
+  description: A switch for toggling lights that are connected to the same apc.
+  icon:
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  name: directional signal switch
+  id: SignalSwitchDirectionalRecipe
+  graph: SignalSwitchDirectionalGraph
+  startNode: start
+  targetNode: SignalSwitchDirectionalNode
+  category: construction-category-machines
+  description: It's a switch for toggling power to things.
+  icon:
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition
+
+- type: construction
+  name: directional signal button
+  id: SignalButtonDirectionalRecipe
+  graph: SignalButtonDirectionalGraph
+  startNode: start
+  targetNode: SignalButtonDirectionalNode
+  category: construction-category-machines
+  description: It's a button for activating something.
+  icon:
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: true
+  conditions:
+    - !type:WallmountCondition

--- a/Resources/Prototypes/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Recipes/Construction/machines.yml
@@ -95,8 +95,7 @@
   canRotate: true
   canBuildInImpassable: true
   conditions:
-    - !type:WallmountCondition
-    
+    - !type:WallmountCondition    
 
 - type: construction
   name: directional light switch


### PR DESCRIPTION
Changelog:
-adds directional switches w/ sprite offsets to clearly indicate functional direction.

>The purpose of this PR is that making switches directional gives them greater mapping versatility. It is currently fairly difficult to find good placement sometimes that won't be open to abuse from the wrong side of the wall. I left the original switches as well because there are cases where an omni-directional switch is optimal and current maps won't have to scramble to adjust all currently mapped switches.

- [ X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![Screenshot 2022-12-30 121741](https://user-images.githubusercontent.com/107660393/210101212-c8a2a6de-ac60-48d9-ac9c-a60839cc63bf.jpg)

