### PR TITLE
Fixes incorrect access on brig medbay door in kettle

### DIFF
--- a/Resources/Maps/kettle.yml
+++ b/Resources/Maps/kettle.yml
@@ -114414,7 +114414,7 @@ entities:
     parent: 82
     type: Transform
 - uid: 11450
-  type: WindoorMedicalLocked
+  type: WindoorSecurityLocked
   components:
   - rot: 1.5707963267948966 rad
     pos: 53.5,-13.5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pull request fixes the window door access on the brig medbay(I am not sure if this is the correct terminology) in kettle. Currently it is set to WindoorMedicalLocked, as such only people with medical access can open it.
I am not quite sure how to showcase the change in game with an image, so I just included an image of the view variables window in mapping mode.
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Screenshot from 2022-12-30 22-23-12](https://user-images.githubusercontent.com/32041239/210109275-3bf54ee8-1fb2-42a3-ae67-b228b1a04ad0.png)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed door access in brig medbay in kettle so security can access it.

