### PR TITLE
Mopping and puddle tweaks

### DIFF
--- a/Content.Server/Fluids/Components/AbsorbentComponent.cs
+++ b/Content.Server/Fluids/Components/AbsorbentComponent.cs
@@ -22,10 +22,11 @@ public sealed class AbsorbentComponent : Component
     public FixedPoint2 ResidueAmount = FixedPoint2.New(10); // Should be higher than MopLowerLimit
 
     /// <summary>
-    ///     To leave behind a wet floor, this tool will be unable to take from puddles with a volume less than this amount.
+    ///     To leave behind a wet floor, this tool will be unable to take from puddles with a volume less than this
+    ///     amount. This limit is ignored if the target puddle does not evaporate.
     /// </summary>
-    [DataField("mopLowerLimit")]
-    public FixedPoint2 MopLowerLimit = FixedPoint2.New(5);
+    [DataField("lowerLimit")]
+    public FixedPoint2 LowerLimit = FixedPoint2.New(5);
 
     [DataField("pickupSound")]
     public SoundSpecifier PickupSound = new SoundPathSpecifier("/Audio/Effects/Fluids/slosh.ogg");
@@ -34,9 +35,9 @@ public sealed class AbsorbentComponent : Component
     public SoundSpecifier TransferSound = new SoundPathSpecifier("/Audio/Effects/Fluids/watersplash.ogg");
 
     /// <summary>
-    ///     Multiplier for the do_after delay for how quickly the mopping happens.
+    ///     Quantity of reagent that this mop can pick up per second. Determines the length of the do-after.
     /// </summary>
-    [DataField("mopSpeed")] public float MopSpeed = 1;
+    [DataField("speed")] public float Speed = 10;
 
     /// <summary>
     ///     How many entities can this tool interact with at once?

--- a/Content.Server/Fluids/EntitySystems/EvaporationSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/EvaporationSystem.cs
@@ -1,8 +1,7 @@
-﻿using Content.Server.Chemistry.EntitySystems;
+using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Fluids.Components;
 using Content.Shared.FixedPoint;
 using JetBrains.Annotations;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Fluids.EntitySystems
 {
@@ -14,7 +13,6 @@ namespace Content.Server.Fluids.EntitySystems
         public override void Update(float frameTime)
         {
             base.Update(frameTime);
-            var queueDelete = new RemQueue<EvaporationComponent>();
             foreach (var evaporationComponent in EntityManager.EntityQuery<EvaporationComponent>())
             {
                 var uid = evaporationComponent.Owner;
@@ -38,21 +36,9 @@ namespace Content.Server.Fluids.EntitySystems
                         FixedPoint2.Min(FixedPoint2.New(1), solution.CurrentVolume)); // removes 1 unit, or solution current volume, whichever is lower.
                 }
 
-                if (solution.CurrentVolume <= 0)
-                {
-                    EntityManager.QueueDeleteEntity(uid);
-                }
-                else if (solution.CurrentVolume <= evaporationComponent.LowerLimit // if puddle is too big or too small to evaporate.
-                         || solution.CurrentVolume >= evaporationComponent.UpperLimit)
-                {
-                    evaporationComponent.EvaporationToggle = false; // pause evaporation
-                }
-                else evaporationComponent.EvaporationToggle = true; // unpause evaporation, e.g. if a puddle previously above evaporation UpperLimit was brought down below evaporation UpperLimit via mopping.
-            }
-
-            foreach (var evaporationComponent in queueDelete)
-            {
-                EntityManager.RemoveComponent(evaporationComponent.Owner, evaporationComponent);
+                evaporationComponent.EvaporationToggle =
+                    solution.CurrentVolume > evaporationComponent.LowerLimit
+                    && solution.CurrentVolume < evaporationComponent.UpperLimit;
             }
         }
 

--- a/Content.Server/Fluids/EntitySystems/MoppingSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/MoppingSystem.cs
@@ -2,15 +2,15 @@ using Content.Server.Chemistry.Components.SolutionManager;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.DoAfter;
 using Content.Server.Fluids.Components;
+using Content.Server.Popups;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
-using Content.Shared.Popups;
 using Content.Shared.Tag;
-using Robust.Shared.Audio;
-using Robust.Shared.Player;
-using Robust.Shared.Map;
 using JetBrains.Annotations;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Map;
 
 namespace Content.Server.Fluids.EntitySystems;
 
@@ -22,8 +22,10 @@ public sealed class MoppingSystem : EntitySystem
     [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionSystem = default!;
+    [Dependency] private readonly PopupSystem _popups = default!;
+    [Dependency] private readonly AudioSystem _audio = default!;
 
-    const string puddlePrototypeId = "PuddleSmear"; // The puddle prototype to use when releasing liquid to the floor, making a new puddle
+    const string PuddlePrototypeId = "PuddleSmear"; // The puddle prototype to use when releasing liquid to the floor, making a new puddle
 
     public override void Initialize()
     {
@@ -35,264 +37,189 @@ public sealed class MoppingSystem : EntitySystem
 
     private void OnAfterInteract(EntityUid uid, AbsorbentComponent component, AfterInteractEvent args)
     {
-        if (!args.CanReach) // if user cannot reach the target
+        if (!args.CanReach || args.Handled)
+            return;
+
+        if (!_solutionSystem.TryGetSolution(args.Used, AbsorbentComponent.SolutionName, out var absorberSoln))
+            return;
+
+        if (args.Target is not { Valid: true } target)
         {
+            // Add liquid to an empty floor tile
+            args.Handled = TryCreatePuddle(args.User, args.ClickLocation, component, absorberSoln);
             return;
         }
 
-        if (args.Handled) // if the event was already handled
-        {
-            return;
-        }
-
-        _solutionSystem.TryGetSolution(args.Used, AbsorbentComponent.SolutionName, out var absorbedSolution);
-
-        if (absorbedSolution is null)
-        {
-            return;
-        }
-
-        var toolAvailableVolume = absorbedSolution.AvailableVolume;
-        var toolCurrentVolume = absorbedSolution.CurrentVolume;
-
-        // For adding liquid to an empty floor tile
-        if (args.Target is null) // if a tile is clicked
-        {
-            ReleaseToFloor(args.ClickLocation, component, absorbedSolution);
-            args.Handled = true;
-            args.User.PopupMessage(args.User, Loc.GetString("mopping-system-release-to-floor"));
-            return;
-        }
-        else if (args.Target is not null)
-        {
-            // Handle our do_after logic
-            HandleDoAfter(args.User, args.Used, args.Target.Value, component, toolCurrentVolume, toolAvailableVolume);
-        }
-
-        args.Handled = true;
-        return;
+        args.Handled = TryPuddleInteract(args.User, uid, target, component, absorberSoln)
+            || TryEmptyAbsorber(args.User, uid, target, component, absorberSoln)
+            || TryFillAbsorber(args.User, uid, target, component, absorberSoln);
     }
 
-    private void ReleaseToFloor(EntityCoordinates clickLocation, AbsorbentComponent absorbent, Solution? absorbedSolution)
+    /// <summary>
+    ///     Tries to create a puddle using solutions stored in the absorber entity.
+    /// </summary>
+    private bool TryCreatePuddle(EntityUid user, EntityCoordinates clickLocation, AbsorbentComponent absorbent, Solution absorberSoln)
     {
-        if ((_mapManager.TryGetGrid(clickLocation.GetGridUid(EntityManager), out var mapGrid)) // needs valid grid
-            && absorbedSolution is not null) // needs a solution to place on the tile
-        {
-            TileRef tile = mapGrid.GetTileRef(clickLocation);
+        if (absorberSoln.CurrentVolume <= 0)
+            return false;
 
-            // Drop some of the absorbed liquid onto the ground
-            var releaseAmount = FixedPoint2.Min(absorbent.ResidueAmount, absorbedSolution.CurrentVolume); // The release amount specified on the absorbent component, or the amount currently absorbed (whichever is less).
-            var releasedSolution = _solutionSystem.SplitSolution(absorbent.Owner, absorbedSolution, releaseAmount); // Remove releaseAmount of solution from the absorbent component
-            _spillableSystem.SpillAt(tile, releasedSolution, puddlePrototypeId);                                    // And spill it onto the tile.
-        }
+        if (!_mapManager.TryGetGrid(clickLocation.GetGridUid(EntityManager), out var mapGrid))
+            return false;
+
+        var releaseAmount = FixedPoint2.Min(absorbent.ResidueAmount, absorberSoln.CurrentVolume);
+        var releasedSolution = _solutionSystem.SplitSolution(absorbent.Owner, absorberSoln, releaseAmount);
+        _spillableSystem.SpillAt(mapGrid.GetTileRef(clickLocation), releasedSolution, PuddlePrototypeId);
+        _popups.PopupEntity(Loc.GetString("mopping-system-release-to-floor"), user, user);
+        return true;
     }
 
-    // Handles logic for our different types of valid target.
-    // Checks for conditions that would prevent a doAfter from starting.
-    private void HandleDoAfter(EntityUid user, EntityUid used, EntityUid target, AbsorbentComponent component, FixedPoint2 currentVolume, FixedPoint2 availableVolume)
+    /// <summary>
+    ///     Attempt to fill an absorber from some drainable solution.
+    /// </summary>
+    private bool TryFillAbsorber(EntityUid user, EntityUid used, EntityUid target, AbsorbentComponent component, Solution absorberSoln)
     {
-        // Below variables will be set within this function depending on what kind of target was clicked.
-        // They will be passed to the OnTransferComplete if the doAfter succeeds.
+        if (absorberSoln.AvailableVolume <= 0 || !TryComp(target, out DrainableSolutionComponent? drainable))
+            return false;
 
-        EntityUid donor;
-        EntityUid acceptor;
-        string donorSolutionName;
-        string acceptorSolutionName;
+        if (!_solutionSystem.TryGetDrainableSolution(target, out var drainableSolution))
+            return false;
 
-        FixedPoint2 transferAmount;
+        if (drainableSolution.CurrentVolume <= 0)
+        {
+            var msg = Loc.GetString("mopping-system-target-container-empty", ("target", target));
+            _popups.PopupEntity(msg, user, user);
+            return true;
+        }
 
-        var delay = 1.0f; //default do_after delay in seconds.
+        // Let's transfer up to to half the tool's available capacity to the tool.
+        var quantity = FixedPoint2.Max(component.PickupAmount, absorberSoln.AvailableVolume / 2);
+        quantity = FixedPoint2.Min(quantity, drainableSolution.CurrentVolume);
+
+        DoMopInteraction(user, used, target, component, drainable.Solution, quantity, 1, "mopping-system-drainable-success", component.TransferSound);
+        return true;
+    }
+
+    /// <summary>
+    ///     Empty an absorber into a refillable solution.
+    /// </summary>
+    private bool TryEmptyAbsorber(EntityUid user, EntityUid used, EntityUid target, AbsorbentComponent component, Solution absorberSoln)
+    {
+        if (absorberSoln.CurrentVolume <= 0 || !TryComp(target, out RefillableSolutionComponent? refillable))
+            return false;
+
+        if (!_solutionSystem.TryGetRefillableSolution(target, out var targetSolution))
+            return false;
+
         string msg;
-        SoundSpecifier sfx;
-
-        // For our purposes, if our target has a PuddleComponent, treat it as a puddle above all else.
-        if (TryComp<PuddleComponent>(target, out var puddle))
+        if (targetSolution.AvailableVolume <= 0)
         {
-            // These return conditions will abort BEFORE the do_after is called:
-            if(!_solutionSystem.TryGetSolution(target, puddle.SolutionName, out var puddleSolution) // puddle Solution is null
-                || (puddleSolution.TotalVolume <= 0)) // puddle is completely empty
-            {
-                return;
-            }
-            else if (availableVolume < 0) // mop is completely full
-            {
-                msg = "mopping-system-tool-full";
-                user.PopupMessage(user, Loc.GetString(msg, ("used", used))); // play message now because we are aborting.
-                return;
-            }
-            // adding to puddles
-            else if (puddleSolution.TotalVolume < component.MopLowerLimit // if the puddle is too small for the tool to effectively absorb any more solution from it
-                    && currentVolume > 0) // tool needs a solution to dilute the puddle with.
-            {
-                // Dilutes the puddle with some solution from the tool
-                transferAmount = FixedPoint2.Max(component.ResidueAmount, currentVolume);
-                TryTransfer(used, target, "absorbed", puddle.SolutionName, transferAmount); // Complete the transfer right away, with no doAfter.
-
-                sfx = component.TransferSound;
-                SoundSystem.Play(sfx.GetSound(), Filter.Pvs(user), used); // Give instant feedback for diluting puddle, so that it's clear that the player is adding to the puddle (as opposed to other behaviours, which have a doAfter).
-
-                msg = "mopping-system-puddle-diluted";
-                user.PopupMessage(user, Loc.GetString(msg)); // play message now because we are aborting.
-
-                return; // Do not begin a doAfter.
-            }
-            else
-            {
-                // Taking from puddles:
-
-                // Determine transferAmount:
-                transferAmount = FixedPoint2.Min(component.PickupAmount, puddleSolution.TotalVolume, availableVolume);
-
-                // TODO: consider onelining this with the above, using additional args on Min()?
-                if ((puddleSolution.TotalVolume - transferAmount) < component.MopLowerLimit) // If the transferAmount would bring the puddle below the MopLowerLimit
-                {
-                    transferAmount = puddleSolution.TotalVolume - component.MopLowerLimit; // Then the transferAmount should bring the puddle down to the MopLowerLimit exactly
-                }
-
-                donor = target; // the puddle Uid
-                donorSolutionName = puddle.SolutionName;
-
-                acceptor  = used; // the mop/tool Uid
-                acceptorSolutionName = "absorbed"; // by definition on AbsorbentComponent
-
-                // Set delay/popup/sound if nondefault. Popup and sound will only play on a successful doAfter.
-                delay = (component.PickupAmount.Float() / 10.0f) * component.MopSpeed; // Delay should scale with PickupAmount, which represents the maximum we can pick up per click.
-                msg = "mopping-system-puddle-success";
-                sfx = component.PickupSound;
-
-                DoMopInteraction(user, used, target, donor, acceptor, component, donorSolutionName, acceptorSolutionName, transferAmount, delay, msg, sfx);
-            }
+            msg = Loc.GetString("mopping-system-target-container-full", ("target", target));
+            _popups.PopupEntity(msg, user, user);
+            return true;
         }
-        else if ((TryComp<RefillableSolutionComponent>(target, out var refillable)) // We can put solution from the tool into the target
-                && (currentVolume > 0))                                             // And the tool is wet
+
+        // check if the target container is too small (e.g. syringe)
+        // TODO this should really be a tag or something, not a capacity check.
+        if (targetSolution.MaxVolume <= FixedPoint2.New(20))
         {
-            // These return conditions will abort BEFORE the do_after is called:
-            if (!_solutionSystem.TryGetRefillableSolution(target, out var refillableSolution)) // refillable Solution is null
-            {
-                return;
-            }
-            else if (refillableSolution.AvailableVolume <= 0) // target container is full (liquid destination)
-            {
-                msg = "mopping-system-target-container-full";
-                user.PopupMessage(user, Loc.GetString(msg, ("target", target))); // play message now because we are aborting.
-                return;
-            }
-            else if (refillableSolution.MaxVolume <= FixedPoint2.New(20)) // target container is too small (e.g. syringe)
-            {
-                msg = "mopping-system-target-container-too-small";
-                user.PopupMessage(user, Loc.GetString(msg, ("target", target))); // play message now because we are aborting.
-                return;
-            }
-            else
-            {
-                // Determine transferAmount
-                if (_tagSystem.HasTag(used, "Mop") // if the tool used is a literal mop (and not a sponge, rag, etc.)
-                    && !_tagSystem.HasTag(target, "Wringer")) // and if the target does not have a wringer for properly drying the mop
-                {
-                    delay = 5.0f; // Should take much longer if you don't have a wringer
-
-                    if ((currentVolume / (currentVolume + availableVolume) ) > 0.25) // mop is more than one-quarter full
-                    {
-                        transferAmount = FixedPoint2.Min(refillableSolution.AvailableVolume, currentVolume * 0.6); // squeeze up to 60% of the solution from the mop.
-                        msg = "mopping-system-hand-squeeze-little-wet";
-
-                        if ((currentVolume / (currentVolume + availableVolume) ) > 0.5) // if the mop is more than half full
-                            msg = "mopping-system-hand-squeeze-still-wet"; // overwrites the above
-
-                    }
-                    else // mop is less than one-quarter full
-                    {
-                        transferAmount = FixedPoint2.Min(refillableSolution.AvailableVolume, currentVolume); // squeeze remainder of solution from the mop.
-                        msg = "mopping-system-hand-squeeze-dry";
-                    }
-
-                }
-                else
-                {
-                    transferAmount = FixedPoint2.Min(refillableSolution.AvailableVolume, currentVolume); //Transfer all liquid from the tool to the container, but only if it will fit.
-                    msg = "mopping-system-refillable-success";
-                    delay = 1.0f;
-                }
-
-                donor = used; // the mop/tool Uid
-                donorSolutionName = "absorbed"; // by definition on AbsorbentComponent
-
-                acceptor  = target; // the refillable container's Uid
-                acceptorSolutionName = refillable.Solution;
-
-                // Set delay/popup/sound if nondefault. Popup and sound will only play on a successful doAfter.
-
-                sfx = component.TransferSound;
-
-                DoMopInteraction(user, used, target, donor, acceptor, component, donorSolutionName, acceptorSolutionName, transferAmount, delay, msg, sfx);
-            }
+            msg = Loc.GetString("mopping-system-target-container-too-small", ("target", target));
+            _popups.PopupEntity(msg, user, user);
+            return true;
         }
-        else if (TryComp<DrainableSolutionComponent>(target, out var drainable) // We can take solution from the target
-                && currentVolume <= 0 ) // tool is dry
+
+        float delay;
+        FixedPoint2 quantity = absorberSoln.CurrentVolume;
+
+        // TODO this really needs cleaning up. Less magic numbers, more data-fields.
+
+        if (_tagSystem.HasTag(used, "Mop") // if the tool used is a literal mop (and not a sponge, rag, etc.)
+            && !_tagSystem.HasTag(target, "Wringer")) // and if the target does not have a wringer for properly drying the mop
         {
-            // These return conditions will abort BEFORE the do_after is called:
-            if (!_solutionSystem.TryGetDrainableSolution(target, out var drainableSolution))
-            {
-                return;
-            }
-            else if (drainableSolution.CurrentVolume <= 0) // target container is empty (liquid source)
-            {
-                msg = "mopping-system-target-container-empty";
-                user.PopupMessage(user, Loc.GetString(msg, ("target", target))); // play message now because we are returning.
-                return;
-            }
+            delay = 5.0f; // Should take much longer if you don't have a wringer
+
+            var frac = quantity / absorberSoln.MaxVolume;
+
+            // squeeze up to 60% of the solution from the mop if the mop is more than one-quarter full
+            if (frac > 0.25)
+                quantity *= 0.6;
+
+            if (frac > 0.5)
+                msg = "mopping-system-hand-squeeze-still-wet";
+            else if (frac > 0.5)
+                msg = "mopping-system-hand-squeeze-little-wet";
             else
-            {
-                // Determine transferAmount
-                transferAmount = FixedPoint2.Min(availableVolume * 0.5, drainableSolution.CurrentVolume); // Let's transfer up to to half the tool's available capacity to the tool.
-
-                donor = target; // the drainable container's Uid
-                donorSolutionName = drainable.Solution;
-
-                acceptor  = used; // the mop/tool Uid
-                acceptorSolutionName = "absorbed"; // by definition on AbsorbentComponent
-
-                // Set delay/popup/sound if nondefault. Popup and sound will only play on a successful doAfter.
-                // default delay is fine for this case.
-                msg = "mopping-system-drainable-success";
-                sfx = component.TransferSound;
-
-                DoMopInteraction(user, used, target, donor, acceptor, component, donorSolutionName, acceptorSolutionName, transferAmount, delay, msg, sfx);
-            }
+                msg = "mopping-system-hand-squeeze-dry";
         }
+        else
+        {
+            msg = "mopping-system-refillable-success";
+            delay = 1.0f;
+        }
+
+        // negative quantity as we are removing solutions from the mop
+        quantity = -FixedPoint2.Min(targetSolution.AvailableVolume, quantity);
+
+        DoMopInteraction(user, used, target, component, refillable.Solution, quantity, delay, msg, component.TransferSound);
+        return true;
     }
 
-    private void DoMopInteraction(EntityUid user, EntityUid used, EntityUid target, EntityUid donor, EntityUid acceptor,
-                                  AbsorbentComponent component, string donorSolutionName, string acceptorSolutionName,
+    /// <summary>
+    ///     Logic for an absorbing entity interacting with a puddle.
+    /// </summary>
+    private bool TryPuddleInteract(EntityUid user, EntityUid used, EntityUid target, AbsorbentComponent absorber, Solution absorberSoln)
+    {
+        if (!TryComp(target, out PuddleComponent? puddle))
+            return false;
+
+        if (!_solutionSystem.TryGetSolution(target, puddle.SolutionName, out var puddleSolution) || puddleSolution.TotalVolume <= 0)
+            return false;
+
+        FixedPoint2 quantity;
+
+        // Get lower limit for mopping
+        FixedPoint2 lowerLimit = FixedPoint2.Zero;
+        if (TryComp(target, out EvaporationComponent? evaporation)
+            && evaporation.EvaporationToggle
+            && evaporation.LowerLimit == 0)
+        {
+            lowerLimit = absorber.LowerLimit;
+        }
+
+        // Can our absorber even absorb any liquid?
+        if (puddleSolution.TotalVolume <= lowerLimit)
+        {
+            // Cannot absorb any more liquid. So clearly the user wants to add liquid to the puddle... right?
+            // This is the old behavior and I CBF fixing this, for the record I don't like this.
+
+            quantity = FixedPoint2.Min(absorber.ResidueAmount, absorberSoln.CurrentVolume);
+            if (quantity <= 0)
+                return false;
+
+            // Dilutes the puddle with some solution from the tool
+            _solutionSystem.TryTransferSolution(used, target, absorberSoln, puddleSolution, quantity);
+            _audio.PlayPvs(absorber.TransferSound, used);
+            _popups.PopupEntity(Loc.GetString("mopping-system-puddle-diluted"), user);
+            return true;
+        }
+
+        if (absorberSoln.AvailableVolume < 0)
+        {
+            _popups.PopupEntity(Loc.GetString("mopping-system-tool-full", ("used", used)), user, user);
+            return true;
+        }
+
+        quantity = FixedPoint2.Min(absorber.PickupAmount, puddleSolution.TotalVolume - lowerLimit, absorberSoln.AvailableVolume);
+        if (quantity <= 0)
+            return false;
+
+        var delay = absorber.PickupAmount.Float() / absorber.Speed;
+        DoMopInteraction(user, used, target, absorber, puddle.SolutionName, quantity, delay, "mopping-system-puddle-success", absorber.PickupSound);
+        return true;
+    }
+
+    private void DoMopInteraction(EntityUid user, EntityUid used, EntityUid target, AbsorbentComponent component, string targetSolution,
                                   FixedPoint2 transferAmount, float delay, string msg, SoundSpecifier sfx)
     {
-        var doAfterArgs = new DoAfterEventArgs(user, delay, target: target)
-        {
-            BreakOnUserMove = true,
-            BreakOnStun = true,
-            BreakOnDamage = true,
-            MovementThreshold = 0.2f,
-            BroadcastCancelledEvent = new TransferCancelledEvent()
-            {
-                Target = target,
-                Component = component // (the AbsorbentComponent)
-            },
-            BroadcastFinishedEvent = new TransferCompleteEvent()
-            {
-                User = user,
-                Tool = used,
-                Target = target,
-                Donor = donor,
-                Acceptor = acceptor,
-                Component = component,
-                DonorSolutionName = donorSolutionName,
-                AcceptorSolutionName = acceptorSolutionName,
-                Message = msg,
-                Sound = sfx,
-                TransferAmount = transferAmount
-            }
-        };
-
         // Can't interact with too many entities at once.
         if (component.MaxInteractingEntities < component.InteractingEntities.Count + 1)
             return;
@@ -301,60 +228,63 @@ public sealed class MoppingSystem : EntitySystem
         if (!component.InteractingEntities.Add(target))
             return;
 
-        var result = _doAfterSystem.WaitDoAfter(doAfterArgs);
+        var doAfterArgs = new DoAfterEventArgs(user, delay, target: target)
+        {
+            BreakOnUserMove = true,
+            BreakOnStun = true,
+            BreakOnDamage = true,
+            MovementThreshold = 0.2f,
+            BroadcastCancelledEvent = new TransferCancelledEvent(target, component),
+            BroadcastFinishedEvent = new TransferCompleteEvent(used, target, component, targetSolution, msg, sfx, transferAmount)
+        };
+
+        _doAfterSystem.DoAfter(doAfterArgs);
     }
 
     private void OnTransferComplete(TransferCompleteEvent ev)
     {
-        SoundSystem.Play(ev.Sound.GetSound(), Filter.Pvs(ev.User), ev.Tool); // Play the After SFX
-
-        ev.User.PopupMessage(ev.User, Loc.GetString(ev.Message, ("target", ev.Target), ("used", ev.Tool))); // Play the After popup message
-
-        TryTransfer(ev.Donor, ev.Acceptor, ev.DonorSolutionName, ev.AcceptorSolutionName, ev.TransferAmount);
-
-        ev.Component.InteractingEntities.Remove(ev.Target); // Tell the absorbentComponent that we have stopped interacting with the target.
-        return;
+        _audio.PlayPvs(ev.Sound, ev.Tool);
+        _popups.PopupEntity(ev.Message, ev.Tool);
+        _solutionSystem.TryTransferSolution(ev.Target, ev.Tool, ev.TargetSolution, AbsorbentComponent.SolutionName, ev.TransferAmount);
+        ev.Component.InteractingEntities.Remove(ev.Target);
     }
 
     private void OnTransferCancelled(TransferCancelledEvent ev)
     {
-        if (!ev.Component.Deleted)
-            ev.Component.InteractingEntities.Remove(ev.Target); // Tell the absorbentComponent that we have stopped interacting with the target.
-
-        return;
-    }
-
-    private void TryTransfer(EntityUid donor, EntityUid acceptor, string donorSolutionName, string acceptorSolutionName, FixedPoint2 transferAmount)
-    {
-        if (_solutionSystem.TryGetSolution(donor, donorSolutionName, out var donorSolution) // If the donor solution is valid
-            && _solutionSystem.TryGetSolution(acceptor, acceptorSolutionName, out var acceptorSolution)) // And the acceptor solution is valid
-        {
-            var solutionToTransfer = _solutionSystem.SplitSolution(donor, donorSolution, transferAmount);   // Split a portion of the donor solution
-            _solutionSystem.TryAddSolution(acceptor, acceptorSolution, solutionToTransfer);                 // And add it to the acceptor solution
-        }
+        ev.Component.InteractingEntities.Remove(ev.Target);
     }
 }
 
-
 public sealed class TransferCompleteEvent : EntityEventArgs
 {
-    public EntityUid User;
-    public EntityUid Tool;
-    public EntityUid Target;
-    public EntityUid Donor;
-    public EntityUid Acceptor;
-    public AbsorbentComponent Component { get; init; } = default!;
-    public string DonorSolutionName = "";
-    public string AcceptorSolutionName = "";
-    public string Message = "";
-    public SoundSpecifier Sound { get; init; } = default!;
-    public FixedPoint2 TransferAmount;
+    public readonly EntityUid Tool;
+    public readonly EntityUid Target;
+    public readonly AbsorbentComponent Component;
+    public readonly string TargetSolution;
+    public readonly string Message;
+    public readonly SoundSpecifier Sound;
+    public readonly FixedPoint2 TransferAmount;
 
+    public TransferCompleteEvent(EntityUid tool, EntityUid target, AbsorbentComponent component, string targetSolution, string message, SoundSpecifier sound, FixedPoint2 transferAmount)
+    {
+        Tool = tool;
+        Target = target;
+        Component = component;
+        TargetSolution = targetSolution;
+        Message = Loc.GetString(message, ("target", target), ("used", tool));
+        Sound = sound;
+        TransferAmount = transferAmount;
+    }
 }
 
 public sealed class TransferCancelledEvent : EntityEventArgs
 {
-    public EntityUid Target;
-    public AbsorbentComponent Component { get; init; } = default!;
+    public readonly EntityUid Target;
+    public readonly AbsorbentComponent Component;
 
+    public TransferCancelledEvent(EntityUid target, AbsorbentComponent component)
+    {
+        Target = target;
+        Component = component;
+    }
 }

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -1,8 +1,11 @@
 using Content.Shared.StepTrigger.Components;
 using Robust.Shared.Collections;
 using Robust.Shared.GameStates;
+using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
+using Robust.Shared.Utility;
+using System.Linq;
 
 namespace Content.Shared.StepTrigger.Systems;
 
@@ -16,6 +19,17 @@ public sealed class StepTriggerSystem : EntitySystem
         SubscribeLocalEvent<StepTriggerComponent, ComponentHandleState>(TriggerHandleState);
 
         SubscribeLocalEvent<StepTriggerComponent, StartCollideEvent>(HandleCollide);
+#if DEBUG
+        SubscribeLocalEvent<StepTriggerComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, StepTriggerComponent component, ComponentStartup args)
+    {
+        if (!component.Active)
+            return;
+
+        DebugTools.Assert(TryComp(uid, out FixturesComponent? fixtures) && fixtures.FixtureCount > 0);
+#endif
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -4,7 +4,6 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
-using Robust.Shared.Utility;
 
 namespace Content.Shared.StepTrigger.Systems;
 
@@ -27,7 +26,8 @@ public sealed class StepTriggerSystem : EntitySystem
         if (!component.Active)
             return;
 
-        DebugTools.Assert(TryComp(uid, out FixturesComponent? fixtures) && fixtures.FixtureCount > 0);
+        if (!TryComp(uid, out FixturesComponent? fixtures) || fixtures.FixtureCount == 0)
+            Logger.Warning($"{ToPrettyString(uid)} has an active step trigger without any fixtures.");
 #endif
     }
 

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -5,7 +5,6 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Utility;
-using System.Linq;
 
 namespace Content.Shared.StepTrigger.Systems;
 

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -29,6 +29,7 @@
       hard: false
   - type: Appearance
   - type: PuddleVisualizer
+    wetFloorEffectThreshold: 0 # non-evaporating puddles don't become sparkles.
 
 - type: entity
   id: EvaporatingPuddle
@@ -36,6 +37,8 @@
   abstract: true
   components:
   - type: Evaporation
+  - type: PuddleVisualizer
+    wetFloorEffectThreshold: 5;
 
 - type: entity
   name: gibblets
@@ -47,16 +50,12 @@
     sprite: Fluids/gibblet.rsi # Placeholder
     state: gibblet-0
     netsync: false
-  - type: Puddle
-    wetFloorEffectThreshold: 0 # No wet floor sparkles
   - type: SolutionContainerManager
     solutions:
       puddle:
         reagents:
         - ReagentId: Water
           Quantity: 10
-  - type: Appearance
-  - type: PuddleVisualizer
   - type: Slippery
     launchForwardsMultiplier: 2.0
   - type: StepTrigger
@@ -110,9 +109,6 @@
   - type: Puddle
     overflowVolume: 50
     opacityModifier: 8
-  - type: Appearance
-  - type: PuddleVisualizer
-    wetFloorEffectThreshold: 0 # No wet floor sparkles
 
 - type: entity
   name: vomit

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -38,7 +38,7 @@
   components:
   - type: Evaporation
   - type: PuddleVisualizer
-    wetFloorEffectThreshold: 5;
+    wetFloorEffectThreshold: 5
 
 - type: entity
   name: gibblets

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -15,11 +15,11 @@
       path: /Audio/Effects/Fluids/splat.ogg
     recolor: true
   - type: Clickable
-  - type: Evaporation
   - type: Physics
   - type: Fixtures
     fixtures:
-    - shape:
+    - id: slipFixture
+      shape:
         !type:PhysShapeAabb
         bounds: "-0.4,-0.4,0.4,0.4"
       mask:
@@ -29,6 +29,13 @@
       hard: false
   - type: Appearance
   - type: PuddleVisualizer
+
+- type: entity
+  id: EvaporatingPuddle
+  parent: PuddleBase
+  abstract: true
+  components:
+  - type: Evaporation
 
 - type: entity
   name: gibblets
@@ -57,7 +64,7 @@
 - type: entity
   name: puddle
   id: PuddleSmear
-  parent: PuddleBase
+  parent: EvaporatingPuddle
   description: A puddle of liquid.
   components:
   - type: Sprite
@@ -75,7 +82,7 @@
 - type: entity
   name: puddle
   id: PuddleSplatter
-  parent: PuddleBase
+  parent: EvaporatingPuddle
   description: A puddle of liquid.
   components:
   - type: Sprite
@@ -103,8 +110,6 @@
   - type: Puddle
     overflowVolume: 50
     opacityModifier: 8
-  - type: Evaporation
-    evaporateTime: 400 # very slow
   - type: Appearance
   - type: PuddleVisualizer
     wetFloorEffectThreshold: 0 # No wet floor sparkles
@@ -117,18 +122,7 @@
   - type: Transform
     anchored: true
   - type: Clickable
-  - type: Evaporation
   - type: Physics
-  - type: Fixtures
-    fixtures:
-    - shape:
-        !type:PhysShapeAabb
-        bounds: "-0.4,-0.4,0.4,0.4"
-      mask:
-      - ItemMask
-      layer:
-      - SlipLayer
-      hard: false
   - type: Sprite
     sprite: Fluids/vomit.rsi
     state: vomit-0
@@ -188,6 +182,7 @@
     state: writing-0
     netsync: false
   - type: Puddle
+  - type: Evaporation
     evaporateTime: 10
   - type: Appearance
   - type: PuddleVisualizer

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -119,6 +119,17 @@
     anchored: true
   - type: Clickable
   - type: Physics
+  - type: Fixtures
+    fixtures:
+    - id: slipFixture
+      shape:
+        !type:PhysShapeAabb
+        bounds: "-0.4,-0.4,0.4,0.4"
+      mask:
+      - ItemMask
+      layer:
+      - SlipLayer
+      hard: false
   - type: Sprite
     sprite: Fluids/vomit.rsi
     state: vomit-0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -78,16 +78,12 @@
     sprite: Fluids/egg_splat.rsi
     state: egg-0
     netsync: false
-  - type: Puddle
-    wetFloorEffectThreshold: 0 # No wet floor sparkles
   - type: SolutionContainerManager
     solutions:
       puddle:
         reagents:
         - ReagentId: Egg
           Quantity: 2
-  - type: Appearance
-  - type: PuddleVisualizer
 
 - type: entity
   name: eggshells

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -86,7 +86,6 @@
         reagents:
         - ReagentId: Egg
           Quantity: 2
-  - type: Evaporation
   - type: Appearance
   - type: PuddleVisualizer
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -20,7 +20,6 @@
         reagents:
         - ReagentId: Flour
           Quantity: 10
-  - type: Evaporation
   - type: Appearance
   - type: PuddleVisualizer
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -415,7 +415,6 @@
         reagents:
         - ReagentId: JuiceTomato
           Quantity: 10
-  - type: Evaporation
     lowerLimit: 0 # todo: reimplement stain behaviour, ideally in a way that doesn't use evaporation lowerLimit
   - type: Appearance
   - type: PuddleVisualizer

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -407,17 +407,12 @@
     sprite: Fluids/tomato_splat.rsi
     state: puddle-0
     netsync: false
-  - type: Puddle
-    wetFloorEffectThreshold: 0 # No wet floor sparkles
   - type: SolutionContainerManager
     solutions:
       puddle:
         reagents:
         - ReagentId: JuiceTomato
           Quantity: 10
-    lowerLimit: 0 # todo: reimplement stain behaviour, ideally in a way that doesn't use evaporation lowerLimit
-  - type: Appearance
-  - type: PuddleVisualizer
 
 - type: entity
   name: eggplant


### PR DESCRIPTION
- Non-evaporating puddles now ignore the "mop lower limit" so that they can always be cleaned up.
- Empty puddles now delete themselves.
- Blood, eggs, giblets etc no longer evaporate. 
  - Previously it took a minimum of 33 minutes to evaporate, maybe more. If its going to be that slow, just not having it evaporate is better for performance.
  - This & the previous changes will fix #13228
  - Eventually, maybe evaporation time should be based on puddle reagents, so that a blood puddle can become a quickly evaporating (mostly) water puddle.
- Changes around the mopping system interaction logic to make it easier to parse. No more quadruple nested if statements at the end of a chain of nested if-else blocks.
  - Other than the lower limit/evaporation changes, functionality should be unchanged.
  -  Some of the component datafields have been renamed.

Fixes #11830

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://user-images.githubusercontent.com/60421075/210110306-b0638ecc-0b07-4b12-b77b-d073df4cecd0.mp4


:cl:
- fix: Fixed being unable to mop up blood stains.
- tweak: Various stains no longer evaporate.

