### PR TITLE
Self-regenerating zombies

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -215,7 +215,7 @@ namespace Content.Server.Zombies
             }
 
 
-            // Healing to 80% of HP. Not too big and not too small.
+            // Healing to 20% of HP. Not too big and not too small.
             var healingThreshold = aliveThreshold + (nextThreshold - aliveThreshold) * 0.8;
 
             if (dmg > healingThreshold)

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -197,16 +197,26 @@ namespace Content.Server.Zombies
 
             // Always zero, I guess?
             var aliveThreshold = 0f;
-            var critStateData = _state.GetEarliestCriticalState(state, 0);
-            if (critStateData == null)
+            var critStateData = _state.GetEarliestCriticalState(state, dmg);
+            var nextThreshold = FixedPoint2.Zero;
+            if (critStateData != null)
             {
-                return;
+                nextThreshold = critStateData.Value.threshold;
+            }
+            else
+            {
+                var deadStateData = _state.GetEarliestDeadState(state, dmg);
+                if (deadStateData == null)
+                {
+                    return;
+                }
+
+                nextThreshold = deadStateData.Value.threshold;
             }
 
-            var critThreshold = critStateData.Value.threshold;
 
             // Healing to 80% of HP. Not too big and not too small.
-            var healingThreshold = aliveThreshold + (critThreshold - aliveThreshold) * 0.8;
+            var healingThreshold = aliveThreshold + (nextThreshold - aliveThreshold) * 0.8;
 
             if (dmg > healingThreshold)
             {

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -1,4 +1,4 @@
-using Content.Shared.Damage;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.Roles;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -66,13 +66,28 @@ namespace Content.Shared.Zombies
         /// How much time passes between healing attempts
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float HealingCooldown = 30;
+        [DataField("healingCooldown")]
+        public TimeSpan HealingCooldown = TimeSpan.FromSeconds(30);
 
+        /// <summary>
+        /// Time when last healing was performed
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float HealingAccumulator;
+        [DataField("healingStart")]
+        public TimeSpan HealingStart;
 
-        // Set this up through your disease or something
-        [ViewVariables]
-        public DamageSpecifier HealingDamageSpecifier = new DamageSpecifier();
+        /// <summary>
+        /// Is this zombie currently regenerating
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("isHealing")]
+        public bool IsHealing;
+
+        /// <summary>
+        /// Solution used for zombie healing
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("healingSolution")]
+        public Solution? HealingSolution;
     }
 }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage;
 using Content.Shared.Roles;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -60,5 +61,18 @@ namespace Content.Shared.Zombies
         /// </summary>
         [DataField("zombieRoleId", customTypeSerializer: typeof(PrototypeIdSerializer<AntagPrototype>))]
         public readonly string ZombieRoleId = "Zombie";
+
+        /// <summary>
+        /// How much time passes between healing attempts
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float HealingCooldown = 30;
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float HealingAccumulator;
+
+        // Set this up through your disease or something
+        [ViewVariables]
+        public DamageSpecifier HealingDamageSpecifier = new DamageSpecifier();
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Right now getting to crit state as zombie means you have to ghost. That's boring. So I decided to add regen to zombie entity while they lie in critical state or close to it. That should encourage people to actually kill zombie players and spend some time to check if they are dead forever or not.
P.S. Should I instead inject some omnizine inside them? Because I didn't find a way to initialize DamageSpecifier in code normally.
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Prentor
- tweak: zombies now regenerate while low on hp

